### PR TITLE
Migrate PRIMS test logging (#3735)

### DIFF
--- a/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogIbMockTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogIbMockTest.cc
@@ -12,6 +12,7 @@
 #include "comms/mccl/tests/CudaStream.h"
 #include "comms/mccl/tests/CudaTestUtil.h"
 #include "comms/testinfra/IbverbMockTestUtils.h"
+#include "meta/NcclxLogger.h"
 
 namespace {
 struct GpuBuffer {
@@ -33,20 +34,20 @@ struct GpuBuffer {
 };
 } // namespace
 
-#define NCCLCHECK_FATAL(cmd)                                            \
-  do {                                                                  \
-    ncclResult_t res = cmd;                                             \
-    if (res != ncclSuccess) {                                           \
-      XLOGF(FATAL, "NCCL error {} '{}'", res, ncclGetErrorString(res)); \
-    }                                                                   \
+#define NCCLCHECK_FATAL(cmd)                                                \
+  do {                                                                      \
+    ncclResult_t res = cmd;                                                 \
+    if (res != ncclSuccess) {                                               \
+      NCCLX_LOG(FATAL, "NCCL error {} '{}'", res, ncclGetErrorString(res)); \
+    }                                                                       \
   } while (0)
 
-#define CUDACHECK_FATAL(cmd)                                            \
-  do {                                                                  \
-    cudaError_t err = cmd;                                              \
-    if (err != cudaSuccess) {                                           \
-      XLOGF(FATAL, "CUDA error {} '{}'", err, cudaGetErrorString(err)); \
-    }                                                                   \
+#define CUDACHECK_FATAL(cmd)                                                \
+  do {                                                                      \
+    cudaError_t err = cmd;                                                  \
+    if (err != cudaSuccess) {                                               \
+      NCCLX_LOG(FATAL, "CUDA error {} '{}'", err, cudaGetErrorString(err)); \
+    }                                                                       \
   } while (0)
 
 // RAII for NCCL Communicator
@@ -168,7 +169,7 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorWithIbVerbMock) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
   mccl::cuda::CudaStream stream;
 
   // Initialize NCCL communicator

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
@@ -12,10 +12,12 @@
 #include "comms/mccl/integration_tests/McclIntegrationTestUtil.h"
 #include "comms/mccl/tests/CudaStream.h"
 #include "comms/mccl/tests/CudaTestUtil.h"
-#include "comms/ncclx/meta/NcclxLogger.h"
 #include "comms/utils/colltrace/tests/nvidia-only/CPUControlledKernel.h"
+#include "meta/NcclxLogger.h"
 
 namespace {
+constexpr std::string_view kLogFilePrefix{"logfile"};
+
 struct GpuBuffer {
   explicit GpuBuffer(size_t size) : size_(size) {
     cudaMalloc(&ptr_, size);
@@ -35,20 +37,20 @@ struct GpuBuffer {
 };
 } // namespace
 
-#define NCCLCHECK_FATAL(cmd)                                            \
-  do {                                                                  \
-    ncclResult_t res = cmd;                                             \
-    if (res != ncclSuccess) {                                           \
-      XLOGF(FATAL, "NCCL error {} '{}'", res, ncclGetErrorString(res)); \
-    }                                                                   \
+#define NCCLCHECK_FATAL(cmd)                                                \
+  do {                                                                      \
+    ncclResult_t res = cmd;                                                 \
+    if (res != ncclSuccess) {                                               \
+      NCCLX_LOG(FATAL, "NCCL error {} '{}'", res, ncclGetErrorString(res)); \
+    }                                                                       \
   } while (0)
 
-#define CUDACHECK_FATAL(cmd)                                            \
-  do {                                                                  \
-    cudaError_t err = cmd;                                              \
-    if (err != cudaSuccess) {                                           \
-      XLOGF(FATAL, "CUDA error {} '{}'", err, cudaGetErrorString(err)); \
-    }                                                                   \
+#define CUDACHECK_FATAL(cmd)                                                \
+  do {                                                                      \
+    cudaError_t err = cmd;                                                  \
+    if (err != cudaSuccess) {                                               \
+      NCCLX_LOG(FATAL, "CUDA error {} '{}'", err, cudaGetErrorString(err)); \
+    }                                                                       \
   } while (0)
 
 // RAII for NCCL Communicator
@@ -102,7 +104,7 @@ void waitStreamWithTimeout(
       return;
     }
     if (res != cudaErrorNotReady) {
-      XLOGF(
+      NCCLX_LOG(
           FATAL, "Unexpected CUDA error {} '{}'", res, cudaGetErrorString(res));
     }
     std::this_thread::sleep_for(std::chrono::milliseconds{100});
@@ -139,7 +141,8 @@ class CollTraceWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
                     "NCCL_DEBUG=INFO",
                     fmt::format(
                         "NCCL_DEBUG_FILE={}",
-                        (tmpDir_.path() / "logfile%p").string()),
+                        (tmpDir_.path() / (std::string{kLogFilePrefix} + "%p"))
+                            .string()),
                 },
         });
   }
@@ -160,7 +163,7 @@ class CollTraceWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
         testDriverState.workerExitCodes, ::testing::Each(::testing::Eq(0)));
   }
 
-  void testDriverCheckCrashedWithWatchdog() {
+  void testDriverCheckCrashedWithWatchdog(bool expectPeerTerminations = false) {
     ASSERT_TRUE(
         std::holds_alternative<
             mccl::CollectiveIntegrationTestMixin::TestDriverState>(
@@ -172,14 +175,41 @@ class CollTraceWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
     EXPECT_THAT(
         testDriverState.workerExitCodes, ::testing::Each(::testing::Ne(0)));
 
-    int count = 0;
+    const auto expectedFileCount = testDriverState.workerExitCodes.size();
+    ASSERT_GT(expectedFileCount, 0);
+    size_t fileCount = 0;
+    size_t nonEmptyFileCount = 0;
+    size_t watchdogFatalCount = 0;
+    size_t peerFatalCount = 0;
     for (const auto& entry : folly::fs::directory_iterator(tmpDir_.path())) {
+      const auto fileName = entry.path().filename().string();
+      if (fileName.compare(0, kLogFilePrefix.size(), kLogFilePrefix) != 0) {
+        continue;
+      }
       std::string fileContents;
       ASSERT_TRUE(folly::readFile(entry.path().c_str(), fileContents));
-      EXPECT_THAT(fileContents, ::testing::HasSubstr("COMM FATAL"));
-      count++;
+      if (!fileContents.empty()) {
+        ++nonEmptyFileCount;
+      }
+      if (fileContents.find("COMM FATAL: FatalError: Collective") !=
+          std::string::npos) {
+        ++watchdogFatalCount;
+      }
+      if (fileContents.find("Peer terminated after rank 0 watchdog timeout") !=
+          std::string::npos) {
+        ++peerFatalCount;
+      }
+      ++fileCount;
     }
-    EXPECT_EQ(count, 4);
+    EXPECT_EQ(fileCount, expectedFileCount);
+    EXPECT_EQ(nonEmptyFileCount, expectedFileCount);
+    if (expectPeerTerminations) {
+      EXPECT_GE(watchdogFatalCount, 1);
+      EXPECT_EQ(peerFatalCount, expectedFileCount - 1);
+    } else {
+      EXPECT_GT(watchdogFatalCount, 0);
+      EXPECT_EQ(peerFatalCount, 0);
+    }
   }
 };
 
@@ -217,7 +247,7 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorFromGPE) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
   mccl::cuda::CudaStream stream;
 
   // Initialize NCCL communicator
@@ -272,7 +302,7 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorWithGenericAsyncError) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
@@ -313,7 +343,7 @@ TEST_F(CollTraceWatchdogTest, TestTimeoutBeforeColl) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
@@ -344,7 +374,7 @@ TEST_F(CollTraceWatchdogTest, TestTimeoutBeforeColl) {
 
 TEST_F(CollTraceWatchdogTest, TestTimeoutInColl) {
   if (isTestDriverProcess()) {
-    testDriverCheckCrashedWithWatchdog();
+    testDriverCheckCrashedWithWatchdog(true /*expectPeerTerminations*/);
     return;
   }
 
@@ -364,7 +394,7 @@ TEST_F(CollTraceWatchdogTest, TestTimeoutInColl) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
@@ -381,8 +411,9 @@ TEST_F(CollTraceWatchdogTest, TestTimeoutInColl) {
   if (rank != 0) {
     // Sleep long enough to make other ranks timeout
     std::this_thread::sleep_for(timeoutSec + std::chrono::seconds{3});
-    // Hacky way to make the driver process believe rank 0 is faulty as well.
-    NCCLX_LOG(FATAL, "COMM FATAL");
+    // Rank 0 owns the collective that times out. Terminate the peer ranks after
+    // it has had enough time to emit the production watchdog diagnostic.
+    NCCLX_LOG(FATAL, "Peer terminated after rank 0 watchdog timeout");
   } else {
     NcclAllReduce allReduce(comm.raw(), stream, 32);
     std::this_thread::sleep_for(timeoutSec + std::chrono::seconds{3});
@@ -413,7 +444,7 @@ TEST_F(CollTraceWatchdogTest, TestBelowTimeoutInColl) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);
@@ -461,7 +492,7 @@ TEST_F(CollTraceWatchdogTest, TestBelowTimeoutBeforeColl) {
 
   // Initialize CUDA state
   auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
-  XLOG(INFO) << "CUDA device id: " << deviceId;
+  NCCLX_LOG_STREAM(INFO) << "CUDA device id: " << deviceId;
 
   // Initialize NCCL communicator
   NcclComm comm(worldSize, rank);

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWrapperUT.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWrapperUT.cc
@@ -18,6 +18,7 @@
 #include "comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.h"
 #include "comms/utils/colltrace/tests/MockTypes.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/NcclxLogger.h"
 #include "meta/colltrace/CollTraceWrapper.h"
 
 using namespace meta::comms::ncclx;
@@ -123,7 +124,7 @@ class CollTraceWrapperUT : public ::testing::Test {
     // Create a mock collective task
     auto* collTask = createNewCollTask();
     if (collTask == nullptr) {
-      XLOG(FATAL) << "Failed to create new collective task" << std::endl;
+      NCCLX_LOG_STREAM(FATAL) << "Failed to create new collective task";
     }
     collTask->func = ncclFuncAllReduce;
     collTask->algorithm = NCCL_ALGO_RING;

--- a/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -25,6 +25,7 @@
 #include "comms/utils/colltrace/tests/nvidia-only/CPUControlledKernel.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/Logger.h"
+#include "meta/NcclxLogger.h"
 #include "meta/commDump.h"
 
 using ::meta::comms::colltrace::CollTraceConfig;
@@ -604,7 +605,7 @@ TEST_F(CollTraceTest, winPutWait) {
   EXPECT_EQ(pastCollsJson.size(), 3 * kNumIters);
 
   for (int i = 0; i < pastCollsJson.size(); i++) {
-    XLOGF(DBG, "coll {}: {}", i, pastCollsJson[i]["opName"].asString());
+    NCCLX_LOG(DBG, "coll {}: {}", i, pastCollsJson[i]["opName"].asString());
   }
 
   for (int i = 0; i < kNumIters; i++) {

--- a/comms/ncclx/meta/tests/CommDumpTest.cc
+++ b/comms/ncclx/meta/tests/CommDumpTest.cc
@@ -17,6 +17,7 @@
 #include "comms/testinfra/TestUtils.h"
 #include "comms/utils/StrUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/NcclxLogger.h"
 
 #include "meta/NcclxConfig.h"
 #include "meta/colltrace/ProxyMock.h"
@@ -810,7 +811,7 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTrace) {
   // Check past collectives are dumped correctly and simply check if can be
   // parsed as json entries.
   if (dump.count("CT_pastColls")) {
-    XLOG(DBG1) << "Entered CT_pastColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered CT_pastColls if statement";
     auto ctPastCollsObjs = folly::parseJson(dump["CT_pastColls"]);
     EXPECT_EQ(ctPastCollsObjs.size(), numColls);
     for (int i = 0; i < numColls; i++) {
@@ -821,7 +822,7 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTrace) {
 
   // Proxy trace would be empty if nNodes == 1
   if (dump.count("PT_pastColls") && comm->nNodes > 1) {
-    XLOG(DBG1) << "Entered PT_pastColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered PT_pastColls if statement";
     auto ptPastCollsObjs = folly::parseJson(dump["PT_pastColls"]);
     EXPECT_EQ(ptPastCollsObjs.size(), numColls);
     for (int i = 0; i < numColls; i++) {
@@ -832,18 +833,18 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTrace) {
 
   // Check no pending/current entries
   if (dump.count("CT_pendingColls")) {
-    XLOG(DBG1) << "Entered CT_pendingColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered CT_pendingColls if statement";
     auto ctPendingCollsObjs = folly::parseJson(dump["CT_pendingColls"]);
     EXPECT_EQ(ctPendingCollsObjs.size(), 0);
   }
 
   if (dump.count("CT_currentColls")) {
-    XLOG(DBG1) << "Entered CT_currentColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered CT_currentColls if statement";
     EXPECT_EQ(dump["CT_currentColls"], "[]");
   }
 
   if (dump.count("PT_activeOps")) {
-    XLOG(DBG1) << "Entered PT_activeOps if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered PT_activeOps if statement";
     auto ptActiveOpsObjs = folly::parseJson(dump["PT_activeOps"]);
     EXPECT_EQ(ptActiveOpsObjs.size(), 0);
   }
@@ -905,7 +906,7 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTraceWithCommsMonitor) {
   // Check past collectives are dumped correctly and simply check if can be
   // parsed as json entries.
   if (dump.count("CT_pastColls")) {
-    XLOG(DBG1) << "Entered CT_pastColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered CT_pastColls if statement";
     auto ctPastCollsObjs = folly::parseJson(dump["CT_pastColls"]);
     EXPECT_EQ(ctPastCollsObjs.size(), numColls);
     for (int i = 0; i < numColls; i++) {
@@ -919,7 +920,7 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTraceWithCommsMonitor) {
 
   // Proxy trace would be empty if nNodes == 1
   if (dump.count("PT_pastColls") && comm->nNodes > 1) {
-    XLOG(DBG1) << "Entered PT_pastColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered PT_pastColls if statement";
     auto ptPastCollsObjs = folly::parseJson(dump["PT_pastColls"]);
     EXPECT_EQ(ptPastCollsObjs.size(), numColls);
     for (int i = 0; i < numColls; i++) {
@@ -930,18 +931,18 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTraceWithCommsMonitor) {
 
   // Check no pending/current entries
   if (dump.count("CT_pendingColls")) {
-    XLOG(DBG1) << "Entered CT_pendingColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered CT_pendingColls if statement";
     auto ctPendingCollsObjs = folly::parseJson(dump["CT_pendingColls"]);
     EXPECT_EQ(ctPendingCollsObjs.size(), 0);
   }
 
   if (dump.count("CT_currentColls")) {
-    XLOG(DBG1) << "Entered CT_currentColls if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered CT_currentColls if statement";
     EXPECT_EQ(dump["CT_currentColls"], "[]");
   }
 
   if (dump.count("PT_activeOps")) {
-    XLOG(DBG1) << "Entered PT_activeOps if statement";
+    NCCLX_LOG_STREAM(DBG) << "Entered PT_activeOps if statement";
     auto ptActiveOpsObjs = folly::parseJson(dump["PT_activeOps"]);
     EXPECT_EQ(ptActiveOpsObjs.size(), 0);
   }

--- a/comms/ncclx/meta/tests/LogTest.cc
+++ b/comms/ncclx/meta/tests/LogTest.cc
@@ -11,6 +11,7 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/Logger.h"
 #include "debug.h"
+#include "meta/NcclxLogger.h"
 
 class LogTest : public ::testing::Test {
  public:
@@ -126,7 +127,7 @@ TEST_F(LogTest, InfoWarnToFile) {
   const std::string kTestInfoStr = "Testing INFO to FILE";
   const std::string kTestWarnStr = "Testing WARN to FILE";
 
-  XLOG(WARN) << kDebugFile;
+  NCCLX_LOG_STREAM(WARN) << kDebugFile;
   auto envGuard0 = EnvRAII(NCCL_DEBUG_FILE, kDebugFile);
   SysEnvRAII sysDebugFileGuard("NCCL_DEBUG_FILE", kDebugFile);
   auto envGuard1 = EnvRAII(NCCL_DEBUG, std::string("INFO"));

--- a/comms/prims/benchmarks/BenchmarkMacros.h
+++ b/comms/prims/benchmarks/BenchmarkMacros.h
@@ -3,8 +3,8 @@
 #pragma once
 
 #include <cuda_runtime.h>
-#include <folly/logging/xlog.h>
 #include <nccl.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 namespace comms::prims::benchmark {
 
@@ -24,7 +24,7 @@ constexpr std::size_t kDefaultDataBufferSize = 8 * 1024 * 1024;
   do {                               \
     cudaError_t err = call;          \
     if (err != cudaSuccess) {        \
-      XLOGF(                         \
+      COMMS_LOG(                     \
           ERR,                       \
           "CUDA error at {}:{}: {}", \
           __FILE__,                  \
@@ -39,7 +39,7 @@ constexpr std::size_t kDefaultDataBufferSize = 8 * 1024 * 1024;
   do {                               \
     ncclResult_t res = call;         \
     if (res != ncclSuccess) {        \
-      XLOGF(                         \
+      COMMS_LOG(                     \
           ERR,                       \
           "NCCL error at {}:{}: {}", \
           __FILE__,                  \
@@ -54,7 +54,7 @@ constexpr std::size_t kDefaultDataBufferSize = 8 * 1024 * 1024;
   do {                               \
     cudaError_t err = call;          \
     if (err != cudaSuccess) {        \
-      XLOGF(                         \
+      COMMS_LOG(                     \
           ERR,                       \
           "CUDA error at {}:{}: {}", \
           __FILE__,                  \
@@ -69,7 +69,7 @@ constexpr std::size_t kDefaultDataBufferSize = 8 * 1024 * 1024;
   do {                               \
     ncclResult_t res = call;         \
     if (res != ncclSuccess) {        \
-      XLOGF(                         \
+      COMMS_LOG(                     \
           ERR,                       \
           "NCCL error at {}:{}: {}", \
           __FILE__,                  \
@@ -84,7 +84,7 @@ constexpr std::size_t kDefaultDataBufferSize = 8 * 1024 * 1024;
   do {                               \
     cudaError_t err = call;          \
     if (err != cudaSuccess) {        \
-      XLOGF(                         \
+      COMMS_LOG(                     \
           ERR,                       \
           "CUDA error at {}:{}: {}", \
           __FILE__,                  \

--- a/comms/prims/benchmarks/IbgdaBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cc
@@ -4,7 +4,7 @@
 
 #include <cuda_runtime.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <cstdlib>
 #include <iomanip>
@@ -85,7 +85,8 @@ class BenchIbTransport {
       int numRanks,
       const std::shared_ptr<meta::comms::IBootstrap>& bootstrap,
       const MultipeerIbTransportConfig& config) {
-    XLOGF(INFO, "BenchIbTransport: backend={}", benchIbBackendName(backend));
+    COMMS_LOG(
+        INFO, "BenchIbTransport: backend={}", benchIbBackendName(backend));
     if (backend == BenchIbBackend::IBRC) {
       ibrc_ = std::make_unique<MultipeerIbrcTransport>(
           globalRank, numRanks, bootstrap, config);
@@ -128,7 +129,7 @@ class BenchIbTransport {
   do {                               \
     cudaError_t err = call;          \
     if (err != cudaSuccess) {        \
-      XLOGF(                         \
+      COMMS_LOG(                     \
           ERR,                       \
           "CUDA error at {}:{}: {}", \
           __FILE__,                  \
@@ -143,7 +144,7 @@ class BenchIbTransport {
   do {                               \
     cudaError_t err = call;          \
     if (err != cudaSuccess) {        \
-      XLOGF(                         \
+      COMMS_LOG(                     \
           ERR,                       \
           "CUDA error at {}:{}: {}", \
           __FILE__,                  \
@@ -306,7 +307,7 @@ class IbgdaBenchmarkFixture
        << ", GPU clock: " << clockRateGHz_ << " GHz\n";
     ss << "================================================================================\n\n";
 
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 
   // Standard message size configurations
@@ -391,7 +392,7 @@ class IbgdaBenchmarkFixture
       bool correct = true;
       for (std::size_t i = 0; i < nbytes; i++) {
         if (hostBuf[i] != fillPattern) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "{}: data mismatch at byte {}: expected 0x{:02X}, got 0x{:02X}",
               methodName,
@@ -405,7 +406,8 @@ class IbgdaBenchmarkFixture
       EXPECT_TRUE(correct) << methodName
                            << ": put data correctness check failed";
       if (correct) {
-        XLOGF(INFO, "{}: data correctness OK ({} bytes)", methodName, nbytes);
+        COMMS_LOG(
+            INFO, "{}: data correctness OK ({} bytes)", methodName, nbytes);
       }
     }
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -415,7 +417,8 @@ class IbgdaBenchmarkFixture
 TEST_P(IbgdaBenchmarkFixture, PutFlush) {
   // Measures raw RDMA Write latency as put + flush.
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -459,7 +462,7 @@ TEST_P(IbgdaBenchmarkFixture, PutFlush) {
     unsigned long long* d_totalCycles;
     CUDA_CHECK_VOID(cudaMalloc(&d_totalCycles, sizeof(unsigned long long)));
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: GPU clock rate = {:.2f} GHz",
         globalRank,
@@ -494,7 +497,7 @@ TEST_P(IbgdaBenchmarkFixture, PutFlush) {
 
         results.push_back(result);
 
-        XLOGF(
+        COMMS_LOG(
             INFO,
             "Rank {}: {} - Latency: {:.2f} us, BW: {:.2f} GB/s",
             globalRank,
@@ -520,7 +523,8 @@ TEST_P(IbgdaBenchmarkFixture, ThreadScopeMultiBlockPutFlush) {
   // block-private slice. This checks that thread-scope wrappers inherit the
   // physical block id instead of routing all blocks through block 0's QPs.
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -644,7 +648,8 @@ TEST_P(IbgdaBenchmarkFixture, PutCompletionComparison) {
   // Serialize every put with its completion wait to isolate the primitive
   // completion cost. This does not model pipelined send/recv overlap.
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -692,7 +697,7 @@ TEST_P(IbgdaBenchmarkFixture, PutCompletionComparison) {
     unsigned long long* d_totalCycles;
     CUDA_CHECK_VOID(cudaMalloc(&d_totalCycles, sizeof(unsigned long long)));
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: GPU clock rate = {:.2f} GHz",
         globalRank,
@@ -729,7 +734,7 @@ TEST_P(IbgdaBenchmarkFixture, PutCompletionComparison) {
 
         counterResults.push_back(result);
 
-        XLOGF(
+        COMMS_LOG(
             INFO,
             "Rank {}: {} - Latency: {:.2f} us, BW: {:.2f} GB/s",
             globalRank,
@@ -760,7 +765,7 @@ TEST_P(IbgdaBenchmarkFixture, PutCompletionComparison) {
             (config.nBytes / 1e9f) / (localResult.latency / 1e6f);
         localResults.push_back(localResult);
 
-        XLOGF(
+        COMMS_LOG(
             INFO,
             "Rank {}: {} wait_local - Latency: {:.2f} us, BW: {:.2f} GB/s",
             globalRank,
@@ -786,7 +791,8 @@ TEST_P(IbgdaBenchmarkFixture, PutCompletionComparison) {
 TEST_P(IbgdaBenchmarkFixture, PutSignalWaitCounter) {
   // Measures RDMA Write + atomic signal latency (put + signal + counter wait)
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -835,7 +841,7 @@ TEST_P(IbgdaBenchmarkFixture, PutSignalWaitCounter) {
     unsigned long long* d_totalCycles;
     CUDA_CHECK_VOID(cudaMalloc(&d_totalCycles, sizeof(unsigned long long)));
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: GPU clock rate = {:.2f} GHz",
         globalRank,
@@ -873,7 +879,7 @@ TEST_P(IbgdaBenchmarkFixture, PutSignalWaitCounter) {
 
         results.push_back(result);
 
-        XLOGF(
+        COMMS_LOG(
             INFO,
             "Rank {}: {} - Latency: {:.2f} us, BW: {:.2f} GB/s",
             globalRank,
@@ -898,7 +904,8 @@ TEST_P(IbgdaBenchmarkFixture, PutSignalWaitCounter) {
 TEST_P(IbgdaBenchmarkFixture, SignalOnly) {
   // Measures atomic signal-only latency (no data transfer)
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -934,7 +941,7 @@ TEST_P(IbgdaBenchmarkFixture, SignalOnly) {
     unsigned long long* d_totalCycles;
     CUDA_CHECK_VOID(cudaMalloc(&d_totalCycles, sizeof(unsigned long long)));
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: GPU clock rate = {:.2f} GHz",
         globalRank,
@@ -964,13 +971,13 @@ TEST_P(IbgdaBenchmarkFixture, SignalOnly) {
 
       latencyUs = cyclesToUs(totalCycles) / kIbgdaBatchIters;
 
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "\n=== {} Signal-Only Latency (Raw, no kernel launch overhead) ===",
           backendName());
-      XLOGF(INFO, "Average latency: {:.2f} us", latencyUs);
-      XLOGF(INFO, "Batch iterations: {}", kIbgdaBatchIters);
-      XLOGF(
+      COMMS_LOG(INFO, "Average latency: {:.2f} us", latencyUs);
+      COMMS_LOG(INFO, "Batch iterations: {}", kIbgdaBatchIters);
+      COMMS_LOG(
           INFO,
           "===========================================================\n");
     }
@@ -988,7 +995,8 @@ TEST_P(IbgdaBenchmarkFixture, SignalOnly) {
 // Counter = put + signal + transport counter-slot completion + local poll.
 TEST_P(IbgdaBenchmarkFixture, PutSignalComparison) {
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1056,7 +1064,7 @@ TEST_P(IbgdaBenchmarkFixture, PutSignalComparison) {
       uint8_t basePattern = static_cast<uint8_t>((ci + 1) * 3);
 
       if (globalRank == 0) {
-        XLOGF(INFO, "Verifying put data correctness ({})...", cfg.name);
+        COMMS_LOG(INFO, "Verifying put data correctness ({})...", cfg.name);
       }
 
       verifyPutDataCorrectness(
@@ -1071,16 +1079,17 @@ TEST_P(IbgdaBenchmarkFixture, PutSignalComparison) {
     }
 
     if (globalRank == 0) {
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "\n================================================================================");
-      XLOGF(INFO, "    {} put+signal+counter latency", backendName());
-      XLOGF(INFO, "    (Using batched kernels - no kernel launch overhead)");
-      XLOGF(
+      COMMS_LOG(INFO, "    {} put+signal+counter latency", backendName());
+      COMMS_LOG(
+          INFO, "    (Using batched kernels - no kernel launch overhead)");
+      COMMS_LOG(
           INFO,
           "================================================================================");
-      XLOGF(INFO, "{:>10} {:>18}", "Size", "Counter Lat (us)");
-      XLOGF(
+      COMMS_LOG(INFO, "{:>10} {:>18}", "Size", "Counter Lat (us)");
+      COMMS_LOG(
           INFO,
           "--------------------------------------------------------------------------------");
     }
@@ -1097,18 +1106,18 @@ TEST_P(IbgdaBenchmarkFixture, PutSignalComparison) {
           counterLatency);
 
       if (globalRank == 0) {
-        XLOGF(INFO, "{:>10} {:>18.2f}", config.name, counterLatency);
+        COMMS_LOG(INFO, "{:>10} {:>18.2f}", config.name, counterLatency);
       }
     }
 
     if (globalRank == 0) {
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "================================================================================");
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "Counter = put + signal + transport counter-slot completion + local poll");
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "================================================================================\n");
     }
@@ -1134,7 +1143,7 @@ TEST_P(IbgdaBenchmarkFixture, PutSignalComparison) {
 TEST_P(IbgdaBenchmarkFixture, MultiPeerCounterFanOut) {
   const int numPeers = numRanks - 1;
   if (numPeers < 1) {
-    XLOGF(INFO, "Skipping test: requires >= 2 ranks, got {}", numRanks);
+    COMMS_LOG(INFO, "Skipping test: requires >= 2 ranks, got {}", numRanks);
     return;
   }
   if (backend() == BenchIbBackend::IBRC) {
@@ -1285,46 +1294,46 @@ TEST_P(IbgdaBenchmarkFixture, MultiPeerCounterFanOut) {
 
     if (globalRank == 0) {
       float delta = fanOutLatency - serialLatency;
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "\n================================================================================");
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "    {} Multi-Peer Counter Fan-Out ({} peers, {} per peer)",
           backendName(),
           numPeers,
           formatSize(kDataSize));
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "================================================================================");
-      XLOGF(
+      COMMS_LOG(
           INFO, "  Serial (N wait_counter calls): {:>8.2f} us", serialLatency);
-      XLOGF(
+      COMMS_LOG(
           INFO, "  FanOut (1 wait_counter call):  {:>8.2f} us", fanOutLatency);
-      XLOGF(INFO, "  Delta (FanOut - Serial):       {:>+8.2f} us", delta);
-      XLOGF(
+      COMMS_LOG(INFO, "  Delta (FanOut - Serial):       {:>+8.2f} us", delta);
+      COMMS_LOG(
           INFO,
           "  Serial / peer:                 {:>8.2f} us",
           serialLatency / numPeers);
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "  FanOut / peer (amortized):     {:>8.2f} us",
           fanOutLatency / numPeers);
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "--------------------------------------------------------------------------------");
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "  Serial:  put+signal+counter (per-peer slot) + wait_counter per peer (O(N))");
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "  FanOut:  put+signal+counter (shared slot) + single wait_counter (O(1))");
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "  Batch iterations: {}, GPU clock: {:.2f} GHz",
           kIbgdaBatchIters,
           clockRateGHz_);
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "================================================================================\n");
     }
@@ -1349,5 +1358,7 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
   folly::Init init(&argc, &argv);
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/benchmarks/IbgdaForwardBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaForwardBenchmark.cc
@@ -4,7 +4,7 @@
 
 #include <cuda_runtime.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <cstdint>
 #include <memory>
@@ -39,7 +39,7 @@ class IbgdaForwardBenchmarkTest : public BenchmarkTestFixture {
 
 TEST_F(IbgdaForwardBenchmarkTest, Correctness) {
   if (worldSize != 3) {
-    XLOGF(INFO, "Skipping: requires exactly 3 ranks, got {}", worldSize);
+    COMMS_LOG(INFO, "Skipping: requires exactly 3 ranks, got {}", worldSize);
     return;
   }
 
@@ -101,7 +101,7 @@ TEST_F(IbgdaForwardBenchmarkTest, Correctness) {
     for (std::size_t i = 0; i < kDataBytes; ++i) {
       if (hostBuf[i] != fillPattern) {
         if (errors < 10) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: byte {} expected 0x{:02X} got 0x{:02X}",
               globalRank,
@@ -119,7 +119,7 @@ TEST_F(IbgdaForwardBenchmarkTest, Correctness) {
 
 TEST_F(IbgdaForwardBenchmarkTest, Bandwidth) {
   if (worldSize != 3) {
-    XLOGF(INFO, "Skipping: requires exactly 3 ranks, got {}", worldSize);
+    COMMS_LOG(INFO, "Skipping: requires exactly 3 ranks, got {}", worldSize);
     return;
   }
 
@@ -165,29 +165,29 @@ TEST_F(IbgdaForwardBenchmarkTest, Bandwidth) {
   cudaEventCreate(&stop);
 
   if (globalRank == 0) {
-    XLOGF(INFO, "");
-    XLOGF(
+    COMMS_LOG(INFO, "");
+    COMMS_LOG(
         INFO,
         "================================================================");
-    XLOGF(
+    COMMS_LOG(
         INFO, "  recv_forward vs recv+send (3-rank chain: rank0→rank1→rank2)");
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "  numBlocks={}, slotSize={}MB, pipelineDepth={}",
         kNumBlocks,
         kSlotSize / (1024 * 1024),
         kPipelineDepth);
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "================================================================");
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "{:>10s}  {:>14s}  {:>14s}  {:>10s}",
         "MsgSize",
         "recv_fwd GB/s",
         "recv+snd GB/s",
         "Speedup");
-    XLOGF(
+    COMMS_LOG(
         INFO, "--------------------------------------------------------------");
   }
 
@@ -293,7 +293,7 @@ TEST_F(IbgdaForwardBenchmarkTest, Bandwidth) {
         sizeStr = fmt::format("{}MB", nBytes >> 20);
       }
       float speedup = (recvSndBw > 0) ? (recvFwdBw / recvSndBw) : 0;
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "{:>10s}  {:>14.2f}  {:>14.2f}  {:>9.2f}x",
           sizeStr,
@@ -304,7 +304,7 @@ TEST_F(IbgdaForwardBenchmarkTest, Bandwidth) {
   }
 
   if (globalRank == 0) {
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "================================================================");
   }
@@ -321,5 +321,7 @@ int main(int argc, char* argv[]) {
   if (!meta::comms::isTcpEnvironment()) {
     ::testing::AddGlobalTestEnvironment(new BenchmarkEnvironment());
   }
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/benchmarks/MultiPeerBenchmark.cc
+++ b/comms/prims/benchmarks/MultiPeerBenchmark.cc
@@ -3,9 +3,9 @@
 #include <cuda_runtime.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <algorithm>
 #include <iomanip>
@@ -177,7 +177,7 @@ class MultiPeerBenchmarkFixture : public MpiBaseTestFixture {
     for (int i = 0; i < warmupIters; ++i) {
       cudaError_t err = launchKernel();
       if (err != cudaSuccess) {
-        XLOGF(
+        COMMS_LOG(
             ERR,
             "Kernel launch failed during warmup: {}",
             cudaGetErrorString(err));
@@ -186,7 +186,7 @@ class MultiPeerBenchmarkFixture : public MpiBaseTestFixture {
       }
       err = cudaStreamSynchronize(stream_);
       if (err != cudaSuccess) {
-        XLOGF(
+        COMMS_LOG(
             ERR,
             "Stream sync failed during warmup: {}",
             cudaGetErrorString(err));
@@ -198,7 +198,7 @@ class MultiPeerBenchmarkFixture : public MpiBaseTestFixture {
     // Verify no CUDA errors accumulated after warmup
     cudaError_t lastErr = cudaGetLastError();
     if (lastErr != cudaSuccess) {
-      XLOGF(
+      COMMS_LOG(
           ERR,
           "CUDA error detected after warmup: {}",
           cudaGetErrorString(lastErr));
@@ -302,7 +302,7 @@ class MultiPeerBenchmarkFixture : public MpiBaseTestFixture {
        << getStepsPerIter() << " steps/iter\n";
     ss << "========================================================================\n\n";
 
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 
   cudaStream_t stream_{};
@@ -522,5 +522,7 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
   folly::Init init(&argc, &argv);
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/benchmarks/P2pNvlLl128Benchmark.cc
+++ b/comms/prims/benchmarks/P2pNvlLl128Benchmark.cc
@@ -1,8 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <nccl.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/common/CudaWrap.h"
 #include "comms/prims/benchmarks/BenchmarkKernel.cuh"
@@ -98,7 +98,7 @@ class P2pLl128BenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     if (globalRank == 0) {
       ncclResult_t res = ncclGetUniqueId(&id);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
         std::abort();
       }
     }
@@ -111,7 +111,7 @@ class P2pLl128BenchmarkFixture : public meta::comms::BenchmarkTestFixture {
                 allIds.data(), sizeof(ncclUniqueId), globalRank, worldSize)
             .get();
     if (result != 0) {
-      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      COMMS_LOG_STREAM(ERR) << "Bootstrap allGather for NCCL ID failed";
       std::abort();
     }
     id = allIds[0];
@@ -827,7 +827,8 @@ class P2pLl128BenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
 TEST_F(P2pLl128BenchmarkFixture, UnidirectionalBenchmark) {
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -935,7 +936,8 @@ TEST_F(P2pLl128BenchmarkFixture, UnidirectionalBenchmark) {
 
 TEST_F(P2pLl128BenchmarkFixture, BidirectionalBenchmark) {
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -1055,7 +1057,8 @@ TEST_F(P2pLl128BenchmarkFixture, BidirectionalBenchmark) {
 
 TEST_F(P2pLl128BenchmarkFixture, ChunkedUnidirectionalBenchmark) {
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
   int peerRank = (globalRank == 0) ? 1 : 0;
@@ -1088,7 +1091,8 @@ TEST_F(P2pLl128BenchmarkFixture, ChunkedUnidirectionalBenchmark) {
 
 TEST_F(P2pLl128BenchmarkFixture, ChunkedBidirectionalBenchmark) {
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
   int peerRank = (globalRank == 0) ? 1 : 0;
@@ -1121,7 +1125,8 @@ TEST_F(P2pLl128BenchmarkFixture, ChunkedBidirectionalBenchmark) {
 
 TEST_F(P2pLl128BenchmarkFixture, AutoTunedBenchmark) {
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -1140,7 +1145,8 @@ TEST_F(P2pLl128BenchmarkFixture, AutoTunedBenchmark) {
 
 TEST_F(P2pLl128BenchmarkFixture, AutoTunedBidirectionalBenchmark) {
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -1170,5 +1176,7 @@ int main(int argc, char* argv[]) {
         new meta::comms::BenchmarkEnvironment());
   }
 
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/benchmarks/P2pNvlLlBenchmark.cc
+++ b/comms/prims/benchmarks/P2pNvlLlBenchmark.cc
@@ -1,8 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <nccl.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/common/CudaWrap.h"
 #include "comms/prims/benchmarks/BenchmarkKernel.cuh"
@@ -63,13 +63,13 @@ class P2pLlBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     if (ncclComm_ != nullptr) {
       ncclResult_t res = ncclCommDestroy(ncclComm_);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclCommDestroy failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclCommDestroy failed: {}", ncclGetErrorString(res));
       }
     }
     if (stream_ != nullptr) {
       cudaError_t err = cudaStreamDestroy(stream_);
       if (err != cudaSuccess) {
-        XLOGF(ERR, "cudaStreamDestroy failed: {}", cudaGetErrorString(err));
+        COMMS_LOG(ERR, "cudaStreamDestroy failed: {}", cudaGetErrorString(err));
       }
     }
     BenchmarkTestFixture::TearDown();
@@ -80,7 +80,7 @@ class P2pLlBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     if (globalRank == 0) {
       ncclResult_t res = ncclGetUniqueId(&id);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
         std::abort();
       }
     }
@@ -93,7 +93,7 @@ class P2pLlBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
                 allIds.data(), sizeof(ncclUniqueId), globalRank, worldSize)
             .get();
     if (result != 0) {
-      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      COMMS_LOG_STREAM(ERR) << "Bootstrap allGather for NCCL ID failed";
       std::abort();
     }
     id = allIds[0];
@@ -695,5 +695,7 @@ int main(int argc, char* argv[]) {
         new meta::comms::BenchmarkEnvironment());
   }
 
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/benchmarks/P2pNvlSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/P2pNvlSendRecvBenchmark.cc
@@ -1,8 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <nccl.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/common/CudaWrap.h"
 #include "comms/prims/benchmarks/BenchmarkKernel.cuh"
@@ -53,7 +53,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     if (globalRank == 0) {
       ncclResult_t res = ncclGetUniqueId(&id);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
         std::abort();
       }
     }
@@ -67,7 +67,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
                 allIds.data(), sizeof(ncclUniqueId), globalRank, worldSize)
             .get();
     if (result != 0) {
-      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      COMMS_LOG_STREAM(ERR) << "Bootstrap allGather for NCCL ID failed";
       std::abort();
     }
     id = allIds[0]; // Take rank 0's ID
@@ -76,7 +76,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
   // Helper function to run NCCL benchmark - returns bandwidth
   float runNcclBenchmark(const BenchmarkConfig& config, float& timeUs) {
-    XLOGF(DBG1, "=== Running NCCL benchmark: {} ===", config.name);
+    COMMS_LOG(DBG, "=== Running NCCL benchmark: {} ===", config.name);
 
     DeviceBuffer sendBuff(config.nBytes);
     DeviceBuffer recvBuff(config.nBytes);
@@ -176,7 +176,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
           cudaMemcpyDeviceToHost));
       for (size_t i = 0; i < config.nBytes; i++) {
         if (static_cast<unsigned char>(hostBuf[i]) != testValue) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "VERIFY FAILED {}: byte {} expected 0x{:02X} got 0x{:02X}",
               config.name,
@@ -198,7 +198,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
       comms::prims::P2pNvlTransportDevice* p2pDevicePtr,
       const BenchmarkConfig& config,
       float& timeUs) {
-    XLOGF(DBG1, "=== Running P2P NVL benchmark: {} ===", config.name);
+    COMMS_LOG(DBG, "=== Running P2P NVL benchmark: {} ===", config.name);
 
     DeviceBuffer sendBuff(config.nBytes);
     DeviceBuffer recvBuff(config.nBytes);
@@ -275,7 +275,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
       comms::prims::P2pNvlTransportDevice* p2pDevicePtr,
       const BenchmarkConfig& config,
       float& timeUs) {
-    XLOGF(DBG1, "=== Running Tile benchmark: {} ===", config.name);
+    COMMS_LOG(DBG, "=== Running Tile benchmark: {} ===", config.name);
 
     DeviceBuffer sendBuff(config.nBytes);
     DeviceBuffer recvBuff(config.nBytes);
@@ -337,7 +337,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
       for (size_t i = 0; i < config.nBytes; i++) {
         if (static_cast<unsigned char>(hostBuf[i]) !=
             static_cast<unsigned char>(peerPattern)) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "TILE VERIFY FAILED {}: byte {} expected 0x{:02X} got 0x{:02X}",
               config.name,
@@ -391,8 +391,8 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
   float runNcclBidirectionalBenchmark(
       const BenchmarkConfig& config,
       float& timeUs) {
-    XLOGF(
-        DBG1,
+    COMMS_LOG(
+        DBG,
         "Rank {}: Starting NCCL bidirectional benchmark: {}",
         globalRank,
         config.name);
@@ -409,7 +409,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     CudaEvent start, stop;
 
     // Warmup
-    XLOGF(DBG1, "Rank {}: NCCL bidi warmup starting", globalRank);
+    COMMS_LOG(DBG, "Rank {}: NCCL bidi warmup starting", globalRank);
     bootstrap->barrierAll();
     for (int i = 0; i < kWarmupIters; i++) {
       NCCL_CHECK(ncclGroupStart());
@@ -430,7 +430,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
       NCCL_CHECK(ncclGroupEnd());
       CUDA_CHECK(cudaStreamSynchronize(stream_));
     }
-    XLOGF(DBG1, "Rank {}: NCCL bidi warmup complete", globalRank);
+    COMMS_LOG(DBG, "Rank {}: NCCL bidi warmup complete", globalRank);
 
     // Benchmark - measure time across all iterations
     // No barrier between iterations - rely on NCCL's internal synchronization
@@ -476,8 +476,8 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
       comms::prims::P2pNvlTransportDevice* p2pDevicePtr,
       const BenchmarkConfig& config,
       float& timeUs) {
-    XLOGF(
-        DBG1,
+    COMMS_LOG(
+        DBG,
         "Rank {}: Starting P2P NVL bidirectional benchmark: {}",
         globalRank,
         config.name);
@@ -616,7 +616,8 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 TEST_F(P2pSendRecvBenchmarkFixture, UnidirectionalBenchmark) {
   // Only test with 2 ranks
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -718,7 +719,7 @@ TEST_F(P2pSendRecvBenchmarkFixture, UnidirectionalBenchmark) {
 
     // Verify correctness before benchmarking
     if (!verifyP2pCorrectness(&p2pHost, config)) {
-      XLOGF(ERR, "CORRECTNESS CHECK FAILED for config: {}", config.name);
+      COMMS_LOG(ERR, "CORRECTNESS CHECK FAILED for config: {}", config.name);
       if (globalRank == 0) {
         std::cout << "*** VERIFY FAILED: " << config.name << " ***\n";
       }
@@ -746,7 +747,8 @@ TEST_F(P2pSendRecvBenchmarkFixture, UnidirectionalBenchmark) {
 TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
   // Only test with 2 ranks
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -1015,7 +1017,8 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
 
 TEST_F(P2pSendRecvBenchmarkFixture, MatchedBidirCtaBenchmark) {
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -1118,5 +1121,7 @@ int main(int argc, char* argv[]) {
         new meta::comms::BenchmarkEnvironment());
   }
 
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/benchmarks/P2pNvlSignalBenchmark.cc
+++ b/comms/prims/benchmarks/P2pNvlSignalBenchmark.cc
@@ -1,8 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <nccl.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/common/CudaWrap.h"
 #include "comms/prims/benchmarks/BenchmarkKernel.cuh"
@@ -50,7 +50,7 @@ class P2pSignalBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     if (globalRank == 0) {
       ncclResult_t res = ncclGetUniqueId(&id);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
         std::abort();
       }
     }
@@ -64,7 +64,7 @@ class P2pSignalBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
                 allIds.data(), sizeof(ncclUniqueId), globalRank, worldSize)
             .get();
     if (result != 0) {
-      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      COMMS_LOG_STREAM(ERR) << "Bootstrap allGather for NCCL ID failed";
       std::abort();
     }
     id = allIds[0]; // Take rank 0's ID
@@ -77,7 +77,7 @@ class P2pSignalBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
       comms::prims::P2pNvlTransportDevice* p2p,
       const BenchmarkConfig& config,
       int nSteps = 1000) {
-    XLOGF(DBG1, "=== Running Signal benchmark: {} ===", config.name);
+    COMMS_LOG(DBG, "=== Running Signal benchmark: {} ===", config.name);
 
     dim3 gridDim(config.numBlocks);
     dim3 blockDim(config.numThreads);
@@ -118,7 +118,8 @@ class P2pSignalBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 TEST_F(P2pSignalBenchmarkFixture, SignalBenchmark) {
   // Only test with 2 ranks
   if (worldSize != 2) {
-    XLOGF(DBG1, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(
+        DBG, "Skipping test: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -270,5 +271,7 @@ int main(int argc, char* argv[]) {
         new meta::comms::BenchmarkEnvironment());
   }
 
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/bootstrap/tests/NvlBootstrapAdapterTest.cc
+++ b/comms/prims/bootstrap/tests/NvlBootstrapAdapterTest.cc
@@ -3,7 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/prims/bootstrap/NvlBootstrapAdapter.h"
 #include "comms/testinfra/mpi/MpiBootstrap.h"
@@ -63,8 +63,8 @@ TEST_F(NvlBootstrapAdapterTest, AllGatherNvlDomainAllRanks) {
  */
 TEST_F(NvlBootstrapAdapterTest, AllGatherNvlDomainSubset) {
   if (numRanks < 4) {
-    XLOGF(
-        WARNING, "Skipping subset test: requires >= 4 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping subset test: requires >= 4 ranks, got {}", numRanks);
     return;
   }
 
@@ -84,7 +84,7 @@ TEST_F(NvlBootstrapAdapterTest, AllGatherNvlDomainSubset) {
   }
 
   if (nvlLocalRank < 0) {
-    XLOGF(INFO, "Rank {} not in NVL domain, skipping", globalRank);
+    COMMS_LOG(INFO, "Rank {} not in NVL domain, skipping", globalRank);
     return;
   }
 
@@ -227,8 +227,8 @@ TEST_F(NvlBootstrapAdapterTest, AdapterSendRecvMapping) {
  */
 TEST_F(NvlBootstrapAdapterTest, AdapterSubsetMapping) {
   if (numRanks < 4) {
-    XLOGF(
-        WARNING,
+    COMMS_LOG(
+        WARN,
         "Skipping subset mapping test: requires >= 4 ranks, got {}",
         numRanks);
     return;
@@ -250,7 +250,7 @@ TEST_F(NvlBootstrapAdapterTest, AdapterSubsetMapping) {
   }
 
   if (nvlLocalRank < 0) {
-    XLOGF(INFO, "Rank {} not in odd NVL domain, skipping", globalRank);
+    COMMS_LOG(INFO, "Rank {} not in odd NVL domain, skipping", globalRank);
     return;
   }
 

--- a/comms/prims/collectives/benchmarks/AllGatherBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/AllGatherBenchmark.cc
@@ -1,8 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <nccl.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/common/CudaWrap.h"
 #include "comms/prims/benchmarks/BenchmarkMacros.h"
@@ -76,7 +76,7 @@ class AllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     if (globalRank == 0) {
       ncclResult_t res = ncclGetUniqueId(&id);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
         std::abort();
       }
     }
@@ -89,7 +89,7 @@ class AllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
                 allIds.data(), sizeof(ncclUniqueId), globalRank, worldSize)
             .get();
     if (result != 0) {
-      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      COMMS_LOG_STREAM(ERR) << "Bootstrap allGather for NCCL ID failed";
       std::abort();
     }
     id = allIds[0]; // Take rank 0's ID
@@ -103,8 +103,8 @@ class AllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
   float runNcclAllGatherBenchmark(
       const AllGatherBenchmarkConfig& config,
       float& latencyUs) {
-    XLOGF(
-        DBG1,
+    COMMS_LOG(
+        DBG,
         "Rank {}: Running NCCL AllGather benchmark: {}",
         globalRank,
         config.name);
@@ -180,8 +180,8 @@ class AllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
   float runAllGatherBenchmark(
       const AllGatherBenchmarkConfig& config,
       float& latencyUs) {
-    XLOGF(
-        DBG1,
+    COMMS_LOG(
+        DBG,
         "Rank {}: Running AllGather benchmark: {}",
         globalRank,
         config.name);
@@ -377,7 +377,7 @@ class AllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     ss << "================================================================================\n";
     ss << "\n";
 
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 
   ncclComm_t ncclComm_{};
@@ -386,7 +386,7 @@ class AllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
 TEST_F(AllGatherBenchmarkFixture, OptimalConfigs) {
   if (globalRank == 0) {
-    XLOG(INFO)
+    COMMS_LOG_STREAM(INFO)
         << "\n=== OPTIMAL AllGather vs NCCL Comparison (All Message Sizes) ===\n";
   }
 
@@ -611,5 +611,7 @@ int main(int argc, char* argv[]) {
   // Set up distributed environment
   ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
 
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/collectives/benchmarks/AllToAllvBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/AllToAllvBenchmark.cc
@@ -1,8 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <chrono>
+#include "comms/utils/logger/SpdlogLogger.h"
 #ifndef __HIP_PLATFORM_AMD__
 #include <nccl.h>
 #endif
@@ -92,7 +92,7 @@ class AllToAllvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     if (globalRank == 0) {
       ncclResult_t res = ncclGetUniqueId(&id);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
         std::abort();
       }
     }
@@ -106,7 +106,7 @@ class AllToAllvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
                 allIds.data(), sizeof(ncclUniqueId), globalRank, worldSize)
             .get();
     if (result != 0) {
-      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      COMMS_LOG_STREAM(ERR) << "Bootstrap allGather for NCCL ID failed";
       std::abort();
     }
     id = allIds[0]; // Take rank 0's ID
@@ -120,8 +120,8 @@ class AllToAllvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
   float runNcclAllToAllvBenchmark(
       const AllToAllvBenchmarkConfig& config,
       float& latencyUs) {
-    XLOGF(
-        DBG1,
+    COMMS_LOG(
+        DBG,
         "Rank {}: Running NCCL AllToAllv benchmark: {}",
         globalRank,
         config.name);
@@ -218,8 +218,8 @@ class AllToAllvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
   float runAllToAllvBenchmark(
       const AllToAllvBenchmarkConfig& config,
       float& latencyUs) {
-    XLOGF(
-        DBG1,
+    COMMS_LOG(
+        DBG,
         "Rank {}: Running AllToAllv benchmark: {}",
         globalRank,
         config.name);
@@ -420,7 +420,7 @@ class AllToAllvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     ss << "================================================================================================================\n";
     ss << "\n";
 
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 
 #ifndef __HIP_PLATFORM_AMD__
@@ -460,7 +460,7 @@ TEST_F(AllToAllvBenchmarkFixture, OptimalConfigs) {
   // Optimal configurations for multiple message sizes
 
   if (globalRank == 0) {
-    XLOG(INFO)
+    COMMS_LOG_STREAM(INFO)
         << "\n=== OPTIMAL AllToAllv vs NCCL Comparison (All Message Sizes) ===\n";
   }
 
@@ -674,5 +674,7 @@ int main(int argc, char* argv[]) {
   // Set up distributed environment
   ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
 
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/collectives/benchmarks/AllToAllvLl128Benchmark.cc
+++ b/comms/prims/collectives/benchmarks/AllToAllvLl128Benchmark.cc
@@ -1,9 +1,9 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <nccl.h>
 #include <chrono>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/common/CudaWrap.h"
 #include "comms/common/fault_tolerance/Abort.h"
@@ -78,7 +78,7 @@ class AllToAllvLl128BenchmarkFixture
     if (globalRank == 0) {
       ncclResult_t res = ncclGetUniqueId(&id);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
         std::abort();
       }
     }
@@ -90,7 +90,7 @@ class AllToAllvLl128BenchmarkFixture
                 allIds.data(), sizeof(ncclUniqueId), globalRank, worldSize)
             .get();
     if (result != 0) {
-      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      COMMS_LOG_STREAM(ERR) << "Bootstrap allGather for NCCL ID failed";
       std::abort();
     }
     id = allIds[0];
@@ -135,8 +135,9 @@ class AllToAllvLl128BenchmarkFixture
       bootstrap->barrierAll();
 
       if (globalRank == 0) {
-        XLOG(INFO) << "Global warmup complete (" << kGlobalWarmupIters
-                   << " NCCL iterations at 16KB/peer)";
+        COMMS_LOG_STREAM(INFO)
+            << "Global warmup complete (" << kGlobalWarmupIters
+            << " NCCL iterations at 16KB/peer)";
       }
     }
   }
@@ -490,7 +491,7 @@ class AllToAllvLl128BenchmarkFixture
     ss << "LL128/NCCL = LL128 BW / NCCL BW, LL128/Simp = LL128 BW / Simple BW\n";
     ss << std::string(125, '=') << "\n";
 
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 
   ncclComm_t ncclComm_{};
@@ -499,7 +500,8 @@ class AllToAllvLl128BenchmarkFixture
 
 TEST_F(AllToAllvLl128BenchmarkFixture, Ll128VsSimpleVsNccl) {
   if (globalRank == 0) {
-    XLOG(INFO) << "\n=== LL128 vs Simple vs NCCL AllToAllv Comparison ===\n";
+    COMMS_LOG_STREAM(INFO)
+        << "\n=== LL128 vs Simple vs NCCL AllToAllv Comparison ===\n";
   }
 
   std::vector<Ll128BenchmarkConfig> configs;
@@ -674,7 +676,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128VsSimpleVsNccl) {
 
 TEST_F(AllToAllvLl128BenchmarkFixture, LatencySweep) {
   if (globalRank == 0) {
-    XLOG(INFO)
+    COMMS_LOG_STREAM(INFO)
         << "\n=== LL128 vs Simple vs NCCL Latency Sweep (for Triton comparison) ===\n";
   }
 
@@ -815,7 +817,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, LatencySweep) {
     ss << "LL128/NCCL and LL128/Simple are speedup ratios (higher is better)\n";
     ss << std::string(90, '=') << "\n";
 
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
 
     // CSV output to file if BENCH_CSV_OUTPUT is set
     const char* csvPath = std::getenv("BENCH_CSV_OUTPUT");
@@ -832,9 +834,9 @@ TEST_F(AllToAllvLl128BenchmarkFixture, LatencySweep) {
           csvFile << "\n";
         }
         csvFile.close();
-        XLOG(INFO) << "CSV results written to: " << csvPath;
+        COMMS_LOG_STREAM(INFO) << "CSV results written to: " << csvPath;
       } else {
-        XLOG(ERR) << "Failed to open CSV output file: " << csvPath;
+        COMMS_LOG_STREAM(ERR) << "Failed to open CSV output file: " << csvPath;
       }
     }
 
@@ -851,13 +853,14 @@ TEST_F(AllToAllvLl128BenchmarkFixture, LatencySweep) {
       ss << "\n";
     }
     ss << "--- CSV END ---";
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 }
 
 TEST_F(AllToAllvLl128BenchmarkFixture, Ll128BlockThreadSweep) {
   if (globalRank == 0) {
-    XLOG(INFO) << "\n=== LL128 AllToAllv Block Count Sweep (threads=512) ===\n";
+    COMMS_LOG_STREAM(INFO)
+        << "\n=== LL128 AllToAllv Block Count Sweep (threads=512) ===\n";
   }
 
   // Message sizes that span medium-to-large range where block count matters
@@ -952,13 +955,13 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128BlockThreadSweep) {
     }
 
     ss << std::string(80, '=') << "\n";
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 }
 
 TEST_F(AllToAllvLl128BenchmarkFixture, Ll128ThreadSweep) {
   if (globalRank == 0) {
-    XLOG(INFO)
+    COMMS_LOG_STREAM(INFO)
         << "\n=== LL128 AllToAllv Thread Count Sweep (256 vs 512 threads) ===\n";
   }
 
@@ -1047,7 +1050,7 @@ TEST_F(AllToAllvLl128BenchmarkFixture, Ll128ThreadSweep) {
     }
 
     ss << std::string(80, '=') << "\n";
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 }
 
@@ -1059,5 +1062,7 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   folly::Init init(&argc, &argv);
   ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/collectives/benchmarks/AnsCopyOpBench.cc
+++ b/comms/prims/collectives/benchmarks/AnsCopyOpBench.cc
@@ -8,11 +8,11 @@
 // AllToAllv-tile collective.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <algorithm>
 #include <cstdint>
 #include <string>
 #include <vector>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <cuda.h> // driver API: green contexts for SM partitioning
 
@@ -39,15 +39,16 @@ struct LocalCompStats {
 };
 
 // Driver-API error check (runtime calls use PIPES_CUDA_CHECK).
-#define PIPES_CU_CHECK(expr)                                           \
-  do {                                                                 \
-    CUresult _res = (expr);                                            \
-    if (_res != CUDA_SUCCESS) {                                        \
-      const char* _msg = nullptr;                                      \
-      cuGetErrorString(_res, &_msg);                                   \
-      XLOG(FATAL) << "[AnsCopyOpStandalone] CUDA driver error: " #expr \
-                  << " -> " << (_msg ? _msg : "unknown");              \
-    }                                                                  \
+#define PIPES_CU_CHECK(expr)                                             \
+  do {                                                                   \
+    CUresult _res = (expr);                                              \
+    if (_res != CUDA_SUCCESS) {                                          \
+      const char* _msg = nullptr;                                        \
+      cuGetErrorString(_res, &_msg);                                     \
+      COMMS_LOG_STREAM(FATAL)                                            \
+          << "[AnsCopyOpStandalone] CUDA driver error: " #expr << " -> " \
+          << (_msg ? _msg : "unknown");                                  \
+    }                                                                    \
   } while (0)
 
 // A stream confined to a green context spanning >= `numSms` SMs of the
@@ -78,7 +79,7 @@ GreenCtxStream makeGreenCtxStream(int numSms) {
   if (smRes != CUDA_SUCCESS) {
     const char* nm = nullptr;
     cuGetErrorName(smRes, &nm);
-    XLOG(FATAL)
+    COMMS_LOG_STREAM(FATAL)
         << "[AnsCopyOpStandalone] green-context SM partitioning unavailable "
         << "(cuDeviceGetDevResource -> " << (nm ? nm : "?") << "). "
         << "PIPES_COPYOP_BENCH_NUM_SMS requires CUDA driver >= 12.4 (R550); "
@@ -241,26 +242,26 @@ TEST_F(AnsCopyOpBenchFixture, AnsCopyOpStandalone) {
   const cudaStream_t benchStream =
       gctx.stream; // nullptr => default stream (whole GPU)
 
-  XLOG(INFO) << "\n=== ANS CopyOp Standalone Microbenchmark "
-             << "(single GPU) ===\n"
-             << "PIPES_COPYOP_BENCH_BLOCKS=" << kCopyOpBlocks
-             << " PIPES_COPYOP_BENCH_THREADS=" << kCopyOpThreads
-             << " PIPES_COPYOP_BENCH_MIN_BLOCKS_PER_SM="
-             << kCopyOpMinBlocksPerSM
-             << " PIPES_COPYOP_BENCH_NUM_SMS=" << kCopyOpNumSms
-             << (kCopyOpNumSms > 0 ? " (green-ctx SM-limited)" : " (full GPU)")
-             << "\n"
-             << kCopyOpBlocks << " threadblocks × " << kCopyOpThreads
-             << " threads/block, " << kCopyOpWarmupIter << " warmup + "
-             << kCopyOpMeasureIter << " timed iterations per cell\n"
-             << "Sweep: sizes {256KB, 512KB, 1MB, 2MB, 4MB} × "
-             << "sparsity 0%→100% step 10%\n"
-             << "BW = aggregate uncompressed bytes / measured kernel "
-             << "time (sum over all " << kCopyOpBlocks << " blocks)\n";
+  COMMS_LOG_STREAM(INFO)
+      << "\n=== ANS CopyOp Standalone Microbenchmark "
+      << "(single GPU) ===\n"
+      << "PIPES_COPYOP_BENCH_BLOCKS=" << kCopyOpBlocks
+      << " PIPES_COPYOP_BENCH_THREADS=" << kCopyOpThreads
+      << " PIPES_COPYOP_BENCH_MIN_BLOCKS_PER_SM=" << kCopyOpMinBlocksPerSM
+      << " PIPES_COPYOP_BENCH_NUM_SMS=" << kCopyOpNumSms
+      << (kCopyOpNumSms > 0 ? " (green-ctx SM-limited)" : " (full GPU)") << "\n"
+      << kCopyOpBlocks << " threadblocks × " << kCopyOpThreads
+      << " threads/block, " << kCopyOpWarmupIter << " warmup + "
+      << kCopyOpMeasureIter << " timed iterations per cell\n"
+      << "Sweep: sizes {256KB, 512KB, 1MB, 2MB, 4MB} × "
+      << "sparsity 0%→100% step 10%\n"
+      << "BW = aggregate uncompressed bytes / measured kernel "
+      << "time (sum over all " << kCopyOpBlocks << " blocks)\n";
 
   for (int sparsityPct = 0; sparsityPct <= 100; sparsityPct += 10) {
-    XLOG(INFO) << "\n--- Sparsity " << sparsityPct
-               << "% (zero-byte prefix of each block's input region) ---";
+    COMMS_LOG_STREAM(INFO)
+        << "\n--- Sparsity " << sparsityPct
+        << "% (zero-byte prefix of each block's input region) ---";
     printf(
         "%-10s  %14s  %16s  %10s  %11s\n",
         "Size",
@@ -327,23 +328,23 @@ TEST_F(AnsCopyOpBenchFixture, AnsCopyOpStandalone) {
       auto sync_check = [&](const char* phase) {
         const cudaError_t launchErr = cudaGetLastError();
         if (launchErr != cudaSuccess) {
-          XLOG(FATAL) << "[AnsCopyOpStandalone] launch error in " << phase
-                      << " sparsity=" << sparsityPct
-                      << "% size=" << format_bytes(inputBytes)
-                      << " blocks=" << kCopyOpBlocks
-                      << " threads=" << kCopyOpThreads
-                      << " stagingStride=" << stagingStride
-                      << " err=" << cudaGetErrorString(launchErr);
+          COMMS_LOG_STREAM(FATAL)
+              << "[AnsCopyOpStandalone] launch error in " << phase
+              << " sparsity=" << sparsityPct
+              << "% size=" << format_bytes(inputBytes)
+              << " blocks=" << kCopyOpBlocks << " threads=" << kCopyOpThreads
+              << " stagingStride=" << stagingStride
+              << " err=" << cudaGetErrorString(launchErr);
         }
         const cudaError_t syncErr = cudaDeviceSynchronize();
         if (syncErr != cudaSuccess) {
-          XLOG(FATAL) << "[AnsCopyOpStandalone] async error in " << phase
-                      << " sparsity=" << sparsityPct
-                      << "% size=" << format_bytes(inputBytes)
-                      << " blocks=" << kCopyOpBlocks
-                      << " threads=" << kCopyOpThreads
-                      << " stagingStride=" << stagingStride
-                      << " err=" << cudaGetErrorString(syncErr);
+          COMMS_LOG_STREAM(FATAL)
+              << "[AnsCopyOpStandalone] async error in " << phase
+              << " sparsity=" << sparsityPct
+              << "% size=" << format_bytes(inputBytes)
+              << " blocks=" << kCopyOpBlocks << " threads=" << kCopyOpThreads
+              << " stagingStride=" << stagingStride
+              << " err=" << cudaGetErrorString(syncErr);
         }
       };
 
@@ -499,12 +500,12 @@ TEST_F(AnsCopyOpBenchFixture, AnsCopyOpStandalone) {
           // row in the table makes clear which cell crashed.
           printf("%11s\n", "FAIL");
           fflush(stdout);
-          XLOG(FATAL) << "[AnsCopyOpStandalone] round-trip mismatch sparsity="
-                      << sparsityPct << "% size=" << format_bytes(inputBytes)
-                      << " block=" << b << " firstMismatch=" << firstMismatch
-                      << " in=" << static_cast<int>(host_input[firstMismatch])
-                      << " out="
-                      << static_cast<int>(host_output[firstMismatch]);
+          COMMS_LOG_STREAM(FATAL)
+              << "[AnsCopyOpStandalone] round-trip mismatch sparsity="
+              << sparsityPct << "% size=" << format_bytes(inputBytes)
+              << " block=" << b << " firstMismatch=" << firstMismatch
+              << " in=" << static_cast<int>(host_input[firstMismatch])
+              << " out=" << static_cast<int>(host_output[firstMismatch]);
         }
       }
       printf("%11s\n", "OK");
@@ -524,5 +525,7 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   folly::Init init(&argc, &argv);
   ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/collectives/benchmarks/HierarchicalAllGatherBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/HierarchicalAllGatherBenchmark.cc
@@ -1,8 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <nccl.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -245,7 +245,7 @@ class HierarchicalAllGatherBenchmarkFixture
     if (globalRank == 0) {
       ncclResult_t res = ncclGetUniqueId(&id);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
         std::abort();
       }
     }
@@ -257,7 +257,7 @@ class HierarchicalAllGatherBenchmarkFixture
                 all_ids.data(), sizeof(ncclUniqueId), globalRank, worldSize)
             .get();
     if (result != 0) {
-      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      COMMS_LOG_STREAM(ERR) << "Bootstrap allGather for NCCL ID failed";
       std::abort();
     }
     return all_ids[0];
@@ -341,7 +341,7 @@ class HierarchicalAllGatherBenchmarkFixture
       ib_transport->exchange();
       ib_nics = ib_transport->numNics();
     } catch (const std::exception& e) {
-      XLOGF(ERR, "IBGDA transport not available: {}", e.what());
+      COMMS_LOG(ERR, "IBGDA transport not available: {}", e.what());
       latency_us = 0.0f;
       return 0.0f;
     }
@@ -367,7 +367,7 @@ class HierarchicalAllGatherBenchmarkFixture
             nvl_rank, config.nvl_size, nvl_bootstrap, transport_config);
         nvl_transport->exchange();
       } catch (const std::exception& e) {
-        XLOGF(ERR, "NVLink transport not available: {}", e.what());
+        COMMS_LOG(ERR, "NVLink transport not available: {}", e.what());
         latency_us = 0.0f;
         return 0.0f;
       }
@@ -390,7 +390,8 @@ class HierarchicalAllGatherBenchmarkFixture
     if (config.ib_size > 1) {
       auto ib_rings_opt = make_standard_rings(config.ib_size, ib_rank, 1);
       if (!ib_rings_opt) {
-        XLOGF(ERR, "Cannot construct IB ring for {} IB ranks", config.ib_size);
+        COMMS_LOG(
+            ERR, "Cannot construct IB ring for {} IB ranks", config.ib_size);
         latency_us = 0.0f;
         return 0.0f;
       }
@@ -509,7 +510,7 @@ class HierarchicalAllGatherBenchmarkFixture
     }
     ss << "================================================================================\n";
 
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 
   ncclComm_t nccl_comm_{};
@@ -520,7 +521,7 @@ TEST_F(HierarchicalAllGatherBenchmarkFixture, VsNccl) {
   const int nvl_size = benchmark_nvl_size(worldSize);
   if (nvl_size <= 0 || nvl_size > kDirectNvlMaxRanks ||
       worldSize % nvl_size != 0) {
-    XLOGF(
+    COMMS_LOG(
         ERR,
         "Invalid HIER_AG_BENCH_NVL_SIZE={} for worldSize={}",
         nvl_size,
@@ -529,7 +530,7 @@ TEST_F(HierarchicalAllGatherBenchmarkFixture, VsNccl) {
   }
 
   if (globalRank == 0) {
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "\n=== Hierarchical AllGather vs NCCL Comparison (IB groups={}, NVL groups={}) ===\n",
         worldSize / nvl_size,
@@ -543,15 +544,15 @@ TEST_F(HierarchicalAllGatherBenchmarkFixture, VsNccl) {
   const int pipeline_depth = benchmark_pipeline_depth();
   const std::string ib_hca = benchmark_ib_hca();
   if (ib_links <= 0) {
-    XLOGF(ERR, "Invalid HIER_AG_BENCH_IB_LINKS={}", ib_links);
+    COMMS_LOG(ERR, "Invalid HIER_AG_BENCH_IB_LINKS={}", ib_links);
     std::abort();
   }
   if (data_buffer_size == 0) {
-    XLOG(ERR, "Invalid HIER_AG_BENCH_DATA_BUFFER_SIZE=0");
+    COMMS_LOG(ERR, "Invalid HIER_AG_BENCH_DATA_BUFFER_SIZE=0");
     std::abort();
   }
   if (pipeline_depth <= 0) {
-    XLOGF(ERR, "Invalid HIER_AG_BENCH_PIPELINE_DEPTH={}", pipeline_depth);
+    COMMS_LOG(ERR, "Invalid HIER_AG_BENCH_PIPELINE_DEPTH={}", pipeline_depth);
     std::abort();
   }
   const std::size_t ib_signal_bytes =
@@ -562,7 +563,7 @@ TEST_F(HierarchicalAllGatherBenchmarkFixture, VsNccl) {
   const bool skip_nccl = benchmark_skip_nccl();
   for (std::size_t total_bytes : configured_benchmark_sizes()) {
     if (total_bytes % static_cast<std::size_t>(worldSize) != 0) {
-      XLOGF(
+      COMMS_LOG(
           ERR,
           "AllGather size {} is not divisible by {} ranks",
           total_bytes,
@@ -591,7 +592,7 @@ TEST_F(HierarchicalAllGatherBenchmarkFixture, VsNccl) {
 
   for (const auto& config : configs) {
     if (globalRank == 0) {
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "Running hierarchical AllGather {}: size={}, chunk={}, blocks={}, ib_size={}, nvl_size={}, ib_links_per_nic={}, ib_signal_bytes={}, nvl_signal_bytes={}",
           config.name,
@@ -617,7 +618,7 @@ TEST_F(HierarchicalAllGatherBenchmarkFixture, VsNccl) {
         run_hierarchical_benchmark(config, ib_nics, hierarchical_lat);
 
     if (globalRank == 0) {
-      XLOGF(
+      COMMS_LOG(
           INFO,
           "AllGather {} result: NCCL={:.2f} GB/s ({:.1f} us), Hier={:.2f} GB/s ({:.1f} us), Hier/NCCL={:.2f}x",
           config.name,
@@ -661,5 +662,7 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   folly::Init init(&argc, &argv);
   ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/collectives/benchmarks/RingAllGatherBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/RingAllGatherBenchmark.cc
@@ -2,9 +2,9 @@
 
 #include <folly/ScopeGuard.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <glog/logging.h>
 #include <nccl.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <cstdlib>
 #include <iomanip>
@@ -69,7 +69,7 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     if (globalRank == 0) {
       ncclResult_t res = ncclGetUniqueId(&id);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
         std::abort();
       }
     }
@@ -81,7 +81,7 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
                 all_ids.data(), sizeof(ncclUniqueId), globalRank, worldSize)
             .get();
     if (result != 0) {
-      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      COMMS_LOG_STREAM(ERR) << "Bootstrap allGather for NCCL ID failed";
       std::abort();
     }
     return all_ids[0];
@@ -103,7 +103,7 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     auto ncclCommGuard = folly::makeGuard([&] {
       const ncclResult_t res = ncclCommDestroy(nccl_comm);
       if (res != ncclSuccess) {
-        XLOGF(ERR, "ncclCommDestroy failed: {}", ncclGetErrorString(res));
+        COMMS_LOG(ERR, "ncclCommDestroy failed: {}", ncclGetErrorString(res));
       }
     });
 
@@ -190,7 +190,7 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     auto rings_opt =
         make_standard_rings(worldSize, globalRank, config.num_rings);
     if (!rings_opt) {
-      XLOGF(
+      COMMS_LOG(
           ERR,
           "Cannot construct {} distinct rings for {} ranks",
           config.num_rings,
@@ -318,7 +318,7 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     ss << worldSize << " ranks, sendcount = per-rank message size\n";
     ss << "================================================================================\n";
 
-    XLOG(INFO) << ss.str();
+    COMMS_LOG_STREAM(INFO) << ss.str();
   }
 
   std::vector<RingAllGatherBenchmarkConfig> make_benchmark_configs(
@@ -441,7 +441,8 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
   void run_ibgda_vs_nccl_benchmark_suite() {
     if (globalRank == 0) {
-      XLOG(INFO) << "\n=== Ring AllGather (IBGDA) vs NCCL Comparison ===\n";
+      COMMS_LOG_STREAM(INFO)
+          << "\n=== Ring AllGather (IBGDA) vs NCCL Comparison ===\n";
     }
 
     std::vector<RingAllGatherBenchmarkResult> results;
@@ -462,7 +463,8 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
   void run_ibrc_vs_ibgda_benchmark_suite() {
     if (globalRank == 0) {
-      XLOG(INFO) << "\n=== Ring AllGather (IBRC) vs IBGDA Comparison ===\n";
+      COMMS_LOG_STREAM(INFO)
+          << "\n=== Ring AllGather (IBRC) vs IBGDA Comparison ===\n";
     }
 
     std::vector<RingAllGatherBenchmarkResult> results;
@@ -508,5 +510,7 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   folly::Init init(&argc, &argv);
   ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
-  return RUN_ALL_TESTS();
+  const auto result = RUN_ALL_TESTS();
+  spdlog::shutdown();
+  return result;
 }

--- a/comms/prims/collectives/tests/AllToAllvLl128Test.cc
+++ b/comms/prims/collectives/tests/AllToAllvLl128Test.cc
@@ -6,7 +6,7 @@
 #include <cstddef>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <algorithm>
 
@@ -64,8 +64,8 @@ TEST_P(AllToAllvLl128EqualSizeTest, AllToAllvLl128EqualSize) {
   const int numBlocks = params.numBlocks;
   const int blockSize = params.blockSize;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: Running {} with numBlocks={}, blockSize={}, numIntsPerRank={}",
       globalRank,
       params.testName,
@@ -93,7 +93,7 @@ TEST_P(AllToAllvLl128EqualSizeTest, AllToAllvLl128EqualSize) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -178,7 +178,7 @@ TEST_P(AllToAllvLl128EqualSizeTest, AllToAllvLl128EqualSize) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: Error at peer {} position {}: expected {}, got {}",
               globalRank,
@@ -469,8 +469,8 @@ TEST_P(AllToAllvLl128UnequalSizeTest, AllToAllvLl128UnequalSize) {
   const int blockSize = params.blockSize;
   const size_t base_ints = params.base_ints;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: Running {} with numBlocks={}, blockSize={}, base_ints={}",
       globalRank,
       params.testName,
@@ -496,7 +496,7 @@ TEST_P(AllToAllvLl128UnequalSizeTest, AllToAllvLl128UnequalSize) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -603,7 +603,7 @@ TEST_P(AllToAllvLl128UnequalSizeTest, AllToAllvLl128UnequalSize) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: Error at peer {} position {}: expected {}, got {}",
               globalRank,
@@ -676,8 +676,8 @@ TEST_P(AllToAllvLl128ZeroPeerTest, AllToAllvLl128ZeroPeer) {
   const int blockSize = params.blockSize;
   const size_t base_ints = params.base_ints;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: Running {} with zero-byte peers",
       globalRank,
       params.testName);
@@ -702,7 +702,7 @@ TEST_P(AllToAllvLl128ZeroPeerTest, AllToAllvLl128ZeroPeer) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -815,7 +815,7 @@ TEST_P(AllToAllvLl128ZeroPeerTest, AllToAllvLl128ZeroPeer) {
         if (expected != actual) {
           h_errorCount++;
           if (h_errorCount <= 10) {
-            XLOGF(
+            COMMS_LOG(
                 ERR,
                 "Rank {}: Error at peer {} position {}: expected {}, got {}",
                 globalRank,
@@ -878,7 +878,7 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedMultiCall) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -958,7 +958,7 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedMultiCall) {
         if (expected != actual) {
           h_errorCount++;
           if (h_errorCount <= 5) {
-            XLOGF(
+            COMMS_LOG(
                 ERR,
                 "Rank {}: Iter {} error at peer {} pos {}: expected {}, got {}",
                 globalRank,
@@ -1014,7 +1014,7 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedMultiCallChunked) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -1095,7 +1095,7 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedMultiCallChunked) {
         if (expected != actual) {
           h_errorCount++;
           if (h_errorCount <= 5) {
-            XLOGF(
+            COMMS_LOG(
                 ERR,
                 "Rank {}: Iter {} error at peer {} pos {}: expected {}, got {}",
                 globalRank,
@@ -1138,7 +1138,7 @@ TEST_F(AllToAllvLl128TestFixture, ChunkedBlockCountSweep) {
   const std::vector<int> blockCounts = {8, 16, 32, 64, 128, 256};
 
   for (int numBlocks : blockCounts) {
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: ChunkedBlockCountSweep numBlocks={}",
         globalRank,
@@ -1157,7 +1157,8 @@ TEST_F(AllToAllvLl128TestFixture, ChunkedBlockCountSweep) {
           globalRank, worldSize, bootstrap, config);
       transport->exchange();
     } catch (const std::runtime_error& e) {
-      XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+      COMMS_LOG(
+          ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
       std::abort();
     }
 
@@ -1233,7 +1234,7 @@ TEST_F(AllToAllvLl128TestFixture, ChunkedBlockCountSweep) {
         if (expected != actual) {
           h_errorCount++;
           if (h_errorCount <= 5) {
-            XLOGF(
+            COMMS_LOG(
                 ERR,
                 "Rank {}: numBlocks={} error at peer {} pos {}: expected {}, got {}",
                 globalRank,
@@ -1316,7 +1317,7 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedVaryingSizes) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -1400,7 +1401,7 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedVaryingSizes) {
         if (expected != actual) {
           h_errorCount++;
           if (h_errorCount <= 5) {
-            XLOGF(
+            COMMS_LOG(
                 ERR,
                 "Rank {}: Iter {} ({}KB) error at peer {} pos {}: expected {}, got {}",
                 globalRank,
@@ -1456,7 +1457,7 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedVaryingSizes_Chunked) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -1537,7 +1538,7 @@ TEST_F(AllToAllvLl128TestFixture, PipelinedVaryingSizes_Chunked) {
         if (expected != actual) {
           h_errorCount++;
           if (h_errorCount <= 5) {
-            XLOGF(
+            COMMS_LOG(
                 ERR,
                 "Rank {}: Iter {} ({}KB chunked) error at peer {} pos {}: expected {}, got {}",
                 globalRank,
@@ -1586,7 +1587,7 @@ TEST_F(AllToAllvLl128TestFixture, AutoDispatch_1KB_UsesLl128) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -1660,7 +1661,7 @@ TEST_F(AllToAllvLl128TestFixture, AutoDispatch_1KB_UsesLl128) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: AutoDispatch 1KB error at peer {} pos {}: expected {}, got {}",
               globalRank,
@@ -1699,7 +1700,7 @@ TEST_F(AllToAllvLl128TestFixture, AutoDispatch_256KB_UsesLl128) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -1773,7 +1774,7 @@ TEST_F(AllToAllvLl128TestFixture, AutoDispatch_256KB_UsesLl128) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: AutoDispatch 256KB error at peer {} pos {}: expected {}, got {}",
               globalRank,
@@ -1812,7 +1813,7 @@ TEST_F(AllToAllvLl128TestFixture, AutoDispatch_512KB_UsesSimple) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -1886,7 +1887,7 @@ TEST_F(AllToAllvLl128TestFixture, AutoDispatch_512KB_UsesSimple) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: AutoDispatch 512KB error at peer {} pos {}: expected {}, got {}",
               globalRank,

--- a/comms/prims/collectives/tests/AllToAllvLl128_2GpuTest.cc
+++ b/comms/prims/collectives/tests/AllToAllvLl128_2GpuTest.cc
@@ -5,7 +5,7 @@
 #include <cstddef>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/prims/collectives/AllToAllvLl128.cuh"
 #include "comms/prims/collectives/tests/AllToAllvLl128Test.cuh"
@@ -46,8 +46,8 @@ TEST_F(AllToAllvLl128_2GpuTestFixture, EqualSize_2GPU_4KB) {
   const int numBlocks = 18;
   const int blockSize = 512;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: Running EqualSize_2GPU_4KB with worldSize={}",
       globalRank,
       worldSize);
@@ -69,7 +69,7 @@ TEST_F(AllToAllvLl128_2GpuTestFixture, EqualSize_2GPU_4KB) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -150,7 +150,7 @@ TEST_F(AllToAllvLl128_2GpuTestFixture, EqualSize_2GPU_4KB) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: Error at peer {} position {}: expected {}, got {}",
               globalRank,
@@ -173,8 +173,8 @@ TEST_F(AllToAllvLl128_2GpuTestFixture, EqualSize_2GPU_64KB) {
   const int numBlocks = 18;
   const int blockSize = 512;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: Running EqualSize_2GPU_64KB with worldSize={}",
       globalRank,
       worldSize);
@@ -196,7 +196,7 @@ TEST_F(AllToAllvLl128_2GpuTestFixture, EqualSize_2GPU_64KB) {
         globalRank, worldSize, bootstrap, config);
     transport->exchange();
   } catch (const std::runtime_error& e) {
-    XLOGF(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
+    COMMS_LOG(ERR, "Rank {}: transport init failed: {}", globalRank, e.what());
     std::abort();
   }
 
@@ -277,7 +277,7 @@ TEST_F(AllToAllvLl128_2GpuTestFixture, EqualSize_2GPU_64KB) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: Error at peer {} position {}: expected {}, got {}",
               globalRank,

--- a/comms/prims/collectives/tests/DirectIbReduceScatterTest.cc
+++ b/comms/prims/collectives/tests/DirectIbReduceScatterTest.cc
@@ -1,7 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 
 #include <memory>
 #include <string>

--- a/comms/prims/collectives/tests/RingAllGatherTest.cc
+++ b/comms/prims/collectives/tests/RingAllGatherTest.cc
@@ -1,7 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/prims/collectives/RingAllgatherLauncher.h"
 #include "comms/prims/collectives/RingUtils.h"

--- a/comms/prims/tests/AllGatherTest.cc
+++ b/comms/prims/tests/AllGatherTest.cc
@@ -3,7 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/prims/collectives/AllGather.cuh"
 #include "comms/prims/tests/AllGatherTest.cuh"
@@ -35,8 +35,8 @@ void printDeviceBuffer(
       totalInts * sizeof(int32_t),
       cudaMemcpyDeviceToHost));
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: {} (showing {} values for each peer):",
       rank,
       label,
@@ -52,7 +52,7 @@ void printDeviceBuffer(
     if (!showAll && numIntsPerRank > 8) {
       line += "...";
     }
-    XLOG(DBG1) << line;
+    COMMS_LOG_STREAM(DBG) << line;
   }
 }
 } // namespace
@@ -85,8 +85,8 @@ TEST_P(AllGatherTest, AllGatherBasic) {
   const int numBlocks = params.numBlocks;
   const int blockSize = params.blockSize;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: Running {} with numBlocks={}, blockSize={}, numIntsPerRank={}",
       globalRank,
       params.testName,
@@ -115,7 +115,7 @@ TEST_P(AllGatherTest, AllGatherBasic) {
   // Create transport and exchange IPC handles
   MultiPeerNvlTransport transport(globalRank, worldSize, bootstrap, config);
   transport.exchange();
-  XLOGF(DBG1, "Rank {} created transport and exchanged IPC", globalRank);
+  COMMS_LOG(DBG, "Rank {} created transport and exchanged IPC", globalRank);
 
   auto transports_span = transport.getDeviceTransports();
 
@@ -144,7 +144,7 @@ TEST_P(AllGatherTest, AllGatherBasic) {
   bootstrap->barrierAll();
 
   // Debug: Print send buffer before all_gather
-  XLOGF(DBG1, "Rank {}: Send buffer (my data): ", globalRank);
+  COMMS_LOG(DBG, "Rank {}: Send buffer (my data): ", globalRank);
   std::vector<int32_t> h_send_debug(numIntsPerRank);
   CUDACHECK_TEST(cudaMemcpy(
       h_send_debug.data(),
@@ -158,7 +158,7 @@ TEST_P(AllGatherTest, AllGatherBasic) {
   if (numIntsPerRank > 8) {
     sendLine += "...";
   }
-  XLOG(DBG1) << sendLine;
+  COMMS_LOG_STREAM(DBG) << sendLine;
 
   // Debug: Print recv buffer before all_gather
   printDeviceBuffer(
@@ -168,7 +168,7 @@ TEST_P(AllGatherTest, AllGatherBasic) {
       worldSize,
       numIntsPerRank);
 
-  XLOGF(DBG1, "Rank {}: calling all_gather", globalRank);
+  COMMS_LOG(DBG, "Rank {}: calling all_gather", globalRank);
 
   // Call all_gather with actual data transfer
   test::testAllGather(
@@ -212,7 +212,7 @@ TEST_P(AllGatherTest, AllGatherBasic) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) { // Only print first 10 errors
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: Error at source_rank {} position {}: expected {}, got {}",
               globalRank,
@@ -225,8 +225,8 @@ TEST_P(AllGatherTest, AllGatherBasic) {
     }
   }
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: verification completed, errors = {}",
       globalRank,
       h_errorCount);
@@ -287,8 +287,8 @@ TEST_P(AllGatherLargeTest, AllGatherLarge) {
   const int numBlocks = params.numBlocks;
   const int blockSize = params.blockSize;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: Running {} with numBlocks={}, blockSize={}, numIntsPerRank={}",
       globalRank,
       params.testName,
@@ -355,7 +355,7 @@ TEST_P(AllGatherLargeTest, AllGatherLarge) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: Error at source_rank {} position {}: expected {}, got {}",
               globalRank,

--- a/comms/prims/tests/AllToAllvTest.cc
+++ b/comms/prims/tests/AllToAllvTest.cc
@@ -3,7 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #ifdef __HIP_PLATFORM_AMD__
 #include "comms/prims/transport/amd/HipHostCompat.h"
@@ -42,8 +42,8 @@ void printDeviceBuffer(
       totalInts * sizeof(int32_t),
       cudaMemcpyDeviceToHost));
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: {} (showing {} values for each peer):",
       rank,
       label,
@@ -59,7 +59,7 @@ void printDeviceBuffer(
     if (!showAll && numIntsPerRank > 8) {
       line += "...";
     }
-    XLOG(DBG1) << line;
+    COMMS_LOG_STREAM(DBG) << line;
   }
 }
 } // namespace
@@ -92,8 +92,8 @@ TEST_P(AllToAllvEqualSizeTest, AllToAllvEqualSize) {
   const int numBlocks = params.numBlocks;
   const int blockSize = params.blockSize;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: Running {} with numBlocks={}, blockSize={}, numIntsPerRank={}",
       globalRank,
       params.testName,
@@ -114,7 +114,7 @@ TEST_P(AllToAllvEqualSizeTest, AllToAllvEqualSize) {
   // Create transport and exchange IPC handles
   MultiPeerNvlTransport transport(globalRank, worldSize, bootstrap, config);
   transport.exchange();
-  XLOGF(DBG1, "Rank {} created transport and exchanged IPC", globalRank);
+  COMMS_LOG(DBG, "Rank {} created transport and exchanged IPC", globalRank);
 
   auto transports_span = transport.getDeviceTransports();
 
@@ -192,7 +192,7 @@ TEST_P(AllToAllvEqualSizeTest, AllToAllvEqualSize) {
       worldSize,
       numIntsPerRank);
 
-  XLOGF(DBG1, "Rank {}: calling all_to_allv", globalRank);
+  COMMS_LOG(DBG, "Rank {}: calling all_to_allv", globalRank);
 
   // Call all_to_allv with actual data transfer
   test::testAllToAllv(
@@ -237,7 +237,7 @@ TEST_P(AllToAllvEqualSizeTest, AllToAllvEqualSize) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) { // Only print first 10 errors
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: Error at peer {} position {}: expected {}, got {}",
               globalRank,
@@ -250,8 +250,8 @@ TEST_P(AllToAllvEqualSizeTest, AllToAllvEqualSize) {
     }
   }
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: verification completed, errors = {}",
       globalRank,
       h_errorCount);
@@ -312,8 +312,8 @@ TEST_P(AllToAllvUnequalSizeTest, AllToAllvUnequalSize) {
   const int blockSize = params.blockSize;
   const size_t base_ints = params.base_ints;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: Running {} with numBlocks={}, blockSize={}, base_ints={}",
       globalRank,
       params.testName,
@@ -330,7 +330,7 @@ TEST_P(AllToAllvUnequalSizeTest, AllToAllvUnequalSize) {
   // Create transport and exchange IPC handles
   MultiPeerNvlTransport transport(globalRank, worldSize, bootstrap, config);
   transport.exchange();
-  XLOGF(DBG1, "Rank {} created transport and exchanged IPC", globalRank);
+  COMMS_LOG(DBG, "Rank {} created transport and exchanged IPC", globalRank);
 
   auto transports_span = transport.getDeviceTransports();
 
@@ -358,8 +358,8 @@ TEST_P(AllToAllvUnequalSizeTest, AllToAllvUnequalSize) {
   const size_t sendBufferSize = send_offset;
   const size_t recvBufferSize = recv_offset;
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: sendBufferSize = {}, recvBufferSize = {}",
       globalRank,
       sendBufferSize,
@@ -415,7 +415,8 @@ TEST_P(AllToAllvUnequalSizeTest, AllToAllvUnequalSize) {
   // Barrier to ensure all ranks are ready
   bootstrap->barrierAll();
 
-  XLOGF(DBG1, "Rank {}: calling all_to_allv with variable sizes", globalRank);
+  COMMS_LOG(
+      DBG, "Rank {}: calling all_to_allv with variable sizes", globalRank);
 
   // Call all_to_allv with variable sizes
   test::testAllToAllv(
@@ -452,7 +453,7 @@ TEST_P(AllToAllvUnequalSizeTest, AllToAllvUnequalSize) {
       if (expected != actual) {
         h_errorCount++;
         if (h_errorCount <= 10) { // Only print first 10 errors
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "Rank {}: Error at peer {} position {}: expected {}, got {}",
               globalRank,
@@ -466,8 +467,8 @@ TEST_P(AllToAllvUnequalSizeTest, AllToAllvUnequalSize) {
     int_offset += num_ints;
   }
 
-  XLOGF(
-      DBG1,
+  COMMS_LOG(
+      DBG,
       "Rank {}: verification completed, errors = {}",
       globalRank,
       h_errorCount);

--- a/comms/prims/tests/BarrierTest.cc
+++ b/comms/prims/tests/BarrierTest.cc
@@ -3,7 +3,6 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 
 #include <vector>
 

--- a/comms/prims/tests/ExternalStagingBuffersTest.cc
+++ b/comms/prims/tests/ExternalStagingBuffersTest.cc
@@ -4,7 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <memory>
 #include <vector>
@@ -192,7 +192,7 @@ TEST_F(ExternalStagingBuffersTestFixture, IpcMemAccessThroughExternalBuffers) {
   auto remoteAddr =
       static_cast<int*>(static_cast<void*>(p2p.getRemoteState().dataBuffer));
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: localAddr={}, remoteAddr={}",
       globalRank,

--- a/comms/prims/tests/GpuMemHandlerTest.cc
+++ b/comms/prims/tests/GpuMemHandlerTest.cc
@@ -4,7 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <cstddef>
 #include <cstring>
@@ -51,7 +51,8 @@ class GpuMemHandlerTestFixture : public MpiBaseTestFixture {
 TEST_F(GpuMemHandlerTestFixture, RemoteWriteLocalRead) {
   // Only test with 2 ranks
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -63,19 +64,19 @@ TEST_F(GpuMemHandlerTestFixture, RemoteWriteLocalRead) {
   auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
   GpuMemHandler handler(bootstrap, globalRank, numRanks, bufferSize);
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {} created handler in {} mode",
       globalRank,
       handler.getMode() == MemSharingMode::kFabric ? "fabric" : "cudaIpc");
 
   handler.exchangeMemPtrs();
-  XLOGF(INFO, "Rank {} exchanged memory handles", globalRank);
+  COMMS_LOG(INFO, "Rank {} exchanged memory handles", globalRank);
 
   auto localAddr = static_cast<int*>(handler.getLocalDeviceMemPtr());
   auto remoteAddr = static_cast<int*>(handler.getPeerDeviceMemPtr(peerRank));
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: localAddr: {}, remoteAddr: {}",
       globalRank,
@@ -87,11 +88,12 @@ TEST_F(GpuMemHandlerTestFixture, RemoteWriteLocalRead) {
   int writeValue = globalRank;
   test::fillBuffer(localAddr, writeValue, numElements);
   CUDACHECK_TEST(cudaDeviceSynchronize());
-  XLOGF(INFO, "Rank {} filled local buffer with {}", globalRank, writeValue);
+  COMMS_LOG(
+      INFO, "Rank {} filled local buffer with {}", globalRank, writeValue);
 
   // Barrier to ensure both ranks have written their data
   MPI_Barrier(MPI_COMM_WORLD);
-  XLOGF(INFO, "Rank {} passed barrier", globalRank);
+  COMMS_LOG(INFO, "Rank {} passed barrier", globalRank);
 
   // Each rank reads from peer's buffer and verifies
   // rank0 should read all 1s from rank1
@@ -111,7 +113,7 @@ TEST_F(GpuMemHandlerTestFixture, RemoteWriteLocalRead) {
   CUDACHECK_TEST(cudaMemcpy(
       &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {} verified peer buffer, errors: {}",
       globalRank,
@@ -129,7 +131,8 @@ TEST_F(GpuMemHandlerTestFixture, RemoteWriteLocalRead) {
 TEST_F(GpuMemHandlerTestFixture, SelfRankReturnsLocalPtr) {
   // Only test with 2 ranks
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -153,7 +156,8 @@ TEST_F(GpuMemHandlerTestFixture, SelfRankReturnsLocalPtr) {
 TEST_F(GpuMemHandlerTestFixture, ExplicitCudaIpcMode) {
   // Only test with 2 ranks
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -168,7 +172,8 @@ TEST_F(GpuMemHandlerTestFixture, ExplicitCudaIpcMode) {
       bootstrap, globalRank, numRanks, bufferSize, MemSharingMode::kCudaIpc);
 
   EXPECT_EQ(handler.getMode(), MemSharingMode::kCudaIpc);
-  XLOGF(INFO, "Rank {} created handler with explicit cudaIpc mode", globalRank);
+  COMMS_LOG(
+      INFO, "Rank {} created handler with explicit cudaIpc mode", globalRank);
 
   handler.exchangeMemPtrs();
 
@@ -216,14 +221,14 @@ TEST_F(GpuMemHandlerTestFixture, SingleRankExchange) {
   GpuMemHandler handler(
       bootstrap, 0 /* selfRank */, 1 /* nRanks */, bufferSize);
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "MPI Rank {} testing single-rank exchange in {} mode",
       globalRank,
       handler.getMode() == MemSharingMode::kFabric ? "fabric" : "cudaIpc");
 
   handler.exchangeMemPtrs();
-  XLOGF(INFO, "MPI Rank {} completed single-rank exchange", globalRank);
+  COMMS_LOG(INFO, "MPI Rank {} completed single-rank exchange", globalRank);
 
   // Get local pointer
   auto localAddr = static_cast<int*>(handler.getLocalDeviceMemPtr());
@@ -254,7 +259,7 @@ TEST_F(GpuMemHandlerTestFixture, SingleRankExchange) {
 
   ASSERT_EQ(h_errorCount, 0) << "Single-rank exchange verification failed";
 
-  XLOGF(INFO, "MPI Rank {} single-rank exchange test passed", globalRank);
+  COMMS_LOG(INFO, "MPI Rank {} single-rank exchange test passed", globalRank);
 }
 
 TEST_F(GpuMemHandlerTestFixture, VmmImportFailurePropagatesToEveryRank) {

--- a/comms/prims/tests/HostWindowTest.cc
+++ b/comms/prims/tests/HostWindowTest.cc
@@ -3,7 +3,6 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/prims/transport/MultiPeerTransport.h"
 #include "comms/prims/window/HostWindow.h"

--- a/comms/prims/tests/MultiPeerNvlTransportIntegrationTest.cc
+++ b/comms/prims/tests/MultiPeerNvlTransportIntegrationTest.cc
@@ -4,7 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <optional>
 #include <string>
@@ -153,7 +153,7 @@ class MultiPeerNvlTransportIntegrationTestFixture : public MpiBaseTestFixture {
 
     EXPECT_EQ(result_h, 1) << label << " Signal/Wait operation failed";
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: {} Signal/Wait test completed (isSignaler={})",
         globalRank,
@@ -263,7 +263,7 @@ class MultiPeerNvlTransportIntegrationTestFixture : public MpiBaseTestFixture {
           << label << " data mismatch after put_signal";
     }
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: {} Put/Signal operation test completed (isWriter={})",
         globalRank,
@@ -309,7 +309,7 @@ TEST_F(
   EXPECT_EQ(results_h[2], numRanks - 1)
       << "numPeers() should return " << (numRanks - 1);
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: MultiPeerDeviceTransport construction test completed (rank={}, nRanks={}, numPeers={})",
       globalRank,
@@ -377,7 +377,7 @@ TEST_F(
   EXPECT_EQ(results1_h, results3_h)
       << "Repeated DeviceWindow constructions returned different values";
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Repeated DeviceWindow construction test completed",
       globalRank);
@@ -451,7 +451,8 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BidirectionalSignalWait) {
   EXPECT_EQ(result1_h, 1) << "Phase 1 Signal/Wait failed";
   EXPECT_EQ(result2_h, 1) << "Phase 2 Signal/Wait failed";
 
-  XLOGF(INFO, "Rank {}: Bidirectional Signal/Wait test completed", globalRank);
+  COMMS_LOG(
+      INFO, "Rank {}: Bidirectional Signal/Wait test completed", globalRank);
 }
 
 // =============================================================================
@@ -488,7 +489,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, Barrier) {
 
   EXPECT_EQ(result_h, 1) << "Barrier operation failed";
 
-  XLOGF(INFO, "Rank {}: Barrier test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: Barrier test completed", globalRank);
 }
 
 // =============================================================================
@@ -533,7 +534,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierPeer) {
   EXPECT_EQ(result_h, 1) << "barrier_peer() operation failed on rank "
                          << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: BarrierPeer test completed (peerRank={})",
       globalRank,
@@ -586,7 +587,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MultipleBarriers) {
                            << slotIdx << ") failed on rank " << globalRank;
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Multiple Barriers test completed ({} iterations, {} slots)",
       globalRank,
@@ -641,7 +642,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MultipleSignalSlots) {
                            << globalRank;
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Multiple signal slots test completed ({} slots)",
       globalRank,
@@ -698,7 +699,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, ConcurrentSignalSlots) {
                            << " failed on rank " << globalRank;
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Concurrent signal slots test completed ({} slots)",
       globalRank,
@@ -744,7 +745,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MultipleBarrierSlots) {
                            << globalRank;
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Multiple barrier slots test completed ({} slots)",
       globalRank,
@@ -789,7 +790,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierSlotStress) {
                            << slotIdx << ") failed on rank " << globalRank;
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Barrier slot stress test completed ({} iterations, {} slots)",
       globalRank,
@@ -835,7 +836,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierMonotonicCounters) {
   EXPECT_EQ(result_h, 1) << "Barrier monotonic counters test failed on rank "
                          << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Barrier monotonic counters test completed ({} phases)",
       globalRank,
@@ -886,7 +887,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, BarrierMultiBlockStress) {
   EXPECT_EQ(results_h, expected)
       << "Not all blocks completed barrier successfully on rank " << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Barrier multi-block stress test completed ({} blocks, {} slots)",
       globalRank,
@@ -999,7 +1000,7 @@ TEST_F(
     EXPECT_EQ(result_h, 1) << "Phase 4 barrier failed";
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Combined signal/barrier config test completed ({} signal slots, {} barrier slots)",
       globalRank,
@@ -1056,7 +1057,7 @@ TEST_F(
 
   EXPECT_EQ(results_h, std::vector<int>(kNumBlocks, 1));
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Concurrent signal multi-block test completed ({} blocks)",
       globalRank,
@@ -1115,7 +1116,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalResetBetweenPhases) {
     // testSignalWait For explicit reset testing, we would call resetSignalFrom
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Signal reset between phases test completed ({} phases)",
       globalRank,
@@ -1179,7 +1180,7 @@ TEST_F(
         << "Iteration " << iter << " failed on rank " << globalRank;
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Concurrent signal stress extended test completed ({} iterations, {} blocks)",
       globalRank,
@@ -1241,7 +1242,7 @@ TEST_F(
   EXPECT_EQ(results_h, expected)
       << "Not all warps completed successfully on rank " << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Concurrent signal multi-warp test completed ({} warps)",
       globalRank,
@@ -1287,7 +1288,8 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, TransportAccessorTypes) {
         << "Transport type mismatch for peer " << peer;
   }
 
-  XLOGF(INFO, "Rank {}: Transport accessor types test completed", globalRank);
+  COMMS_LOG(
+      INFO, "Rank {}: Transport accessor types test completed", globalRank);
 }
 
 // =============================================================================
@@ -1362,7 +1364,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalAll) {
   EXPECT_EQ(result_h, 1) << "signal_all() operation failed on rank "
                          << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: signal_all() test completed (signalerRank={})",
       globalRank,
@@ -1413,7 +1415,7 @@ TEST_F(
       << "read_signal() aggregate on rank " << globalRank
       << " should equal numRanks-1 (" << (numRanks - 1) << ")";
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: signal_all() aggregate test completed (aggregate={}, expected={})",
       globalRank,
@@ -1463,7 +1465,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, WaitSignalFromAll) {
   EXPECT_EQ(result_h, 1) << "wait_signal_from_all() operation failed on rank "
                          << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: wait_signal_from_all() test completed (targetRank={})",
       globalRank,
@@ -1515,7 +1517,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, WaitWithCmpEq) {
   EXPECT_EQ(result_h, 1) << "CMP_EQ wait operation failed on rank "
                          << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: WaitWithCmpEq test completed (expectedValue={})",
       globalRank,
@@ -1568,7 +1570,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, MonotonicWaitValues) {
   EXPECT_EQ(result_h, 1) << "Monotonic wait values test failed on rank "
                          << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: MonotonicWaitValues test completed ({} iterations)",
       globalRank,
@@ -1620,7 +1622,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalWithSet) {
   EXPECT_EQ(result_h, 1) << "SIGNAL_SET operation failed on rank "
                          << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: SignalWithSet test completed (setValue={})",
       globalRank,
@@ -1677,7 +1679,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, WaitSignalFromPeer) {
 
   EXPECT_EQ(result_h, 1) << "wait_signal_from() failed on rank " << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: WaitSignalFromPeer test completed (isSignaler={})",
       globalRank,
@@ -1729,7 +1731,7 @@ TEST_F(
   EXPECT_EQ(result_h, 1) << "WaitSignalFromMultiPeerIsolation failed on rank "
                          << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: WaitSignalFromMultiPeerIsolation test completed (targetRank={})",
       globalRank,
@@ -1781,7 +1783,7 @@ TEST_F(
   EXPECT_EQ(result_h, 1)
       << "WaitSignalAndWaitSignalFromBothWork failed on rank " << globalRank;
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: WaitSignalAndWaitSignalFromBothWork test completed (targetRank={})",
       globalRank,
@@ -1832,7 +1834,7 @@ TEST_F(MultiPeerNvlTransportIntegrationTestFixture, SignalWaitBlockScope) {
 
   EXPECT_EQ(result_h, 1) << "Signal/Wait (BLOCK scope) operation failed";
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Signal/Wait (BLOCK scope) test completed (isSignaler={})",
       globalRank,

--- a/comms/prims/tests/MultiPeerTransportIntegrationTest.cc
+++ b/comms/prims/tests/MultiPeerTransportIntegrationTest.cc
@@ -4,7 +4,6 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/common/fault_tolerance/Abort.h"
 #include "comms/prims/tests/MultiPeerTransportKernelTest.cuh"

--- a/comms/prims/tests/MultiPeerTransportMultiNodeTest.cc
+++ b/comms/prims/tests/MultiPeerTransportMultiNodeTest.cc
@@ -10,7 +10,7 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/prims/topology/NvmlFabricInfo.h"
 #include "comms/prims/transport/MultiPeerDeviceHandle.cuh"
@@ -99,7 +99,7 @@ class MultiPeerTransportMultiNodeFixture : public MpiBaseTestFixture {
       }
     }
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {} platform detection: isMnnvl={}, localSize={}",
         globalRank,
@@ -169,7 +169,7 @@ TEST_F(MultiPeerTransportMultiNodeFixture, TopologyDiscoveryMultiNode) {
   // Invariant: NVL peers are a subset of IBGDA peers.
   EXPECT_LE(nvlCount, ibgdaCount);
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {} (localRank {}): isMnnvl={}, {} NVL peers, {} IBGDA peers",
       globalRank,
@@ -298,7 +298,7 @@ TEST_F(MultiPeerTransportMultiNodeFixture, HostAccessorsMultiNode) {
     EXPECT_NE(p2p, nullptr) << "IBGDA transport device null for peer " << r;
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: isMnnvl={}, validated {} NVL peers, {} IBGDA peers",
       globalRank,

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -3,9 +3,9 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <array>
 #include <chrono>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <memory>
 #include <string>
@@ -252,8 +252,8 @@ class MultipeerIbgdaTransportTestFixture : public MpiBaseTestFixture {
 
 TEST_P(MultipeerIbTransportTestFixture, ConstructAndExchange) {
   if (numRanks < 2) {
-    XLOGF(
-        WARNING, "Skipping test: requires at least 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires at least 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -265,7 +265,7 @@ TEST_P(MultipeerIbTransportTestFixture, ConstructAndExchange) {
     EXPECT_EQ(transport->numPeers(), numRanks - 1);
     EXPECT_NE(transport->getDeviceTransportPtr(), nullptr);
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: Transport created with GID index {}",
         globalRank,
@@ -276,7 +276,7 @@ TEST_P(MultipeerIbTransportTestFixture, ConstructAndExchange) {
   }
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
-  XLOGF(INFO, "Rank {}: ConstructAndExchange test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: ConstructAndExchange test completed", globalRank);
 }
 
 TEST_P(MultipeerIbTransportTestFixture, PipelineGeometry) {
@@ -339,7 +339,8 @@ TEST_P(MultipeerIbTransportTestFixture, PipelineGeometry) {
 
 TEST_P(MultipeerIbTransportTestFixture, PutSignalBasic) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -364,7 +365,7 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalBasic) {
     // Signal/counter buffers are transport-owned (numSignalSlots=1,
     // numCounterSlots=1)
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: localDataBuf ptr={} lkey={}, remoteDataBuf ptr={} rkey={}",
         globalRank,
@@ -442,7 +443,7 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalBasic) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(INFO, "Rank {}: PutSignalBasic test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: PutSignalBasic test completed", globalRank);
 }
 
 // =============================================================================
@@ -451,7 +452,8 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalBasic) {
 
 TEST_P(MultipeerIbTransportTestFixture, PutSignalGroupBasic) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -528,7 +530,7 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalGroupBasic) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(INFO, "Rank {}: PutSignalGroupBasic test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: PutSignalGroupBasic test completed", globalRank);
 }
 
 // =============================================================================
@@ -537,7 +539,8 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalGroupBasic) {
 
 TEST_P(MultipeerIbTransportTestFixture, PutSignalGroupMultiWarp) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -622,7 +625,8 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalGroupMultiWarp) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(INFO, "Rank {}: PutSignalGroupMultiWarp test completed", globalRank);
+  COMMS_LOG(
+      INFO, "Rank {}: PutSignalGroupMultiWarp test completed", globalRank);
 }
 
 // =============================================================================
@@ -631,7 +635,8 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalGroupMultiWarp) {
 
 TEST_P(MultipeerIbTransportTestFixture, PutSignalGroupBlock) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -715,7 +720,7 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalGroupBlock) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(INFO, "Rank {}: PutSignalGroupBlock test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: PutSignalGroupBlock test completed", globalRank);
 }
 
 // =============================================================================
@@ -740,7 +745,8 @@ class TransferSizeTestFixture
 
 TEST_P(TransferSizeTestFixture, PutSignal) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -751,7 +757,7 @@ TEST_P(TransferSizeTestFixture, PutSignal) {
   const int peerRank = (globalRank == 0) ? 1 : 0;
   const uint8_t testPattern = static_cast<uint8_t>(globalRank + 0x10);
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Running {} transfer size test {} with {} bytes",
       globalRank,
@@ -823,7 +829,7 @@ TEST_P(TransferSizeTestFixture, PutSignal) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Transfer size test {} completed",
       globalRank,
@@ -903,7 +909,8 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(MultipeerIbTransportTestFixture, Bidirectional) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1028,7 +1035,7 @@ TEST_P(MultipeerIbTransportTestFixture, Bidirectional) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(INFO, "Rank {}: Bidirectional test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: Bidirectional test completed", globalRank);
 }
 
 // =============================================================================
@@ -1037,7 +1044,8 @@ TEST_P(MultipeerIbTransportTestFixture, Bidirectional) {
 
 TEST_P(MultipeerIbTransportTestFixture, StressTest) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1114,7 +1122,7 @@ TEST_P(MultipeerIbTransportTestFixture, StressTest) {
 
         if (h_errorCount > 0) {
           totalErrors += h_errorCount;
-          XLOGF(ERR, "Iteration {}: Found {} errors", iter, h_errorCount);
+          COMMS_LOG(ERR, "Iteration {}: Found {} errors", iter, h_errorCount);
         }
       }
     }
@@ -1129,7 +1137,7 @@ TEST_P(MultipeerIbTransportTestFixture, StressTest) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Stress test completed ({} iterations)",
       globalRank,
@@ -1142,7 +1150,8 @@ TEST_P(MultipeerIbTransportTestFixture, StressTest) {
 
 TEST_P(MultipeerIbTransportTestFixture, SignalOnly) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1176,7 +1185,7 @@ TEST_P(MultipeerIbTransportTestFixture, SignalOnly) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(INFO, "Rank {}: SignalOnly test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: SignalOnly test completed", globalRank);
 }
 
 // =============================================================================
@@ -1185,7 +1194,8 @@ TEST_P(MultipeerIbTransportTestFixture, SignalOnly) {
 
 TEST_P(MultipeerIbTransportTestFixture, PutSignalCounter) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2737,7 +2747,8 @@ TEST_F(
 
 TEST_P(MultipeerIbTransportTestFixture, ResetSignal) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2786,7 +2797,7 @@ TEST_P(MultipeerIbTransportTestFixture, ResetSignal) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: ResetSignal test completed ({} iterations)",
       globalRank,
@@ -2799,7 +2810,8 @@ TEST_P(MultipeerIbTransportTestFixture, ResetSignal) {
 
 TEST_P(MultipeerIbTransportTestFixture, MultipleSignalSlots) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2848,7 +2860,7 @@ TEST_P(MultipeerIbTransportTestFixture, MultipleSignalSlots) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(INFO, "Rank {}: MultipleSignalSlots test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: MultipleSignalSlots test completed", globalRank);
 }
 
 // =============================================================================
@@ -2857,7 +2869,8 @@ TEST_P(MultipeerIbTransportTestFixture, MultipleSignalSlots) {
 
 TEST_P(MultipeerIbTransportTestFixture, PutSignalWaitForReady) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2946,7 +2959,7 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalWaitForReady) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(INFO, "Rank {}: PutSignalWaitForReady test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: PutSignalWaitForReady test completed", globalRank);
 }
 
 // =============================================================================
@@ -2955,7 +2968,8 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalWaitForReady) {
 
 TEST_P(MultipeerIbTransportTestFixture, BidirectionalConcurrent) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -3028,7 +3042,8 @@ TEST_P(MultipeerIbTransportTestFixture, BidirectionalConcurrent) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(INFO, "Rank {}: BidirectionalConcurrent test completed", globalRank);
+  COMMS_LOG(
+      INFO, "Rank {}: BidirectionalConcurrent test completed", globalRank);
 }
 
 // =============================================================================
@@ -3037,8 +3052,8 @@ TEST_P(MultipeerIbTransportTestFixture, BidirectionalConcurrent) {
 
 TEST_P(MultipeerIbTransportTestFixture, AllToAll) {
   if (numRanks < 2) {
-    XLOGF(
-        WARNING, "Skipping test: requires at least 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires at least 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -3143,7 +3158,7 @@ TEST_P(MultipeerIbTransportTestFixture, AllToAll) {
 
       if (h_errorCount > 0) {
         totalErrors += h_errorCount;
-        XLOGF(
+        COMMS_LOG(
             ERR,
             "Rank {}: {} byte mismatches receiving from rank {}",
             globalRank,
@@ -3161,7 +3176,7 @@ TEST_P(MultipeerIbTransportTestFixture, AllToAll) {
                  << " transport not available: " << e.what();
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: AllToAll test completed with {} peers",
       globalRank,
@@ -3174,8 +3189,8 @@ TEST_P(MultipeerIbTransportTestFixture, AllToAll) {
 
 TEST_P(MultipeerIbTransportTestFixture, MultiQpConstructAndExchange) {
   if (numRanks < 2) {
-    XLOGF(
-        WARNING, "Skipping test: requires at least 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires at least 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -3193,7 +3208,7 @@ TEST_P(MultipeerIbTransportTestFixture, MultiQpConstructAndExchange) {
           << "getP2pTransportDevice(" << r << ") returned null";
     }
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {}: Multi-QP transport created with {} QPs/block/NIC",
         globalRank,
@@ -3225,7 +3240,8 @@ TEST_P(MultipeerIbTransportTestFixture, MultiQpConstructAndExchange) {
 
 TEST_P(MultipeerIbTransportTestFixture, MultiNicAggregateBandwidth) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -3310,20 +3326,20 @@ TEST_P(MultipeerIbTransportTestFixture, MultiNicAggregateBandwidth) {
         static_cast<double>(nbytes) * static_cast<double>(measureIters);
     const double bwGbps = (totalBytes / elapsedSec) / 1e9;
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "MultiNicAggregateBandwidth: numNics={} qpsPerBlockPerNic={} numBlocks={}",
         detectedNics,
         numQps,
         numBlocks);
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "  transferred {:.2f} GB in {:.2f} ms ({} iters × {} MiB)",
         totalBytes / 1e9,
         elapsedSec * 1000.0,
         measureIters,
         nbytes >> 20);
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "  aggregate BW = {:.2f} GB/s (min expected = {:.0f} GB/s)",
         bwGbps,
@@ -3342,7 +3358,8 @@ TEST_P(MultipeerIbTransportTestFixture, MultiNicAggregateBandwidth) {
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
   }
 
-  XLOGF(INFO, "Rank {}: MultiNicAggregateBandwidth test completed", globalRank);
+  COMMS_LOG(
+      INFO, "Rank {}: MultiNicAggregateBandwidth test completed", globalRank);
 }
 
 // =============================================================================

--- a/comms/prims/tests/P2pNvlTransportDeviceTest.cc
+++ b/comms/prims/tests/P2pNvlTransportDeviceTest.cc
@@ -3,7 +3,6 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 
 #include <vector>
 

--- a/comms/prims/tests/P2pNvlTransportTest.cc
+++ b/comms/prims/tests/P2pNvlTransportTest.cc
@@ -3,7 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include <algorithm>
 #include <chrono>
@@ -99,7 +99,8 @@ TEST_F(P2pNvlTransportTestFixture, PipelineGeometry) {
 TEST_F(P2pNvlTransportTestFixture, IpcMemAccess) {
   // Only test with 2 ranks
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -111,7 +112,7 @@ TEST_F(P2pNvlTransportTestFixture, IpcMemAccess) {
   auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
-  XLOGF(INFO, "Rank {} created transport and exchanged IPC", globalRank);
+  COMMS_LOG(INFO, "Rank {} created transport and exchanged IPC", globalRank);
 
   // Get host-side copy to access buffer pointers from host
   auto p2p = transport.buildP2pTransportDevice(peerRank);
@@ -120,7 +121,7 @@ TEST_F(P2pNvlTransportTestFixture, IpcMemAccess) {
       static_cast<int*>(static_cast<void*>(p2p.getLocalState().dataBuffer));
   auto remoteAddr =
       static_cast<int*>(static_cast<void*>(p2p.getRemoteState().dataBuffer));
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: localAddr: {}, remoteAddr: {}",
       globalRank,
@@ -132,11 +133,12 @@ TEST_F(P2pNvlTransportTestFixture, IpcMemAccess) {
   int writeValue = globalRank;
   test::fillBuffer(localAddr, writeValue, numElements);
   CUDACHECK_TEST(cudaDeviceSynchronize());
-  XLOGF(INFO, "Rank {} filled local buffer with {}", globalRank, writeValue);
+  COMMS_LOG(
+      INFO, "Rank {} filled local buffer with {}", globalRank, writeValue);
 
   // Barrier to ensure both ranks have written their data
   MPI_Barrier(MPI_COMM_WORLD);
-  XLOGF(INFO, "Rank {} passed barrier", globalRank);
+  COMMS_LOG(INFO, "Rank {} passed barrier", globalRank);
 
   // Now each rank reads from peer buffer and verifies
   // rank0 should read all 1s from rank1
@@ -156,7 +158,7 @@ TEST_F(P2pNvlTransportTestFixture, IpcMemAccess) {
   CUDACHECK_TEST(cudaMemcpy(
       &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {} verified peer buffer, errors: {}",
       globalRank,
@@ -242,7 +244,7 @@ class TransportTestHelper {
 
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCall) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping: requires 2 ranks, got {}", numRanks);
+    COMMS_LOG(WARN, "Skipping: requires 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -380,7 +382,7 @@ TEST_F(
 
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvCudaGraphReplay) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping: requires 2 ranks, got {}", numRanks);
+    COMMS_LOG(WARN, "Skipping: requires 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1502,7 +1504,7 @@ TEST_F(
     P2pNvlTransportTestFixture,
     TileSendRecvChangingLaunchedBlocksWithSameActiveBlocks) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping: requires 2 ranks, got {}", numRanks);
+    COMMS_LOG(WARN, "Skipping: requires 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2022,7 +2024,7 @@ void runPutTest(
       if (hostBuffer[i] != testValue) {
         ++errorCount;
         if (errorCount <= 5) {
-          XLOGF(
+          COMMS_LOG(
               ERR,
               "{}: Mismatch at index {}: expected 0x{:02x}, got 0x{:02x}",
               testName,
@@ -2041,7 +2043,8 @@ void runPutTest(
 // Basic write() test with aligned pointers
 TEST_F(P2pNvlTransportTestFixture, PutBasic) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2058,7 +2061,7 @@ TEST_F(P2pNvlTransportTestFixture, PutBasic) {
 
   runPutTest(globalRank, p2p, localSrc, remoteDst, nbytes, 4, 128, "PutBasic");
 
-  XLOGF(INFO, "Rank {}: PutBasic test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: PutBasic test completed", globalRank);
 }
 
 // Parameterized test for write() with various transfer sizes
@@ -2079,12 +2082,13 @@ class PutTransferSizeTestFixture
 
 TEST_P(PutTransferSizeTestFixture, Put) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
   const auto& params = GetParam();
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Running write transfer size test: {} (nbytes={})",
       params.name,
@@ -2102,7 +2106,7 @@ TEST_P(PutTransferSizeTestFixture, Put) {
   runPutTest(
       globalRank, p2p, localSrc, remoteDst, params.nbytes, 4, 128, params.name);
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Put transfer size test '{}' completed",
       globalRank,
@@ -2161,12 +2165,13 @@ class PutUnalignedTestFixture
 
 TEST_P(PutUnalignedTestFixture, Put) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
   const auto& params = GetParam();
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Running write unaligned test: {} (srcOffset={}, dstOffset={}, nbytes={})",
       params.name,
@@ -2197,7 +2202,7 @@ TEST_P(PutUnalignedTestFixture, Put) {
   runPutTest(
       globalRank, p2p, localSrc, remoteDst, params.nbytes, 4, 128, params.name);
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: Put unaligned test '{}' completed",
       globalRank,
@@ -2290,7 +2295,8 @@ INSTANTIATE_TEST_SUITE_P(
 // buffer overflows and data corruption.
 TEST_F(P2pNvlTransportTestFixture, PutMultiChunkAccumulationRegression) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2367,7 +2373,8 @@ TEST_F(P2pNvlTransportTestFixture, PutMultiChunkAccumulationRegression) {
 
 TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Enabled) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2392,12 +2399,14 @@ TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Enabled) {
       << "Rank " << globalRank
       << ": local and remote ll128Buffer should point to different ranks' buffers";
 
-  XLOGF(INFO, "Rank {}: Ll128BufferWiring_Enabled test completed", globalRank);
+  COMMS_LOG(
+      INFO, "Rank {}: Ll128BufferWiring_Enabled test completed", globalRank);
 }
 
 TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Disabled) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2424,7 +2433,8 @@ TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Disabled) {
       << "Rank " << globalRank
       << ": remoteState.llBuffer should be null when llBufferSize == 0";
 
-  XLOGF(INFO, "Rank {}: Ll128BufferWiring_Disabled test completed", globalRank);
+  COMMS_LOG(
+      INFO, "Rank {}: Ll128BufferWiring_Disabled test completed", globalRank);
 }
 
 // =============================================================================
@@ -2435,7 +2445,7 @@ TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Disabled) {
 
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvDynamicBlockCount) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping: requires 2 ranks, got {}", numRanks);
+    COMMS_LOG(WARN, "Skipping: requires 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -2689,7 +2699,7 @@ static void runTileForwardTest(
 // Basic single-call test
 TEST_F(P2pNvlTransportTestFixture, TileForwardBasic) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping: requires 2 ranks, got {}", numRanks);
+    COMMS_LOG(WARN, "Skipping: requires 2 ranks, got {}", numRanks);
     return;
   }
   auto bs = std::make_shared<meta::comms::MpiBootstrap>();
@@ -3176,12 +3186,13 @@ class TileForwardUnalignedTestFixture
 
 TEST_P(TileForwardUnalignedTestFixture, TileForward) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
   const auto& params = GetParam();
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Running tile forward unaligned test: {} (nbytes={}, dstOffset={})",
       params.name,
@@ -3251,7 +3262,8 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_F(P2pNvlTransportTestFixture, LlBufferWiring_Enabled) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -3276,12 +3288,13 @@ TEST_F(P2pNvlTransportTestFixture, LlBufferWiring_Enabled) {
       << "Rank " << globalRank
       << ": local and remote llBuffer should point to different ranks' buffers";
 
-  XLOGF(INFO, "Rank {}: LlBufferWiring_Enabled test completed", globalRank);
+  COMMS_LOG(INFO, "Rank {}: LlBufferWiring_Enabled test completed", globalRank);
 }
 
 TEST_F(P2pNvlTransportTestFixture, LlBufferWiring_Disabled) {
   if (numRanks != 2) {
-    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    COMMS_LOG(
+        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -3302,7 +3315,8 @@ TEST_F(P2pNvlTransportTestFixture, LlBufferWiring_Disabled) {
       << "Rank " << globalRank
       << ": remoteState.llBuffer should be null when llBufferSize == 0";
 
-  XLOGF(INFO, "Rank {}: LlBufferWiring_Disabled test completed", globalRank);
+  COMMS_LOG(
+      INFO, "Rank {}: LlBufferWiring_Disabled test completed", globalRank);
 }
 
 } // namespace comms::prims::tests

--- a/comms/prims/tests/P2pSelfTransportDeviceTest.cc
+++ b/comms/prims/tests/P2pSelfTransportDeviceTest.cc
@@ -3,7 +3,6 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 
 #include <algorithm>
 #include <string>

--- a/comms/prims/tests/RecvForwardChainTest.cc
+++ b/comms/prims/tests/RecvForwardChainTest.cc
@@ -4,9 +4,8 @@
 
 #include <cuda_runtime.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
-#include <array>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -60,7 +59,7 @@ class RecvForwardChainTest : public BenchmarkTestFixture {
 // Verify all ranks that receive data see the correct pattern.
 TEST_F(RecvForwardChainTest, ForwardWithCopy) {
   if (worldSize < 2) {
-    XLOGF(INFO, "Skipping: requires >= 2 ranks, got {}", worldSize);
+    COMMS_LOG(INFO, "Skipping: requires >= 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -119,7 +118,7 @@ TEST_F(RecvForwardChainTest, ForwardWithCopy) {
       for (std::size_t i = 0; i < kDataBytes; ++i) {
         if (hostBuf[i] != fillPattern) {
           if (errors < 10) {
-            XLOGF(
+            COMMS_LOG(
                 ERR,
                 "Rank {}: byte {} expected 0x{:02X} got 0x{:02X}",
                 globalRank,
@@ -142,7 +141,7 @@ TEST_F(RecvForwardChainTest, ForwardWithCopy) {
 // Only the last rank should have the data.
 TEST_F(RecvForwardChainTest, ForwardOnly) {
   if (worldSize < 3) {
-    XLOGF(INFO, "Skipping: requires >= 3 ranks for forward-only test");
+    COMMS_LOG(INFO, "Skipping: requires >= 3 ranks for forward-only test");
     return;
   }
 
@@ -213,7 +212,7 @@ TEST_F(RecvForwardChainTest, ForwardOnly) {
 // is compatible when recv_forward is not involved — just send + recv.
 TEST_F(RecvForwardChainTest, SendRecvDirect) {
   if (worldSize != 2) {
-    XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
+    COMMS_LOG(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
     return;
   }
 
@@ -283,7 +282,7 @@ TEST_F(RecvForwardChainTest, SendRecvDirect) {
 // Multi-section test: transfer more data than one slot to exercise pipelining.
 TEST_F(RecvForwardChainTest, MultiSection) {
   if (worldSize < 2) {
-    XLOGF(INFO, "Skipping: requires >= 2 ranks, got {}", worldSize);
+    COMMS_LOG(INFO, "Skipping: requires >= 2 ranks, got {}", worldSize);
     return;
   }
 

--- a/comms/prims/tests/TopologyDiscoveryE2eTest.cc
+++ b/comms/prims/tests/TopologyDiscoveryE2eTest.cc
@@ -9,9 +9,9 @@
 
 #include <cuda_runtime.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
 #include <mpi.h>
+#include "comms/utils/logger/SpdlogLogger.h"
 
 #include "comms/prims/topology/NvmlFabricInfo.h"
 #include "comms/prims/topology/TopologyDiscovery.h"
@@ -86,7 +86,7 @@ class TopologyDiscoveryE2eFixture : public MpiBaseTestFixture {
       }
     }
 
-    XLOGF(
+    COMMS_LOG(
         INFO,
         "Rank {} platform detection: isMnnvl={}, localSize={}",
         globalRank,
@@ -122,7 +122,7 @@ TEST_F(TopologyDiscoveryE2eFixture, BasicTopologyClassification) {
   int nvlNRanks = static_cast<int>(result.nvlPeerRanks.size()) + 1;
   EXPECT_EQ(static_cast<int>(result.globalToNvlLocal.size()), nvlNRanks);
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {}: {} NVL peers, fabricAvailable={}",
       globalRank,
@@ -197,7 +197,7 @@ TEST_F(TopologyDiscoveryE2eFixture, PlatformNvlPeerCount) {
         << "Non-MNNVL: NVL peers should be same-host only";
   }
 
-  XLOGF(
+  COMMS_LOG(
       INFO,
       "Rank {} (localRank {}): isMnnvl={}, {} NVL peers (expected {})",
       globalRank,


### PR DESCRIPTION
Summary:

Migrate PRIMS benchmark and test logging to the shared spdlog path across NVLink, IBGDA, IBRC, collective, bootstrap, staging-buffer, topology, and window coverage.

Preserve rate limits, formatted diagnostics, error propagation, and capability-based skips while removing direct Folly logging dependencies from the affected targets.

Hot-path impact:
This diff changes benchmark and test code only. It adds no work to production device kernels, transport progress, or collective paths.

Reviewed By: shr

Differential Revision: D116694642
