### PR TITLE
Migrate CTRAN test logging (#3736)

### DIFF
--- a/comms/ctran/backends/ib/benchmarks/CtranIbBench.cc
+++ b/comms/ctran/backends/ib/benchmarks/CtranIbBench.cc
@@ -16,6 +16,7 @@
 #include "comms/ctran/backends/ib/BootstrapExternal.h"
 #include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/utils/Alloc.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/Exception.h"
 
 using namespace ctran;
@@ -194,11 +195,11 @@ static BenchmarkContext setupBenchmarkContext(size_t bufferSize) {
 
 static void cleanupBenchmarkContext(BenchmarkContext& ctx) {
   if (CtranIb::deregMem(ctx.senderRegHdl) != commSuccess) {
-    XLOGF(ERR, "deregMem failed for senderRegHdl");
+    CTRAN_LOG(ERR, "deregMem failed for senderRegHdl");
   }
 
   if (CtranIb::deregMem(ctx.receiverRegHdl) != commSuccess) {
-    XLOGF(ERR, "deregMem failed for receiverRegHdl");
+    CTRAN_LOG(ERR, "deregMem failed for receiverRegHdl");
   }
 
   // Free each buffer on the device it was allocated on (CUDA VMM unmap is
@@ -583,6 +584,7 @@ int main(int argc, char** argv) {
   // Initialize and run benchmark
   ::benchmark::Initialize(&argc, argv);
   folly::init(&argc, &argv);
+  ctran::logging::configureStandaloneCtranLogging(spdlog::level::info);
   ::benchmark::RunSpecifiedBenchmarks();
 
   // Cleanup

--- a/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <memory>
 #include <thread>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include <folly/SocketAddress.h>
 #include <folly/futures/Future.h>
@@ -681,7 +682,7 @@ class CtranIbAbortCtrlMsgTest
           &msg, sizeof(msg), kPeerRank, req, &peerServerAddr);
     }
 
-    XLOGF(INFO, "i(send|recv)CtrlMsg received result={}", result);
+    CTRAN_LOG(INFO, "i(send|recv)CtrlMsg received result={}", result);
 
     auto elapsed = std::chrono::steady_clock::now() - start;
 
@@ -694,7 +695,7 @@ class CtranIbAbortCtrlMsgTest
 
     EXPECT_LT(elapsed, 5s) << "Abort should fail quickly";
 
-    XLOGF(
+    CTRAN_LOG(
         INFO,
         "Control message {} {}",
         operation == CtrlMsgOperation::Send ? "send" : "recv",
@@ -1202,7 +1203,7 @@ TEST_F(CtranIbBootstrapCommonTest, AbortWaitNotify) {
     // Set timeout to abort waitNotify
     abortCtrl->startTimeout(std::chrono::milliseconds(500));
 
-    XLOG(INFO) << "Rank 0 calling ctranIb->waitNotify(1, 1)";
+    CTRAN_LOG_STREAM(INFO) << "Rank 0 calling ctranIb->waitNotify(1, 1)";
 
     // Try to wait for a notify that will never come
     auto startWaitNotify = std::chrono::steady_clock::now();
@@ -1212,7 +1213,7 @@ TEST_F(CtranIbBootstrapCommonTest, AbortWaitNotify) {
     // Should abort after timeout
     EXPECT_LT(elapsed, std::chrono::seconds(5));
     EXPECT_TRUE(abortCtrl->isAborted());
-    XLOGF(INFO, "Rank 0 waitNotify aborted by timeout as expected");
+    CTRAN_LOG(INFO, "Rank 0 waitNotify aborted by timeout as expected");
   };
 
   auto rank1Action = [this](
@@ -1227,7 +1228,7 @@ TEST_F(CtranIbBootstrapCommonTest, AbortWaitNotify) {
     // Don't send notifications - let rank 0 timeout
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    XLOGF(INFO, "Rank 1 completed without sending notify");
+    CTRAN_LOG(INFO, "Rank 1 completed without sending notify");
   };
 
   TwoRankTestHelper(rank0Action, rank1Action).run();
@@ -1235,24 +1236,26 @@ TEST_F(CtranIbBootstrapCommonTest, AbortWaitNotify) {
 
 // Test multiple sequential control messages over the same connection
 TEST_P(CtranIbBootstrapParameterizedTest, MultipleSequentialCtrlMsg) {
-  auto rank0Action = [this](
-                         CtranIb* ctranIb,
-                         const folly::SocketAddress& peerAddr,
-                         AbortPtr abortCtrl) {
-    SocketServerAddr peerServerAddr = getSocketServerAddress(
-        peerAddr.getPort(), peerAddr.getIPAddress().str().c_str(), "lo");
+  auto rank0Action =
+      [this](
+          CtranIb* ctranIb,
+          const folly::SocketAddress& peerAddr,
+          AbortPtr abortCtrl) {
+        SocketServerAddr peerServerAddr = getSocketServerAddress(
+            peerAddr.getPort(), peerAddr.getIPAddress().str().c_str(), "lo");
 
-    // Send first control message
-    sendCtrlMsg(ctranIb, /*peerRank=*/1, &peerServerAddr);
+        // Send first control message
+        sendCtrlMsg(ctranIb, /*peerRank=*/1, &peerServerAddr);
 
-    // Send second control message over the same established connection
-    sendCtrlMsg(ctranIb, /*peerRank=*/1, &peerServerAddr);
+        // Send second control message over the same established connection
+        sendCtrlMsg(ctranIb, /*peerRank=*/1, &peerServerAddr);
 
-    // Send third control message
-    sendCtrlMsg(ctranIb, /*peerRank=*/1, &peerServerAddr);
+        // Send third control message
+        sendCtrlMsg(ctranIb, /*peerRank=*/1, &peerServerAddr);
 
-    XLOG(INFO) << "Rank 0 successfully sent 3 sequential control messages";
-  };
+        CTRAN_LOG_STREAM(INFO)
+            << "Rank 0 successfully sent 3 sequential control messages";
+      };
 
   auto rank1Action = [this](
                          CtranIb* ctranIb,
@@ -1265,7 +1268,7 @@ TEST_P(CtranIbBootstrapParameterizedTest, MultipleSequentialCtrlMsg) {
     for (int i = 0; i < 3; ++i) {
       recvCtrlMsg(ctranIb, 0, &peerServerAddr);
 
-      XLOGF(INFO, "Rank 1 received control message {}", i + 1);
+      CTRAN_LOG(INFO, "Rank 1 received control message {}", i + 1);
     }
   };
 
@@ -1289,7 +1292,7 @@ TEST_P(CtranIbBootstrapParameterizedTest, BidirectionalCtrlMsg) {
     // Receive control message from rank 1
     recvCtrlMsg(ctranIb, /*peerRank=*/1, &peerServerAddr);
 
-    XLOG(INFO) << "Rank 0 completed bidirectional communication";
+    CTRAN_LOG_STREAM(INFO) << "Rank 0 completed bidirectional communication";
 
     rank0Complete.post();
     rank1Complete.wait();
@@ -1308,7 +1311,7 @@ TEST_P(CtranIbBootstrapParameterizedTest, BidirectionalCtrlMsg) {
     // Send control message to rank 0
     sendCtrlMsg(ctranIb, /*peerRank=*/0, &peerServerAddr);
 
-    XLOG(INFO) << "Rank 1 completed bidirectional communication";
+    CTRAN_LOG_STREAM(INFO) << "Rank 1 completed bidirectional communication";
 
     rank1Complete.post();
     rank0Complete.wait();
@@ -1369,8 +1372,8 @@ TEST_P(CtranIbBootstrapParameterizedTest, GetVcAfterConnection) {
       std::this_thread::sleep_for(10ms);
     }
 
-    XLOG(INFO) << "Rank 0 verified VC state and sent " << kNumNotifications
-               << " notifications";
+    CTRAN_LOG_STREAM(INFO) << "Rank 0 verified VC state and sent "
+                           << kNumNotifications << " notifications";
   };
 
   auto rank1Action = [this](
@@ -1433,8 +1436,8 @@ TEST_P(CtranIbBootstrapParameterizedTest, GetVcAfterConnection) {
     EXPECT_EQ(notificationsReceived, kNumNotifications)
         << "Should have received all notifications from rank 0";
 
-    XLOG(INFO) << "Rank 1 verified VC state and received "
-               << notificationsReceived << " notifications";
+    CTRAN_LOG_STREAM(INFO) << "Rank 1 verified VC state and received "
+                           << notificationsReceived << " notifications";
   };
 
   TwoRankTestHelper(rank0Action, rank1Action).run();

--- a/comms/ctran/backends/ib/tests/CtranIbCtrlMsgDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbCtrlMsgDistUT.cc
@@ -5,7 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/backends/ib/CtranIbBase.h"
@@ -37,9 +37,9 @@ class CtranIbCtrlMsgTest : public ctran::CtranDistTestFixture {
   }
 
   void printTestDesc(const std::string& testName, const std::string& testDesc) {
-    XLOG_IF(WARN, this->globalRank == 0)
+    CTRAN_LOG_STREAM_IF(WARN, this->globalRank == 0)
         << testName << " numRanks " << this->numRanks
-        << ". Description: " << testDesc << std::endl;
+        << ". Description: " << testDesc;
   }
 
  protected:

--- a/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
@@ -11,7 +11,7 @@
 
 #include <folly/ScopeGuard.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include <gmock/gmock.h>
 #include "comms/ctran/algos/common/GpeKernelSync.h"
@@ -58,9 +58,9 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
   void printTestDesc(const std::string& testName, const std::string& testDesc) {
     // NOTE: Printing it as WARN to make this log visible as our default setting
     // is to only print WARN and above logs.
-    XLOG_IF(WARN, this->globalRank == 0)
+    CTRAN_LOG_STREAM_IF(WARN, this->globalRank == 0)
         << testName << " numRanks " << this->numRanks
-        << ". Description: " << testDesc << std::endl;
+        << ". Description: " << testDesc;
   }
 
   size_t getIbRegCount() {

--- a/comms/ctran/backends/ib/tests/CtranIbDqplbRelayDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDqplbRelayDistUT.cc
@@ -13,7 +13,7 @@
 
 #include <folly/ScopeGuard.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/backends/ib/CtranIbBase.h"
@@ -49,8 +49,9 @@ class CtranIbDqplbRelayTest : public ctran::CtranDistTestFixture {
   }
 
   void printTestDesc(const std::string& testName, const std::string& testDesc) {
-    XLOG_IF(WARN, globalRank == 0) << testName << " numRanks " << numRanks
-                                   << ". Description: " << testDesc;
+    CTRAN_LOG_STREAM_IF(WARN, globalRank == 0)
+        << testName << " numRanks " << numRanks
+        << ". Description: " << testDesc;
   }
 
   size_t getIbRegCount() {
@@ -216,7 +217,7 @@ class CtranIbDqplbRelayTest : public ctran::CtranDistTestFixture {
       }
     }
 
-    XLOG_IF(WARN, globalRank == kSinkRank)
+    CTRAN_LOG_STREAM_IF(WARN, globalRank == kSinkRank)
         << "dqplb relay " << (notifyAll ? "notify-all" : "notify-last")
         << " rank1SinkFirstUnexpectedOffset="
         << observation->firstUnexpectedOffset
@@ -386,7 +387,7 @@ TEST_F(CtranIbDqplbRelayTest, DqplbGpuRelayNotifyLastOrderingObservation) {
   Observation observation;
   runRelayOrderingCase(/*notifyAll*/ false, &observation);
   if (globalRank == kSinkRank) {
-    XLOG_IF(WARN, observation.firstUnexpectedOffset >= 0)
+    CTRAN_LOG_STREAM_IF(WARN, observation.firstUnexpectedOffset >= 0)
         << "rank 1 received bytes other than rank 0 data after notify-last "
            "relay: firstUnexpectedOffset="
         << observation.firstUnexpectedOffset
@@ -394,7 +395,7 @@ TEST_F(CtranIbDqplbRelayTest, DqplbGpuRelayNotifyLastOrderingObservation) {
         << static_cast<int>(observation.firstUnexpectedValue)
         << " rank0ByteCount=" << observation.rank0ByteCount
         << " rank2InitByteCount=" << observation.rank2InitByteCount;
-    XLOG_IF(WARN, observation.firstUnexpectedOffset < 0)
+    CTRAN_LOG_STREAM_IF(WARN, observation.firstUnexpectedOffset < 0)
         << "notify-last relay did not reproduce stale rank 2 bytes in this "
            "run: rank0ByteCount="
         << observation.rank0ByteCount

--- a/comms/ctran/backends/tcpdevmem/tests/CtranTcpDmDistUT.cc
+++ b/comms/ctran/backends/tcpdevmem/tests/CtranTcpDmDistUT.cc
@@ -10,13 +10,13 @@
 
 #include <folly/ScopeGuard.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDm.h"
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.h"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/utils/Exception.h"
 #include "comms/testinfra/TestUtils.h"
@@ -66,7 +66,7 @@ class CtranTcpTest : public ctran::CtranDistTestFixture {
   void printTestDesc(const std::string& testName, const std::string& testDesc) {
     // NOTE: Printing it as WARN to make this log visible as our default setting
     // is to only print WARN and above logs.
-    CLOGF_IF(
+    CTRAN_LOG_IF(
         WARN,
         this->globalRank == 0,
         "{} numRanks {}. Description: {}",

--- a/comms/ctran/bootstrap/tests/AbortableSocketTest.cpp
+++ b/comms/ctran/bootstrap/tests/AbortableSocketTest.cpp
@@ -12,14 +12,19 @@
 
 #include <gtest/gtest.h>
 
-#include <folly/logging/xlog.h>
 #include <folly/synchronization/Baton.h>
 #include <folly/synchronization/Latch.h>
 
 #include "comms/ctran/bootstrap/AbortableSocket.h"
+#include "comms/ctran/bootstrap/tests/CtranLoggingEnvironment.h"
 
 using namespace ::testing;
 using namespace std::literals::chrono_literals;
+
+namespace {
+[[maybe_unused]] auto* const kCtranLoggingEnvironment =
+    ctran::bootstrap::testing::registerCtranLoggingEnvironment();
+} // namespace
 
 class AbortableServerSocketTest : public ::testing::Test {
  public:
@@ -196,7 +201,7 @@ TEST_F(AbortableSocketTest, MultipleConnectionAttempts) {
   ctran::bootstrap::AbortableServerSocket server{1};
 
   // Bind server on the loopback interface but do not listen
-  XLOG(INFO) << "Binding server..";
+  CTRAN_LOG_STREAM(INFO) << "Binding server..";
   ASSERT_EQ(0, server.bind(folly::SocketAddress("::1", 0), "lo"));
   const auto& maybeServerAddr = server.getListenAddress();
   ASSERT_FALSE(maybeServerAddr.hasError());
@@ -204,7 +209,7 @@ TEST_F(AbortableSocketTest, MultipleConnectionAttempts) {
 
   // Connect client to the server. It may experience few connect errors but
   // retry will eventually make it succeed
-  XLOG(INFO) << "Connecting to server..";
+  CTRAN_LOG_STREAM(INFO) << "Connecting to server..";
   auto abortCtrl = comms::fault_tolerance::createAbort(/*enabled=*/true);
   ctran::bootstrap::AbortableSocket client1(abortCtrl);
   std::atomic<int> result{-1};
@@ -223,7 +228,7 @@ TEST_F(AbortableSocketTest, ConnectionEventuallySucceeds) {
   ctran::bootstrap::AbortableServerSocket server{1};
 
   // Bind server on the loopback interface but do not listen
-  XLOG(INFO) << "Binding server..";
+  CTRAN_LOG_STREAM(INFO) << "Binding server..";
   ASSERT_EQ(0, server.bind(folly::SocketAddress("::1", 0), "lo"));
   const auto& maybeServerAddr = server.getListenAddress();
   ASSERT_FALSE(maybeServerAddr.hasError());
@@ -235,7 +240,7 @@ TEST_F(AbortableSocketTest, ConnectionEventuallySucceeds) {
   std::thread listenThread([&]() {
     connecting.wait();
     std::this_thread::sleep_for(100ms);
-    XLOG(INFO) << "Starting to listen on server";
+    CTRAN_LOG_STREAM(INFO) << "Starting to listen on server";
     ASSERT_EQ(0, server.listen());
   });
 
@@ -244,7 +249,7 @@ TEST_F(AbortableSocketTest, ConnectionEventuallySucceeds) {
   connecting.post();
 
   // Attempt to connect to server again .. we may succeed after few more retries
-  XLOG(INFO) << "Attempting to connect to server again..";
+  CTRAN_LOG_STREAM(INFO) << "Attempting to connect to server again..";
   ASSERT_EQ(
       0, client2.connect(serverAddr, "lo", 0ms /*ignored*/, 0 /*ignored*/));
   EXPECT_NE(client2.getFd(), -1);
@@ -446,7 +451,7 @@ TEST_F(AbortableSocketTest, CloseWhileOperationPending) {
     char buffer[100];
     int result = acceptedClient->recv(buffer, sizeof(buffer));
     EXPECT_NE(result, 0);
-    XLOG(INFO, "RecvThread is exiting");
+    CTRAN_LOG(INFO, "RecvThread is exiting");
   });
 
   std::this_thread::sleep_for(100ms);
@@ -489,7 +494,7 @@ TEST_F(AbortableSocketTest, CloseThreadSafety) {
     threads.emplace_back([this, &results, i, &successCount, &sync_point]() {
       sync_point.arrive_and_wait();
       results[i] = acceptedClient->close();
-      XLOGF(INFO, "Thread #{} closed socket with result={}", i, results[i]);
+      CTRAN_LOG(INFO, "Thread #{} closed socket with result={}", i, results[i]);
       if (results[i] == 0) {
         successCount++;
       }
@@ -709,8 +714,8 @@ TEST_F(AbortableSocketTest, AbortSendRecvConcurrent) {
       }
       std::this_thread::sleep_for(10ms);
       numSends += 1;
-      XLOG(INFO) << "Sent message #" << numSends.load()
-                 << ". sendResult=" << sendResult;
+      CTRAN_LOG_STREAM(INFO) << "Sent message #" << numSends.load()
+                             << ". sendResult=" << sendResult;
     } while (true);
   });
 
@@ -721,8 +726,8 @@ TEST_F(AbortableSocketTest, AbortSendRecvConcurrent) {
       char buffer[2048];
       recvResult = client.recv(buffer, sizeof(buffer));
       numRecvs += 1;
-      XLOG(INFO) << "Received message #" << numRecvs.load()
-                 << ". recvResult=" << recvResult;
+      CTRAN_LOG_STREAM(INFO) << "Received message #" << numRecvs.load()
+                             << ". recvResult=" << recvResult;
       if (recvResult.load() != 0 || numRecvs.load() >= messageLimit) {
         break;
       }

--- a/comms/ctran/bootstrap/tests/AsyncSocketTest.cpp
+++ b/comms/ctran/bootstrap/tests/AsyncSocketTest.cpp
@@ -5,21 +5,24 @@
 #include <gtest/gtest.h>
 
 #include <folly/io/async/ScopedEventBaseThread.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/ctran/bootstrap/AsyncSocket.h"
 #include "comms/ctran/bootstrap/Socket.h"
+#include "comms/ctran/bootstrap/tests/CtranLoggingEnvironment.h"
 
 using namespace ::testing;
 using namespace std::literals::chrono_literals;
 
 namespace {
+[[maybe_unused]] auto* const kCtranLoggingEnvironment =
+    ctran::bootstrap::testing::registerCtranLoggingEnvironment();
+
 enum ReqStatus {
   INCOMPLETE,
   COMPLETE,
   ERROR,
 };
-}
+} // namespace
 
 TEST(AsyncSocket, AsyncSocketLifeCycle) {
   const std::string request = "ping";
@@ -197,8 +200,13 @@ TEST(AsyncSocket, AsyncServerSocketReceiveTimeout) {
       [&recvCallbackInvoked](std::unique_ptr<folly::IOBuf> buf) {
         // This callback should NOT be invoked if timeout happens before data
         // arrives
-        XLOGF(INFO, "Server received {} bytes", buf->computeChainDataLength());
         recvCallbackInvoked.store(true);
+        if (buf == nullptr) {
+          ADD_FAILURE() << "Receive callback returned a null buffer";
+          return;
+        }
+        CTRAN_LOG(
+            INFO, "Server received {} bytes", buf->computeChainDataLength());
       },
       std::chrono::milliseconds(500)); // 500ms timeout
 
@@ -207,8 +215,8 @@ TEST(AsyncSocket, AsyncServerSocketReceiveTimeout) {
   // Connect a client but don't send any data (simulating hung client)
   ctran::bootstrap::Socket silentClient;
   ASSERT_EQ(0, silentClient.connect(serverAddr, "lo"));
-  XLOG(INFO) << "Client connected to server at " << serverAddr.describe()
-             << " but not sending data";
+  CTRAN_LOG_STREAM(INFO) << "Client connected to server at "
+                         << serverAddr.describe() << " but not sending data";
 
   // Wait for timeout to occur (timeout is 500ms, wait a bit longer to ensure
   // timeout fires)
@@ -297,8 +305,13 @@ TEST(AsyncSocket, AsyncServerSocketReceivePartialDataTimeout) {
       expectedSize,
       [&recvCallbackInvoked](std::unique_ptr<folly::IOBuf> buf) {
         // This callback should NOT be invoked if we only send partial data
-        XLOGF(INFO, "Server received {} bytes", buf->computeChainDataLength());
         recvCallbackInvoked.store(true);
+        if (buf == nullptr) {
+          ADD_FAILURE() << "Receive callback returned a null buffer";
+          return;
+        }
+        CTRAN_LOG(
+            INFO, "Server received {} bytes", buf->computeChainDataLength());
       },
       std::chrono::milliseconds(500)); // 500ms timeout
 
@@ -311,7 +324,7 @@ TEST(AsyncSocket, AsyncServerSocketReceivePartialDataTimeout) {
   // Send only 50 bytes when server expects 100 bytes
   const std::string partialData(50, 'x');
   ASSERT_EQ(0, partialClient.send(partialData.data(), partialData.size()));
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "Client sent {} bytes (partial), server expects {} bytes",
       partialData.size(),

--- a/comms/ctran/bootstrap/tests/CtranLoggingEnvironment.h
+++ b/comms/ctran/bootstrap/tests/CtranLoggingEnvironment.h
@@ -1,0 +1,22 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/utils/CtranLogger.h"
+
+namespace ctran::bootstrap::testing {
+
+class CtranLoggingEnvironment final : public ::testing::Environment {
+ public:
+  void SetUp() override {
+    logging::configureStandaloneCtranLogging(spdlog::level::info);
+  }
+};
+
+inline ::testing::Environment* registerCtranLoggingEnvironment() {
+  return ::testing::AddGlobalTestEnvironment(new CtranLoggingEnvironment);
+}
+
+} // namespace ctran::bootstrap::testing

--- a/comms/ctran/bootstrap/tests/SocketTest.cpp
+++ b/comms/ctran/bootstrap/tests/SocketTest.cpp
@@ -6,13 +6,17 @@
 
 #include <gtest/gtest.h>
 
-#include <folly/logging/xlog.h>
-
 #include "comms/ctran/bootstrap/Socket.h"
+#include "comms/ctran/bootstrap/tests/CtranLoggingEnvironment.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 using namespace ::testing;
 using namespace std::literals::chrono_literals;
+
+namespace {
+[[maybe_unused]] auto* const kCtranLoggingEnvironment =
+    ctran::bootstrap::testing::registerCtranLoggingEnvironment();
+} // namespace
 
 TEST(Socket, GetInterfaceAddress) {
   const bool kPreferV6{true};
@@ -49,7 +53,7 @@ TEST(Socket, GetInterfaceAddress) {
   maybeEth0Addr6 =
       ctran::bootstrap::getInterfaceAddress("eth0", "2401", kPreferV6);
   if (maybeEth0Addr6.hasValue()) {
-    XLOG(INFO) << "Found v6 address: " << maybeEth0Addr6->str();
+    CTRAN_LOG_STREAM(INFO) << "Found v6 address: " << maybeEth0Addr6->str();
     EXPECT_TRUE(maybeEth0Addr6->isV6());
     EXPECT_EQ(0, maybeEth0Addr6->str().find("2401"));
   }
@@ -170,7 +174,7 @@ TEST(Socket, ConnectRetries) {
   ctran::bootstrap::ServerSocket server{1};
 
   // Bind server on the loopback interface but do not listen
-  XLOG(INFO) << "Binding server..";
+  CTRAN_LOG_STREAM(INFO) << "Binding server..";
   ASSERT_EQ(0, server.bind(folly::SocketAddress("::1", 0), "lo"));
   const auto& maybeServerAddr = server.getListenAddress();
   ASSERT_FALSE(maybeServerAddr.hasError());
@@ -178,7 +182,7 @@ TEST(Socket, ConnectRetries) {
 
   // Connect client to the server. It may experience few connect errors but
   // retry will eventually make it succeed
-  XLOG(INFO) << "Connecting to server..";
+  CTRAN_LOG_STREAM(INFO) << "Connecting to server..";
   ctran::bootstrap::Socket client;
   ASSERT_EQ(
       ECONNREFUSED, client.connect(serverAddr, "lo", 100ms, 5 /* retries */));
@@ -187,12 +191,12 @@ TEST(Socket, ConnectRetries) {
   // Delay the listen in a separate thread to simulate a connect error
   std::thread listenThread([&]() {
     std::this_thread::sleep_for(500ms);
-    XLOG(INFO) << "Starting to listen on server";
+    CTRAN_LOG_STREAM(INFO) << "Starting to listen on server";
     ASSERT_EQ(0, server.listen());
   });
 
   // Attempt to connect to server again .. we may succeed after few more retries
-  XLOG(INFO) << "Attempting to connect to server again..";
+  CTRAN_LOG_STREAM(INFO) << "Attempting to connect to server again..";
   ASSERT_EQ(0, client.connect(serverAddr, "lo", 100ms, 10 /* retries */));
   EXPECT_NE(client.getFd(), -1);
 
@@ -272,26 +276,27 @@ TEST(Socket, SocketNonBlocking) {
       timeout_counter += 1;
       ret = poll(fds, 2, 500);
       if (ret == 0) {
-        XLOG(INFO) << "Poll timeout counter: " << timeout_counter;
+        CTRAN_LOG_STREAM(INFO) << "Poll timeout counter: " << timeout_counter;
         continue;
       } else if (ret < 0) {
-        XLOG(ERR) << "Poll error" << std::endl;
+        CTRAN_LOG_STREAM(ERR) << "Poll error";
         break;
       } else {
-        XLOG(INFO) << "Successfully polled " << ret << " fds";
+        CTRAN_LOG_STREAM(INFO) << "Successfully polled " << ret << " fds";
         for (int fid = 0; fid < 2; fid++) {
           if (fds[fid].revents & POLLIN) {
-            XLOG(INFO) << "fid: " << fid << " fd: " << fds[fid].fd
-                       << " revents: " << fds[fid].revents;
+            CTRAN_LOG_STREAM(INFO) << "fid: " << fid << " fd: " << fds[fid].fd
+                                   << " revents: " << fds[fid].revents;
             int rcvd = sockets[fid]->recvAsync(buffer, 100);
             if (rcvd < 0) {
-              XLOG(ERR) << "Read error" << std::endl;
+              CTRAN_LOG_STREAM(ERR) << "Read error";
               break;
             } else if (rcvd == 0) {
-              XLOG(INFO) << "Server closed the connection";
+              CTRAN_LOG_STREAM(INFO) << "Server closed the connection";
             } else {
-              XLOG(INFO) << "fd " << fds[fid].fd << " successfully read "
-                         << rcvd << " bytes";
+              CTRAN_LOG_STREAM(INFO)
+                  << "fd " << fds[fid].fd << " successfully read " << rcvd
+                  << " bytes";
 
               EXPECT_EQ(
                   0, std::memcmp(buffer, expected.data(), expected.size()));

--- a/comms/ctran/gpe/tests/CtranGpeFaultToleranceUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeFaultToleranceUT.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/ctran/gpe/tests/CtranGpeFaultToleranceUTBase.h"
+#include "comms/ctran/utils/CtranLogger.h"
 
 namespace ctran::fttesting {
 
@@ -193,7 +194,7 @@ void CtranGpeFTEnabledAbortTest::runTestWillAbort(
   auto waitMs = tryQueryStreamFor(stream, /*patience=*/statusCheckDelay);
 
   if (activeAbort) {
-    CLOGF(INFO, "host active abort");
+    CTRAN_LOG(INFO, "host active abort");
     ctranComm->setAbort();
     ASSERT_TRUE(ctranComm->testAbort());
     EXPECT_GE(waitMs, statusCheckDelay) << "kernel unblocked too early";

--- a/comms/ctran/gpe/tests/CtranGpeFaultToleranceUTBase.h
+++ b/comms/ctran/gpe/tests/CtranGpeFaultToleranceUTBase.h
@@ -4,6 +4,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include <cuda_runtime.h>
 
@@ -44,7 +45,7 @@ struct FtTestSync {
   void wait(std::chrono::milliseconds timeout) {
     bool signaled = baton_.try_wait_for(timeout);
     if (!signaled) {
-      CLOGF(INFO, "wait timeout");
+      CTRAN_LOG(INFO, "wait timeout");
     }
   }
 

--- a/comms/ctran/ibverbx/benchmarks/IbverbsCrossHostBench.cc
+++ b/comms/ctran/ibverbx/benchmarks/IbverbsCrossHostBench.cc
@@ -24,10 +24,10 @@
 
 #include <folly/init/Init.h>
 #include <folly/logging/Init.h>
-#include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
 
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -514,24 +514,6 @@ static QpExchangeInfo exchangeAndConnect(BenchmarkContext* ctx, int peerRank) {
 }
 
 //------------------------------------------------------------------------------
-// Poll completion queue helper
-//------------------------------------------------------------------------------
-
-static void pollCqUntilCompletion(BenchmarkContext* ctx) {
-  auto pollCqFn = ctx->endpoint->cq->context->ops.poll_cq;
-  while (true) {
-    int ne = pollCqFn(ctx->endpoint->cq, 1, &ctx->wc);
-    if (ne > 0) {
-      if (ctx->wc.status != ibverbx::IBV_WC_SUCCESS) {
-        XLOGF(ERR, "WC failed with status {}", ctx->wc.status);
-        throw std::runtime_error("Work completion failed");
-      }
-      break;
-    }
-  }
-}
-
-//------------------------------------------------------------------------------
 // Benchmark Result
 //------------------------------------------------------------------------------
 
@@ -575,7 +557,7 @@ class IbverbsBenchmarkFixture : public MpiBaseTestFixture {
     char* postBuf = ctx->sendBuf + ctx->msgSize - 1;
     volatile char* pollBuf = ctx->recvBuf + ctx->msgSize - 1;
 
-    XLOGF(INFO, "[Sender] Running ping-pong benchmark: {}", testName);
+    CTRAN_LOG(INFO, "[Sender] Running ping-pong benchmark: {}", testName);
 
     *postBuf = 0;
     *pollBuf = 0;
@@ -598,7 +580,8 @@ class IbverbsBenchmarkFixture : public MpiBaseTestFixture {
       }
     }
 
-    XLOG(INFO) << "[Sender] Warmup complete, starting measurement...";
+    CTRAN_LOG_STREAM(INFO)
+        << "[Sender] Warmup complete, starting measurement...";
 
     // Benchmark
     using Clock = std::chrono::high_resolution_clock;
@@ -649,7 +632,7 @@ class IbverbsBenchmarkFixture : public MpiBaseTestFixture {
     char* postBuf = ctx->sendBuf + ctx->msgSize - 1;
     volatile char* pollBuf = ctx->recvBuf + ctx->msgSize - 1;
 
-    XLOGF(INFO, "[Receiver] Running ping-pong benchmark: {}", testName);
+    CTRAN_LOG(INFO, "[Receiver] Running ping-pong benchmark: {}", testName);
 
     *postBuf = 0;
     *pollBuf = 0;
@@ -673,7 +656,7 @@ class IbverbsBenchmarkFixture : public MpiBaseTestFixture {
       }
     }
 
-    XLOGF(INFO, "[Receiver] Completed {} iterations", iterations);
+    CTRAN_LOG(INFO, "[Receiver] Completed {} iterations", iterations);
   }
 
   void printResultsTable(
@@ -799,7 +782,8 @@ class IbverbsBenchmarkFixture : public MpiBaseTestFixture {
 TEST_F(IbverbsBenchmarkFixture, CrossHostPingPongHalfRttLatency_RdmaWrite) {
   // Only test with 2 ranks (one per host)
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    CTRAN_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1251,7 +1235,8 @@ static BenchmarkResult runBandwidthBenchmark(
 
 TEST_F(IbverbsBenchmarkFixture, CrossHostFullRttLatency_RdmaWrite) {
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    CTRAN_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1307,7 +1292,8 @@ TEST_F(IbverbsBenchmarkFixture, CrossHostFullRttLatency_RdmaWrite) {
 
 TEST_F(IbverbsBenchmarkFixture, CrossHostFullRttLatency_RdmaRead) {
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    CTRAN_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1384,7 +1370,8 @@ TEST_F(IbverbsBenchmarkFixture, CrossHostFullRttLatency_RdmaRead) {
 
 TEST_F(IbverbsBenchmarkFixture, CrossHostFullRttLatency_RdmaWriteWithImm) {
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    CTRAN_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1442,7 +1429,8 @@ TEST_F(IbverbsBenchmarkFixture, CrossHostFullRttLatency_RdmaWriteWithImm) {
 
 TEST_F(IbverbsBenchmarkFixture, CrossHostBandwidth_RdmaWrite) {
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    CTRAN_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1505,5 +1493,6 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
   folly::Init init(&argc, &argv);
+  ctran::logging::configureStandaloneCtranLogging(spdlog::level::warn);
   return RUN_ALL_TESTS();
 }

--- a/comms/ctran/ibverbx/benchmarks/IbverbxDcBenchUtils.h
+++ b/comms/ctran/ibverbx/benchmarks/IbverbxDcBenchUtils.h
@@ -11,11 +11,11 @@
 
 #include <fmt/format.h>
 #include <folly/Expected.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/ctran/ibverbx/Ibverbx.h"
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
 #include "comms/ctran/ibverbx/tests/dc_utils.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 namespace ibverbx {
@@ -77,9 +77,9 @@ inline folly::Expected<RdmaResources, Error> initRdmaResources(
     return folly::makeUnexpected(Error(ENODEV, "Failed to get device list"));
   }
 
-  XLOGF(DBG, "Found {} RDMA devices", devices->size());
+  CTRAN_LOG(DBG, "Found {} RDMA devices", devices->size());
   for (size_t i = 0; i < devices->size(); ++i) {
-    XLOGF(DBG, "  Device {}: {}", i, devices->at(i).device()->name);
+    CTRAN_LOG(DBG, "  Device {}: {}", i, devices->at(i).device()->name);
   }
 
   if (deviceIndex < 0 || deviceIndex >= static_cast<int>(devices->size())) {
@@ -94,7 +94,7 @@ inline folly::Expected<RdmaResources, Error> initRdmaResources(
   RdmaResources resources;
   resources.device =
       std::make_unique<IbvDevice>(std::move(devices->at(deviceIndex)));
-  XLOGF(
+  CTRAN_LOG(
       DBG,
       "Using device {}: {}",
       deviceIndex,
@@ -173,12 +173,12 @@ class EndPointBase {
     while (completed < expectedCompletions) {
       int n = rawCq->context->ops.poll_cq(rawCq, 1, &wc);
       if (n < 0) {
-        XLOGF(ERR, "CQ poll error: returned {}", n);
+        CTRAN_LOG(ERR, "CQ poll error: returned {}", n);
         return false;
       }
       if (n == 1) {
         if (wc.status != IBV_WC_SUCCESS) {
-          XLOGF(
+          CTRAN_LOG(
               ERR,
               "WC error: status={}, opcode={}, vendor_err={}",
               wc.status,
@@ -192,7 +192,7 @@ class EndPointBase {
         auto elapsed = std::chrono::steady_clock::now() - start;
         if (std::chrono::duration_cast<std::chrono::milliseconds>(elapsed)
                 .count() > timeoutMs) {
-          XLOGF(
+          CTRAN_LOG(
               ERR,
               "CQ busy-spin timeout: got {}/{} completions",
               completed,
@@ -214,13 +214,13 @@ class EndPointBase {
     while (completed < expectedCompletions) {
       auto result = cq_->pollCq(expectedCompletions - completed);
       if (result.hasError()) {
-        XLOGF(ERR, "CQ poll error: {}", result.error().errStr);
+        CTRAN_LOG(ERR, "CQ poll error: {}", result.error().errStr);
         return false;
       }
 
       for (const auto& wc : *result) {
         if (wc.status != IBV_WC_SUCCESS) {
-          XLOGF(
+          CTRAN_LOG(
               ERR,
               "WC error: status={}, opcode={}, vendor_err={}",
               wc.status,
@@ -234,7 +234,7 @@ class EndPointBase {
       auto elapsed = std::chrono::steady_clock::now() - start;
       if (std::chrono::duration_cast<std::chrono::milliseconds>(elapsed)
               .count() > timeoutMs) {
-        XLOGF(
+        CTRAN_LOG(
             ERR,
             "CQ poll timeout: got {}/{} completions",
             completed,
@@ -388,19 +388,19 @@ class RdmaAvailabilityChecker {
 
     ncclCvarInit();
     if (!ibvInit()) {
-      XLOG(WARNING) << "Failed to initialize ibverbs";
+      CTRAN_LOG_STREAM(WARN) << "Failed to initialize ibverbs";
       return false;
     }
 
     auto devices = IbvDevice::ibvGetDeviceList(NCCL_IB_HCA, NCCL_IB_HCA_PREFIX);
     if (!devices || devices->empty()) {
-      XLOG(WARNING) << "No RDMA devices found";
+      CTRAN_LOG_STREAM(WARN) << "No RDMA devices found";
       return false;
     }
 
     if (devices->size() < 2) {
-      XLOG(WARNING) << "Need at least 2 RDMA devices, found "
-                    << devices->size();
+      CTRAN_LOG_STREAM(WARN)
+          << "Need at least 2 RDMA devices, found " << devices->size();
       return false;
     }
 
@@ -415,14 +415,14 @@ class RdmaAvailabilityChecker {
     dcChecked_ = true;
 
     if (!checkRdmaAvailable()) {
-      XLOG(WARNING) << "DC check: RDMA not available";
+      CTRAN_LOG_STREAM(WARN) << "DC check: RDMA not available";
       return false;
     }
 
     ncclCvarInit();
     auto devices = IbvDevice::ibvGetDeviceList(NCCL_IB_HCA, NCCL_IB_HCA_PREFIX);
     if (!devices || devices->empty()) {
-      XLOG(WARNING) << "DC check: No RDMA devices found";
+      CTRAN_LOG_STREAM(WARN) << "DC check: No RDMA devices found";
       return false;
     }
 
@@ -431,8 +431,8 @@ class RdmaAvailabilityChecker {
       DcEndPoint testEndpoint;
       auto initResult = testEndpoint.init(static_cast<int>(i));
       if (!initResult) {
-        XLOGF(
-            WARNING,
+        CTRAN_LOG(
+            WARN,
             "DC check: device {} ({}) init failed: {}",
             i,
             devices->at(i).device()->name,
@@ -442,8 +442,8 @@ class RdmaAvailabilityChecker {
 
       auto dcResult = testEndpoint.initDc();
       if (!dcResult) {
-        XLOGF(
-            WARNING,
+        CTRAN_LOG(
+            WARN,
             "DC check: device {} ({}) initDc failed: {}",
             i,
             devices->at(i).device()->name,
@@ -451,7 +451,7 @@ class RdmaAvailabilityChecker {
         continue;
       }
 
-      XLOGF(
+      CTRAN_LOG(
           DBG,
           "DC check: device {} ({}) supports DC",
           i,
@@ -460,8 +460,8 @@ class RdmaAvailabilityChecker {
     }
 
     if (dcCapableDevices.size() < 2) {
-      XLOGF(
-          WARNING,
+      CTRAN_LOG(
+          WARN,
           "Need at least 2 DC-capable devices, found {}",
           dcCapableDevices.size());
       return false;
@@ -469,7 +469,7 @@ class RdmaAvailabilityChecker {
 
     dcCapableDevices_ = std::move(dcCapableDevices);
     dcAvailable_ = true;
-    XLOGF(
+    CTRAN_LOG(
         DBG,
         "DC transport is available - using devices {} and {} for benchmarks",
         dcCapableDevices_[0],
@@ -714,12 +714,12 @@ inline bool pollCqBusySpin(
   while (completed < expected) {
     int n = rawCq->context->ops.poll_cq(rawCq, 1, &wc);
     if (n < 0) {
-      XLOGF(ERR, "CQ poll error: returned {}", n);
+      CTRAN_LOG(ERR, "CQ poll error: returned {}", n);
       return false;
     }
     if (n == 1) {
       if (wc.status != IBV_WC_SUCCESS) {
-        XLOGF(
+        CTRAN_LOG(
             ERR,
             "WC error: status={}, opcode={}, vendor_err={}",
             wc.status,
@@ -732,7 +732,7 @@ inline bool pollCqBusySpin(
       auto elapsed = std::chrono::steady_clock::now() - start;
       if (std::chrono::duration_cast<std::chrono::milliseconds>(elapsed)
               .count() > timeoutMs) {
-        XLOGF(
+        CTRAN_LOG(
             ERR,
             "CQ busy-spin timeout: got {}/{} completions",
             completed,

--- a/comms/ctran/ibverbx/benchmarks/IbverbxDcConnectionProbeBench.cc
+++ b/comms/ctran/ibverbx/benchmarks/IbverbxDcConnectionProbeBench.cc
@@ -22,7 +22,6 @@
 
 #include <folly/init/Init.h>
 #include <folly/logging/Init.h>
-#include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
 
 #include "comms/ctran/ibverbx/Ibverbx.h"

--- a/comms/ctran/ibverbx/benchmarks/IbverbxDcOneToManyBench.cc
+++ b/comms/ctran/ibverbx/benchmarks/IbverbxDcOneToManyBench.cc
@@ -44,13 +44,13 @@
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 #include <folly/logging/Init.h>
-#include <folly/logging/xlog.h>
 #include <gflags/gflags.h>
 
 #include "comms/ctran/ibverbx/Ibverbx.h"
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
 #include "comms/ctran/ibverbx/benchmarks/IbverbxDcBenchUtils.h"
 #include "comms/ctran/ibverbx/tests/dc_utils.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/testinfra/BenchUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -92,7 +92,7 @@ bool initResources(
     folly::UserCounters& counters) {
   auto result = initRdmaResources(deviceIndex, kSharedCqDepth);
   if (!result) {
-    XLOGF(
+    CTRAN_LOG(
         ERR,
         "Failed to initialize RDMA resources for device {}: {}",
         deviceIndex,
@@ -1348,18 +1348,20 @@ BENCHMARK_DRAW_LINE();
 
 int main(int argc, char** argv) {
   folly::Init init(&argc, &argv);
+  ctran::logging::configureStandaloneCtranLogging(spdlog::level::warn);
 
-  XLOG(INFO) << "DC vs RC RDMA Scalability Benchmark";
-  XLOG(INFO) << "====================================";
-  XLOG(INFO) << "Total input size: " << kTotalInputSize << " bytes (128 MB)";
-  XLOG(INFO) << "Shared CQ depth: " << kSharedCqDepth;
-  XLOG(INFO) << "DCI SQ depth: " << kDciSqDepth;
-  XLOG(INFO) << "RC QP SQ depth: " << kRcQpSqDepth;
+  CTRAN_LOG_STREAM(INFO) << "DC vs RC RDMA Scalability Benchmark";
+  CTRAN_LOG_STREAM(INFO) << "====================================";
+  CTRAN_LOG_STREAM(INFO) << "Total input size: " << kTotalInputSize
+                         << " bytes (128 MB)";
+  CTRAN_LOG_STREAM(INFO) << "Shared CQ depth: " << kSharedCqDepth;
+  CTRAN_LOG_STREAM(INFO) << "DCI SQ depth: " << kDciSqDepth;
+  CTRAN_LOG_STREAM(INFO) << "RC QP SQ depth: " << kRcQpSqDepth;
 
   if (!g_rdmaAvailability.checkRdmaAvailable()) {
-    XLOG(ERR) << "RDMA not available - benchmarks will be skipped";
+    CTRAN_LOG_STREAM(ERR) << "RDMA not available - benchmarks will be skipped";
   } else {
-    XLOG(INFO) << "RDMA devices available";
+    CTRAN_LOG_STREAM(INFO) << "RDMA devices available";
   }
 
   // Suppress folly benchmark table when --raw_only is set

--- a/comms/ctran/ibverbx/benchmarks/IbverbxDcP2PBench.cc
+++ b/comms/ctran/ibverbx/benchmarks/IbverbxDcP2PBench.cc
@@ -29,13 +29,13 @@
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 #include <folly/logging/Init.h>
-#include <folly/logging/xlog.h>
 #include <gflags/gflags.h>
 
 #include "comms/ctran/ibverbx/Ibverbx.h"
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
 #include "comms/ctran/ibverbx/benchmarks/IbverbxDcBenchUtils.h"
 #include "comms/ctran/ibverbx/tests/dc_utils.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/testinfra/BenchUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -89,12 +89,13 @@ struct DcBenchmarkState {
     auto senderInitResult =
         sender->init(g_rdmaAvailability.dcCapableDevices()[0]);
     if (!senderInitResult) {
-      XLOGF(ERR, "Sender init failed: {}", senderInitResult.error().errStr);
+      CTRAN_LOG(ERR, "Sender init failed: {}", senderInitResult.error().errStr);
       return false;
     }
     auto senderDcResult = sender->initDc();
     if (!senderDcResult) {
-      XLOGF(ERR, "Sender DC init failed: {}", senderDcResult.error().errStr);
+      CTRAN_LOG(
+          ERR, "Sender DC init failed: {}", senderDcResult.error().errStr);
       return false;
     }
 
@@ -103,12 +104,13 @@ struct DcBenchmarkState {
     auto receiverInitResult =
         receiver->init(g_rdmaAvailability.dcCapableDevices()[1]);
     if (!receiverInitResult) {
-      XLOGF(ERR, "Receiver init failed: {}", receiverInitResult.error().errStr);
+      CTRAN_LOG(
+          ERR, "Receiver init failed: {}", receiverInitResult.error().errStr);
       return false;
     }
     auto receiverDcResult = receiver->initDc();
     if (!receiverDcResult) {
-      XLOGF(
+      CTRAN_LOG(
           ERR, "Receiver DC init failed: {}", receiverDcResult.error().errStr);
       return false;
     }
@@ -117,7 +119,7 @@ struct DcBenchmarkState {
     auto senderMrResult =
         sender->registerMr(senderBuf.data(), senderBuf.size());
     if (!senderMrResult) {
-      XLOGF(ERR, "Sender MR failed: {}", senderMrResult.error().errStr);
+      CTRAN_LOG(ERR, "Sender MR failed: {}", senderMrResult.error().errStr);
       return false;
     }
     senderMr = std::make_unique<IbvMr>(std::move(*senderMrResult));
@@ -125,7 +127,7 @@ struct DcBenchmarkState {
     auto receiverMrResult =
         receiver->registerMr(receiverBuf.data(), receiverBuf.size());
     if (!receiverMrResult) {
-      XLOGF(ERR, "Receiver MR failed: {}", receiverMrResult.error().errStr);
+      CTRAN_LOG(ERR, "Receiver MR failed: {}", receiverMrResult.error().errStr);
       return false;
     }
     receiverMr = std::make_unique<IbvMr>(std::move(*receiverMrResult));
@@ -139,7 +141,7 @@ struct DcBenchmarkState {
     // Create address handle from sender to receiver
     auto ahResult = sender->createAh(receiverCard);
     if (!ahResult) {
-      XLOGF(ERR, "AH creation failed: {}", ahResult.error().errStr);
+      CTRAN_LOG(ERR, "AH creation failed: {}", ahResult.error().errStr);
       return false;
     }
     ah = std::make_unique<IbvAh>(std::move(*ahResult));
@@ -195,12 +197,13 @@ struct RcBenchmarkState {
     sender = std::make_unique<RcEndPoint>();
     auto senderInitResult = sender->init(senderDevIdx);
     if (!senderInitResult) {
-      XLOGF(ERR, "Sender init failed: {}", senderInitResult.error().errStr);
+      CTRAN_LOG(ERR, "Sender init failed: {}", senderInitResult.error().errStr);
       return false;
     }
     auto senderRcResult = sender->initRc();
     if (!senderRcResult) {
-      XLOGF(ERR, "Sender RC init failed: {}", senderRcResult.error().errStr);
+      CTRAN_LOG(
+          ERR, "Sender RC init failed: {}", senderRcResult.error().errStr);
       return false;
     }
 
@@ -209,12 +212,13 @@ struct RcBenchmarkState {
     receiver = std::make_unique<RcEndPoint>();
     auto receiverInitResult = receiver->init(receiverDevIdx);
     if (!receiverInitResult) {
-      XLOGF(ERR, "Receiver init failed: {}", receiverInitResult.error().errStr);
+      CTRAN_LOG(
+          ERR, "Receiver init failed: {}", receiverInitResult.error().errStr);
       return false;
     }
     auto receiverRcResult = receiver->initRc();
     if (!receiverRcResult) {
-      XLOGF(
+      CTRAN_LOG(
           ERR, "Receiver RC init failed: {}", receiverRcResult.error().errStr);
       return false;
     }
@@ -223,7 +227,7 @@ struct RcBenchmarkState {
     auto senderMrResult =
         sender->registerMr(senderBuf.data(), senderBuf.size());
     if (!senderMrResult) {
-      XLOGF(ERR, "Sender MR failed: {}", senderMrResult.error().errStr);
+      CTRAN_LOG(ERR, "Sender MR failed: {}", senderMrResult.error().errStr);
       return false;
     }
     senderMr = std::make_unique<IbvMr>(std::move(*senderMrResult));
@@ -231,7 +235,7 @@ struct RcBenchmarkState {
     auto receiverMrResult =
         receiver->registerMr(receiverBuf.data(), receiverBuf.size());
     if (!receiverMrResult) {
-      XLOGF(ERR, "Receiver MR failed: {}", receiverMrResult.error().errStr);
+      CTRAN_LOG(ERR, "Receiver MR failed: {}", receiverMrResult.error().errStr);
       return false;
     }
     receiverMr = std::make_unique<IbvMr>(std::move(*receiverMrResult));
@@ -245,14 +249,14 @@ struct RcBenchmarkState {
     // Connect QPs (bidirectional)
     auto senderConnectResult = sender->connect(receiverCard);
     if (!senderConnectResult) {
-      XLOGF(
+      CTRAN_LOG(
           ERR, "Sender connect failed: {}", senderConnectResult.error().errStr);
       return false;
     }
 
     auto receiverConnectResult = receiver->connect(senderCard);
     if (!receiverConnectResult) {
-      XLOGF(
+      CTRAN_LOG(
           ERR,
           "Receiver connect failed: {}",
           receiverConnectResult.error().errStr);
@@ -723,14 +727,15 @@ BENCHMARK_MULTI_PARAM_COUNTERS(rcQpCreation, rc_qp_init);
 
 int main(int argc, char** argv) {
   folly::Init init(&argc, &argv);
+  ctran::logging::configureStandaloneCtranLogging(spdlog::level::warn);
 
-  XLOG(INFO) << "DC vs RC RDMA Single-Pair Benchmark";
-  XLOG(INFO) << "===================================";
+  CTRAN_LOG_STREAM(INFO) << "DC vs RC RDMA Single-Pair Benchmark";
+  CTRAN_LOG_STREAM(INFO) << "===================================";
 
   if (!g_rdmaAvailability.checkRdmaAvailable()) {
-    XLOG(ERR) << "RDMA not available - benchmarks will be skipped";
+    CTRAN_LOG_STREAM(ERR) << "RDMA not available - benchmarks will be skipped";
   } else {
-    XLOG(INFO) << "RDMA devices available - running benchmarks";
+    CTRAN_LOG_STREAM(INFO) << "RDMA devices available - running benchmarks";
   }
 
   // Suppress folly benchmark table when --raw_only is set

--- a/comms/ctran/ibverbx/benchmarks/IbverbxVirtualQpCrossHostBench.cc
+++ b/comms/ctran/ibverbx/benchmarks/IbverbxVirtualQpCrossHostBench.cc
@@ -23,10 +23,10 @@
 
 #include <folly/init/Init.h>
 #include <folly/logging/Init.h>
-#include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
 
 #include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -474,7 +474,7 @@ static void pollCqUntilCompletion(IbvVirtualCq& cq) {
     if (maybeWcs && !maybeWcs->empty()) {
       const auto& wc = maybeWcs->at(0);
       if (wc.status != IBV_WC_SUCCESS) {
-        XLOGF(ERR, "WC failed with status {}", wc.status);
+        CTRAN_LOG(ERR, "WC failed with status {}", wc.status);
         throw std::runtime_error("Work completion failed");
       }
       break;
@@ -521,7 +521,7 @@ class IbverbxVirtualQpBenchmarkFixture : public MpiBaseTestFixture {
     char* postBuf = ctx->sendBuf + ctx->msgSize - 1;
     volatile char* pollBuf = ctx->recvBuf + ctx->msgSize - 1;
 
-    XLOGF(INFO, "[Sender] Running ping-pong benchmark: {}", testName);
+    CTRAN_LOG(INFO, "[Sender] Running ping-pong benchmark: {}", testName);
 
     *postBuf = 0;
     *pollBuf = 0;
@@ -540,7 +540,8 @@ class IbverbxVirtualQpBenchmarkFixture : public MpiBaseTestFixture {
       }
     }
 
-    XLOG(INFO) << "[Sender] Warmup complete, starting measurement...";
+    CTRAN_LOG_STREAM(INFO)
+        << "[Sender] Warmup complete, starting measurement...";
 
     // Benchmark
     using Clock = std::chrono::high_resolution_clock;
@@ -590,7 +591,7 @@ class IbverbxVirtualQpBenchmarkFixture : public MpiBaseTestFixture {
     char* postBuf = ctx->sendBuf + ctx->msgSize - 1;
     volatile char* pollBuf = ctx->recvBuf + ctx->msgSize - 1;
 
-    XLOGF(INFO, "[Receiver] Running ping-pong benchmark: {}", testName);
+    CTRAN_LOG(INFO, "[Receiver] Running ping-pong benchmark: {}", testName);
 
     *postBuf = 0;
     *pollBuf = 0;
@@ -610,7 +611,7 @@ class IbverbxVirtualQpBenchmarkFixture : public MpiBaseTestFixture {
       pollCqUntilCompletion(ctx->endpoint->cq);
     }
 
-    XLOGF(INFO, "[Receiver] Completed {} iterations", iterations);
+    CTRAN_LOG(INFO, "[Receiver] Completed {} iterations", iterations);
   }
 
   void printResultsTable(
@@ -739,7 +740,8 @@ TEST_F(
     CrossHostPingPongHalfRttLatency_RdmaWrite) {
   // Only test with 2 ranks (one per host)
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    CTRAN_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1145,7 +1147,8 @@ static BenchmarkResult runBandwidthBenchmark(
 
 TEST_F(IbverbxVirtualQpBenchmarkFixture, CrossHostFullRttLatency_RdmaWrite) {
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    CTRAN_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1201,7 +1204,8 @@ TEST_F(IbverbxVirtualQpBenchmarkFixture, CrossHostFullRttLatency_RdmaWrite) {
 
 TEST_F(IbverbxVirtualQpBenchmarkFixture, CrossHostFullRttLatency_RdmaRead) {
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    CTRAN_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1280,7 +1284,8 @@ TEST_F(
     IbverbxVirtualQpBenchmarkFixture,
     CrossHostFullRttLatency_RdmaWriteWithImm) {
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    CTRAN_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1336,7 +1341,8 @@ TEST_F(
 // TODO: Fix and re-enable bandwidth test
 TEST_F(IbverbxVirtualQpBenchmarkFixture, CrossHostBandwidth_RdmaWrite) {
   if (numRanks != 2) {
-    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    CTRAN_LOG(
+        INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
   }
 
@@ -1400,5 +1406,6 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
   folly::Init init(&argc, &argv);
+  ctran::logging::configureStandaloneCtranLogging(spdlog::level::warn);
   return RUN_ALL_TESTS();
 }

--- a/comms/ctran/ibverbx/tests/IbverbxDcMultiRankTest.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxDcMultiRankTest.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <optional>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include <cuda.h>
 #include <cuda_runtime.h>
@@ -165,7 +166,7 @@ TEST_F(DcMultiRankTestFixture, RingRdmaWrite) {
 
   for (int i = 0; i < numRanks; i++) {
     const auto& card = cards.at(i);
-    XLOG(INFO) << "rank " << globalRank << ": got card " << card;
+    CTRAN_LOG_STREAM(INFO) << "rank " << globalRank << ": got card " << card;
   }
 
   // Send to next rank, receive from previous rank
@@ -173,7 +174,7 @@ TEST_F(DcMultiRankTestFixture, RingRdmaWrite) {
   int recvFromRank = (globalRank + numRanks - 1) % numRanks;
   const auto& targetCard = cards.at(sendToRank);
 
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "rank {}: sending to rank {}, receiving from rank {}",
       globalRank,
@@ -217,7 +218,8 @@ TEST_F(DcMultiRankTestFixture, RingRdmaWrite) {
   int ret = ibverbx::ibvSymbols.ibv_internal_wr_complete(exQp_);
   ASSERT_EQ(ret, 0) << "Failed to post DC RDMA write";
 
-  XLOGF(INFO, "Rank {}: Posted RDMA write to rank {}", globalRank, sendToRank);
+  CTRAN_LOG(
+      INFO, "Rank {}: Posted RDMA write to rank {}", globalRank, sendToRank);
 
   // Wait for send completion only (plain RDMA write has no receiver completion)
   auto pollResult = pollCqForCompletions(globalRank, *cq_, 1);
@@ -236,7 +238,7 @@ TEST_F(DcMultiRankTestFixture, RingRdmaWrite) {
   ASSERT_EQ(recvBuf, expectedBuf)
       << "Data mismatch: expected data from rank " << recvFromRank;
 
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "Rank {}: Ring RDMA write test passed - verified data from rank {}",
       globalRank,
@@ -326,11 +328,12 @@ TEST_F(DcMultiRankTestFixture, AllToAllRdmaWrite) {
 
     int recvFromRank = i;
     int sendToRank = i;
-    XLOG(INFO) << "rank " << globalRank << ": sending to rank " << sendToRank
-               << ", receiving from rank " << recvFromRank;
+    CTRAN_LOG_STREAM(INFO) << "rank " << globalRank << ": sending to rank "
+                           << sendToRank << ", receiving from rank "
+                           << recvFromRank;
 
     const auto& card = cards.at(i);
-    XLOG(INFO) << "rank " << globalRank << ": got card " << card;
+    CTRAN_LOG_STREAM(INFO) << "rank " << globalRank << ": got card " << card;
 
     // Each sender writes to their designated slot in the receiver's buffer
     uint64_t targetAddr = card.remoteAddr + (globalRank * slotSize);
@@ -354,7 +357,7 @@ TEST_F(DcMultiRankTestFixture, AllToAllRdmaWrite) {
                       << recvFromRank;
   }
 
-  XLOGF(INFO, "Rank {}: Posted RDMA write to all other ranks", globalRank);
+  CTRAN_LOG(INFO, "Rank {}: Posted RDMA write to all other ranks", globalRank);
 
   // Wait for send completions only (plain RDMA write has no receiver
   // completion)
@@ -384,7 +387,7 @@ TEST_F(DcMultiRankTestFixture, AllToAllRdmaWrite) {
   ASSERT_EQ(recvHostBuf, expectedBuf)
       << "Data mismatch in all-to-all verification at rank " << globalRank;
 
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "Rank {}: All-to-all RDMA write test passed - verified data from all {} peers",
       globalRank,
@@ -399,5 +402,6 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new meta::comms::MPIEnvironmentBase);
   folly::Init init(&argc, &argv);
+  ctran::logging::configureStandaloneCtranLogging(spdlog::level::warn);
   return RUN_ALL_TESTS();
 }

--- a/comms/ctran/ibverbx/tests/IbverbxDciStreamsTest.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxDciStreamsTest.cc
@@ -6,8 +6,8 @@
 
 #include <folly/init/Init.h>
 #include <folly/logging/Init.h>
-#include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include "comms/ctran/ibverbx/Ibverbx.h"
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
@@ -161,7 +161,7 @@ TEST_F(DciStreamsTestFixture, DciStreamsMultiTargetWrite) {
   auto pollOk1 = pollCqForCompletions(0, *cq_, 1);
   ASSERT_TRUE(pollOk1) << "stream 0 -> DCT-A poll failed: "
                        << pollOk1.error().errStr;
-  XLOG(INFO) << "stream_id=0 -> DCT-A: success";
+  CTRAN_LOG_STREAM(INFO) << "stream_id=0 -> DCT-A: success";
 
   // Post RDMA write with stream_id=1 to DCT-B
   ASSERT_EQ(postDcRdmaWriteStream(exQp_, dvQp_, *ahB_, cardB_, sge_, 1, 1), 0)
@@ -170,7 +170,7 @@ TEST_F(DciStreamsTestFixture, DciStreamsMultiTargetWrite) {
   auto pollOk2 = pollCqForCompletions(0, *cq_, 1);
   ASSERT_TRUE(pollOk2) << "stream 1 -> DCT-B poll failed: "
                        << pollOk2.error().errStr;
-  XLOG(INFO) << "stream_id=1 -> DCT-B: success";
+  CTRAN_LOG_STREAM(INFO) << "stream_id=1 -> DCT-B: success";
 
   // Verify DCI is still in RTS after successful multi-stream writes
   {
@@ -181,7 +181,7 @@ TEST_F(DciStreamsTestFixture, DciStreamsMultiTargetWrite) {
         << "DCI should remain in RTS after successful writes";
   }
 
-  XLOG(INFO) << "Multi-target stream writes verified successfully.";
+  CTRAN_LOG_STREAM(INFO) << "Multi-target stream writes verified successfully.";
 }
 
 // Kill one peer (DCT-B), keep sending on both streams.
@@ -193,10 +193,10 @@ TEST_F(DciStreamsTestFixture, DciStreamsFaultIsolation) {
       postDcRdmaWriteStream(exQp_, dvQp_, *ahA_, cardA_, sge_, 100, 0), 0);
   auto preOk = pollCqForCompletions(0, *cq_, 1);
   ASSERT_TRUE(preOk) << "Pre-kill stream 0 -> DCT-A failed";
-  XLOG(INFO) << "Pre-kill: stream_id=0 -> DCT-A: success";
+  CTRAN_LOG_STREAM(INFO) << "Pre-kill: stream_id=0 -> DCT-A: success";
 
   // --- Step 2: Kill DCT-B (simulate peer going down) ---
-  XLOG(INFO) << "Destroying DCT-B (simulating peer failure)";
+  CTRAN_LOG_STREAM(INFO) << "Destroying DCT-B (simulating peer failure)";
   dctB_.reset();
 
   // --- Step 3: Send to dead DCT-B on stream 1 → expect error ---
@@ -215,7 +215,7 @@ TEST_F(DciStreamsTestFixture, DciStreamsFaultIsolation) {
             << "Expected error completion for dead DCT-B";
         EXPECT_EQ(wc.wr_id, 1u) << "Error should be for stream 1 (wr_id=1)";
         gotError = true;
-        XLOGF(
+        CTRAN_LOG(
             INFO,
             "stream_id=1 -> dead DCT-B: error status={}, vendor_err={}",
             wc.status,
@@ -234,10 +234,10 @@ TEST_F(DciStreamsTestFixture, DciStreamsFaultIsolation) {
     auto queryResult = dci_->queryQp(IBV_QP_STATE);
     ASSERT_TRUE(queryResult) << "queryQp failed";
     auto& [qpAttr, qpInitAttr] = *queryResult;
-    XLOGF(INFO, "DCI QP state after stream error: {}", qpAttr.qp_state);
+    CTRAN_LOG(INFO, "DCI QP state after stream error: {}", qpAttr.qp_state);
 
     if (qpAttr.qp_state != IBV_QPS_RTS) {
-      XLOGF(
+      CTRAN_LOG(
           WARN,
           "DCI moved to state {} (not RTS). HW max_log_num_errored may be 0, "
           "meaning 1 errored stream pushes the DCI to ERR. Fault isolation "
@@ -255,14 +255,15 @@ TEST_F(DciStreamsTestFixture, DciStreamsFaultIsolation) {
   // --- Step 5: Keep sending on healthy stream 0 to live DCT-A ---
   // With max_log_num_errored=0, the DCI may report RTS but still fail on
   // other streams. True fault isolation requires max_log_num_errored > 0.
-  XLOG(INFO) << "DCI still in RTS — sending on healthy stream to live peer";
+  CTRAN_LOG_STREAM(INFO)
+      << "DCI still in RTS — sending on healthy stream to live peer";
   ASSERT_EQ(postDcRdmaWriteStream(exQp_, dvQp_, *ahA_, cardA_, sge_, 2, 0), 0);
 
   // Poll — on HW with max_log_num_errored=0, this may fail even though the
   // DCI is in RTS, because the errored stream contaminates the DCI.
   auto pollOk = pollCqForCompletions(0, *cq_, 1);
   if (pollOk.hasError()) {
-    XLOGF(
+    CTRAN_LOG(
         WARN,
         "Post-kill stream 0 -> DCT-A failed: {}. "
         "DCI is in RTS but errored stream contaminated other streams. "
@@ -273,19 +274,19 @@ TEST_F(DciStreamsTestFixture, DciStreamsFaultIsolation) {
         << "Firmware max_log_num_errored=0 does not provide true fault "
         << "isolation: " << pollOk.error().errStr;
   }
-  XLOG(INFO)
+  CTRAN_LOG_STREAM(INFO)
       << "Post-kill: stream_id=0 -> DCT-A: success. Fault isolation verified.";
 
   // --- Step 6: Try resetting the errored stream if supported ---
   auto resetResult = resetDciStream(*dci_, 1);
   if (resetResult.hasError()) {
-    XLOGF(
+    CTRAN_LOG(
         INFO,
         "dci_stream_id_reset not supported (errno={}): {}",
         resetResult.error().errNum,
         resetResult.error().errStr);
   } else {
-    XLOG(INFO) << "stream_id=1 reset successfully";
+    CTRAN_LOG_STREAM(INFO) << "stream_id=1 reset successfully";
   }
 }
 
@@ -306,10 +307,11 @@ TEST_F(DciStreamsTestFixture, DciStreamsCompletionClassification) {
   auto preOk = pollCqForCompletions(0, *cq_, kWrsPerStream);
   ASSERT_TRUE(preOk) << "Pre-kill stream 0 writes failed: "
                      << preOk.error().errStr;
-  XLOG(INFO) << "Pre-kill: 3 WRs on stream 0 -> DCT-A all succeeded";
+  CTRAN_LOG_STREAM(INFO)
+      << "Pre-kill: 3 WRs on stream 0 -> DCT-A all succeeded";
 
   // --- Step 2: Kill DCT-B ---
-  XLOG(INFO) << "Destroying DCT-B (simulating peer failure)";
+  CTRAN_LOG_STREAM(INFO) << "Destroying DCT-B (simulating peer failure)";
   dctB_.reset();
 
   // --- Step 3: Post 3 WRs on stream 1 to dead DCT-B ---
@@ -368,7 +370,7 @@ TEST_F(DciStreamsTestFixture, DciStreamsCompletionClassification) {
         ok ? stream1Success++ : stream1Error++;
       }
 
-      XLOGF(
+      CTRAN_LOG(
           INFO,
           "  WC: stream={}, seq={}, status={}, vendor_err={} [{}]",
           sid,
@@ -390,18 +392,18 @@ TEST_F(DciStreamsTestFixture, DciStreamsCompletionClassification) {
 
   int stuck = kTotalPosted - totalPolled;
 
-  XLOG(INFO) << "=== Completion Classification ===";
-  XLOGF(
+  CTRAN_LOG_STREAM(INFO) << "=== Completion Classification ===";
+  CTRAN_LOG(
       INFO,
       "  Stream 0 (live DCT-A):  {} success, {} error",
       stream0Success,
       stream0Error);
-  XLOGF(
+  CTRAN_LOG(
       INFO,
       "  Stream 1 (dead DCT-B): {} success, {} error",
       stream1Success,
       stream1Error);
-  XLOGF(INFO, "  Stuck (no completion):  {}", stuck);
+  CTRAN_LOG(INFO, "  Stuck (no completion):  {}", stuck);
 
   // Stream 1 should have errors (sent to dead DCT)
   EXPECT_GT(stream1Error, 0) << "Expected errors on stream 1 (dead DCT-B)";
@@ -412,18 +414,20 @@ TEST_F(DciStreamsTestFixture, DciStreamsCompletionClassification) {
     auto queryResult = dci_->queryQp(IBV_QP_STATE);
     ASSERT_TRUE(queryResult);
     auto& [qpAttr, qpInitAttr] = *queryResult;
-    XLOGF(INFO, "  DCI QP state: {}", qpAttr.qp_state);
+    CTRAN_LOG(INFO, "  DCI QP state: {}", qpAttr.qp_state);
   }
 
   // On HW with max_log_num_errored=0, stream 0's post-kill WRs may also
   // error or be stuck. Log it either way — the classification is the value.
   if (stream0Error > 0 || stuck > 0) {
-    XLOG(INFO) << "  Note: stream 0 WRs also affected — fault isolation not "
-               << "available (max_log_num_errored likely 0)";
+    CTRAN_LOG_STREAM(INFO)
+        << "  Note: stream 0 WRs also affected — fault isolation not "
+        << "available (max_log_num_errored likely 0)";
   }
   if (stream0Success == kWrsPerStream && stream0Error == 0) {
-    XLOG(INFO) << "  Fault isolation confirmed: stream 0 fully operational "
-               << "despite stream 1 errors";
+    CTRAN_LOG_STREAM(INFO)
+        << "  Fault isolation confirmed: stream 0 fully operational "
+        << "despite stream 1 errors";
   }
 }
 
@@ -432,5 +436,6 @@ TEST_F(DciStreamsTestFixture, DciStreamsCompletionClassification) {
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   folly::Init init(&argc, &argv);
+  ctran::logging::configureStandaloneCtranLogging(spdlog::level::warn);
   return RUN_ALL_TESTS();
 }

--- a/comms/ctran/ibverbx/tests/IbverbxDistributedTest.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxDistributedTest.cc
@@ -6,6 +6,7 @@
 #include <folly/logging/Init.h>
 #include <gtest/gtest.h>
 #include <numeric>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include "comms/ctran/ibverbx/Ibverbx.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
@@ -171,7 +172,7 @@ void pollOneWcFromCq(int rank, IbvCq& cq) {
   while (!stop) {
     auto maybeWcsVector = cq.pollCq(numEntries);
     if (maybeWcsVector.hasError()) {
-      XLOGF(
+      CTRAN_LOG(
           FATAL,
           "rank {}: cq poll failed with error {}",
           rank,
@@ -183,7 +184,7 @@ void pollOneWcFromCq(int rank, IbvCq& cq) {
     ASSERT_GE(numWc, 0);
     if (numWc == 0) {
       // CQ empty, sleep and retry
-      XLOGF(WARN, "rank {}: cq empty, retry in 500ms", rank);
+      CTRAN_LOG(WARN, "rank {}: cq empty, retry in 500ms", rank);
       /* sleep override */
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
       continue;
@@ -193,8 +194,8 @@ void pollOneWcFromCq(int rank, IbvCq& cq) {
 
     // got a WC
     const auto wc = maybeWcsVector->at(0);
-    XLOGF(
-        DBG1,
+    CTRAN_LOG(
+        DBG5,
         "Rank {} got a wc: wr_id {}, status {}, opcode {}, byte_len {}",
         rank,
         wc.wr_id,
@@ -371,7 +372,7 @@ void IbverbxSingleQpTestFixtureWithParam::runSendRecvTest(int devBufSize) {
       MPI_COMM_WORLD));
   for (int i = 0; i < numRanks; ++i) {
     const auto& card = cards.at(i);
-    XLOG(DBG1) << "rank " << globalRank << ": got card " << card;
+    CTRAN_LOG_STREAM(DBG5) << "rank " << globalRank << ": got card " << card;
   }
 
   const auto& remoteCard = globalRank == 0 ? cards.at(1) : cards.at(0);
@@ -429,7 +430,7 @@ void IbverbxSingleQpTestFixtureWithParam::runSendRecvTest(int devBufSize) {
     ASSERT_TRUE(qp->postSend(&sendWr, &sendWrBad));
     pollOneWcFromCq(globalRank, *cq);
   }
-  XLOGF(DBG1, "rank {} send/recv OK", globalRank);
+  CTRAN_LOG(DBG5, "rank {} send/recv OK", globalRank);
 
   CUDA_CHECK(cudaFree(devBuf));
 }
@@ -516,7 +517,7 @@ void IbverbxSingleQpTestFixtureWithParam::runRdmaWriteTest(int devBufSize) {
       MPI_COMM_WORLD));
   for (int i = 0; i < numRanks; ++i) {
     const auto& card = cards.at(i);
-    XLOG(DBG1) << "rank " << globalRank << ": got card " << card;
+    CTRAN_LOG_STREAM(DBG5) << "rank " << globalRank << ": got card " << card;
   }
 
   const auto& remoteCard = globalRank == 0 ? cards.at(1) : cards.at(0);
@@ -580,7 +581,7 @@ void IbverbxSingleQpTestFixtureWithParam::runRdmaWriteTest(int devBufSize) {
     // the remote NIC/PCIe has completed memory transaction and sent an ACK to
     // us
   }
-  XLOGF(DBG1, "rank {} RDMA-WRITE OK", globalRank);
+  CTRAN_LOG(DBG5, "rank {} RDMA-WRITE OK", globalRank);
 
   CUDA_CHECK(cudaFree(devBuf));
 }
@@ -625,7 +626,7 @@ TEST_F(IbverbxSingleQpTestFixture, IbvQpModifyQp) {
       MPI_COMM_WORLD));
   for (int i = 0; i < numRanks; ++i) {
     const auto& card = cards.at(i);
-    XLOG(DBG1) << "rank " << globalRank << ": got card " << card;
+    CTRAN_LOG_STREAM(DBG5) << "rank " << globalRank << ": got card " << card;
   }
 
   const auto& remoteCard = globalRank == 0 ? cards.at(1) : cards.at(0);
@@ -704,5 +705,6 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
   folly::Init init(&argc, &argv);
+  ctran::logging::configureStandaloneCtranLogging(spdlog::level::warn);
   return RUN_ALL_TESTS();
 }

--- a/comms/ctran/ibverbx/tests/IbverbxDistributedVirtualQpGb200Test.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxDistributedVirtualQpGb200Test.cc
@@ -7,6 +7,7 @@
 #include <folly/logging/Init.h>
 #include <gtest/gtest.h>
 #include <numeric>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include "comms/ctran/ibverbx/Ibverbx.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
@@ -466,7 +467,7 @@ class IbverbxVirtualQpTestFixture : public MpiBaseTestFixture {
         MPI_COMM_WORLD));
     for (int i = 0; i < numRanks; ++i) {
       const auto& card = cards.at(i);
-      XLOG(DBG1) << "rank " << globalRank << ": got card " << card;
+      CTRAN_LOG_STREAM(DBG5) << "rank " << globalRank << ": got card " << card;
     }
     const auto& remoteCard = globalRank == 0 ? cards.at(1) : cards.at(0);
 
@@ -765,7 +766,7 @@ void IbverbxVirtualQpRdmaWriteTestFixture::runRdmaWriteVirtualQpTest(
     ASSERT_GE(numWc, 0);
     if (numWc == 0) {
       // CQ empty, sleep and retry
-      XLOGF(WARN, "rank {}: cq empty, retry in 500ms", globalRank);
+      CTRAN_LOG(WARN, "rank {}: cq empty, retry in 500ms", globalRank);
       /* sleep override */
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
       continue;
@@ -782,7 +783,7 @@ void IbverbxVirtualQpRdmaWriteTestFixture::runRdmaWriteVirtualQpTest(
     // layer (SPRAY uses it for notify signaling, DQPLB uses it for
     // sequence tracking). User-level immData is not forwarded through
     // the virtual completion path.
-    XLOGF(DBG1, "Rank {} got a wc: wr_id {}", globalRank, wc.wrId);
+    CTRAN_LOG(DBG5, "Rank {} got a wc: wr_id {}", globalRank, wc.wrId);
     stop = true;
   }
 
@@ -808,7 +809,7 @@ void IbverbxVirtualQpRdmaWriteTestFixture::runRdmaWriteVirtualQpTest(
     CUDA_CHECK(cudaDeviceSynchronize());
     ASSERT_EQ(hostExpectedBuf, hostRecvBuf);
   }
-  XLOGF(DBG1, "rank {} RDMA-WRITE OK", globalRank);
+  CTRAN_LOG(DBG5, "rank {} RDMA-WRITE OK", globalRank);
 
   // Clean up device buffer
   CUDA_CHECK(cudaFree(setup.devBuf));
@@ -859,7 +860,7 @@ void IbverbxVirtualQpRdmaReadTestFixture::runRdmaReadVirtualQpTest(
       ASSERT_GE(numWc, 0);
       if (numWc == 0) {
         // CQ empty, sleep and retry
-        XLOGF(WARN, "rank {}: cq empty, retry in 500ms", globalRank);
+        CTRAN_LOG(WARN, "rank {}: cq empty, retry in 500ms", globalRank);
         /* sleep override */
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
         continue;
@@ -871,7 +872,7 @@ void IbverbxVirtualQpRdmaReadTestFixture::runRdmaReadVirtualQpTest(
       const auto wc = maybeWcsVector->at(0);
       ASSERT_EQ(wc.wrId, wr_id);
       ASSERT_EQ(wc.status, IBV_WC_SUCCESS);
-      XLOGF(DBG1, "Rank {} got a wc: wr_id {}", globalRank, wc.wrId);
+      CTRAN_LOG(DBG5, "Rank {} got a wc: wr_id {}", globalRank, wc.wrId);
       break;
     }
 
@@ -903,7 +904,7 @@ void IbverbxVirtualQpRdmaReadTestFixture::runRdmaReadVirtualQpTest(
   // are ready before continuing, since a control QP is not available.
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
-  XLOGF(DBG1, "rank {} RDMA-READ OK", globalRank);
+  CTRAN_LOG(DBG5, "rank {} RDMA-READ OK", globalRank);
 
   // Clean up device buffer
   CUDA_CHECK(cudaFree(setup.devBuf));
@@ -950,7 +951,7 @@ void IbverbxVirtualQpSendRecvTestFixture::runSendRecvVirtualQpTest(
     ASSERT_GE(numWc, 0);
     if (numWc == 0) {
       // CQ empty, sleep and retry
-      XLOGF(WARN, "rank {}: cq empty, retry in 500ms", globalRank);
+      CTRAN_LOG(WARN, "rank {}: cq empty, retry in 500ms", globalRank);
       /* sleep override */
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
       continue;
@@ -971,7 +972,7 @@ void IbverbxVirtualQpSendRecvTestFixture::runSendRecvVirtualQpTest(
       // byte_len here.
       ASSERT_EQ(wc.byteLen, devBufSize);
     }
-    XLOGF(DBG1, "Rank {} got a wc: wr_id {}", globalRank, wc.wrId);
+    CTRAN_LOG(DBG5, "Rank {} got a wc: wr_id {}", globalRank, wc.wrId);
     stop = true;
   }
 
@@ -997,7 +998,7 @@ void IbverbxVirtualQpSendRecvTestFixture::runSendRecvVirtualQpTest(
     CUDA_CHECK(cudaDeviceSynchronize());
     ASSERT_EQ(hostExpectedBuf, hostRecvBuf);
   }
-  XLOGF(DBG1, "rank {} send/recv OK", globalRank);
+  CTRAN_LOG(DBG5, "rank {} send/recv OK", globalRank);
 
   // Clean up device buffer
   CUDA_CHECK(cudaFree(setup.devBuf));
@@ -1285,5 +1286,6 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
   folly::Init init(&argc, &argv);
+  ctran::logging::configureStandaloneCtranLogging(spdlog::level::warn);
   return RUN_ALL_TESTS();
 }

--- a/comms/ctran/ibverbx/tests/IbverbxDistributedVirtualQpTest.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxDistributedVirtualQpTest.cc
@@ -6,6 +6,7 @@
 #include <folly/logging/Init.h>
 #include <gtest/gtest.h>
 #include <numeric>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include "comms/ctran/ibverbx/Ibverbx.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
@@ -296,7 +297,7 @@ class IbverbxVirtualQpTestFixture : public MpiBaseTestFixture {
         MPI_COMM_WORLD));
     for (int i = 0; i < numRanks; ++i) {
       const auto& card = cards.at(i);
-      XLOG(DBG1) << "rank " << globalRank << ": got card " << card;
+      CTRAN_LOG_STREAM(DBG5) << "rank " << globalRank << ": got card " << card;
     }
     const auto& remoteCard = globalRank == 0 ? cards.at(1) : cards.at(0);
 
@@ -395,7 +396,7 @@ TEST_F(IbverbxVirtualQpTestFixture, IbvVirtualQpModifyVirtualQp) {
       MPI_COMM_WORLD));
   for (int i = 0; i < numRanks; ++i) {
     const auto& card = cards.at(i);
-    XLOG(DBG1) << "rank " << globalRank << ": got card " << card;
+    CTRAN_LOG_STREAM(DBG5) << "rank " << globalRank << ": got card " << card;
   }
   const auto& remoteCard = globalRank == 0 ? cards.at(1) : cards.at(0);
 
@@ -530,7 +531,7 @@ TEST_F(IbverbxVirtualQpTestFixture, IbvVirtualQpMultipleRdmaWrites) {
       MPI_COMM_WORLD));
   for (int i = 0; i < numRanks; ++i) {
     const auto& card = cards.at(i);
-    XLOG(DBG1) << "rank " << globalRank << ": got card " << card;
+    CTRAN_LOG_STREAM(DBG5) << "rank " << globalRank << ": got card " << card;
   }
   const auto& remoteCard = globalRank == 0 ? cards.at(1) : cards.at(0);
 
@@ -631,7 +632,7 @@ TEST_F(IbverbxVirtualQpTestFixture, IbvVirtualQpMultipleRdmaWrites) {
 
     if (numWc == 0) {
       // CQ empty, sleep and retry
-      XLOGF(WARN, "rank {}: cq empty, retry in 500ms", globalRank);
+      CTRAN_LOG(WARN, "rank {}: cq empty, retry in 500ms", globalRank);
       /* sleep override */
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
       continue;
@@ -652,7 +653,7 @@ TEST_F(IbverbxVirtualQpTestFixture, IbvVirtualQpMultipleRdmaWrites) {
         ASSERT_TRUE(wc.wrId == 0 || wc.wrId == 1);
       }
 
-      XLOGF(INFO, "Rank {} got WC: wrId {}", globalRank, wc.wrId);
+      CTRAN_LOG(INFO, "Rank {} got WC: wrId {}", globalRank, wc.wrId);
       completedOps++;
     }
   }
@@ -671,11 +672,12 @@ TEST_F(IbverbxVirtualQpTestFixture, IbvVirtualQpMultipleRdmaWrites) {
     CUDA_CHECK(cudaDeviceSynchronize());
 
     ASSERT_EQ(hostExpectedBuf, hostRecvBuf);
-    XLOGF(INFO, "rank {} verified data matches second RDMA write", globalRank);
+    CTRAN_LOG(
+        INFO, "rank {} verified data matches second RDMA write", globalRank);
   }
 
-  XLOGF(
-      DBG1,
+  CTRAN_LOG(
+      DBG5,
       "rank {} multiple RDMA writes test completed successfully",
       globalRank);
 
@@ -926,7 +928,7 @@ void IbverbxVirtualQpRdmaWriteTestFixture::runRdmaWriteVirtualQpTest(
     ASSERT_GE(numWc, 0);
     if (numWc == 0) {
       // CQ empty, sleep and retry
-      XLOGF(WARN, "rank {}: cq empty, retry in 500ms", globalRank);
+      CTRAN_LOG(WARN, "rank {}: cq empty, retry in 500ms", globalRank);
       /* sleep override */
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
       continue;
@@ -943,7 +945,7 @@ void IbverbxVirtualQpRdmaWriteTestFixture::runRdmaWriteVirtualQpTest(
     // layer (SPRAY uses it for notify signaling, DQPLB uses it for
     // sequence tracking). User-level immData is not forwarded through
     // the virtual completion path.
-    XLOGF(DBG1, "Rank {} got a wc: wrId {}", globalRank, wc.wrId);
+    CTRAN_LOG(DBG5, "Rank {} got a wc: wrId {}", globalRank, wc.wrId);
     stop = true;
   }
 
@@ -969,7 +971,7 @@ void IbverbxVirtualQpRdmaWriteTestFixture::runRdmaWriteVirtualQpTest(
     CUDA_CHECK(cudaDeviceSynchronize());
     ASSERT_EQ(hostExpectedBuf, hostRecvBuf);
   }
-  XLOGF(DBG1, "rank {} RDMA-WRITE OK", globalRank);
+  CTRAN_LOG(DBG5, "rank {} RDMA-WRITE OK", globalRank);
 
   // Clean up device buffer
   CUDA_CHECK(cudaFree(setup.devBuf));
@@ -1022,7 +1024,7 @@ void IbverbxVirtualQpRdmaReadTestFixture::runRdmaReadVirtualQpTest(
       ASSERT_GE(numWc, 0);
       if (numWc == 0) {
         // CQ empty, sleep and retry
-        XLOGF(WARN, "rank {}: cq empty, retry in 500ms", globalRank);
+        CTRAN_LOG(WARN, "rank {}: cq empty, retry in 500ms", globalRank);
         /* sleep override */
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
         continue;
@@ -1034,7 +1036,7 @@ void IbverbxVirtualQpRdmaReadTestFixture::runRdmaReadVirtualQpTest(
       const auto wc = maybeWcsVector->at(0);
       ASSERT_EQ(wc.wrId, wr_id);
       ASSERT_EQ(wc.status, IBV_WC_SUCCESS);
-      XLOGF(DBG1, "Rank {} got a wc: wrId {}", globalRank, wc.wrId);
+      CTRAN_LOG(DBG5, "Rank {} got a wc: wrId {}", globalRank, wc.wrId);
       break;
     }
 
@@ -1066,7 +1068,7 @@ void IbverbxVirtualQpRdmaReadTestFixture::runRdmaReadVirtualQpTest(
   // are ready before continuing, since a control QP is not available.
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
-  XLOGF(DBG1, "rank {} RDMA-READ OK", globalRank);
+  CTRAN_LOG(DBG5, "rank {} RDMA-READ OK", globalRank);
 
   // Clean up device buffer
   CUDA_CHECK(cudaFree(setup.devBuf));
@@ -1117,7 +1119,7 @@ void IbverbxVirtualQpSendRecvTestFixture::runSendRecvVirtualQpTest(
     ASSERT_GE(numWc, 0);
     if (numWc == 0) {
       // CQ empty, sleep and retry
-      XLOGF(WARN, "rank {}: cq empty, retry in 500ms", globalRank);
+      CTRAN_LOG(WARN, "rank {}: cq empty, retry in 500ms", globalRank);
       /* sleep override */
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
       continue;
@@ -1138,7 +1140,7 @@ void IbverbxVirtualQpSendRecvTestFixture::runSendRecvVirtualQpTest(
       // byteLen here.
       ASSERT_EQ(wc.byteLen, devBufSize);
     }
-    XLOGF(DBG1, "Rank {} got a wc: wrId {}", globalRank, wc.wrId);
+    CTRAN_LOG(DBG5, "Rank {} got a wc: wrId {}", globalRank, wc.wrId);
     stop = true;
   }
 
@@ -1164,7 +1166,7 @@ void IbverbxVirtualQpSendRecvTestFixture::runSendRecvVirtualQpTest(
     CUDA_CHECK(cudaDeviceSynchronize());
     ASSERT_EQ(hostExpectedBuf, hostRecvBuf);
   }
-  XLOGF(DBG1, "rank {} send/recv OK", globalRank);
+  CTRAN_LOG(DBG5, "rank {} send/recv OK", globalRank);
 
   // Clean up device buffer
   CUDA_CHECK(cudaFree(setup.devBuf));
@@ -1452,5 +1454,6 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new MPIEnvironmentBase);
   folly::Init init(&argc, &argv);
+  ctran::logging::configureStandaloneCtranLogging(spdlog::level::warn);
   return RUN_ALL_TESTS();
 }

--- a/comms/ctran/ibverbx/tests/dc_utils.cc
+++ b/comms/ctran/ibverbx/tests/dc_utils.cc
@@ -5,7 +5,7 @@
 #include <chrono>
 
 #include <fmt/format.h>
-#include <folly/logging/xlog.h>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
 
@@ -270,8 +270,8 @@ folly::Expected<folly::Unit, Error> pollCqForCompletions(
                 wc.vendor_err)));
       }
       completedCount++;
-      XLOGF(
-          DBG1,
+      CTRAN_LOG(
+          DBG5,
           "Rank {} got WC {}/{}: wr_id={}, opcode={}",
           rank,
           completedCount,

--- a/comms/ctran/mapper/tests/CtranMapperUT.cc
+++ b/comms/ctran/mapper/tests/CtranMapperUT.cc
@@ -2,6 +2,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include <cstdlib>
 #include <memory>
@@ -1451,7 +1452,7 @@ class CtranMapperTestDisjoint : public ::testing::Test {
     }
     usedDisjointAllocation = true;
 
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "Disjoint allocation created {} segments: seg0[{}, {}], seg1[{}, {}]",
         segments.size(),
@@ -1462,7 +1463,7 @@ class CtranMapperTestDisjoint : public ::testing::Test {
 
     buf = (char*)bufBase + offset;
 
-    CLOGF(INFO, "bufBase: {}, buf: {}", bufBase, buf);
+    CTRAN_LOG(INFO, "bufBase: {}, buf: {}", bufBase, buf);
 
     // Turn on profiler after initialization to track only test registrations
     NCCL_CTRAN_REGISTER_REPORT_SNAPSHOT_COUNT = 0;

--- a/comms/ctran/regcache/tests/RegCacheBench.cc
+++ b/comms/ctran/regcache/tests/RegCacheBench.cc
@@ -9,6 +9,7 @@
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/regcache/RegCache.h"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/testinfra/TestUtils.h"
 
 class RegCacheBench : public ctran::CtranDistTestFixture {
@@ -72,7 +73,7 @@ TEST_P(RegCacheTestParam, RegMemAndSearchRegHandleTime) {
     allSegments.insert(allSegments.end(), segments.begin(), segments.end());
   }
 
-  XLOG(INFO) << fmt::format(
+  CTRAN_LOG_STREAM(INFO) << fmt::format(
       "offset={}, numSegments={}, segmentSize={}, allSegments.size={},"
       " allBufs.size={}",
       offset,

--- a/comms/ctran/tests/CtranAllGatherTest.cc
+++ b/comms/ctran/tests/CtranAllGatherTest.cc
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <vector>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -90,7 +91,8 @@ class CtranAllGatherTest : public CtranIntraProcessFixture,
   void runAllGather(size_t sendCount, PerRankState& state) {
     validateConfigs(sendCount * kNRanks);
 
-    CLOGF(INFO, "rank {} allGather with {} sendCount", state.rank, sendCount);
+    CTRAN_LOG(
+        INFO, "rank {} allGather with {} sendCount", state.rank, sendCount);
 
     initBufferValues(sendCount, state);
 
@@ -109,7 +111,7 @@ class CtranAllGatherTest : public CtranIntraProcessFixture,
       state.ctranComm->ctran_->commDeregister(srcHandle);
     };
 
-    CLOGF(INFO, "rank {} allGather completed registration", state.rank);
+    CTRAN_LOG(INFO, "rank {} allGather completed registration", state.rank);
 
     if (!ctranAllGatherSupport(state.ctranComm.get(), NCCL_ALLGATHER_ALGO)) {
       GTEST_SKIP() << "ctranAllGatherSupport returns fails, skip test";
@@ -124,14 +126,14 @@ class CtranAllGatherTest : public CtranIntraProcessFixture,
         NCCL_ALLGATHER_ALGO);
     EXPECT_EQ(commSuccess, result);
 
-    CLOGF(INFO, "rank {} allGather scheduled", state.rank);
+    CTRAN_LOG(INFO, "rank {} allGather scheduled", state.rank);
 
     EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(state.stream));
     EXPECT_EQ(commSuccess, state.ctranComm->getAsyncResult());
 
     validateAllGatherData(sendCount, state);
 
-    CLOGF(INFO, "rank {} allGather task completed", state.rank);
+    CTRAN_LOG(INFO, "rank {} allGather task completed", state.rank);
   }
 
   void validateAllGatherData(size_t sendCount, PerRankState& state) {

--- a/comms/ctran/tests/CtranAllReduceTest.cc
+++ b/comms/ctran/tests/CtranAllReduceTest.cc
@@ -4,6 +4,7 @@
 #include <future>
 #include <memory>
 #include <optional>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -71,7 +72,7 @@ class CtranAllReduceTest
       std::optional<std::chrono::milliseconds> timeout = std::nullopt) {
     validateConfigs(nElem);
 
-    CLOGF(INFO, "rank {} allReduce with {} elems", state.rank, nElem);
+    CTRAN_LOG(INFO, "rank {} allReduce with {} elems", state.rank, nElem);
 
     void* srcHandle;
     void* dstHandle;
@@ -89,7 +90,7 @@ class CtranAllReduceTest
       state.ctranComm->ctran_->commDeregister(srcHandle);
     };
 
-    CLOGF(INFO, "rank {} allReduce completed registration", state.rank);
+    CTRAN_LOG(INFO, "rank {} allReduce completed registration", state.rank);
 
     EXPECT_EQ(
         commSuccess,
@@ -107,7 +108,7 @@ class CtranAllReduceTest
       workEnqueued->post();
     }
 
-    CLOGF(
+    CTRAN_LOG(
         INFO,
         "rank {} allReduce scheduled, expecting {}",
         state.rank,
@@ -124,7 +125,7 @@ class CtranAllReduceTest
       EXPECT_EQ(commRemoteError, state.ctranComm->getAsyncResult());
     }
 
-    CLOGF(INFO, "rank {} allReduce task completed", state.rank);
+    CTRAN_LOG(INFO, "rank {} allReduce task completed", state.rank);
   }
 
   void runTestRanksAbsent(
@@ -538,7 +539,7 @@ class CtranAllReduceRingOneRankTest : public CtranIntraProcessFixture {
         state.ctranComm->ctran_->commDeregister(srcHandle);
       };
 
-      CLOGF(INFO, "rank {} allReduce completed registration", state.rank);
+      CTRAN_LOG(INFO, "rank {} allReduce completed registration", state.rank);
 
       EXPECT_EQ(
           commSuccess,
@@ -553,13 +554,13 @@ class CtranAllReduceRingOneRankTest : public CtranIntraProcessFixture {
               NCCL_ALLREDUCE_ALGO::ctring,
               /*timeout=*/std::nullopt));
 
-      CLOGF(INFO, "rank {} allReduce scheduled", state.rank);
+      CTRAN_LOG(INFO, "rank {} allReduce scheduled", state.rank);
 
       // ensure async execution completion and no error
       EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(state.stream));
       EXPECT_EQ(commSuccess, state.ctranComm->getAsyncResult());
 
-      CLOGF(INFO, "rank {} allReduce task completed", state.rank);
+      CTRAN_LOG(INFO, "rank {} allReduce task completed", state.rank);
 
       // validate results
       ASSERT_EQ(

--- a/comms/ctran/tests/CtranBroadcastTest.cc
+++ b/comms/ctran/tests/CtranBroadcastTest.cc
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <vector>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -83,7 +84,7 @@ class CtranBroadcastTest : public CtranIntraProcessFixture,
   void runBroadcast(size_t nElem, PerRankState& state, int root = 0) {
     validateConfigs(nElem);
 
-    CLOGF(INFO, "rank {} broadcast with {} elems", state.rank, nElem);
+    CTRAN_LOG(INFO, "rank {} broadcast with {} elems", state.rank, nElem);
 
     initBufferValues(nElem, state);
 
@@ -102,7 +103,7 @@ class CtranBroadcastTest : public CtranIntraProcessFixture,
       state.ctranComm->ctran_->commDeregister(srcHandle);
     };
 
-    CLOGF(INFO, "rank {} broadcast completed registration", state.rank);
+    CTRAN_LOG(INFO, "rank {} broadcast completed registration", state.rank);
 
     auto result = ctranBroadcast(
         state.srcBuffer,
@@ -115,14 +116,14 @@ class CtranBroadcastTest : public CtranIntraProcessFixture,
         NCCL_BROADCAST_ALGO);
     EXPECT_EQ(commSuccess, result);
 
-    CLOGF(INFO, "rank {} broadcast scheduled", state.rank);
+    CTRAN_LOG(INFO, "rank {} broadcast scheduled", state.rank);
 
     EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(state.stream));
     EXPECT_EQ(commSuccess, state.ctranComm->getAsyncResult());
 
     validateBroadcastData(nElem, state, root);
 
-    CLOGF(INFO, "rank {} broadcast task completed", state.rank);
+    CTRAN_LOG(INFO, "rank {} broadcast task completed", state.rank);
   }
 
   void validateBroadcastData(size_t nElem, PerRankState& state, int root) {

--- a/comms/ctran/tests/CtranDistAllReduceTest.cc
+++ b/comms/ctran/tests/CtranDistAllReduceTest.cc
@@ -7,6 +7,7 @@
 #include <mpi.h>
 #include <stdlib.h>
 #include <thread>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include "CtranUtUtils.h"
 #include "comms/ctran/Ctran.h"
@@ -127,8 +128,9 @@ class CtranAllReduceTest : public ctran::CtranDistTestFixture,
       // count errors
       if (observedVals[i] != exp) {
         if (error_count < 20) {
-          XLOG(WARN) << "error[" << error_count << "]: " << " data[" << i
-                     << "] " << observedVals[i] << " vs exp " << exp;
+          CTRAN_LOG_STREAM(WARN)
+              << "error[" << error_count << "]: " << " data[" << i << "] "
+              << observedVals[i] << " vs exp " << exp;
         }
         error_count++;
       }

--- a/comms/ctran/tests/CtranDistAllgatherPTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherPTests.cc
@@ -3,6 +3,7 @@
 #include <folly/init/Init.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include <stdlib.h>
 
@@ -513,7 +514,7 @@ TEST_F(CtranAllgatherPTest, InvalidCount) {
   const auto maxRecvCount = 8192 * numRanks;
   for (auto memType : memTypes) {
     if (memType == kMemNcclMemAlloc && ncclIsCuMemSupported() == false) {
-      XLOG(INFO)
+      CTRAN_LOG_STREAM(INFO)
           << "CuMem not supported, skipping InvalidCount test with memType = kMemNcclMemAlloc";
       ;
       continue;
@@ -754,7 +755,7 @@ TEST_F(CtranAllgatherPTest, SharePersistentBuffer) {
   }
 
   if (ncclIsCuMemSupported() == false) {
-    XLOG(INFO)
+    CTRAN_LOG_STREAM(INFO)
         << "CuMem not supported, skipping SharePersistentBuffer test with memType = kMemNcclMemAlloc";
     return;
   }

--- a/comms/ctran/tests/CtranDistAlltoAllvTest.cc
+++ b/comms/ctran/tests/CtranDistAlltoAllvTest.cc
@@ -2,11 +2,11 @@
 
 #include <folly/init/Init.h>
 #include <folly/json/json.h>
-#include <folly/logging/xlog.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <stdlib.h>
 #include <thread>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include "CtranUtUtils.h"
 #include "comms/ctran/Ctran.h"
@@ -391,7 +391,7 @@ TEST_F(ctranAllToAllvIbTest, AllToAllvIbconfig) {
 
   if (this->globalRank == 0) {
     if (ctranComm->ctran_->algo == nullptr) {
-      XLOGF(INFO, "No ctran algo found, skip test");
+      CTRAN_LOG(INFO, "No ctran algo found, skip test");
     } else {
       CtranIbConfig* ctranIbConfigPtr =
           ctranComm->ctran_->algo->getCollToVcConfig(CollType::ALLTOALL);

--- a/comms/ctran/tests/CtranDistRMATest.cc
+++ b/comms/ctran/tests/CtranDistRMATest.cc
@@ -4,6 +4,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <stdlib.h>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include "CtranUtUtils.h"
 #include "comms/ctran/Ctran.h"
@@ -287,9 +288,9 @@ TEST_P(CtranRMATestParam, winPutWait) {
         cudaEventElapsedTime(&elapsed_time_ms, start_event, end_event));
     // time captured with kNumIters - 1 iterations
     float achieved_bw = chunkBytes / elapsed_time_ms / 1e6 * (kNumIters - 1);
-    XLOGF(
+    CTRAN_LOG(
         INFO,
-        "[%d] elapsed time %.2f ms for %zu bytes * %ld iterations (%.2f GB/s), on %s\n",
+        "[{}] elapsed time {:.2f} ms for {} bytes * {} iterations ({:.2f} GB/s), on {}",
         statex->rank(),
         elapsed_time_ms,
         chunkBytes,
@@ -411,9 +412,9 @@ TEST_P(CtranRMATestParam, winWaitPut) {
         cudaEventElapsedTime(&elapsed_time_ms, start_event, end_event));
     // time captured with kNumIters - 1 iterations
     float achieved_bw = chunkBytes / elapsed_time_ms / 1e6 * (kNumIters - 1);
-    XLOGF(
+    CTRAN_LOG(
         INFO,
-        "[%d] elapsed time %.2f ms for %zu bytes * %ld iterations (%.2f GB/s), on %s\n",
+        "[{}] elapsed time {:.2f} ms for {} bytes * {} iterations ({:.2f} GB/s), on {}",
         statex->rank(),
         elapsed_time_ms,
         chunkBytes,

--- a/comms/ctran/tests/CtranDistTestUtils.cc
+++ b/comms/ctran/tests/CtranDistTestUtils.cc
@@ -2,7 +2,7 @@
 
 #include "CtranDistTestUtils.h"
 
-#include <folly/logging/xlog.h>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include "comms/ctran/tests/bootstrap/CtranTestBootstrap.h"
 #include "comms/ctran/utils/CudaUtils.h"
@@ -71,8 +71,8 @@ void CtranDistTestFixture::SetUp(const CtranEnvs& envs) {
   setenv("RANK", std::to_string(globalRank).c_str(), 1);
 
   if (globalRank == 0) {
-    XLOG(DBG) << "Testing with NCCL_COMM_STATE_DEBUG_TOPO="
-              << (isNolocalTopo() ? "nolocal" : "default");
+    CTRAN_LOG_STREAM(DBG) << "Testing with NCCL_COMM_STATE_DEBUG_TOPO="
+                          << (isNolocalTopo() ? "nolocal" : "default");
   }
 
   stream.emplace(cudaStreamNonBlocking);

--- a/comms/ctran/tests/CtranExampleDistTest.cc
+++ b/comms/ctran/tests/CtranExampleDistTest.cc
@@ -2,6 +2,7 @@
 
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include <vector>
 
@@ -44,7 +45,7 @@ TEST_F(CtranExampleDistTest, Basic) {
   auto devStated_d = algo->getDevState();
   ASSERT_NE(devStated_d, nullptr);
 
-  XLOG(WARN) << "Rank " << globalRank << ": ctran comm created";
+  CTRAN_LOG_STREAM(WARN) << "Rank " << globalRank << ": ctran comm created";
   size_t numElements = 10;
 
   // Create input/output device buffers
@@ -95,8 +96,8 @@ TEST_F(CtranExampleDistTest, Basic) {
         << expected << ", got " << output_h[i];
   }
 
-  XLOG(WARN) << "Rank " << globalRank
-             << ": AllGather Direct verification passed";
+  CTRAN_LOG_STREAM(WARN) << "Rank " << globalRank
+                         << ": AllGather Direct verification passed";
 }
 
 int main(int argc, char* argv[]) {

--- a/comms/ctran/tests/CtranNcclTestUtils.cc
+++ b/comms/ctran/tests/CtranNcclTestUtils.cc
@@ -6,7 +6,7 @@
 // driver APIs since libcuda.so is not exposed in fbcode
 #include "comms/ctran/utils/CudaWrap.h"
 
-#include <folly/logging/xlog.h>
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/testinfra/TestsCuUtils.h"
 #include "meta/wrapper/MetaFactory.h"
 
@@ -50,7 +50,7 @@ void* CtranNcclTestHelpers::prepareBuf(
     NCCLCHECK_TEST(ncclMemAlloc(&buf, bufSize));
     segments.emplace_back(buf, bufSize);
 #else
-    XLOG(FATAL) << "kMemNcclMemAlloc is not supported on AMD/HIP";
+    CTRAN_LOG_STREAM(FATAL) << "kMemNcclMemAlloc is not supported on AMD/HIP";
 #endif
   } else {
 #if !defined(USE_ROCM)
@@ -58,7 +58,8 @@ void* CtranNcclTestHelpers::prepareBuf(
         numSegments, bufSize / numSegments);
     COMMCHECK_TEST(commMemAllocDisjoint(&buf, disjointSegmentSizes, segments));
 #else
-    XLOG(FATAL) << "kCuMemAllocDisjoint is not supported on AMD/HIP";
+    CTRAN_LOG_STREAM(FATAL)
+        << "kCuMemAllocDisjoint is not supported on AMD/HIP";
 #endif
   }
   return buf;
@@ -81,7 +82,7 @@ void CtranNcclTestHelpers::releaseBuf(
       ncclMemFree(buf);
     }
 #else
-    XLOG(FATAL) << "kMemNcclMemAlloc is not supported on AMD/HIP";
+    CTRAN_LOG_STREAM(FATAL) << "kMemNcclMemAlloc is not supported on AMD/HIP";
 #endif
   } else {
 #if !defined(USE_ROCM)
@@ -89,7 +90,8 @@ void CtranNcclTestHelpers::releaseBuf(
         numSegments, bufSize / numSegments);
     COMMCHECK_TEST(commMemFreeDisjoint(buf, disjointSegmentSizes));
 #else
-    XLOG(FATAL) << "kCuMemAllocDisjoint is not supported on AMD/HIP";
+    CTRAN_LOG_STREAM(FATAL)
+        << "kCuMemAllocDisjoint is not supported on AMD/HIP";
 #endif
   }
 }

--- a/comms/ctran/tests/CtranTestUtils.cc
+++ b/comms/ctran/tests/CtranTestUtils.cc
@@ -6,7 +6,7 @@
 #include <chrono>
 #include <thread>
 
-#include <folly/logging/xlog.h>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include "comms/ctran/tests/bootstrap/MockBootstrap.h"
 #include "comms/ctran/utils/Alloc.h"
@@ -58,9 +58,9 @@ void logGpuMemoryStats(int gpu) {
   CUDACHECK_TEST(cudaMemGetInfo(&free, &total));
   auto mbFree = static_cast<double>(free) / (1024 * 1024);
   auto mbTotal = static_cast<double>(total) / (1024 * 1024);
-  XLOG(DBG) << "GPU " << gpu << " memory: " << "freeBytes=" << free << " ("
-            << mbFree << "MB), " << "totalBytes=" << total << "(" << mbTotal
-            << "MB)";
+  CTRAN_LOG_STREAM(DBG) << "GPU " << gpu << " memory: " << "freeBytes=" << free
+                        << " (" << mbFree << "MB), " << "totalBytes=" << total
+                        << "(" << mbTotal << "MB)";
 }
 
 void commSetMyThreadLoggingName(std::string_view name) {
@@ -159,9 +159,9 @@ commResult_t commMemAllocDisjoint(
   for (int i = 0; i < numSegments; i++) {
     FB_CUCHECK(cuMemMap(curPtr, alignedSizes[i], 0, handles[i], 0));
     segments.emplace_back(reinterpret_cast<void*>(curPtr), alignedSizes[i]);
-    XLOG(DBG) << "ncclMemAllocDisjoint maps segments[" << i << "] ptr "
-              << reinterpret_cast<void*>(curPtr) << " size " << alignedSizes[i]
-              << "/" << vaSize;
+    CTRAN_LOG_STREAM(DBG) << "ncclMemAllocDisjoint maps segments[" << i
+                          << "] ptr " << reinterpret_cast<void*>(curPtr)
+                          << " size " << alignedSizes[i] << "/" << vaSize;
 
     curPtr = ctran::utils::addDevicePtr(curPtr, alignedSizes[i]);
   }
@@ -225,9 +225,9 @@ commResult_t commMemFreeDisjoint(
   CUdeviceptr curPtr = (CUdeviceptr)ptr;
   for (int i = 0; i < alignedSizes.size(); i++) {
     FB_CUCHECK(cuMemRetainAllocationHandle(&handle, (void*)curPtr));
-    XLOG(DBG) << "ncclMemFreeDisjoint unmaps segments[" << i << "] ptr "
-              << reinterpret_cast<void*>(curPtr) << " size " << alignedSizes[i]
-              << "/" << vaSize;
+    CTRAN_LOG_STREAM(DBG) << "ncclMemFreeDisjoint unmaps segments[" << i
+                          << "] ptr " << reinterpret_cast<void*>(curPtr)
+                          << " size " << alignedSizes[i] << "/" << vaSize;
     FB_CUCHECK(cuMemRelease(handle));
     FB_CUCHECK(cuMemUnmap(curPtr, alignedSizes[i]));
     // call to cuMemRetainAllocationHandle increments reference count, requires
@@ -320,9 +320,9 @@ commResult_t commMemExpandBuffer(
     buf->segments.emplace_back(
         reinterpret_cast<void*>(curPtr), buf->segmentSize);
 
-    XLOG(DBG) << "commMemExpandBuffer maps new segment ptr "
-              << reinterpret_cast<void*>(curPtr) << " size "
-              << buf->segmentSize;
+    CTRAN_LOG_STREAM(DBG) << "commMemExpandBuffer maps new segment ptr "
+                          << reinterpret_cast<void*>(curPtr) << " size "
+                          << buf->segmentSize;
 
     curPtr = ctran::utils::addDevicePtr(curPtr, buf->segmentSize);
   }
@@ -409,7 +409,7 @@ void* commMemAlloc(
       segments.emplace_back(buf, bufSize);
       break;
     default:
-      XLOG(FATAL) << "Unsupported memType: " << memType;
+      CTRAN_LOG_STREAM(FATAL) << "Unsupported memType: " << memType;
       break;
   }
   return buf;
@@ -442,7 +442,7 @@ void commMemFree(
       free(buf);
       break;
     default:
-      XLOG(FATAL) << "Unsupported memType: " << memType;
+      CTRAN_LOG_STREAM(FATAL) << "Unsupported memType: " << memType;
       break;
   }
 }
@@ -519,7 +519,7 @@ std::unique_ptr<CtranComm> CtranStandaloneFixture::makeCtranComm(
 
   EXPECT_EQ(ctranInit(ctranComm.get()), commSuccess);
 
-  CLOGF(INFO, "UT CTran initialized");
+  CTRAN_LOG(INFO, "UT CTran initialized");
 
   return ctranComm;
 }
@@ -604,7 +604,7 @@ void initCtranCommMultiRank(PerRankState& state) {
 
   FB_COMMCHECKTHROW_EX_NOCOMM(ctranInit(ctranComm));
 
-  CLOGF(INFO, "UT MultiRank CTran initialized");
+  CTRAN_LOG(INFO, "UT MultiRank CTran initialized");
 }
 
 void workerRoutine(PerRankState& state) {
@@ -615,7 +615,7 @@ void workerRoutine(PerRankState& state) {
   SCOPE_EXIT {
     resetPerRankState(state);
   };
-  CLOGF(
+  CTRAN_LOG(
       INFO,
       "rank [{}/{}] worker started, cudaDev {}",
       rank,
@@ -640,17 +640,17 @@ void workerRoutine(PerRankState& state) {
           "UT_workerRoutine"),
       state.ctranComm->logMetaData_);
 
-  CLOGF(INFO, "rank [{}/{}] worker waiting for work", rank, state.nRanks);
+  CTRAN_LOG(INFO, "rank [{}/{}] worker waiting for work", rank, state.nRanks);
 
   auto& sf = state.workSemiFuture;
   sf.wait();
 
-  CLOGF(INFO, "rank [{}/{}] worker received work", rank, state.nRanks);
+  CTRAN_LOG(INFO, "rank [{}/{}] worker received work", rank, state.nRanks);
 
   auto work = sf.value();
   work(state);
 
-  CLOGF(INFO, "rank [{}/{}] worker completed work", rank, state.nRanks);
+  CTRAN_LOG(INFO, "rank [{}/{}] worker completed work", rank, state.nRanks);
 }
 
 } // namespace
@@ -660,7 +660,7 @@ void CtranIntraProcessFixture::SharedState::barrierNamed(
     int nRanks,
     int timeoutSeconds,
     const std::string& name) {
-  CLOGF(INFO, "rank [{}/{}] barrier '{}' enter", rank, nRanks, name);
+  CTRAN_LOG(INFO, "rank [{}/{}] barrier '{}' enter", rank, nRanks, name);
   // Each thread gets its own sense
   bool local_sense = !sense.load();
   // Atomically increment the count
@@ -689,7 +689,7 @@ void CtranIntraProcessFixture::SharedState::barrierNamed(
     }
   }
 
-  CLOGF(INFO, "rank [{}/{}] barrier '{}' leave", rank, nRanks, name);
+  CTRAN_LOG(INFO, "rank [{}/{}] barrier '{}' leave", rank, nRanks, name);
 }
 
 void CtranIntraProcessFixture::SetUp() {
@@ -843,7 +843,7 @@ void* CtranTestHelpers::prepareBuf(
     CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
     segments.emplace_back(buf, bufSize);
   } else {
-    XLOG(FATAL)
+    CTRAN_LOG_STREAM(FATAL)
         << "CtranTestHelpers only supports kMemCudaMalloc. "
         << "Use CtranNcclTestHelpers for kMemNcclMemAlloc or kCuMemAllocDisjoint.";
   }
@@ -857,7 +857,7 @@ void CtranTestHelpers::releaseBuf(
   if (memType == kMemCudaMalloc) {
     CUDACHECK_TEST(cudaFree(buf));
   } else {
-    XLOG(FATAL)
+    CTRAN_LOG_STREAM(FATAL)
         << "CtranTestHelpers only supports kMemCudaMalloc. "
         << "Use CtranNcclTestHelpers for kMemNcclMemAlloc or kCuMemAllocDisjoint.";
   }

--- a/comms/ctran/tests/MultiPeerTransportTest.cc
+++ b/comms/ctran/tests/MultiPeerTransportTest.cc
@@ -2,6 +2,7 @@
 
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include "comms/ctran/utils/CtranLogger.h"
 
 #include <algorithm>
 
@@ -62,8 +63,8 @@ TEST_F(MultiPeerTransportTest, InitAndExchange) {
   EXPECT_EQ(comm->multiPeerTransport_->n_ranks(), numRanks)
       << "MultiPeerTransport nRanks should match numRanks";
 
-  XLOG(INFO) << "Rank " << globalRank << "/" << numRanks
-             << ": MultiPeerTransport initialized successfully";
+  CTRAN_LOG_STREAM(INFO) << "Rank " << globalRank << "/" << numRanks
+                         << ": MultiPeerTransport initialized successfully";
 
   // Verify transport types are set for all peers
   for (int peer = 0; peer < numRanks; peer++) {
@@ -78,15 +79,16 @@ TEST_F(MultiPeerTransportTest, InitAndExchange) {
           transportType == comms::prims::TransportType::P2P_IBGDA)
           << "Transport to peer " << peer << " should be P2P_NVL or P2P_IBGDA";
     }
-    XLOG(INFO) << "Rank " << globalRank << ": transport to peer " << peer
-               << " is type " << static_cast<int>(transportType);
+    CTRAN_LOG_STREAM(INFO) << "Rank " << globalRank << ": transport to peer "
+                           << peer << " is type "
+                           << static_cast<int>(transportType);
   }
 
   // Verify NVL peer info
   int nvlNRanks = comm->multiPeerTransport_->nvl_n_ranks();
   int nvlLocalRank = comm->multiPeerTransport_->nvl_local_rank();
-  XLOG(INFO) << "Rank " << globalRank << ": NVL local rank " << nvlLocalRank
-             << "/" << nvlNRanks;
+  CTRAN_LOG_STREAM(INFO) << "Rank " << globalRank << ": NVL local rank "
+                         << nvlLocalRank << "/" << nvlNRanks;
 
   EXPECT_GE(nvlNRanks, 1) << "Should have at least 1 NVL rank (self)";
   EXPECT_GE(nvlLocalRank, 0) << "NVL local rank should be >= 0";
@@ -131,10 +133,11 @@ TEST_F(MultiPeerTransportTest, DeviceHandle) {
   EXPECT_EQ(deviceHandle.transports.size(), static_cast<size_t>(numRanks))
       << "Device handle transports should have nRanks entries";
 
-  XLOG(INFO) << "Rank " << globalRank
-             << ": MultiPeerTransport device handle created successfully"
-             << ", numNvlPeers=" << deviceHandle.numNvlPeers
-             << ", numIbPeers=" << deviceHandle.numIbPeers;
+  CTRAN_LOG_STREAM(INFO)
+      << "Rank " << globalRank
+      << ": MultiPeerTransport device handle created successfully"
+      << ", numNvlPeers=" << deviceHandle.numNvlPeers
+      << ", numIbPeers=" << deviceHandle.numIbPeers;
 }
 
 // Verify that the P2pNvlTransportDevice objects constructed by CtranAlgo
@@ -207,10 +210,12 @@ TEST_F(MultiPeerTransportTest, TransportBufferPointersMatchStagingBuffers) {
         << ": P2pNvlTransportDevice remote data buffer for peer " << peer
         << " does not match SharedResource staging buffer";
 
-    XLOG(INFO) << "Rank " << globalRank << ": peer " << peer
-               << " buffer pointers verified"
-               << " localData=" << static_cast<void*>(expectedLocalData)
-               << " remoteData=" << static_cast<void*>(expectedRemoteData);
+    CTRAN_LOG_STREAM(INFO) << "Rank " << globalRank << ": peer " << peer
+                           << " buffer pointers verified"
+                           << " localData="
+                           << static_cast<void*>(expectedLocalData)
+                           << " remoteData="
+                           << static_cast<void*>(expectedRemoteData);
   }
 }
 
@@ -284,9 +289,9 @@ TEST_F(MultiPeerTransportTest, StagingBufferIpcAccessible) {
       << "'s staging buffer through IPC. "
       << "This indicates the external buffer wiring is incorrect.";
 
-  XLOG(INFO) << "Rank " << globalRank << ": IPC read from peer "
-             << peerGlobalRank << "'s staging buffer verified (" << kNumElements
-             << " elements)";
+  CTRAN_LOG_STREAM(INFO) << "Rank " << globalRank << ": IPC read from peer "
+                         << peerGlobalRank << "'s staging buffer verified ("
+                         << kNumElements << " elements)";
 
   comm->bootstrap_->barrier(comm->statex_->rank(), comm->statex_->nRanks())
       .get();

--- a/comms/ctran/transport/ib/tests/HostTransportDistUT.cc
+++ b/comms/ctran/transport/ib/tests/HostTransportDistUT.cc
@@ -17,7 +17,6 @@
 #include <gtest/gtest.h>
 
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
 
 #include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
@@ -26,6 +25,7 @@
 #include "comms/ctran/transport/ib/HostTransportImpl.h"
 #include "comms/ctran/transport/ib/HostZcTransport.h"
 #include "comms/ctran/transport/ib/tests/HostTestKernels.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -380,10 +380,10 @@ class HostTransportParamTest : public ctran::CtranDistTestFixture,
   }
 
   void printTestDesc(const std::string& testName, const std::string& testDesc) {
-    XLOG_IF(WARN, this->globalRank == 0)
+    CTRAN_LOG_STREAM_IF(WARN, this->globalRank == 0)
         << testName << "/" << (isZc() ? "Zc" : "Cb")
         << "/Channels=" << numChannels() << " numRanks " << this->numRanks
-        << ". Description: " << testDesc << std::endl;
+        << ". Description: " << testDesc;
   }
 
   void verifyData(

--- a/comms/ctran/transport/tests/CtranMapperHostTransportUT.cc
+++ b/comms/ctran/transport/tests/CtranMapperHostTransportUT.cc
@@ -173,7 +173,7 @@ TEST_F(CtranMapperHostTransportDistTest, ModeMismatchAborts) {
   // Asking for the same peer with a different mode must abort
   // (FB_CHECKABORT). gtest's death-test matcher inspects only the
   // child process's captured stderr; FB_CHECKABORT writes its message
-  // through CLOGF (which goes to the logger sink, not raw stderr), so
+  // through CTRAN_LOG (which goes to the logger sink, not raw stderr), so
   // the message itself isn't visible to EXPECT_DEATH. The signal
   // handler's "*** Aborted at ..." banner IS visible — match on that
   // so the test asserts only the death itself.

--- a/comms/ctran/utils/CtranLogger.h
+++ b/comms/ctran/utils/CtranLogger.h
@@ -11,6 +11,17 @@ namespace ctran::logging {
 
 inline constexpr std::string_view kCtranLoggerName = "comms.ctran";
 
+inline void configureStandaloneCtranLogging(
+    spdlog::level::level_enum logLevel) {
+  /*
+   * Standalone binaries do not call the production logging initializer. Keep
+   * their legacy synchronous delivery while preserving each binary's level.
+   */
+  auto& logger = meta::comms::logger::getSpdlogLogger(kCtranLoggerName);
+  logger.configure("CTRAN", []() { return 0; }, {}, false);
+  logger.set_level(logLevel);
+}
+
 } // namespace ctran::logging
 
 #define CTRAN_LOG_IMPL(spdlog_level, spdlog_macro, ...)                  \
@@ -24,6 +35,8 @@ inline constexpr std::string_view kCtranLoggerName = "comms.ctran";
 
 #define CTRAN_LOG_DBG(...) \
   CTRAN_LOG_IMPL(::spdlog::level::debug, COMMS_LOGGER_DEBUG, __VA_ARGS__)
+#define CTRAN_LOG_DBG5(...) \
+  CTRAN_LOG_IMPL(::spdlog::level::trace, COMMS_LOGGER_TRACE, __VA_ARGS__)
 #define CTRAN_LOG_INFO(...) \
   CTRAN_LOG_IMPL(::spdlog::level::info, SPDLOG_LOGGER_INFO, __VA_ARGS__)
 #define CTRAN_LOG_WARN(...) \
@@ -70,6 +83,8 @@ inline constexpr std::string_view kCtranLoggerName = "comms.ctran";
   CTRAN_LOG_IF_IMPL(WARN, ::spdlog::level::warn, condition, __VA_ARGS__)
 #define CTRAN_LOG_IF_DBG(condition, ...) \
   CTRAN_LOG_IF_IMPL(DBG, ::spdlog::level::debug, condition, __VA_ARGS__)
+#define CTRAN_LOG_IF_DBG5(condition, ...) \
+  CTRAN_LOG_IF_IMPL(DBG5, ::spdlog::level::trace, condition, __VA_ARGS__)
 #define CTRAN_LOG_IF_INFO(condition, ...) \
   CTRAN_LOG_IF_IMPL(INFO, ::spdlog::level::info, condition, __VA_ARGS__)
 #define CTRAN_LOG_IF_ERR(condition, ...) \

--- a/comms/ctran/utils/tests/AllocUT.cc
+++ b/comms/ctran/utils/tests/AllocUT.cc
@@ -5,6 +5,7 @@
 
 #include "comms/ctran/tests/CtranTestUtils.h"
 #include "comms/ctran/utils/Alloc.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/utils/commSpecs.h"
@@ -21,7 +22,7 @@ class CommAllocTest : public ::testing::Test {
     cudaDeviceProp prop;
     CUDACHECK_TEST(cudaGetDeviceProperties(&prop, 0));
     gpuName_ = prop.name;
-    CLOGF(INFO, "GPU name: {}", gpuName_);
+    CTRAN_LOG(INFO, "GPU name: {}", gpuName_);
   }
 
   void TearDown() override {}

--- a/comms/ctran/utils/tests/AsyncErrorUT.cc
+++ b/comms/ctran/utils/tests/AsyncErrorUT.cc
@@ -52,7 +52,7 @@ TEST(CtranAsyncErrorTest, SetAndGet) {
 }
 
 TEST(AsyncErrorTest, AbortOnError) {
-  // Do not check exit code since CLOGF(FATAL) may trigger core dump, and
+  // Do not check exit code since CTRAN_LOG(FATAL) may trigger core dump, and
   // changed SIGABRT to core dump
   EXPECT_DEATH(
       {

--- a/comms/ctran/utils/tests/DevMemTypeUT.cc
+++ b/comms/ctran/utils/tests/DevMemTypeUT.cc
@@ -4,7 +4,6 @@
 
 #include <cuda.h>
 #include <cuda_runtime.h>
-#include <folly/logging/xlog.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/comms/ctran/utils/tests/LogUT.cc
+++ b/comms/ctran/utils/tests/LogUT.cc
@@ -105,6 +105,44 @@ TEST_F(CtranUtilsLogTest, TestCtranErrEvaluatesArgumentsOnce) {
       testing::HasSubstr("CTRAN error 1"));
 }
 
+TEST_F(CtranUtilsLogTest, TestCtranDbg5UsesTraceLevel) {
+  auto& logger =
+      meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName);
+  logger.configure("CTRAN", []() { return 0; }, {}, false);
+  logger.configureOutput({});
+
+  int argumentEvaluations = 0;
+  testing::internal::CaptureStdout();
+  logger.set_level(spdlog::level::debug);
+  CTRAN_LOG(DBG5, "suppressed trace {}", ++argumentEvaluations);
+  CTRAN_LOG_STREAM(DBG5) << "suppressed trace " << ++argumentEvaluations;
+
+  logger.set_level(spdlog::level::trace);
+  CTRAN_LOG(DBG5, "enabled trace {}", ++argumentEvaluations);
+  CTRAN_LOG_STREAM(DBG5) << "enabled trace " << ++argumentEvaluations;
+  logger.flush();
+  const auto output = testing::internal::GetCapturedStdout();
+
+  EXPECT_EQ(argumentEvaluations, 2);
+  EXPECT_THAT(output, testing::Not(testing::HasSubstr("suppressed trace")));
+  EXPECT_THAT(output, testing::HasSubstr("enabled trace 1"));
+  EXPECT_THAT(output, testing::HasSubstr("enabled trace 2"));
+}
+
+TEST_F(CtranUtilsLogTest, StandaloneLoggingPreservesLegacyDelivery) {
+  ctran::logging::configureStandaloneCtranLogging(spdlog::level::warn);
+
+  auto& logger =
+      meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName);
+  EXPECT_FALSE(logger.usesAsyncLogging());
+  EXPECT_FALSE(logger.should_log(spdlog::level::info));
+  EXPECT_TRUE(logger.should_log(spdlog::level::warn));
+
+  ctran::logging::configureStandaloneCtranLogging(spdlog::level::info);
+  EXPECT_FALSE(logger.usesAsyncLogging());
+  EXPECT_TRUE(logger.should_log(spdlog::level::info));
+}
+
 TEST_F(CtranUtilsLogTest, TestCtranLogFirstNPreservesEnabledBudget) {
   auto& logger =
       meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName);

--- a/comms/ctran/window/tests/CtranWinTests.cc
+++ b/comms/ctran/window/tests/CtranWinTests.cc
@@ -13,6 +13,7 @@
 #include "comms/ctran/tests/CtranDistTestUtils.h"
 #include "comms/ctran/tests/CtranTestUtils.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CtranLogger.h"
 #include "comms/ctran/window/CtranWin.h"
 #include "comms/testinfra/TestUtils.h"
 
@@ -500,8 +501,9 @@ TEST_F(CtranWinDistTest, asymmetricWindowPutGet) {
   for (size_t i = 0; i < prevPeerCount; ++i) {
     int expected = prevPeer * 1000 + static_cast<int>(i);
     if (putRecvData[i] != expected && putErrs++ < 10) {
-      XLOG(ERR) << "PUT: Rank " << rank << ": data[" << i
-                << "] = " << putRecvData[i] << ", expected = " << expected;
+      CTRAN_LOG_STREAM(ERR)
+          << "PUT: Rank " << rank << ": data[" << i << "] = " << putRecvData[i]
+          << ", expected = " << expected;
     }
   }
   EXPECT_EQ(putErrs, 0) << "PUT verification failed";
@@ -536,8 +538,9 @@ TEST_F(CtranWinDistTest, asymmetricWindowPutGet) {
   for (size_t i = 0; i < localCount; ++i) {
     int expected = rank * 1000 + static_cast<int>(i);
     if (getRecvData[i] != expected && getErrs++ < 10) {
-      XLOG(ERR) << "GET: Rank " << rank << ": data[" << i
-                << "] = " << getRecvData[i] << ", expected = " << expected;
+      CTRAN_LOG_STREAM(ERR)
+          << "GET: Rank " << rank << ": data[" << i << "] = " << getRecvData[i]
+          << ", expected = " << expected;
     }
   }
   EXPECT_EQ(getErrs, 0) << "GET verification failed";
@@ -654,8 +657,9 @@ TEST_F(CtranWinDistTest, signalResetAcrossGraphReplays) {
     for (size_t i = 0; i < count; ++i) {
       int expected = prevPeer * 1000 + static_cast<int>(i);
       if (recvData[i] != expected && errs++ < 5) {
-        XLOG(ERR) << "Replay " << replay << ": Rank " << rank << ": data[" << i
-                  << "] = " << recvData[i] << ", expected = " << expected;
+        CTRAN_LOG_STREAM(ERR)
+            << "Replay " << replay << ": Rank " << rank << ": data[" << i
+            << "] = " << recvData[i] << ", expected = " << expected;
       }
     }
     EXPECT_EQ(errs, 0) << "Replay " << replay

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -53,8 +53,9 @@ spdlog::level::level_enum loggerLevelToSpdlogLevel(LogLevel level) {
     case LogLevel::INFO:
       return spdlog::level::info;
     case LogLevel::ABORT:
-    case LogLevel::TRACE:
       return spdlog::level::debug;
+    case LogLevel::TRACE:
+      return spdlog::level::trace;
   }
   return spdlog::level::off;
 }

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -236,6 +236,8 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
 
 #define COMMS_LOGGER_DEBUG(logger, ...) \
   SPDLOG_LOGGER_CALL(logger, ::spdlog::level::debug, __VA_ARGS__)
+#define COMMS_LOGGER_TRACE(logger, ...) \
+  SPDLOG_LOGGER_CALL(logger, ::spdlog::level::trace, __VA_ARGS__)
 
 /*
  * shutdownSpdlogForFatal() releases the library-owned async pool. It drains

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -245,6 +245,17 @@ TEST(SpdlogLoggerTest, MapsFollyLevelNames) {
   });
 }
 
+TEST(SpdlogLoggerTest, MapsLegacyTraceAndAbortLevels) {
+  EXPECT_EQ(
+      meta::comms::logger::loggerLevelToSpdlogLevel(
+          meta::comms::logger::LogLevel::TRACE),
+      spdlog::level::trace);
+  EXPECT_EQ(
+      meta::comms::logger::loggerLevelToSpdlogLevel(
+          meta::comms::logger::LogLevel::ABORT),
+      spdlog::level::debug);
+}
+
 TEST(SpdlogLoggerTest, FatalTerminatesProcess) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(


### PR DESCRIPTION
Summary:

Migrate the remaining CTRAN benchmark and test logging to the CTRAN spdlog facade, including backend, bootstrap, GPE, mapper, memory, regcache, transport, utility, and window coverage.

Preserve stream formatting, subsystem filters, producer-thread metadata, error capture, disabled-log evaluation semantics, and the standalone binaries' prior log thresholds and synchronous delivery. Standalone binaries explicitly configure the CTRAN logger instead of inheriting spdlog's asynchronous INFO default.

This diff also changes the shared `LogLevel::TRACE` conversion from spdlog debug to spdlog trace and adds the shared `COMMS_LOGGER_TRACE` wrapper. This is intentional: legacy DBG1/DBG5 diagnostics remain trace-only when `NCCL_DEBUG=TRACE`; `LogLevel::ABORT` remains mapped to debug. The shared mapping is covered in `SpdlogLoggerUT` and the CTRAN DBG5 facade is covered in `LogUT`.

Hot-path impact:
The migrated callsites are benchmark and test code. The shared TRACE conversion runs during logger initialization, not collective, transport-progress, polling, or kernel-launch paths. Existing trace diagnostics become active only when TRACE logging is explicitly selected. The MCCL macro change is a token-equivalent hoist to the shared wrapper.

Reviewed By: shr

Differential Revision: D116694637
