### PR TITLE
Validate uniform NVL signal layout stride (#3746)

### DIFF
--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cu
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cu
@@ -23,8 +23,12 @@ __global__ void nvlSignalTrapKernel(
   const uint32_t pipelineDepth =
       testCase == NvlSignalTrapCase::AggregateDepthTooLarge ? 33 : 1;
   const int nvlRanks = tooManyRanks ? 65 : 4;
-  const uint32_t signalsPerChannel =
-      static_cast<uint32_t>(3 * nvlRanks + 4 * pipelineDepth);
+  uint32_t signalsPerChannel =
+      static_cast<uint32_t>(multimem_staging_signals_per_channel(
+          static_cast<uint64_t>(nvlRanks), pipelineDepth));
+  if (testCase == NvlSignalTrapCase::SignalsPerChannelMismatch) {
+    --signalsPerChannel;
+  }
   MultimemNvlTransportDevice transport{
       .internalLocalSignals =
           DeviceSpan<SignalState>(trapSignals, signalsPerChannel),
@@ -90,7 +94,8 @@ __global__ void nvlSignalTrapKernel(
     return;
   }
   if (testCase == NvlSignalTrapCase::AggregateDepthTooLarge ||
-      testCase == NvlSignalTrapCase::ArrivalCountMismatch) {
+      testCase == NvlSignalTrapCase::ArrivalCountMismatch ||
+      testCase == NvlSignalTrapCase::SignalsPerChannelMismatch) {
     auto group = make_warp_group();
     signal_publish_and_wait<
         NvlSignalAccess::Multimem,

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
@@ -17,6 +17,7 @@ enum class NvlSignalTrapCase : uint32_t {
   SerialMinWaitTimeout,
   TreeMinWaitTimeout,
   ButterflyMinWaitTimeout,
+  SignalsPerChannelMismatch,
 };
 
 void launchNvlSignalTrap(NvlSignalTrapCase testCase);

--- a/comms/prims/transport/nvl/MultimemNvlSignal.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlSignal.cuh
@@ -140,6 +140,10 @@ __device__ __forceinline__ void validate_common(
   if (validRankCount && transport.nvlRanks < 64) {
     validRankMask = (uint64_t{1} << transport.nvlRanks) - 1;
   }
+  const uint64_t expectedSignalsPerChannel = validRankCount
+      ? multimem_staging_signals_per_channel(
+            static_cast<uint64_t>(transport.nvlRanks), transport.pipelineDepth)
+      : 0;
   if (!validRankCount || transport.nvlRank < 0 ||
       transport.nvlRank >= transport.nvlRanks ||
       participants.publisherMask == 0 || participants.waiterMask == 0 ||
@@ -149,7 +153,7 @@ __device__ __forceinline__ void validate_common(
       participants.expectedArrivals !=
           static_cast<uint32_t>(__popcll(participants.publisherMask)) ||
       round.channel >= transport.maxChannels || round.value == 0 ||
-      transport.signalsPerChannel == 0) {
+      transport.signalsPerChannel != expectedSignalsPerChannel) {
     printf(
         "NVL signal invalid geometry: rank=%d ranks=%d channel=%u "
         "round=%llu maxChannels=%u publishers=%llu waiters=%llu arrivals=%u\n",


### PR DESCRIPTION
Summary:
## Core implementation

Require `signalsPerChannel` to match the canonical `3R + 4P` internal signal layout before any signal index is formed.
Derive the expected stride with `multimem_staging_signals_per_channel()` so allocation and validation cannot drift.
Add an isolated device-trap case for an undersized inconsistent stride.

## Background

Uniform NVL signal addressing assumes that each channel contains three per-rank signal stripes and four signals per pipeline lane.
Rejecting an inconsistent stride before indexing prevents a malformed transport view from addressing the wrong signal slot.


Reviewed By: dboyda

Differential Revision: D116668037


