### PR TITLE
Avoid duplicate fences in scalar NVL signals (#3749)

### DIFF
--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -1606,6 +1606,75 @@ TEST_F(
 
 TEST_F(
     MultimemNvlTransportTestFixture,
+    UniformSignalAggregatePublishesRelaxedPayloadFromAnotherLane) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  for (const uint32_t pipelineDepth : {1u, 4u}) {
+    auto bootstrap = makeBootstrap(
+        "mmnvl_uniform_relaxed_payload_depth_" + std::to_string(pipelineDepth));
+    if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+      GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+    }
+    MultimemNvlTransport transport(
+        bootstrap,
+        globalRank,
+        identityRankMap(numRanks),
+        makeConfig(
+            4096,
+            0,
+            pipelineDepth,
+            /*maxChannels=*/1,
+            /*enableUnicastPeerViews=*/true));
+    transport.exchange();
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+
+    const auto values = runSignalProtocol(1, [&](uint64_t* output) {
+      test::launchAggregateMultimemRelaxedPayload(
+          transport.getDeviceTransport(), output);
+    });
+    if (globalRank == 0) {
+      EXPECT_EQ(values[0], 11) << "pipelineDepth=" << pipelineDepth;
+    }
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+  }
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    UniformSignalPerPeerPublishesRelaxedPayloadFromAnotherWarp) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_uniform_per_peer_relaxed_payload");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(
+          4096,
+          0,
+          /*pipelineDepth=*/1,
+          /*maxChannels=*/1,
+          /*enableUnicastPeerViews=*/true));
+  transport.exchange();
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+
+  const auto values = runSignalProtocol(1, [&](uint64_t* output) {
+    test::launchPerPeerMultimemRelaxedPayload(
+        transport.getDeviceTransport(), output);
+  });
+  if (globalRank == 0) {
+    EXPECT_EQ(values[0], 22);
+  }
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
     UniformSignalPerPeerRoundTripUsesAggregateAck) {
   if (numRanks < 3) {
     GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -284,6 +284,82 @@ __global__ void aggregateMultimemWaiterTransitionKernel(
   }
 }
 
+__global__ void aggregateMultimemRelaxedPayloadKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t* observedPayload) {
+  auto group = make_warp_group();
+  const NvlSignalParticipants participants{
+      .publisherMask = NvlSignalRankMask::single(1),
+      .waiterMask = NvlSignalRankMask::single(0),
+      .expectedArrivals = 1,
+  };
+  const uint64_t payloadId = static_cast<uint64_t>(2) * transport.nvlRanks;
+  constexpr uint32_t kPayloadLane = kWarpSize - 1;
+  auto* remotePayload =
+      &transport.internalUnicastSignalsByRank[0][payloadId].signal_;
+  const auto* localPayload = &transport.internalLocalSignals[payloadId].signal_;
+
+  if (transport.nvlRank == 1 && group.thread_id_in_group == kPayloadLane) {
+    comms::device::st_relaxed_sys_global(remotePayload, 11);
+  }
+  signal_publish_and_wait<
+      NvlSignalAccess::Multimem,
+      NvlSignalTopology::Aggregate,
+      NvlSignalPhase::Ready>(
+      transport,
+      StageRound{.channel = 0, .value = 1},
+      participants,
+      group,
+      Timeout{});
+  if (transport.nvlRank == 0 && group.thread_id_in_group == kPayloadLane) {
+    *observedPayload = comms::device::ld_relaxed_sys_global(localPayload);
+  }
+}
+
+__global__ void perPeerMultimemRelaxedPayloadKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t* observedPayload) {
+  auto group = make_block_group();
+  const NvlSignalParticipants participants{
+      .publisherMask = NvlSignalRankMask::single(1),
+      .waiterMask = NvlSignalRankMask::single(0),
+      .expectedArrivals = 1,
+  };
+  const uint64_t payloadId = static_cast<uint64_t>(2) * transport.nvlRanks;
+  const uint64_t waiterReadyId = payloadId + 1;
+  constexpr uint32_t kPayloadThread = kWarpSize;
+  auto* remotePayload =
+      &transport.internalUnicastSignalsByRank[0][payloadId].signal_;
+  const auto* localPayload = &transport.internalLocalSignals[payloadId].signal_;
+
+  if (transport.nvlRank == 0 && group.is_leader()) {
+    transport.internalUnicastSignalsByRank[1][waiterReadyId].store(1);
+  }
+  if (transport.nvlRank == 1) {
+    if (group.is_leader()) {
+      while (transport.internalLocalSignals[waiterReadyId].load() != 1) {
+      }
+    }
+    group.sync();
+  }
+  if (transport.nvlRank == 1 && group.thread_id_in_group == kPayloadThread) {
+    __nanosleep(100'000'000);
+    comms::device::st_relaxed_sys_global(remotePayload, 22);
+  }
+  signal_publish_and_wait<
+      NvlSignalAccess::Multimem,
+      NvlSignalTopology::PerPeer,
+      NvlSignalPhase::Ready>(
+      transport,
+      StageRound{.channel = 0, .value = 1},
+      participants,
+      group,
+      Timeout{});
+  if (transport.nvlRank == 0 && group.is_leader()) {
+    *observedPayload = comms::device::ld_relaxed_sys_global(localPayload);
+  }
+}
+
 __global__ void separatePublishAndWaitKernel(
     MultimemNvlTransportDevice transport,
     uint64_t roundValue,
@@ -708,6 +784,27 @@ void launchAggregateMultimemWaiterTransition(
     uint64_t* out,
     cudaStream_t stream) {
   aggregateMultimemWaiterTransitionKernel<<<1, 32, 0, stream>>>(transport, out);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchAggregateMultimemRelaxedPayload(
+    MultimemNvlTransportDevice transport,
+    uint64_t* observedPayload,
+    cudaStream_t stream) {
+  aggregateMultimemRelaxedPayloadKernel<<<1, 32, 0, stream>>>(
+      transport, observedPayload);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchPerPeerMultimemRelaxedPayload(
+    MultimemNvlTransportDevice transport,
+    uint64_t* observedPayload,
+    cudaStream_t stream) {
+  perPeerMultimemRelaxedPayloadKernel<<<
+      1,
+      nvl_signal_per_peer_group_size(static_cast<uint32_t>(transport.nvlRanks)),
+      0,
+      stream>>>(transport, observedPayload);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -154,6 +154,16 @@ void launchAggregateMultimemWaiterTransition(
     uint64_t* out,
     cudaStream_t stream = nullptr);
 
+void launchAggregateMultimemRelaxedPayload(
+    MultimemNvlTransportDevice transport,
+    uint64_t* observedPayload,
+    cudaStream_t stream = nullptr);
+
+void launchPerPeerMultimemRelaxedPayload(
+    MultimemNvlTransportDevice transport,
+    uint64_t* observedPayload,
+    cudaStream_t stream = nullptr);
+
 void launchSeparatePublishAndWait(
     MultimemNvlTransportDevice transport,
     uint64_t roundValue,

--- a/comms/prims/transport/nvl/MultimemNvlSignal.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlSignal.cuh
@@ -541,8 +541,9 @@ __device__ __forceinline__ void signal_publish_impl(
             nvl_signal_detail::aggregate_counter_id<phase>(
                 transport, round, lane);
         if constexpr (access == NvlSignalAccess::Multimem) {
-          transport.template signal_internal_scalar<SignalOp::SIGNAL_ADD>(
-              signalId, 1);
+          transport
+              .template signal_internal_scalar_prefenced<SignalOp::SIGNAL_ADD>(
+                  signalId, 1);
         } else {
           for (int destination = 0; destination < transport.nvlRanks;
                ++destination) {
@@ -559,8 +560,9 @@ __device__ __forceinline__ void signal_publish_impl(
           transport, round, transport.nvlRank);
       if constexpr (access == NvlSignalAccess::Multimem) {
         if (group.is_leader()) {
-          transport.template signal_internal_scalar<SignalOp::SIGNAL_SET>(
-              signalId, round.value);
+          transport
+              .template signal_internal_scalar_prefenced<SignalOp::SIGNAL_SET>(
+                  signalId, round.value);
         }
       } else {
         const int destination = static_cast<int>(group.thread_id_in_group);

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -124,8 +124,18 @@ struct MultimemNvlTransportDevice {
   __device__ __forceinline__ void signal_internal_scalar(
       uint64_t signal_id,
       uint64_t value) const {
-    auto* signal = internal_multimem_signal_ptr(signal_id);
     comms::device::fence_acq_rel_sys();
+    signal_internal_scalar_prefenced<op>(signal_id, value);
+  }
+
+  template <SignalOp op>
+  __device__ __forceinline__ void signal_internal_scalar_prefenced(
+      uint64_t signal_id,
+      uint64_t value) const {
+    // Every cooperative-group thread that may have produced published data
+    // must complete the required system-scope fence. All participating threads
+    // must then synchronize before the signaling thread invokes this helper.
+    auto* signal = internal_multimem_signal_ptr(signal_id);
     if constexpr (op == SignalOp::SIGNAL_SET) {
       detail::multimem_store_release_sys_u64(&signal->signal_, value);
     } else {


### PR DESCRIPTION
Summary:

## Core implementation

Preserve the standalone system fence in <signal_internal_scalar>.
Add <signal_internal_scalar_prefenced> for callers that have already fenced every producing thread and synchronized the cooperative group.
Use the pre-fenced helper from uniform aggregate ADD and per-peer SET publication so each operation executes one system fence instead of two.

## Background

Uniform publication already performs a system-scope fence on every cooperative-group thread and synchronizes the group before the signaling thread publishes.
Calling the standalone scalar helper after that handoff repeated the same system fence without strengthening the ordering contract.

Reviewed By: dboyda

Differential Revision: D116668038


