### PR TITLE
document aggregate Ready/Ack ordering

### DIFF
--- a/comms/prims/docs/UniformNvlSignals.md
+++ b/comms/prims/docs/UniformNvlSignals.md
@@ -204,6 +204,70 @@ Fan-in publishers target the coordinator's lane counter.
 Global publishers update every destination's lane counter, including their local destination.
 
 Each active lane owner waits on the corresponding local counter with acquire semantics.
+Aggregate counters carry anonymous cumulative credits. They do not identify
+which publisher produced a credit or encode `StageRound::value`.
+
+The caller defines the credit contract for each acknowledged producer-consumer
+epoch. For epoch `k`, let `quota[k][publisher]` be the maximum number of Ready
+credits that publisher may contribute before Ack(k), and let
+`readyDelta[k]` be the sum of those quotas. A valid contract requires:
+
+```text
+budget:
+    every Ready publisher has a fixed credit quota for epoch k
+
+bound:
+    no publisher exceeds its quota before Ack(k)
+
+completion:
+    the consumer waits for previousReady + readyDelta[k]
+    the consumer performs the protected payload work
+
+acknowledgment:
+    publish Ack(k) only after Ready(k) and payload consumption complete
+
+turnstile:
+    every rank that may contribute to epoch k + 1
+    wait for Ack(k) before publishing the next Ready credit
+```
+
+Because each publisher cannot exceed its quota, reaching the sum of all quotas
+proves that every publisher met its assigned contribution. A total-credit
+threshold without per-publisher bounds is insufficient: one fast publisher
+could substitute extra credits for a delayed publisher. The Ack waiter mask
+must include every rank that may contribute to the next epoch, including ranks
+introduced by a participant-mask transition.
+
+For example, an `N`-producer-to-one-consumer protocol may assign two Ready
+credits to every producer before each Ack:
+
+```text
+initial state: Ready = 0, Ack = 0
+
+epoch 1:
+    each of N producers contributes at most 2 Ready credits
+    consumer waits for Ready >= 2 * N
+    consumer performs the protected work
+    consumer publishes Ack(1); every next-epoch producer waits for it
+
+epoch 2:
+    each of N producers contributes at most 2 more Ready credits
+    consumer waits for Ready >= 4 * N
+    consumer performs the protected work
+    consumer publishes Ack(2)
+```
+
+The quota may be one, two, or another caller-defined value, and may vary by
+publisher or epoch. Payload protected by the full epoch must not be consumed at
+an intermediate anonymous Ready threshold that does not establish the complete
+credit budget.
+
+Ready-only aggregate fan-in is unsupported when a publisher is not also a
+waiter and no external turnstile bounds its credits. Such a publisher could
+enter a later epoch and contribute another anonymous Ready credit before a
+delayed current-epoch publisher contributes.
+Ready-only aggregate barriers remain valid when every publisher is also a
+waiter for the same operation.
 For multicast access, every rank advances its local epoch by the expected arrival count for every operation.
 A selected waiter advances the epoch after observing the counter, while a nonwaiter reserves the same arrival count without blocking.
 This keeps each rank's counter and epoch accounting aligned when the waiter mask changes on a reused channel and lane.

--- a/comms/prims/docs/UniformNvlSignals.md
+++ b/comms/prims/docs/UniformNvlSignals.md
@@ -130,10 +130,16 @@ Device validation traps on an out-of-range channel, lane, rank, or signal offset
 
 ## Execution Ownership
 
-One CUDA block owns one logical channel.
-A channel is the logical staging group selected by the block index.
+One cooperative `ThreadGroup` owns one logical channel.
+Signal kernels use one-dimensional grids and blocks, and both topologies
+require `group.group_id == channel`. The logical group id is authoritative even
+when a caller has deliberately renumbered groups; `block_id` continues to name
+the physical CUDA block rather than the channel.
+Concurrent operations may use separate streams only when they own disjoint
+channels; concurrent launches targeting the same channel are invalid.
 
-Aggregate topology uses one warp per channel.
+Aggregate topology uses one full owning warp per channel, so multiple warp
+groups in one CUDA block may own distinct channels.
 Pipeline depth determines the active lane owners:
 
 ```text
@@ -156,6 +162,7 @@ threads R..127 own no peer slot
 ```
 
 Per-peer launches use 64 threads through 64 ranks and 128 threads for 65-72 ranks.
+The block contains exactly that many threads.
 Every launched thread participates in required block synchronization.
 `TreeMin` and `ButterflyMin` additionally use all threads for their reductions.
 
@@ -187,6 +194,7 @@ Wait-policy selection changes observation geometry, not protocol semantics.
 
 Aggregate multicast publication issues one `multimem.red.release.sys.global.add.u64` for each active lane.
 Every publisher targets the counter owned by its channel and lane.
+Global warp group `C` owns aggregate channel `C`.
 The multicast instruction advances the corresponding counter on every rank, regardless of which ranks wait for that operation.
 Global completion advances each rank's counter by `R`.
 Fan-in completion advances each rank's counter by `R - 1`.

--- a/comms/prims/docs/UniformNvlSignals.md
+++ b/comms/prims/docs/UniformNvlSignals.md
@@ -125,7 +125,7 @@ The following combinations are rejected at compile time:
 - Split aggregate multimem publication or waiting.
 - A phase or access operation that has no storage or instruction mapping.
 
-Host launch validation rejects aggregate pipeline depth above one warp and per-peer teams above two warps.
+Host launch validation rejects aggregate pipeline depth above one warp and per-peer teams above four warps.
 Device validation traps on an out-of-range channel, lane, rank, or signal offset before issuing a signal operation.
 
 ## Execution Ownership
@@ -144,17 +144,19 @@ thread P - 1 owns pipeline lane P - 1
 threads P..31 do not publish or wait
 ```
 
-Per-peer topology uses two warps per channel:
+Per-peer topology uses one whole block per channel: two warps through 64
+ranks and four warps for 65-72 ranks:
 
 ```text
 thread 0     owns NVL peer 0
 thread 1     owns NVL peer 1
 ...
 thread R - 1 owns NVL peer R - 1
-threads R..63 own no peer slot
+threads R..127 own no peer slot
 ```
 
-All 64 threads participate in required block synchronization.
+Per-peer launches use 64 threads through 64 ranks and 128 threads for 65-72 ranks.
+Every launched thread participates in required block synchronization.
 `TreeMin` and `ButterflyMin` additionally use all threads for their reductions.
 
 Per-peer slots are shared across pipeline lanes, so per-peer operations use pipeline depth one.

--- a/comms/prims/tests/MultimemNvlSignalRankBoundaryTest.cc
+++ b/comms/prims/tests/MultimemNvlSignalRankBoundaryTest.cc
@@ -1,0 +1,33 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include "comms/prims/tests/MultimemNvlSignalTrapTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+namespace comms::prims::tests {
+
+TEST(MultimemNvlSignalRankBoundaryTest, Supports64_65And72Ranks) {
+  int deviceCount = 0;
+  CUDACHECK_TEST(cudaGetDeviceCount(&deviceCount));
+  if (deviceCount == 0) {
+    GTEST_SKIP() << "No CUDA devices available";
+  }
+  CUDACHECK_TEST(cudaSetDevice(0));
+
+  uint64_t* output = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&output, sizeof(uint64_t)));
+  for (const int nvlRanks : {64, 65, 72}) {
+    CUDACHECK_TEST(cudaMemset(output, 0, sizeof(uint64_t)));
+    test::launchNvlSignalRankBoundary(nvlRanks, output);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    uint64_t observed = 0;
+    CUDACHECK_TEST(cudaMemcpy(
+        &observed, output, sizeof(uint64_t), cudaMemcpyDeviceToHost));
+    EXPECT_EQ(observed, static_cast<uint64_t>(nvlRanks));
+  }
+  CUDACHECK_TEST(cudaFree(output));
+}
+
+} // namespace comms::prims::tests

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cu
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cu
@@ -90,7 +90,10 @@ __global__ void nvlSignalTrapKernel(NvlSignalTrapCase testCase) {
   }
   if (testCase == NvlSignalTrapCase::AggregateDepthTooLarge ||
       testCase == NvlSignalTrapCase::ArrivalCountMismatch ||
-      testCase == NvlSignalTrapCase::SignalsPerChannelMismatch) {
+      testCase == NvlSignalTrapCase::SignalsPerChannelMismatch ||
+      testCase == NvlSignalTrapCase::DuplicateChannelOwner ||
+      testCase == NvlSignalTrapCase::AggregatePartialWarp ||
+      testCase == NvlSignalTrapCase::AggregateNon1DGrid) {
     auto group = make_warp_group();
     signal_publish_and_wait<
         NvlSignalAccess::Multimem,
@@ -159,12 +162,42 @@ __global__ void nvlSignalRankBoundaryKernel(int nvlRanks, uint64_t* output) {
   }
 }
 
+dim3 signal_trap_threads(NvlSignalTrapCase testCase) {
+  switch (testCase) {
+    case NvlSignalTrapCase::AggregatePartialWarp:
+      return dim3(kWarpSize / 2);
+    case NvlSignalTrapCase::DuplicateChannelOwner:
+      return dim3(2 * kWarpSize);
+    case NvlSignalTrapCase::PerPeerNon1DBlock:
+      return dim3(kNvlSignalSmallPerPeerThreads, 2);
+    case NvlSignalTrapCase::AggregateDepthTooLarge:
+    case NvlSignalTrapCase::ArrivalCountMismatch:
+    case NvlSignalTrapCase::SignalsPerChannelMismatch:
+    case NvlSignalTrapCase::AggregateNon1DGrid:
+    case NvlSignalTrapCase::PerPeerGroupTooSmall:
+      return dim3(kWarpSize);
+    default:
+      return dim3(kNvlSignalSmallPerPeerThreads);
+  }
+}
+
+dim3 signal_trap_blocks(NvlSignalTrapCase testCase) {
+  switch (testCase) {
+    case NvlSignalTrapCase::PerPeerDuplicateChannelOwner:
+      return dim3(2);
+    case NvlSignalTrapCase::AggregateNon1DGrid:
+      return dim3(1, 2);
+    default:
+      return dim3(1);
+  }
+}
+
 } // namespace
 
 void launchNvlSignalTrap(NvlSignalTrapCase testCase) {
-  const uint32_t threads =
-      testCase == NvlSignalTrapCase::PerPeerGroupTooSmall ? 32 : 64;
-  nvlSignalTrapKernel<<<1, threads>>>(
+  nvlSignalTrapKernel<<<
+      signal_trap_blocks(testCase),
+      signal_trap_threads(testCase)>>>(
       testCase); // NOLINT(facebook-cuda-safe-kernel-call-check)
 }
 

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cu
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cu
@@ -20,8 +20,11 @@ __global__ void nvlSignalTrapKernel(NvlSignalTrapCase testCase) {
   const uint32_t pipelineDepth =
       testCase == NvlSignalTrapCase::AggregateDepthTooLarge ? 33 : 1;
   const int nvlRanks = tooManyRanks ? 65 : 4;
-  const uint32_t signalsPerChannel =
+  uint32_t signalsPerChannel =
       static_cast<uint32_t>(3 * nvlRanks + 4 * pipelineDepth);
+  if (testCase == NvlSignalTrapCase::SignalsPerChannelMismatch) {
+    --signalsPerChannel;
+  }
   MultimemNvlTransportDevice transport{
       .internalLocalSignals =
           DeviceSpan<SignalState>(trapSignals, signalsPerChannel),
@@ -64,7 +67,8 @@ __global__ void nvlSignalTrapKernel(NvlSignalTrapCase testCase) {
     return;
   }
   if (testCase == NvlSignalTrapCase::AggregateDepthTooLarge ||
-      testCase == NvlSignalTrapCase::ArrivalCountMismatch) {
+      testCase == NvlSignalTrapCase::ArrivalCountMismatch ||
+      testCase == NvlSignalTrapCase::SignalsPerChannelMismatch) {
     auto group = make_warp_group();
     signal_publish_and_wait<
         NvlSignalAccess::Multimem,

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cu
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cu
@@ -9,8 +9,29 @@
 namespace comms::prims::test {
 namespace {
 
+constexpr auto kZeroRankMask = NvlSignalRankMask::first(0);
+constexpr auto kTooManyRankMask =
+    NvlSignalRankMask::first(kMaxNvlSignalRanks + 1);
+static_assert(kZeroRankMask.low == 0 && kZeroRankMask.high == 0);
+static_assert(kTooManyRankMask.low == 0 && kTooManyRankMask.high == 0);
+static_assert(
+    nvl_signal_per_peer_group_size(0) == kNvlSignalSmallPerPeerThreads);
+static_assert(
+    nvl_signal_per_peer_group_size(kMaxNvlSignalRanks + 1) ==
+    kNvlSignalLargePerPeerThreads);
+
 __device__ alignas(SignalState) uint64_t
     trapSignalStorage[16 * sizeof(SignalState) / sizeof(uint64_t)];
+
+constexpr int kBoundaryMaxRanks = static_cast<int>(kMaxNvlSignalRanks);
+constexpr uint32_t kBoundaryPipelineDepth = 1;
+constexpr uint32_t kBoundarySignalCount =
+    static_cast<uint32_t>(multimem_staging_signals_per_channel(
+        kBoundaryMaxRanks,
+        kBoundaryPipelineDepth));
+__device__ alignas(SignalState) uint64_t boundarySignalStorage
+    [kBoundarySignalCount * sizeof(SignalState) / sizeof(uint64_t)];
+__device__ SignalState* boundaryPeerSignals[kBoundaryMaxRanks];
 
 __global__ void nvlSignalTrapKernel(NvlSignalTrapCase testCase) {
   auto* trapSignals = reinterpret_cast<SignalState*>(trapSignalStorage);
@@ -19,7 +40,8 @@ __global__ void nvlSignalTrapKernel(NvlSignalTrapCase testCase) {
   const bool tooManyRanks = testCase == NvlSignalTrapCase::RankCountTooLarge;
   const uint32_t pipelineDepth =
       testCase == NvlSignalTrapCase::AggregateDepthTooLarge ? 33 : 1;
-  const int nvlRanks = tooManyRanks ? 65 : 4;
+  const int nvlRanks =
+      tooManyRanks ? static_cast<int>(kMaxNvlSignalRanks + 1) : 4;
   uint32_t signalsPerChannel =
       static_cast<uint32_t>(3 * nvlRanks + 4 * pipelineDepth);
   if (testCase == NvlSignalTrapCase::SignalsPerChannelMismatch) {
@@ -84,6 +106,59 @@ __global__ void nvlSignalTrapKernel(NvlSignalTrapCase testCase) {
       NvlSignalPhase::Ready>(transport, round, participants, group);
 }
 
+__global__ void nvlSignalRankBoundaryKernel(int nvlRanks, uint64_t* output) {
+  auto group = make_block_group();
+  auto* signals = reinterpret_cast<SignalState*>(boundarySignalStorage);
+  for (int rank = static_cast<int>(threadIdx.x); rank < nvlRanks;
+       rank += static_cast<int>(blockDim.x)) {
+    boundaryPeerSignals[rank] = signals;
+  }
+  group.sync();
+
+  const int selectedRank = nvlRanks - 1;
+  const uint64_t roundValue = static_cast<uint64_t>(nvlRanks);
+  auto publishers =
+      NvlSignalRankMask::single(static_cast<uint32_t>(selectedRank));
+  publishers.low |= uint64_t{1};
+  if (group.is_leader()) {
+    signals[0].store(roundValue);
+  }
+  group.sync();
+  const auto selected =
+      NvlSignalRankMask::single(static_cast<uint32_t>(selectedRank));
+  const uint32_t signalsPerChannel = static_cast<uint32_t>(
+      multimem_staging_signals_per_channel(nvlRanks, kBoundaryPipelineDepth));
+  MultimemNvlTransportDevice transport{
+      .internalLocalSignals =
+          DeviceSpan<SignalState>(signals, signalsPerChannel),
+      .internalMultimemSignals =
+          DeviceSpan<SignalState>(signals, signalsPerChannel),
+      .nvlRank = selectedRank,
+      .nvlRanks = nvlRanks,
+      .pipelineDepth = kBoundaryPipelineDepth,
+      .maxChannels = 1,
+      .signalsPerChannel = signalsPerChannel,
+      .internalUnicastSignalsByRank =
+          DeviceSpan<SignalState*>(boundaryPeerSignals, nvlRanks),
+  };
+  signal_publish_and_wait<
+      NvlSignalAccess::Unicast,
+      NvlSignalTopology::PerPeer,
+      NvlSignalPhase::Ready>(
+      transport,
+      StageRound{.channel = 0, .value = roundValue},
+      NvlSignalParticipants{
+          .publisherMask = publishers,
+          .waiterMask = selected,
+          .expectedArrivals = nvl_signal_detail::mask_rank_count(publishers),
+      },
+      group,
+      Timeout{});
+  if (group.is_leader()) {
+    *output = signals[selectedRank].load();
+  }
+}
+
 } // namespace
 
 void launchNvlSignalTrap(NvlSignalTrapCase testCase) {
@@ -91,6 +166,13 @@ void launchNvlSignalTrap(NvlSignalTrapCase testCase) {
       testCase == NvlSignalTrapCase::PerPeerGroupTooSmall ? 32 : 64;
   nvlSignalTrapKernel<<<1, threads>>>(
       testCase); // NOLINT(facebook-cuda-safe-kernel-call-check)
+}
+
+void launchNvlSignalRankBoundary(int nvlRanks, uint64_t* output) {
+  const uint32_t threads =
+      nvl_signal_per_peer_group_size(static_cast<uint32_t>(nvlRanks));
+  nvlSignalRankBoundaryKernel<<<1, threads>>>(
+      nvlRanks, output); // NOLINT(facebook-cuda-safe-kernel-call-check)
 }
 
 } // namespace comms::prims::test

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
@@ -14,6 +14,7 @@ enum class NvlSignalTrapCase : uint32_t {
   PerPeerGroupTooSmall,
   WaitTimeout,
   ZeroRound,
+  SignalsPerChannelMismatch,
 };
 
 void launchNvlSignalTrap(NvlSignalTrapCase testCase);

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
@@ -15,6 +15,11 @@ enum class NvlSignalTrapCase : uint32_t {
   WaitTimeout,
   ZeroRound,
   SignalsPerChannelMismatch,
+  DuplicateChannelOwner,
+  AggregatePartialWarp,
+  AggregateNon1DGrid,
+  PerPeerDuplicateChannelOwner,
+  PerPeerNon1DBlock,
 };
 
 void launchNvlSignalTrap(NvlSignalTrapCase testCase);

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
@@ -18,5 +18,6 @@ enum class NvlSignalTrapCase : uint32_t {
 };
 
 void launchNvlSignalTrap(NvlSignalTrapCase testCase);
+void launchNvlSignalRankBoundary(int nvlRanks, uint64_t* output);
 
 } // namespace comms::prims::test

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -108,11 +108,10 @@ __global__ void readPeerInternalSignalsKernel(
 
 __device__ NvlSignalParticipants
 makeTestParticipants(const MultimemNvlTransportDevice& transport, bool fanIn) {
-  const uint64_t allRanks = transport.nvlRanks == 64
-      ? ~uint64_t{0}
-      : (uint64_t{1} << transport.nvlRanks) - 1;
+  const auto allRanks =
+      NvlSignalRankMask::first(static_cast<uint32_t>(transport.nvlRanks));
   return NvlSignalParticipants{
-      .publisherMask = fanIn ? allRanks & ~uint64_t{1} : allRanks,
+      .publisherMask = fanIn ? allRanks.without(0) : allRanks,
       .waiterMask = fanIn ? uint64_t{1} : allRanks,
       .expectedArrivals = static_cast<uint32_t>(
           fanIn ? transport.nvlRanks - 1 : transport.nvlRanks),
@@ -121,9 +120,8 @@ makeTestParticipants(const MultimemNvlTransportDevice& transport, bool fanIn) {
 
 __device__ NvlSignalParticipants
 makeAckParticipants(const MultimemNvlTransportDevice& transport) {
-  const uint64_t allRanks = transport.nvlRanks == 64
-      ? ~uint64_t{0}
-      : (uint64_t{1} << transport.nvlRanks) - 1;
+  const auto allRanks =
+      NvlSignalRankMask::first(static_cast<uint32_t>(transport.nvlRanks));
   return NvlSignalParticipants{
       .publisherMask = 1,
       .waiterMask = allRanks,
@@ -291,11 +289,10 @@ __global__ void separatePublishAndWaitKernel(
     uint64_t roundValue,
     uint64_t* out) {
   auto group = make_block_group();
-  const uint64_t allRanks = transport.nvlRanks == 64
-      ? ~uint64_t{0}
-      : (uint64_t{1} << transport.nvlRanks) - 1;
+  const auto allRanks =
+      NvlSignalRankMask::first(static_cast<uint32_t>(transport.nvlRanks));
   const NvlSignalParticipants participants{
-      .publisherMask = allRanks & ~uint64_t{1},
+      .publisherMask = allRanks.without(0),
       .waiterMask = 1,
       .expectedArrivals = static_cast<uint32_t>(transport.nvlRanks - 1),
   };
@@ -375,7 +372,11 @@ void launchPerPeerSignalProtocolTyped(
     uint64_t* out,
     cudaStream_t stream) {
   perPeerSignalProtocolKernel<access, phase, waitPolicy>
-      <<<1, 64, 0, stream>>>(transport, fanIn, roundValue, out);
+      <<<1,
+         nvl_signal_per_peer_group_size(
+             static_cast<uint32_t>(transport.nvlRanks)),
+         0,
+         stream>>>(transport, fanIn, roundValue, out);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -715,8 +716,11 @@ void launchSeparatePublishAndWait(
     uint64_t roundValue,
     uint64_t* out,
     cudaStream_t stream) {
-  separatePublishAndWaitKernel<<<1, 64, 0, stream>>>(
-      transport, roundValue, out);
+  separatePublishAndWaitKernel<<<
+      1,
+      nvl_signal_per_peer_group_size(static_cast<uint32_t>(transport.nvlRanks)),
+      0,
+      stream>>>(transport, roundValue, out);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -735,7 +739,11 @@ void launchPerPeerWaitOnly(
     uint64_t roundValue,
     uint64_t* out,
     cudaStream_t stream) {
-  perPeerWaitOnlyKernel<<<1, 64, 0, stream>>>(transport, roundValue, out);
+  perPeerWaitOnlyKernel<<<
+      1,
+      nvl_signal_per_peer_group_size(static_cast<uint32_t>(transport.nvlRanks)),
+      0,
+      stream>>>(transport, roundValue, out);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -219,8 +219,9 @@ __global__ void multiChannelAggregateSignalKernel(
     MultimemNvlTransportDevice transport,
     uint64_t* out) {
   auto group = make_warp_group();
+  const auto layout = multimem::make_stage_layout<uint64_t>(transport, group);
   const StageRound round{
-      .channel = static_cast<uint32_t>(blockIdx.x),
+      .channel = group.group_id,
       .value = 1,
   };
   signal_publish_and_wait<
@@ -234,11 +235,10 @@ __global__ void multiChannelAggregateSignalKernel(
       Timeout{});
   const uint32_t lane = group.thread_id_in_group;
   if (lane < transport.pipelineDepth) {
-    const uint64_t signalId =
-        static_cast<uint64_t>(round.channel) * transport.signalsPerChannel +
+    const uint64_t signalId = layout.signalBase +
         static_cast<uint64_t>(3 * transport.nvlRanks) + 4 * lane;
     const uint64_t outputBase =
-        static_cast<uint64_t>(round.channel) * 2 * transport.pipelineDepth;
+        static_cast<uint64_t>(group.group_id) * 2 * transport.pipelineDepth;
     out[outputBase + lane] = transport.internalLocalSignals[signalId].load();
     out[outputBase + transport.pipelineDepth + lane] =
         transport.internalLocalSignals[signalId + 1].load();
@@ -698,7 +698,7 @@ void launchMultiChannelAggregateSignal(
     uint32_t channels,
     uint64_t* out,
     cudaStream_t stream) {
-  multiChannelAggregateSignalKernel<<<channels, 32, 0, stream>>>(
+  multiChannelAggregateSignalKernel<<<1, channels * kWarpSize, 0, stream>>>(
       transport, out);
   PIPES_KERNEL_LAUNCH_CHECK();
 }

--- a/comms/prims/transport/nvl/MultimemNvlSignal.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlSignal.cuh
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/Timeout.cuh"
@@ -23,23 +24,132 @@ enum class NvlSignalPhase { Ready, Ack, Consumed };
 /** Selects how a per-peer waiter combines peer completion state. */
 enum class NvlPerPeerWaitPolicy { WaitAll, SerialMin, TreeMin, ButterflyMin };
 
+inline constexpr uint32_t kMaxNvlSignalRanks = 72;
+inline constexpr uint32_t kNvlSignalRanksPerMaskWord =
+    std::numeric_limits<uint64_t>::digits;
+inline constexpr uint32_t kNvlSignalSmallPerPeerThreads =
+    kNvlSignalRanksPerMaskWord;
+inline constexpr uint32_t kNvlSignalLargePerPeerThreads =
+    2 * kNvlSignalSmallPerPeerThreads;
+
+__host__ __device__ constexpr bool nvl_signal_rank_count_supported(
+    uint32_t ranks) {
+  return ranks > 0 && ranks <= kMaxNvlSignalRanks;
+}
+
+/**
+ * Returns a launchable one-dimensional per-peer CUDA block size.
+ *
+ * Rank validity is checked separately so an invalid count still reaches
+ * device-side protocol validation instead of producing a zero-thread launch.
+ */
+__host__ __device__ constexpr uint32_t nvl_signal_per_peer_group_size(
+    uint32_t ranks) {
+  return ranks <= kNvlSignalSmallPerPeerThreads ? kNvlSignalSmallPerPeerThreads
+                                                : kNvlSignalLargePerPeerThreads;
+}
+
+inline constexpr uint32_t kMaxNvlSignalPerPeerThreads =
+    nvl_signal_per_peer_group_size(kMaxNvlSignalRanks);
+inline constexpr uint32_t kMaxNvlSignalPerPeerWarps =
+    kMaxNvlSignalPerPeerThreads / kWarpSize;
+
+static_assert(kMaxNvlSignalPerPeerThreads % kWarpSize == 0);
+
 /** Identifies one channel and one monotonic per-peer round value. */
 struct StageRound {
   uint32_t channel;
   uint64_t value;
 };
 
+/** Selects up to 72 NVL-local ranks; ranks 64-71 use the high word. */
+struct NvlSignalRankMask {
+  uint64_t low{0};
+  uint64_t high{0};
+
+  __host__ __device__ constexpr NvlSignalRankMask() = default;
+  __host__ __device__ constexpr NvlSignalRankMask(uint64_t lowBits)
+      : low(lowBits) {}
+  __host__ __device__ constexpr NvlSignalRankMask(
+      uint64_t lowBits,
+      uint64_t highBits)
+      : low(lowBits), high(highBits) {}
+
+  __host__ __device__ static constexpr NvlSignalRankMask first(uint32_t ranks) {
+    if (!nvl_signal_rank_count_supported(ranks)) {
+      return {};
+    }
+    if (ranks < kNvlSignalRanksPerMaskWord) {
+      return {(uint64_t{1} << ranks) - 1};
+    }
+    if (ranks == kNvlSignalRanksPerMaskWord) {
+      return {~uint64_t{0}};
+    }
+    return {
+        ~uint64_t{0},
+        (uint64_t{1} << (ranks - kNvlSignalRanksPerMaskWord)) - 1};
+  }
+
+  __host__ __device__ static constexpr NvlSignalRankMask single(uint32_t rank) {
+    if (rank < kNvlSignalRanksPerMaskWord) {
+      return {uint64_t{1} << rank};
+    }
+    if (rank < kMaxNvlSignalRanks) {
+      return {0, uint64_t{1} << (rank - kNvlSignalRanksPerMaskWord)};
+    }
+    return {};
+  }
+
+  __host__ __device__ constexpr NvlSignalRankMask without(uint32_t rank) const {
+    auto result = *this;
+    if (rank < kNvlSignalRanksPerMaskWord) {
+      result.low &= ~(uint64_t{1} << rank);
+    } else if (rank < kMaxNvlSignalRanks) {
+      result.high &= ~(uint64_t{1} << (rank - kNvlSignalRanksPerMaskWord));
+    }
+    return result;
+  }
+};
+
 /** Describes the ranks participating in one signal operation. */
 struct NvlSignalParticipants {
-  uint64_t publisherMask{0};
-  uint64_t waiterMask{0};
+  NvlSignalRankMask publisherMask{};
+  NvlSignalRankMask waiterMask{};
   uint32_t expectedArrivals{0};
 };
 
 namespace nvl_signal_detail {
 
-__device__ __forceinline__ bool rank_selected(uint64_t mask, int rank) {
-  return rank >= 0 && rank < 64 && ((mask >> rank) & uint64_t{1}) != 0;
+__device__ __forceinline__ bool rank_selected(
+    const NvlSignalRankMask& mask,
+    int rank) {
+  if (rank < 0 || rank >= static_cast<int>(kMaxNvlSignalRanks)) {
+    return false;
+  }
+  const uint64_t word = rank < static_cast<int>(kNvlSignalRanksPerMaskWord)
+      ? mask.low
+      : mask.high;
+  return ((word >> (rank % kNvlSignalRanksPerMaskWord)) & uint64_t{1}) != 0;
+}
+
+__device__ __forceinline__ bool mask_is_empty(const NvlSignalRankMask& mask) {
+  return mask.low == 0 && mask.high == 0;
+}
+
+__device__ __forceinline__ bool mask_fits(
+    const NvlSignalRankMask& mask,
+    const NvlSignalRankMask& valid) {
+  return (mask.low & ~valid.low) == 0 && (mask.high & ~valid.high) == 0;
+}
+
+__device__ __forceinline__ uint32_t
+mask_rank_count(const NvlSignalRankMask& mask) {
+#if defined(__CUDA_ARCH__)
+  return static_cast<uint32_t>(__popcll(mask.low) + __popcll(mask.high));
+#else
+  (void)mask;
+  return 0;
+#endif
 }
 
 __device__ __forceinline__ bool sequence_reached(
@@ -131,36 +241,39 @@ __device__ __forceinline__ void validate_common(
     const StageRound& round,
     const NvlSignalParticipants& participants) {
 #if defined(__CUDA_ARCH__)
-  const bool validRankCount =
-      transport.nvlRanks > 0 && transport.nvlRanks <= 64;
-  uint64_t validRankMask = ~uint64_t{0};
-  if (validRankCount && transport.nvlRanks < 64) {
-    validRankMask = (uint64_t{1} << transport.nvlRanks) - 1;
-  }
+  const bool validRankCount = transport.nvlRanks > 0 &&
+      nvl_signal_rank_count_supported(
+                                  static_cast<uint32_t>(transport.nvlRanks));
+  const auto validRankMask = NvlSignalRankMask::first(
+      validRankCount ? static_cast<uint32_t>(transport.nvlRanks) : 0);
   const uint64_t expectedSignalsPerChannel = validRankCount
       ? static_cast<uint64_t>(3) * static_cast<uint64_t>(transport.nvlRanks) +
           static_cast<uint64_t>(4) * transport.pipelineDepth
       : 0;
   if (!validRankCount || transport.nvlRank < 0 ||
       transport.nvlRank >= transport.nvlRanks ||
-      participants.publisherMask == 0 || participants.waiterMask == 0 ||
-      (participants.publisherMask & ~validRankMask) != 0 ||
-      (participants.waiterMask & ~validRankMask) != 0 ||
+      mask_is_empty(participants.publisherMask) ||
+      mask_is_empty(participants.waiterMask) ||
+      !mask_fits(participants.publisherMask, validRankMask) ||
+      !mask_fits(participants.waiterMask, validRankMask) ||
       participants.expectedArrivals == 0 ||
       participants.expectedArrivals !=
-          static_cast<uint32_t>(__popcll(participants.publisherMask)) ||
+          mask_rank_count(participants.publisherMask) ||
       round.channel >= transport.maxChannels || round.value == 0 ||
       transport.signalsPerChannel != expectedSignalsPerChannel) {
     printf(
         "NVL signal invalid geometry: rank=%d ranks=%d channel=%u "
-        "round=%llu maxChannels=%u publishers=%llu waiters=%llu arrivals=%u\n",
+        "round=%llu maxChannels=%u publishers=(%llu,%llu) "
+        "waiters=(%llu,%llu) arrivals=%u\n",
         transport.nvlRank,
         transport.nvlRanks,
         static_cast<unsigned>(round.channel),
         static_cast<unsigned long long>(round.value),
         static_cast<unsigned>(transport.maxChannels),
-        static_cast<unsigned long long>(participants.publisherMask),
-        static_cast<unsigned long long>(participants.waiterMask),
+        static_cast<unsigned long long>(participants.publisherMask.low),
+        static_cast<unsigned long long>(participants.publisherMask.high),
+        static_cast<unsigned long long>(participants.waiterMask.low),
+        static_cast<unsigned long long>(participants.waiterMask.high),
         static_cast<unsigned>(participants.expectedArrivals));
     __trap();
   }
@@ -179,8 +292,11 @@ __device__ __forceinline__ void validate_per_peer(
   const uint64_t requiredSignals =
       static_cast<uint64_t>(transport.maxChannels) *
       transport.signalsPerChannel;
-  if (group.scope != SyncScope::BLOCK || group.group_size != 64 ||
-      transport.nvlRanks > 64 ||
+  const uint32_t requiredGroupSize =
+      nvl_signal_per_peer_group_size(static_cast<uint32_t>(transport.nvlRanks));
+  if (group.scope != SyncScope::BLOCK ||
+      group.group_size != requiredGroupSize ||
+      transport.nvlRanks > static_cast<int>(kMaxNvlSignalRanks) ||
       requiredSignals > transport.internalLocalSignals.size() ||
       requiredSignals > transport.internalMultimemSignals.size() ||
       (access == NvlSignalAccess::Unicast &&
@@ -261,12 +377,12 @@ __device__ __forceinline__ void wait_per_peer_tree(
     const NvlSignalParticipants& participants,
     ThreadGroup& group,
     const Timeout& timeout) {
-  __shared__ uint32_t completeByPeer[64];
+  __shared__ uint32_t completeByThread[kMaxNvlSignalPerPeerThreads];
   const uint32_t thread = group.thread_id_in_group;
   bool complete = false;
   while (!complete) {
     const int source = static_cast<int>(thread);
-    completeByPeer[thread] = source >= transport.nvlRanks ||
+    completeByThread[thread] = source >= transport.nvlRanks ||
             !rank_selected(participants.publisherMask, source) ||
             sequence_reached(transport
                                  .internalLocalSignals[peer_signal_id<phase>(
@@ -276,13 +392,13 @@ __device__ __forceinline__ void wait_per_peer_tree(
         ? 1
         : 0;
     group.sync();
-    for (uint32_t stride = 32; stride != 0; stride /= 2) {
+    for (uint32_t stride = group.group_size / 2; stride != 0; stride /= 2) {
       if (thread < stride) {
-        completeByPeer[thread] &= completeByPeer[thread + stride];
+        completeByThread[thread] &= completeByThread[thread + stride];
       }
       group.sync();
     }
-    complete = completeByPeer[0] != 0;
+    complete = completeByThread[0] != 0;
     if (!complete && group.is_leader()) {
       TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
           timeout,
@@ -300,7 +416,7 @@ __device__ __forceinline__ void wait_per_peer_butterfly(
     const NvlSignalParticipants& participants,
     ThreadGroup& group,
     const Timeout& timeout) {
-  __shared__ uint32_t completeByWarp[2];
+  __shared__ uint32_t completeByWarp[kMaxNvlSignalPerPeerWarps];
   const uint32_t thread = group.thread_id_in_group;
   const uint32_t lane = thread % kWarpSize;
   const uint32_t warp = thread / kWarpSize;
@@ -325,7 +441,10 @@ __device__ __forceinline__ void wait_per_peer_butterfly(
       completeByWarp[warp] = laneComplete;
     }
     group.sync();
-    complete = completeByWarp[0] != 0 && completeByWarp[1] != 0;
+    complete = true;
+    for (uint32_t index = 0; index < group.group_size / kWarpSize; ++index) {
+      complete &= completeByWarp[index] != 0;
+    }
     if (!complete && group.is_leader()) {
       TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
           timeout,
@@ -374,7 +493,8 @@ __device__ __forceinline__ void validate_aggregate(
  *
  * Aggregate topology requires one warp and maps active threads to pipeline
  * lanes.
- * Per-peer topology requires one 64-thread block and maps threads to peers.
+ * Per-peer topology requires one block sized by
+ * `nvl_signal_per_peer_group_size()` and maps threads to peers.
  *
  * @param transport Exchanged multimem transport device view.
  * @param round Logical channel and per-peer round value.

--- a/comms/prims/transport/nvl/MultimemNvlSignal.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlSignal.cuh
@@ -137,6 +137,10 @@ __device__ __forceinline__ void validate_common(
   if (validRankCount && transport.nvlRanks < 64) {
     validRankMask = (uint64_t{1} << transport.nvlRanks) - 1;
   }
+  const uint64_t expectedSignalsPerChannel = validRankCount
+      ? static_cast<uint64_t>(3) * static_cast<uint64_t>(transport.nvlRanks) +
+          static_cast<uint64_t>(4) * transport.pipelineDepth
+      : 0;
   if (!validRankCount || transport.nvlRank < 0 ||
       transport.nvlRank >= transport.nvlRanks ||
       participants.publisherMask == 0 || participants.waiterMask == 0 ||
@@ -146,7 +150,7 @@ __device__ __forceinline__ void validate_common(
       participants.expectedArrivals !=
           static_cast<uint32_t>(__popcll(participants.publisherMask)) ||
       round.channel >= transport.maxChannels || round.value == 0 ||
-      transport.signalsPerChannel == 0) {
+      transport.signalsPerChannel != expectedSignalsPerChannel) {
     printf(
         "NVL signal invalid geometry: rank=%d ranks=%d channel=%u "
         "round=%llu maxChannels=%u publishers=%llu waiters=%llu arrivals=%u\n",

--- a/comms/prims/transport/nvl/MultimemNvlSignal.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlSignal.cuh
@@ -287,6 +287,7 @@ __device__ __forceinline__ void validate_common(
 template <NvlSignalAccess access>
 __device__ __forceinline__ void validate_per_peer(
     const MultimemNvlTransportDevice& transport,
+    const StageRound& round,
     const ThreadGroup& group) {
 #if defined(__CUDA_ARCH__)
   const uint64_t requiredSignals =
@@ -294,8 +295,10 @@ __device__ __forceinline__ void validate_per_peer(
       transport.signalsPerChannel;
   const uint32_t requiredGroupSize =
       nvl_signal_per_peer_group_size(static_cast<uint32_t>(transport.nvlRanks));
-  if (group.scope != SyncScope::BLOCK ||
+  if (blockDim.y != 1 || blockDim.z != 1 || gridDim.y != 1 || gridDim.z != 1 ||
+      blockDim.x != requiredGroupSize || group.scope != SyncScope::BLOCK ||
       group.group_size != requiredGroupSize ||
+      group.group_id != round.channel ||
       transport.nvlRanks > static_cast<int>(kMaxNvlSignalRanks) ||
       requiredSignals > transport.internalLocalSignals.size() ||
       requiredSignals > transport.internalMultimemSignals.size() ||
@@ -303,8 +306,19 @@ __device__ __forceinline__ void validate_per_peer(
        transport.internalUnicastSignalsByRank.size() !=
            static_cast<uint32_t>(transport.nvlRanks))) {
     printf(
-        "NVL per-peer signal invalid execution geometry: groupSize=%u "
-        "ranks=%d localSignals=%u multimemSignals=%u peers=%u\n",
+        "NVL per-peer signal invalid execution geometry: block=(%u,%u,%u) "
+        "grid=(%u,%u,%u) groupId=%u blockId=%u channel=%u groupSize=%u "
+        "ranks=%d "
+        "localSignals=%u multimemSignals=%u peers=%u\n",
+        static_cast<unsigned>(blockDim.x),
+        static_cast<unsigned>(blockDim.y),
+        static_cast<unsigned>(blockDim.z),
+        static_cast<unsigned>(gridDim.x),
+        static_cast<unsigned>(gridDim.y),
+        static_cast<unsigned>(gridDim.z),
+        static_cast<unsigned>(group.group_id),
+        static_cast<unsigned>(group.block_id),
+        static_cast<unsigned>(round.channel),
         static_cast<unsigned>(group.group_size),
         transport.nvlRanks,
         static_cast<unsigned>(transport.internalLocalSignals.size()),
@@ -314,6 +328,7 @@ __device__ __forceinline__ void validate_per_peer(
   }
 #else
   (void)transport;
+  (void)round;
   (void)group;
 #endif
 }
@@ -458,21 +473,40 @@ __device__ __forceinline__ void wait_per_peer_butterfly(
 template <NvlSignalAccess access>
 __device__ __forceinline__ void validate_aggregate(
     const MultimemNvlTransportDevice& transport,
+    const StageRound& round,
     const ThreadGroup& group) {
 #if defined(__CUDA_ARCH__)
   const uint64_t requiredSignals =
       static_cast<uint64_t>(transport.maxChannels) *
       transport.signalsPerChannel;
-  if (group.scope != SyncScope::WARP || group.group_size != kWarpSize ||
-      transport.pipelineDepth == 0 || transport.pipelineDepth > kWarpSize ||
+  const uint32_t threadInBlock = threadIdx.x + threadIdx.y * blockDim.x +
+      threadIdx.z * blockDim.x * blockDim.y;
+  const uint32_t warpInBlock = threadInBlock / kWarpSize;
+  if (blockDim.x < kWarpSize || blockDim.x % kWarpSize != 0 ||
+      blockDim.y != 1 || blockDim.z != 1 || gridDim.y != 1 || gridDim.z != 1 ||
+      group.scope != SyncScope::WARP || group.group_size != kWarpSize ||
+      group.group_id != round.channel || transport.pipelineDepth == 0 ||
+      transport.pipelineDepth > kWarpSize ||
       requiredSignals > transport.internalLocalSignals.size() ||
       requiredSignals > transport.internalMultimemSignals.size() ||
       (access == NvlSignalAccess::Unicast &&
        transport.internalUnicastSignalsByRank.size() !=
            static_cast<uint32_t>(transport.nvlRanks))) {
     printf(
-        "NVL aggregate signal invalid execution geometry: groupSize=%u "
+        "NVL aggregate signal invalid execution geometry: block=(%u,%u,%u) "
+        "grid=(%u,%u,%u) groupId=%u blockId=%u channel=%u warp=%u "
+        "groupSize=%u "
         "pipelineDepth=%u localSignals=%u multimemSignals=%u peers=%u\n",
+        static_cast<unsigned>(blockDim.x),
+        static_cast<unsigned>(blockDim.y),
+        static_cast<unsigned>(blockDim.z),
+        static_cast<unsigned>(gridDim.x),
+        static_cast<unsigned>(gridDim.y),
+        static_cast<unsigned>(gridDim.z),
+        static_cast<unsigned>(group.group_id),
+        static_cast<unsigned>(group.block_id),
+        static_cast<unsigned>(round.channel),
+        static_cast<unsigned>(warpInBlock),
         static_cast<unsigned>(group.group_size),
         static_cast<unsigned>(transport.pipelineDepth),
         static_cast<unsigned>(transport.internalLocalSignals.size()),
@@ -482,6 +516,7 @@ __device__ __forceinline__ void validate_aggregate(
   }
 #else
   (void)transport;
+  (void)round;
   (void)group;
 #endif
 }
@@ -516,9 +551,9 @@ __device__ __forceinline__ void signal_publish_impl(
   nvl_signal_detail::validate_protocol<access, topology, phase, waitPolicy>();
   nvl_signal_detail::validate_common(transport, round, participants);
   if constexpr (topology == NvlSignalTopology::Aggregate) {
-    nvl_signal_detail::validate_aggregate<access>(transport, group);
+    nvl_signal_detail::validate_aggregate<access>(transport, round, group);
   } else {
-    nvl_signal_detail::validate_per_peer<access>(transport, group);
+    nvl_signal_detail::validate_per_peer<access>(transport, round, group);
   }
 
   comms::device::fence_acq_rel_sys();
@@ -616,9 +651,9 @@ __device__ __forceinline__ void signal_wait_impl(
   nvl_signal_detail::validate_protocol<access, topology, phase, waitPolicy>();
   nvl_signal_detail::validate_common(transport, round, participants);
   if constexpr (topology == NvlSignalTopology::Aggregate) {
-    nvl_signal_detail::validate_aggregate<access>(transport, group);
+    nvl_signal_detail::validate_aggregate<access>(transport, round, group);
   } else {
-    nvl_signal_detail::validate_per_peer<access>(transport, group);
+    nvl_signal_detail::validate_per_peer<access>(transport, round, group);
   }
 
   const bool isWaiter = nvl_signal_detail::rank_selected(

--- a/comms/prims/transport/nvl/MultimemNvlSignal.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlSignal.cuh
@@ -567,8 +567,9 @@ __device__ __forceinline__ void signal_publish_impl(
             nvl_signal_detail::aggregate_counter_id<phase>(
                 transport, round, lane);
         if constexpr (access == NvlSignalAccess::Multimem) {
-          transport.template signal_internal_scalar<SignalOp::SIGNAL_ADD>(
-              signalId, 1);
+          transport
+              .template signal_internal_scalar_prefenced<SignalOp::SIGNAL_ADD>(
+                  signalId, 1);
         } else {
           for (int destination = 0; destination < transport.nvlRanks;
                ++destination) {
@@ -585,8 +586,9 @@ __device__ __forceinline__ void signal_publish_impl(
           transport, round, transport.nvlRank);
       if constexpr (access == NvlSignalAccess::Multimem) {
         if (group.is_leader()) {
-          transport.template signal_internal_scalar<SignalOp::SIGNAL_SET>(
-              signalId, round.value);
+          transport
+              .template signal_internal_scalar_prefenced<SignalOp::SIGNAL_SET>(
+                  signalId, round.value);
         }
       } else {
         const int destination = static_cast<int>(group.thread_id_in_group);

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -124,8 +124,19 @@ struct MultimemNvlTransportDevice {
   __device__ __forceinline__ void signal_internal_scalar(
       uint64_t signal_id,
       uint64_t value) const {
-    auto* signal = internal_multimem_signal_ptr(signal_id);
     comms::device::fence_acq_rel_sys();
+    signal_internal_scalar_prefenced<op>(signal_id, value);
+  }
+
+  template <SignalOp op>
+  __device__ __forceinline__ void signal_internal_scalar_prefenced(
+      uint64_t signal_id,
+      uint64_t value) const {
+    // The caller must have already issued the required system-scope fence.
+    // When the signal publishes data produced by a cooperative group, the
+    // caller must also synchronize that group after the fence and before any
+    // thread invokes this helper.
+    auto* signal = internal_multimem_signal_ptr(signal_id);
     if constexpr (op == SignalOp::SIGNAL_SET) {
       detail::multimem_store_release_sys_u64(&signal->signal_, value);
     } else {


### PR DESCRIPTION
Summary: Document caller-defined aggregate Ready/Ack credit epochs: per-publisher quotas, summed Ready thresholds, protected payload work before Ack, and a global Ack turnstile that blocks next-epoch contributors. Include an N-producer, two-credit example and explain why an anonymous total without per-publisher bounds cannot prove complete participation.

Differential Revision: D116730343


