### PR TITLE
Register caller-owned multicast windows (#3751)

### DIFF
--- a/comms/ctran/utils/CtranMulticast.cc
+++ b/comms/ctran/utils/CtranMulticast.cc
@@ -6,6 +6,7 @@
 #include "comms/ctran/utils/Alloc.h" // isCuMemFabricEnabled
 #include "comms/ctran/utils/Checks.h" // FB_COMMCHECK
 #include "comms/ctran/utils/CudaWrap.h"
+#include "comms/ctran/utils/ExtUtils.h"
 #if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12010
 #include "comms/ctran/utils/CtranLogger.h"
 #endif
@@ -20,6 +21,7 @@ CtranMulticast::CtranMulticast(int nvlLocalRank, int nLocalRanks, int cudaDev)
       cudaDev_(cudaDev) {}
 
 CtranMulticast::~CtranMulticast() {
+  SetCudaDevRAII setCudaDev(cudaDev_);
   // Safe teardown: cuMulticastUnbind can return an RM error if the backing
   // buffer was already freed by the user (see NCCL's "safe to ignore" note);
   // ignore all teardown errors so a partially-created or user-freed overlay
@@ -59,6 +61,7 @@ bool CtranMulticast::isSupported(int cudaDev) {
   // multicast-capable/incapable split within a process). Also logs the
   // unsupported reason at most once.
   static const bool supported = [cudaDev]() -> bool {
+    SetCudaDevRAII setCudaDev(cudaDev);
     // Driver-version gate: the multicast entry points are loaded (non-null).
     if (FB_CUPFN(cuMulticastCreate) == nullptr ||
         FB_CUPFN(cuMulticastAddDevice) == nullptr ||
@@ -111,7 +114,7 @@ bool CtranMulticast::isSupported(int cudaDev) {
 
 commResult_t
 CtranMulticast::granularity(int cudaDev, int nLocalRanks, size_t& gran) {
-  (void)cudaDev;
+  SetCudaDevRAII setCudaDev(cudaDev);
   CUmulticastObjectProp prop = {};
   prop.numDevices = static_cast<unsigned int>(nLocalRanks);
   prop.size = 0;
@@ -130,6 +133,7 @@ commResult_t CtranMulticast::createRoot(
     size_t mcSize,
     CUmemAllocationHandleType handleType,
     CUmemGenericAllocationHandle& outHandle) {
+  SetCudaDevRAII setCudaDev(cudaDev_);
   // Release anything we already hold before creating a new one, so a misuse
   // (double createRoot, or createRoot after adoptImported) cannot silently drop
   // -- and leak -- the previously-held multicast object. Zero each first so a
@@ -160,6 +164,7 @@ commResult_t CtranMulticast::createRoot(
 }
 
 void CtranMulticast::adoptImported(CUmemGenericAllocationHandle handle) {
+  SetCudaDevRAII setCudaDev(cudaDev_);
   // mcHandle_ is only ever non-zero once we have already adopted, so this is a
   // double-adopt: release the old reference rather than silently dropping --
   // and leaking -- it. A root's create reference lives in createdHandle_ and is
@@ -172,6 +177,7 @@ void CtranMulticast::adoptImported(CUmemGenericAllocationHandle handle) {
 }
 
 commResult_t CtranMulticast::retainSegments(const void* dptr, size_t len) {
+  SetCudaDevRAII setCudaDev(cudaDev_);
   // Single-use: one instance retains exactly one buffer's segments (like
   // createRoot/adoptImported). Re-retaining would silently drop the prior
   // call's segments, so reject it as an explicit misuse.
@@ -230,6 +236,7 @@ bool CtranMulticast::segmentsAlignedTo(size_t gran) const {
 }
 
 commResult_t CtranMulticast::addDeviceAndBind() {
+  SetCudaDevRAII setCudaDev(cudaDev_);
   // Every rank, the root included, binds and maps through its IMPORTED handle,
   // so adoptImported() must have run: createRoot() alone leaves mcHandle_ at 0.
   if (mcHandle_ == 0) {
@@ -252,6 +259,7 @@ commResult_t CtranMulticast::addDeviceAndBind() {
 }
 
 commResult_t CtranMulticast::mapVA(size_t mcSize, size_t gran) {
+  SetCudaDevRAII setCudaDev(cudaDev_);
   FB_CUCHECK(cuMemAddressReserve(
       &mcVA_, mcSize, /*alignment=*/gran, /*addr=*/0, /*flags=*/0));
   // Record the reserved size now so a failure in the map/setAccess below leaves

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -156,6 +156,16 @@ struct CtranWin {
 
   commResult_t free(bool skipBarrier = false);
 
+  // Retain ordinary RegCache segment references for a caller-owned data
+  // buffer. These references make explicit window registration independent of
+  // allocator hooks and are released by free() after scoped registrations and
+  // imported peer mappings are gone.
+  commResult_t retainDataSegments();
+
+  inline bool ownsDataSegmentRefs() const {
+    return !ownedDataSegHdls_.empty();
+  }
+
   bool nvlEnabled(int rank) const;
 
   // Get data size for specific rank
@@ -263,6 +273,10 @@ struct CtranWin {
   // peerBase + (buf - localBase). Records the upstream NCCL_WIN_COLL_SYMMETRIC
   // hint; consumed by a later window-based allgather. Cached only for now.
   bool symmetric_{false};
+  // Ordinary RegCache references retained for a caller-owned data buffer.
+  // They are released non-forced so an allocator hook or another explicit
+  // owner of the same physical segment remains valid.
+  std::vector<void*> ownedDataSegHdls_;
   // The standalone NVL CE-multicast object for this window's data buffer, set
   // in exchange() and read via multicastWriteBase(). Self-owning; released with
   // the window. null unless multicast engaged.

--- a/comms/ctran/window/tests/CtranWinTests.cc
+++ b/comms/ctran/window/tests/CtranWinTests.cc
@@ -1221,11 +1221,10 @@ TEST_F(CtranWinTest, RegisterOverRangeUserBufferNoLeak) {
   // discovery takes the cumem path; a cudaMalloc/host over-range buffer does
   // not reliably error there.
   //
-  // Note: the user buffer registers via acquireScopedRegister, whose
-  // regRangeCached runs pinRange (the over-range step above) BEFORE its
-  // allocator-cached-segment check, so the over-range failure still triggers
-  // here and is surfaced as commInvalidUsage. The oversizedBytes trigger stays
-  // required; no globalRegister/CCA-hook simulation is needed for this path.
+  // Note: ctranWinRegister retains the user buffer's physical segments before
+  // exchange. That retention runs pinRange over the oversized range and fails
+  // before any scoped registration is acquired. The oversizedBytes trigger
+  // stays required; no globalRegister/CCA-hook simulation is needed.
   //
   // With the RAII guard fix, the failed register frees the window (and its
   // signal-buffer segment), so getSegments() returns to baseline.
@@ -1272,12 +1271,12 @@ TEST_F(CtranWinTest, RegisterOverRangeUserBufferNoLeak) {
       segments.end());
 }
 
-TEST_F(CtranWinTest, RegisterUncachedUserBufferReturnsInvalidUsageNoLeak) {
+TEST_F(CtranWinTest, RegisterUncachedUserBufferOwnsAndReleasesSegment) {
   auto comm = makeCtranComm();
   ASSERT_NE(comm, nullptr);
 
   constexpr size_t sizeBytes = 8192 * sizeof(int);
-  const MemAllocType bufType = MemAllocType::kMemCudaMalloc;
+  const MemAllocType bufType = MemAllocType::kMemCuMemAlloc;
   void* userBuf = commMemAlloc(sizeBytes, bufType, segments);
   ASSERT_NE(userBuf, nullptr);
 
@@ -1286,13 +1285,109 @@ TEST_F(CtranWinTest, RegisterUncachedUserBufferReturnsInvalidUsageNoLeak) {
 
   CtranWin* win = nullptr;
   meta::comms::Hints hints;
-  const auto res =
-      ctranWinRegister(userBuf, sizeBytes, comm.get(), &win, hints);
-  EXPECT_EQ(res, commInvalidUsage);
-  EXPECT_EQ(win, nullptr);
-  EXPECT_EQ(regCache->getSegments().size(), segsBefore)
-      << "ctranWinRegister leaked RegCache segments on uncached user buffer";
+  ASSERT_EQ(hints.set("win_register_ipc_only", "1"), commSuccess);
+  ASSERT_EQ(hints.set("win_register_enable_signal", "0"), commSuccess);
+  auto res = ctranWinRegister(userBuf, sizeBytes, comm.get(), &win, hints);
+  ASSERT_EQ(res, commSuccess);
+  ASSERT_NE(win, nullptr);
+  EXPECT_TRUE(win->ownsDataSegmentRefs());
 
+  std::vector<void*> segHdls;
+  std::vector<ctran::regcache::RegElem*> regElems;
+  ASSERT_EQ(
+      regCache->lookupSegmentsForBuffer(
+          userBuf, sizeBytes, comm->statex_->cudaDev(), segHdls, regElems),
+      commSuccess);
+  EXPECT_FALSE(segHdls.empty());
+
+  oobBarrier();
+  res = ctranWinFree(win);
+  EXPECT_EQ(res, commSuccess);
+
+  segHdls.clear();
+  regElems.clear();
+  ASSERT_EQ(
+      regCache->lookupSegmentsForBuffer(
+          userBuf, sizeBytes, comm->statex_->cudaDev(), segHdls, regElems),
+      commSuccess);
+  EXPECT_TRUE(segHdls.empty());
+  EXPECT_TRUE(regElems.empty());
+  EXPECT_EQ(regCache->getSegments().size(), segsBefore)
+      << "ctranWinFree leaked its caller-owned RegCache segment";
+
+  commMemFree(userBuf, sizeBytes, bufType);
+  segments.erase(
+      std::remove_if(
+          segments.begin(),
+          segments.end(),
+          [userBuf](const TestMemSegment& seg) { return seg.ptr == userBuf; }),
+      segments.end());
+}
+
+TEST_F(CtranWinTest, RegisterPreservesAllocatorOwnedSegment) {
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  constexpr size_t sizeBytes = 8192 * sizeof(int);
+  const MemAllocType bufType = MemAllocType::kMemCuMemAlloc;
+  void* userBuf = commMemAlloc(sizeBytes, bufType, segments);
+  ASSERT_NE(userBuf, nullptr);
+
+  auto regCache = ctran::RegCache::getInstance();
+  ASSERT_NE(regCache, nullptr);
+  ASSERT_EQ(
+      regCache->globalRegister(
+          userBuf,
+          sizeBytes,
+          /*forceReg=*/false,
+          /*ncclManaged=*/false,
+          comm->statex_->cudaDev()),
+      commSuccess);
+
+  std::vector<void*> allocatorSegHdls;
+  std::vector<ctran::regcache::RegElem*> regElems;
+  ASSERT_EQ(
+      regCache->lookupSegmentsForBuffer(
+          userBuf,
+          sizeBytes,
+          comm->statex_->cudaDev(),
+          allocatorSegHdls,
+          regElems),
+      commSuccess);
+  ASSERT_FALSE(allocatorSegHdls.empty());
+
+  CtranWin* win = nullptr;
+  meta::comms::Hints hints;
+  ASSERT_EQ(hints.set("win_register_ipc_only", "1"), commSuccess);
+  ASSERT_EQ(hints.set("win_register_enable_signal", "0"), commSuccess);
+  ASSERT_EQ(
+      ctranWinRegister(userBuf, sizeBytes, comm.get(), &win, hints),
+      commSuccess);
+  ASSERT_NE(win, nullptr);
+
+  oobBarrier();
+  ASSERT_EQ(ctranWinFree(win), commSuccess);
+
+  std::vector<void*> remainingSegHdls;
+  regElems.clear();
+  ASSERT_EQ(
+      regCache->lookupSegmentsForBuffer(
+          userBuf,
+          sizeBytes,
+          comm->statex_->cudaDev(),
+          remainingSegHdls,
+          regElems),
+      commSuccess);
+  EXPECT_EQ(remainingSegHdls, allocatorSegHdls)
+      << "Window teardown removed the allocator-owned RegCache reference";
+
+  ASSERT_EQ(
+      regCache->globalDeregister(
+          userBuf,
+          sizeBytes,
+          /*skipRemRelease=*/false,
+          comm->statex_->cudaDev()),
+      commSuccess);
   commMemFree(userBuf, sizeBytes, bufType);
   segments.erase(
       std::remove_if(

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -340,6 +340,27 @@ CtranWin::CtranWin(CtranComm* comm, size_t size, DevMemType bufType)
     val.store(1);
 }
 
+commResult_t CtranWin::retainDataSegments() {
+  if (allocDataBuf_ || winDataPtr == nullptr || dataBytes == 0 ||
+      !ownedDataSegHdls_.empty()) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "CtranWin: retainDataSegments requires one unretained caller-owned data buffer.");
+  }
+
+  auto regCache = ctran::RegCache::getInstance();
+  ctran::CHECK_VALID_REGCACHE(regCache);
+  std::vector<ctran::regcache::Segment*> segments;
+  return regCache->cacheSegment(
+      winDataPtr,
+      dataBytes,
+      comm->statex_->cudaDev(),
+      /*ncclManaged=*/false,
+      comm->statex_->commHash(),
+      segments,
+      ownedDataSegHdls_);
+}
+
 commResult_t CtranWin::exchange() {
   CtranMapperTimer exchangeTotalTimer;
   auto statex = comm->statex_.get();
@@ -393,9 +414,8 @@ commResult_t CtranWin::exchange() {
     dataRegHdl = baseRegHdl;
   } else {
     // User-provided buffer: acquire a scoped local registration. The buffer's
-    // segment must already be allocator-cached (CCA hook);
-    // acquireScopedRegister does not cache segments and returns
-    // commInvalidUsage otherwise. The window owns the scoped ref via
+    // segments were retained by ctranWinRegister before exchange, so this path
+    // does not depend on an allocator hook. The window owns the scoped ref via
     // dataScopedReg (released SW-only in free()); dataRegHdl borrows the
     // RegElem* for the allGatherCtrl handle exchange.
     auto regCache = ctran::RegCache::getInstance();
@@ -752,8 +772,6 @@ commResult_t CtranWin::free(bool skipBarrier) {
     FB_COMMCHECK(windowBarrier(comm, mapper));
   }
 
-  auto nRanks = statex->nRanks();
-
   // utils funcs to deregister memory
   auto deregMemIfNotNull = [&](void* segHdl) {
     if (segHdl != nullptr) {
@@ -778,8 +796,8 @@ commResult_t CtranWin::free(bool skipBarrier) {
   // signalRkey when signals are enabled (shared with dataRkey on the allocate
   // path). With signals disabled the allocate path tracks it via dataRkey, and
   // the register path has no base buffer to release.
-  for (auto i = 0; i < nRanks; ++i) {
-    if (i != statex->rank()) {
+  for (size_t i = 0; i < remWinInfo.size(); ++i) {
+    if (static_cast<int>(i) != statex->rank()) {
       if (enableSignal_) {
         FB_COMMCHECK(mapper->deregRemReg(&remWinInfo[i].signalRkey));
       } else if (allocDataBuf_) {
@@ -801,6 +819,21 @@ commResult_t CtranWin::free(bool skipBarrier) {
     auto ipcRegCache = ctran::IpcRegCache::getInstance();
     ctran::CHECK_VALID_IPC_REGCACHE(ipcRegCache);
     ipcRegCache->cleanupInvalidImports();
+
+    auto regCache = ctran::RegCache::getInstance();
+    ctran::CHECK_VALID_REGCACHE(regCache);
+    for (auto segHdl : ownedDataSegHdls_) {
+      bool freed = false;
+      bool ncclManaged = false;
+      std::vector<std::unique_ptr<ctran::regcache::RegElem>> regElems;
+      FB_COMMCHECK(regCache->freeSegment(
+          segHdl,
+          freed,
+          ncclManaged,
+          regElems,
+          /*forceFree=*/false));
+    }
+    ownedDataSegHdls_.clear();
   }
 
 #if defined(ENABLE_PRIMS)
@@ -1006,6 +1039,8 @@ commResult_t ctranWinRegister(
   }
 
   FB_COMMCHECK(newWin->allocate((void*)databuf));
+
+  FB_COMMCHECK(newWin->retainDataSegments());
 
   FB_COMMCHECK(newWin->exchange()); // register and exchange both signal
                                     // & data buffer


### PR DESCRIPTION
Summary:

## Core implementation

Add `WinRegisterOpts` and `IComm::winRegister` so callers can collectively register owned GPU allocations through the existing Ctran window path.
Require every registered window to provide an NVL multicast mapping and reject the unsupported non-multicast mode.
Retain caller-owned data segments in `CtranWin` before scoped backend registration and release them after scoped registrations and imported mappings during window teardown.
Use every mapper backend required by the communicator even for IPC-only windows, while keeping remote handle exchange scoped to NVL peers.
Guard multicast CUDA operations with the communicator device so registration remains correct when the caller thread has another CUDA device current.
Agree required-multicast availability across the full communicator before accepting a window, and use local no-barrier teardown for rejected or failed agreement paths.
Expose a communicator-owned local resolver that translates a registered pointer range through the existing Ctran `WinCache` and multicast mapping.
Keep registration ownership in `CtranWin` and remove the redundant MCCL-level global registration lifecycle.

## Background

Registered NVLMM collectives need an explicit caller-owned window whose allocation lifetime remains controlled by the application.
The existing MCCL surface only allocates window storage internally, while Ctran already owns collective registration, physical-memory retention, range lookup, and multicast mapping.
This change exposes the NVL multicast ownership contract without requiring allocator-hook registration or adding a second cache.

Reviewed By: dboyda

Differential Revision: D116400450


