### PR TITLE
Fix broken stable -> last-stable rotation, add --rotate-only

### DIFF
--- a/comms/rcclx/snapshots/README.md
+++ b/comms/rcclx/snapshots/README.md
@@ -35,6 +35,12 @@ python3 comms/rcclx/snapshots/scripts/create_snapshot.py \
     --rotate \
     --snapshots-root comms/rcclx/snapshots \
     --repo-root /path/to/fbsource
+
+# Rotate only: mirror stable → last-stable, leaving stable untouched
+python3 comms/rcclx/snapshots/scripts/create_snapshot.py \
+    --rotate-only \
+    --snapshots-root comms/rcclx/snapshots \
+    --repo-root /path/to/fbsource
 ```
 
 ### Building with Snapshots
@@ -55,7 +61,7 @@ buck2 build -m rcclx_stable //comms/rcclx:rcclx --modifier=rocm70
 ```
 snapshots/
 ├── stable/
-│   ├── rcclx/                    # Pre-extracted rcclx sources
+│   ├── comms/rcclx/              # Pre-extracted rcclx sources
 │   │   ├── BUCK
 │   │   ├── defs.bzl
 │   │   ├── rccl_build_config.bzl
@@ -65,14 +71,17 @@ snapshots/
 │   │       └── ...
 │   └── metadata.txt              # Commit hash, timestamp
 ├── last-stable/
-│   ├── rcclx/                    # Pre-extracted rcclx sources
+│   ├── comms/rcclx/              # Pre-extracted rcclx sources
 │   └── metadata.txt
 ├── scripts/
-│   ├── create_snapshot.py        # Main snapshot creation script
-│   └── constants.py              # Configuration constants
-├── DESIGN_PRE_EXTRACTED_SOURCES.md  # Design document
+│   ├── create_snapshot.py        # Snapshot creation / rotation script
+│   └── README.md                 # Script usage reference
 └── README.md                     # This file
 ```
+
+The `comms/rcclx/` nesting is not redundant: `sl archive` preserves the repository path,
+and includes such as `#include "comms/rcclx/develop/meta/lib/CollTraceUtils.h"` resolve
+against it via the snapshot's `-I fbcode/comms/rcclx/snapshots/<stage>` flag.
 
 ## How It Works
 
@@ -83,10 +92,10 @@ User runs: buck2 build //comms/rcclx:rcclx-stable --modifier=rocm70
 
 Buck2 resolves:
   //comms/rcclx:rcclx-stable
-    → alias to //comms/rcclx/snapshots/stable/rcclx:rcclx-dev
+    → alias to //comms/rcclx/snapshots/stable/comms/rcclx:rcclx-dev
 
 Buck2 builds from:
-  snapshots/stable/rcclx/BUCK (frozen rcclx source)
+  snapshots/stable/comms/rcclx/BUCK (frozen rcclx source)
     ├── //comms/ctran:...        (from HEAD)
     ├── //comms/utils:...        (from HEAD)
     ├── //comms/common:...       (from HEAD)
@@ -116,11 +125,12 @@ Main script for creating source snapshots.
 **Arguments:**
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `--stage` | Yes | Snapshot stage: `stable` or `last-stable` |
-| `--commit` | No | Commit hash to snapshot from (default: current HEAD) |
 | `--snapshots-root` | Yes | Path to snapshots directory |
 | `--repo-root` | Yes | Path to repository root |
+| `--stage` | Unless `--rotate-only` | Snapshot stage: `stable` or `last-stable` |
+| `--commit` | No | Commit hash to snapshot from (default: current HEAD) |
 | `--rotate` | No | If creating stable, first copy current stable to last-stable |
+| `--rotate-only` | No | Only mirror stable into last-stable, then exit. Cannot be combined with `--stage`/`--commit`/`--rotate` |
 
 **Examples:**
 ```bash
@@ -138,24 +148,61 @@ python3 create_snapshot.py \
     --rotate \
     --snapshots-root comms/rcclx/snapshots \
     --repo-root /path/to/fbsource
+
+# Rotate only
+python3 create_snapshot.py \
+    --rotate-only \
+    --snapshots-root comms/rcclx/snapshots \
+    --repo-root /path/to/fbsource
 ```
+
+### Rotation Semantics
+
+Rotation **copies the `stable` tree** into `last-stable` rather than re-extracting from
+`stable/metadata.txt`'s commit. Snapshots accumulate in-repo patches after they are cut
+(ROCm bumps, build fixes, backported upstream changes), so re-extraction would silently
+discard them.
+
+After the copy, stage-specific Buck load paths and the `-I` include path are retargeted
+from `stable` to `last-stable`, and the script verifies no stale `stable` references
+remain. A correct rotation leaves the two trees byte-identical except for those path
+references.
 
 ## Metadata
 
-Each snapshot includes a `metadata.txt` file recording:
-- Commit hash
-- Commit date
-- Commit description
-- Snapshot creation timestamp
+Each snapshot includes a `metadata.txt` file recording two hashes:
+
+| Field | Meaning |
+|-------|---------|
+| `source_commit` | The commit these sources were originally extracted from |
+| `fbsource_revision` | The landed fbsource revision the snapshot was last created or rotated at |
+| `snapshot_created` | Timestamp of the last create/rotate |
+| `rotated_from` | Present on rotated snapshots only |
+
+Both hashes are needed because a snapshot is not a frozen copy of one commit.
+Patches land on the tree after it is cut, so `source_commit` alone understates the
+contents, while `fbsource_revision` alone loses the drop it came from. Run `sl log`
+on the snapshot directory to see the patches applied in between.
+
+`fbsource_revision` is the latest *landed* ancestor rather than the working copy
+revision, which is usually a draft commit whose hash is rewritten on land.
+
+Rotation carries `source_commit` across from stable rather than regenerating it,
+so the record of which drop the sources came from survives.
 
 Example:
 ```
 # RCCLX Snapshot Metadata
-commit: abc123def456...
-commit_date: 2026-02-01 12:00:00
-commit_description: Fix critical bug in rcclx
-snapshot_created: 2026-02-01T12:30:00.000000
+source_commit: 6f840ba5d808af9407979bca2132790a72898887
+source_commit_date: 2026-01-30 10:51 -0800
+source_commit_description: DDA nranks check patch
+
+fbsource_revision: 34f53cfe1715f09b9c6750ed51e38e49eb204dfc
+fbsource_revision_date: 2026-08-20 11:14 -0700
+
+snapshot_created: 2026-08-20T12:29:49.732133
 created_by: create_snapshot.py
+rotated_from: stable
 ```
 
 ## Testing
@@ -174,19 +221,14 @@ buck2 test @fbcode//mode/opt-amd-gpu -m rocm70 -m rcclx_stable \
     fbcode//param_bench/train/comms/cpp/rccl-tests/src:
 ```
 
-## Design Documents
-
-- **[DESIGN_PRE_EXTRACTED_SOURCES.md](DESIGN_PRE_EXTRACTED_SOURCES.md)** - Current design (pre-extracted sources)
-- **[DESIGN_BUNDLED_DEPS.md](DESIGN_BUNDLED_DEPS.md)** - Deprecated design (bundled dependencies)
-
 ## Benefits
 
 | Benefit | Description |
 |---------|-------------|
 | **No ABI mismatches** | All code compiles together at build time with current headers |
 | **Reuses existing BUCK files** | Snapshot includes rcclx's BUCK, used directly |
-| **Same build as rcclx-dev** | `rcclx-stable` is alias to `snapshots/stable/rcclx:rcclx-dev` |
+| **Same build as rcclx-dev** | `rcclx-stable` is alias to `snapshots/stable/comms/rcclx:rcclx-dev` |
 | **Full Buck caching** | Standard Buck compilation, incremental builds work |
-| **Simple to maintain** | Update = extract rcclx/ from a commit |
+| **Simple to maintain** | Update = extract comms/rcclx/ from a commit |
 | **Easy to debug** | Standard Buck build, standard tools |
 | **No Manifold dependency** | Sources committed to repo |

--- a/comms/rcclx/snapshots/scripts/README.md
+++ b/comms/rcclx/snapshots/scripts/README.md
@@ -20,6 +20,19 @@ snapshots/
 
 Note: The `sl archive` command preserves the `comms/rcclx/` path structure from the repository.
 
+### Snapshots Are Maintained In-Repo
+
+A snapshot is *not* a read-only mirror of its recorded commit. Once created, snapshots
+receive compatibility patches directly in the repo (ROCm version bumps, build fixes,
+backported upstream patches). This matters for rotation: `stable` → `last-stable` is a
+**tree copy**, not a re-extraction of `stable/metadata.txt`'s commit. Re-extracting would
+silently discard every patch applied since the snapshot was cut.
+
+Because of this, `metadata.txt` records **two** hashes: `source_commit`, the drop
+the sources were originally extracted from, and `fbsource_revision`, the landed
+revision the snapshot was last created or rotated at. Rotation carries
+`source_commit` across from stable rather than regenerating it.
+
 ## Quick Start
 
 All commands should be run from the `fbcode` directory.
@@ -54,27 +67,57 @@ python3 comms/rcclx/snapshots/scripts/create_snapshot.py \
     --repo-root /data/users/$USER/fbsource
 ```
 
+### Rotate Only (Mirror Stable into Last-Stable)
+
+Promotes the current `stable` tree into `last-stable` and stops. Use this when you want
+to archive the current stable without cutting a new one yet.
+
+```bash
+python3 comms/rcclx/snapshots/scripts/create_snapshot.py \
+    --rotate-only \
+    --snapshots-root comms/rcclx/snapshots \
+    --repo-root /data/users/$USER/fbsource
+```
+
 ## Command Reference
 
 ```
 Usage: create_snapshot.py [OPTIONS]
 
 Required:
-  --stage <stable|last-stable>    Snapshot stage to create
   --snapshots-root <path>         Path to snapshots directory
   --repo-root <path>              Path to repository root (for sl commands)
+  --stage <stable|last-stable>    Snapshot stage to create (not used with --rotate-only)
 
 Optional:
   --commit <hash>                 Commit hash to snapshot from (default: HEAD)
   --rotate                        If creating stable, first copy stable to last-stable
+  --rotate-only                   Only mirror stable into last-stable, then exit.
+                                  Cannot be combined with --stage/--commit/--rotate.
 ```
 
 ## How It Works
 
+### Creating a snapshot (`--stage`)
+
 1. **Extract Sources**: Uses `sl archive` to extract `fbcode/comms/rcclx/` from the specified commit
-2. **Store in Repo**: Sources are committed to `snapshots/{stage}/rcclx/`
-3. **Write Metadata**: Records commit hash and timestamp in `metadata.txt`
-4. **Build at Use Time**: When users build `rcclx-stable`, Buck compiles from the snapshot sources
+2. **Store in Repo**: Sources are committed to `snapshots/{stage}/comms/rcclx/`
+3. **Retarget Paths**: Rewrites Buck load paths and the `-I` include path to point inside the snapshot
+4. **Write Metadata**: Records commit hash and timestamp in `metadata.txt`
+5. **Build at Use Time**: When users build `rcclx-stable`, Buck compiles from the snapshot sources
+
+### Rotating (`--rotate` / `--rotate-only`)
+
+1. **Copy Tree**: `stable/comms/rcclx/` is copied verbatim to `last-stable/comms/rcclx/`,
+   preserving symlinks and file modes
+2. **Retarget Stage**: Path-like references to `comms/rcclx/snapshots/stable` are rewritten
+   to `last-stable` in `BUCK` and `.bzl` files, then verified to leave no stale references.
+   Runtime package-name checks such as `elif "snapshots/stable" in pkg:` in `def_build.bzl`
+   are deliberately left alone — they must keep matching every stage.
+3. **Write Metadata**: Both snapshots record `source_commit` (carried across from
+   stable) and `fbsource_revision` (the latest landed ancestor); `last-stable` also
+   gets `rotated_from: stable`
+4. **Lint**: `arc lint -a` runs over the rotated `BUCK`/`.bzl` files
 
 ## Benefits
 
@@ -90,12 +133,11 @@ Optional:
 
 | Script | Purpose |
 |--------|---------|
-| `create_snapshot.py` | Main script for creating source snapshots |
-| `constants.py` | Configuration constants |
+| `create_snapshot.py` | Main script for creating and rotating source snapshots |
 
 ## Related Files
 
 - `/comms/rcclx/BUCK` - Build targets including `rcclx-stable` and `rcclx-last-stable` aliases
-- `/comms/rcclx/snapshots/DESIGN_PRE_EXTRACTED_SOURCES.md` - Detailed design documentation
+- `/comms/rcclx/snapshots/README.md` - Snapshot system overview
 - `/comms/rcclx/snapshots/stable/metadata.txt` - Current stable snapshot info
 - `/comms/rcclx/snapshots/last-stable/metadata.txt` - Previous stable snapshot info

--- a/comms/rcclx/snapshots/scripts/create_snapshot.py
+++ b/comms/rcclx/snapshots/scripts/create_snapshot.py
@@ -30,15 +30,24 @@ Usage:
         --snapshots-root fbcode/comms/rcclx/snapshots \\
         --repo-root /path/to/fbsource
 
+    # Rotate only: mirror stable → last-stable, leaving stable untouched
+    python3 create_snapshot.py \\
+        --rotate-only \\
+        --snapshots-root fbcode/comms/rcclx/snapshots \\
+        --repo-root /path/to/fbsource
+
 The snapshot structure is:
-    snapshots/stable/rcclx/          # Extracted rcclx sources
+    snapshots/stable/comms/rcclx/    # Extracted rcclx sources
     snapshots/stable/metadata.txt    # Commit hash, timestamp
-    snapshots/last-stable/rcclx/
+    snapshots/last-stable/comms/rcclx/
     snapshots/last-stable/metadata.txt
 """
 
+from __future__ import annotations
+
 import argparse
 import logging
+import re
 import shutil
 import subprocess
 import sys
@@ -51,6 +60,10 @@ logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(message)s",
 )
 logger: logging.Logger = logging.getLogger(__name__)
+
+# `sl archive` preserves the repository path, so extracted sources always land at
+# <stage>/comms/rcclx/ rather than <stage>/rcclx/.
+SNAPSHOT_SRC_SUBDIR = "comms/rcclx"
 
 
 def get_current_commit(repo_root: Path) -> str:
@@ -75,6 +88,46 @@ def get_commit_info(commit: str, repo_root: Path) -> str:
         check=True,
     )
     return result.stdout.strip()
+
+
+def get_landed_revision(repo_root: Path) -> str:
+    """
+    Get the latest landed (public) ancestor of the working copy.
+
+    The working copy revision is usually a draft commit whose hash is rewritten
+    on rebase, amend or land, so recording it would leave metadata pointing at a
+    hash that never reaches master. The newest public ancestor is stable and
+    identifies the fbsource state the snapshot was taken against.
+    """
+    result = subprocess.run(
+        ["sl", "log", "-r", "max(::. & public())", "-T", "{node}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def read_metadata_value(metadata_path: Path, keys: list[str]) -> str | None:
+    """
+    Read the first of `keys` present in a metadata.txt.
+
+    `commit` is accepted alongside `source_commit` so snapshots written before
+    the two-hash format can still be rotated without losing their provenance.
+    """
+    if not metadata_path.exists():
+        return None
+
+    for line in metadata_path.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        name, sep, value = stripped.partition(":")
+        if sep and name.strip() in keys:
+            return value.strip() or None
+
+    return None
 
 
 def extract_rcclx_from_commit(
@@ -1093,64 +1146,177 @@ def _remove_manifold_comments(content: str) -> str:
 
 def write_metadata(
     metadata_path: Path,
-    commit: str,
+    source_commit: str,
     repo_root: Path,
+    description: str = "The rcclx/ directory contains sources extracted from source_commit.",
+    extra_fields: dict[str, str] | None = None,
 ) -> None:
-    """Write metadata file with commit hash and timestamp."""
-    commit_info = get_commit_info(commit, repo_root)
-    lines = commit_info.split("\n")
+    """
+    Write metadata recording both hashes that describe a snapshot.
 
-    full_hash = lines[0] if len(lines) > 0 else commit
-    commit_date = lines[1] if len(lines) > 1 else "unknown"
-    commit_desc = lines[2] if len(lines) > 2 else "unknown"
+    Two hashes are needed because a snapshot is not a frozen copy of one commit.
+    `source_commit` is the drop the sources were originally extracted from, and
+    `fbsource_revision` is the landed revision the snapshot was last created or
+    rotated at. Patches land on the tree in between, so recording only the first
+    understates the contents and recording only the second loses the drop it
+    came from.
+    """
+    source_info = get_commit_info(source_commit, repo_root).split("\n")
+    source_hash = source_info[0] if len(source_info) > 0 else source_commit
+    source_date = source_info[1] if len(source_info) > 1 else "unknown"
+    source_desc = source_info[2] if len(source_info) > 2 else "unknown"
+
+    revision_info = get_commit_info(get_landed_revision(repo_root), repo_root).split("\n")
+    revision_hash = revision_info[0] if len(revision_info) > 0 else "unknown"
+    revision_date = revision_info[1] if len(revision_info) > 1 else "unknown"
 
     metadata_content = f"""# RCCLX Snapshot Metadata
-# This file records the source commit for this snapshot.
-# The rcclx/ directory contains sources extracted from this commit.
+# {description}
+#
+# source_commit      the commit these sources were originally extracted from
+# fbsource_revision  the landed fbsource revision this snapshot was last
+#                    created or rotated at
+#
+# The tree is maintained in-repo, so patches may have landed on top of
+# source_commit. Run `sl log` on this directory to see them.
 
-commit: {full_hash}
-commit_date: {commit_date}
-commit_description: {commit_desc}
+source_commit: {source_hash}
+source_commit_date: {source_date}
+source_commit_description: {source_desc}
+
+fbsource_revision: {revision_hash}
+fbsource_revision_date: {revision_date}
+
 snapshot_created: {datetime.now().isoformat()}
 created_by: create_snapshot.py
 """
 
-    with open(metadata_path, "w") as f:
-        f.write(metadata_content)
+    for key, value in (extra_fields or {}).items():
+        metadata_content += f"{key}: {value}\n"
 
-    logger.info(f"Wrote metadata to {metadata_path}")
+    metadata_path.write_text(metadata_content)
+
+    logger.info(
+        f"Wrote metadata to {metadata_path} "
+        f"(source={source_hash[:12]}, fbsource={revision_hash[:12]})"
+    )
 
 
-def rotate_stable_to_last_stable(snapshots_root: Path) -> None:
+def _retarget_snapshot_stage(rcclx_dir: Path, from_stage: str, to_stage: str) -> None:
     """
-    Copy stable snapshot to last-stable.
+    Point a copied snapshot's Buck load paths and include paths at its new stage.
 
-    This preserves the previous stable snapshot before creating a new one.
+    Only path-like references are rewritten, i.e. "comms/rcclx/snapshots/<stage>"
+    followed by "/", ":" or a closing quote. Runtime package-name checks such as
+    `elif "snapshots/stable" in pkg:` in def_build.bzl must keep matching every
+    stage, so they are deliberately left alone.
+
+    Args:
+        rcclx_dir: Path to the rcclx directory within the destination snapshot
+        from_stage: Stage the sources were copied from ("stable")
+        to_stage: Stage the sources now live in ("last-stable")
     """
-    stable_rcclx = snapshots_root / "stable" / "rcclx"
-    stable_meta = snapshots_root / "stable" / "metadata.txt"
-    last_stable_rcclx = snapshots_root / "last-stable" / "rcclx"
-    last_stable_meta = snapshots_root / "last-stable" / "metadata.txt"
+    logger.info(f"Retargeting snapshot paths from {from_stage} to {to_stage}")
+
+    pattern = re.compile(rf'comms/rcclx/snapshots/{re.escape(from_stage)}(?=[/:"])')
+    replacement = f"comms/rcclx/snapshots/{to_stage}"
+
+    files_updated = 0
+    for path in sorted([*rcclx_dir.rglob("BUCK"), *rcclx_dir.rglob("*.bzl")]):
+        content = path.read_text()
+        new_content = pattern.sub(replacement, content)
+        if new_content != content:
+            path.write_text(new_content)
+            logger.info(f"  Retargeted {path.relative_to(rcclx_dir)}")
+            files_updated += 1
+
+    if files_updated == 0:
+        logger.warning(
+            f"  No {from_stage} paths found to retarget - the copy may not build under {to_stage}"
+        )
+    else:
+        logger.info(f"  Retargeted {files_updated} file(s)")
+
+    # Nothing should still point at the stage we copied from.
+    stale = [
+        str(path.relative_to(rcclx_dir))
+        for path in sorted([*rcclx_dir.rglob("BUCK"), *rcclx_dir.rglob("*.bzl")])
+        if pattern.search(path.read_text())
+    ]
+    if stale:
+        raise RuntimeError(
+            f"Files still reference the {from_stage} snapshot after retargeting: {stale}"
+        )
+
+
+def rotate_stable_to_last_stable(snapshots_root: Path, repo_root: Path) -> None:
+    """
+    Mirror the current stable snapshot into last-stable.
+
+    The stable tree is copied verbatim rather than re-extracted from its recorded
+    commit. Snapshots are maintained in-repo after creation (compatibility
+    patches, build fixes, ROCm bumps), so re-extracting would silently drop
+    everything applied since. Copying is the only faithful mirror.
+
+    After the copy, stage-specific Buck load paths and include paths are
+    retargeted so last-stable references its own sources instead of stable's.
+    """
+    stable_dir = snapshots_root / "stable"
+    last_stable_dir = snapshots_root / "last-stable"
+    stable_rcclx = stable_dir / SNAPSHOT_SRC_SUBDIR
+    last_stable_rcclx = last_stable_dir / SNAPSHOT_SRC_SUBDIR
 
     if not stable_rcclx.exists():
-        logger.warning("No stable snapshot exists, skipping rotation")
-        return
+        raise RuntimeError(f"No stable snapshot to rotate from: {stable_rcclx} does not exist")
 
-    logger.info("Rotating: copying stable → last-stable...")
+    logger.info("=" * 60)
+    logger.info("Rotating: mirroring stable -> last-stable")
+    logger.info("=" * 60)
 
-    # Remove existing last-stable
     if last_stable_rcclx.exists():
         logger.info(f"Removing existing last-stable: {last_stable_rcclx}")
         shutil.rmtree(last_stable_rcclx)
 
-    # Copy stable to last-stable
-    logger.info(f"Copying {stable_rcclx} → {last_stable_rcclx}")
-    shutil.copytree(stable_rcclx, last_stable_rcclx)
+    logger.info(f"Copying {stable_rcclx} -> {last_stable_rcclx}")
+    last_stable_rcclx.parent.mkdir(parents=True, exist_ok=True)
+    # symlinks=True keeps symlinks as symlinks instead of materializing their targets.
+    shutil.copytree(stable_rcclx, last_stable_rcclx, symlinks=True)
 
-    # Copy metadata
-    if stable_meta.exists():
-        shutil.copy(stable_meta, last_stable_meta)
-        logger.info(f"Copied metadata to {last_stable_meta}")
+    _retarget_snapshot_stage(last_stable_rcclx, "stable", "last-stable")
+
+    # The tree is copied from stable, so its provenance is stable's: carry the
+    # original source_commit across rather than regenerating it. Overwriting it
+    # with the current revision would destroy the record of which drop these
+    # sources came from, which no later run could recover.
+    stable_metadata = stable_dir / "metadata.txt"
+    source_commit = read_metadata_value(stable_metadata, ["source_commit", "commit"])
+    if source_commit is None:
+        raise RuntimeError(
+            f"Could not read source_commit from {stable_metadata}. Refusing to rotate, "
+            "because writing last-stable without it would lose the record of which "
+            "commit these sources came from."
+        )
+    logger.info(f"Carrying stable's source_commit {source_commit[:12]} into last-stable")
+
+    write_metadata(
+        last_stable_dir / "metadata.txt",
+        source_commit,
+        repo_root,
+        description=(
+            "The rcclx/ directory mirrors the stable snapshot as of fbsource_revision."
+        ),
+        extra_fields={"rotated_from": "stable"},
+    )
+    write_metadata(
+        stable_dir / "metadata.txt",
+        source_commit,
+        repo_root,
+        description=(
+            "The rcclx/ directory holds the current stable snapshot sources."
+        ),
+    )
+
+    run_arc_lint(last_stable_dir, repo_root)
 
     logger.info("Rotation complete")
 
@@ -1178,14 +1344,14 @@ def create_snapshot(
 
     # Handle rotation: stable → last-stable
     if rotate and stage == "stable":
-        rotate_stable_to_last_stable(snapshots_root)
+        rotate_stable_to_last_stable(snapshots_root, repo_root)
 
     # Prepare destination paths
     stage_dir = snapshots_root / stage
-    dest_rcclx = stage_dir / "rcclx"
+    dest_rcclx = stage_dir / SNAPSHOT_SRC_SUBDIR
     metadata_path = stage_dir / "metadata.txt"
 
-    # Remove old snapshot if exists
+    # Remove old snapshot if exists, so files deleted upstream do not survive
     if dest_rcclx.exists():
         logger.info(f"Removing existing snapshot: {dest_rcclx}")
         shutil.rmtree(dest_rcclx)
@@ -1205,7 +1371,7 @@ def create_snapshot(
     logger.info("")
     logger.info("=" * 60)
     logger.info(f"Successfully created {stage} snapshot")
-    logger.info(f"  Sources: {stage_dir}/rcclx/")
+    logger.info(f"  Sources: {dest_rcclx}/")
     logger.info(f"  Metadata: {metadata_path}")
     logger.info("=" * 60)
 
@@ -1220,7 +1386,7 @@ def run_arc_lint(stage_dir: Path, repo_root: Path) -> None:
         stage_dir: Path to the snapshot stage directory (e.g., snapshots/stable/)
         repo_root: Path to the repository root
     """
-    rcclx_dir = stage_dir / "comms" / "rcclx"
+    rcclx_dir = stage_dir / SNAPSHOT_SRC_SUBDIR
     if not rcclx_dir.exists():
         logger.warning(f"rcclx directory not found at {rcclx_dir}, skipping arc lint")
         return
@@ -1291,14 +1457,19 @@ Examples:
     python3 create_snapshot.py --stage stable --commit abc123def --rotate \\
         --snapshots-root fbcode/comms/rcclx/snapshots \\
         --repo-root /path/to/fbsource
+
+    # Rotate only: mirror stable → last-stable, leaving stable untouched
+    python3 create_snapshot.py --rotate-only \\
+        --snapshots-root fbcode/comms/rcclx/snapshots \\
+        --repo-root /path/to/fbsource
         """,
     )
     parser.add_argument(
         "--stage",
         type=str,
-        required=True,
+        default=None,
         choices=["stable", "last-stable"],
-        help="Snapshot stage: stable or last-stable",
+        help="Snapshot stage: stable or last-stable (required unless --rotate-only)",
     )
     parser.add_argument(
         "--commit",
@@ -1323,6 +1494,12 @@ Examples:
         action="store_true",
         help="If creating stable, first copy current stable to last-stable",
     )
+    parser.add_argument(
+        "--rotate-only",
+        action="store_true",
+        help="Only mirror the current stable snapshot into last-stable, then exit "
+        "(no new stable snapshot is created)",
+    )
 
     args = parser.parse_args()
 
@@ -1330,6 +1507,15 @@ Examples:
         # Validate paths
         if not args.repo_root.exists():
             parser.error(f"Repository root does not exist: {args.repo_root}")
+
+        if args.rotate_only:
+            if args.stage or args.commit or args.rotate:
+                parser.error("--rotate-only cannot be combined with --stage, --commit or --rotate")
+            rotate_stable_to_last_stable(args.snapshots_root, args.repo_root)
+            return 0
+
+        if not args.stage:
+            parser.error("--stage is required unless --rotate-only is given")
 
         # Resolve commit
         commit: str


### PR DESCRIPTION
Summary:
The rotation path in create_snapshot.py has never worked. Rotating stable into
last-stable was a silent no-op, and there was no way to rotate without also
cutting a new stable. This fixes the rotation and adds a rotate-only mode.

Four defects, all in fbcode/comms/rcclx/snapshots/scripts/create_snapshot.py:

1. Wrong path in rotate_stable_to_last_stable(). It looked for
   snapshots/stable/rcclx, but `sl archive` preserves the repo path so the tree
   actually lives at snapshots/stable/comms/rcclx. The existence check therefore
   always failed and the function logged "No stable snapshot exists, skipping
   rotation" and returned, doing nothing. Now uses the correct path and raises
   instead of silently skipping when there is genuinely nothing to rotate.

2. Raw copy produced an unbuildable last-stable. The copied tree still contained
   8 hardcoded `snapshots/stable` references (Buck load paths in BUCK and
   rccl_build_config.bzl, plus the `-I fbcode/comms/rcclx/snapshots/stable`
   include path), so last-stable would have loaded stable's .bzl files and
   compiled against stable's headers. Added _retarget_snapshot_stage(), which
   rewrites only path-like references -- `comms/rcclx/snapshots/<stage>` followed
   by `/`, `:` or a closing quote -- and then asserts none remain. The narrow
   match deliberately leaves the runtime package-name checks in def_build.bzl
   (`elif "snapshots/stable" in pkg:`) intact, since those must keep matching
   every stage.

3. --rotate was hard-coupled to --stage stable and always cut a new stable
   afterward. Added --rotate-only to mirror stable into last-stable and exit.
   --stage is now optional but required unless --rotate-only is given, and
   --rotate-only rejects being combined with --stage/--commit/--rotate.

4. create_snapshot() deleted the old tree at stage_dir/"rcclx" -- the same wrong
   path as (1) -- so a re-snapshot layered new files on top of the old tree and
   files deleted upstream survived. Fixed to stage_dir/comms/rcclx. Both call
   sites now share a SNAPSHOT_SRC_SUBDIR constant so the two cannot drift again.

Metadata now records two hashes instead of one:

  source_commit      the commit the sources were originally extracted from
  fbsource_revision  the landed revision the snapshot was last created/rotated at

A snapshot is not a frozen copy of one commit: patches land on the tree after it
is cut, so source_commit alone understates the contents while fbsource_revision
alone loses the drop it came from. stable's recorded commit had drifted eight
months from its actual contents precisely because only the first was kept.

Two supporting details:
- Rotation carries source_commit across from stable via read_metadata_value()
  rather than regenerating it, and refuses to rotate if it cannot be read.
  Overwriting it would destroy the record of which drop the sources came from,
  and no later run could recover it. read_metadata_value() also accepts the
  legacy `commit:` key so snapshots predating this format still rotate.
- fbsource_revision uses get_landed_revision() -- `max(::. & public())` -- not
  the working copy revision. The working copy is usually a draft commit whose
  hash is rewritten on rebase or land, so recording it would leave metadata
  pointing at a hash that never reaches master.

Also:
- The copy uses symlinks=True to preserve symlinks (the tree has one, at
  develop/pkg/debian/copyright) rather than materializing their targets.
- Added `from __future__ import annotations` so the `dict[str, str] | None`
  annotation works under the python3 3.9 that devservers put on PATH, which the
  READMEs tell people to invoke.
- READMEs: documented --rotate-only, rotation semantics and the two-hash
  metadata format, corrected the stable/rcclx -> stable/comms/rcclx paths
  throughout, and dropped references to files that do not exist (constants.py,
  DESIGN_PRE_EXTRACTED_SOURCES.md, DESIGN_BUNDLED_DEPS.md).

Note that rotation copies the stable tree rather than re-extracting from
source_commit. Snapshots accumulate in-repo patches after they are cut
(device-linker port, PR6023 init-hang fixes, ROCm 7.0 bumps, ScubaLogger sync),
so re-extraction would silently discard all of them. Verified: extracting
stable's source_commit 6f840ba5 yields a tree missing device_linker.bzl and
develop/tools/ entirely, with ~28 source files differing.

No snapshot content changes in this diff; it is script and docs only.

Reviewed By: sunguobao

Differential Revision: D116894981


