### PR TITLE
Fix NVL signal timeout builds

### DIFF
--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cu
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cu
@@ -2,6 +2,7 @@
 
 #include "comms/prims/tests/MultimemNvlSignalTrapTest.cuh"
 
+#include "comms/common/fault_tolerance/TestAbort.h"
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlSignal.cuh"
@@ -12,7 +13,9 @@ namespace {
 __device__ alignas(SignalState) uint64_t
     trapSignalStorage[16 * sizeof(SignalState) / sizeof(uint64_t)];
 
-__global__ void nvlSignalTrapKernel(NvlSignalTrapCase testCase) {
+__global__ void nvlSignalTrapKernel(
+    NvlSignalTrapCase testCase,
+    Timeout waitAbort) {
   auto* trapSignals = reinterpret_cast<SignalState*>(trapSignalStorage);
   SignalState* peerSignals[4] = {
       trapSignals, trapSignals, trapSignals, trapSignals};
@@ -44,23 +47,46 @@ __global__ void nvlSignalTrapKernel(NvlSignalTrapCase testCase) {
       .channel = 0,
       .value = testCase == NvlSignalTrapCase::ZeroRound ? 0u : 1u,
   };
-  if (testCase == NvlSignalTrapCase::WaitTimeout) {
+  if (testCase == NvlSignalTrapCase::WaitTimeout ||
+      testCase == NvlSignalTrapCase::SerialMinWaitTimeout ||
+      testCase == NvlSignalTrapCase::TreeMinWaitTimeout ||
+      testCase == NvlSignalTrapCase::ButterflyMinWaitTimeout) {
     auto group = make_block_group();
-    Timeout timeout{1};
-    timeout.start();
-    signal_wait<
-        NvlSignalAccess::Unicast,
-        NvlSignalTopology::PerPeer,
-        NvlSignalPhase::Ready>(
-        transport,
-        round,
-        NvlSignalParticipants{
-            .publisherMask = uint64_t{1} << 1,
-            .waiterMask = 1,
-            .expectedArrivals = 1,
-        },
-        group,
-        timeout);
+    waitAbort.start();
+    const NvlSignalParticipants waitParticipants{
+        .publisherMask = uint64_t{1} << 1,
+        .waiterMask = 1,
+        .expectedArrivals = 1,
+    };
+    if (testCase == NvlSignalTrapCase::WaitTimeout) {
+      signal_wait<
+          NvlSignalAccess::Unicast,
+          NvlSignalTopology::PerPeer,
+          NvlSignalPhase::Ready,
+          NvlPerPeerWaitPolicy::WaitAll>(
+          transport, round, waitParticipants, group, waitAbort);
+    } else if (testCase == NvlSignalTrapCase::SerialMinWaitTimeout) {
+      signal_wait<
+          NvlSignalAccess::Unicast,
+          NvlSignalTopology::PerPeer,
+          NvlSignalPhase::Ready,
+          NvlPerPeerWaitPolicy::SerialMin>(
+          transport, round, waitParticipants, group, waitAbort);
+    } else if (testCase == NvlSignalTrapCase::TreeMinWaitTimeout) {
+      signal_wait<
+          NvlSignalAccess::Unicast,
+          NvlSignalTopology::PerPeer,
+          NvlSignalPhase::Ready,
+          NvlPerPeerWaitPolicy::TreeMin>(
+          transport, round, waitParticipants, group, waitAbort);
+    } else {
+      signal_wait<
+          NvlSignalAccess::Unicast,
+          NvlSignalTopology::PerPeer,
+          NvlSignalPhase::Ready,
+          NvlPerPeerWaitPolicy::ButterflyMin>(
+          transport, round, waitParticipants, group, waitAbort);
+    }
     return;
   }
   if (testCase == NvlSignalTrapCase::AggregateDepthTooLarge ||
@@ -85,8 +111,11 @@ __global__ void nvlSignalTrapKernel(NvlSignalTrapCase testCase) {
 void launchNvlSignalTrap(NvlSignalTrapCase testCase) {
   const uint32_t threads =
       testCase == NvlSignalTrapCase::PerPeerGroupTooSmall ? 32 : 64;
+  auto waitAbort = comms::fault_tolerance::testing::testAbortDevice();
+  waitAbort.setOpTimeoutMs(1);
   nvlSignalTrapKernel<<<1, threads>>>(
-      testCase); // NOLINT(facebook-cuda-safe-kernel-call-check)
+      testCase,
+      waitAbort); // NOLINT(facebook-cuda-safe-kernel-call-check)
 }
 
 } // namespace comms::prims::test

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
@@ -14,6 +14,9 @@ enum class NvlSignalTrapCase : uint32_t {
   PerPeerGroupTooSmall,
   WaitTimeout,
   ZeroRound,
+  SerialMinWaitTimeout,
+  TreeMinWaitTimeout,
+  ButterflyMinWaitTimeout,
 };
 
 void launchNvlSignalTrap(NvlSignalTrapCase testCase);

--- a/comms/prims/transport/nvl/MultimemNvlSignal.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlSignal.cuh
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 
+#include "comms/common/fault_tolerance/AbortMacros.cuh"
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/Timeout.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
@@ -83,10 +84,12 @@ __device__ __forceinline__ void wait_until_reached(
     uint64_t expected,
     const Timeout& timeout) {
   while (!sequence_reached(signal.load(), expected)) {
-    TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
-        timeout,
-        "NVL signal wait for sequence=%llu",
-        static_cast<unsigned long long>(expected));
+    if (FT_ABORT_CHECK(
+            timeout,
+            "NVL signal wait for sequence=%llu",
+            static_cast<unsigned long long>(expected))) {
+      FT_DEVICE_TRAP();
+    }
   }
 }
 
@@ -240,10 +243,12 @@ __device__ __forceinline__ void wait_per_peer_serial(
         }
       }
       if (!complete) {
-        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
-            timeout,
-            "NVL serial per-peer wait for round=%llu",
-            static_cast<unsigned long long>(round.value));
+        if (FT_ABORT_CHECK(
+                timeout,
+                "NVL serial per-peer wait for round=%llu",
+                static_cast<unsigned long long>(round.value))) {
+          FT_DEVICE_TRAP();
+        }
       }
     }
   }
@@ -280,10 +285,12 @@ __device__ __forceinline__ void wait_per_peer_tree(
     }
     complete = completeByPeer[0] != 0;
     if (!complete && group.is_leader()) {
-      TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
-          timeout,
-          "NVL tree per-peer wait for round=%llu",
-          static_cast<unsigned long long>(round.value));
+      if (FT_ABORT_CHECK(
+              timeout,
+              "NVL tree per-peer wait for round=%llu",
+              static_cast<unsigned long long>(round.value))) {
+        FT_DEVICE_TRAP();
+      }
     }
     group.sync();
   }
@@ -323,10 +330,12 @@ __device__ __forceinline__ void wait_per_peer_butterfly(
     group.sync();
     complete = completeByWarp[0] != 0 && completeByWarp[1] != 0;
     if (!complete && group.is_leader()) {
-      TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
-          timeout,
-          "NVL butterfly per-peer wait for round=%llu",
-          static_cast<unsigned long long>(round.value));
+      if (FT_ABORT_CHECK(
+              timeout,
+              "NVL butterfly per-peer wait for round=%llu",
+              static_cast<unsigned long long>(round.value))) {
+        FT_DEVICE_TRAP();
+      }
     }
     group.sync();
   }


### PR DESCRIPTION
Summary:
## Core implementation

Replace removed `TIMEOUT_TRAP_IF_EXPIRED_SINGLE` uses with `FT_ABORT_CHECK` followed by the existing host-safe `FT_DEVICE_TRAP()` wrapper.
Preserve the existing void wait APIs, polling topology, synchronization, and trap-only behavior.
Construct the timeout death-test handle on the host using the current `AbortDevice` API.
Add isolated timeout coverage for `WaitAll`, `SerialMin`, `TreeMin`, and `ButterflyMin`.
Leave `AbortMacros.cuh` unchanged.

## Background

The timeout macro and the cycle-count constructor were removed while `MultimemNvlSignal` still referenced them.
Their combination leaves the NVL signal target and its timeout death test unable to compile.

Differential Revision: D116892733


