### PR TITLE
Add ncclQueryCollTuning to expose the collective tuning model

### DIFF
--- a/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx_internal.pxd
+++ b/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx_internal.pxd
@@ -1,7 +1,7 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 # NCCLx C++ namespace bindings (direct linkage, not dlsym)
 
-from libc.stdint cimport uint64_t
+from libc.stdint cimport int8_t, int16_t, uint64_t
 from libcpp.string cimport string
 from libcpp.unordered_map cimport unordered_map
 from libcpp.vector cimport vector
@@ -44,6 +44,40 @@ cdef extern from "nccl.h" nogil:
         ncclComm_t comm, unordered_map[string, string]& result)
     ncclResult_t ncclCommDumpAll(
         unordered_map[string, unordered_map[string, string]]& result)
+
+    enum: NCCL_COLL_TUNING_VERSION
+    enum: NCCL_TUNING_MAX_FUNCTIONS
+    enum: NCCL_TUNING_MAX_ALGORITHMS
+    enum: NCCL_TUNING_MAX_PROTOCOLS
+    enum: NCCL_TUNING_SIZE_POINTS
+    enum: NCCL_TUNING_NAME_LEN
+
+    ctypedef struct ncclCollTuningEntry:
+        int8_t algorithm
+        int8_t protocol
+        int16_t nChannels
+        int16_t nThreads
+        float timeUs
+
+    ctypedef struct ncclCollTuning:
+        int version
+        int nRanks
+        int nNodes
+        int nChannels
+        int minCompCap
+        int maxCompCap
+        int numFunctions
+        int numAlgorithms
+        int numProtocols
+        char functionNames[NCCL_TUNING_MAX_FUNCTIONS][NCCL_TUNING_NAME_LEN]
+        char algorithmNames[NCCL_TUNING_MAX_ALGORITHMS][NCCL_TUNING_NAME_LEN]
+        char protocolNames[NCCL_TUNING_MAX_PROTOCOLS][NCCL_TUNING_NAME_LEN]
+        float bandwidths[NCCL_TUNING_MAX_FUNCTIONS][NCCL_TUNING_MAX_ALGORITHMS][NCCL_TUNING_MAX_PROTOCOLS]
+        float latencies[NCCL_TUNING_MAX_FUNCTIONS][NCCL_TUNING_MAX_ALGORITHMS][NCCL_TUNING_MAX_PROTOCOLS]
+        uint64_t messageSizes[NCCL_TUNING_SIZE_POINTS]
+        ncclCollTuningEntry bestBySize[NCCL_TUNING_MAX_FUNCTIONS][NCCL_TUNING_SIZE_POINTS]
+
+    ncclResult_t ncclQueryCollTuning(ncclComm_t comm, ncclCollTuning* tuning)
 
     ctypedef struct ncclConfig_t:
         pass

--- a/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx_internal.pyx
+++ b/comms/ncclx/v2_30/bindings/nccl4py/nccl/bindings/ncclx_internal.pyx
@@ -15,13 +15,16 @@ from .ncclx_internal cimport (
     Hints as CppHints,
     LifecycleEvent as CppLifecycleEvent,
     LifecycleEventType as CppLifecycleEventType,
+    NCCL_TUNING_SIZE_POINTS,
     ncclAllToAllv as _ncclAllToAllv,
+    ncclCollTuning,
     ncclCommDump as _ncclCommDump,
     ncclCommDumpAll as _ncclCommDumpAll,
     ncclComm_t,
     ncclConfig_t,
     ncclDataType_t,
     ncclPut as _ncclPut,
+    ncclQueryCollTuning as _ncclQueryCollTuning,
     ncclRedOp_t,
     ncclReduceScatterQuantize as _ncclReduceScatterQuantize,
     ncclWindow_t,
@@ -192,6 +195,89 @@ cdef list _colltrace_events_to_python(vector[CppLifecycleEvent]& result):
             event.timestamp,
         ))
     return events
+
+
+cpdef dict query_coll_tuning(intptr_t comm):
+    """Snapshot of the communicator's collective tuning model.
+
+    Returns a dict:
+      - "version", "n_ranks", "n_nodes", "n_channels", "min_comp_cap",
+        "max_comp_cap": ints
+      - "functions", "algorithms", "protocols": name lists; indexes below
+        refer to these
+      - "bandwidths", "latencies": {function: [algorithm][protocol]} nested
+        lists -- the raw init-time model (GB/s and us; bandwidth 0 means the
+        combination is disabled). Per-size correction factors NOT included.
+      - "best_by_size": {function: [(size_bytes, algorithm, protocol,
+        n_channels, n_threads, time_us), ...]} -- the selection and predicted
+        time (all correction factors included) a collective of that size
+        would run with; algorithm/protocol are None and time_us is -1.0 when
+        no combination is available. Linear interpolation between adjacent
+        sizes reproduces the model within a selection regime.
+    """
+    cdef ncclCollTuning tuning
+    cdef int status
+    cdef int f, a, p, s
+    with nogil:
+        status = _ncclQueryCollTuning(<ncclComm_t>comm, &tuning)
+    check_status(status)
+
+    functions = [
+        (<bytes>tuning.functionNames[f]).decode("utf-8")
+        for f in range(tuning.numFunctions)
+    ]
+    algorithms = [
+        (<bytes>tuning.algorithmNames[a]).decode("utf-8")
+        for a in range(tuning.numAlgorithms)
+    ]
+    protocols = [
+        (<bytes>tuning.protocolNames[p]).decode("utf-8")
+        for p in range(tuning.numProtocols)
+    ]
+
+    bandwidths = {}
+    latencies = {}
+    best_by_size = {}
+    for f in range(tuning.numFunctions):
+        bandwidths[functions[f]] = [
+            [tuning.bandwidths[f][a][p] for p in range(tuning.numProtocols)]
+            for a in range(tuning.numAlgorithms)
+        ]
+        latencies[functions[f]] = [
+            [tuning.latencies[f][a][p] for p in range(tuning.numProtocols)]
+            for a in range(tuning.numAlgorithms)
+        ]
+        entries = []
+        for s in range(NCCL_TUNING_SIZE_POINTS):
+            if tuning.bestBySize[f][s].algorithm < 0:
+                entries.append(
+                    (tuning.messageSizes[s], None, None, 0, 0, -1.0)
+                )
+            else:
+                entries.append((
+                    tuning.messageSizes[s],
+                    algorithms[tuning.bestBySize[f][s].algorithm],
+                    protocols[tuning.bestBySize[f][s].protocol],
+                    tuning.bestBySize[f][s].nChannels,
+                    tuning.bestBySize[f][s].nThreads,
+                    tuning.bestBySize[f][s].timeUs,
+                ))
+        best_by_size[functions[f]] = entries
+
+    return {
+        "version": tuning.version,
+        "n_ranks": tuning.nRanks,
+        "n_nodes": tuning.nNodes,
+        "n_channels": tuning.nChannels,
+        "min_comp_cap": tuning.minCompCap,
+        "max_comp_cap": tuning.maxCompCap,
+        "functions": functions,
+        "algorithms": algorithms,
+        "protocols": protocols,
+        "bandwidths": bandwidths,
+        "latencies": latencies,
+        "best_by_size": best_by_size,
+    }
 
 
 cpdef uint64_t colltrace_get_comm_id(intptr_t comm) except? 0:

--- a/comms/ncclx/v2_30/src/enqueue.cc
+++ b/comms/ncclx/v2_30/src/enqueue.cc
@@ -1992,6 +1992,61 @@ static ncclResult_t updateCollCostTable(
   return ncclSuccess;
 }
 
+// Channel/thread selection for a given algorithm/protocol and size. Shared by
+// topoGetAlgoInfo() and ncclQueryCollTuning() so the query cannot drift from
+// the real selection.
+static void topoGetChannelThreadCount(
+    struct ncclComm* comm, int algorithm, int protocol, size_t nBytes,
+    int* nChannels, int* nThreads
+  ) {
+  int nc = comm->nChannels;
+  int nt = comm->maxThreads[algorithm][protocol];
+  int threadThreshold = comm->threadThresholds[algorithm][protocol];
+  if (algorithm == NCCL_ALGO_COLLNET_DIRECT) {
+    // CollNet channel tuning
+    int ncSwitch = 16;
+    bool flag = true;
+    while (ncSwitch >= 1 && flag) {
+      while ((flag = nBytes < nc*nt*comm->channels[0].collnetDirect.nHeads*threadThreshold) && nc > ncSwitch) {
+        if (nc == ncSwitch+ncSwitch/2) threadThreshold /= 2;
+        nc--;
+      }
+      ncSwitch /= 2;
+    }
+  } else if (algorithm == NCCL_ALGO_NVLS || algorithm == NCCL_ALGO_NVLS_TREE) {
+    // NVLS should not need more than 16 channels to get peak BW.
+    if (comm->nNodes > 1 && algorithm == NCCL_ALGO_NVLS) {
+      nc = std::min(comm->nvlsChannels, comm->nChannels);
+    } else {
+      nc = comm->nvlsChannels;
+    }
+  } else {
+    // Ring/Tree channel tuning
+    while (nBytes < nc * nt * threadThreshold) {
+      if (nc >= 2) nc--;
+      else break;
+    }
+  }
+
+  if (algorithm != NCCL_ALGO_NVLS && algorithm != NCCL_ALGO_NVLS_TREE &&
+    algorithm != NCCL_ALGO_COLLNET_DIRECT) {
+    while (nBytes < nc * nt * threadThreshold) {
+      if (nt % 128 == 0) nt /= 2;
+      else break;
+    }
+  }
+  if (protocol == NCCL_PROTO_SIMPLE) {
+    if (algorithm == NCCL_ALGO_RING) nt += WARP_SIZE; // Extra warp for sync
+    // More threads or sync warps needed due to split thread model
+    if (algorithm == NCCL_ALGO_TREE) nt += 4*WARP_SIZE;
+  }
+  nt = nt/WARP_SIZE < 3 ? 3*WARP_SIZE : nt;
+  if (algorithm == NCCL_ALGO_TREE) nt = NCCL_MAX_NTHREADS; // Tree now uses all threads always.
+  if (algorithm == NCCL_ALGO_PAT) nt = NCCL_MAX_NTHREADS;
+  *nChannels = nc;
+  *nThreads = nt;
+}
+
 static ncclResult_t topoGetAlgoInfo(
     struct ncclComm* comm, struct ncclTaskColl* info, size_t nBytes,
     float** collCostTable, ncclSimInfo_t* simInfo
@@ -2035,50 +2090,8 @@ static ncclResult_t topoGetAlgoInfo(
   if (simInfo) simInfo->estimatedTime = time;
   TRACE(NCCL_COLL, "%ld Bytes -> Algo %d proto %d time %f", nBytes, info->algorithm, info->protocol, time);
 
-  int nc = comm->nChannels;
-  int nt = comm->maxThreads[info->algorithm][info->protocol];
-  int threadThreshold = comm->threadThresholds[info->algorithm][info->protocol];
-  if (info->algorithm == NCCL_ALGO_COLLNET_DIRECT) {
-    // CollNet channel tuning
-    int ncSwitch = 16;
-    bool flag = true;
-    while (ncSwitch >= 1 && flag) {
-      while ((flag = nBytes < nc*nt*comm->channels[0].collnetDirect.nHeads*threadThreshold) && nc > ncSwitch) {
-        if (nc == ncSwitch+ncSwitch/2) threadThreshold /= 2;
-        nc--;
-      }
-      ncSwitch /= 2;
-    }
-  } else if (info->algorithm == NCCL_ALGO_NVLS || info->algorithm == NCCL_ALGO_NVLS_TREE) {
-    // NVLS should not need more than 16 channels to get peak BW.
-    if (comm->nNodes > 1 && info->algorithm == NCCL_ALGO_NVLS) {
-      nc = std::min(comm->nvlsChannels, comm->nChannels);
-    } else {
-      nc = comm->nvlsChannels;
-    }
-  } else {
-    // Ring/Tree channel tuning
-    while (nBytes < nc * nt * threadThreshold) {
-      if (nc >= 2) nc--;
-      else break;
-    }
-  }
-
-  if (info->algorithm != NCCL_ALGO_NVLS && info->algorithm != NCCL_ALGO_NVLS_TREE &&
-    info->algorithm != NCCL_ALGO_COLLNET_DIRECT) {
-    while (nBytes < nc * nt * threadThreshold) {
-      if (nt % 128 == 0) nt /= 2;
-      else break;
-    }
-  }
-  if (info->protocol == NCCL_PROTO_SIMPLE) {
-    if (info->algorithm == NCCL_ALGO_RING) nt += WARP_SIZE; // Extra warp for sync
-    // More threads or sync warps needed due to split thread model
-    if (info->algorithm == NCCL_ALGO_TREE) nt += 4*WARP_SIZE;
-  }
-  nt = nt/WARP_SIZE < 3 ? 3*WARP_SIZE : nt;
-  if (info->algorithm == NCCL_ALGO_TREE) nt = NCCL_MAX_NTHREADS; // Tree now uses all threads always.
-  if (info->algorithm == NCCL_ALGO_PAT) nt = NCCL_MAX_NTHREADS;
+  int nc, nt;
+  topoGetChannelThreadCount(comm, info->algorithm, info->protocol, nBytes, &nc, &nt);
   info->nMaxChannels = nc;
   info->nWarps = nt/WARP_SIZE;
   return ncclSuccess;
@@ -2144,6 +2157,107 @@ ncclResult_t ncclGetAlgoInfo(
   }
 
   info->nMaxChannels = nMaxChannels == 0 ? info->nMaxChannels : nMaxChannels;
+  return ncclSuccess;
+}
+
+__attribute__((visibility("default"))) ncclResult_t ncclQueryCollTuning(
+    ncclComm_t comm, ncclCollTuning* tuning) {
+  static_assert(NCCL_NUM_FUNCTIONS <= NCCL_TUNING_MAX_FUNCTIONS,
+      "ncclCollTuning function capacity too small");
+  static_assert(NCCL_NUM_ALGORITHMS <= NCCL_TUNING_MAX_ALGORITHMS,
+      "ncclCollTuning algorithm capacity too small");
+  static_assert(NCCL_NUM_PROTOCOLS <= NCCL_TUNING_MAX_PROTOCOLS,
+      "ncclCollTuning protocol capacity too small");
+
+  if (comm == NULL || tuning == NULL) return ncclInvalidArgument;
+
+  memset(tuning, 0, sizeof(*tuning));
+  tuning->version = NCCL_COLL_TUNING_VERSION;
+  tuning->nRanks = comm->nRanks;
+  tuning->nNodes = comm->nNodes;
+  tuning->nChannels = comm->nChannels;
+  tuning->minCompCap = comm->minCompCap;
+  tuning->maxCompCap = comm->maxCompCap;
+  tuning->numFunctions = NCCL_NUM_FUNCTIONS;
+  tuning->numAlgorithms = NCCL_NUM_ALGORITHMS;
+  tuning->numProtocols = NCCL_NUM_PROTOCOLS;
+  for (int f=0; f<NCCL_NUM_FUNCTIONS; f++) {
+    snprintf(tuning->functionNames[f], sizeof(tuning->functionNames[f]), "%s", ncclFuncStr[f]);
+  }
+  for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) {
+    snprintf(tuning->algorithmNames[a], sizeof(tuning->algorithmNames[a]), "%s", ncclAlgoStr[a]);
+  }
+  for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+    snprintf(tuning->protocolNames[p], sizeof(tuning->protocolNames[p]), "%s", ncclProtoStr[p]);
+  }
+  for (int f=0; f<NCCL_NUM_FUNCTIONS; f++) {
+    for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) {
+      for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+        tuning->bandwidths[f][a][p] = comm->bandwidths[f][a][p];
+        tuning->latencies[f][a][p] = comm->latencies[f][a][p];
+      }
+    }
+  }
+  for (int s=0; s<NCCL_TUNING_SIZE_POINTS; s++) {
+    tuning->messageSizes[s] = (uint64_t)1 << s;
+  }
+
+  for (int f=0; f<NCCL_NUM_FUNCTIONS; f++) {
+    // A synthetic float32 sum task: datatype and op only feed the collnet/nvls
+    // support checks and the fp8 relegation, none of which should shape the
+    // reported baseline.
+    struct ncclTaskColl info = {};
+    info.func = (ncclFunc_t)f;
+    info.datatype = ncclFloat32;
+    info.opHost = ncclSum;
+    info.opDev.op = ncclDevSum;
+    int collNetSupport = 0;
+    NCCLCHECK(ncclGetCollNetSupport(comm, &info, &collNetSupport));
+    int nvlsSupport = comm->nvlsSupport &&
+        (ncclNvlsSupported(info.opDev.op, info.datatype) || info.func == ncclFuncAllGather);
+    for (int s=0; s<NCCL_TUNING_SIZE_POINTS; s++) {
+      size_t nBytes = (size_t)1 << s;
+      float collCostTable[NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
+      initCollCostTable((float**)collCostTable);
+      NCCLCHECK(updateCollCostTable(
+          comm, &info, nBytes, collNetSupport, nvlsSupport, /*numPipeOps=*/1,
+          (float**)collCostTable));
+      int pluginNc = 0;
+      if (comm->tuner != NULL) {
+        NCCLCHECK(comm->tuner->getCollInfo(
+            comm->tunerContext, info.func, nBytes, /*numPipeOps=*/1,
+            (float**)collCostTable, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
+            /*regBuff=*/0, &pluginNc));
+      }
+      float minTime = FLT_MAX;
+      int algorithm = -1, protocol = -1;
+      for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) {
+        for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+          if (collCostTable[a][p] == NCCL_ALGO_PROTO_IGNORE) continue;
+          if (collCostTable[a][p] >= 0.0 && collCostTable[a][p] < minTime) {
+            algorithm = a;
+            protocol = p;
+            minTime = collCostTable[a][p];
+          }
+        }
+      }
+      ncclCollTuningEntry* entry = &tuning->bestBySize[f][s];
+      if (algorithm < 0) {
+        entry->algorithm = -1;
+        entry->protocol = -1;
+        entry->timeUs = -1.0f;
+        continue;
+      }
+      int nc, nt;
+      topoGetChannelThreadCount(comm, algorithm, protocol, nBytes, &nc, &nt);
+      if (pluginNc != 0) nc = pluginNc;
+      entry->algorithm = (int8_t)algorithm;
+      entry->protocol = (int8_t)protocol;
+      entry->nChannels = (int16_t)nc;
+      entry->nThreads = (int16_t)nt;
+      entry->timeUs = minTime;
+    }
+  }
   return ncclSuccess;
 }
 

--- a/comms/ncclx/v2_30/src/nccl.h.in
+++ b/comms/ncclx/v2_30/src/nccl.h.in
@@ -1127,6 +1127,67 @@ ncclResult_t  ncclCommDump(ncclComm_t comm, std::unordered_map<std::string, std:
 ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<std::string, std::string>>& map,
     const std::unordered_map<std::string, std::string>& hints = {});
 
+/* Snapshot of a communicator's collective tuning model.
+ *
+ * The bandwidths/latencies tables are the raw model built once at communicator
+ * init by ncclTopoTuneModel(): algorithm bandwidth in GB/s (0 means the
+ * (function, algorithm, protocol) combination is disabled or unavailable,
+ * including NCCL_ALGO/NCCL_PROTO masks) and base latency in microseconds.
+ * They are uncorrected: the per-size correction factors that
+ * ncclTopoGetAlgoTime() applies are NOT reflected in them.
+ *
+ * bestBySize[f][s] is the evaluated model at messageSizes[s] bytes: the
+ * algorithm/protocol/channel/thread selection a real collective of that size
+ * would run with, and its predicted execution time in microseconds with all
+ * correction factors applied. It is produced by the same selection path real
+ * calls take (including an external tuner plugin when one is loaded), with
+ * numPipeOps = 1 and unregistered buffers (regBuff = 0). algorithm = -1 and
+ * timeUs = -1 mean no combination is available. Within an interval where the
+ * selection does not change, predicted time is affine in nBytes, so linear
+ * interpolation between adjacent entries reproduces the model.
+ *
+ * Not modeled: the fp8 ring relegation for comms larger than 8 ranks (a
+ * precision preference, not a time estimate), and per-call op aggregation
+ * (numPipeOps > 1 scales only the latency term).
+ */
+#define NCCL_COLL_TUNING_VERSION 1
+#define NCCL_TUNING_MAX_FUNCTIONS 8
+#define NCCL_TUNING_MAX_ALGORITHMS 16
+#define NCCL_TUNING_MAX_PROTOCOLS 8
+#define NCCL_TUNING_SIZE_POINTS 31
+#define NCCL_TUNING_NAME_LEN 16 /* incl. NUL; longest today is "ReduceScatter" */
+
+typedef struct {
+  int8_t algorithm;  /* index into algorithmNames, -1 if none available */
+  int8_t protocol;   /* index into protocolNames */
+  int16_t nChannels;
+  int16_t nThreads;
+  float timeUs;
+} ncclCollTuningEntry;
+
+typedef struct {
+  int version; /* NCCL_COLL_TUNING_VERSION */
+
+  int nRanks, nNodes, nChannels;
+  int minCompCap, maxCompCap;
+
+  int numFunctions, numAlgorithms, numProtocols;
+  char functionNames[NCCL_TUNING_MAX_FUNCTIONS][NCCL_TUNING_NAME_LEN];
+  char algorithmNames[NCCL_TUNING_MAX_ALGORITHMS][NCCL_TUNING_NAME_LEN];
+  char protocolNames[NCCL_TUNING_MAX_PROTOCOLS][NCCL_TUNING_NAME_LEN];
+
+  float bandwidths[NCCL_TUNING_MAX_FUNCTIONS][NCCL_TUNING_MAX_ALGORITHMS][NCCL_TUNING_MAX_PROTOCOLS];
+  float latencies[NCCL_TUNING_MAX_FUNCTIONS][NCCL_TUNING_MAX_ALGORITHMS][NCCL_TUNING_MAX_PROTOCOLS];
+
+  uint64_t messageSizes[NCCL_TUNING_SIZE_POINTS]; /* messageSizes[s] = 1 << s */
+  ncclCollTuningEntry bestBySize[NCCL_TUNING_MAX_FUNCTIONS][NCCL_TUNING_SIZE_POINTS];
+} ncclCollTuning;
+
+/* Fill `tuning` from the communicator's init-time tuning state. Read-only
+ * with respect to the communicator and callable from any thread once the
+ * communicator is initialized. */
+ncclResult_t ncclQueryCollTuning(ncclComm_t comm, ncclCollTuning* tuning);
+
 namespace ncclx::colltrace {
 
 inline constexpr uint64_t kInvalidReplayId = UINT64_MAX;


### PR DESCRIPTION
Summary:
New public API `ncclQueryCollTuning(ncclComm_t, ncclCollTuning*)` returning a
snapshot of the communicator's tuning model, plus the nccl4py binding
`query_coll_tuning(comm)`.

The struct carries the raw init-time `bandwidths`/`latencies` tables
(uncorrected, zeros for disabled combos) and `bestBySize[func][2^0..2^30]`:
the algorithm/protocol/channel/thread selection a collective of that size
would run with and its predicted time via `ncclTopoGetAlgoTime` (all
correction factors applied). The sweep goes through the real selection path
(`updateCollCostTable` -> tuner plugin if loaded -> argmin -> channel/thread
selection) with `numPipeOps=1` and `regBuff=0`; the channel/thread block is
factored out of `topoGetAlgoInfo` into `topoGetChannelThreadCount` so the
query cannot drift from real selection. Names are reported as strings so no
internal enum values leak.

Consumer: clog v2 step analysis, to replace its fixed busbw warn floor with
the model's per-comm, per-size expectation (NVLink vs RoCE aware for free).

Differential Revision: D116906711


