### PR TITLE
Prototype copy-free registered Ring AllReduce

### DIFF
--- a/comms/prims/tests/MultiSegmentRegistrationTest.cc
+++ b/comms/prims/tests/MultiSegmentRegistrationTest.cc
@@ -325,6 +325,18 @@ TEST_P(MultiSegmentRegistrationTest, BulkLeaseBoundsContainedViews) {
   ASSERT_TRUE(tail.has_value());
   EXPECT_EQ(exact->localBuffer.ptr, leasePtr);
   EXPECT_EQ(contained->localBuffer.ptr, leasePtr + kViewOffset);
+  EXPECT_EQ(exact->exchangeInfo.addr, reinterpret_cast<uint64_t>(leasePtr));
+  EXPECT_EQ(
+      contained->exchangeInfo.addr,
+      reinterpret_cast<uint64_t>(leasePtr + kViewOffset));
+  EXPECT_EQ(
+      contained->exchangeInfo.numNics,
+      contained->localBuffer.lkey_per_device.size);
+  const auto remoteContained = contained->exchangeInfo.toRemoteBuffer();
+  EXPECT_EQ(remoteContained.ptr, contained->localBuffer.ptr);
+  EXPECT_EQ(
+      remoteContained.rkey_per_device.size,
+      contained->localBuffer.lkey_per_device.size);
   EXPECT_EQ(contained->size, kViewSize);
   EXPECT_EQ(contained->leaseGeneration, lease.generation());
   EXPECT_FALSE(before.has_value());

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -1405,10 +1405,27 @@ MultiPeerIbTransportBase::lookupIbBulkBuffer(
     return std::nullopt;
   }
 
+  IbgdaBufferExchInfo exchangeInfo;
+  exchangeInfo.addr = reinterpret_cast<uint64_t>(ptr);
+  exchangeInfo.numNics = numNics_;
+  auto mrIt = registeredBuffers_.upper_bound(requestedBegin);
+  if (mrIt == registeredBuffers_.begin()) {
+    return std::nullopt;
+  }
+  --mrIt;
+  if (!rangeContains(
+          mrIt->first, mrIt->second.allocSize, requestedBegin, size)) {
+    return std::nullopt;
+  }
+  for (int n = 0; n < numNics_; ++n) {
+    exchangeInfo.rkey_per_device[n] = HostRKey(mrIt->second.mrs[n]->rkey);
+  }
+
   return IbBufferRegistrationView{
       .leaseGeneration = lease.generation(),
       .localBuffer =
           active.localBuffer.subBuffer(requestedBegin - registeredBegin),
+      .exchangeInfo = exchangeInfo,
       .size = size,
       .relaxedOrdering = active.relaxedOrdering,
   };

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -306,6 +306,7 @@ class IbBufferRegistrationLease {
 struct IbBufferRegistrationView {
   uint64_t leaseGeneration{0};
   IbgdaLocalBuffer localBuffer;
+  IbgdaBufferExchInfo exchangeInfo;
   std::size_t size{0};
   bool relaxedOrdering{false};
 

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -82,6 +82,17 @@ progress_registered_send_once(
 
 template <typename Transport>
 __device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+progress_registered_put_once(
+    Transport& transport,
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& src,
+    const IbgdaRemoteBuffer& dst,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes = 0,
+    const Timeout& timeout = Timeout());
+
+template <typename Transport>
+__device__ __forceinline__ IbgdaRegisteredSendProgressStatus
 progress_registered_send_drain_once(
     Transport& transport,
     ThreadGroup& group,

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -656,10 +656,11 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
 
 template <typename Transport>
 __device__ __forceinline__ IbgdaRegisteredSendProgressStatus
-progress_registered_send_once(
+progress_registered_send_once_impl(
     Transport& transport,
     ThreadGroup& group,
     const IbgdaLocalBuffer& src,
+    const IbgdaRemoteBuffer* directDst,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
     const Timeout& timeout) {
@@ -766,10 +767,13 @@ progress_registered_send_once(
       __threadfence_system();
       ThreadGroup solo{
           0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+      const IbgdaRemoteBuffer destination = directDst == nullptr
+          ? remoteChannel.recvStaging.subBuffer(chunk.stagingOff)
+          : directDst->subBuffer(chunk.dataOff);
       const auto completion = transport.put(
           solo,
           src.subBuffer(chunk.dataOff),
-          remoteChannel.recvStaging.subBuffer(chunk.stagingOff),
+          destination,
           validBytes,
           remoteChannel.dataReady,
           protocolBytesThis,
@@ -806,11 +810,39 @@ progress_registered_send_once(
   (void)transport;
   (void)group;
   (void)src;
+  (void)directDst;
   (void)nbytes;
   (void)max_signal_bytes;
   (void)timeout;
   return IbgdaRegisteredSendProgressStatus::Drained;
 #endif
+}
+
+template <typename Transport>
+__device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+progress_registered_send_once(
+    Transport& transport,
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& src,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout) {
+  return progress_registered_send_once_impl(
+      transport, group, src, nullptr, nbytes, max_signal_bytes, timeout);
+}
+
+template <typename Transport>
+__device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+progress_registered_put_once(
+    Transport& transport,
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& src,
+    const IbgdaRemoteBuffer& dst,
+    std::size_t nbytes,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout) {
+  return progress_registered_send_once_impl(
+      transport, group, src, &dst, nbytes, max_signal_bytes, timeout);
 }
 
 template <typename Transport>

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -2199,6 +2199,66 @@ class P2pIbgdaTransportDevice {
   }
 
   /**
+   * Post a registered-source send directly into an explicit registered remote
+   * destination while retaining the fixed-channel DATA_READY/SLOT_FREE
+   * protocol.
+   */
+  template <typename = void>
+  __device__ __forceinline__ IbgdaRegisteredSendProgressStatus
+  progress_registered_put_once(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& src,
+      const IbgdaRemoteBuffer& dst,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout()) {
+    return detail::progress_registered_put_once(
+        *this, group, src, dst, nbytes, max_signal_bytes, timeout);
+  }
+
+  /**
+   * Flush inbound RDMA writes to a locally registered GPU buffer before a
+   * different NIC is allowed to read that buffer for forwarding.
+   */
+  __device__ __forceinline__ bool flush_remote_writes(
+      ThreadGroup& group,
+      const IbgdaRemoteBuffer& localBuffer,
+      const Timeout& timeout = Timeout()) {
+#if defined(__CUDA_ARCH__)
+    for (uint32_t nicId = 0; nicId < nicDevices_.size(); ++nicId) {
+      if (group.is_leader()) {
+        const IbgdaLane lane =
+            lane_from_ordinal(group.group_id, IbDirection::Send, nicId);
+        const NicDeviceIbgdaResources& nic = nicDevices_[nicId];
+        const doca_gpu_dev_verbs_addr remoteAddr = {
+            .addr = reinterpret_cast<uint64_t>(localBuffer.ptr),
+            .key = localBuffer.rkey_per_device[nicId].value};
+        const doca_gpu_dev_verbs_addr sinkAddr = {
+            .addr = 0, .key = nic.sink_lkey.value};
+        doca_gpu_dev_verbs_ticket_t ticket = 0;
+        doca_gpu_dev_verbs_get_thread(
+            lane.companion_qp,
+            remoteAddr,
+            sinkAddr,
+            1,
+            doca_gpu_dev_verbs_addr{},
+            &ticket);
+        wait_local_on_qp(lane.companion_qp, ticket, timeout);
+      }
+      group.sync();
+      if (groupAborted(group, timeout)) {
+        return false;
+      }
+    }
+#else
+    (void)group;
+    (void)localBuffer;
+    (void)timeout;
+#endif
+    return true;
+  }
+
+  /**
    * Poll all outstanding send completion tickets for this channel. `Drained`
    * means registered source ranges posted before the call are reusable.
    */


### PR DESCRIPTION
Summary:
For ppn=1 registered Ring AllReduce, avoid the full out-of-place Phase-1 copy by staging only the originating ring shard and reducing directly from `sendbuff` into the registered Phase-2 buffer.

Receive all-gather payloads directly into registered output memory and forward them with registered puts. Exchange and validate remote registration metadata, flush remote writes through every local NIC before forwarding, and stop registered progress cleanly on abort.

This is an experimental implementation. The 4x1 GB300 S10 benchmark regressed average bus bandwidth from 11.8733 GB/s to 7.81583 GB/s (-34.2%), but the diff is being submitted for review and follow-up iteration as requested.

Differential Revision: D116907354


