### PR TITLE
Resolve keys to dense slots on the host (#3764)

### DIFF
--- a/comms/utils/collstats/CollStatsKeyRegistry.cc
+++ b/comms/utils/collstats/CollStatsKeyRegistry.cc
@@ -1,0 +1,38 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/collstats/CollStatsKeyRegistry.h"
+
+namespace meta::comms::collstats {
+
+uint32_t CollStatsKeyRegistry::resolve(const CollStatKey& key) {
+  std::lock_guard<std::mutex> lock(mu_);
+  const auto it = ids_.find(key);
+  if (it != ids_.end()) {
+    return it->second;
+  }
+  if (byId_.size() >= capacity_) {
+    ++catchAllCount_;
+    return capacity_;
+  }
+  const uint32_t id = static_cast<uint32_t>(byId_.size());
+  byId_.push_back(key);
+  ids_.emplace(key, id);
+  return id;
+}
+
+uint32_t CollStatsKeyRegistry::size() const {
+  std::lock_guard<std::mutex> lock(mu_);
+  return static_cast<uint32_t>(byId_.size());
+}
+
+std::vector<CollStatKey> CollStatsKeyRegistry::keys() const {
+  std::lock_guard<std::mutex> lock(mu_);
+  return byId_;
+}
+
+uint64_t CollStatsKeyRegistry::catchAllCount() const {
+  std::lock_guard<std::mutex> lock(mu_);
+  return catchAllCount_;
+}
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsKeyRegistry.h
+++ b/comms/utils/collstats/CollStatsKeyRegistry.h
@@ -1,0 +1,93 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+// Host-side key registry: maps a CollStatKey to the dense value slot the device
+// accumulates into.
+//
+// Every field of the key — op, algorithm, protocol, datatype and the size class
+// derived from the message size — is known on the enqueue thread before the
+// collective launches, so the mapping is resolved here and the resolved id is
+// handed to the kernel. The device then indexes rather than searches: no CAS,
+// no probing, no saturation policy in device code.
+//
+// Ids are dense and allocated in first-touch order, which is what lets the
+// reader copy only the occupied prefix of the value bank instead of its whole
+// capacity. Ids are never recycled, so a key keeps its id for the life of the
+// communicator and the id space only grows.
+//
+// Keys beyond `capacity` all resolve to `catchAllId()`, the trailing value
+// slot, and are counted so saturation is visible rather than silent.
+
+namespace meta::comms::collstats {
+
+inline bool operator==(const CollStatKey& a, const CollStatKey& b) {
+  return a.op == b.op && a.algorithm == b.algorithm &&
+      a.protocol == b.protocol && a.dtype == b.dtype &&
+      a.sizeClass == b.sizeClass;
+}
+
+class CollStatsKeyRegistry {
+ public:
+  explicit CollStatsKeyRegistry(uint32_t capacity) : capacity_(capacity) {
+    byId_.reserve(capacity);
+  }
+
+  // The value slot shared by every key that did not fit. The value bank holds
+  // capacity + 1 slots so this one always exists.
+  uint32_t catchAllId() const {
+    return capacity_;
+  }
+
+  // Resolve `key`, assigning the next dense id on first sight. Returns
+  // catchAllId() once `capacity` distinct keys have been assigned. Called from
+  // the enqueue thread on every instrumented collective.
+  uint32_t resolve(const CollStatKey& key);
+
+  // Number of ids assigned so far, i.e. the occupied prefix length of the value
+  // bank. Monotonic.
+  uint32_t size() const;
+
+  // Keys indexed by id, for attributing a readout window. Index i holds the key
+  // that owns value slot i.
+  std::vector<CollStatKey> keys() const;
+
+  // Collectives that resolved to the catch-all because the registry was full.
+  uint64_t catchAllCount() const;
+
+ private:
+  struct Hash {
+    std::size_t operator()(const CollStatKey& k) const noexcept {
+      // FNV-1a over the five fields. Host-only: the device indexes a slot the
+      // host already resolved, so there is no device-side hash for this to
+      // agree with.
+      uint64_t h = 1469598103934665603ull;
+      for (uint32_t f :
+           {static_cast<uint32_t>(k.op),
+            static_cast<uint32_t>(k.algorithm),
+            static_cast<uint32_t>(k.protocol),
+            static_cast<uint32_t>(k.dtype),
+            static_cast<uint32_t>(k.sizeClass)}) {
+        for (int b = 0; b < 4; ++b) {
+          h ^= static_cast<uint64_t>((f >> (b * 8)) & 0xFF);
+          h *= 1099511628211ull;
+        }
+      }
+      return static_cast<std::size_t>(h);
+    }
+  };
+
+  mutable std::mutex mu_;
+  uint32_t capacity_;
+  std::unordered_map<CollStatKey, uint32_t, Hash> ids_;
+  std::vector<CollStatKey> byId_;
+  uint64_t catchAllCount_{0};
+};
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/tests/CollStatsKeyRegistryTest.cpp
+++ b/comms/utils/collstats/tests/CollStatsKeyRegistryTest.cpp
@@ -1,0 +1,143 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/collstats/CollStatsKeyRegistry.h"
+
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace meta::comms::collstats {
+namespace {
+
+// `id` varies the dtype field so each call yields a distinct key. These tests
+// need more distinct keys than the op enum has enumerators, so op and algorithm
+// stay fixed and a raw code field carries the variation.
+CollStatKey key(uint8_t id, uint8_t sizeClass = 0) {
+  return CollStatKey{
+      CollStatOp::AllReduce,
+      CollStatAlgo::Direct,
+      CollStatProto::Unknown,
+      id,
+      sizeClass};
+}
+
+TEST(CollStatsKeyRegistryTest, AssignsDenseIdsInFirstTouchOrder) {
+  CollStatsKeyRegistry reg(16);
+  EXPECT_EQ(reg.size(), 0u);
+
+  EXPECT_EQ(reg.resolve(key(1)), 0u);
+  EXPECT_EQ(reg.resolve(key(2)), 1u);
+  EXPECT_EQ(reg.resolve(key(3)), 2u);
+  EXPECT_EQ(reg.size(), 3u);
+}
+
+TEST(CollStatsKeyRegistryTest, SameKeyKeepsItsId) {
+  CollStatsKeyRegistry reg(16);
+  const uint32_t id = reg.resolve(key(1, 4));
+  for (int i = 0; i < 100; ++i) {
+    EXPECT_EQ(reg.resolve(key(1, 4)), id);
+  }
+  EXPECT_EQ(reg.size(), 1u);
+}
+
+TEST(CollStatsKeyRegistryTest, EveryKeyFieldParticipates) {
+  CollStatsKeyRegistry reg(16);
+  const CollStatKey baseKey{
+      CollStatOp::AllReduce, CollStatAlgo::Direct, CollStatProto::Simple, 1, 1};
+  const uint32_t base = reg.resolve(baseKey);
+
+  const auto differs = [&](const CollStatKey& k) {
+    EXPECT_NE(reg.resolve(k), base);
+  };
+  differs(
+      {CollStatOp::AllGather,
+       CollStatAlgo::Direct,
+       CollStatProto::Simple,
+       1,
+       1});
+  differs(
+      {CollStatOp::AllReduce, CollStatAlgo::Ring, CollStatProto::Simple, 1, 1});
+  differs(
+      {CollStatOp::AllReduce, CollStatAlgo::Direct, CollStatProto::LL, 1, 1});
+  differs(
+      {CollStatOp::AllReduce,
+       CollStatAlgo::Direct,
+       CollStatProto::Simple,
+       2,
+       1});
+  differs(
+      {CollStatOp::AllReduce,
+       CollStatAlgo::Direct,
+       CollStatProto::Simple,
+       1,
+       2});
+  EXPECT_EQ(reg.size(), 6u);
+}
+
+TEST(CollStatsKeyRegistryTest, KeysAreIndexedById) {
+  CollStatsKeyRegistry reg(16);
+  const uint32_t a = reg.resolve(key(1));
+  const uint32_t b = reg.resolve(key(2));
+
+  const auto keys = reg.keys();
+  ASSERT_EQ(keys.size(), 2u);
+  EXPECT_EQ(keys[a].dtype, 1u);
+  EXPECT_EQ(keys[b].dtype, 2u);
+}
+
+// Saturation must be visible: overflow keys share the catch-all slot and are
+// counted, rather than silently displacing an existing key.
+TEST(CollStatsKeyRegistryTest, OverflowGoesToCountedCatchAll) {
+  CollStatsKeyRegistry reg(3);
+  EXPECT_EQ(reg.resolve(key(1)), 0u);
+  EXPECT_EQ(reg.resolve(key(2)), 1u);
+  EXPECT_EQ(reg.resolve(key(3)), 2u);
+  EXPECT_EQ(reg.catchAllCount(), 0u);
+
+  EXPECT_EQ(reg.resolve(key(4)), reg.catchAllId());
+  EXPECT_EQ(reg.resolve(key(5)), reg.catchAllId());
+  EXPECT_EQ(reg.catchAllCount(), 2u);
+
+  // Already-assigned keys keep working after saturation.
+  EXPECT_EQ(reg.resolve(key(2)), 1u);
+  EXPECT_EQ(reg.size(), 3u);
+}
+
+TEST(CollStatsKeyRegistryTest, CatchAllIsTheTrailingValueSlot) {
+  CollStatsKeyRegistry reg(8);
+  EXPECT_EQ(reg.catchAllId(), 8u);
+}
+
+// The enqueue thread is the normal caller, but readout attribution reads the
+// registry from whichever thread harvested the window.
+TEST(CollStatsKeyRegistryTest, ConcurrentResolveAssignsEachKeyOneId) {
+  CollStatsKeyRegistry reg(64);
+  constexpr int kThreads = 8;
+  constexpr int kKeys = 32;
+
+  std::vector<std::vector<uint32_t>> seen(kThreads);
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&, t] {
+      for (int k = 0; k < kKeys; ++k) {
+        seen[t].push_back(reg.resolve(key(static_cast<uint8_t>(k))));
+      }
+    });
+  }
+  for (auto& th : threads) {
+    th.join();
+  }
+
+  // Exactly kKeys ids handed out, and every thread saw the same id per key.
+  EXPECT_EQ(reg.size(), static_cast<uint32_t>(kKeys));
+  for (int t = 1; t < kThreads; ++t) {
+    EXPECT_EQ(seen[t], seen[0]);
+  }
+  std::unordered_set<uint32_t> unique(seen[0].begin(), seen[0].end());
+  EXPECT_EQ(unique.size(), static_cast<size_t>(kKeys));
+}
+
+} // namespace
+} // namespace meta::comms::collstats

--- a/scripts/_build_wheel.sh
+++ b/scripts/_build_wheel.sh
@@ -36,6 +36,9 @@ export CLEAN_BUILD=1
 export CXXSTD="-std=c++20"
 export NCCL_PATCH_FMT_NVCC_CXX20=1
 # NCCLX device compilation can exhaust memory at full host parallelism.
-export NCCL_BUILD_JOBS=16
+# Lower to 8 to avoid OOM on g5.12xlarge self-hosted runners for old CUDA
+# builders (cu126/cu130) that have been hitting "lost communication"
+# (D113661114).
+export NCCL_BUILD_JOBS=8
 
 python setup.py bdist_wheel


### PR DESCRIPTION
Summary:

Every instrumented collective needs a value slot for its `(op, algorithm, protocol, dtype, sizeClass)` key. Resolving that on the device would put a hash, a probe loop and a CAS in the kernel hot path, plus a saturation policy in device code. All five fields are already known on the enqueue thread before the launch, so `CollStatsKeyRegistry` resolves them there: a mutex-guarded map assigns a dense `uint32_t` id on first touch, and the id is handed to the kernel, which indexes rather than searches.

Two properties follow from dense, never-recycled ids:

- A key keeps its id for the life of the communicator, so a captured graph replaying the same launch indexes the same slot.
- Everything past the highest assigned id has provably never been written, so a readout can copy the occupied prefix instead of the full bank. At 1024 bytes per `CollStatValue`, a workload touching 20 keys copies ~20KB per window rather than 0.5MiB at the default 512-key capacity.

Keys arriving after capacity is exhausted all resolve to a single reserved catch-all slot at index `capacity`, and `catchAllCount()` reports how many did, so saturation is visible rather than silent.

Reviewed By: rmahidhar

Differential Revision: D113661114
