### PR TITLE
Expose contextual abort status

### DIFF
--- a/comms/common/fault_tolerance/Abort.cc
+++ b/comms/common/fault_tolerance/Abort.cc
@@ -12,21 +12,8 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include <string_view>
 
 namespace comms::fault_tolerance {
-
-std::string_view abortReasonToString(AbortReason reason) {
-  switch (reason) {
-    case AbortReason::NONE:
-      return "none";
-    case AbortReason::ABORTED:
-      return "aborted";
-    case AbortReason::TIMED_OUT:
-      return "timed_out";
-  }
-  return "unknown";
-}
 
 Abort::Abort(bool enabled, AbortBehavior behavior) : behavior_(behavior) {
   if (!enabled) {
@@ -74,12 +61,35 @@ Abort::~Abort() {
 #endif
 }
 
-void Abort::setAbort(AbortReason newReason) {
+bool Abort::setAbort(AbortReason newReason, std::string_view context) {
+  if (!isTerminalAbortReason(newReason)) {
+    throw std::invalid_argument("Invalid terminal abort reason");
+  }
   if (state_ == nullptr) {
-    return;
+    return false;
   }
 
-  markAbort(newReason);
+  // Own the caller's context before publishing the reason. This keeps the
+  // post-CAS path allocation-free and makes a transient caller buffer safe.
+  return trySetAbort(newReason, std::string{context.data(), context.size()});
+}
+
+std::optional<AbortInfo> Abort::getAbortInfo() {
+  if (state_ == nullptr) {
+    return std::nullopt;
+  }
+
+  (void)isAborted();
+  const auto reason = static_cast<AbortReason>(loadAbortReason());
+  if (reason == AbortReason::NONE) {
+    return std::nullopt;
+  }
+
+  std::string context;
+  if (contextReady_.load(std::memory_order_acquire)) {
+    context = context_;
+  }
+  return AbortInfo{.reason = reason, .context = std::move(context)};
 }
 
 bool Abort::isAborted() {
@@ -124,7 +134,7 @@ bool Abort::isTimedOut() {
 
   auto now = std::chrono::steady_clock::now();
   if (now >= deadline_.load(std::memory_order_acquire)) {
-    markAbort(AbortReason::TIMED_OUT);
+    trySetAbort(AbortReason::TIMED_OUT, "timeout expired");
     return loadAbortReason() == encode(AbortReason::TIMED_OUT);
   }
 
@@ -193,16 +203,23 @@ int Abort::loadAbortReason() const {
   return std::atomic_ref<int>{state_->abort}.load(std::memory_order_acquire);
 }
 
-void Abort::markAbort(AbortReason newReason) {
-  if (!isValidTerminalReason(newReason)) {
-    throw std::invalid_argument("Abort reason must be ABORTED or TIMED_OUT");
-  }
+bool Abort::trySetAbort(AbortReason newReason, std::string context) {
   int expected = encode(AbortReason::NONE);
-  std::atomic_ref<int>{state_->abort}.compare_exchange_strong(
+  const bool won = std::atomic_ref<int>{state_->abort}.compare_exchange_strong(
       expected,
       encode(newReason),
       std::memory_order_acq_rel,
       std::memory_order_acquire);
+  if (!won) {
+    return false;
+  }
+
+  // The reason CAS gives this call exclusive ownership of context_. Publishing
+  // happens afterwards on purpose: a racing reader may return the reason with
+  // empty context, but it never reads context_ while this swap is in progress.
+  context_.swap(context);
+  contextReady_.store(true, std::memory_order_release);
+  return true;
 }
 
 std::shared_ptr<Abort> createAbort(bool enabled, AbortBehavior behavior) {

--- a/comms/common/fault_tolerance/Abort.h
+++ b/comms/common/fault_tolerance/Abort.h
@@ -8,22 +8,12 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
 #include <string_view>
 
+#include "comms/common/fault_tolerance/AbortTypes.h"
+
 namespace comms::fault_tolerance {
-
-enum class AbortReason : int {
-  NONE = 0,
-  ABORTED = 1,
-  TIMED_OUT = 2,
-};
-
-std::string_view abortReasonToString(AbortReason reason);
-
-enum class AbortBehavior : int {
-  SKIP = 0,
-  TRAP = 1,
-};
 
 enum class AbortCheckResult : int {
   CONTINUE = 0,
@@ -131,17 +121,35 @@ class Abort final {
   }
 
   /**
-   * Records the first abort reason.
+   * Records the first abort reason and optional diagnostic context.
    *
    * The abort state starts as `AbortReason::NONE` and can transition exactly
    * once to one valid terminal reason. The first writer wins. Later calls with
    * a different reason do not override the reason already visible to other host
-   * threads and device consumers. Valid terminal reasons are
-   * `AbortReason::ABORTED` and `AbortReason::TIMED_OUT`; `AbortReason::NONE`
-   * and unknown enum values are invalid input and are rejected before
-   * attempting to update shared state.
+   * threads and device consumers. `AbortReason::NONE` and unknown enum values
+   * are invalid input and are rejected before attempting to update shared
+   * state.
+   *
+   * The context is copied before attempting the transition. When this call
+   * wins, that owned string is published in host-only state and becomes
+   * available through `getAbortInfo()`. A racing reader may observe the winning
+   * reason before the context is published and receive an empty context.
+   * Device-originated aborts never publish host context.
+   *
+   * Returns whether this call performed the `NONE` to terminal transition.
    */
-  void setAbort(AbortReason newReason = AbortReason::ABORTED);
+  bool setAbort(
+      AbortReason newReason = AbortReason::ABORTED,
+      std::string_view context = {});
+
+  /**
+   * Returns an immutable snapshot of the winning abort reason and context, or
+   * std::nullopt when this controller has not been aborted.
+   *
+   * Like `isAborted()`, this materializes an expired host timeout before
+   * reading the snapshot. Device-originated aborts have an empty context.
+   */
+  std::optional<AbortInfo> getAbortInfo();
 
   /**
    * Returns true when an explicit abort or expired active timeout has aborted
@@ -236,25 +244,19 @@ class Abort final {
     return static_cast<int>(reason);
   }
 
-  static constexpr bool isValidTerminalReason(AbortReason reason) {
-    switch (reason) {
-      case AbortReason::ABORTED:
-      case AbortReason::TIMED_OUT:
-        return true;
-      case AbortReason::NONE:
-        return false;
-    }
-    return false;
-  }
-
   int loadAbortReason() const;
-  void markAbort(AbortReason newReason);
+  bool trySetAbort(AbortReason newReason, std::string context);
 
   AbortState* state_{nullptr};
   bool stateMapped_{false};
   std::atomic<bool> hasTimeout_{false};
   std::atomic<std::chrono::steady_clock::time_point> deadline_{
       std::chrono::steady_clock::time_point{}};
+  // Only the host reason-CAS winner writes context_. Readers copy it only after
+  // an acquire load observes contextReady_, so no mutex is needed. The flag is
+  // host-only and is never accessed by AbortDevice.
+  std::atomic<bool> contextReady_{false};
+  std::string context_;
   AbortBehavior behavior_{AbortBehavior::SKIP};
 
   static_assert(std::atomic<bool>::is_always_lock_free);

--- a/comms/common/fault_tolerance/AbortDevice.cuh
+++ b/comms/common/fault_tolerance/AbortDevice.cuh
@@ -85,6 +85,9 @@ __device__ __forceinline__ bool deviceIsValidTerminalReason(
   switch (reason) {
     case AbortReason::ABORTED:
     case AbortReason::TIMED_OUT:
+    case AbortReason::BOOTSTRAP_POLL:
+    case AbortReason::NETWORK_ERROR:
+    case AbortReason::INTERNAL_ERROR:
       return true;
     case AbortReason::NONE:
       return false;
@@ -344,25 +347,31 @@ struct AbortDevice final {
   /**
    * Records the first shared abort reason from device code.
    *
-   * Valid terminal reasons are `AbortReason::ABORTED` and
-   * `AbortReason::TIMED_OUT`. `AbortReason::NONE` and unknown enum values are
-   * invalid; debug/device assert builds catch them, and release-compatible
-   * builds return before touching shared state. The CAS only transitions the
-   * shared state from `NONE`, so later writers cannot overwrite the first
-   * terminal reason.
+   * Every non-`NONE` AbortReason is terminal. `AbortReason::NONE` and unknown
+   * enum values are invalid; debug/device assert builds catch them, and
+   * release-compatible builds return before touching shared state. The CAS
+   * only transitions the shared state from `NONE`, so later writers cannot
+   * overwrite the first terminal reason. `context` matches the host API but is
+   * never persisted in shared state; device-side diagnostics may consume it at
+   * the winning callsite without adding mapped-memory traffic.
+   *
+   * Returns whether this call performed the `NONE` to terminal transition.
    */
-  __device__ void setAbort(AbortReason newReason = AbortReason::ABORTED) const {
+  __device__ bool setAbort(
+      AbortReason newReason = AbortReason::ABORTED,
+      const char* context = nullptr) const {
     if (!isEnabled()) {
-      return;
+      return false;
     }
+    (void)context;
     const bool validReason = detail::deviceIsValidTerminalReason(newReason);
     assert(validReason);
     if (!validReason) {
-      return;
+      return false;
     }
 
     int expected = static_cast<int>(AbortReason::NONE);
-    detail::deviceCompareExchangeSystem(
+    return detail::deviceCompareExchangeSystem(
         &state_->abort, &expected, static_cast<int>(newReason));
   }
 

--- a/comms/common/fault_tolerance/AbortTypes.h
+++ b/comms/common/fault_tolerance/AbortTypes.h
@@ -1,0 +1,73 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace comms::fault_tolerance {
+
+// Device-side action to take after observing an abort.
+enum class AbortBehavior : int {
+  SKIP = 0,
+  TRAP = 1,
+};
+
+// Stable, append-only values shared by host and device abort state.
+enum class AbortReason : int {
+  NONE = 0,
+  ABORTED = 1,
+  TIMED_OUT = 2,
+  BOOTSTRAP_POLL = 3,
+  NETWORK_ERROR = 4,
+  INTERNAL_ERROR = 5,
+};
+
+constexpr bool isTerminalAbortReason(AbortReason reason) {
+  switch (reason) {
+    case AbortReason::ABORTED:
+    case AbortReason::TIMED_OUT:
+    case AbortReason::BOOTSTRAP_POLL:
+    case AbortReason::NETWORK_ERROR:
+    case AbortReason::INTERNAL_ERROR:
+      return true;
+    case AbortReason::NONE:
+      return false;
+  }
+  return false;
+}
+
+constexpr std::string_view abortReasonToString(AbortReason reason) {
+  switch (reason) {
+    case AbortReason::NONE:
+      return "none";
+    case AbortReason::ABORTED:
+      return "aborted";
+    case AbortReason::TIMED_OUT:
+      return "timed_out";
+    case AbortReason::BOOTSTRAP_POLL:
+      return "bootstrap_poll";
+    case AbortReason::NETWORK_ERROR:
+      return "network_error";
+    case AbortReason::INTERNAL_ERROR:
+      return "internal_error";
+  }
+  return "unknown";
+}
+
+struct AbortInfo {
+  // AbortInfo always describes an actual abort. Absence is represented by
+  // std::nullopt at query boundaries.
+  AbortReason reason{AbortReason::ABORTED};
+  std::string context;
+
+  std::string_view reasonString() const {
+    return abortReasonToString(reason);
+  }
+
+  bool operator==(const AbortInfo& other) const {
+    return reason == other.reason && context == other.context;
+  }
+};
+
+} // namespace comms::fault_tolerance

--- a/comms/common/fault_tolerance/FAULT_TOLERANCE.md
+++ b/comms/common/fault_tolerance/FAULT_TOLERANCE.md
@@ -296,7 +296,7 @@ host can tell those apart.
 ### What the caller sees
 
 - The collective completes; **output buffers are undefined** after an abort.
-- Check `IComm::isAborted()`, `getAbortReason()` and `getAbortReasonStr()`.
+- Check `IComm::isAborted()` and `getAbortInfo()`.
 - Where the host can determine it cheaply, the work handle also reports a
   non-success result — but a `commSuccess` after an abort is contract-legal and
   its data must still be ignored.

--- a/comms/common/fault_tolerance/FAULT_TOLERANCE.md
+++ b/comms/common/fault_tolerance/FAULT_TOLERANCE.md
@@ -61,10 +61,21 @@ The abort reason is first-writer-wins:
 
 - `AbortReason::ABORTED` records an explicit user or transport abort.
 - `AbortReason::TIMED_OUT` records an expired timeout.
+- `AbortReason::BOOTSTRAP_POLL` records a failure detected by Bootstrap socket-health polling.
+- `AbortReason::NETWORK_ERROR` records a transport or peer-network failure.
+- `AbortReason::INTERNAL_ERROR` records an internal communication failure.
 - `AbortReason::NONE` means no terminal reason has been recorded.
 
 Host and device writers only transition from `NONE` to one terminal reason.
 Later writers cannot overwrite the recorded reason.
+
+`AbortInfo` pairs that winning reason with optional host diagnostic context.
+`AbortInfo::reasonString()` computes the stable lowercase reason label directly
+from the enum, so callers always have displayable text without duplicating it in
+the stored object. `Abort::getAbortInfo()` may materialize an expired host
+timeout before returning. A device-originated abort, or a host read that races
+the winning host writer before context publication, returns the winning reason
+with an empty context.
 
 ## Device `AbortDevice`
 
@@ -307,7 +318,9 @@ Host explicit abort:
 
 ```cpp
 auto abort = comm->getAbort();
-abort->setAbort(comms::fault_tolerance::AbortReason::ABORTED);
+abort->setAbort(
+    comms::fault_tolerance::AbortReason::ABORTED,
+    "user requested abort");
 ```
 
 Host default timeout:
@@ -340,8 +353,14 @@ __global__ void kernel(KernArgs args) {
 Device explicit abort:
 
 ```cpp
-abort.setAbort(comms::fault_tolerance::AbortReason::ABORTED);
+abort.setAbort(
+    comms::fault_tolerance::AbortReason::ABORTED,
+    "device callsite");
 ```
+
+The host copies the context into host-only storage. The device never stores the
+string in mapped shared state; a device diagnostic may consume the
+device-accessible string only at the winning callsite.
 
 Device timeout:
 

--- a/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
@@ -94,6 +94,35 @@ TEST(AbortDeviceTest, hostProducerDeviceConsumer) {
       readDeviceValue(observedMode), static_cast<int>(AbortReason::ABORTED));
 }
 
+TEST(AbortDeviceTest, deviceObservesDetailedHostReasonWithoutContext) {
+  Abort abort{/*enabled=*/true};
+  auto observed = makeDeviceValue<int>();
+  auto observedReason = makeDeviceValue<int>();
+  ASSERT_NE(observed, nullptr);
+  ASSERT_NE(observedReason, nullptr);
+
+  abort.setAbort(AbortReason::BOOTSTRAP_POLL, "socket health poll");
+
+  EXPECT_EQ(
+      launchDeviceReadAbort(
+          abort.getDeviceHandle(),
+          observed.get(),
+          observedReason.get(),
+          /*stream=*/nullptr),
+      cudaSuccess);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  EXPECT_EQ(readDeviceValue(observed), 1);
+  EXPECT_EQ(
+      readDeviceValue(observedReason),
+      static_cast<int>(AbortReason::BOOTSTRAP_POLL));
+  EXPECT_EQ(
+      abort.getAbortInfo(),
+      (AbortInfo{
+          .reason = AbortReason::BOOTSTRAP_POLL,
+          .context = "socket health poll",
+      }));
+}
+
 TEST(AbortDeviceTest, checkExpiredSeesHostAbort) {
   Abort abort{/*enabled=*/true};
   auto observedCheckExpired = makeDeviceValue<int>();
@@ -184,6 +213,93 @@ TEST(AbortDeviceTest, deviceProducerHostConsumer) {
 
   EXPECT_TRUE(abort.isAborted());
   EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+}
+
+TEST(AbortDeviceTest, deviceProducerSupportsDetailedTerminalReasons) {
+  for (const auto reason : {
+           AbortReason::BOOTSTRAP_POLL,
+           AbortReason::NETWORK_ERROR,
+           AbortReason::INTERNAL_ERROR,
+       }) {
+    Abort abort{/*enabled=*/true};
+
+    EXPECT_EQ(
+        launchDeviceSetAbort(
+            abort.getDeviceHandle(), reason, /*stream=*/nullptr),
+        cudaSuccess);
+    EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    const auto info = abort.getAbortInfo();
+    ASSERT_TRUE(info.has_value());
+    EXPECT_EQ(info->reason, reason);
+    EXPECT_TRUE(info->context.empty());
+  }
+}
+
+TEST(AbortDeviceTest, deviceWinnerDoesNotExposeLosingHostContext) {
+  Abort abort{/*enabled=*/true};
+
+  EXPECT_EQ(
+      launchDeviceSetAbort(
+          abort.getDeviceHandle(),
+          AbortReason::INTERNAL_ERROR,
+          /*stream=*/nullptr),
+      cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  abort.setAbort(AbortReason::NETWORK_ERROR, "losing host context");
+
+  EXPECT_EQ(
+      abort.getAbortInfo(),
+      (AbortInfo{
+          .reason = AbortReason::INTERNAL_ERROR,
+          .context = "",
+      }));
+}
+
+TEST(AbortDeviceTest, hostWinnerPreservesContextAgainstDeviceAbort) {
+  Abort abort{/*enabled=*/true};
+  abort.setAbort(AbortReason::NETWORK_ERROR, "winning host context");
+
+  EXPECT_EQ(
+      launchDeviceSetAbort(
+          abort.getDeviceHandle(),
+          AbortReason::INTERNAL_ERROR,
+          /*stream=*/nullptr),
+      cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(
+      abort.getAbortInfo(),
+      (AbortInfo{
+          .reason = AbortReason::NETWORK_ERROR,
+          .context = "winning host context",
+      }));
+}
+
+TEST(AbortDeviceTest, hostDeviceRaceNeverMismatchesContext) {
+  constexpr int kIterations = 100;
+  for (int i = 0; i < kIterations; ++i) {
+    Abort abort{/*enabled=*/true};
+
+    EXPECT_EQ(
+        launchDeviceSetAbort(
+            abort.getDeviceHandle(),
+            AbortReason::INTERNAL_ERROR,
+            /*stream=*/nullptr),
+        cudaSuccess);
+    abort.setAbort(AbortReason::NETWORK_ERROR, "host context");
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    const auto info = abort.getAbortInfo();
+    ASSERT_TRUE(info.has_value());
+    if (info->reason == AbortReason::NETWORK_ERROR) {
+      EXPECT_EQ(info->context, "host context");
+    } else {
+      EXPECT_EQ(info->reason, AbortReason::INTERNAL_ERROR);
+      EXPECT_TRUE(info->context.empty());
+    }
+  }
 }
 
 TEST(AbortDeviceTest, deviceProducerDeviceConsumer) {

--- a/comms/common/fault_tolerance/tests/AbortUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortUT.cc
@@ -5,6 +5,7 @@
 #include <optional>
 #include <stdexcept>
 #include <thread>
+#include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -460,11 +461,21 @@ TEST(AbortTest, timedOutFalseForExplicitSet) {
 TEST(AbortTest, setAbortTimedOutRecordsTimeout) {
   Abort abort{/*enabled=*/true};
 
-  abort.setAbort(AbortReason::TIMED_OUT);
+  EXPECT_TRUE(abort.setAbort(AbortReason::TIMED_OUT));
 
   EXPECT_TRUE(abort.isAborted());
   EXPECT_TRUE(abort.isTimedOut());
   EXPECT_EQ(abort.reason(), AbortReason::TIMED_OUT);
+}
+
+TEST(AbortTest, reasonOnlySetAbortIsPreserved) {
+  Abort abort{/*enabled=*/true};
+
+  abort.setAbort(AbortReason::NETWORK_ERROR);
+
+  EXPECT_EQ(
+      abort.getAbortInfo(),
+      (AbortInfo{.reason = AbortReason::NETWORK_ERROR, .context = ""}));
 }
 
 TEST(AbortTest, setAbortRejectsNone) {
@@ -478,7 +489,7 @@ TEST(AbortTest, setAbortRejectsUnknownReason) {
   Abort abort{/*enabled=*/true};
 
   EXPECT_THROW(
-      abort.setAbort(static_cast<AbortReason>(3)), std::invalid_argument);
+      abort.setAbort(static_cast<AbortReason>(99)), std::invalid_argument);
   EXPECT_FALSE(abort.isAborted());
 
   abort.setAbort(AbortReason::ABORTED);
@@ -487,11 +498,110 @@ TEST(AbortTest, setAbortRejectsUnknownReason) {
   EXPECT_FALSE(abort.isTimedOut());
 }
 
+TEST(AbortTest, setAbortRejectsInvalidReasonsWhenDisabled) {
+  Abort abort{/*enabled=*/false};
+
+  EXPECT_THROW(abort.setAbort(AbortReason::NONE), std::invalid_argument);
+  EXPECT_THROW(
+      abort.setAbort(static_cast<AbortReason>(99)), std::invalid_argument);
+  EXPECT_EQ(abort.getAbortInfo(), std::nullopt);
+}
+
+TEST(AbortTest, abortInfoInitiallyEmpty) {
+  Abort abort{/*enabled=*/true};
+
+  EXPECT_EQ(abort.getAbortInfo(), std::nullopt);
+}
+
+TEST(AbortTest, abortInfoDisabledRemainsEmpty) {
+  Abort abort{/*enabled=*/false};
+
+  EXPECT_FALSE(abort.setAbort(AbortReason::ABORTED, "ignored"));
+
+  EXPECT_EQ(abort.getAbortInfo(), std::nullopt);
+}
+
+TEST(AbortTest, abortInfoRecordsEveryTerminalReasonAndContext) {
+  const std::vector reasons{
+      AbortReason::ABORTED,
+      AbortReason::TIMED_OUT,
+      AbortReason::BOOTSTRAP_POLL,
+      AbortReason::NETWORK_ERROR,
+      AbortReason::INTERNAL_ERROR,
+  };
+
+  for (const auto reason : reasons) {
+    Abort abort{/*enabled=*/true};
+    EXPECT_TRUE(abort.setAbort(reason, "details"));
+    EXPECT_EQ(
+        abort.getAbortInfo(),
+        (AbortInfo{.reason = reason, .context = "details"}));
+  }
+}
+
+TEST(AbortTest, abortInfoPreservesEmbeddedNullInContext) {
+  Abort abort{/*enabled=*/true};
+  const std::string context{"prefix\0suffix", 13};
+
+  EXPECT_TRUE(abort.setAbort(AbortReason::INTERNAL_ERROR, context));
+  EXPECT_EQ(
+      abort.getAbortInfo(),
+      (AbortInfo{
+          .reason = AbortReason::INTERNAL_ERROR,
+          .context = context,
+      }));
+}
+
+TEST(AbortTest, firstTerminalReasonAndContextWinTogether) {
+  Abort abort{/*enabled=*/true};
+
+  EXPECT_TRUE(abort.setAbort(AbortReason::BOOTSTRAP_POLL, "first"));
+  EXPECT_FALSE(abort.setAbort(AbortReason::INTERNAL_ERROR, "second"));
+
+  EXPECT_EQ(
+      abort.getAbortInfo(),
+      (AbortInfo{
+          .reason = AbortReason::BOOTSTRAP_POLL,
+          .context = "first",
+      }));
+}
+
+TEST(AbortTest, expiredTimeoutRecordsContext) {
+  Abort abort{/*enabled=*/true};
+  abort.startTimeout(std::chrono::milliseconds{0});
+
+  EXPECT_EQ(
+      abort.getAbortInfo(),
+      (AbortInfo{
+          .reason = AbortReason::TIMED_OUT, .context = "timeout expired"}));
+}
+
+TEST(AbortTest, concurrentWinnerKeepsMatchingContext) {
+  for (int iteration = 0; iteration < 100; ++iteration) {
+    Abort abort{/*enabled=*/true};
+    std::thread network(
+        [&]() { abort.setAbort(AbortReason::NETWORK_ERROR, "network"); });
+    std::thread internal(
+        [&]() { abort.setAbort(AbortReason::INTERNAL_ERROR, "internal"); });
+    network.join();
+    internal.join();
+
+    const auto info = abort.getAbortInfo();
+    ASSERT_TRUE(info.has_value());
+    if (info->reason == AbortReason::NETWORK_ERROR) {
+      EXPECT_EQ(info->context, "network");
+    } else {
+      EXPECT_EQ(info->reason, AbortReason::INTERNAL_ERROR);
+      EXPECT_EQ(info->context, "internal");
+    }
+  }
+}
+
 TEST(AbortTest, firstTerminalReasonWins) {
   Abort abort{/*enabled=*/true};
 
-  abort.setAbort(AbortReason::TIMED_OUT);
-  abort.setAbort(AbortReason::ABORTED);
+  EXPECT_TRUE(abort.setAbort(AbortReason::TIMED_OUT));
+  EXPECT_FALSE(abort.setAbort(AbortReason::ABORTED));
 
   EXPECT_TRUE(abort.isAborted());
   EXPECT_TRUE(abort.isTimedOut());
@@ -502,7 +612,19 @@ TEST(AbortTest, abortReasonToString) {
   EXPECT_EQ(abortReasonToString(AbortReason::NONE), "none");
   EXPECT_EQ(abortReasonToString(AbortReason::ABORTED), "aborted");
   EXPECT_EQ(abortReasonToString(AbortReason::TIMED_OUT), "timed_out");
+  EXPECT_EQ(abortReasonToString(AbortReason::BOOTSTRAP_POLL), "bootstrap_poll");
+  EXPECT_EQ(abortReasonToString(AbortReason::NETWORK_ERROR), "network_error");
+  EXPECT_EQ(abortReasonToString(AbortReason::INTERNAL_ERROR), "internal_error");
   EXPECT_EQ(abortReasonToString(static_cast<AbortReason>(99)), "unknown");
+}
+
+TEST(AbortTest, abortInfoReasonStringIsComputedFromReason) {
+  const AbortInfo info{
+      .reason = AbortReason::NETWORK_ERROR,
+      .context = "",
+  };
+
+  EXPECT_EQ(info.reasonString(), "network_error");
 }
 
 TEST(AbortTest, timeRemainingNoTimeout) {

--- a/comms/common/fault_tolerance/tests/AbortUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortUT.cc
@@ -145,6 +145,21 @@ TEST(AbortFactoryTest, disabledNoop) {
   EXPECT_FALSE(abort->isAborted());
 }
 
+TEST(AbortFactoryTest, DisabledSingletonDoesNotStoreAbortInfo) {
+  auto first = ::comms::fault_tolerance::createAbort(/*enabled=*/false);
+  auto second = ::comms::fault_tolerance::createAbort(/*enabled=*/false);
+
+  ASSERT_EQ(first.get(), second.get());
+
+  EXPECT_FALSE(
+      first->setAbort(AbortReason::NETWORK_ERROR, "ignored disabled abort"));
+
+  EXPECT_FALSE(first->isAborted());
+  EXPECT_EQ(first->getAbortInfo(), std::nullopt);
+  EXPECT_FALSE(second->isAborted());
+  EXPECT_EQ(second->getAbortInfo(), std::nullopt);
+}
+
 TEST(AbortTest, timeoutNotExpired) {
   Abort abort{/*enabled=*/true};
 

--- a/scripts/_build_wheel.sh
+++ b/scripts/_build_wheel.sh
@@ -30,6 +30,11 @@ pip install pyyaml
 
 export NCCL_SKIP_CONDA_INSTALL=1
 export CLEAN_BUILD=1
+# Match the NCCLX feedstock and TorchComms iter build. NCCLX headers require
+# C++20, and fmt needs its NVCC C++20 compatibility patch applied after the
+# environment's dependency installation.
+export CXXSTD="-std=c++20"
+export NCCL_PATCH_FMT_NVCC_CXX20=1
 # NCCLX device compilation can exhaust memory at full host parallelism.
 export NCCL_BUILD_JOBS=16
 


### PR DESCRIPTION
Summary:
- expose AbortInfo through the MCCL abort API and return std::optional<AbortInfo> from getAbortInfo(), while keeping isAborted() as the fast boolean polling path
- keep the no-argument abort call without putting a default argument on the virtual override, and remove redundant reason-only query APIs
- log the winning cause once while preserving cheap repeated polling, escaping embedded-NUL context without truncation
- validate terminal reasons consistently even when abort support is disabled
- cover disabled-abort no-op behavior at the MCCL API and createAbort() levels

Differential Revision: D115748769


