### PR TITLE
Release the IB progress slot when a transfer aborts (#3767)

### DIFF
--- a/comms/common/fault_tolerance/FAULT_TOLERANCE.md
+++ b/comms/common/fault_tolerance/FAULT_TOLERANCE.md
@@ -45,6 +45,23 @@ rules the detail exists to serve.
     silently means "no override".
 11. **Fault tolerance is an MCCL-communicator feature.** Communicators created
     through the NCCLX/CTRAN factory get a disabled `Abort`; see *Scope*.
+12. **Terminate the kernel cleanly; never trap to do it.** A trap takes the CUDA
+    context down and loses every other stream on the device, which is a worse
+    outcome than the hang it replaces. Abort must unwind to a normal kernel
+    exit. `FT_DEVICE_TRAP()` stays reserved for the death tests that assert trap
+    semantics deliberately.
+13. **Contain the abort path in the transport.** The transport leaves its
+    per-channel state releasable on abort -- an unwinding operation drives its
+    progress slot to the terminal stage (`abandon_progress_state()`), so a
+    kernel already queued on the same channel re-initializes without tripping
+    `assert_progress_slot_idle()`, and any further progress call short-circuits
+    to `Done`. A collective therefore drains and exits on its existing loop
+    conditions. This is a liveness guarantee, not a promise that the channel
+    still carries meaningful data: after an abort the flow-control counters are
+    skewed against the peer's, and recovery is still `reconfigure()`. Do not add
+    group-uniform abort gates, entry guards, or slot bookkeeping to a
+    collective: if a collective needs one, the transport is leaving state behind
+    and that is where the fix belongs.
 
 ## Host `Abort`
 
@@ -250,6 +267,19 @@ unlikely case of a `commSuccess`, the comm result data should still be ignored."
    and the IB progress path returns `Aborted`; that lets callers stop sooner and
    more precisely. Callers are not *obliged* to consume it, so never rely on
    propagation for liveness.
+7. **Leave the channel state releasable.** A wait that unwinds must not strand
+   the resource it was waiting on. In the IB progress path this is
+   `abandon_progress_state()` (`P2pIbTransportProgressImpl.cuh`): every abort
+   exit drives the progress slot to `Done` before returning `Aborted`, so the
+   next `init_send_progress()` / `init_recv_progress()` on that channel passes
+   `assert_progress_slot_idle()` instead of trapping, and a driver loop that
+   keeps calling progress simply drains. The reserved byte range is abandoned
+   rather than returned to the channel cursor: a peer RDMA write may still land
+   in it, and the flow-control counters are skewed after an abort regardless —
+   the point is that the queued kernel exits instead of trapping, not that the
+   channel is fit to reuse. If a new wait acquires state of its own, releasing
+   it on abort is part of adding the wait — pushing that onto the collective
+   violates the containment principle.
 
 ### Collective Enablement — onboarding a collective
 
@@ -262,6 +292,9 @@ unlikely case of a `commSuccess`, the comm result data should still be ignored."
    **only** from a timeout the caller supplied on the collective API. Never seed
    it from the communicator default; see *Per-operation timeouts*.
 5. You do **not** need to check the return value of any wait to be hang-safe.
+6. You do **not** need an abort gate, an entry guard, or slot bookkeeping of your
+   own. The transport releases its state on abort (see *Principles*), so a loop that
+   already retires on `Done` retires on an aborted channel too.
 
 Steps 1–3 are the entire integration. Forgetting them means the collective runs
 with a disabled handle and silently has no fault tolerance.

--- a/comms/prims/tests/ProgressSlotReleaseTest.cc
+++ b/comms/prims/tests/ProgressSlotReleaseTest.cc
@@ -1,0 +1,63 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+#include <cstddef>
+
+#include "comms/prims/tests/ProgressSlotReleaseTest.cuh"
+
+namespace comms::prims {
+namespace {
+
+using test::SlotProbe;
+
+// Every non-terminal stage a transfer can unwind from. `Busy` is deliberately
+// absent: it belongs to the blocking send()/recv(), which runs its waits to
+// completion under SKIP and clears the stage itself.
+constexpr int kNonTerminalStages[] = {
+    test::kStageWaitLocalCompletion,
+    test::kStageWaitSlotFree,
+    test::kStageWaitDataReady,
+};
+
+// Half a chunk in, so the slot is unambiguously mid-transfer.
+constexpr std::size_t kNextByte = 8192;
+
+// Control. If staging did not actually produce a non-idle slot, the test below
+// would pass without proving anything.
+TEST(ProgressSlotReleaseTest, StagedSlotIsNotIdle) {
+  for (const int stage : kNonTerminalStages) {
+    const SlotProbe probe = test::stage_slot(stage, kNextByte);
+    EXPECT_EQ(probe.stage, stage);
+    EXPECT_NE(probe.stage, test::kStageDone) << "stage=" << stage;
+  }
+}
+
+// The containment property: an aborted transfer leaves the slot reusable, so
+// the next kernel on the channel re-initializes instead of trapping. The
+// assert_progress_slot_idle() call inside the second kernel launch is itself
+// half the assertion -- it traps the whole context if the slot is not released,
+// which surfaces here as a CUDA error from the readback.
+TEST(ProgressSlotReleaseTest, AbandonedSlotIsIdleForTheNextKernel) {
+  for (const int stage : kNonTerminalStages) {
+    const SlotProbe probe = test::abandon_then_reinit(stage, kNextByte);
+    EXPECT_EQ(probe.stage, test::kStageDone) << "stage=" << stage;
+    EXPECT_EQ(probe.nextByte, 0u) << "stage=" << stage;
+    EXPECT_EQ(probe.tailPadding, 0u) << "stage=" << stage;
+    EXPECT_EQ(probe.baseStep, 0) << "stage=" << stage;
+  }
+}
+
+// The reserved range is abandoned, not recycled. A peer's RDMA write may still
+// land in it, so rewinding the channel cursor would hand those bytes to the
+// next operation.
+TEST(ProgressSlotReleaseTest, AbandonKeepsTheChannelCursorAdvanced) {
+  const SlotProbe staged =
+      test::stage_slot(test::kStageWaitSlotFree, kNextByte);
+  const SlotProbe abandoned =
+      test::abandon_then_reinit(test::kStageWaitSlotFree, kNextByte);
+  EXPECT_GT(staged.nextStep, 0);
+  EXPECT_EQ(abandoned.nextStep, staged.nextStep);
+}
+
+} // namespace
+} // namespace comms::prims

--- a/comms/prims/tests/ProgressSlotReleaseTest.cu
+++ b/comms/prims/tests/ProgressSlotReleaseTest.cu
@@ -1,0 +1,142 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <cstddef>
+
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/tests/Checks.h"
+#include "comms/prims/tests/ProgressSlotReleaseTest.cuh"
+#include "comms/prims/transport/P2pIbTransportProgressImpl.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+using detail::IbSendRecvProgressStage;
+
+static_assert(static_cast<int>(IbSendRecvProgressStage::Done) == kStageDone);
+static_assert(
+    static_cast<int>(IbSendRecvProgressStage::WaitLocalCompletion) ==
+    kStageWaitLocalCompletion);
+static_assert(
+    static_cast<int>(IbSendRecvProgressStage::WaitSlotFree) ==
+    kStageWaitSlotFree);
+static_assert(
+    static_cast<int>(IbSendRecvProgressStage::WaitDataReady) ==
+    kStageWaitDataReady);
+
+// Arbitrary non-zero cursors. They exist only so the probe can tell an
+// abandoned slot from an untouched one.
+constexpr std::size_t kTailPadding = 64;
+constexpr int64_t kBaseStep = 4096;
+constexpr int64_t kNextStep = 1ll << 20;
+
+__device__ ThreadGroup make_group() {
+  return ThreadGroup{
+      threadIdx.x,
+      blockDim.x,
+      blockIdx.x,
+      blockIdx.x,
+      gridDim.x,
+      SyncScope::BLOCK};
+}
+
+// Reproduces the state a transfer leaves behind when it unwinds part-way
+// through: the byte range is reserved (nextStep advanced) and the state machine
+// sits in a non-terminal stage.
+__global__ void stage_slot_kernel(
+    int startStage,
+    std::size_t startNextByte,
+    IbChannelProgress* slot) {
+  if (threadIdx.x != 0 || blockIdx.x != 0) {
+    return;
+  }
+  slot->nextStep = kNextStep;
+  slot->activeNextByte = startNextByte;
+  slot->activeTailPadding = kTailPadding;
+  slot->activeBaseStep = kBaseStep;
+  slot->activeStage = static_cast<IbSendRecvProgressStage>(startStage);
+  slot->activeVariableSize = false;
+}
+
+__global__ void abandon_kernel(IbChannelProgress* slot) {
+  ThreadGroup g = make_group();
+  IbChannelProgress state = *slot;
+  detail::abandon_progress_state(g, *slot, state);
+}
+
+// Stands in for the next collective queued on this channel. Traps unless the
+// preceding abort left the slot idle.
+__global__ void reinit_kernel(IbChannelProgress* slot) {
+  ThreadGroup g = make_group();
+  detail::assert_progress_slot_idle(g, *slot, "send");
+}
+
+__global__ void read_slot_kernel(
+    const IbChannelProgress* slot,
+    SlotProbe* out) {
+  if (threadIdx.x != 0 || blockIdx.x != 0) {
+    return;
+  }
+  out->stage = static_cast<int>(slot->activeStage);
+  out->nextByte = static_cast<unsigned long long>(slot->activeNextByte);
+  out->tailPadding = static_cast<unsigned long long>(slot->activeTailPadding);
+  out->baseStep = static_cast<long long>(slot->activeBaseStep);
+  out->nextStep = static_cast<long long>(slot->nextStep);
+}
+
+// The slot lives in device global memory, not shared or local, because the
+// property under test is that it survives the aborted kernel in a reusable
+// state for the next one.
+class SlotFixture {
+ public:
+  SlotFixture(int startStage, std::size_t startNextByte) {
+    PIPES_CUDA_CHECK(cudaMalloc(&slot_, sizeof(IbChannelProgress)));
+    PIPES_CUDA_CHECK(cudaMalloc(&probe_, sizeof(SlotProbe)));
+    stage_slot_kernel<<<1, 1>>>(startStage, startNextByte, slot_);
+    PIPES_KERNEL_LAUNCH_CHECK();
+  }
+
+  ~SlotFixture() {
+    (void)cudaFree(slot_);
+    (void)cudaFree(probe_);
+  }
+
+  SlotFixture(const SlotFixture&) = delete;
+  SlotFixture& operator=(const SlotFixture&) = delete;
+
+  IbChannelProgress* slot() {
+    return slot_;
+  }
+
+  SlotProbe read() {
+    read_slot_kernel<<<1, 1>>>(slot_, probe_);
+    PIPES_KERNEL_LAUNCH_CHECK();
+    PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+    SlotProbe host{};
+    PIPES_CUDA_CHECK(
+        cudaMemcpy(&host, probe_, sizeof(host), cudaMemcpyDeviceToHost));
+    return host;
+  }
+
+ private:
+  IbChannelProgress* slot_{nullptr};
+  SlotProbe* probe_{nullptr};
+};
+
+} // namespace
+
+SlotProbe stage_slot(int startStage, std::size_t startNextByte) {
+  SlotFixture fixture(startStage, startNextByte);
+  return fixture.read();
+}
+
+SlotProbe abandon_then_reinit(int startStage, std::size_t startNextByte) {
+  SlotFixture fixture(startStage, startNextByte);
+  abandon_kernel<<<1, 32>>>(fixture.slot());
+  PIPES_KERNEL_LAUNCH_CHECK();
+  reinit_kernel<<<1, 32>>>(fixture.slot());
+  PIPES_KERNEL_LAUNCH_CHECK();
+  return fixture.read();
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/ProgressSlotReleaseTest.cuh
+++ b/comms/prims/tests/ProgressSlotReleaseTest.cuh
@@ -1,0 +1,42 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+namespace comms::prims::test {
+
+/// Host-visible copy of the fields of one `IbChannelProgress` slot, so the .cc
+/// can assert on the slot without including any transport header.
+struct SlotProbe {
+  int stage;
+  unsigned long long nextByte;
+  unsigned long long tailPadding;
+  long long baseStep;
+  long long nextStep;
+};
+
+/// `detail::IbSendRecvProgressStage` mirrored as plain ints, same reason.
+/// Static-asserted against the enum in the .cu.
+constexpr int kStageDone = 0;
+constexpr int kStageWaitLocalCompletion = 1;
+constexpr int kStageWaitSlotFree = 2;
+constexpr int kStageWaitDataReady = 3;
+
+/// Writes a mid-transfer progress slot into device memory and reads it back
+/// without touching it, so a test can show the staged state is one that
+/// `assert_progress_slot_idle()` would reject.
+SlotProbe stage_slot(int startStage, std::size_t startNextByte);
+
+/// Stages the same mid-transfer slot, runs `abandon_progress_state()` over it,
+/// then -- from a SECOND kernel launch -- runs `assert_progress_slot_idle()`
+/// and reads the slot back.
+///
+/// The second launch is the whole point. The trap this containment change
+/// exists to remove does not fire in the kernel that aborted; it fires in the
+/// next kernel queued on the same channel, when its `init_send_progress()`
+/// finds the slot still mid-transfer. Running the assert in the same kernel
+/// would not exercise that.
+SlotProbe abandon_then_reinit(int startStage, std::size_t startNextByte);
+
+} // namespace comms::prims::test

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -67,6 +67,11 @@ __device__ __forceinline__ void store_progress_state(
     IbChannelProgress& slot,
     const IbChannelProgress& state);
 
+__device__ __forceinline__ void abandon_progress_state(
+    ThreadGroup& group,
+    IbChannelProgress& slot,
+    IbChannelProgress& state);
+
 template <typename Proto = protocol::Simple>
 __device__ __forceinline__ ProgressGeometry make_progress_geometry(
     const IbChannelLayout& channelLayout,
@@ -458,9 +463,11 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
             chunk.wireBytes);
         traceState->localCompletionWaitOpen = true;
       }
-      return slotReadiness == kProgressAborted
-          ? IbgdaSendRecvProgressStatus::Aborted
-          : IbgdaSendRecvProgressStatus::Waiting;
+      if (slotReadiness == kProgressAborted) {
+        abandon_progress_state(group, progressSlot, state);
+        return IbgdaSendRecvProgressStatus::Aborted;
+      }
+      return IbgdaSendRecvProgressStatus::Waiting;
     }
     if (fine_trace_enabled(traceContext) && traceState != nullptr &&
         traceState->localCompletionWaitOpen && group.is_leader()) {
@@ -527,7 +534,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
       }
       ready = group.broadcast<uint32_t>(ready);
       if (ready == kProgressAborted) {
-        store_progress_state(group, progressSlot, state);
+        abandon_progress_state(group, progressSlot, state);
         return IbgdaSendRecvProgressStatus::Aborted;
       }
       if (!ready) {
@@ -705,9 +712,11 @@ progress_registered_send_once(
     const uint32_t slotReadiness = try_prepare_send_slot<protocol::Simple>(
         transport, group, chunk.slotId, chunk.pipelineGeneration, timeout);
     if (slotReadiness != kProgressReady) {
-      return slotReadiness == kProgressAborted
-          ? IbgdaRegisteredSendProgressStatus::Aborted
-          : IbgdaRegisteredSendProgressStatus::Waiting;
+      if (slotReadiness == kProgressAborted) {
+        abandon_progress_state(group, progressSlot, state);
+        return IbgdaRegisteredSendProgressStatus::Aborted;
+      }
+      return IbgdaRegisteredSendProgressStatus::Waiting;
     }
     transition_progress_stage(
         group, state, detail::IbSendRecvProgressStage::WaitSlotFree);
@@ -742,7 +751,7 @@ progress_registered_send_once(
       }
       ready = group.broadcast<uint32_t>(ready);
       if (ready == kProgressAborted) {
-        store_progress_state(group, progressSlot, state);
+        abandon_progress_state(group, progressSlot, state);
         return IbgdaRegisteredSendProgressStatus::Aborted;
       }
       if (!ready) {
@@ -813,6 +822,30 @@ progress_registered_send_once(
 #endif
 }
 
+/**
+ * Drain outstanding local send completions for this channel, one bounded pass.
+ *
+ * Terminal once the abort is latched, which is the drain-side counterpart of
+ * `abandon_progress_state()`. Without it this call is not terminal at all: the
+ * abort path persists the lanes it did NOT drain (`slot.laneMask = pending`
+ * below) and stops the outer loop early, so every later call re-finds the same
+ * lanes and returns `Aborted` again forever. A caller that loops until
+ * `Drained`
+ * -- `ReduceScatterDirectIbV2.cu` does exactly that -- then spins for the life
+ * of the kernel. The `activeStage == Done` short-circuit that saves the other
+ * progress entry points has no analogue here, because the drain reads the
+ * completion lane masks rather than the progress slot.
+ *
+ * The masks are deliberately left ALONE rather than cleared. Clearing would
+ * tell `try_prepare_send_slot()` that those completions have landed when they
+ * have not, dropping the one guard that stops a later operation overwriting
+ * send-staging while the NIC is still reading out of it. Reporting `Drained`
+ * costs nothing by comparison: after an abort the channel is not expected to
+ * carry meaningful traffic anyway, and recovery is a `reconfigure()`.
+ *
+ * The call that first observes the abort mid-scan still reports `Aborted`, so
+ * the signal is not lost; only subsequent calls short-circuit.
+ */
 template <typename Transport>
 __device__ __forceinline__ IbgdaRegisteredSendProgressStatus
 progress_registered_send_drain_once(
@@ -822,7 +855,7 @@ progress_registered_send_drain_once(
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t result =
       static_cast<uint32_t>(IbgdaRegisteredSendProgressStatus::Drained);
-  if (group.is_leader()) {
+  if (group.is_leader() && !timeout.isAborted()) {
     bool foundPending = false;
     bool madeProgress = false;
     bool aborted = false;
@@ -1407,9 +1440,11 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once_impl(
       traceState,
       qpLane);
   if (recvReadiness != kProgressReady) {
-    return recvReadiness == kProgressAborted
-        ? IbgdaSendRecvProgressStatus::Aborted
-        : IbgdaSendRecvProgressStatus::Waiting;
+    if (recvReadiness == kProgressAborted) {
+      abandon_progress_state(group, progressSlot, state);
+      return IbgdaSendRecvProgressStatus::Aborted;
+    }
+    return IbgdaSendRecvProgressStatus::Waiting;
   }
 
   progress_recv_consume_buf<CopyOp>(
@@ -1603,9 +1638,11 @@ progress_recv_acquire_once(
       nullptr,
       qpLane);
   if (recvReadiness != kProgressReady) {
-    return recvReadiness == kProgressAborted
-        ? IbgdaSendRecvProgressStatus::Aborted
-        : IbgdaSendRecvProgressStatus::Waiting;
+    if (recvReadiness == kProgressAborted) {
+      abandon_progress_state(group, progressSlot, state);
+      return IbgdaSendRecvProgressStatus::Aborted;
+    }
+    return IbgdaSendRecvProgressStatus::Waiting;
   }
 
   out.staging = channelLayout.recvStagingPtr + chunk.stagingOff;
@@ -1692,6 +1729,49 @@ __device__ __forceinline__ void store_progress_state(
     slot.activeStage = state.activeStage;
   }
   group.sync();
+#else
+  (void)group;
+  (void)slot;
+  (void)state;
+#endif
+}
+
+/**
+ * Drive an aborted progress slot to its terminal stage.
+ *
+ * A transfer that unwinds on abort leaves the slot mid-state machine, and
+ * `assert_progress_slot_idle()` traps on anything but `Done`. The next kernel
+ * queued on this channel would therefore trap inside init_send_progress() --
+ * turning a clean abort into a device fault one kernel later. Marking the slot
+ * terminal converts that into a clean exit, and keeps the collective path free
+ * of abort bookkeeping: every later progress call on this slot short-circuits
+ * to `Done`, so a driver loop simply drains and the kernel exits.
+ *
+ * This buys LIVENESS, not a usable channel. After an abort the DATA_READY /
+ * SLOT_FREE counters are skewed against the peer's, so traffic that follows on
+ * this channel is not meaningful -- which the abort contract already says
+ * ("results from work that completes after an abort should be treated as the
+ * reason for abort"). Recovery is still a `reconfigure()` that destroys and
+ * rebuilds the transport with zeroed state. What changes is that the host now
+ * reaches that point, instead of losing the CUDA context to a trap first.
+ *
+ * The reserved byte range is deliberately NOT returned to `slot.nextStep`. The
+ * peer may still land an RDMA write into it, so the cursor stays advanced and
+ * the range is abandoned rather than recycled.
+ *
+ * Bypasses transition_progress_stage() on purpose: abandoning is not a protocol
+ * transition, and it is legal from every stage.
+ */
+__device__ __forceinline__ void abandon_progress_state(
+    ThreadGroup& group,
+    IbChannelProgress& slot,
+    IbChannelProgress& state) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  state.activeStage = detail::IbSendRecvProgressStage::Done;
+  state.activeNextByte = 0;
+  state.activeTailPadding = 0;
+  state.activeBaseStep = 0;
+  store_progress_state(group, slot, state);
 #else
   (void)group;
   (void)slot;


### PR DESCRIPTION
Summary:

An IB transfer that unwinds on abort leaves its progress slot mid-state-machine. `assert_progress_slot_idle()` traps on anything but `Done`, so the trap does not fire in the kernel that aborted -- it fires in the *next* kernel queued on the same channel, inside its `init_send_progress()`. Aborting one collective therefore takes the CUDA context down one kernel later, which is precisely the outcome fault tolerance exists to avoid.

Every abort exit in the resumable progress path now calls a new `abandon_progress_state()` before returning `Aborted`: it drives the slot to `Done` and clears the active cursors. Six sites, covering send, registered send, fused recv, and split recv-acquire.

Two consequences, both wanted:

- A kernel queued behind the aborted one re-initializes normally. The transport stays usable; it does not need to be torn down and rebuilt.
- Any further progress call on that slot short-circuits to `Done` at the existing `activeStage == Done` early return. A driver loop that already retires on `Done` drains and exits with no abort handling of its own, which is what keeps this complexity inside the transport instead of spreading into every collective.

The reserved byte range is deliberately **not** returned to `slot.nextStep`. A peer's RDMA write may still land in it, so the cursor stays advanced and the range is abandoned rather than recycled. `abandon_progress_state()` also bypasses `transition_progress_stage()` on purpose: abandoning is not a protocol transition and is legal from every stage, whereas the transition table (correctly) rejects `WaitLocalCompletion -> Done`.

`FAULT_TOLERANCE.md` gains the two principles this follows from -- terminate the kernel cleanly rather than trapping, and contain the abort path in the transport -- plus the matching entries under *Transport Foundation* and *Collective Enablement*.

The blocking `send()`/`recv()` path needs nothing: its waits return under SKIP rather than unwinding, so it reaches its own `activeStage = Done` store.

Reviewed By: arttianezhu

Differential Revision: D116982768


