### PR TITLE
comms/uniflow/controller: accepted sockets honour TcpSocketConfig (#3768)

### DIFF
--- a/comms/uniflow/controller/TcpController.cpp
+++ b/comms/uniflow/controller/TcpController.cpp
@@ -68,7 +68,6 @@ Status TcpSocketConfig::validate() const {
 namespace {
 
 constexpr uint32_t kMaxMessageSize = 64 << 20;
-constexpr int kSocketBufSize = 1 << 20;
 constexpr int kAcceptTimeoutSec = 5;
 constexpr int kConnectedTimeoutSec = 30;
 constexpr int kKeepaliveIdleSec = 60;
@@ -248,10 +247,22 @@ Result<int> createListenSocket(int domain) {
   return sock;
 }
 
-Status configureAcceptedSocket(int sock) {
+// Applies the connected-socket options to a freshly accepted fd.
+//
+// Only @p socketBufSize is caller-controlled; the keepalive and timeout values
+// remain the constants above. Buffer sizing is the one option a caller has a
+// reason to override per connection: setting SO_RCVBUF explicitly disables
+// Linux receive-window autotuning, which caps a single stream at window/RTT, so
+// a bulk-data connection wants it left unset while the control connection does
+// not care.
+Status configureAcceptedSocket(
+    int sock,
+    const std::optional<int>& socketBufSize) {
   SockOptSetter opt(sock);
-  opt.set(SOL_SOCKET, SO_SNDBUF, kSocketBufSize, "SO_SNDBUF");
-  opt.set(SOL_SOCKET, SO_RCVBUF, kSocketBufSize, "SO_RCVBUF");
+  if (socketBufSize) {
+    opt.set(SOL_SOCKET, SO_SNDBUF, *socketBufSize, "SO_SNDBUF");
+    opt.set(SOL_SOCKET, SO_RCVBUF, *socketBufSize, "SO_RCVBUF");
+  }
   opt.set(IPPROTO_TCP, TCP_NODELAY, 1, "TCP_NODELAY");
   opt.set(SOL_SOCKET, SO_KEEPALIVE, 1, "SO_KEEPALIVE");
   opt.set(IPPROTO_TCP, TCP_KEEPIDLE, kKeepaliveIdleSec, "TCP_KEEPIDLE");
@@ -947,7 +958,7 @@ template class TcpConn<AsyncIO>;
 
 std::future<std::unique_ptr<Conn>> SyncAccept::accept(
     std::atomic<int>& listenSock,
-    int acceptRetryCnt,
+    const TcpSocketConfig& config,
     const std::string& id) {
   std::lock_guard<std::mutex> lock(mutex_);
   if (listenSock.load() < 0) {
@@ -961,7 +972,7 @@ std::future<std::unique_ptr<Conn>> SyncAccept::accept(
   // EAGAIN from SO_RCVTIMEO loops back for shutdown checks without
   // counting as a retry. Transient errors retry up to acceptRetryCnt.
   int retryCnt = 0;
-  while (retryCnt < acceptRetryCnt) {
+  while (retryCnt < config.acceptRetryCnt) {
     socklen_t clientLen = sizeof(clientAddr);
     int clientSock = ::accept4(
         listenSock.load(),
@@ -973,7 +984,7 @@ std::future<std::unique_ptr<Conn>> SyncAccept::accept(
           "TcpServer: accepted fd={} from {}",
           clientSock,
           formatAddr(clientAddr));
-      auto status = configureAcceptedSocket(clientSock);
+      auto status = configureAcceptedSocket(clientSock, config.socketBufSize);
       if (!status) {
         UNIFLOW_LOG_ERROR(
             "TcpServer: socket config failed fd={}: {}",
@@ -1018,13 +1029,15 @@ std::future<std::unique_ptr<Conn>> SyncAccept::accept(
     UNIFLOW_LOG_WARN(
         "TcpServer: accept retry {}/{}: errno={} ({})",
         retryCnt,
-        acceptRetryCnt,
+        config.acceptRetryCnt,
         savedErrno,
         std::system_category().message(savedErrno));
   }
 
   UNIFLOW_LOG_ERROR(
-      "TcpServer: accept exhausted {} retries on {}", acceptRetryCnt, id);
+      "TcpServer: accept exhausted {} retries on {}",
+      config.acceptRetryCnt,
+      id);
   return make_ready_future(std::unique_ptr<Conn>(nullptr));
 }
 
@@ -1121,7 +1134,7 @@ void AsyncAccept::acceptPendingConnections(std::atomic<int>& listenSock) {
 
     // configureAcceptedSocket sets 30s timeouts — must come after the
     // 500ms handshake timeout to avoid overriding it.
-    auto status = configureAcceptedSocket(conn->getFd());
+    auto status = configureAcceptedSocket(conn->getFd(), socketBufSize_);
     if (!status) {
       UNIFLOW_LOG_ERROR(
           "TcpServer: async socket config failed fd={}: {}",
@@ -1141,7 +1154,7 @@ void AsyncAccept::acceptPendingConnections(std::atomic<int>& listenSock) {
 
 std::future<std::unique_ptr<Conn>> AsyncAccept::accept(
     std::atomic<int>& listenSock,
-    int /*acceptRetryCnt*/,
+    const TcpSocketConfig& config,
     const std::string& /*id*/) {
   if (listenSock.load() < 0) {
     return make_ready_future(std::unique_ptr<Conn>(nullptr));
@@ -1150,12 +1163,23 @@ std::future<std::unique_ptr<Conn>> AsyncAccept::accept(
   std::promise<std::unique_ptr<Conn>> promise;
   auto future = promise.get_future();
 
-  evb_.dispatch([this, &listenSock, p = std::move(promise)]() mutable noexcept {
+  evb_.dispatch([this,
+                 &listenSock,
+                 bufSize = config.socketBufSize,
+                 p = std::move(promise)]() mutable noexcept {
     int sock = listenSock.load();
     if (sock < 0) {
       p.set_value(nullptr);
       return;
     }
+
+    // Server-level, not per-accept: BasicTcpServer passes its own config_ to
+    // every accept() call, so every dispatch writes the same value and there is
+    // no per-call setting to lose. Nothing here binds an accepted fd to a
+    // particular accept() anyway -- connections go to whichever promise is
+    // queued first. A future per-accept override would have to travel with the
+    // connection instead.
+    socketBufSize_ = bufSize;
 
     // Lazy setup: fcntl + registerFd both on the loop thread.
     if (!accepting_) {

--- a/comms/uniflow/controller/TcpController.h
+++ b/comms/uniflow/controller/TcpController.h
@@ -194,7 +194,7 @@ extern template class TcpConn<AsyncIO>;
 struct SyncAccept {
   std::future<std::unique_ptr<Conn>> accept(
       std::atomic<int>& listenSock,
-      int acceptRetryCnt,
+      const TcpSocketConfig& config,
       const std::string& id);
 
   /// Blocks until any in-flight accept() has returned, then closes the
@@ -220,7 +220,7 @@ struct AsyncAccept {
 
   std::future<std::unique_ptr<Conn>> accept(
       std::atomic<int>& listenSock,
-      int acceptRetryCnt,
+      const TcpSocketConfig& config,
       const std::string& id);
 
   void shutdown(std::atomic<int>& listenSock, const std::string& id);
@@ -232,6 +232,9 @@ struct AsyncAccept {
 
   EventBase& evb_;
   bool accepting_{false}; // loop-thread-only
+  // Buffer sizing for sockets accepted on the loop thread. Copied rather than
+  // referenced because accept() returns before acceptPendingConnections runs.
+  std::optional<int> socketBufSize_; // loop-thread-only
   std::queue<std::unique_ptr<Conn>> readyConns_;
   std::queue<std::promise<std::unique_ptr<Conn>>> pendingPromises_;
 };
@@ -271,7 +274,7 @@ class BasicTcpServer : public Server {
   }
 
   std::future<std::unique_ptr<Conn>> accept() override {
-    return policy_.accept(listenSock_, config_.acceptRetryCnt, id_);
+    return policy_.accept(listenSock_, config_, id_);
   }
 
   int getPort() const {

--- a/comms/uniflow/controller/tests/TcpAsyncAcceptTest.cpp
+++ b/comms/uniflow/controller/tests/TcpAsyncAcceptTest.cpp
@@ -5,6 +5,7 @@
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <optional>
 #include <thread>
 #include <vector>
 
@@ -31,6 +32,62 @@ class TcpAsyncAcceptTest : public ::testing::TestWithParam<AddrFamily> {
   }
 };
 
+namespace {
+
+int getRcvBuf(int fd) {
+  int val = 0;
+  socklen_t len = sizeof(val);
+  EXPECT_EQ(::getsockopt(fd, SOL_SOCKET, SO_RCVBUF, &val, &len), 0);
+  return val;
+}
+
+// SO_RCVBUF on a socket nobody has configured. Used as the control for "the
+// kernel is still in charge" so the assertions do not depend on the host's
+// net.core.rmem_max / tcp_rmem values. Takes the family from the caller because
+// this fixture runs over both IPv4 and IPv6, and a probe from the wrong family
+// is not guaranteed to report the same default.
+//
+// SOCK_STREAM matters: tcp_init_sock() overwrites the sock_init_data() default
+// with tcp_rmem[1], which is the same value an accepted TCP socket starts from,
+// so net.core.rmem_default never enters into it for either socket.
+int kernelDefaultRcvBuf(int family) {
+  int probe = ::socket(family, SOCK_STREAM, 0);
+  if (probe < 0) {
+    return -1;
+  }
+  int val = getRcvBuf(probe);
+  ::close(probe);
+  return val;
+}
+
+// SO_RCVBUF as this kernel stores it for a given request, measured on a
+// throwaway socket of the same family. Requesting a size is not the same as
+// getting it: the kernel clamps the request to net.core.rmem_max, doubles it
+// for skb overhead, and floors it at SOCK_MIN_RCVBUF. Measuring that instead of
+// reproducing the arithmetic keeps the expectation correct on any host tuning.
+int rcvBufForRequest(int family, int request) {
+  int probe = ::socket(family, SOCK_STREAM, 0);
+  if (probe < 0) {
+    return -1;
+  }
+  if (::setsockopt(probe, SOL_SOCKET, SO_RCVBUF, &request, sizeof(request)) !=
+      0) {
+    ::close(probe);
+    return -1;
+  }
+  int val = getRcvBuf(probe);
+  ::close(probe);
+  return val;
+}
+
+// Accepted connections are TcpConn<SyncIO>; only that type exposes the fd.
+int acceptedFd(const std::unique_ptr<Conn>& conn) {
+  auto* tcp = dynamic_cast<TcpConn<SyncIO>*>(conn.get());
+  return tcp == nullptr ? -1 : tcp->getFd();
+}
+
+} // namespace
+
 TEST_P(TcpAsyncAcceptTest, SingleAsyncAccept) {
   ScopedEventBaseThread evbThread("async-accept");
   AsyncTcpServer server(GetParam().serverAddr, {}, *evbThread.getEventBase());
@@ -48,6 +105,101 @@ TEST_P(TcpAsyncAcceptTest, SingleAsyncAccept) {
 
   auto conn = future.get();
   EXPECT_NE(conn, nullptr);
+}
+
+// Leaving socketBufSize unset must leave the kernel's own buffer sizing alone.
+// An explicit SO_RCVBUF disables receive-window autotuning, so the buffer can
+// no longer grow to absorb a stall while the reader is busy with a multi-MiB
+// copy. Before the config was threaded through the accept policy,
+// configureAcceptedSocket hardcoded 1 MiB, so a caller had no way to opt out.
+TEST_P(TcpAsyncAcceptTest, UnsetSocketBufSizeLeavesKernelAutotuning) {
+  const int family = GetParam().clientHost == "127.0.0.1" ? AF_INET : AF_INET6;
+  const int kernelDefault = kernelDefaultRcvBuf(family);
+  ASSERT_GT(kernelDefault, 0);
+
+  TcpSocketConfig cfg;
+  cfg.socketBufSize = std::nullopt;
+
+  ScopedEventBaseThread evbThread("async-accept");
+  AsyncTcpServer server(GetParam().serverAddr, cfg, *evbThread.getEventBase());
+  auto status = server.init();
+  if (status.hasError()) {
+    GTEST_SKIP() << "Not available: " << status.error().toString();
+  }
+
+  auto future = server.accept();
+  TcpClient client;
+  auto clientConn = client.connect(clientAddr(server.getPort())).get();
+  ASSERT_NE(clientConn, nullptr) << "Client failed to connect";
+  auto conn = future.get();
+  ASSERT_NE(conn, nullptr);
+
+  const int fd = acceptedFd(conn);
+  ASSERT_GE(fd, 0);
+  // Read once: with autotuning active the kernel may adjust sk_rcvbuf between
+  // calls, and both bounds should describe the same observation.
+  const int rcvBuf = getRcvBuf(fd);
+  // A lower bound rather than equality: this socket has completed a handshake,
+  // and with autotuning left on (which is the thing being asserted) the kernel
+  // is allowed to grow sk_rcvbuf above the initial tcp_rmem[1].
+  EXPECT_GE(rcvBuf, kernelDefault);
+  // The upper bound carries the regression. It is scaled off the probe rather
+  // than a 1 MiB literal so that a host tuned with a large tcp_rmem[1] cannot
+  // make the two bounds mutually unsatisfiable. Restoring the hardcode sets
+  // SO_RCVBUF explicitly, which the kernel doubles, so it lands well outside
+  // this bound; autotuning alone does not double the buffer on a connection
+  // that has carried no payload.
+  EXPECT_LT(rcvBuf, 2 * kernelDefault);
+}
+
+// The configured value reaches the accepted socket. The assertion is pinned to
+// the exact value the kernel stores for the request, because a range wide
+// enough to contain the unconfigured default would also be satisfied if
+// socketBufSize were dropped again.
+TEST_P(TcpAsyncAcceptTest, AcceptedSocketAppliesConfiguredSocketBufSize) {
+  const int family = GetParam().clientHost == "127.0.0.1" ? AF_INET : AF_INET6;
+  const int kernelDefault = kernelDefaultRcvBuf(family);
+  ASSERT_GT(kernelDefault, 0);
+
+  // Scaled off the probe rather than a literal. A quarter of the default
+  // doubles to half the default, which cannot coincide with the default itself;
+  // a fixed 64 KiB doubles to exactly the stock tcp_rmem[1] of 131072, which
+  // would make a correctly configured socket indistinguishable from an
+  // untouched one on any stock host. Staying below the default also keeps the
+  // request clear of net.core.rmem_max, so it is not silently clamped.
+  const int requested = kernelDefault / 4;
+  const int expected = rcvBufForRequest(family, requested);
+  ASSERT_GT(expected, 0);
+
+  // Whether the configured size is observably different from the default is a
+  // property of the host, not of the code under test, so skip rather than fail:
+  // where the two coincide this test can prove nothing either way.
+  if (expected == kernelDefault) {
+    GTEST_SKIP() << "configured size is indistinguishable from the kernel "
+                    "default ("
+                 << kernelDefault << ") on this host";
+  }
+
+  TcpSocketConfig cfg;
+  cfg.socketBufSize = requested;
+
+  ScopedEventBaseThread evbThread("async-accept");
+  AsyncTcpServer server(GetParam().serverAddr, cfg, *evbThread.getEventBase());
+  auto status = server.init();
+  if (status.hasError()) {
+    GTEST_SKIP() << "Not available: " << status.error().toString();
+  }
+
+  auto future = server.accept();
+  TcpClient client;
+  auto clientConn = client.connect(clientAddr(server.getPort())).get();
+  ASSERT_NE(clientConn, nullptr) << "Client failed to connect";
+  auto conn = future.get();
+  ASSERT_NE(conn, nullptr);
+
+  const int fd = acceptedFd(conn);
+  ASSERT_GE(fd, 0);
+  EXPECT_EQ(getRcvBuf(fd), expected);
 }
 
 TEST_P(TcpAsyncAcceptTest, MultipleAsyncAccepts) {


### PR DESCRIPTION
Summary:

configureAcceptedSocket() hardcoded a 1 MiB SO_SNDBUF/SO_RCVBUF and silently
discarded whatever the caller had configured. The asymmetry was structural: connect
policies already received the full TcpSocketConfig, while accept policies received
only an int acceptRetryCnt, so socketBufSize had no way to reach an accepted fd.

Pass TcpSocketConfig to the accept policies instead, and apply socketBufSize only
when it is set, leaving the kernel's own autotuning in place otherwise. AsyncAccept
copies the value rather than holding a reference, because accept() returns before
acceptPendingConnections() runs on the loop thread.

Neither test contains a socket-size literal. Both scale off a probe socket of the
same family: the unset path bounds the result at twice the untouched default, and
the configured path requests a quarter of the default and asserts the value the
kernel is measured to store for that request, so the doubling, the
net.core.rmem_max clamp and the SOCK_MIN_RCVBUF floor are observed rather than
assumed. Where a host cannot distinguish the configured result from its own default
the configured test skips, because that is a property of the host and not of this
code.

Not a performance change on its own; measured effects are in the diff that adds the
benchmark knob.

Differential Revision: D117132557


