### PR TITLE
comms/uniflow/controller: send a frame's prefix and payload in one sendmsg (#3769)

### DIFF
--- a/comms/uniflow/controller/TcpController.cpp
+++ b/comms/uniflow/controller/TcpController.cpp
@@ -68,7 +68,6 @@ Status TcpSocketConfig::validate() const {
 namespace {
 
 constexpr uint32_t kMaxMessageSize = 64 << 20;
-constexpr int kSocketBufSize = 1 << 20;
 constexpr int kAcceptTimeoutSec = 5;
 constexpr int kConnectedTimeoutSec = 30;
 constexpr int kKeepaliveIdleSec = 60;
@@ -248,10 +247,22 @@ Result<int> createListenSocket(int domain) {
   return sock;
 }
 
-Status configureAcceptedSocket(int sock) {
+// Applies the connected-socket options to a freshly accepted fd.
+//
+// Only @p socketBufSize is caller-controlled; the keepalive and timeout values
+// remain the constants above. Buffer sizing is the one option a caller has a
+// reason to override per connection: setting SO_RCVBUF explicitly disables
+// Linux receive-window autotuning, which caps a single stream at window/RTT, so
+// a bulk-data connection wants it left unset while the control connection does
+// not care.
+Status configureAcceptedSocket(
+    int sock,
+    const std::optional<int>& socketBufSize) {
   SockOptSetter opt(sock);
-  opt.set(SOL_SOCKET, SO_SNDBUF, kSocketBufSize, "SO_SNDBUF");
-  opt.set(SOL_SOCKET, SO_RCVBUF, kSocketBufSize, "SO_RCVBUF");
+  if (socketBufSize) {
+    opt.set(SOL_SOCKET, SO_SNDBUF, *socketBufSize, "SO_SNDBUF");
+    opt.set(SOL_SOCKET, SO_RCVBUF, *socketBufSize, "SO_RCVBUF");
+  }
   opt.set(IPPROTO_TCP, TCP_NODELAY, 1, "TCP_NODELAY");
   opt.set(SOL_SOCKET, SO_KEEPALIVE, 1, "SO_KEEPALIVE");
   opt.set(IPPROTO_TCP, TCP_KEEPIDLE, kKeepaliveIdleSec, "TCP_KEEPIDLE");
@@ -947,7 +958,7 @@ template class TcpConn<AsyncIO>;
 
 std::future<std::unique_ptr<Conn>> SyncAccept::accept(
     std::atomic<int>& listenSock,
-    int acceptRetryCnt,
+    const TcpSocketConfig& config,
     const std::string& id) {
   std::lock_guard<std::mutex> lock(mutex_);
   if (listenSock.load() < 0) {
@@ -961,7 +972,7 @@ std::future<std::unique_ptr<Conn>> SyncAccept::accept(
   // EAGAIN from SO_RCVTIMEO loops back for shutdown checks without
   // counting as a retry. Transient errors retry up to acceptRetryCnt.
   int retryCnt = 0;
-  while (retryCnt < acceptRetryCnt) {
+  while (retryCnt < config.acceptRetryCnt) {
     socklen_t clientLen = sizeof(clientAddr);
     int clientSock = ::accept4(
         listenSock.load(),
@@ -973,7 +984,7 @@ std::future<std::unique_ptr<Conn>> SyncAccept::accept(
           "TcpServer: accepted fd={} from {}",
           clientSock,
           formatAddr(clientAddr));
-      auto status = configureAcceptedSocket(clientSock);
+      auto status = configureAcceptedSocket(clientSock, config.socketBufSize);
       if (!status) {
         UNIFLOW_LOG_ERROR(
             "TcpServer: socket config failed fd={}: {}",
@@ -1018,13 +1029,15 @@ std::future<std::unique_ptr<Conn>> SyncAccept::accept(
     UNIFLOW_LOG_WARN(
         "TcpServer: accept retry {}/{}: errno={} ({})",
         retryCnt,
-        acceptRetryCnt,
+        config.acceptRetryCnt,
         savedErrno,
         std::system_category().message(savedErrno));
   }
 
   UNIFLOW_LOG_ERROR(
-      "TcpServer: accept exhausted {} retries on {}", acceptRetryCnt, id);
+      "TcpServer: accept exhausted {} retries on {}",
+      config.acceptRetryCnt,
+      id);
   return make_ready_future(std::unique_ptr<Conn>(nullptr));
 }
 
@@ -1121,7 +1134,7 @@ void AsyncAccept::acceptPendingConnections(std::atomic<int>& listenSock) {
 
     // configureAcceptedSocket sets 30s timeouts — must come after the
     // 500ms handshake timeout to avoid overriding it.
-    auto status = configureAcceptedSocket(conn->getFd());
+    auto status = configureAcceptedSocket(conn->getFd(), socketBufSize_);
     if (!status) {
       UNIFLOW_LOG_ERROR(
           "TcpServer: async socket config failed fd={}: {}",
@@ -1141,7 +1154,7 @@ void AsyncAccept::acceptPendingConnections(std::atomic<int>& listenSock) {
 
 std::future<std::unique_ptr<Conn>> AsyncAccept::accept(
     std::atomic<int>& listenSock,
-    int /*acceptRetryCnt*/,
+    const TcpSocketConfig& config,
     const std::string& /*id*/) {
   if (listenSock.load() < 0) {
     return make_ready_future(std::unique_ptr<Conn>(nullptr));
@@ -1150,12 +1163,23 @@ std::future<std::unique_ptr<Conn>> AsyncAccept::accept(
   std::promise<std::unique_ptr<Conn>> promise;
   auto future = promise.get_future();
 
-  evb_.dispatch([this, &listenSock, p = std::move(promise)]() mutable noexcept {
+  evb_.dispatch([this,
+                 &listenSock,
+                 bufSize = config.socketBufSize,
+                 p = std::move(promise)]() mutable noexcept {
     int sock = listenSock.load();
     if (sock < 0) {
       p.set_value(nullptr);
       return;
     }
+
+    // Server-level, not per-accept: BasicTcpServer passes its own config_ to
+    // every accept() call, so every dispatch writes the same value and there is
+    // no per-call setting to lose. Nothing here binds an accepted fd to a
+    // particular accept() anyway -- connections go to whichever promise is
+    // queued first. A future per-accept override would have to travel with the
+    // connection instead.
+    socketBufSize_ = bufSize;
 
     // Lazy setup: fcntl + registerFd both on the loop thread.
     if (!accepting_) {

--- a/comms/uniflow/controller/TcpController.cpp
+++ b/comms/uniflow/controller/TcpController.cpp
@@ -7,6 +7,7 @@
 #include <netinet/tcp.h>
 #include <sys/epoll.h>
 #include <sys/socket.h>
+#include <sys/uio.h>
 #include <unistd.h>
 #include <cassert>
 #include <cerrno>
@@ -341,6 +342,53 @@ bool TcpConn<IOPolicy>::sendAll(const void* buf, size_t len) {
   return true;
 }
 
+// Sends every byte of @p iov, coalescing the length prefix and the payload into
+// one syscall instead of two. Mutates @p iov to track progress, so the caller
+// must not reuse it.
+//
+// Error handling deliberately mirrors sendAll(): only EINTR is retried, and
+// anything else -- EAGAIN included -- is fatal. That is the existing contract
+// for these sockets, and widening it here would hide a non-blocking data socket
+// rather than fix one.
+template <typename IOPolicy>
+bool TcpConn<IOPolicy>::sendAllVec(iovec* iov, int iovCnt) {
+  int idx = 0;
+  while (idx < iovCnt) {
+    msghdr msg{};
+    msg.msg_iov = iov + idx;
+    msg.msg_iovlen = static_cast<size_t>(iovCnt - idx);
+    ssize_t n = ::sendmsg(sock_, &msg, MSG_NOSIGNAL);
+    if (n < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      int savedErrno = errno;
+      UNIFLOW_LOG_ERROR(
+          "sendAllVec failed: fd={} errno={} ({})",
+          sock_,
+          savedErrno,
+          std::system_category().message(savedErrno));
+      errno = savedErrno;
+      return false;
+    }
+    // A short write can land mid-iovec: retire the entries it fully covered,
+    // then advance the base of the one it split. On a blocking socket this is
+    // only reachable when a signal interrupts a partial transfer, so it is not
+    // covered by tests -- an attempt to force it with an oversized payload did
+    // not reach this branch.
+    auto consumed = static_cast<size_t>(n);
+    while (idx < iovCnt && consumed >= iov[idx].iov_len) {
+      consumed -= iov[idx].iov_len;
+      ++idx;
+    }
+    if (idx < iovCnt && consumed > 0) {
+      iov[idx].iov_base = static_cast<uint8_t*>(iov[idx].iov_base) + consumed;
+      iov[idx].iov_len -= consumed;
+    }
+  }
+  return true;
+}
+
 template <typename IOPolicy>
 bool TcpConn<IOPolicy>::recvAll(void* buf, size_t len) {
   auto* ptr = static_cast<uint8_t*>(buf);
@@ -456,16 +504,24 @@ Result<size_t> TcpConn<IOPolicy>::syncSend(std::span<const uint8_t> data) {
 
   UNIFLOW_LOG_DEBUG("TcpConn::send: fd={} bytes={}", sock_, data.size());
 
+  // One sendmsg for prefix + payload. With TCP_NODELAY set, sending the 4-byte
+  // prefix separately hands the kernel a 4-byte segment it may put on the wire
+  // immediately, so coalescing also stops emitting a runt segment per frame.
   uint32_t len = htonl(static_cast<uint32_t>(data.size()));
-  if (!sendAll(&len, sizeof(len))) {
-    return Err(
-        ErrCode::ConnectionFailed,
-        "send header failed: " + std::system_category().message(errno));
+  iovec iov[2];
+  iov[0].iov_base = &len;
+  iov[0].iov_len = sizeof(len);
+  int iovCnt = 1;
+  if (!data.empty()) {
+    // const_cast: iovec has no const variant, and sendmsg only reads.
+    iov[1].iov_base = const_cast<uint8_t*>(data.data());
+    iov[1].iov_len = data.size();
+    iovCnt = 2;
   }
-  if (!data.empty() && !sendAll(data.data(), data.size())) {
+  if (!sendAllVec(iov, iovCnt)) {
     return Err(
         ErrCode::ConnectionFailed,
-        "send payload failed: " + std::system_category().message(errno));
+        "send frame failed: " + std::system_category().message(errno));
   }
   return data.size();
 }

--- a/comms/uniflow/controller/TcpController.h
+++ b/comms/uniflow/controller/TcpController.h
@@ -194,7 +194,7 @@ extern template class TcpConn<AsyncIO>;
 struct SyncAccept {
   std::future<std::unique_ptr<Conn>> accept(
       std::atomic<int>& listenSock,
-      int acceptRetryCnt,
+      const TcpSocketConfig& config,
       const std::string& id);
 
   /// Blocks until any in-flight accept() has returned, then closes the
@@ -220,7 +220,7 @@ struct AsyncAccept {
 
   std::future<std::unique_ptr<Conn>> accept(
       std::atomic<int>& listenSock,
-      int acceptRetryCnt,
+      const TcpSocketConfig& config,
       const std::string& id);
 
   void shutdown(std::atomic<int>& listenSock, const std::string& id);
@@ -232,6 +232,9 @@ struct AsyncAccept {
 
   EventBase& evb_;
   bool accepting_{false}; // loop-thread-only
+  // Buffer sizing for sockets accepted on the loop thread. Copied rather than
+  // referenced because accept() returns before acceptPendingConnections runs.
+  std::optional<int> socketBufSize_; // loop-thread-only
   std::queue<std::unique_ptr<Conn>> readyConns_;
   std::queue<std::promise<std::unique_ptr<Conn>>> pendingPromises_;
 };
@@ -271,7 +274,7 @@ class BasicTcpServer : public Server {
   }
 
   std::future<std::unique_ptr<Conn>> accept() override {
-    return policy_.accept(listenSock_, config_.acceptRetryCnt, id_);
+    return policy_.accept(listenSock_, config_, id_);
   }
 
   int getPort() const {

--- a/comms/uniflow/controller/TcpController.h
+++ b/comms/uniflow/controller/TcpController.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <sys/uio.h>
+
 #include <atomic>
 #include <chrono>
 #include <concepts>
@@ -136,6 +138,9 @@ class TcpConn : public Conn {
   TcpConn(int sock, IOPolicy io) : sock_(sock), io_(std::move(io)) {}
 
   bool sendAll(const void* buf, size_t len);
+  /// Vectored sendAll: one syscall for the length prefix plus payload. Mutates
+  /// @p iov to track partial writes, so it must not be reused by the caller.
+  bool sendAllVec(iovec* iov, int iovCnt);
   bool recvAll(void* buf, size_t len);
   bool exchangeMagic();
   Result<size_t> syncSend(std::span<const uint8_t> data);

--- a/comms/uniflow/controller/tests/TcpAsyncAcceptTest.cpp
+++ b/comms/uniflow/controller/tests/TcpAsyncAcceptTest.cpp
@@ -5,6 +5,7 @@
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <optional>
 #include <thread>
 #include <vector>
 
@@ -31,6 +32,42 @@ class TcpAsyncAcceptTest : public ::testing::TestWithParam<AddrFamily> {
   }
 };
 
+namespace {
+
+int getRcvBuf(int fd) {
+  int val = 0;
+  socklen_t len = sizeof(val);
+  EXPECT_EQ(::getsockopt(fd, SOL_SOCKET, SO_RCVBUF, &val, &len), 0);
+  return val;
+}
+
+// SO_RCVBUF on a socket nobody has configured. Used as the control for "the
+// kernel is still in charge" so the assertions do not depend on the host's
+// net.core.rmem_max / tcp_rmem values. Takes the family from the caller because
+// this fixture runs over both IPv4 and IPv6, and a probe from the wrong family
+// is not guaranteed to report the same default.
+//
+// SOCK_STREAM matters: tcp_init_sock() overwrites the sock_init_data() default
+// with tcp_rmem[1], which is the same value an accepted TCP socket starts from,
+// so net.core.rmem_default never enters into it for either socket.
+int kernelDefaultRcvBuf(int family) {
+  int probe = ::socket(family, SOCK_STREAM, 0);
+  if (probe < 0) {
+    return -1;
+  }
+  int val = getRcvBuf(probe);
+  ::close(probe);
+  return val;
+}
+
+// Accepted connections are TcpConn<SyncIO>; only that type exposes the fd.
+int acceptedFd(const std::unique_ptr<Conn>& conn) {
+  auto* tcp = dynamic_cast<TcpConn<SyncIO>*>(conn.get());
+  return tcp == nullptr ? -1 : tcp->getFd();
+}
+
+} // namespace
+
 TEST_P(TcpAsyncAcceptTest, SingleAsyncAccept) {
   ScopedEventBaseThread evbThread("async-accept");
   AsyncTcpServer server(GetParam().serverAddr, {}, *evbThread.getEventBase());
@@ -48,6 +85,93 @@ TEST_P(TcpAsyncAcceptTest, SingleAsyncAccept) {
 
   auto conn = future.get();
   EXPECT_NE(conn, nullptr);
+}
+
+// Leaving socketBufSize unset must leave the kernel's own buffer sizing alone.
+// An explicit SO_RCVBUF disables receive-window autotuning, so the buffer can
+// no longer grow to absorb a stall while the reader is busy with a multi-MiB
+// copy. Before the config was threaded through the accept policy,
+// configureAcceptedSocket hardcoded 1 MiB, so a caller had no way to opt out.
+TEST_P(TcpAsyncAcceptTest, UnsetSocketBufSizeLeavesKernelAutotuning) {
+  const int family = GetParam().clientHost == "127.0.0.1" ? AF_INET : AF_INET6;
+  const int kernelDefault = kernelDefaultRcvBuf(family);
+  ASSERT_GT(kernelDefault, 0);
+
+  TcpSocketConfig cfg;
+  cfg.socketBufSize = std::nullopt;
+
+  ScopedEventBaseThread evbThread("async-accept");
+  AsyncTcpServer server(GetParam().serverAddr, cfg, *evbThread.getEventBase());
+  auto status = server.init();
+  if (status.hasError()) {
+    GTEST_SKIP() << "Not available: " << status.error().toString();
+  }
+
+  auto future = server.accept();
+  TcpClient client;
+  auto clientConn = client.connect(clientAddr(server.getPort())).get();
+  ASSERT_NE(clientConn, nullptr) << "Client failed to connect";
+  auto conn = future.get();
+  ASSERT_NE(conn, nullptr);
+
+  const int fd = acceptedFd(conn);
+  ASSERT_GE(fd, 0);
+  // Read once: with autotuning active the kernel may adjust sk_rcvbuf between
+  // calls, and both bounds should describe the same observation.
+  const int rcvBuf = getRcvBuf(fd);
+  // A lower bound rather than equality: this socket has completed a handshake,
+  // and with autotuning left on (which is the thing being asserted) the kernel
+  // is allowed to grow sk_rcvbuf above the initial tcp_rmem[1].
+  EXPECT_GE(rcvBuf, kernelDefault);
+  // The upper bound carries the regression. It is scaled off the probe rather
+  // than a 1 MiB literal so that a host tuned with a large tcp_rmem[1] cannot
+  // make the two bounds mutually unsatisfiable. Restoring the hardcode sets
+  // SO_RCVBUF explicitly, which the kernel doubles, so it lands well outside
+  // this bound; autotuning alone does not double the buffer on a connection
+  // that has carried no payload.
+  EXPECT_LT(rcvBuf, 2 * kernelDefault);
+}
+
+// The configured value reaches the accepted socket. The assertion is pinned to
+// the exact value the kernel derives from the request, because a range wide
+// enough to contain the unconfigured default would also be satisfied if
+// socketBufSize were dropped again.
+TEST_P(TcpAsyncAcceptTest, AcceptedSocketAppliesConfiguredSocketBufSize) {
+  constexpr int kRequested = 64 << 10;
+  // __sock_set_rcvbuf() stores exactly twice the requested size to cover skb
+  // overhead. 64 KiB also sits well below the 1 MiB that used to be hardcoded.
+  constexpr int kExpected = 2 * kRequested;
+
+  const int family = GetParam().clientHost == "127.0.0.1" ? AF_INET : AF_INET6;
+  const int kernelDefault = kernelDefaultRcvBuf(family);
+  ASSERT_GT(kernelDefault, 0);
+  // Calibration of the test itself, not a property of the code under test: if
+  // this host's default happened to equal the configured result, the assertion
+  // below would hold even if socketBufSize never reached the socket.
+  ASSERT_NE(kernelDefault, kExpected)
+      << "host default equals the configured size, so this test cannot "
+         "distinguish a dropped socketBufSize on this host";
+
+  TcpSocketConfig cfg;
+  cfg.socketBufSize = kRequested;
+
+  ScopedEventBaseThread evbThread("async-accept");
+  AsyncTcpServer server(GetParam().serverAddr, cfg, *evbThread.getEventBase());
+  auto status = server.init();
+  if (status.hasError()) {
+    GTEST_SKIP() << "Not available: " << status.error().toString();
+  }
+
+  auto future = server.accept();
+  TcpClient client;
+  auto clientConn = client.connect(clientAddr(server.getPort())).get();
+  ASSERT_NE(clientConn, nullptr) << "Client failed to connect";
+  auto conn = future.get();
+  ASSERT_NE(conn, nullptr);
+
+  const int fd = acceptedFd(conn);
+  ASSERT_GE(fd, 0);
+  EXPECT_EQ(getRcvBuf(fd), kExpected);
 }
 
 TEST_P(TcpAsyncAcceptTest, MultipleAsyncAccepts) {

--- a/comms/uniflow/controller/tests/TcpConnTest.cpp
+++ b/comms/uniflow/controller/tests/TcpConnTest.cpp
@@ -291,6 +291,44 @@ TEST_P(TcpConnTest, RejectsPeerClosedBeforeMagic) {
       << "accept() should reject when peer closes before magic exchange";
 }
 
+// Large frames now leave as a single sendmsg with the length prefix and payload
+// in separate iovecs. This checks the frame still round-trips byte-exactly at a
+// size well past the socket send buffer, with position-dependent content so a
+// dropped, duplicated, or reordered run fails rather than merely changing the
+// length.
+//
+// NOT covered here: sendAllVec's mid-iovec resume. On a blocking socket Linux
+// sendmsg transfers everything requested before returning, so no payload size
+// forces a short write -- a partial return needs EINTR after a partial
+// transfer, which this test cannot produce. Verified by injecting a break into
+// the resume branch: this test still passed, so it must not be read as covering
+// it.
+TEST_P(TcpConnTest, LargeFrameRoundTripsThroughCoalescedSend) {
+  auto [clientConn, serverConn] = connectPair();
+  ASSERT_NE(clientConn, nullptr);
+  ASSERT_NE(serverConn, nullptr);
+
+  constexpr size_t kPayload = 4UL * 1024 * 1024;
+  std::vector<uint8_t> msg(kPayload);
+  for (size_t i = 0; i < msg.size(); ++i) {
+    msg[i] = static_cast<uint8_t>((i * 31u + (i >> 13)) & 0xFF);
+  }
+
+  // Reader runs concurrently: the payload exceeds the send buffer, so the
+  // sender blocks until the peer drains and a send-then-recv ordering would
+  // deadlock.
+  std::vector<uint8_t> got;
+  std::thread reader([&] { (void)serverConn->recv(got).get(); });
+
+  auto result = clientConn->send(msg).get();
+  reader.join();
+
+  ASSERT_TRUE(result.hasValue()) << result.error().toString();
+  EXPECT_EQ(result.value(), kPayload);
+  ASSERT_EQ(got.size(), kPayload) << "frame truncated or over-sent";
+  EXPECT_EQ(got, msg) << "payload corrupted through the coalesced send path";
+}
+
 INSTANTIATE_TEST_SUITE_P(
     AddrFamilies,
     TcpConnTest,


### PR DESCRIPTION
Summary:

syncSend() issued two sendAll() calls per frame, one for the 4-byte length prefix
and one for the payload. With TCP_NODELAY set, the prefix could go out as its own
runt segment, so this also stops emitting a 4-byte segment ahead of every frame.

sendAllVec() mirrors sendAll()'s error handling exactly -- only EINTR is retried,
EAGAIN stays fatal -- so this changes syscall count and nothing else. It handles a
short write landing mid-iovec, though on a blocking socket that is only reachable
when a signal interrupts a partial transfer; the added test does not cover that
branch and says so, having been checked against an injected break.

Scope: this is a small-message latency and cleanliness change, NOT a bandwidth one.
It saves one syscall per 4 MiB frame, about 0.02% of frame time, and instrumentation
puts first-byte latency at 0.8% of a bulk get frame, so there is no room for a
throughput win here. Do not attribute bandwidth numbers to it.

Differential Revision: D117132590


