### PR TITLE
Add LLImpl::all_flags_set, extracted helper function into LLImpl

### DIFF
--- a/comms/prims/core/LLImpl.cuh
+++ b/comms/prims/core/LLImpl.cuh
@@ -128,6 +128,52 @@ struct LLImpl {
 #endif
   }
 
+  /// True once EVERY packet covering `nbytes` of payload in `staging` carries
+  /// `flagVal`. Cooperative across `group`: each thread checks the packets it
+  /// owns (the same grid-stride mapping `unpack` uses) with early exit, then
+  /// the group AND-reduces so all threads reach the same verdict.
+  ///
+  /// The non-spinning counterpart to `unpack`'s per-packet wait, for callers
+  /// that must not block inside the codec -- the resumable recv path returns
+  /// `Waiting` on false rather than spinning.
+  ///
+  /// Lives here rather than in the transport because deciding which packets
+  /// cover `nbytes`, and where each one sits, is packet-format knowledge --
+  /// the same knowledge `pack` and `unpack` below encode. A copy of this walk
+  /// outside this class is a second place for that layout to drift.
+  ///
+  /// Takes PAYLOAD bytes, like every other entry point here; callers holding a
+  /// wire length must convert with `P::max_payload()`.
+  template <typename Group>
+  __device__ __forceinline__ static bool all_flags_set(
+      Group& group,
+      const void* staging,
+      std::size_t nbytes,
+      FlagType flagVal) {
+#ifdef __CUDA_ARCH__
+    const std::size_t nPackets = P::packet_count(nbytes);
+    const auto* base = reinterpret_cast<const char*>(staging);
+    bool myReady = true;
+    for (std::size_t i = group.thread_id_in_group; i < nPackets;
+         i += group.group_size) {
+      if (!is_flag_set(
+              base + i * static_cast<std::size_t>(P::kPacketBytes), flagVal)) {
+        myReady = false;
+        break;
+      }
+    }
+    // group.all() rather than a hand-rolled reduction: it keeps the scratch
+    // index tied to the group's own barrier.
+    return group.all(myReady);
+#else
+    (void)group;
+    (void)staging;
+    (void)nbytes;
+    (void)flagVal;
+    return true;
+#endif
+  }
+
   /// Encode `nbytes` of `src` into consecutive packets in `staging`, stamping
   /// every packet's trailing flag with `flagVal`. Cooperative across `group`.
   template <typename Group>

--- a/comms/prims/tests/LLImplTest.cc
+++ b/comms/prims/tests/LLImplTest.cc
@@ -226,6 +226,77 @@ TEST_F(LLImplTest, UnpackReduceElementSpansPackets) {
   EXPECT_EQ(actual, expected) << "int64 spanning-packet reduce wrong";
 }
 
+namespace {
+
+// pack `nbytes`, optionally break packet `corruptPacket`, return the verdict.
+uint32_t runAllFlagsSet(std::size_t nbytes, int corruptPacket) {
+  using P = LlxPacketGeometry;
+  std::vector<char> h_src(nbytes);
+  for (std::size_t i = 0; i < nbytes; ++i) {
+    h_src[i] = static_cast<char>(i * 131u + 7u);
+  }
+
+  DeviceBuffer src(nbytes);
+  DeviceBuffer staging(P::wire_bytes(nbytes));
+  DeviceBuffer readyBuf(sizeof(uint32_t));
+  auto* ready_d = static_cast<uint32_t*>(readyBuf.get());
+
+  CUDACHECK_TEST(
+      cudaMemcpy(src.get(), h_src.data(), nbytes, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(staging.get(), 0xEE, P::wire_bytes(nbytes)));
+  CUDACHECK_TEST(cudaMemset(ready_d, 0xFF, sizeof(uint32_t)));
+
+  test::test_ll_all_flags_set(
+      static_cast<const char*>(src.get()),
+      static_cast<char*>(staging.get()),
+      nbytes,
+      corruptPacket,
+      ready_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  uint32_t ready = 0;
+  CUDACHECK_TEST(
+      cudaMemcpy(&ready, ready_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+  return ready;
+}
+
+} // namespace
+
+// A fully packed chunk reports ready. kData = 4, so the sweep covers every
+// `nbytes % kData` remainder as well as sizes spanning many packets.
+TEST_F(LLImplTest, AllFlagsSetTrueOnCompleteChunk) {
+  for (std::size_t n :
+       {std::size_t(1),
+        std::size_t(3),
+        std::size_t(4),
+        std::size_t(7),
+        std::size_t(64),
+        std::size_t(533),
+        std::size_t(4096)}) {
+    EXPECT_EQ(runAllFlagsSet(n, /*corruptPacket=*/-1), 1u)
+        << "nbytes=" << n << ": complete chunk reported not-ready";
+  }
+}
+
+// One packet carrying a different generation must sink the whole verdict --
+// and must come back as `false`, not as a hang. The group AND-reduce is the
+// part being pinned: a thread whose own packets are all fine must still agree
+// with the thread that found the bad one.
+TEST_F(LLImplTest, AllFlagsSetFalseOnAnyMissingPacket) {
+  constexpr std::size_t kBytes = 533; // 134 packets, tail is partial
+  const int nPackets =
+      static_cast<int>(LlxPacketGeometry::packet_count(kBytes));
+
+  // First, middle and last: the first is found by thread 0 immediately, the
+  // last only by whichever thread owns the tail, and the middle by neither
+  // edge case -- so all three exercise different threads reporting.
+  for (int p : {0, nPackets / 2, nPackets - 1}) {
+    EXPECT_EQ(runAllFlagsSet(kBytes, p), 0u)
+        << "packet " << p << " of " << nPackets
+        << " had the wrong generation but the chunk reported ready";
+  }
+}
+
 TEST_F(LLImplTest, FlagRoundTrip) {
   DeviceBuffer p8(LlxPacketGeometry::kPacketBytes);
   CUDACHECK_TEST(cudaMemset(p8.get(), 0, LlxPacketGeometry::kPacketBytes));

--- a/comms/prims/tests/LLImplTest.cu
+++ b/comms/prims/tests/LLImplTest.cu
@@ -57,6 +57,54 @@ void test_ll_pack_unpack(
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
+// pack the chunk, optionally break one packet's flag, then ask all_flags_set.
+template <typename P>
+__global__ void all_flags_set_kernel(
+    const char* src,
+    char* staging,
+    std::size_t nbytes,
+    int corruptPacket,
+    uint32_t* ready) {
+  ThreadGroup g{
+      threadIdx.x,
+      blockDim.x,
+      blockIdx.x,
+      blockIdx.x,
+      gridDim.x,
+      SyncScope::BLOCK};
+
+  const auto flagVal = static_cast<typename P::FlagType>(7);
+
+  LLImpl<P>::pack(g, staging, src, nbytes, flagVal);
+  g.sync();
+  if (corruptPacket >= 0 && threadIdx.x == 0) {
+    // A different generation is exactly what an un-arrived packet looks like:
+    // the memory holds whatever the previous ring pass left there.
+    LLImpl<P>::store_flag(
+        staging +
+            static_cast<std::size_t>(corruptPacket) *
+                static_cast<std::size_t>(P::kPacketBytes),
+        static_cast<typename P::FlagType>(flagVal + 1));
+  }
+  g.sync();
+
+  const bool r = LLImpl<P>::all_flags_set(g, staging, nbytes, flagVal);
+  if (threadIdx.x == 0) {
+    *ready = r ? 1u : 0u;
+  }
+}
+
+void test_ll_all_flags_set(
+    const char* src_d,
+    char* staging_d,
+    std::size_t nbytes,
+    int corruptPacket,
+    uint32_t* ready_d) {
+  all_flags_set_kernel<LlxPacketGeometry>
+      <<<1, 256>>>(src_d, staging_d, nbytes, corruptPacket, ready_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
 // LLImpl::store_flag/load_flag/is_flag_set round-trip over a single global
 // packet. `pkt` is GLOBAL memory -> flag I/O uses global volatile ops.
 template <typename P>

--- a/comms/prims/tests/LLImplTest.cuh
+++ b/comms/prims/tests/LLImplTest.cuh
@@ -21,6 +21,23 @@ void test_ll_pack_unpack(
 /// I/O uses global volatile ops, which are illegal on shared memory.
 void test_ll_flag_roundtrip(void* p8_d, uint32_t* errorCount_d);
 
+/// pack(src) into `staging_d` under `flagVal`, then ask
+/// `LLImpl::all_flags_set` whether the whole chunk has landed.
+///
+/// `corruptPacket >= 0` first rewrites that one packet's flag to a DIFFERENT
+/// generation, which is what a not-yet-arrived packet looks like. The check
+/// must then report false -- and must REPORT it, not spin: this entry point
+/// exists precisely for callers that cannot block, so a hang here is the
+/// failure, and the test would time out rather than assert.
+///
+/// Writes 1/0 to `ready_d`.
+void test_ll_all_flags_set(
+    const char* src_d,
+    char* staging_d,
+    std::size_t nbytes,
+    int corruptPacket,
+    uint32_t* ready_d);
+
 /// Reduce op selector for the unpack_reduce launchers below.
 enum class ReduceKind { Sum, Max, Min };
 

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -1210,15 +1210,6 @@ __device__ __forceinline__ void progress_recv_consume_buf(
 #endif
 }
 
-// Group-wide AND, used by the LL readiness poll to fold each thread's local
-// packet-flag check into one collective decision. Delegates to
-// ThreadGroup::all() so the scratch index stays tied to the group's barrier;
-// keeping a second copy of that indexing here is what let it drift from
-// ThreadGroup::broadcast().
-__device__ __forceinline__ bool group_all_ready(ThreadGroup& group, bool pred) {
-  return group.all(pred);
-}
-
 // Non-blocking readiness check for one recv chunk (LL: cooperative,
 // non-spinning poll of every packet's inline flag == chunk.flagVal, then a
 // group AND-reduce). There is no DATA_READY counter for LL, so
@@ -1256,22 +1247,14 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
   (void)traceState;
   (void)qpLane;
   const char* staging = channelLayout.recvStagingPtr + chunk.stagingOff;
-  const std::size_t nPackets =
-      chunk.wireBytes / static_cast<std::size_t>(P::kPacketBytes);
-  const auto flagVal = static_cast<typename P::FlagType>(chunk.flagVal);
-  // Each thread inspects the packets it owns (grid-strided, mirroring
-  // LLImpl::unpack) with early-exit, then the group AND-reduces so all threads
-  // agree to decode or to return Waiting -- no spin.
-  uint32_t myReady = 1;
-  for (std::size_t i = group.thread_id_in_group; i < nPackets;
-       i += group.group_size) {
-    if (!LLImpl<P>::is_flag_set(
-            staging + i * static_cast<std::size_t>(P::kPacketBytes), flagVal)) {
-      myReady = 0;
-      break;
-    }
-  }
-  if (group_all_ready(group, myReady != 0U)) {
+  // Packet geometry lives in LLImpl, which owns the format; this seam only
+  // decides what to do with the verdict -- report not-ready on false, rather
+  // than spin.
+  if (LLImpl<P>::all_flags_set(
+          group,
+          staging,
+          P::max_payload(chunk.wireBytes),
+          static_cast<typename P::FlagType>(chunk.flagVal))) {
     if (group.is_leader()) {
       // LL carries no DATA_READY, but its put still advanced the sender's
       // IbQpState::cursor -- select_put_lane_ordinal() increments that cursor


### PR DESCRIPTION
Summary:
`progress_recv_ready(protocol::LL)` hand-rolls a packet walk: work out how many
packets cover the chunk, grid-stride over the ones this thread owns, check each
trailing flag, AND-reduce. That is packet-format knowledge, and it was sitting
in the transport rather than in the class that owns the format.

`LLImpl` already has both tiers this needs -- per-packet primitives
(`is_flag_set`, `store_flag`) and cooperative whole-chunk walks (`pack`,
`unpack`, `unpack_reduce`, all taking `Group&` + payload `nbytes`). The
readiness scan belongs in the second tier, with the same shape as `unpack`
minus the destination and the timeout:

    unpack       (Group&, void* dst, const void* staging, size_t nbytes, FlagType, const Timeout&)
    all_flags_set(Group&,            const void* staging, size_t nbytes, FlagType)

So this moves the walk into `LLImpl<P>::all_flags_set` and has
`progress_recv_ready(LL)` call it. Net effect: no packet arithmetic left in the
transport for this path.

`group_all_ready` goes away with it. It was a one-line wrapper over
`group.all()` that only this walk used, and its name invited the reading "all
packets are ready" when it only ever meant "all threads agree" -- it never saw
a packet. `all_flags_set` calls `group.all()` directly and its name says what
it checks.

No behaviour change: same packets inspected, same early exit, same reduction.

Reviewed By: Scusemua

Differential Revision: D116866203


