### PR TITLE
Add LLImpl::repack, the LL relay codec (#3771)

### DIFF
--- a/comms/prims/core/LLImpl.cuh
+++ b/comms/prims/core/LLImpl.cuh
@@ -480,6 +480,101 @@ struct LLImpl {
     (void)abortDevice;
 #endif
   }
+
+  /// Relay one already-ready chunk: decode `recvStaging`'s payload into `dst`
+  /// (when non-null) AND re-encode it into `fwdStaging` stamped with
+  /// `fwdFlagVal`, in a single pass. Cooperative across `group`.
+  ///
+  /// This is the LL counterpart of a fused forward, and it cannot be a
+  /// packet-to-packet copy: the two staging rings advance on independent
+  /// cursors, so the outbound packets need the DOWNSTREAM ring's generation,
+  /// not the one the upstream sender stamped. Copying the packets verbatim
+  /// would ship a stale flag and the next hop would either accept the previous
+  /// pass's data or wait forever.
+  ///
+  /// Unlike `unpack` this never spins: the caller confirms every packet's flag
+  /// before invoking it (blocking `prepareForwardBuf(LL)` polls, the resumable
+  /// path uses `progress_recv_ready(LL)`). A spin here would be unrecoverable
+  /// anyway -- a partial pass has already written `fwdStaging`.
+  template <typename Group>
+  __device__ __forceinline__ static void repack(
+      Group& group,
+      void* dst,
+      void* fwdStaging,
+      const void* recvStaging,
+      std::size_t nbytes,
+      FlagType fwdFlagVal) {
+#ifdef __CUDA_ARCH__
+    const std::size_t nPackets = P::packet_count(nbytes);
+    const auto* recvBase = reinterpret_cast<const char*>(recvStaging);
+    auto* fwdBase = reinterpret_cast<char*>(fwdStaging);
+    auto* d = reinterpret_cast<char*>(dst);
+    for (std::size_t i = group.thread_id_in_group; i < nPackets;
+         i += group.group_size) {
+      const char* recvPkt =
+          recvBase + i * static_cast<std::size_t>(P::kPacketBytes);
+      char* fwdPkt = fwdBase + i * static_cast<std::size_t>(P::kPacketBytes);
+      const std::size_t valid = P::valid_payload(i, nbytes);
+      const std::size_t off = i * static_cast<std::size_t>(P::kData);
+
+      if constexpr (P::kPacketBytes == static_cast<int>(sizeof(uint64_t))) {
+        // 8 B packet: {data:4, flag:4}. One wide load pulls both halves; one
+        // wide store re-stamps the payload with the downstream generation.
+        // Bytes past `valid` are the upstream packer's zero padding, so
+        // carrying the whole data half through preserves it.
+        const uint64_t v = comms::device::ld_volatile_global(
+            reinterpret_cast<const volatile uint64_t*>(recvPkt));
+        const auto data = static_cast<uint32_t>(v);
+        comms::device::st_volatile_global(
+            reinterpret_cast<volatile uint64_t*>(fwdPkt),
+            (static_cast<uint64_t>(fwdFlagVal) << 32) |
+                static_cast<uint64_t>(data));
+        if (d != nullptr) {
+          const auto* db = reinterpret_cast<const char*>(&data);
+#pragma unroll
+          for (int b = 0; b < P::kData; ++b) {
+            if (static_cast<std::size_t>(b) < valid) {
+              d[off + b] = db[b];
+            }
+          }
+        }
+      } else {
+        // Large packet: copy the data region word-wise, then stamp the flag
+        // last, mirroring pack()'s ordering.
+        constexpr int kDataWords =
+            P::kData / static_cast<int>(sizeof(uint64_t));
+        const auto* sp = reinterpret_cast<const volatile uint64_t*>(recvPkt);
+        auto* fp = reinterpret_cast<volatile uint64_t*>(fwdPkt);
+#pragma unroll
+        for (int w = 0; w < kDataWords; ++w) {
+          const uint64_t word = comms::device::ld_volatile_global(sp + w);
+          comms::device::st_volatile_global(fp + w, word);
+          if (d != nullptr) {
+            const auto* wb = reinterpret_cast<const char*>(&word);
+#pragma unroll
+            for (int b = 0; b < static_cast<int>(sizeof(uint64_t)); ++b) {
+              const std::size_t gb =
+                  static_cast<std::size_t>(w) * sizeof(uint64_t) +
+                  static_cast<std::size_t>(b);
+              if (gb < valid) {
+                d[off + gb] = wb[b];
+              }
+            }
+          }
+        }
+        store_flag(fwdPkt, fwdFlagVal);
+      }
+    }
+    group.sync();
+#else
+    (void)group;
+    (void)dst;
+    (void)fwdStaging;
+    (void)recvStaging;
+    (void)nbytes;
+    (void)fwdFlagVal;
+#endif
+  }
 };
 
 } // namespace comms::prims

--- a/comms/prims/core/MemcpyCopyOp.cuh
+++ b/comms/prims/core/MemcpyCopyOp.cuh
@@ -100,6 +100,32 @@ struct Memcpy {
       Args...) {
     LLImpl<P>::unpack(group, dst, staging, nbytes, flagVal, abortDevice);
   }
+
+  // LL counterpart of forward(): decode the relayed chunk into `dst` and
+  // re-encode it into the next hop's staging in one pass. `recvFlagVal` is the
+  // generation the upstream sender stamped, `fwdFlagVal` the one the
+  // downstream ring expects -- they differ because the two staging rings
+  // advance on independent cursors, which is why this cannot be a
+  // packet-to-packet copy. A plain copy delegates to LLImpl<P>::repack; a
+  // reduce/convert op overrides this the way it overrides recvLL. Presence is
+  // detected by has_forwardLL_v.
+  //
+  // Takes no Timeout where recvLL() does: the caller has already confirmed
+  // every packet flag, so this hook must not spin -- a partial pass has
+  // already written fwd_staging and could not be retried.
+  template <typename P, typename... Args>
+  __device__ __forceinline__ static void forwardLL(
+      ThreadGroup& group,
+      char* dst,
+      char* fwd_staging,
+      const char* staging,
+      std::size_t nbytes,
+      std::size_t /*byte_offset*/,
+      typename P::FlagType /*recvFlagVal*/,
+      typename P::FlagType fwdFlagVal,
+      Args...) {
+    LLImpl<P>::repack(group, dst, fwd_staging, staging, nbytes, fwdFlagVal);
+  }
 };
 
 // Detection traits: does CopyOp `Op` provide packet-aware LL hooks for packet
@@ -135,5 +161,21 @@ inline constexpr bool has_recvLL_v<
         std::declval<std::size_t>(),
         std::declval<typename P::FlagType>(),
         std::declval<const AbortDevice&>()))>> = true;
+
+template <typename Op, typename P, typename = void>
+inline constexpr bool has_forwardLL_v = false;
+template <typename Op, typename P>
+inline constexpr bool has_forwardLL_v<
+    Op,
+    P,
+    std::void_t<decltype(Op::template forwardLL<P>(
+        std::declval<ThreadGroup&>(),
+        std::declval<char*>(),
+        std::declval<char*>(),
+        std::declval<const char*>(),
+        std::declval<std::size_t>(),
+        std::declval<std::size_t>(),
+        std::declval<typename P::FlagType>(),
+        std::declval<typename P::FlagType>()))>> = true;
 
 } // namespace comms::prims

--- a/comms/prims/tests/LLImplTest.cc
+++ b/comms/prims/tests/LLImplTest.cc
@@ -24,6 +24,35 @@ namespace comms::prims {
 // dispatch report it as LL-capable.
 static_assert(has_sendLL_v<Memcpy, LlxPacketGeometry>);
 static_assert(has_recvLL_v<Memcpy, LlxPacketGeometry>);
+static_assert(has_forwardLL_v<Memcpy, LlxPacketGeometry>);
+
+namespace {
+// has_forwardLL_v probes a FIXED 8-argument list, so it silently reports false
+// for a hook whose signature drifts -- and the transport turns that false into
+// a static_assert in whichever .cu instantiated the LL forward, far from the
+// edit that caused it. Pin the negative verdicts here, next to the trait.
+//
+// Declarations only: these are never called, and the trait is an unevaluated
+// decltype.
+struct NoLlHooks {};
+
+// forwardLL present, but one argument short -- the shape a hook would have if
+// it relayed packets verbatim, with no downstream generation to re-stamp with.
+struct MissingFwdFlag {
+  template <typename P>
+  static void forwardLL(
+      ThreadGroup&,
+      char*,
+      char*,
+      const char*,
+      std::size_t,
+      std::size_t,
+      typename P::FlagType);
+};
+
+static_assert(!has_forwardLL_v<NoLlHooks, LlxPacketGeometry>);
+static_assert(!has_forwardLL_v<MissingFwdFlag, LlxPacketGeometry>);
+} // namespace
 
 namespace {
 
@@ -295,6 +324,114 @@ TEST_F(LLImplTest, AllFlagsSetFalseOnAnyMissingPacket) {
         << "packet " << p << " of " << nPackets
         << " had the wrong generation but the chunk reported ready";
   }
+}
+
+namespace {
+
+struct RepackResult {
+  uint32_t flagErrors;
+  std::vector<char> dst; // decoded by the relay itself (empty when useDst)
+  std::vector<char> packetOut; // decoded back out of the forwarded packets
+};
+
+// pack -> repack -> inspect. See test_ll_repack() for the two-pass split.
+RepackResult runRepack(const std::vector<char>& src, bool useDst) {
+  using P = LlxPacketGeometry;
+  const std::size_t nbytes = src.size();
+  const std::size_t wire = P::wire_bytes(nbytes);
+
+  DeviceBuffer srcBuf(nbytes);
+  DeviceBuffer recvStaging(wire);
+  DeviceBuffer fwdStaging(wire);
+  DeviceBuffer dstBuf(nbytes);
+  DeviceBuffer packetOut(nbytes);
+  DeviceBuffer errBuf(sizeof(uint32_t));
+
+  CUDACHECK_TEST(
+      cudaMemcpy(srcBuf.get(), src.data(), nbytes, cudaMemcpyHostToDevice));
+  // Poison both outputs: a relay that writes nothing must not look like a pass.
+  CUDACHECK_TEST(cudaMemset(dstBuf.get(), 0xA5, nbytes));
+  CUDACHECK_TEST(cudaMemset(packetOut.get(), 0xA5, nbytes));
+  // Poison the forward staging with the UPSTREAM generation, so a relay that
+  // copies packets verbatim cannot accidentally leave the right flag behind.
+  CUDACHECK_TEST(cudaMemset(fwdStaging.get(), 0x07, wire));
+  CUDACHECK_TEST(cudaMemset(errBuf.get(), 0, sizeof(uint32_t)));
+
+  test::test_ll_repack(
+      static_cast<const char*>(srcBuf.get()),
+      static_cast<char*>(recvStaging.get()),
+      static_cast<char*>(fwdStaging.get()),
+      static_cast<char*>(dstBuf.get()),
+      static_cast<char*>(packetOut.get()),
+      nbytes,
+      useDst,
+      static_cast<uint32_t*>(errBuf.get()));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  RepackResult out;
+  CUDACHECK_TEST(cudaMemcpy(
+      &out.flagErrors, errBuf.get(), sizeof(uint32_t), cudaMemcpyDeviceToHost));
+  out.packetOut.resize(nbytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      out.packetOut.data(), packetOut.get(), nbytes, cudaMemcpyDeviceToHost));
+  if (useDst) {
+    out.dst.resize(nbytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        out.dst.data(), dstBuf.get(), nbytes, cudaMemcpyDeviceToHost));
+  }
+  return out;
+}
+
+std::vector<char> pattern(std::size_t nbytes) {
+  // Position-dependent, so a relay that shifts or duplicates a packet shows up.
+  std::vector<char> v(nbytes);
+  for (std::size_t i = 0; i < nbytes; ++i) {
+    v[i] = static_cast<char>(i * 131u + 7u);
+  }
+  return v;
+}
+
+} // namespace
+
+// kData = 4, so `nbytes % 4` decides how much of the final packet is the
+// packer's zero padding. Sweep every remainder, plus sizes on either side of a
+// single packet and a few large enough to give every thread several packets.
+TEST_F(LLImplTest, RepackReStampsAndPreservesPayload) {
+  for (std::size_t n :
+       {std::size_t(1),
+        std::size_t(2),
+        std::size_t(3),
+        std::size_t(4),
+        std::size_t(5),
+        std::size_t(7),
+        std::size_t(64),
+        std::size_t(533),
+        std::size_t(1000),
+        std::size_t(4096)}) {
+    const auto src = pattern(n);
+    const auto got = runRepack(src, /*useDst=*/true);
+
+    EXPECT_EQ(got.flagErrors, 0u)
+        << "nbytes=" << n << ": " << got.flagErrors
+        << " forwarded packet(s) still carry the upstream generation";
+    EXPECT_EQ(got.dst, src)
+        << "nbytes=" << n << ": relay decode into dst wrong";
+    EXPECT_EQ(got.packetOut, src)
+        << "nbytes=" << n << ": forwarded packet payload wrong";
+  }
+}
+
+// Forward-only relay: the chain's intermediate ranks pass dst == nullptr, and
+// the packets must still be re-stamped and carry the payload.
+TEST_F(LLImplTest, RepackForwardOnlyNullDst) {
+  constexpr std::size_t kBytes = 1000;
+  const auto src = pattern(kBytes);
+  const auto got = runRepack(src, /*useDst=*/false);
+
+  EXPECT_EQ(got.flagErrors, 0u)
+      << got.flagErrors << " forwarded packet(s) still carry the upstream "
+      << "generation with dst == nullptr";
+  EXPECT_EQ(got.packetOut, src) << "forward-only relay payload wrong";
 }
 
 TEST_F(LLImplTest, FlagRoundTrip) {

--- a/comms/prims/tests/LLImplTest.cu
+++ b/comms/prims/tests/LLImplTest.cu
@@ -241,4 +241,78 @@ void test_ll_unpack_reduce_i64(
   launchByKind<int64_t>(src_d, staging_d, accum_d, nelems, ReduceKind::Sum);
 }
 
+// pack(src) under the upstream generation, relay it into a second staging
+// region under the downstream one, then check the two halves of the result
+// separately. See test_ll_repack() in the header for why the flag pass does
+// not go through unpack().
+template <typename P>
+__global__ void repack_kernel(
+    const char* src,
+    char* recvStaging,
+    char* fwdStaging,
+    char* dst,
+    char* packetOut,
+    std::size_t nbytes,
+    bool useDst,
+    uint32_t* flagErrors) {
+  ThreadGroup g{
+      threadIdx.x,
+      blockDim.x,
+      blockIdx.x,
+      blockIdx.x,
+      gridDim.x,
+      SyncScope::BLOCK};
+
+  const auto recvFlag = static_cast<typename P::FlagType>(7);
+  const auto fwdFlag = static_cast<typename P::FlagType>(9);
+
+  LLImpl<P>::pack(g, recvStaging, src, nbytes, recvFlag);
+  g.sync();
+  LLImpl<P>::repack(
+      g, useDst ? dst : nullptr, fwdStaging, recvStaging, nbytes, fwdFlag);
+  g.sync();
+
+  // (1) Flag pass. One read per packet, no spin.
+  const std::size_t nPackets = P::packet_count(nbytes);
+  for (std::size_t i = threadIdx.x; i < nPackets; i += blockDim.x) {
+    const char* pkt =
+        fwdStaging + i * static_cast<std::size_t>(P::kPacketBytes);
+    if (!LLImpl<P>::is_flag_set(pkt, fwdFlag)) {
+      atomicAdd(flagErrors, 1u);
+    }
+  }
+  g.sync();
+
+  // (2) Payload pass. Force every flag to the downstream generation first so
+  // unpack() is guaranteed to terminate even when the relay mis-stamped -- the
+  // flag verdict is already recorded above, and this isolates the data half.
+  for (std::size_t i = threadIdx.x; i < nPackets; i += blockDim.x) {
+    LLImpl<P>::store_flag(
+        fwdStaging + i * static_cast<std::size_t>(P::kPacketBytes), fwdFlag);
+  }
+  g.sync();
+  LLImpl<P>::unpack(g, packetOut, fwdStaging, nbytes, fwdFlag);
+}
+
+void test_ll_repack(
+    const char* src_d,
+    char* recvStaging_d,
+    char* fwdStaging_d,
+    char* dst_d,
+    char* packetOut_d,
+    std::size_t nbytes,
+    bool useDst,
+    uint32_t* flagErrors_d) {
+  repack_kernel<LlxPacketGeometry><<<1, 256>>>(
+      src_d,
+      recvStaging_d,
+      fwdStaging_d,
+      dst_d,
+      packetOut_d,
+      nbytes,
+      useDst,
+      flagErrors_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
 } // namespace comms::prims::test

--- a/comms/prims/tests/LLImplTest.cuh
+++ b/comms/prims/tests/LLImplTest.cuh
@@ -69,4 +69,36 @@ void test_ll_unpack_reduce_i64(
     int64_t* accum_d,
     std::size_t nelems);
 
+/// pack(src) into `recvStaging_d` under the UPSTREAM generation, then relay it
+/// with `repack` into `fwdStaging_d` under the DOWNSTREAM generation, decoding
+/// into `dst_d` on the way.
+///
+/// The two generations are deliberately different: the relay must re-stamp
+/// every forwarded packet, and shipping the upstream flag through is the bug
+/// this pins. `repack` is byte-granular (no element type), so the axis that
+/// matters is `nbytes` -- specifically `nbytes % kData`, which decides how much
+/// of the final packet is the packer's zero padding.
+///
+/// Verification is split into two independent passes so neither failure mode
+/// can mask or hang on the other:
+///   1. flags: count packets in `fwdStaging_d` whose flag is not the
+///      downstream one, into `flagErrors_d`. Read once, never spun on -- a
+///      relay that forgot to re-stamp fails the test instead of hanging it,
+///      which is what calling `unpack()` here would do.
+///   2. payload: re-stamp every packet with the downstream flag, then `unpack`
+///      into `packetOut_d`. That cannot hang, and it checks the data half
+///      independently of the flag half.
+///
+/// `useDst == false` passes `dst == nullptr` (the forward-only relay shape the
+/// chain's intermediate ranks use); `dst_d` is then left untouched.
+void test_ll_repack(
+    const char* src_d,
+    char* recvStaging_d,
+    char* fwdStaging_d,
+    char* dst_d,
+    char* packetOut_d,
+    std::size_t nbytes,
+    bool useDst,
+    uint32_t* flagErrors_d);
+
 } // namespace comms::prims::test


### PR DESCRIPTION
Summary:

The LL forward seam needs to do something neither `pack` nor `unpack` does:
take an already-ready chunk out of the recv staging ring and put it into the
send staging ring of the *next* hop, decoding into the local destination on the
way. It cannot be a packet-to-packet copy. The two rings advance on independent
cursors, so the outbound packets have to carry the DOWNSTREAM generation;
shipping the upstream flag through leaves the next hop either accepting the
previous pass's data or waiting forever.

- `LLImpl<P>::repack(group, dst, fwdStaging, recvStaging, nbytes, fwdFlagVal)`.
  One pass, cooperative across `group`, `dst` optional (the forward-only relay
  shape). Never spins: the transport seam confirms every flag first, and a
  partial pass has already written `fwdStaging`, so a spin here would be
  unrecoverable anyway.
- `Memcpy::forwardLL<P>` delegating to it, and the `has_forwardLL_v<Op, P>`
  detection trait, mirroring the existing `sendLL`/`recvLL` pair.

Nothing calls this yet; the transport seams that do come next in the stack.

Reviewed By: zhiyongww

Differential Revision: D116866201


