### PR TITLE
Validate registered multicast layout (#3773)

### DIFF
--- a/comms/ctran/utils/CtranMulticast.h
+++ b/comms/ctran/utils/CtranMulticast.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <vector>
 
@@ -114,6 +115,26 @@ class CtranMulticast {
                              : reinterpret_cast<void*>(segments_[0].base);
   }
 
+  // Byte offset of a requested range within the retained backing allocation.
+  // Returns nullopt unless the full range is covered.
+  std::optional<size_t> retainedOffset(const void* userPtr, size_t bytes)
+      const {
+    void* base = getBase();
+    if (base == nullptr || userPtr == nullptr || bytes == 0) {
+      return std::nullopt;
+    }
+    const auto baseAddr = reinterpret_cast<uintptr_t>(base);
+    const auto userAddr = reinterpret_cast<uintptr_t>(userPtr);
+    if (userAddr < baseAddr) {
+      return std::nullopt;
+    }
+    const size_t offset = userAddr - baseAddr;
+    if (offset > totalSize_ || bytes > totalSize_ - offset) {
+      return std::nullopt;
+    }
+    return offset;
+  }
+
   // Multicast write target for a user pointer inside the imported range:
   // getMulticastPtr() + (userPtr - getBase()). std::nullopt when there is no
   // mapped VA yet or userPtr falls outside [getBase(),
@@ -121,16 +142,11 @@ class CtranMulticast {
   // address from the overlay alone -- no CtranIpc involvement.
   std::optional<void*> writeBase(const void* userPtr) const {
     void* mcPtr = getMulticastPtr();
-    void* base = getBase();
-    if (mcPtr == nullptr || base == nullptr) {
+    const auto offset = retainedOffset(userPtr, 1);
+    if (mcPtr == nullptr || !offset.has_value()) {
       return std::nullopt;
     }
-    const auto* b = static_cast<const char*>(base);
-    const auto* u = static_cast<const char*>(userPtr);
-    if (u < b || u >= b + totalSize_) {
-      return std::nullopt;
-    }
-    return static_cast<void*>(static_cast<char*>(mcPtr) + (u - b));
+    return static_cast<void*>(static_cast<char*>(mcPtr) + *offset);
   }
 
  private:

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -168,6 +168,8 @@ commResult_t setupMulticast(
     CtranComm* comm,
     CtranMapper* mapper,
     void* dataRegHdl,
+    const void* dataPtr,
+    size_t dataBytes,
     std::unique_ptr<ctran::utils::CtranMulticast>& outMulticast) {
   outMulticast = nullptr;
 #if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12040
@@ -176,6 +178,8 @@ commResult_t setupMulticast(
   (void)comm;
   (void)mapper;
   (void)dataRegHdl;
+  (void)dataPtr;
+  (void)dataBytes;
   return commSuccess;
 #else
   const auto& statex = comm->statex_;
@@ -212,23 +216,38 @@ commResult_t setupMulticast(
   bool localOk = hasNvlReg &&
       (mc->retainSegments(regElem->buf, regElem->len) == commSuccess);
   const size_t mcSize = localOk ? mc->retainedSize() : 0;
+  const auto dataOffset =
+      localOk ? mc->retainedOffset(dataPtr, dataBytes) : std::nullopt;
   size_t gran = 0;
-  localOk = localOk && ctran::utils::CtranMulticast::isSupported(cudaDev) &&
+  localOk = localOk && dataOffset.has_value() &&
+      ctran::utils::CtranMulticast::isSupported(cudaDev) &&
       ctran::utils::CtranMulticast::granularity(cudaDev, nLocalRanks, gran) ==
           commSuccess &&
       gran != 0 && (mcSize % gran) == 0 && mc->segmentsAlignedTo(gran);
 
   // Single-round rendezvous: the root creates + exports its fabric handle up
-  // front if its own validation passed; one all-gather of {ok, handle} then
-  // lets every rank decide unanimously (all must pass) and pick up the root's
-  // handle.
+  // front if its own validation passed; one all-gather lets every rank require
+  // unanimous eligibility and an identical registered-buffer layout before
+  // picking up the root's handle.
+  struct McLayout {
+    size_t mcSize{0};
+    size_t dataOffset{0};
+    size_t dataBytes{0};
+
+    bool operator==(const McLayout& other) const {
+      return mcSize == other.mcSize && dataOffset == other.dataOffset &&
+          dataBytes == other.dataBytes;
+    }
+  };
   struct McRzv {
     int ok{0};
+    McLayout layout{};
     ctran::utils::CtranIpcHandle handle{};
   };
   McRzv myRzv{}; // value-init: zeroes any padding, since the whole struct is
                  // shipped over the wire by intraNvlDomainAllGather
   myRzv.ok = localOk ? 1 : 0;
+  myRzv.layout = {mcSize, dataOffset.value_or(0), dataBytes};
   if (isRoot && localOk) {
     CUmemGenericAllocationHandle mcHandle = 0;
     if (mc->createRoot(mcSize, CU_MEM_HANDLE_TYPE_FABRIC, mcHandle) !=
@@ -245,22 +264,20 @@ commResult_t setupMulticast(
 
   // Proceed only if every rank validated (root's handle is in allRzv[0]:
   // intraNvlDomainAllGather indexes by domain rank, and root == domain rank 0).
-  bool allOk = true;
+  const auto& rootRzv = allRzv[0];
+  bool allEligible = true;
+  bool sameLayout = true;
   for (const auto& r : allRzv) {
-    allOk = allOk && (r.ok != 0);
+    allEligible = allEligible && (r.ok != 0);
+    sameLayout = sameLayout && r.layout == rootRzv.layout;
   }
-  if (!allOk) {
-    int declined = 0;
-    for (const auto& r : allRzv) {
-      if (r.ok == 0) {
-        declined++;
-      }
-    }
+  if (!allEligible || !sameLayout) {
     CTRAN_LOG(
         WARN,
-        "CTRAN-MC: rank {} falling back to unicast -- {} of {} NVL-domain ranks declined multicast (unsupported HW/IMEX, or a non-cuMem / unregistered buffer)",
+        "CTRAN-MC: rank {} falling back to unicast -- eligibility {}, registered-buffer layout {} across {} NVL-domain ranks",
         rank,
-        declined,
+        allEligible ? "available" : "unavailable",
+        sameLayout ? "matches" : "differs",
         nLocalRanks);
     // `mc` (incl. the root's just-created object, if any) is released by its
     // dtor at scope exit; no leak.
@@ -582,7 +599,8 @@ commResult_t CtranWin::exchange() {
   if (NCCL_CTRAN_WIN_ENABLE_MULTICAST && ipcOnly_ && isSymmetric() &&
       winDataPtr != nullptr) {
     std::unique_ptr<ctran::utils::CtranMulticast> mc;
-    FB_COMMCHECK(setupMulticast(comm, mapper, dataRegHdl, mc));
+    FB_COMMCHECK(
+        setupMulticast(comm, mapper, dataRegHdl, winDataPtr, dataBytes, mc));
     const bool mcEngaged = (mc != nullptr);
     if (mcEngaged) {
       // exchange() is a CtranWin member; store the window's multicast object


### PR DESCRIPTION
Summary:

Validate that every rank in an NVL multicast domain retained the same backing size and registered the same logical range offset and size before importing or binding the multicast object.

Previously, ranks could all pass multicast eligibility while describing different logical windows.
Because multicast addresses are indexed relative to each retained backing allocation, that disagreement could silently target the wrong bytes on peer ranks.
For example:

```
Rank 0: allocation +   0, size 2 MiB
Rank 1: allocation + 128, size 2 MiB
```

A write intended for byte `N` of the logical window would use one multicast offset across the domain, but that offset would not name byte `N` of both registered slices.

The collective rendezvous now compares this layout tuple across every rank:

```
{retained backing size, registered offset, registered size}
```

This rejects different backing allocation sizes, same-sized slices at different backing offsets, and different registered sizes.
If any rank is ineligible or its layout differs, Ctran unanimously declines multicast.
Optional Ctran multicast users fall back to unicast, while `McclComm::winRegister()`, which requires multicast, observes no multicast mapping and returns `nullptr`.

Add `retainedOffset(ptr, bytes)` as the shared bounds-checked range calculation.
It rejects null or empty ranges, pointers before the retained allocation, and ranges extending beyond it.
`writeBase()` reuses the helper with a one-byte range because it resolves an individual address, keeping registration validation and multicast address translation consistent.

Reviewed By: saifhhasan

Differential Revision: D117096836


