### PR TITLE
Link ncclx logger sources in conda builds (#3774)

### DIFF
--- a/comms/torchcomms/ncclx/CMakeLists.txt
+++ b/comms/torchcomms/ncclx/CMakeLists.txt
@@ -100,6 +100,28 @@ else()
     message(STATUS "ENABLE_PRIMS not set, building without prims support")
 endif()
 
+set(TORCHCOMMS_NCCLX_LOGGER_SOURCES "")
+if(USE_SYSTEM_LIBS)
+    # CudaRAII.cc calls into CommsSpdlogLogger, whose out-of-line definitions
+    # live in these three. libnccl.so cannot supply them: it is built
+    # -fvisibility=hidden behind version.script, which exports only the nccl*
+    # ABI, so on the USE_SYSTEM_LIBS path the references survive to dlopen and
+    # importing the extension fails. The static path gets the definitions from
+    # the libnccl_static.a archive instead.
+    #
+    # These three are the whole closure and no more: SpdlogLogger.cc needs
+    # formatCommsLogMessage() from CommsLogFormatter.cc and the subsystem-mask
+    # accessors from LogTypes.cc, and neither of those includes any further
+    # comms header. RateLimit.h, the other SpdlogLogger.h dependency, is
+    # header-only.
+    find_package(spdlog CONFIG REQUIRED)
+    list(APPEND TORCHCOMMS_NCCLX_LOGGER_SOURCES
+        comms/utils/logger/SpdlogLogger.cc
+        comms/utils/logger/CommsLogFormatter.cc
+        comms/utils/logger/LogTypes.cc
+    )
+endif()
+
 add_library(torchcomms_comms_ncclx MODULE
     ${TORCHCOMMS_NCCLX_SOURCES}
     ${TORCHCOMMS_CUDA_DEVICE_SOURCES}
@@ -107,6 +129,7 @@ add_library(torchcomms_comms_ncclx MODULE
     ${TORCHCOMMS_DEVICE_PRIMS_SOURCE}
     comms/utils/CudaRAII.cc
     comms/utils/GraphCaptureSideStream.cc
+    ${TORCHCOMMS_NCCLX_LOGGER_SOURCES}
 )
 set_target_properties(torchcomms_comms_ncclx PROPERTIES
     PREFIX ""
@@ -161,6 +184,7 @@ if(USE_SYSTEM_LIBS)
         "-lboost_program_options"
         "-lboost_filesystem"
         "-lfmt"
+        spdlog::spdlog
     )
 else()
     set(TORCHCOMMS_NCCLX_PRIMS_LINK_LIBS "")


### PR DESCRIPTION
Summary:

D117166335 landed the tcp_devmem SPDLOG CMake fix that this diff originally carried. This revision is now scoped to the remaining conda failure in the ncclx extension.

The `torchcomms_comms_ncclx` module compiles `comms/utils/CudaRAII.cc`, and after the logger migration that file calls into `CommsSpdlogLogger`. The out-of-line definitions live in `SpdlogLogger.cc`, `CommsLogFormatter.cc`, and `LogTypes.cc`. On the `USE_SYSTEM_LIBS` conda/shared-library path, those definitions are not exported from `libnccl.so` because ncclx is built with hidden visibility and a version script that exports only the `nccl*` ABI. The unresolved reference therefore survives link and fails at extension import time.

Add the logger implementation sources and `spdlog::spdlog` link only for `USE_SYSTEM_LIBS`. The static path continues to rely on `libnccl_static.a`, avoiding duplicate logger objects there.

Reviewed By: arttianezhu

Differential Revision: D117177353


