### PR TITLE
Fix _comms_ncclx wheel dlopen break from D116694639 (#3775)

### DIFF
--- a/comms/torchcomms/ncclx/CMakeLists.txt
+++ b/comms/torchcomms/ncclx/CMakeLists.txt
@@ -107,6 +107,10 @@ add_library(torchcomms_comms_ncclx MODULE
     ${TORCHCOMMS_DEVICE_PRIMS_SOURCE}
     comms/utils/CudaRAII.cc
     comms/utils/GraphCaptureSideStream.cc
+    # libnccl hides meta::comms::logger behind its version script, so this
+    # module must carry its own copy of the shared logger implementation.
+    comms/utils/logger/SpdlogLogger.cc
+    comms/utils/logger/CommsLogFormatter.cc
 )
 set_target_properties(torchcomms_comms_ncclx PROPERTIES
     PREFIX ""
@@ -124,8 +128,13 @@ target_include_directories(torchcomms_comms_ncclx PRIVATE
 )
 torchcomms_use_torch_pybind11(torchcomms_comms_ncclx)
 target_compile_features(torchcomms_comms_ncclx PRIVATE cxx_std_20)
-# CudaRAII.cc includes SpdlogLogger.h directly, so this target must carry
-# the logger's compile-time configuration instead of relying on CTRAN.
+# CudaRAII.cc logs through COMMS_LOG, so this module needs both the logger's
+# compile-time configuration and its implementation (added to the sources
+# above). These two definitions without SPDLOG_COMPILED_LIB are header-only
+# spdlog -- the same configuration NCCLX itself builds these sources under
+# (comms/ncclx/*/src/Makefile). Do not link spdlog::spdlog here: it sets
+# SPDLOG_COMPILED_LIB PUBLIC, which would flip every TU in this module to
+# compiled mode and add a libspdlog.a dependency.
 target_compile_definitions(torchcomms_comms_ncclx PRIVATE
     SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO
     SPDLOG_FMT_EXTERNAL


### PR DESCRIPTION
Summary:

`wheel-adhoc` is red on both the `gbunified` and `h100` legs. The wheel
co-installability dlopen smoke test fails with:

```
undefined symbol:
meta::comms::logger::CommsSpdlogLogger::logFormatted(spdlog::source_loc, ...)
```

D116694639 rewrote the check macros in `comms/utils/checks.h` from
`XLOG`/`CERR` to `COMMS_LOG`/`COMMS_ERR`, and moved
`comms/utils/CudaRAII.cc` to `COMMS_LOG_STREAM(ERR)`. `CudaRAII.cc` is
compiled directly into `_comms_ncclx.<soabi>.so`, but that module never
compiles the shared logger's implementation.

libnccl.so does contain the definition -- `comms/ncclx/v2_30/src/Makefile`
globs `comms/utils/logger/*.cc` -- but hides it: the shared library links
with `-Wl,--version-script=version.script`, whose `local: *;` clause catches
everything outside `*nccl*`, `*ctran*`, `*prims*`, `*cxa*`, `*ErrorToScuba*`.
The old `CERR` path resolved fine because `XLOGF` came from folly (linked
into the extension) and `logCommErrorToScuba` matches the `*ErrorToScuba*`
export. The new `COMMS_LOG` path resolves to `CommsSpdlogLogger::logFormatted`,
which is not exported -- hence the dangling reference.

This adds `SpdlogLogger.cc` and `CommsLogFormatter.cc` to
`torchcomms_comms_ncclx`. That is the complete closure: every out-of-line
symbol the macros need is defined in `SpdlogLogger.cc`, whose only cross-TU
call is `formatCommsLogMessage` in `CommsLogFormatter.cc`. It mirrors what
`torchcomms_transport` already gets via the `utils` OBJECT library, and the
buck target `fbcode//comms/utils/logger:spdlog_logger`.
`torchcomms_comms_ncclx` is the only module that cherry-picks individual
`comms/utils/*.cc` sources without that library, which is why it is the only
one that broke.

Deliberately does NOT link `spdlog::spdlog`. The existing
`SPDLOG_ACTIVE_LEVEL` / `SPDLOG_FMT_EXTERNAL` definitions without
`SPDLOG_COMPILED_LIB` are header-only spdlog -- the same configuration NCCLX
builds these exact sources under. Linking the target would set
`SPDLOG_COMPILED_LIB` PUBLIC, flipping every TU in this module to compiled
mode and adding a `libspdlog.a` dependency. A version pin would also have been
fatal: the wheel env ships `spdlog==1.12.0`, not 1.16.0.

Known behaviour delta: this module's logger instance is not configured, so its
CUDA failure logs will not follow `NCCL_DEBUG_FILE`. That is not a regression
-- before D116694639 these sites used folly `XLOG` and did not reach
`NCCL_DEBUG_FILE` either. Establishing a single configured logger owner across
libnccl, `_transport`, and `_comms_ncclx` is left as follow-up for the defolly
stack.

Reviewed By: snarayankh

Differential Revision: D117253692


