### PR TITLE
Restore param export visibility (PENDING DECISION - do not land yet) (#3778)

### DIFF
--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -11,6 +11,8 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/algoconf/AlgoStrConv.h"
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <sstream>
 #include <stdexcept>

--- a/comms/ncclx/meta/baseline_modification_docs/cvars_param_export.md
+++ b/comms/ncclx/meta/baseline_modification_docs/cvars_param_export.md
@@ -1,0 +1,173 @@
+# CVARs row: param export visibility on v2_31
+
+## Status: open. Port drafted in D117238276, not landed.
+
+The CVARs row needs at most one baseline change on v2_31: restoring
+`NCCL_PARAM_COMPILER_EXPORT_SYMBOL`. Everything else the row would have carried is already supplied
+by upstream 2.31 or by D116807651. This document records the analysis so the 2.32 port does not
+repeat it, and states the one question that decides whether the change is required.
+
+## Scope of the row
+
+The Feature Owners Map lists two files (`src/misc/param.cc`, `src/param/param_registry.cc`) and
+says "only the two registry hooks port". Both halves are wrong. The row touches **eight** baseline
+files, all with zero upstream drift between pristine 2.30 and 2.31:
+
+`src/misc/param.cc`, `src/param/param.cc`, `src/param/param_registry.cc`, `src/param/ncclparam.cc`,
+`src/param/c_api.cc`, `src/include/param/param.h`, `src/include/param/utils.h`,
+`src/include/param/param_registry.h`.
+
+Their combined raw delta against v2_31 is roughly 300 lines, but symbol-level comparison shows the
+base already provides `NCCL_PARAM_IF_CONSTEXPR`, `ncclParamEnvPluginGet`,
+`ncclParamIsCacheDisabled`, `srcDefault`/`srcEnvPlugin`, the `misc/param.cc` env-file loader, and
+`ncclParamBind` plus the ENV-deprecation `INFO`. The remainder is formatting and signature drift,
+including upstream's two-argument `ncclParamEnvPluginGet(key, env_init)` superseding v2_30's
+one-argument form. Do not port that drift.
+
+The single symbol absent from v2_31 is `NCCL_PARAM_COMPILER_EXPORT_SYMBOL`: 10 sites in v2_30, 0 in
+v2_31.
+
+## Why the attribute is not decorative
+
+`#define NCCL_PARAM_COMPILER_EXPORT_SYMBOL __attribute__((visibility("default")))`.
+
+The fbcode Buck build compiles the library with `-fvisibility=hidden`
+(`nccl_build_config.bzl:135`, `v2_31/def_build.bzl:535`) and applies **no** linker version script
+(no reference in `nccl_build_config.bzl`, `def_build.bzl`, or `comms/ncclx/BUCK`). So for the
+Buck-built `libncclx.so`, a per-symbol attribute is the only export mechanism that exists.
+
+Upstream does not need the attribute because its Makefile links with
+`-Wl,--version-script=libnccl.map` (`v2_31/src/Makefile:171`), whose `global: nccl*;` prefix the
+symbols match. v2_29/v2_30 instead link Meta's `src/version.script`
+(`v2_30/src/Makefile:314`). **v2_31 has no `version.script` at all.** So the Buck path has neither
+of the two mechanisms upstream assumes, which is why v2_30 added the attribute.
+
+Measured on the Buck-built `libncclx.so.2.31`:
+
+| | exported `ncclParam*` | total dynamic symbols |
+| :---- | :---- | :---- |
+| without the attribute (current v2_31) | 14 | 135884 |
+| with D117238276 applied | 35 | 135905 |
+
+The 14 are entirely the `NCCL_API`-decorated public C API from `c_api.cc`, which is unaffected
+either way. The +21 delta is the 3 accessors plus 18 from `DEFINE_NCCL_PARAM` (9 invocations in
+v2_31, two symbols each). Without the attribute, `ncclParamRegistryInstance`,
+`ncclParamEnvPluginGet` and `ncclParamIsCacheDisabled` do not appear in `nm -D` at all.
+
+## What upstream says the symbols are for
+
+This matters because the mechanism is **symbol interposition**, not by-name calls, and upstream
+states the intent in its own comments:
+
+`include/param/param_registry.h`:
+
+> Returns a process-wide RegistryState so map and mutex share identity across DSOs.
+
+> The underlying state (RegistryState) is held behind a C-linkage accessor
+> (ncclParamRegistryInstance) so that all DSOs in the process share a single map and mutex, even
+> when NCCL is statically linked into multiple libraries.
+
+> Parameters defined through the DEFINE_NCCL_PARAM macro are automatically registered here at
+> program init (before main()). **This also works for DEFINE_NCCL_PARAM in external .so files,
+> where the parameter is registered when the .so is loaded and initialized, or at dlopen().**
+
+`param/param.cc`:
+
+> **Exported** helper for `ncclParam<T>::loadValue()` **so plugins can resolve a single symbol**
+> instead of requiring `ncclInitEnv` + `ncclEnvPluginGetEnv` to be exported.
+
+External `.so` files registering params, and plugins resolving `ncclParamEnvPluginGet`, are
+described as intended behaviour rather than hypotheticals.
+
+## Why code search cannot settle this
+
+A full-repo search found zero references to the three symbols outside `comms/ncclx/v2_*` and
+`third-party/nccl` — including `comms/utils/cvars/`, `comms/ncclx/meta/`, and the `nccl4py`
+bindings, with no `dlsym` call site naming them.
+
+**That result is consistent with either answer and must not be read as "unused."** Interposition
+produces no by-name references by construction: the linker resolves duplicate definitions across
+DSOs to one, and nothing in source mentions it. Any future port that re-runs this search will get
+the same empty result for the same reason.
+
+Note also that `third-party/rccl/develop` matches on these names but is **not** a consumer. It is a
+vendored AMD tree (imported in D116250835) carrying its own `utils.h`, `param.cc`,
+`param_registry.cc` and `param.h`, linking into `librccl.so`.
+
+## The open question
+
+**Does a Meta process end up with more than one copy of the ncclx param registry?**
+
+With one copy, hidden visibility is harmless: the accessor call resolves within the DSO. With two
+or more, each gets a private registry, so a param registered in one is invisible to a lookup in
+another, and the `"PARAM: Duplicate registration for key"` warning that would reveal it does not
+fire either. The failure is silent and would not surface at build time.
+
+The trigger condition exists in our tree. `//comms/torchcomms/ncclx:_comms_ncclx` is a
+`cpp_python_extension` that statically links `//comms/ncclx:nccl` through `ncclx-api` and
+`ncclx-global-api`, and it loads alongside the `//comms/torchcomms:_comms` extension in one Python
+process. Separately, v2_30's `src/version.script` names `_comms_ncclx` explicitly as a cross-`.so`
+caller for the Scuba error loggers, so cross-`.so` resolution from this extension is already an
+established fact rather than a theory.
+
+What is not established is whether the *param registry specifically* ends up duplicated there. The
+way to settle it is `nm -D` on a built `_comms_ncclx.so`, checking whether it defines its own
+`ncclParamRegistryInstance`.
+
+A related consumer to keep in view: if the Meta tuner becomes a real plugin `.so` (the plan for the
+tuner row) and declares params via `DEFINE_NCCL_PARAM`, it lands squarely in the "external .so"
+case upstream describes.
+
+## Decision guidance
+
+- If the registry is duplicated: land D117238276. Absent it, v2_31 silently fragments the registry
+  where v2_30 did not.
+- If it is not duplicated: abandon D117238276 and keep this document. The attribute would then be
+  genuinely inert, and the standing guidance to avoid porting applies.
+
+Either way, do not justify the decision as "no consumers found." That reasoning is unsound for an
+interposition-based symbol and would mislead the next port.
+
+## Related, and NOT resolved by this decision
+
+The OSS build path diverges independently of the attribute. v2_31 dropped Meta's `version.script`
+in favour of upstream's `libnccl.map`, which also drops these entries:
+
+```
+*ctran*; *prims*; *cxa*;
+*ErrorToScuba*;   /* called cross-.so from _comms_ncclx via CERR (CtranMapper.h) */
+*getDevMemType*; *getCudaDevFromPtr*; *StreamCaptureModeGuard*;
+```
+
+and narrows `*nccl*` to `nccl*`, so mangled C++ symbols (which begin `_Z`) no longer match. The
+`*cxa*` entry is load-bearing for folly's exception tracer, which resolves it via
+`dlsym(RTLD_NEXT, "cxa...")` (see D64442615). `logCommErrorToScuba` is defined in
+`comms/utils/logger/LoggingFormat.cc:315` and called from `comms/ctran/utils/CtranLogUtils.h:39`
+and `comms/utils/logger/LogUtils.h:60`.
+
+This affects only the Makefile/CMake path, since Buck applies no version script. Whether that path
+is used for the 2.31 release is unconfirmed. `ErrorToScuba` belongs to the Scuba / Structured
+Logging row, not to CVARs.
+
+One stale entry noted in passing: `v2_30/src/libnccl.map:8` exports `ncclParamNoCacheSet*`, but no
+such symbol exists in either tree.
+
+## Also do not port
+
+`src/misc/param.cc` in v2_30 carries a private copy of `loggerLevelToSpdlogLevel`. D116807651
+deleted the v2_31 equivalent and routed the call to the shared
+`comms/utils/logger/SpdlogLogger.h`. A raw v2_30-vs-v2_31 diff shows it as missing from 2.31;
+porting it back reintroduces an ambiguous overload.
+
+## Forward pointer: the two cvar systems
+
+Upstream 2.31 supplies a native path that the NCCLX cvar framework currently duplicates.
+`ncclParamEnvPluginGet` (`param/param.cc:47`) calls `ncclEnvPluginGetEnv`, which dispatches to an
+env plugin implementing `ncclEnv_v2_t`, whose entire interface is
+`getEnv(const char* name) -> const char*`. `include/param/param.h:151-156` invokes this inside the
+param load chain, gated per-param by `NCCL_PARAM_FLAG_NO_ENVPLUGIN_INIT`.
+
+`comms/utils/cvars/nccl_baseline_adapter.h` exposes `ncclGetEnvImpl(const char* name)`, the same
+signature, but intercepts baseline env reads rather than registering a plugin. Serving cvar values
+as an env plugin would let upstream call NCCLX natively and remove that interception. Not attempted
+for 2.31; recorded here as the likely 2.32 direction.

--- a/comms/ncclx/meta/baseline_modification_docs/socket_eth0.md
+++ b/comms/ncclx/meta/baseline_modification_docs/socket_eth0.md
@@ -1,0 +1,98 @@
+# socket.cc eth0 enhancements: Baseline Modifications
+
+## Background
+
+Meta production jobs configure NCCL's control-plane sockets through four cvars. Three of them have
+no upstream equivalent and are implemented as patches on baseline socket code:
+
+- `NCCL_SOCKET_IPADDR_PREFIX` — selects interfaces whose numeric address starts with a given
+  prefix. 606+ external references; set to `2401` across GB300.
+- `NCCL_CLIENT_SOCKET_IFNAME` — binds the client side of a connection to a named interface via
+  `SO_BINDTODEVICE`. 358+ external references.
+- `NCCL_SOCKET_TOS_CONFIG` — sets `IP_TOS` (IPv4) or `IPV6_TCLASS` (IPv6) on the socket.
+
+The fourth, `NCCL_SOCKET_IFNAME`, is upstream's own and needs no patch: baseline
+`ncclFindInterfaces` reads it via `ncclGetEnv` and v2_30 and v2_31 are byte-identical there.
+
+## Versions Affected
+
+v2_29, v2_30, v2_31
+
+## Baseline Files Modified
+
+Three files. Note the Feature Owners Map historically listed only `src/misc/socket.cc`; the row
+actually spans all three, and `NCCL_SOCKET_IPADDR_PREFIX` lives in the two that were unlisted.
+
+### 1. `src/include/socket.h`
+
+- `#include <string>` for the helper's return type.
+- `ncclSocketConnect` gains a trailing `const char* localIfName = nullptr`. The default keeps all
+  nine existing call sites source-compatible; none passes the argument today.
+- Declares `std::string ncclSocketToIPv6String(union ncclSocketAddress* addr)`.
+
+### 2. `src/misc/socket.cc`
+
+- `#include "comms/utils/cvars/nccl_cvars.h"`.
+- Defines `ncclSocketToIPv6String`, a numeric-host rendering via `getnameinfo` with
+  `NI_NUMERICHOST`, used to match the prefix.
+- `ncclSocketConnect` takes `localIfName`, defaults it from `NCCL_CLIENT_SOCKET_IFNAME`, and binds
+  with `SO_BINDTODEVICE`.
+- `ncclSocketInit` applies `NCCL_SOCKET_TOS_CONFIG` when it is not `-1`.
+
+### 3. `src/os/linux.cc`
+
+- `#include "comms/utils/cvars/nccl_cvars.h"` explicitly. v2_30 got this transitively; relying on
+  that is the same header-hygiene hazard D117198384 fixed for `cpuset.h`.
+- `ncclOsFindInterfaces` skips interfaces whose rendered address does not match
+  `NCCL_SOCKET_IPADDR_PREFIX`.
+
+## Deliberate divergence from v2_30
+
+The 2.31 port is not a byte-for-byte copy of v2_30. Four things were left behind on purpose,
+because they are not this row and are stale relative to upstream. Pristine 2.30's `socket.cc` is
+byte-identical to pristine 2.31's, so upstream already carried all of the below in 2.30; these are
+Meta patches that won earlier rebase conflicts, not 2.31 regressions.
+
+1. **The topology/PCI block** deleted from v2_30's `os/linux.cc` (`ncclOsGetPciPath`,
+   `ncclOsTopoGetStrFromSys`, `memcpylower`, ~108 lines). It is coupled to `include/os.h`,
+   `os/windows.cc` and `graph/xml.cc`, whose Meta patch keeps a private static `getPciPath`. It
+   belongs to the topology row, and porting it here breaks the build because 2.31 still declares
+   and calls those symbols.
+2. **Removal of `ncclSocketDefaultMagic`, `ncclSocketStateBadHandshake`, and `ncclSocketAccept`'s
+   `retry` parameter.** All three are used by other 2.31 files (`ras/`, `transport/net_socket.cc`,
+   `transport/net_ib/connect.cc`, `proxy.cc`, `os/windows.cc`).
+3. **`socketFinalizeAccept` hard-failing on socket-type mismatch.** Upstream logs, discards the
+   peer connection and keeps listening; v2_30 returns `ncclInternalError`.
+4. **The dropped `virbr` exclusion.** v2_30's `ncclFindInterfaces` filters `"^docker,lo"` where
+   upstream filters `"^docker,lo,virbr"`, so v2_30 can select a libvirt bridge as the bootstrap
+   interface. v2_30 flags this itself with `FIXME[max7255]: we dropped virbr for some reason`.
+   2.31 keeps upstream's exclusion.
+
+## Hardening applied on top of the v2_30 behaviour
+
+These were pre-existing issues in v2_30, fixed rather than carried forward:
+
+- `ncclSocketToIPv6String` zero-initializes its buffer and returns empty when `getnameinfo` fails,
+  instead of constructing a `std::string` over uninitialized stack memory. It also passes the
+  family-correct `salen` rather than the union size.
+- The `SO_BINDTODEVICE` `ifreq` is zero-initialized and explicitly NUL-terminated, and `setsockopt`
+  receives `&ifr` with `sizeof(ifr)` so pointer and length agree. The interface name is
+  user-supplied via a cvar.
+- The prefix render and its `INFO` line are gated behind a non-empty `NCCL_SOCKET_IPADDR_PREFIX`.
+  v2_30 ran both unconditionally, costing a `getnameinfo` and a log line per interface on every
+  job, including the majority that never set the prefix.
+
+## Open items
+
+- `FIXME[max7255]` in `socketWait` ties `ncclParamPollTimeOut` to `NCCL_FASTINIT_MODE`. The ncclx
+  patch it refers to was dropped during the 2.30 rebase and only the comment survived;
+  `SOCKET_POLL_TIMEOUT_MSEC` still defaults to `0`, so the poll is skipped and the loop spins.
+  Owned by the Fast Init row.
+- These cvars use the NCCLX cvar framework. If NCCLX converges on upstream 2.31's env plugin ABI
+  (`ncclEnv_v2_t::getEnv`), the two `nccl_cvars.h` includes in baseline files here are what would
+  go away.
+
+## Revert checklist
+
+Remove the three cvar uses and the helper, restore `ncclSocketConnect` to a single parameter, and
+drop the two `nccl_cvars.h` includes. Nothing else in `v2_31/src` depends on them.

--- a/comms/ncclx/meta/baseline_modification_docs/structured_logging_baseline.md
+++ b/comms/ncclx/meta/baseline_modification_docs/structured_logging_baseline.md
@@ -1,0 +1,149 @@
+# Structured Logging (spdlog + Scuba): Baseline Modifications
+
+## Background
+
+NCCLX routes every NCCL log line through Meta's shared comms logging stack
+(`comms/utils/logger/**`) instead of upstream's `vfprintf(ncclDebugFile, ...)`.
+That gives NCCL logs the same spdlog sink, formatter, and `NCCL_DEBUG_FILE`
+handling as CTRAN, and fans root-cause errors out to the
+`nccl_structured_logging` Scuba table.
+
+Two things are layered on top of the plain redirect:
+
+- A dedicated root-cause error macro `ERR(code, ...)`, which carries the
+  `ncclResult_t`. Upstream signals errors with `WARN(...); return code;`, so the
+  code is lost at the log site and the root-cause message is indistinguishable
+  from ordinary non-fatal warnings. `ERR` records the Scuba error record and
+  `ncclGetLastError()` state exactly once, at the origin, instead of at every
+  propagating check-macro layer.
+- A `NCCL_LOG_ERROR` severity between `NCCL_LOG_VERSION` and `NCCL_LOG_WARN`, so
+  oncall automation that keys off ERROR severity can find the real root cause.
+
+Design rationale and the cleanup plan live in
+[`comms/ncclx/docs/error_logging.md`](../../docs/error_logging.md).
+
+## Versions Affected
+
+v2_29, v2_30, v2_31
+
+## What is shared, and what has to be forked
+
+Most of the machinery is version-independent and needs no port:
+
+| Concern | Lives in |
+|---|---|
+| spdlog sink, formatter, async/file routing | `comms/utils/logger/SpdlogLogger.{h,cc}` |
+| Scuba error record | `comms/utils/logger/LoggingFormat.cc` (`logErrorToScuba`) |
+| `ncclGetLastError()` state, native stack | `comms/utils/logger/{LoggingFormat,ErrorStackUtil}.cc` |
+| `ERR` implementation (`ncclMetaDebugLogError`) | `comms/ncclx/meta/logger/DebugExt.cc` |
+| Level mapping + sink entry point (`writeNcclLog`) | `comms/ncclx/meta/logger/NcclDebugLog.h` |
+
+Only the five upstream-derived files below are forked per version.
+
+## Baseline Files Modified
+
+### 1. `src/include/nccl_common.h` — new severity
+
+**Change**: Inserted `NCCL_LOG_ERROR = 2` into `ncclDebugLogLevel`, renumbering
+`WARN`/`INFO`/`ABORT`/`TRACE` to 3/4/5/6.
+
+**Why in baseline**: `ncclDebugLogLevel` is the type every logging entry point
+takes, including the shared `writeNcclLog` switch in `meta/logger/`. The shared
+code does not compile against a version that lacks `NCCL_LOG_ERROR`.
+
+**Caveat**: the enumerator values are part of the `ncclDebugLogger_t` ABI passed
+to net/tuner plugins. A plugin compiled against pristine upstream headers will
+read a shifted level. This is accepted, and matches v2_29/v2_30.
+
+### 2. `src/include/debug.h` — macros and declarations
+
+**Change**: Declared `ncclMetaDebugLog`, `ncclMetaDebugLogError`, and
+`ncclSetMyThreadLoggingName`; added the `ERR(code, ...)` macro and the
+`NCCL_NAMED_THREAD_START[_EXT]` helpers; changed `VERSION`, `INFO`, `TRACE_CALL`,
+and `TRACE` to pass `__FILE__, __func__, __LINE__` where upstream passes
+`nullptr, nullptr, 0`.
+
+**Why in baseline**: these are the macros every call site in the tree expands.
+
+**2.31 note**: upstream 2.31 introduced `ncclDebugLogInternal(level, flags, file,
+func, line, fmt, ...)` — the same signature Meta had forked `ncclMetaDebugLog`
+for. v2_31 therefore keeps upstream's function in the macros and only widens the
+arguments, rather than repointing every macro at a parallel symbol as v2_30 does.
+`ncclMetaDebugLog` survives as a second entry point into the same funnel purely
+because the shared `meta/logger/DebugExt.cc` links against that name across all
+three versions.
+
+### 3. `src/debug.cc` — the funnel
+
+**Change**: Replaced the tail of `ncclDebugLogV()` — timestamp/hostname/pid/tid
+prefixing and `vfprintf` — with a `vsnprintf` of the caller's message followed by
+`ncclx::logging::writeNcclLog(level, file, func, line, message)`. The sink owns
+the line prefix and the output destination. Also: `NCCL_LOG_ERROR` joins
+`NCCL_LOG_WARN` in the `ncclDebugNoWarn` downgrade and the `ncclLastError` save;
+`ncclDebugInit()` publishes the subsystem mask via
+`meta::comms::logger::setSubSystemMask()`; and `ncclMetaDebugLog` /
+`ncclSetMyThreadLoggingName` are defined here.
+
+**Why in baseline**: upstream has no registerable log sink — `ncclDebugLogV`
+writes to `ncclDebugFile` directly, and `ncclDebugLogger_t` points the other way
+(NCCL to plugins). Redirecting the output requires editing this function.
+
+**Deliberately left in place**: `ncclDebugInit()` still parses
+`NCCL_DEBUG_TIMESTAMP_LEVELS` / `NCCL_DEBUG_TIMESTAMP_FORMAT` /
+`NCCL_DEBUG_FILE` and still caches `hostname`/`pid`, even though the sink now
+supplies those. Keeping the upstream parsing intact keeps the fork to one
+function and keeps the published params honest.
+
+### 4. `src/include/checks.h` — check macros
+
+**Change**: Added `ncclCodeToString()`; converted the root-cause check macros
+(`CUDACHECK[GOTO]`, `SYSCHECK[GOTO]`, `PTHREADCHECK[GOTO]`, `NEQCHECK[GOTO]`,
+`EQCHECK[GOTO]`, `CUDACHECKTHREAD`) from `WARN`/`INFO_LOC` to `ERR(code, ...)`;
+raised the propagation macros (`NCCLCHECK[GOTO]`, `NCCLWAIT[GOTO]`,
+`NCCLCHECKIGNORE`, `NCCLCHECKTHREAD`) from `INFO_LOC` to `WARN` so the
+propagation chain stays visible without `NCCL_DEBUG=INFO`; and added
+`CHECKABORT` and `CUDACHECKABORT`, which shared `meta/` code calls and so must
+exist in every version dir. `v2_30`'s `SYSCHECKVAL` is deliberately not ported:
+nothing in `v2_31/src`, `meta/`, or any consumer references it.
+
+**Why in baseline**: `checks.h` is where the bulk of NCCL's error reporting
+actually happens, so converting it here covers most call sites without touching
+them individually.
+
+**2.31 note**: upstream 2.31 added `INFO_LOC`, which prepends `file:line (func)`
+to the message. Since the sink now carries source location in the log record,
+converted macros use 2.31's shorter message text rather than v2_30's explicit
+`"%s:%d -> %d"` spelling.
+
+### 5. `src/misc/param.cc`, `src/include/param.h` — sink registration
+
+**Change**: Added `initNcclLogger()` and called it from `initEnv()`, alongside
+`meta::comms::initFolly()` and `ncclCvarInit()`.
+
+**Why in baseline**: `initEnv()` is the one-time init hook upstream already runs
+before any logging is configured. Registration has to happen there or the first
+log lines are lost.
+
+**Why it is not covered by CTRAN or MCCL initializing spdlog**:
+`getSpdlogLogger(name)` is a name-keyed registry. CTRAN registers
+`"comms.ctran"`; `writeNcclLog` looks up `"comms.ncclx"`. An unregistered name
+is lazily default-constructed — no file sink, no `"NCCL"` prefix, no cudaDev
+thread context, no `setLastError` hook — so the logs go nowhere quietly. Only
+`initCommLogging()` is genuinely shared, and it is `folly::once`-guarded.
+
+**Known duplication**: `initNcclLogger()` is near-identical to
+`comms/ctran/utils/LogInit.cc`, differing only in the logger name and prefix
+(four copies across ctran + v2_29 + v2_30 + v2_31). Hoisting a
+`configureDomainLogger(name, prefix)` helper into `comms/utils/logger` would
+collapse all four; that is a shared-code refactor, tracked separately.
+
+## Upstreaming
+
+Two asks would retire almost all of the above, and both still hold against
+upstream 2.31:
+
+1. A result-code-carrying error macro (`ERR(code, ...)` / `WARNRET(code, ...)`),
+   which removes the `debug.h` and `checks.h` forks and the per-rebase call-site
+   conversions.
+2. A registerable logging callback in `ncclDebugLog`, which removes the
+   `debug.cc` fork entirely.

--- a/comms/ncclx/meta/tests/NcclCommUtils.cc
+++ b/comms/ncclx/meta/tests/NcclCommUtils.cc
@@ -10,12 +10,14 @@
 namespace ncclx::test {
 
 namespace {
+#ifdef IS_NCCLX
 std::atomic<int> commCounter{
     0}; // NOLINT(facebook-avoid-non-const-global-variables)
 
 int getNextCommId() {
   return commCounter.fetch_add(1);
 }
+#endif
 } // namespace
 
 ncclComm_t createNcclComm(
@@ -33,23 +35,26 @@ ncclComm_t createNcclComm(
     config = NCCL_CONFIG_INITIALIZER;
   }
 
-  // Generate a unique commDesc per communicator to avoid stale TCPStore keys
-  // when fast-init mode reuses the same TCPStore across multiple test cases.
-  // Only override when the caller didn't explicitly set commDesc via
-  // ncclConfig_t.commDesc or ncclConfig_t.hints.
+#ifdef IS_NCCLX
+  // commDesc and hints are NCCLX-only ncclConfig_t extensions, present in the
+  // same nccl.h that declares ncclx::Hints (both gated by IS_NCCLX). Generate
+  // a unique commDesc per communicator to avoid key collisions when the
+  // bootstrap store is reused across multiple test cases, but only when the
+  // caller didn't already set commDesc via ncclConfig_t.commDesc or a
+  // "commDesc" hint. commDesc must outlive the ncclCommInitRankConfig call
+  // below because config.commDesc borrows its buffer.
   const auto commDesc =
       std::string(kNcclUtCommDesc) + "_" + std::to_string(getNextCommId());
-  const bool hasCommDescInHints = [&] {
-    if (config.hints == nullptr) {
-      return false;
-    }
+  bool hasCommDescInHints = false;
+  if (config.hints != nullptr) {
     std::string val;
     const auto* hints = static_cast<const ncclx::Hints*>(config.hints);
-    return hints->get("commDesc", val) == ncclSuccess;
-  }();
+    hasCommDescInHints = (hints->get("commDesc", val) == ncclSuccess);
+  }
   if (config.commDesc == nullptr && !hasCommDescInHints) {
     config.commDesc = commDesc.c_str();
   }
+#endif
 
   ncclUniqueId id;
   if (globalRank == 0) {

--- a/comms/ncclx/meta/tests/NcclxBaseTest.cc
+++ b/comms/ncclx/meta/tests/NcclxBaseTest.cc
@@ -2,8 +2,27 @@
 
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 
-#include <folly/logging/xlog.h>
+#include <cstdio>
 #include <cstdlib>
+
+#ifndef CUDACHECKABORT
+// Fallback when CUDACHECKABORT is not provided by the NCCL headers included
+// in this build. Preserves abort-on-failure behavior. Writes to stderr because
+// abort() is not required to flush stdio, and test stdout is usually a pipe.
+#define CUDACHECKABORT(cmd)               \
+  do {                                    \
+    cudaError_t err = cmd;                \
+    if (err != cudaSuccess) {             \
+      fprintf(                            \
+          stderr,                         \
+          "Cuda failure '%s' at %s:%d\n", \
+          cudaGetErrorString(err),        \
+          __FILE__,                       \
+          __LINE__);                      \
+      abort();                            \
+    }                                     \
+  } while (0)
+#endif
 
 void NcclxBaseTestFixture::SetUp(const NcclxEnvs& envs) {
   distSetUp();

--- a/comms/ncclx/v2_31/src/allocator.cc
+++ b/comms/ncclx/v2_31/src/allocator.cc
@@ -225,14 +225,14 @@ ncclResult_t ncclSpaceAlloc(struct ncclSpace* a, int64_t limit, int64_t size, in
     }
     i += 2; // Next empty segment
   }
-  WARN("Allocation failed. No suitable space found to accommodate size=0x%lx within limit=0x%lx", (long)size,
+  ERR(ncclInternalError, "Allocation failed. No suitable space found to accommodate size=0x%lx within limit=0x%lx", (long)size,
        (long)limit);
   return ncclInternalError;
 }
 
 ncclResult_t ncclSpaceFree(struct ncclSpace* a, int64_t offset, int64_t size) {
   if (a->count == 0 || a->cuts[a->count - 1] <= offset) {
-    WARN("No allocation found at offset=0x%lx", (long)offset);
+    ERR(ncclInternalError, "No allocation found at offset=0x%lx", (long)offset);
     return ncclInternalError;
   }
 
@@ -244,7 +244,7 @@ ncclResult_t ncclSpaceFree(struct ncclSpace* a, int64_t offset, int64_t size) {
   int64_t hi = a->cuts[i];
 
   if (offset < lo || hi < offset + size) {
-    WARN("Given size=0x%lx extends beyond allocation.", (long)size);
+    ERR(ncclInternalError, "Given size=0x%lx extends beyond allocation.", (long)size);
     return ncclInternalError;
   }
 
@@ -423,7 +423,7 @@ ncclResult_t ncclShadowPoolFree(struct ncclShadowPool* pool, void* devObj, cudaS
   struct ncclShadowObject** pobj = &pool->table[b];
   while (true) {
     if (*pobj == nullptr) {
-      WARN("Device object does not exist in shadow pool.");
+      ERR(ncclInternalError, "Device object does not exist in shadow pool.");
       return ncclInternalError;
     }
     if ((*pobj)->devObj == devObj) break;
@@ -456,7 +456,7 @@ ncclResult_t ncclShadowPoolToHost(struct ncclShadowPool* pool, void* devObj, voi
   struct ncclShadowObject* obj = pool->table[b];
   while (true) {
     if (obj == nullptr) {
-      WARN("Device object does not exist in shadow pool.");
+      ERR(ncclInternalError, "Device object does not exist in shadow pool.");
       return ncclInternalError;
     }
     if (obj->devObj == devObj) break;

--- a/comms/ncclx/v2_31/src/bootstrap.cc
+++ b/comms/ncclx/v2_31/src/bootstrap.cc
@@ -111,19 +111,19 @@ ncclResult_t bootstrapNetInit() {
       if (env) {
         union ncclSocketAddress remoteAddr;
         if (ncclSocketGetAddrFromString(&remoteAddr, env) != ncclSuccess) {
-          WARN("Invalid NCCL_COMM_ID, please use format: <ipv4>:<port> or [<ipv6>]:<port> or <hostname>:<port>");
+          ERR(ncclInvalidArgument, "Invalid NCCL_COMM_ID, please use format: <ipv4>:<port> or [<ipv6>]:<port> or <hostname>:<port>");
           return ncclInvalidArgument;
         }
         NCCLCHECK(ncclFindInterfaceMatchSubnet(bootstrapNetIfName, &bootstrapNetIfAddr, &remoteAddr, MAX_IF_NAME_SIZE,
                                                &nIfs));
         if (nIfs <= 0) {
-          WARN("NET/Socket : No usable listening interface found");
+          ERR(ncclSystemError, "NET/Socket : No usable listening interface found");
           return ncclSystemError;
         }
       } else {
         NCCLCHECK(ncclFindInterfaces(bootstrapNetIfName, &bootstrapNetIfAddr, MAX_IF_NAME_SIZE, 1, &nIfs));
         if (nIfs <= 0) {
-          WARN("Bootstrap : no socket interface found");
+          ERR(ncclInvalidUsage, "Bootstrap : no socket interface found");
           return ncclInvalidUsage;
         }
       }
@@ -221,7 +221,7 @@ static ncclResult_t socketRecv(struct ncclSocket* sock, void* data, int size) {
   int recvSize;
   NCCLCHECK(ncclSocketRecv(sock, &recvSize, sizeof(int)));
   if (recvSize > size) {
-    WARN("Message truncated : received %d bytes instead of %d", recvSize, size);
+    ERR(ncclInternalError, "Message truncated : received %d bytes instead of %d", recvSize, size);
     return ncclInternalError;
   }
   int actualSize = std::min(recvSize, size);
@@ -233,7 +233,7 @@ static ncclResult_t socketSendRecv(struct ncclSocket* sendSock, void* sendData, 
   int senderRecvSize;
   NCCLCHECK(ncclSocketSendRecv(sendSock, &sendSize, sizeof(int), recvSock, &senderRecvSize, sizeof(int)));
   if (senderRecvSize > recvSize) {
-    WARN("Message truncated : received %d bytes instead of %d", senderRecvSize, recvSize);
+    ERR(ncclInternalError, "Message truncated : received %d bytes instead of %d", senderRecvSize, recvSize);
     return ncclInternalError;
   }
   NCCLCHECK(ncclSocketSendRecv(sendSock, sendData, sendSize, recvSock, recvData, std::min(recvSize, senderRecvSize)));
@@ -246,7 +246,7 @@ static ncclResult_t socketDoubleSendRecv(struct ncclSocketOp ops[4]) {
   NCCLCHECK(ncclSocketSendRecv(ops[0].sock, &ops[0].size, sizeof(int), ops[1].sock, &senderRecvSize1, sizeof(int)));
   NCCLCHECK(ncclSocketSendRecv(ops[2].sock, &ops[2].size, sizeof(int), ops[3].sock, &senderRecvSize2, sizeof(int)));
   if (senderRecvSize1 > ops[1].size || senderRecvSize2 > ops[3].size) {
-    WARN("Message truncated : received %d,%d bytes instead of %d,%d", senderRecvSize1, senderRecvSize2, ops[1].size,
+    ERR(ncclInternalError, "Message truncated : received %d,%d bytes instead of %d,%d", senderRecvSize1, senderRecvSize2, ops[1].size,
          ops[3].size);
     return ncclInternalError;
   }
@@ -332,7 +332,7 @@ static void* bootstrapRoot(void* rargs) {
     }
 
     if (nranks != info.nranks || nroots != info.nroots || iroot != info.iroot || offset != info.offset) {
-      WARN("Bootstrap Root : mismatch in info from procs, nranks %d vs %d, nroots %d vs %d, iroot %d vs %d, offset %d "
+      ERR(ncclInternalError, "Bootstrap Root : mismatch in info from procs, nranks %d vs %d, nroots %d vs %d, iroot %d vs %d, offset %d "
            "vs %d",
            nranks, info.nranks, nroots, info.nroots, iroot, info.iroot, offset, info.offset);
       goto out;
@@ -340,12 +340,12 @@ static void* bootstrapRoot(void* rargs) {
 
     localId = localIdFromRoot(info.rank, iroot, nranks, nroots, offset);
     if (localId < 0 || localId >= nrecv) {
-      WARN("Bootstrap Root : localId %d is out of range", localId);
+      ERR(ncclInternalError, "Bootstrap Root : localId %d is out of range", localId);
       goto out;
     }
     if (memcmp(&zeroAddress, &rankAddressesRoot[localId], sizeof(union ncclSocketAddress)) != 0 ||
         memcmp(&zeroInfo, &rankInfo[localId], sizeof(union ringConnectInfo)) != 0) {
-      WARN("Bootstrap Root : rank %d of %d ranks has already checked in", info.rank, nranks);
+      ERR(ncclInternalError, "Bootstrap Root : rank %d of %d ranks has already checked in", info.rank, nranks);
       goto out;
     }
     // if the previous has already checked in, send the newly received handle, if not save the handle for later
@@ -434,13 +434,13 @@ ncclResult_t bootstrapGetUniqueId(struct ncclBootstrapHandle* handle, struct ncc
   if (env) {
     // If comm is provided (grow operation), NCCL_COMM_ID should not be set
     if (comm) {
-      WARN("ncclCommGetUniqueId should not be called when NCCL_COMM_ID is set");
+      ERR(ncclInvalidUsage, "ncclCommGetUniqueId should not be called when NCCL_COMM_ID is set");
       return ncclInvalidUsage;
     }
     // Normal init: use NCCL_COMM_ID from environment
     INFO(NCCL_ENV, "NCCL_COMM_ID set by environment to %s", env);
     if (ncclSocketGetAddrFromString(&handle->addr, env) != ncclSuccess) {
-      WARN("Invalid NCCL_COMM_ID, please use format: <ipv4>:<port> or [<ipv6>]:<port> or <hostname>:<port>");
+      ERR(ncclInvalidArgument, "Invalid NCCL_COMM_ID, please use format: <ipv4>:<port> or [<ipv6>]:<port> or <hostname>:<port>");
       return ncclInvalidArgument;
     }
     handle->magic = NCCL_MAGIC;
@@ -461,7 +461,7 @@ ncclResult_t bootstrapGetUniqueId(struct ncclBootstrapHandle* handle, struct ncc
 
 ncclResult_t bcastGrowHandle(struct ncclBootstrapHandle* handle, struct ncclComm* parent, bool isRoot) {
   if (!parent || !handle) {
-    WARN("bcastGrowHandle: parent comm and handle must be provided");
+    ERR(ncclInvalidArgument, "bcastGrowHandle: parent comm and handle must be provided");
     return ncclInvalidArgument;
   }
 
@@ -574,9 +574,9 @@ static ncclResult_t netGetDevice(int rank, struct ncclComm* comm, int* dev) {
         }
         if (devOOB == -1) {
           if (!searchNot) {
-            WARN("no device found matching %s%s, verify NCCL_OOB_NET_IFNAME", searchExact ? "exactly " : "", userIfEnv);
+            ERR(ncclInvalidArgument, "no device found matching %s%s, verify NCCL_OOB_NET_IFNAME", searchExact ? "exactly " : "", userIfEnv);
           } else {
-            WARN("no device found after excluding %s%s, verify NCCL_OOB_NET_IFNAME", searchExact ? "exactly " : "",
+            ERR(ncclInvalidArgument, "no device found after excluding %s%s, verify NCCL_OOB_NET_IFNAME", searchExact ? "exactly " : "",
                  userIfEnv);
           }
           return ncclInvalidArgument;
@@ -702,7 +702,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
   } else if (parent != NULL) {
     comm->magic = state->magic = hashCombine(parent->magic, parent->childCount);
   } else {
-    WARN("bootstrapInit: handles and parent are NULL");
+    ERR(ncclSystemError, "bootstrapInit: handles and parent are NULL");
     return ncclSystemError;
   }
 
@@ -737,7 +737,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
       if (handles != NULL) {
         offset = BOOTSTRAP_HANDLE(handles, 0)->nRanks - 1;
       } else {
-        WARN("bootstrapInit: handles and parent are NULL");
+        ERR(ncclSystemError, "bootstrapInit: handles and parent are NULL");
         return ncclSystemError;
       }
     }
@@ -1316,7 +1316,7 @@ ncclResult_t bootstrapClose(void* commState) {
   if (state->unexpectedConnections != NULL) {
     unexpectedFree(state);
     if (COMPILER_ATOMIC_LOAD(state->abortFlag, std::memory_order_acquire) == 0) {
-      WARN("Unexpected connections are not empty");
+      ERR(ncclInternalError, "Unexpected connections are not empty");
       return ncclInternalError;
     }
   }

--- a/comms/ncclx/v2_31/src/debug.cc
+++ b/comms/ncclx/v2_31/src/debug.cc
@@ -19,7 +19,10 @@
 #include "os.h"
 #include "utils.h"
 #include "env.h"
-#include <cinttypes>
+#include <vector>
+
+#include "comms/utils/logger/LoggingFormat.h"
+#include "meta/logger/NcclDebugLog.h"
 
 #define NCCL_DEBUG_RESET_TRIGGERED (-2)
 
@@ -39,13 +42,12 @@ static std::mutex ncclDebugMutex;
 static std::chrono::steady_clock::time_point ncclEpoch;
 static bool ncclWarnSetDebugInfo = false;
 
-static thread_local int tid = -1;
-
 // clang-format off
 DEFINE_NCCL_PARAM(ncclParamDebugLevel, ncclDebugLogLevel, NCCL_DEBUG, NCCL_LOG_NONE,
                   NCCL_PARAM_FLAG_PUBLISHED | NCCL_PARAM_FLAG_NO_ENVPLUGIN_INIT,
                   ncclParamOneOf<ncclDebugLogLevel>(makeOptions(
                     makeOption("VERSION", NCCL_LOG_VERSION, "Prints the NCCL version info only"),
+                    makeOption("ERROR", NCCL_LOG_ERROR, "Prints only root-cause error messages (ERR)."),
                     makeOption("WARN", NCCL_LOG_WARN, "Prints only messages indicating a fatal error."),
                     makeOption("INFO", NCCL_LOG_INFO, "Prints debug message"),
                     makeOption("ABORT", NCCL_LOG_ABORT, ""),
@@ -86,13 +88,14 @@ DEFINE_NCCL_PARAM(ncclParamDebugTimestampLevel, uint32_t, NCCL_DEBUG_TIMESTAMP_L
                   NCCL_PARAM_FLAG_PUBLISHED | NCCL_PARAM_FLAG_NO_ENVPLUGIN_INIT,
                   ncclParamBitsetOf<uint32_t>(
                     makeOptions(makeOption("VERSION", (1u << NCCL_LOG_VERSION), "on NCCL version info message"),
+                                makeOption("ERROR", (1u << NCCL_LOG_ERROR), "on Root-cause error message"),
                                 makeOption("WARN", (1u << NCCL_LOG_WARN), "on Explicit error message"),
                                 makeOption("INFO", (1u << NCCL_LOG_INFO), "on Debug message"),
                                 makeOption("ABORT", (1u << NCCL_LOG_ABORT), ""),
                                 makeOption("TRACE", (1u << NCCL_LOG_TRACE), "on Replayable trace message"),
                                 makeOption("ALL",
-                                           (1u << NCCL_LOG_VERSION | 1u << NCCL_LOG_WARN | 1u << NCCL_LOG_INFO |
-                                            1u << NCCL_LOG_ABORT | 1u << NCCL_LOG_TRACE),
+                                           (1u << NCCL_LOG_VERSION | 1u << NCCL_LOG_ERROR | 1u << NCCL_LOG_WARN |
+                                            1u << NCCL_LOG_INFO | 1u << NCCL_LOG_ABORT | 1u << NCCL_LOG_TRACE),
                                            "on All messages"))),
                   "Set which log lines get a timestamp depending upon the level of the log");
 
@@ -248,6 +251,10 @@ static void ncclDebugInit() {
 
   ncclEpoch = std::chrono::steady_clock::now();
   ncclDebugMask = ncclParamDebugSubsys();
+
+  // NCCLX -> Enable CTRAN subsystems logging as per NCCL_DEBUG_SUBSYS
+  meta::comms::logger::setSubSystemMask(ncclDebugMask);
+
   COMPILER_ATOMIC_STORE(&ncclDebugLevel, tempNcclDebugLevel, std::memory_order_release);
 }
 
@@ -255,13 +262,13 @@ static void ncclDebugLogV(ncclDebugLogLevel level, unsigned long flags, const ch
                           const char* fmt, va_list vargs) {
   int gotLevel = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire);
 
-  if (ncclDebugNoWarn != 0 && level == NCCL_LOG_WARN) {
+  if (ncclDebugNoWarn != 0 && (level == NCCL_LOG_WARN || level == NCCL_LOG_ERROR)) {
     level = NCCL_LOG_INFO;
     flags = ncclDebugNoWarn;
   }
 
-  // Save the last error (WARN) as a human readable string
-  if (level == NCCL_LOG_WARN) {
+  // Save the last error (ERR/WARN) as a human readable string
+  if (level == NCCL_LOG_WARN || level == NCCL_LOG_ERROR) {
     std::lock_guard<std::mutex> lock(ncclDebugMutex);
     va_list vcopy;
     va_copy(vcopy, vargs);
@@ -273,108 +280,63 @@ static void ncclDebugLogV(ncclDebugLogLevel level, unsigned long flags, const ch
     return;
   }
 
-  std::lock_guard<std::mutex> lock(ncclDebugMutex);
-  if (ncclDebugLevel < 0) ncclDebugInit();
-  if (ncclDebugLevel < level || ((flags & ncclDebugMask) == 0)) {
+  /* The mutex guards ncclDebugInit() and the level/mask read only. Upstream
+   * also holds it across the vfprintf; the sink below is thread-safe and can
+   * block on a synchronous file write, so formatting and emitting stay outside
+   * it — holding it there would serialize all logging and would deadlock if
+   * anything under the sink ever logged back through NCCL.
+   */
+  bool escalateToInfo = false;
+  {
+    std::lock_guard<std::mutex> lock(ncclDebugMutex);
+    /* Atomic even under the lock: the escalation store below deliberately runs
+     * outside it, so the mutex alone does not order these reads against it.
+     */
+    int curLevel = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire);
+    if (curLevel < 0) {
+      ncclDebugInit();
+      curLevel = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire);
+    }
+    if (curLevel < level || ((flags & ncclDebugMask) == 0)) {
+      return;
+    }
+    escalateToInfo = ncclWarnSetDebugInfo && level == NCCL_LOG_WARN;
+  }
+
+  if (escalateToInfo) {
+    COMPILER_ATOMIC_STORE(&ncclDebugLevel, static_cast<int>(NCCL_LOG_INFO), std::memory_order_release);
+  }
+
+  /* NCCLX: hand the message to the Meta sink instead of prefixing and
+   * vfprintf-ing it here. The sink owns the line prefix (timestamp, host, pid,
+   * tid, severity) and the output destination, and additionally fans errors
+   * out to Scuba, so only the call site's own message is formatted below.
+   */
+  /* Stack buffer sized as upstream's, with a heap fallback only when the
+   * message overflows it. Formatting twice unconditionally would double
+   * format-string parsing on every INFO/TRACE line, which is a hot path.
+   */
+  char stackBuf[1024];
+  va_list vcopy;
+  va_copy(vcopy, vargs);
+  const int msgLen = std::vsnprintf(stackBuf, sizeof(stackBuf), fmt, vcopy);
+  va_end(vcopy);
+  if (msgLen < 0) {
     return;
   }
 
-  if (tid == -1) {
-    tid = ncclOsGetTid();
+  const char* message = stackBuf;
+  std::vector<char> heapBuf;
+  if (static_cast<size_t>(msgLen) >= sizeof(stackBuf)) {
+    heapBuf.resize(static_cast<size_t>(msgLen) + 1); // +1 for null terminator
+    va_copy(vcopy, vargs);
+    std::vsnprintf(heapBuf.data(), heapBuf.size(), fmt, vcopy);
+    va_end(vcopy);
+    message = heapBuf.data();
   }
 
-  char buffer[1024];
-  size_t len = 0;
-
-  // WARNs come with an extra newline at the beginning.
-  if (level == NCCL_LOG_WARN) {
-    buffer[len++] = '\n';
-  }
-
-  // Add the timestamp to the buffer if they are turned on for this level.
-  if (ncclDebugTimestampLevels & (1 << level)) {
-    if (ncclDebugTimestampFormat[0] != '\0') {
-      struct timespec ts;
-      clockRealtime(&ts);
-      time_t nowTimeT = ts.tv_sec;
-      long nowNs = ts.tv_nsec;
-      std::tm nowTm;
-      ncclOsLocaltime(&nowTimeT, &nowTm);
-
-      // Add the subseconds portion if it is part of the format.
-      char localTimestampFormat[sizeof(ncclDebugTimestampFormat)];
-      const char* pformat = ncclDebugTimestampFormat;
-      if (ncclDebugTimestampSubsecondsStart != -1) {
-        pformat = localTimestampFormat;   // Need to use the local version which has subseconds
-        memcpy(localTimestampFormat, ncclDebugTimestampFormat, ncclDebugTimestampSubsecondsStart);
-        snprintf(localTimestampFormat + ncclDebugTimestampSubsecondsStart, ncclDebugTimestampSubsecondDigits + 1,
-                 "%0*" PRIu64, ncclDebugTimestampSubsecondDigits,
-                 (uint64_t)(nowNs / (1000000000L / ncclDebugTimestampMaxSubseconds)));
-        strcpy(localTimestampFormat + ncclDebugTimestampSubsecondsStart + ncclDebugTimestampSubsecondDigits,
-               ncclDebugTimestampFormat + ncclDebugTimestampSubsecondsStart + ncclDebugTimestampSubsecondDigits);
-      }
-
-      // Format the time. If it runs out of space, fall back on a simpler format.
-      int adv = std::strftime(buffer + len, sizeof(buffer) - len, pformat, &nowTm);
-      if (adv == 0 && ncclDebugTimestampFormat[0] != '\0') {
-        // Ran out of space. Fall back on the default. This should never fail.
-        adv = std::strftime(buffer + len, sizeof(buffer) - len, "[%F %T] ", &nowTm);
-      }
-      len += adv;
-    }
-  }
-  len = std::min(len, sizeof(buffer) - 1);  // prevent overflows
-
-  // Add hostname, pid and tid portion of the log line.
-  if (level != NCCL_LOG_VERSION) {
-    len += snprintf(buffer + len, sizeof(buffer) - len, "%s:%d:%d ", hostname, pid, tid);
-    len = std::min(len, sizeof(buffer) - 1);  // prevent overflows
-  }
-
-  int cudaDev = 0;
-  if (!(level == NCCL_LOG_TRACE && flags == NCCL_CALL)) {
-    (void)cudaGetDevice(&cudaDev);
-  }
-
-  const char* fileStr = file ? file : "<unknown>";
-  const char* funcStr = func ? func : "<unknown>";
-
-  // Add level specific formatting. The format string from the call site is incorporated into this prefix.
-  if (level == NCCL_LOG_WARN) {
-    if (func && func[0]) {
-      len += snprintf(buffer + len, sizeof(buffer) - len, "[%d] %s:%d (%s) NCCL WARN %s\n", cudaDev, fileStr, line,
-                      funcStr, fmt);
-    } else {
-      len += snprintf(buffer + len, sizeof(buffer) - len, "[%d] %s:%d NCCL WARN %s\n", cudaDev, fileStr, line, fmt);
-    }
-    if (ncclWarnSetDebugInfo) {
-      COMPILER_ATOMIC_STORE(&ncclDebugLevel, static_cast<int>(NCCL_LOG_INFO), std::memory_order_release);
-    }
-  } else if (level == NCCL_LOG_INFO) {
-    len += snprintf(buffer + len, sizeof(buffer) - len, "[%d] NCCL INFO %s\n", cudaDev, fmt);
-  } else if (level == NCCL_LOG_TRACE && flags == NCCL_CALL) {
-    len += snprintf(buffer + len, sizeof(buffer) - len, "NCCL CALL %s\n", fmt);
-  } else if (level == NCCL_LOG_TRACE) {
-    auto delta = std::chrono::steady_clock::now() - ncclEpoch;
-    double timestamp = std::chrono::duration_cast<std::chrono::duration<double>>(delta).count() * 1000;
-    len += snprintf(buffer + len, sizeof(buffer) - len, "[%d] %f %s:%d NCCL TRACE %s\n", cudaDev, timestamp, funcStr,
-                    line, fmt);
-  } else {
-    len += snprintf(buffer + len, sizeof(buffer) - len, "%s\n", fmt);
-  }
-
-  // If the prefixed format string overflows, make sure it is still terminated with a newline.
-  if (len > sizeof(buffer) - 1) {
-    // snprintf already placed a \0 at sizeof(buffer)-1
-    buffer[sizeof(buffer) - 2] = '\n';
-  }
-
-  // Add the message as given by the call site.
-  // The call site's format string has been incorporated into `buffer` along with our prefix.
-  va_list vcopy;
-  va_copy(vcopy, vargs);
-  (void)vfprintf(ncclDebugFile, buffer, vcopy);
-  va_end(vcopy);
+  ncclx::logging::writeNcclLog(level, file ? file : "", func ? func : "", line,
+                               std::string_view(message, static_cast<size_t>(msgLen)));
 }
 
 // Internal only Common logging function used by the INFO, WARN and TRACE macros
@@ -384,6 +346,21 @@ void ncclDebugLogInternal(ncclDebugLogLevel level, unsigned long flags, const ch
   va_start(vargs, fmt);
   ncclDebugLogV(level, flags, file, func, line, fmt, vargs);
   va_end(vargs);
+}
+
+/* Same funnel as ncclDebugLogInternal, under the name the shared Meta code in
+ * comms/ncclx/meta/ links against across ncclx versions.
+ */
+void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char* file, const char* func, int line,
+                      const char* fmt, ...) {
+  va_list vargs;
+  va_start(vargs, fmt);
+  ncclDebugLogV(level, flags, file, func, line, fmt, vargs);
+  va_end(vargs);
+}
+
+void ncclSetMyThreadLoggingName(std::string_view name) {
+  meta::comms::logger::initThreadMetaData(name);
 }
 
 /* Exported ABI logging function exported to the dynamically loadable Net

--- a/comms/ncclx/v2_31/src/dev_runtime.cc
+++ b/comms/ncclx/v2_31/src/dev_runtime.cc
@@ -49,7 +49,7 @@ static ncclResult_t getNcclVersionCompat(int version, struct ncclDevCommCompat**
 
   if (version > NCCL_VERSION_CODE && ncclParamEnableVersionCheck()) {
     char compiledBuf[16], runtimeBuf[16];
-    WARN("NCCL library is too old. This application was compiled with NCCL version %s, but is running with NCCL "
+    ERR(ncclInvalidUsage, "NCCL library is too old. This application was compiled with NCCL version %s, but is running with NCCL "
          "library version %s.",
          ncclVersionToString(version, compiledBuf, sizeof(compiledBuf)),
          ncclVersionToString(NCCL_VERSION_CODE, runtimeBuf, sizeof(runtimeBuf)));
@@ -65,7 +65,7 @@ static ncclResult_t getNcclVersionCompat(int version, struct ncclDevCommCompat**
   }
   if (devCompat == nullptr) {
     char compiledBuf[16], runtimeBuf[16];
-    WARN("NCCL library is not backwards compatible. This application was compiled with NCCL version %s, but is running "
+    ERR(ncclInvalidUsage, "NCCL library is not backwards compatible. This application was compiled with NCCL version %s, but is running "
          "with NCCL library version %s.",
          ncclVersionToString(version, compiledBuf, sizeof(compiledBuf)),
          ncclVersionToString(NCCL_VERSION_CODE, runtimeBuf, sizeof(runtimeBuf)));
@@ -443,7 +443,7 @@ ncclResult_t symTeamObtain(struct ncclComm* comm, struct ncclTeam team, bool mul
 
   if (multimem) {
     if (!comm->nvlsSupport) {
-      WARN("Multicast support requested for team but none available on system.");
+      ERR(ncclInvalidArgument, "Multicast support requested for team but none available on system.");
       ret = ncclInvalidArgument;
       goto fail;
     } else {
@@ -1018,7 +1018,7 @@ ncclResult_t ncclDevrWindowRegisterInGroup(struct ncclComm* comm, void* userPtr,
 
   memOffset = reinterpret_cast<CUdeviceptr>(userPtr) - memAddr;
   if (memOffset % NCCL_WIN_REQUIRED_ALIGNMENT != 0) {
-    WARN("Window address must be suitably aligned.");
+    ERR(ncclInvalidArgument, "Window address must be suitably aligned.");
     ret = ncclInvalidArgument;
     goto fail_locReg;
   }
@@ -1274,18 +1274,18 @@ ncclResult_t ncclDevrCommCreateInternal(struct ncclComm* comm, struct ncclDevCom
 
   bool requestedGinResources = ncclGinResourcesRequested(reqs);
   if (requestedGinResources && requestedConnectionType == NCCL_GIN_CONNECTION_NONE) {
-    WARN("User requested GIN resources but did not request GIN to be enabled!");
+    ERR(ncclInvalidArgument, "User requested GIN resources but did not request GIN to be enabled!");
     return ncclInvalidArgument;
   }
 
   if (requestedConnectionType != NCCL_GIN_CONNECTION_NONE) {
     if (comm->globalGinSupport == NCCL_GIN_CONNECTION_NONE) {
-      WARN("User requested GIN but not all ranks in the communicator support GIN");
+      ERR(ncclInvalidArgument, "User requested GIN but not all ranks in the communicator support GIN");
       return ncclInvalidArgument;
     }
     if (requestedConnectionType == NCCL_GIN_CONNECTION_FULL) {
       if (comm->globalGinSupport == NCCL_GIN_CONNECTION_RAIL) {
-        WARN("User requested GIN connection type NCCL_GIN_CONNECTION_FULL but the communicator supports only "
+        ERR(ncclInvalidArgument, "User requested GIN connection type NCCL_GIN_CONNECTION_FULL but the communicator supports only "
              "NCCL_GIN_CONNECTION_RAIL");
         return ncclInvalidArgument;
       }
@@ -1713,7 +1713,7 @@ ncclResult_t ncclCommQueryProperties(ncclComm_t comm, ncclCommProperties_t* prop
   NCCLCHECK(ncclCommEnsureReady(comm));
 
   if (props->magic != NCCL_API_MAGIC) {
-    WARN("Cannot get communicator properties: ncclCommProperties_t argument must be initialized via "
+    ERR(ncclInvalidUsage, "Cannot get communicator properties: ncclCommProperties_t argument must be initialized via "
          "NCCL_COMM_PROPERTIES_INITIALIZER");
     return ncclInvalidUsage;
   }
@@ -1768,7 +1768,7 @@ ncclResult_t ncclDevCommCreate(ncclComm_t comm, struct ncclDevCommRequirements c
   NCCLCHECK(CommCheck(comm, __func__, "comm"));
   NCCLCHECK(PtrCheck(reqs, __func__, "reqs"));
   if (reqs->magic != NCCL_API_MAGIC) {
-    WARN("Cannot create device communicator: ncclDevCommRequirements_t argument must be initialized via "
+    ERR(ncclInvalidUsage, "Cannot create device communicator: ncclDevCommRequirements_t argument must be initialized via "
          "NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER");
     return ncclInvalidUsage;
   }
@@ -1791,7 +1791,7 @@ ncclResult_t ncclDevCommCreate(ncclComm_t comm, struct ncclDevCommRequirements c
   NCCLCHECK(ncclGroupStartInternal());
 
   if (!comm->symmetricSupport) {
-    WARN("Communicator does not support symmetric memory!");
+    ERR(ncclInvalidUsage, "Communicator does not support symmetric memory!");
     ret = ncclInvalidUsage;
     goto fail;
   }
@@ -1926,7 +1926,7 @@ ncclResult_t ncclWinGetUserPtr(struct ncclComm* comm, struct ncclWindow_vidmem* 
 
   winHost = (struct ncclDevrWindow*)winDevHost->winHost;
   if (winHost == nullptr) {
-    WARN("window has a NULL user pointer");
+    ERR(ncclInternalError, "window has a NULL user pointer");
     return ncclInternalError;
   }
 
@@ -1938,7 +1938,7 @@ ncclResult_t ncclDevrWorldToLsaRank(struct ncclComm* comm, int peerWorldRank, in
   ncclTeam_t worldTeam = ncclTeamWorld(comm);
   ncclTeam_t lsaTeam = ncclTeamLsa(comm);
   if (!ncclTeamRankIsMember(lsaTeam, worldTeam, peerWorldRank)) {
-    WARN("ncclDevrWorldToLsaRank: world rank %d is not a member of the LSA team", peerWorldRank);
+    ERR(ncclInternalError, "ncclDevrWorldToLsaRank: world rank %d is not a member of the LSA team", peerWorldRank);
     return ncclInternalError;
   }
   *peerLsaRank = ncclTeamRankToTeam(lsaTeam, worldTeam, peerWorldRank);
@@ -1993,7 +1993,7 @@ ncclResult_t ncclDevrGetLsaTeamPtrMC(struct ncclComm* comm, struct ncclDevrWindo
   if (winHost == nullptr || outPtr == nullptr) return ncclInternalError;
 
   if (!comm->nvlsSupport) {
-    WARN("Multimem pointer requested but system does not support multimem.");
+    ERR(ncclInvalidUsage, "Multimem pointer requested but system does not support multimem.");
     return ncclInvalidUsage;
   }
 
@@ -2016,7 +2016,7 @@ ncclResult_t findCommAndHostWindowFromDeviceWindow(ncclWindow_t devWindow, ncclC
   std::lock_guard<std::mutex> lock(ncclWindowMapMutex);
   NCCLCHECK(ncclIntruAddressMapFind(&ncclWindowMap, devWindow, &winHost));
   if (winHost == nullptr) {
-    WARN("Could not find communicator matching window %p (map hbits=%d count=%d)", devWindow, ncclWindowMap.base.hbits,
+    ERR(ncclInvalidArgument, "Could not find communicator matching window %p (map hbits=%d count=%d)", devWindow, ncclWindowMap.base.hbits,
          ncclWindowMap.base.count);
     return ncclInvalidArgument;
   }
@@ -2034,7 +2034,7 @@ ncclResult_t ncclGetMultimemDevicePointer(ncclWindow_t window, size_t offset, nc
   NCCLCHECK(PtrCheck(window, __func__, "window"));
   NCCLCHECK(PtrCheck(outPtr, __func__, "outPtr"));
   if (multimem.mcBasePtr == nullptr) {
-    WARN("MCBasePtr %p needs to be valid.", multimem.mcBasePtr);
+    ERR(ncclInvalidArgument, "MCBasePtr %p needs to be valid.", multimem.mcBasePtr);
     return ncclInvalidArgument;
   }
 
@@ -2084,7 +2084,7 @@ ncclResult_t ncclGetLsaDevicePointer(ncclWindow_t window, size_t offset, int lsa
 
   devr = &comm->devrState;
   if (lsaRank < 0 || lsaRank >= devr->lsaSize) {
-    WARN("The provided lsaRank %d is not in the valid lsaSize of [0,%d] for the provided window %p.", lsaRank,
+    ERR(ncclInvalidArgument, "The provided lsaRank %d is not in the valid lsaSize of [0,%d] for the provided window %p.", lsaRank,
          devr->lsaSize, window);
     return ncclInvalidArgument; // In this case the user should know what the lsa size is.
   }
@@ -2110,7 +2110,7 @@ ncclResult_t ncclGetPeerDevicePointer(ncclWindow_t window, size_t offset, int pe
   NCCLCHECK(findCommAndHostWindowFromDeviceWindow(window, &comm, &winHost));
   // Validate peer rank is within bounds
   if (peer < 0 || peer >= comm->nRanks) {
-    WARN("peer %d is not within valid range of ranks %d.", peer, comm->nRanks);
+    ERR(ncclInvalidArgument, "peer %d is not within valid range of ranks %d.", peer, comm->nRanks);
     return ncclInvalidArgument;
   }
 

--- a/comms/ncclx/v2_31/src/dev_runtime_segments.cc
+++ b/comms/ncclx/v2_31/src/dev_runtime_segments.cc
@@ -46,7 +46,7 @@ ncclResult_t ncclDevrCheckRegistrationSupport(void* userPtr, size_t userSize, st
   ncclResult_t ret = ncclSuccess;
   if (hasSysmemSegment) {
     if (!ncclParamElasticBufferRegister()) {
-      WARN("VA represented by {userPtr = %p, size = %zu} contains CPU-backed physical segments, but "
+      ERR(ncclInvalidArgument, "VA represented by {userPtr = %p, size = %zu} contains CPU-backed physical segments, but "
            "NCCL_ELASTIC_BUFFER_REGISTER is set to 0. Please set NCCL_ELASTIC_BUFFER_REGISTER=1 and retry window "
            "registration",
            userPtr, userSize);
@@ -60,7 +60,7 @@ ncclResult_t ncclDevrCheckRegistrationSupport(void* userPtr, size_t userSize, st
                                        comm->cudaDev),
                   ret, exit);
       if (!multiNodeLsaSupported) {
-        WARN("VA represented by {userPtr = %p, size = %zu} contains CPU-backed physical segments, but the LSA team "
+        ERR(ncclInvalidArgument, "VA represented by {userPtr = %p, size = %zu} contains CPU-backed physical segments, but the LSA team "
              "does not support multi-node IPC on CPU-backed buffers. Please retry by setting NCCL_MNNVL_ENABLE=0",
              userPtr, userSize);
         ret = ncclInvalidArgument;

--- a/comms/ncclx/v2_31/src/devcomm/devcomm_v22902.cc
+++ b/comms/ncclx/v2_31/src/devcomm/devcomm_v22902.cc
@@ -106,7 +106,7 @@ static ncclResult_t ncclDevCommRequirementsFilter_v22902(ncclComm_t comm, ncclDe
   }
   if (userRequestedGin) {
     char compiledBuf[16], runtimeBuf[16];
-    WARN("The application was compiled with too old version of NCCL. It was compiled with NCCL version %s, but is "
+    ERR(ncclInvalidUsage, "The application was compiled with too old version of NCCL. It was compiled with NCCL version %s, but is "
          "running with NCCL library version %s. Because of its use of GIN device kernels, it needs to be recompiled, "
          "preferably with the same NCCL version that it will be running with.",
          ncclVersionToString(reqs->version, compiledBuf, sizeof(compiledBuf)),

--- a/comms/ncclx/v2_31/src/devcomm/devcomm_v22907.cc
+++ b/comms/ncclx/v2_31/src/devcomm/devcomm_v22907.cc
@@ -86,7 +86,7 @@ static ncclResult_t ncclDevCommRequirementsFilter_v22907(ncclComm_t comm, ncclDe
   }
   if (requestedGinResources && (reqs->ginConnectionType != NCCL_GIN_CONNECTION_NONE || reqs->ginForceEnable)) {
     char compiledBuf[16], runtimeBuf[16];
-    WARN("The application was compiled with too old version of NCCL. It was compiled with NCCL version %s, but is "
+    ERR(ncclInvalidUsage, "The application was compiled with too old version of NCCL. It was compiled with NCCL version %s, but is "
          "running with NCCL library version %s. Because of its use of GIN device kernels, it needs to be recompiled, "
          "preferably with the same NCCL version that it will be running with.",
          ncclVersionToString(reqs->version, compiledBuf, sizeof(compiledBuf)),

--- a/comms/ncclx/v2_31/src/device/common.cu
+++ b/comms/ncclx/v2_31/src/device/common.cu
@@ -9,7 +9,11 @@
 #include "collectives.h"
 #include "common.h"
 #include "nccl_device.h"
-#include "comm.h"
+// [META] Upstream 2.31 includes "comm.h" here; nothing in this file uses it.
+// NCCLX adds host-only C++ members to ncclComm (folly-backed colltrace, ctran
+// and allocator types), which nvcc cannot parse, so pulling comm.h into a
+// device translation unit breaks the build. v2_29/v2_30 were unaffected because
+// their device/common.cu does not include it. Upstreaming candidate.
 
 __shared__ ncclShmemData ncclShmem;
 #if __CUDA_ARCH__ < 700

--- a/comms/ncclx/v2_31/src/enqueue/enqueue.cc
+++ b/comms/ncclx/v2_31/src/enqueue/enqueue.cc
@@ -110,7 +110,7 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
   }
 
   if (ncclShmemDynamicSize(cudaArch) > maxDynamicSmem) {
-    WARN("cudaArch %d dynamic smem %d exceeds device/fn maxSharedMem %d", cudaArch, ncclShmemDynamicSize(cudaArch),
+    ERR(ncclSystemError, "cudaArch %d dynamic smem %d exceeds device/fn maxSharedMem %d", cudaArch, ncclShmemDynamicSize(cudaArch),
          maxDynamicSmem);
     return ncclSystemError;
   }
@@ -1245,11 +1245,11 @@ static ncclResult_t scheduleP2pTasksToPlan(struct ncclComm* comm, int* p2pEpoch,
 
       if (sendRank == comm->rank) {
         if (send != nullptr && recv == nullptr) {
-          WARN("Trying to send to self without a matching recv");
+          ERR(ncclInvalidUsage, "Trying to send to self without a matching recv");
           return ncclInvalidUsage;
         }
         if (send == nullptr && recv != nullptr) {
-          WARN("Trying to recv to self without a matching send");
+          ERR(ncclInvalidUsage, "Trying to recv to self without a matching send");
           return ncclInvalidUsage;
         }
       }
@@ -2197,7 +2197,7 @@ static ncclResult_t calcCollChunking(struct ncclComm* comm, struct ncclTaskColl*
                                                             ncclPatternRingTwice;
     break;
   default:
-    WARN("Unknown pattern for collective %d algorithm %d", info->func, info->algorithm);
+    ERR(ncclInternalError, "Unknown pattern for collective %d algorithm %d", info->func, info->algorithm);
     return ncclInternalError;
   }
 
@@ -2345,7 +2345,7 @@ static ncclResult_t calcCollChunking(struct ncclComm* comm, struct ncclTaskColl*
     nchunksPerLoop = comm->channels[0].nvls.nHeads;
     break;
   default:
-    WARN("Unknown pattern %d", pattern);
+    ERR(ncclInternalError, "Unknown pattern %d", pattern);
     return ncclInternalError;
   }
 
@@ -2412,7 +2412,7 @@ static ncclResult_t calcCollChunking(struct ncclComm* comm, struct ncclTaskColl*
         proxyOp->loopOffset = 0;
       }
     } else {
-      WARN("Net registration invalid algorithm %s", ncclAlgoToString(info->algorithm));
+      ERR(ncclInternalError, "Net registration invalid algorithm %s", ncclAlgoToString(info->algorithm));
       return ncclInternalError;
     }
 
@@ -2459,7 +2459,7 @@ static ncclResult_t calcCollChunking(struct ncclComm* comm, struct ncclTaskColl*
   case ncclPatternSend:
   case ncclPatternRecv:
   default:
-    WARN("Unknown pattern %d", pattern);
+    ERR(ncclInternalError, "Unknown pattern %d", pattern);
     return ncclInternalError;
   }
 
@@ -2563,7 +2563,7 @@ static ncclResult_t hostToDevRedOp(ncclDevRedOpFull* opFull, ncclRedOp_t op, ncc
     int ix = int(ncclUserRedOpMangle(comm, op)) - int(ncclNumOps);
     ncclUserRedOp* user = &comm->userRedOps[ix];
     if (datatype != user->datatype) {
-      WARN("Data type supplied to user-created ncclRedOp_t does not match type "
+      ERR(ncclInvalidArgument, "Data type supplied to user-created ncclRedOp_t does not match type "
            "given to reduction operation");
       return ncclInvalidArgument;
     }
@@ -2584,7 +2584,7 @@ ncclResult_t ncclPlannerSetCapturingGraph(struct ncclComm* comm, struct ncclInfo
         struct ncclCudaGraph graph;
         NCCLCHECK(ncclCudaGetCapturingGraph(&graph, info->stream, comm->config.graphUsageMode));
         if (planner->streams != nullptr && !ncclCudaGraphSame(planner->capturingGraph, graph)) {
-          WARN("Streams given to a communicator within a NCCL group must either be all uncaptured or all captured by "
+          ERR(ncclInvalidUsage, "Streams given to a communicator within a NCCL group must either be all uncaptured or all captured by "
                "the same graph.");
           return ncclInvalidUsage;
         }
@@ -2890,14 +2890,14 @@ static ncclResult_t rmaTaskAppend(struct ncclComm* comm, struct ncclInfo* info) 
   void const* srcBuff = info->sendbuff;
 
   if (!comm->hostRmaSupport) {
-    WARN("One sided RMA: host RMA is not supported in this communicator.");
+    ERR(ncclInvalidArgument, "One sided RMA: host RMA is not supported in this communicator.");
     return ncclInvalidArgument;
   }
 
   int driverVersion;
   NCCLCHECK(ncclCudaDriverVersion(&driverVersion));
   if (driverVersion < 12050) {
-    WARN("One-sided RMA requires CUDA driver 12.5 or later (found %d.%d).", driverVersion / 1000,
+    ERR(ncclInvalidUsage, "One-sided RMA requires CUDA driver 12.5 or later (found %d.%d).", driverVersion / 1000,
          (driverVersion % 1000) / 10);
     return ncclInvalidUsage;
   }
@@ -2917,7 +2917,7 @@ static ncclResult_t rmaTaskAppend(struct ncclComm* comm, struct ncclInfo* info) 
 
   // Check if flags is valid
   if (info->flags != 0) {
-    WARN("Flags %u is invalid (must be 0)", info->flags);
+    ERR(ncclInvalidArgument, "Flags %u is invalid (must be 0)", info->flags);
     return ncclInvalidArgument;
   }
 
@@ -2929,7 +2929,7 @@ static ncclResult_t rmaTaskAppend(struct ncclComm* comm, struct ncclInfo* info) 
   if (info->coll == ncclFuncPutSignal) {
     // Validate peer window with detailed debugging
     if (info->peerWin == NULL) {
-      WARN("ncclPutSignal: peerWin is NULL");
+      ERR(ncclInvalidArgument, "ncclPutSignal: peerWin is NULL");
       return ncclInvalidArgument;
     }
 
@@ -2939,12 +2939,12 @@ static ncclResult_t rmaTaskAppend(struct ncclComm* comm, struct ncclInfo* info) 
 
     // Validate source buffer and window
     if (srcBuff == NULL) {
-      WARN("ncclPutSignal: srcBuff is NULL");
+      ERR(ncclInvalidArgument, "ncclPutSignal: srcBuff is NULL");
       return ncclInvalidArgument;
     }
     NCCLCHECK(ncclDevrFindWindow(comm, srcBuff, &srcWinHost));
     if (srcWinHost == NULL || !(srcWinHost->winFlags & NCCL_WIN_COLL_SYMMETRIC)) {
-      WARN("ncclPutSignal: srcWinHost is not in a valid symmetric window");
+      ERR(ncclInvalidArgument, "ncclPutSignal: srcWinHost is not in a valid symmetric window");
       return ncclInvalidArgument;
     }
     srcWinOffset = (char*)srcBuff - (char*)srcWinHost->userPtr;
@@ -2953,29 +2953,29 @@ static ncclResult_t rmaTaskAppend(struct ncclComm* comm, struct ncclInfo* info) 
     bool hasSysmemSegment = ncclDevrWindowHasSysmemSegment(srcWinHost) || ncclDevrWindowHasSysmemSegment(peerWinHost);
 
     if (isMultiSegment) {
-      WARN("ncclPutSignal currently does not support VAs backed by multiple physical cuMem segments");
+      ERR(ncclInvalidArgument, "ncclPutSignal currently does not support VAs backed by multiple physical cuMem segments");
       return ncclInvalidArgument;
     }
     if (hasSysmemSegment) {
-      WARN("ncclPutSignal currently does not support VAs with host-backed cuMem segments");
+      ERR(ncclInvalidArgument, "ncclPutSignal currently does not support VAs with host-backed cuMem segments");
       return ncclInvalidArgument;
     }
   } else if (info->coll == ncclFuncSignal) {
     // Check if count is valid
     if (info->count != 0) {
-      WARN("ncclSignal: count must be 0");
+      ERR(ncclInvalidArgument, "ncclSignal: count must be 0");
       return ncclInvalidArgument;
     }
   } else if (info->coll == ncclFuncWaitSignal) {
     // Check if signalDescs is valid
     if (info->signalDescs == NULL || info->nDesc == 0) {
-      WARN("ncclWaitSignal: invalid arguments");
+      ERR(ncclInvalidArgument, "ncclWaitSignal: invalid arguments");
       return ncclInvalidArgument;
     }
     // Validate each descriptor
     for (int i = 0; i < info->nDesc; i++) {
       if (info->signalDescs[i].opCnt <= 0) {
-        WARN("ncclWaitSignal: descriptor %d has invalid opCnt %d", i, info->signalDescs[i].opCnt);
+        ERR(ncclInvalidArgument, "ncclWaitSignal: descriptor %d has invalid opCnt %d", i, info->signalDescs[i].opCnt);
         return ncclInvalidArgument;
       }
       if (info->signalDescs[i].sigIdx < 0 || info->signalDescs[i].sigIdx >= comm->config.numRmaSig) {
@@ -3152,7 +3152,7 @@ static ncclResult_t rawTaskAppend(struct ncclComm* comm, struct ncclInfo* info) 
       put->stream = info->stream;
     } else {
       if (info->count != 0) {
-        WARN("ncclSignal: count must be 0");
+        ERR(ncclInvalidArgument, "ncclSignal: count must be 0");
         return ncclInvalidArgument;
       }
       struct ncclRawTaskSignal* sig = &t->rma.rmaOp.signal;
@@ -3165,12 +3165,12 @@ static ncclResult_t rawTaskAppend(struct ncclComm* comm, struct ncclInfo* info) 
     ncclIntruQueueEnqueue(&rtq->genericQueue, t);
   } else if (info->coll == ncclFuncWaitSignal) {
     if (info->nDesc <= 0 || info->signalDescs == NULL) {
-      WARN("ncclWaitSignal: invalid arguments");
+      ERR(ncclInvalidArgument, "ncclWaitSignal: invalid arguments");
       return ncclInvalidArgument;
     }
     for (int i = 0; i < info->nDesc; i++) {
       if (info->signalDescs[i].opCnt <= 0) {
-        WARN("ncclWaitSignal: descriptor %d has invalid opCnt %d", i, info->signalDescs[i].opCnt);
+        ERR(ncclInvalidArgument, "ncclWaitSignal: descriptor %d has invalid opCnt %d", i, info->signalDescs[i].opCnt);
         return ncclInvalidArgument;
       }
       if (info->signalDescs[i].sigIdx < 0 || info->signalDescs[i].sigIdx >= comm->config.numRmaSig) {
@@ -3205,7 +3205,7 @@ static ncclResult_t rawTaskAppend(struct ncclComm* comm, struct ncclInfo* info) 
     if (info->datatype == ncclFloat8e4m3 || info->datatype == ncclFloat8e5m2) {
       if (comm->minCompCap < 90 &&
           (info->coll == ncclFuncReduce || info->coll == ncclFuncReduceScatter || info->coll == ncclFuncAllReduce)) {
-        WARN("FP8 reduction support begins with sm90 capable devices.");
+        ERR(ncclInvalidArgument, "FP8 reduction support begins with sm90 capable devices.");
         return ncclInvalidArgument;
       }
     }
@@ -3269,7 +3269,7 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
     if (info->datatype == ncclFloat8e4m3 || info->datatype == ncclFloat8e5m2) {
       if (comm->minCompCap < 90 && info->coll != ncclFuncAllGather && info->coll != ncclFuncBroadcast &&
           info->coll != ncclFuncAlltoAll && info->coll != ncclFuncScatter && info->coll != ncclFuncGather) {
-        WARN("FP8 reduction support begins with sm90 capable devices.");
+        ERR(ncclInvalidArgument, "FP8 reduction support begins with sm90 capable devices.");
         return ncclInvalidArgument;
       }
     }
@@ -3477,7 +3477,7 @@ ncclResult_t ncclRedOpCreatePreMulSum(ncclRedOp_t* op, void* scalar, ncclDataTyp
 NCCL_API(ncclResult_t, ncclRedOpDestroy, ncclRedOp_t op, ncclComm_t comm);
 ncclResult_t ncclRedOpDestroy(ncclRedOp_t op, ncclComm_t comm) {
   if (0 <= int(op) && int(op) < int(ncclNumOps)) {
-    WARN("ncclRedOpDestroy : operator is a NCCL builtin.");
+    ERR(ncclInvalidArgument, "ncclRedOpDestroy : operator is a NCCL builtin.");
     return ncclInvalidArgument;
   }
   // int(ncclMaxRedOp) < int(op) will always be false due to the sizes of
@@ -3485,17 +3485,17 @@ ncclResult_t ncclRedOpDestroy(ncclRedOp_t op, ncclComm_t comm) {
   // just as a reminder.
   // coverity[result_independent_of_operands]
   if (int(op) < 0 || int(ncclMaxRedOp) < int(op)) {
-    WARN("ncclRedOpDestroy :  operator is garbage.");
+    ERR(ncclInvalidArgument, "ncclRedOpDestroy :  operator is garbage.");
     return ncclInvalidArgument;
   }
   if (comm == NULL) {
-    WARN("ncclRedOpDestroy : invalid communicator passed.");
+    ERR(ncclInvalidArgument, "ncclRedOpDestroy : invalid communicator passed.");
     return ncclInvalidArgument;
   }
 
   int ix = int(ncclUserRedOpMangle(comm, op)) - int(ncclNumOps);
   if (comm->userRedOpCapacity <= ix || comm->userRedOps[ix].freeNext != -1) {
-    WARN("ncclRedOpDestroy : operator unknown to this communicator.");
+    ERR(ncclInvalidArgument, "ncclRedOpDestroy : operator unknown to this communicator.");
     return ncclInvalidArgument;
   }
   // push to free list

--- a/comms/ncclx/v2_31/src/enqueue/task_prep/task_posttuning.cc
+++ b/comms/ncclx/v2_31/src/enqueue/task_prep/task_posttuning.cc
@@ -326,14 +326,14 @@ static ncclResult_t postTuneRmaTaskAppend(struct ncclComm* comm, const struct nc
   }
 
   if (!comm->hostRmaSupport) {
-    WARN("One sided RMA: host RMA is not supported in this communicator.");
+    ERR(ncclInvalidArgument, "One sided RMA: host RMA is not supported in this communicator.");
     return ncclInvalidArgument;
   }
 
   int driverVersion;
   NCCLCHECK(ncclCudaDriverVersion(&driverVersion));
   if (driverVersion < 12050) {
-    WARN("One-sided RMA requires CUDA driver 12.5 or later (found %d.%d).", driverVersion / 1000,
+    ERR(ncclInvalidUsage, "One-sided RMA requires CUDA driver 12.5 or later (found %d.%d).", driverVersion / 1000,
          (driverVersion % 1000) / 10);
     return ncclInvalidUsage;
   }
@@ -346,7 +346,7 @@ static ncclResult_t postTuneRmaTaskAppend(struct ncclComm* comm, const struct nc
 
   // Check if flags is valid
   if (flags != 0) {
-    WARN("Flags %u is invalid (must be 0)", flags);
+    ERR(ncclInvalidArgument, "Flags %u is invalid (must be 0)", flags);
     return ncclInvalidArgument;
   }
 
@@ -367,7 +367,7 @@ static ncclResult_t postTuneRmaTaskAppend(struct ncclComm* comm, const struct nc
   if (func == ncclFuncPutSignal) {
     // Validate peer window with detailed debugging
     if (peerWin == NULL) {
-      WARN("ncclPutSignal: peerWin is NULL");
+      ERR(ncclInvalidArgument, "ncclPutSignal: peerWin is NULL");
       return ncclInvalidArgument;
     }
 
@@ -377,12 +377,12 @@ static ncclResult_t postTuneRmaTaskAppend(struct ncclComm* comm, const struct nc
 
     // Validate source buffer and window
     if (srcBuff == NULL) {
-      WARN("ncclPutSignal: srcBuff is NULL");
+      ERR(ncclInvalidArgument, "ncclPutSignal: srcBuff is NULL");
       return ncclInvalidArgument;
     }
     NCCLCHECK(ncclDevrFindWindow(comm, srcBuff, &srcWinHost));
     if (srcWinHost == NULL || !(srcWinHost->winFlags & NCCL_WIN_COLL_SYMMETRIC)) {
-      WARN("ncclPutSignal: srcWinHost is not in a valid symmetric window");
+      ERR(ncclInvalidArgument, "ncclPutSignal: srcWinHost is not in a valid symmetric window");
       return ncclInvalidArgument;
     }
     srcWinOffset = (char*)srcBuff - (char*)srcWinHost->userPtr;
@@ -391,23 +391,23 @@ static ncclResult_t postTuneRmaTaskAppend(struct ncclComm* comm, const struct nc
     bool hasSysmemSegment = ncclDevrWindowHasSysmemSegment(srcWinHost) || ncclDevrWindowHasSysmemSegment(peerWinHost);
 
     if (isMultiSegment) {
-      WARN("ncclPutSignal currently does not support VAs backed by multiple physical cuMem segments");
+      ERR(ncclInvalidArgument, "ncclPutSignal currently does not support VAs backed by multiple physical cuMem segments");
       return ncclInvalidArgument;
     }
     if (hasSysmemSegment) {
-      WARN("ncclPutSignal currently does not support VAs with host-backed cuMem segments");
+      ERR(ncclInvalidArgument, "ncclPutSignal currently does not support VAs with host-backed cuMem segments");
       return ncclInvalidArgument;
     }
   } else if (func == ncclFuncWaitSignal) {
     // Check if signalDescs is valid
     if (signalDescs == NULL || nDesc == 0) {
-      WARN("ncclWaitSignal: invalid arguments");
+      ERR(ncclInvalidArgument, "ncclWaitSignal: invalid arguments");
       return ncclInvalidArgument;
     }
     // Validate each descriptor
     for (int i = 0; i < nDesc; i++) {
       if (signalDescs[i].opCnt <= 0) {
-        WARN("ncclWaitSignal: descriptor %d has invalid opCnt %d", i, signalDescs[i].opCnt);
+        ERR(ncclInvalidArgument, "ncclWaitSignal: descriptor %d has invalid opCnt %d", i, signalDescs[i].opCnt);
         return ncclInvalidArgument;
       }
       if (signalDescs[i].sigIdx < 0 || signalDescs[i].sigIdx >= comm->config.numRmaSig) {

--- a/comms/ncclx/v2_31/src/gin/gin_host.cc
+++ b/comms/ncclx/v2_31/src/gin/gin_host.cc
@@ -97,19 +97,19 @@ ncclResult_t ncclGinConnectOnce(struct ncclComm* comm) {
 
   ncclResult_t ret = ncclSuccess;
   if (ncclParamGinEnable() == 0) {
-    WARN("GIN is disabled.");
+    ERR(ncclInternalError, "GIN is disabled.");
     return ncclInternalError;
   }
 
   if (!ginState->supported) {
-    WARN("GIN not supported.");
+    ERR(ncclInvalidUsage, "GIN not supported.");
     return ncclInvalidUsage;
   }
 
   ginState->ginConnectionType = comm->globalGinSupport;
 
   if (!comm->symmetricSupport) {
-    WARN("Communicator does not support symmetric memory!");
+    ERR(ncclInternalError, "Communicator does not support symmetric memory!");
     return ncclInternalError;
   }
 
@@ -149,7 +149,7 @@ ncclResult_t ncclGinConnectOnce(struct ncclComm* comm) {
 
     NCCLCHECKGOTO(backend->ncclGin->devices(&ndev), ret, fail);
     if (ndev <= 0) {
-      WARN("No GIN-capable devices found.");
+      ERR(ncclInternalError, "No GIN-capable devices found.");
       ret = ncclInternalError;
       goto fail;
     }
@@ -449,7 +449,7 @@ ncclResult_t ncclGinDevCommFree(struct ncclComm* comm, struct ncclDevComm const*
   struct ncclGinStateDevComm *dc = ginState->devComms, *prevDc = NULL;
   while (1) {
     if (dc == NULL) {
-      WARN("Dev comm not found\n");
+      ERR(ncclInternalError, "Dev comm not found\n");
       return ncclInternalError;
     }
     if (dc->devHandles[0]->handle == devComm->ginHandles[0]) break;
@@ -509,7 +509,7 @@ ncclResult_t ncclGinRegister(struct ncclComm* comm, void* address, size_t size,
       // Multi-segment GIN registration requires DMABUF support on all GIN connections
       for (int commIdx = 0; commIdx < backend->ginCommCount; commIdx++) {
         if (!(backend->ginProps[commIdx].ptrSupport & NCCL_PTR_DMABUF)) {
-          WARN(
+          ERR(ncclInvalidArgument, 
             "Window registration of addresses that span multiple physical segments requires DMABUF support with GIN.");
           return ncclInvalidArgument;
         }
@@ -520,7 +520,7 @@ ncclResult_t ncclGinRegister(struct ncclComm* comm, void* address, size_t size,
       NCCLCHECK(backend->ncclGin->regMrSym(backend->ginComms[commIdx], address, size, memType, mrFlags,
                                            &ginHostWins[slot], &ginDevWins[slot]));
       if (ginHostWins[slot] == NULL) {
-        WARN("rank %d - GIN Symmetric register failed: buff %p, size %ld", comm->rank, address, size);
+        ERR(ncclSystemError, "rank %d - GIN Symmetric register failed: buff %p, size %ld", comm->rank, address, size);
         return ncclSystemError;
       }
     }

--- a/comms/ncclx/v2_31/src/gin/gin_host_proxy.cc
+++ b/comms/ncclx/v2_31/src/gin/gin_host_proxy.cc
@@ -270,7 +270,7 @@ static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx* ctx, struct ginProxyH
     void* dstHandle = (void*)(uint64_t)gfd->qword[ncclGinProxyGfdDstHandle].dstHandle.dstHandle;
     uint64_t size = gfd->qword[ncclGinProxyGfdHeader].header.size;
     if (!rmaBackend->iget) {
-      WARN("GIN plugin does not support GET");
+      ERR(ncclInvalidUsage, "GIN plugin does not support GET");
       return ncclInvalidUsage;
     }
     NCCLCHECK(rmaBackend->iget(ctx->rmaCtx, hostGpuCtx->contextId, srcOff, srcHandle, size, dstOff, dstHandle,
@@ -280,7 +280,7 @@ static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx* ctx, struct ginProxyH
 
   if (extractOp(gfd) & ncclGinProxyOpFlush) {
     if (!rmaBackend->iflush) {
-      WARN("GIN plugin does not support FLUSH");
+      ERR(ncclInvalidUsage, "GIN plugin does not support FLUSH");
       return ncclInvalidUsage;
     }
     NCCLCHECK(rmaBackend->iflush(ctx->rmaCtx, hostGpuCtx->contextId, ctx->signalsGinHandle, targetRank,

--- a/comms/ncclx/v2_31/src/graph/connect.cc
+++ b/comms/ncclx/v2_31/src/graph/connect.cc
@@ -128,7 +128,7 @@ static ncclResult_t setTreeDown(struct ncclTree* tree, int* indexes, int d) {
   int x = 0;
   while (x < NCCL_MAX_TREE_ARITY && tree->down[x] >= 0) x++;
   if (x == NCCL_MAX_TREE_ARITY) {
-    WARN("Internal error : tree already has %d children (%d %d %d)", x, tree->down[0], tree->down[1], tree->down[2]);
+    ERR(ncclInternalError, "Internal error : tree already has %d children (%d %d %d)", x, tree->down[0], tree->down[1], tree->down[2]);
     return ncclInternalError;
   }
   tree->down[x] = indexes[d];

--- a/comms/ncclx/v2_31/src/graph/paths.cc
+++ b/comms/ncclx/v2_31/src/graph/paths.cc
@@ -29,7 +29,7 @@ static ncclResult_t getPath(struct ncclTopoSystem* system, struct ncclTopoNode* 
       return ncclSuccess;
     }
   }
-  WARN("Could not find node of type %d id %lx", t, id);
+  ERR(ncclInternalError, "Could not find node of type %d id %lx", t, id);
   return ncclInternalError;
 }
 
@@ -120,7 +120,7 @@ static ncclResult_t ncclTopoSetPaths(struct ncclTopoNode* baseNode, struct ncclT
             }
           }
           if (reverseLink == nullptr) {
-            WARN("Failed to find reverse path from remNode %d/%lx nlinks %d to node %d/%lx", remNode->type, remNode->id,
+            ERR(ncclInternalError, "Failed to find reverse path from remNode %d/%lx nlinks %d to node %d/%lx", remNode->type, remNode->id,
                  remNode->nlinks, node->type, node->id);
             return ncclInternalError;
           }
@@ -206,7 +206,7 @@ ncclResult_t ncclGetLocalCpu(struct ncclTopoSystem* system, int gpu, int* cpu) {
   int localCpus[NCCL_TOPO_MAX_NODES], count;
   NCCLCHECK(ncclTopoGetLocal(system, GPU, gpu, CPU, localCpus, &count, NULL));
   if (count == 0) {
-    WARN("Error : could not find CPU close to GPU %d", gpu);
+    ERR(ncclInternalError, "Error : could not find CPU close to GPU %d", gpu);
     return ncclInternalError;
   }
   struct ncclTopoLinkList* paths = system->nodes[GPU].nodes[gpu].paths[CPU];
@@ -420,7 +420,7 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
         if (!good) {
           if (!ncclParamIgnoreDisabledP2p()) {
             if (path->type <= PATH_NVB) {
-              WARN("P2P is disabled between NVLINK connected GPUs %d and %d. This should not be the case given their "
+              ERR(ncclUnhandledCudaError, "P2P is disabled between NVLINK connected GPUs %d and %d. This should not be the case given their "
                    "connectivity, and is probably due to a hardware issue. If you still want to proceed, you can set "
                    "NCCL_IGNORE_DISABLED_P2P=1.",
                    indexes[i - 1], indexes[i - 0]);
@@ -684,7 +684,7 @@ ncclResult_t ncclTopoGetIntermediateRank(struct ncclTopoSystem* system, int rank
       }
     }
     if (node->type != GPU) {
-      WARN("Could not find intermediate GPU between GPU rank %d and NIC %lx", rank, netId);
+      ERR(ncclInternalError, "Could not find intermediate GPU between GPU rank %d and NIC %lx", rank, netId);
       return ncclInternalError;
     }
     NCCLCHECK(ncclTopoDevToRank(system, NCCL_TOPO_ID_SYSTEM_ID(node->id), node->gpu.dev, /*warn=*/true,
@@ -925,7 +925,7 @@ ncclResult_t ncclTopoTrimSystem(struct ncclTopoSystem* system, struct ncclComm* 
       else gpu = NULL;
     }
     if (gpu == NULL) {
-      WARN("Could not find id %lx", ids[i]);
+      ERR(ncclInternalError, "Could not find id %lx", ids[i]);
       ret = ncclInternalError;
       goto fail;
     }

--- a/comms/ncclx/v2_31/src/graph/rings.cc
+++ b/comms/ncclx/v2_31/src/graph/rings.cc
@@ -48,7 +48,7 @@ ncclResult_t ncclBuildRings(int nrings, int* rings, int rank, int nranks, int* p
     snprintf(prefix, sizeof(prefix), "Channel %02d/%02d :", r, nrings);
     if (rank == 0) dumpLine(rings + r * nranks, nranks, prefix);
     if (current != rank) {
-      WARN("Error : ring %d does not loop back to start (%d != %d)", r, current, rank);
+      ERR(ncclInternalError, "Error : ring %d does not loop back to start (%d != %d)", r, current, rank);
       ret = ncclInternalError;
       goto end;
     }
@@ -61,7 +61,7 @@ ncclResult_t ncclBuildRings(int nrings, int* rings, int rank, int nranks, int* p
         continue;
       }
       if ((bits & mask) == 0) {
-        WARN("Error : ring %d does not contain rank %d", r, i);
+        ERR(ncclInternalError, "Error : ring %d does not contain rank %d", r, i);
         ret = ncclInternalError;
         goto end;
       }

--- a/comms/ncclx/v2_31/src/graph/search.cc
+++ b/comms/ncclx/v2_31/src/graph/search.cc
@@ -71,7 +71,7 @@ static ncclResult_t findRevLink(struct ncclTopoNode* node1, struct ncclTopoNode*
       return ncclSuccess;
     }
   }
-  WARN("Could not find rev link for %d/%ld -> %d/%ld", node1->type, node1->id, node2->type, node2->id);
+  ERR(ncclInternalError, "Could not find rev link for %d/%ld -> %d/%ld", node1->type, node1->id, node2->type, node2->id);
   return ncclInternalError;
 }
 
@@ -133,7 +133,7 @@ static ncclResult_t ncclTopoFollowPath(struct ncclTopoSystem* system, struct ncc
   struct ncclTopoNode* node2 = system->nodes[type2].nodes + index2;
 
   if (node1->paths[type2] == nullptr || node2->paths[type1] == nullptr) {
-    WARN("No path computed to go from %s/%d to %s/%d", topoNodeTypeStr[type1], index1, topoNodeTypeStr[type2], index2);
+    ERR(ncclInternalError, "No path computed to go from %s/%d to %s/%d", topoNodeTypeStr[type1], index1, topoNodeTypeStr[type2], index2);
     return ncclInternalError;
   }
 
@@ -227,7 +227,7 @@ static ncclResult_t getGpuIndex(struct ncclTopoSystem* system, int rank, int* in
       return ncclSuccess;
     }
   }
-  WARN("Could not find gpu rank %d", rank);
+  ERR(ncclInternalError, "Could not find gpu rank %d", rank);
   return ncclInternalError;
 }
 
@@ -238,7 +238,7 @@ static ncclResult_t getNetIndex(struct ncclTopoSystem* system, int64_t id, int* 
       return ncclSuccess;
     }
   }
-  WARN("Could not find net id %lx", id);
+  ERR(ncclInternalError, "Could not find net id %lx", id);
   return ncclInternalError;
 }
 
@@ -947,7 +947,7 @@ ncclResult_t ncclTopoGetChannelFromXml(struct ncclXmlNode* xmlChannel, int c, st
           }
         }
         if (rank == -1) {
-          WARN("XML Import Channel : dev %ld not found.", dev);
+          ERR(ncclSystemError, "XML Import Channel : dev %ld not found.", dev);
           return ncclSystemError;
         }
       }
@@ -1017,7 +1017,7 @@ ncclResult_t ncclTopoGetXmlFromChannel(struct ncclTopoGraph* graph, int c, struc
       }
     }
     if (dev == -1) {
-      WARN("XML Export Channel : rank %d not found.", intra[g]);
+      ERR(ncclInternalError, "XML Export Channel : rank %d not found.", intra[g]);
       return ncclInternalError;
     }
     NCCLCHECK(xmlSetAttrLong(node, "dev", dev));

--- a/comms/ncclx/v2_31/src/graph/topo.cc
+++ b/comms/ncclx/v2_31/src/graph/topo.cc
@@ -103,7 +103,7 @@ ncclResult_t ncclTopoGetNode(struct ncclTopoSystem* system, struct ncclTopoNode*
 
 ncclResult_t ncclTopoCreateNode(struct ncclTopoSystem* system, struct ncclTopoNode** node, int type, uint64_t id) {
   if (system->nodes[type].count == NCCL_TOPO_MAX_NODES) {
-    WARN("Error : tried to create too many nodes of type %d", type);
+    ERR(ncclInternalError, "Error : tried to create too many nodes of type %d", type);
     return ncclInternalError;
   }
   struct ncclTopoNode* n = system->nodes[type].nodes + system->nodes[type].count;
@@ -179,7 +179,7 @@ ncclResult_t ncclTopoConnectNodes(struct ncclTopoNode* node, struct ncclTopoNode
     if (link->remNode == remNode && link->type == type) break;
   }
   if (link - node->links == NCCL_TOPO_MAX_LINKS) {
-    WARN("Error : too many Topo links (max %d)", NCCL_TOPO_MAX_LINKS);
+    ERR(ncclInternalError, "Error : too many Topo links (max %d)", NCCL_TOPO_MAX_LINKS);
     return ncclInternalError;
   }
   if (link->remNode == NULL) node->nlinks++;
@@ -244,7 +244,7 @@ ncclResult_t ncclTopoFlattenBcmSwitches(struct ncclTopoSystem* system) {
           if (remNode == pciSwitch) continue;
           // Add link from parent PCI switch -> PCI device
           if (pciSwitch->nlinks == NCCL_TOPO_MAX_LINKS) {
-            WARN("Error : too many Topo links (max %d)", NCCL_TOPO_MAX_LINKS);
+            ERR(ncclInternalError, "Error : too many Topo links (max %d)", NCCL_TOPO_MAX_LINKS);
             ret = ncclInternalError;
             goto fail;
           }
@@ -919,7 +919,7 @@ ncclResult_t ncclTopoAddPciLinks(struct ncclXmlNode* node, struct ncclTopoSystem
     pBusId = NCCL_TOPO_ID(systemId, pBusId);
     NCCLCHECK(ncclTopoGetNode(system, &pci, PCI, pBusId));
     if (pci == NULL) {
-      WARN("Add PCI Link error : could not find PCI SW %lx", pBusId);
+      ERR(ncclInternalError, "Add PCI Link error : could not find PCI SW %lx", pBusId);
       return ncclInternalError;
     }
     struct ncclTopoNode* remote = NULL;
@@ -1014,7 +1014,7 @@ ncclResult_t ncclTopoGetSystemFromXml(struct ncclXml* xml, struct ncclTopoSystem
   while (systemId < system->nHosts && system->hostHashes[systemId] != localHostHash) systemId++;
   system->systemId = systemId;
   if (systemId == system->nHosts) {
-    WARN("localHostHash = 0x%lx not found in the list of system hostHashes", localHostHash);
+    ERR(ncclInvalidArgument, "localHostHash = 0x%lx not found in the list of system hostHashes", localHostHash);
     return ncclInvalidArgument;
   }
 
@@ -1281,7 +1281,7 @@ ncclResult_t ncclTopoMakeUniqueBusId(struct ncclXml* xml, char* busId, struct nc
     i++;
   }
 
-  WARN("TOPO/NET : Couldn't generate unique busId after %d tries", i);
+  ERR(ncclInternalError, "TOPO/NET : Couldn't generate unique busId after %d tries", i);
   return ncclInternalError;
 }
 
@@ -1312,7 +1312,7 @@ ncclResult_t ncclTopoMakePciParent(struct ncclXml* xml, struct ncclXmlNode** par
   if (newBusId == NULL) {
     const char* name;
     NCCLCHECK(xmlGetAttr(physNetNode, "name", &name));
-    WARN("TOPO/NET : Can't find busId of child 0 %s", name);
+    ERR(ncclInternalError, "TOPO/NET : Can't find busId of child 0 %s", name);
     return ncclInternalError;
   }
 
@@ -1322,7 +1322,7 @@ ncclResult_t ncclTopoMakePciParent(struct ncclXml* xml, struct ncclXmlNode** par
 ncclResult_t ncclTopoMakeVnic(struct ncclXml* xml, struct ncclTopoNetInfo* netInfo, ncclNetVDeviceProps_t* vProps,
                               struct ncclXmlNode** physNetNodes) {
   if (vProps->ndevs > netInfo->maxDevsPerNic) {
-    WARN("TOPO/NET : Tried to merge too many NICs. %d > %d", vProps->ndevs, netInfo->maxDevsPerNic);
+    ERR(ncclInternalError, "TOPO/NET : Tried to merge too many NICs. %d > %d", vProps->ndevs, netInfo->maxDevsPerNic);
     return ncclInternalError;
   }
 
@@ -1378,13 +1378,13 @@ ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* net
     }
 
     if (vProps.ndevs != nUserIfs) {
-      WARN("TOPO/NET : Only matched %d devices, %d requested from %s", vProps.ndevs, nUserIfs, semi);
+      ERR(ncclInvalidUsage, "TOPO/NET : Only matched %d devices, %d requested from %s", vProps.ndevs, nUserIfs, semi);
       ret = ncclInvalidUsage;
       goto fail;
     }
 
     if (vProps.ndevs > netInfo->maxDevsPerNic) {
-      WARN("Specified fused NIC %s which has too many devices (%d). Max %d", semi, vProps.ndevs,
+      ERR(ncclInvalidUsage, "Specified fused NIC %s which has too many devices (%d). Max %d", semi, vProps.ndevs,
            netInfo->maxDevsPerNic);
       ret = ncclInvalidUsage;
       goto fail;
@@ -1397,7 +1397,7 @@ ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* net
         placedDevs[vProps.devs[i]] = 1;
       }
     } else {
-      WARN("TOPO/NET : Could not force merge NICs %s. Please specify a valid NCCL_NET_FORCE_MERGE string.", semi);
+      ERR(ncclInvalidUsage, "TOPO/NET : Could not force merge NICs %s. Please specify a valid NCCL_NET_FORCE_MERGE string.", semi);
       ret = ncclInvalidUsage;
       goto fail;
     }
@@ -1454,7 +1454,7 @@ ncclResult_t ncclTopoAutoMerge(struct ncclXml* xml, struct ncclTopoNetInfo* netI
       }
 
       if (vProps.ndevs > netInfo->maxDevsPerNic) {
-        WARN("TOPO/NET : Tried to merge too many NICs. %d > %d", vProps.ndevs, netInfo->maxDevsPerNic);
+        ERR(ncclInternalError, "TOPO/NET : Tried to merge too many NICs. %d > %d", vProps.ndevs, netInfo->maxDevsPerNic);
         return ncclInternalError;
       }
 
@@ -2009,7 +2009,7 @@ ncclResult_t ncclTopoGetLocal(struct ncclTopoSystem* system, int type, int index
     }
     if (paths[i].bw == maxBw && paths[i].type == minType) {
       if (count == NCCL_TOPO_MAX_NODES) {
-        WARN("Error : ran out of room to store found nodes in ncclTopoGetLocal."
+        ERR(ncclInternalError, "Error : ran out of room to store found nodes in ncclTopoGetLocal."
              " Filled %d of type %d, starting from index %d of type %d.",
              NCCL_TOPO_MAX_NODES, resultType, index, type);
         return ncclInternalError;
@@ -2078,7 +2078,7 @@ ncclResult_t ncclTopoGetNetDevsPolicy(enum netDevsPolicy* policy, int* policyNum
   static std::once_flag onceFlag;
   std::call_once(onceFlag, getNetDevsPolicyOnce);
   if (netDevsPolicy == NETDEVS_POLICY_MAX && netDevsPolicyNum <= 0) {
-    WARN("Invalid number of network devices = %d for policy MAX", netDevsPolicyNum);
+    ERR(ncclInternalError, "Invalid number of network devices = %d for policy MAX", netDevsPolicyNum);
     return ncclInternalError;
   }
   if (policy) *policy = netDevsPolicy;
@@ -2097,7 +2097,7 @@ ncclResult_t ncclTopoGetLocalNetType(struct ncclTopoSystem* system, int type, in
   int localNetCount;
   NCCLCHECK(ncclTopoGetLocal(system, GPU, gpu, type, localNets, &localNetCount, NULL));
   if (localNetCount == 0) {
-    WARN("Could not find any local path from gpu %d to net.", gpu);
+    ERR(ncclInternalError, "Could not find any local path from gpu %d to net.", gpu);
     return ncclInternalError;
   }
 

--- a/comms/ncclx/v2_31/src/graph/xml.cc
+++ b/comms/ncclx/v2_31/src/graph/xml.cc
@@ -37,7 +37,7 @@ struct xmlHandler {
 
 ncclResult_t xmlGetChar(FILE* file, char* c) {
   if (fread(c, 1, 1, file) == 0) {
-    WARN("XML Parse : Unexpected EOF");
+    ERR(ncclInternalError, "XML Parse : Unexpected EOF");
     return ncclInternalError;
   }
   return ncclSuccess;
@@ -53,7 +53,7 @@ ncclResult_t xmlGetValue(FILE* file, char* value, char* last) {
       value[o] = c;
       if (o == MAX_STR_LEN - 1) {
         value[o] = '\0';
-        WARN("Error : value %s too long (max %d)", value, MAX_STR_LEN);
+        ERR(ncclInternalError, "Error : value %s too long (max %d)", value, MAX_STR_LEN);
         return ncclInternalError;
       }
       o++;
@@ -63,7 +63,7 @@ ncclResult_t xmlGetValue(FILE* file, char* value, char* last) {
     *last = c;
     return ncclSuccess;
 #else
-    WARN("XML Parse : Expected (double) quote.");
+    ERR(ncclInternalError, "XML Parse : Expected (double) quote.");
     return ncclInternalError;
 #endif
   }
@@ -74,7 +74,7 @@ ncclResult_t xmlGetValue(FILE* file, char* value, char* last) {
     value[o] = c;
     if (o == MAX_STR_LEN - 1) {
       value[o] = '\0';
-      WARN("Error : value %s too long (max %d)", value, MAX_STR_LEN);
+      ERR(ncclInternalError, "Error : value %s too long (max %d)", value, MAX_STR_LEN);
       return ncclInternalError;
     }
     o++;
@@ -93,7 +93,7 @@ ncclResult_t xmlGetToken(FILE* file, char* name, char* value, char* last) {
     if (c == '=') {
       ptr[o] = '\0';
       if (value == NULL) {
-        WARN("XML Parse : Unexpected value with name %s", ptr);
+        ERR(ncclInternalError, "XML Parse : Unexpected value with name %s", ptr);
         return ncclInternalError;
       }
       return xmlGetValue(file, value, last);
@@ -101,7 +101,7 @@ ncclResult_t xmlGetToken(FILE* file, char* name, char* value, char* last) {
     ptr[o] = c;
     if (o == MAX_STR_LEN - 1) {
       ptr[o] = '\0';
-      WARN("Error : name %s too long (max %d)", ptr, MAX_STR_LEN);
+      ERR(ncclInternalError, "Error : name %s too long (max %d)", ptr, MAX_STR_LEN);
       return ncclInternalError;
     }
     o++;
@@ -131,7 +131,7 @@ ncclResult_t xmlSkipComment(FILE* file, char* start, char next) {
   while (strcmp(end, "-->") != 0) {
     int c;
     if (fread(&c, 1, 1, file) != 1) {
-      WARN("XML Parse error : unterminated comment");
+      ERR(ncclInternalError, "XML Parse error : unterminated comment");
       return ncclInternalError;
     }
     SHIFT_APPEND(end, c);
@@ -146,7 +146,7 @@ ncclResult_t xmlGetNode(FILE* file, struct ncclXmlNode* node) {
     if (fread(&c, 1, 1, file) == 0) return ncclSuccess;
   }
   if (c != '<') {
-    WARN("XML Parse error : expecting '<', got '%c'", c);
+    ERR(ncclInternalError, "XML Parse error : expecting '<', got '%c'", c);
     return ncclInternalError;
   }
   // Read XML element name
@@ -164,7 +164,7 @@ ncclResult_t xmlGetNode(FILE* file, struct ncclXmlNode* node) {
     // Re-read the name, we got '/' in the first call
     NCCLCHECK(xmlGetToken(file, node->name, NULL, &c));
     if (c != '>') {
-      WARN("XML Parse error : unexpected trailing %c in closing tag %s", c, node->name);
+      ERR(ncclInternalError, "XML Parse error : unexpected trailing %c in closing tag %s", c, node->name);
       return ncclInternalError;
     }
     return ncclSuccess;
@@ -188,7 +188,7 @@ ncclResult_t xmlGetNode(FILE* file, struct ncclXmlNode* node) {
     NCCLCHECK(xmlGetToken(file, str, NULL, &c));
   }
   if (c != '>') {
-    WARN("XML Parse : expected >, got '%c'", c);
+    ERR(ncclInternalError, "XML Parse : expected >, got '%c'", c);
     return ncclInternalError;
   }
   return ncclSuccess;
@@ -199,7 +199,7 @@ ncclResult_t xmlLoadSub(FILE* file, struct ncclXml* xml, struct ncclXmlNode* hea
   if (head && head->type == NODE_TYPE_SINGLE) return ncclSuccess;
   while (1) {
     if (xml->maxIndex == xml->maxNodes) {
-      WARN("Error : XML parser is limited to %d nodes", xml->maxNodes);
+      ERR(ncclInternalError, "Error : XML parser is limited to %d nodes", xml->maxNodes);
       return ncclInternalError;
     }
     struct ncclXmlNode* node = xml->nodes + xml->maxIndex;
@@ -207,7 +207,7 @@ ncclResult_t xmlLoadSub(FILE* file, struct ncclXml* xml, struct ncclXmlNode* hea
     NCCLCHECK(xmlGetNode(file, node));
     if (node->type == NODE_TYPE_NONE) {
       if (head) {
-        WARN("XML Parse : unterminated %s", head->name);
+        ERR(ncclInternalError, "XML Parse : unterminated %s", head->name);
         return ncclInternalError;
       } else {
         // All done
@@ -216,7 +216,7 @@ ncclResult_t xmlLoadSub(FILE* file, struct ncclXml* xml, struct ncclXmlNode* hea
     }
     if (head && node->type == NODE_TYPE_CLOSE) {
       if (strcmp(node->name, head->name) != 0) {
-        WARN("XML Mismatch : %s / %s", head->name, node->name);
+        ERR(ncclInternalError, "XML Mismatch : %s / %s", head->name, node->name);
         return ncclInternalError;
       }
       return ncclSuccess;
@@ -226,7 +226,7 @@ ncclResult_t xmlLoadSub(FILE* file, struct ncclXml* xml, struct ncclXmlNode* hea
       if (strcmp(node->name, handlers[h].name) == 0) {
         if (head) {
           if (head->nSubs == MAX_SUBS) {
-            WARN("Error : XML parser is limited to %d subnodes", MAX_SUBS);
+            ERR(ncclInternalError, "Error : XML parser is limited to %d subnodes", MAX_SUBS);
             return ncclInternalError;
           }
           head->subs[head->nSubs++] = node;
@@ -391,7 +391,7 @@ ncclResult_t ncclTopoXmlLoadSystem(FILE* file, struct ncclXml* xml, struct ncclX
   int version;
   NCCLCHECK(xmlGetAttrInt(head, "version", &version));
   if (version != NCCL_TOPO_XML_VERSION) {
-    WARN("XML Topology has wrong version %d, %d needed", version, NCCL_TOPO_XML_VERSION);
+    ERR(ncclInvalidUsage, "XML Topology has wrong version %d, %d needed", version, NCCL_TOPO_XML_VERSION);
     return ncclInvalidUsage;
   }
   const char* name;
@@ -475,7 +475,7 @@ ncclResult_t ncclTopoGetXmlFromCpu(struct ncclXmlNode* cpuNode, struct ncclXml* 
     const char* numaId;
     NCCLCHECK(xmlGetAttr(cpuNode, "numaid", &numaId));
     if (numaId == NULL) {
-      WARN("GetXmlFromCpu : could not find CPU numa ID.");
+      ERR(ncclInternalError, "GetXmlFromCpu : could not find CPU numa ID.");
       return ncclInternalError;
     }
     // Set affinity using OS-specific implementation
@@ -870,7 +870,7 @@ ncclResult_t ncclTopoGetXmlFromSys(struct ncclXmlNode* pciNode, struct ncclXml* 
       }
     }
     if (parent->nSubs == MAX_SUBS) {
-      WARN("Error : XML parser is limited to %d subnodes", MAX_SUBS);
+      ERR(ncclInternalError, "Error : XML parser is limited to %d subnodes", MAX_SUBS);
       ret = ncclInternalError;
       goto exit;
     }
@@ -1232,7 +1232,7 @@ ncclResult_t ncclTopoXmlGraphLoadGraphs(FILE* file, struct ncclXml* xmlGraph, st
   int version;
   NCCLCHECK(xmlGetAttrInt(head, "version", &version));
   if (version != NCCL_GRAPH_XML_VERSION) {
-    WARN("XML Graph has wrong version %d, %d needed", version, NCCL_GRAPH_XML_VERSION);
+    ERR(ncclInvalidUsage, "XML Graph has wrong version %d, %d needed", version, NCCL_GRAPH_XML_VERSION);
     return ncclInvalidUsage;
   }
   const char* name;
@@ -1248,7 +1248,7 @@ ncclResult_t ncclTopoXmlGraphLoadGraphs(FILE* file, struct ncclXml* xmlGraph, st
 ncclResult_t ncclTopoGetXmlGraphFromFile(const char* xmlGraphFile, struct ncclXml* xml) {
   FILE* file = fopen(xmlGraphFile, "r");
   if (file == NULL) {
-    WARN("Could not open XML graph file %s : %s", xmlGraphFile, strerror(errno));
+    ERR(ncclSystemError, "Could not open XML graph file %s : %s", xmlGraphFile, strerror(errno));
     return ncclSystemError;
   }
   struct xmlHandler handlers[] = {{"graphs", ncclTopoXmlGraphLoadGraphs}};

--- a/comms/ncclx/v2_31/src/group.cc
+++ b/comms/ncclx/v2_31/src/group.cc
@@ -59,7 +59,7 @@ ncclResult_t ncclAsyncLaunch(struct ncclAsyncJob* job, ncclResult_t (*func)(stru
       /* first met communicator */
       ncclGroupBlocking = comm->config.blocking;
     } else if (ncclGroupBlocking != comm->config.blocking) {
-      WARN("Blocking and nonblocking communicators are not allowed in the same group.");
+      ERR(ncclInvalidArgument, "Blocking and nonblocking communicators are not allowed in the same group.");
       ret = ncclInvalidArgument;
     }
     if (ret == ncclSuccess) {
@@ -449,7 +449,7 @@ ncclResult_t doLaunches(struct ncclComm* head, int taskType) {
       // We have entered barriers but are aborting without leaving them. Thus
       // these comms are permanently trashed. We need a good mechanism for
       // tracking and reporting that.
-      WARN("Either none or all communicators in a ncclGroup() can be CUDA graph captured.");
+      ERR(ncclInvalidUsage, "Either none or all communicators in a ncclGroup() can be CUDA graph captured.");
       result = ncclInvalidUsage;
       goto failure;
     }
@@ -1033,7 +1033,7 @@ ncclResult_t ncclGroupEndInternal(ncclSimInfo_t* simInfo) {
   internalSimInfo.magic = 0;
 
   if (ncclGroupDepth == 0) {
-    WARN("ncclGroupEnd: not in a group call.");
+    ERR(ncclInvalidUsage, "ncclGroupEnd: not in a group call.");
     ret = ncclInvalidUsage;
     goto exit;
   }
@@ -1054,7 +1054,7 @@ ncclResult_t ncclGroupEndInternal(ncclSimInfo_t* simInfo) {
     realSize = realSize > sizeof(ncclSimInfo_t) ? sizeof(ncclSimInfo_t) : realSize;
     memcpy((void*)&internalSimInfo, (void*)simInfo, realSize);
     if (internalSimInfo.magic != 0x74685283) {
-      WARN("ncclSimInfo_t argument not initialized via NCCL_SIM_INFO_INITIALIZER");
+      ERR(ncclInvalidArgument, "ncclSimInfo_t argument not initialized via NCCL_SIM_INFO_INITIALIZER");
       ret = ncclInvalidArgument;
       goto fail;
     }

--- a/comms/ncclx/v2_31/src/include/checks.h
+++ b/comms/ncclx/v2_31/src/include/checks.h
@@ -10,12 +10,38 @@
 
 #include "debug.h"
 
+constexpr const char* ncclCodeToString(ncclResult_t code) {
+  switch (code) {
+  case ncclSuccess:
+    return "no error";
+  case ncclUnhandledCudaError:
+    return "unhandled cuda error (run with NCCL_DEBUG=INFO for details)";
+  case ncclSystemError:
+    return "unhandled system error (run with NCCL_DEBUG=INFO for details)";
+  case ncclInternalError:
+    return "internal error - please report this issue to the NCCL developers";
+  case ncclInvalidArgument:
+    return "invalid argument (run with NCCL_DEBUG=WARN for details)";
+  case ncclInvalidUsage:
+    return "invalid usage (run with NCCL_DEBUG=WARN for details)";
+  case ncclRemoteError:
+    return "remote process exited or there was a network error";
+  case ncclInProgress:
+    return "NCCL operation in progress";
+  case ncclTimeout:
+    return "NCCL operation timed out";
+  case ncclNumResults:
+  default:
+    return "unknown result code";
+  }
+}
+
 // Check CUDA RT calls
 #define CUDACHECK(cmd) \
   do { \
     cudaError_t err = cmd; \
     if (err != cudaSuccess) { \
-      WARN("Cuda failure '%s'", cudaGetErrorString(err)); \
+      ERR(ncclUnhandledCudaError, "Cuda failure '%s'", cudaGetErrorString(err)); \
       (void)cudaGetLastError(); \
       return ncclUnhandledCudaError; \
     } \
@@ -25,12 +51,34 @@
   do { \
     cudaError_t err = cmd; \
     if (err != cudaSuccess) { \
-      WARN("Cuda failure '%s'", cudaGetErrorString(err)); \
+      ERR(ncclUnhandledCudaError, "Cuda failure '%s'", cudaGetErrorString(err)); \
       (void)cudaGetLastError(); \
       RES = ncclUnhandledCudaError; \
       goto label; \
     } \
   } while (false)
+
+// Use of abort should be aware of potential memory leak risk
+// and place a signal handler to catch it and trigger termination processing
+#define CUDACHECKABORT(cmd) \
+  do { \
+    cudaError_t err = cmd; \
+    if (err != cudaSuccess) { \
+      ERR(ncclUnhandledCudaError, "Cuda failure '%s'", cudaGetErrorString(err)); \
+      abort(); \
+    } \
+  } while (false)
+
+// fmt is required: WARN expands to a printf-format function, so an
+// argument-less CHECKABORT would expand to a format-less WARN.
+#define CHECKABORT(statement, fmt, ...) \
+  do { \
+    if (!(statement)) { \
+      WARN("Check failed: %s", #statement); \
+      WARN(fmt, ##__VA_ARGS__); \
+      abort(); \
+    } \
+  } while (0)
 
 // Report failure but clear error and continue
 #define CUDACHECKIGNORE(cmd) \
@@ -60,7 +108,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
     int retval; \
     SYSCHECKSYNC((statement), name, retval); \
     if (retval == -1) { \
-      WARN("Call to " name " failed: %s", strerror(errno)); \
+      ERR(ncclSystemError, "Call to " name " failed: %s", strerror(errno)); \
       return ncclSystemError; \
     } \
   } while (false)
@@ -80,7 +128,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
     int retval; \
     SYSCHECKSYNC((statement), name, retval); \
     if (retval == -1) { \
-      WARN("Call to " name " failed: %s", strerror(errno)); \
+      ERR(ncclSystemError, "Call to " name " failed: %s", strerror(errno)); \
       RES = ncclSystemError; \
       goto label; \
     } \
@@ -91,7 +139,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   do { \
     int retval = (statement); \
     if (retval != 0) { \
-      WARN("Call to " name " failed: %s", strerror(retval)); \
+      ERR(ncclSystemError, "Call to " name " failed: %s", strerror(retval)); \
       return ncclSystemError; \
     } \
   } while (0)
@@ -100,7 +148,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   do { \
     int retval = (statement); \
     if (retval != 0) { \
-      WARN("Call to " name " failed: %s", strerror(retval)); \
+      ERR(ncclSystemError, "Call to " name " failed: %s", strerror(retval)); \
       RES = ncclSystemError; \
       goto label; \
     } \
@@ -110,7 +158,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   do { \
     if ((statement) != value) { \
       /* Print the back trace*/ \
-      INFO_LOC(NCCL_ALL, "-> %d (%s)", ncclSystemError, strerror(errno)); \
+      ERR(ncclSystemError, "-> %d (%s)", ncclSystemError, strerror(errno)); \
       return ncclSystemError; \
     } \
   } while (0)
@@ -120,7 +168,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
     if ((statement) != value) { \
       /* Print the back trace*/ \
       RES = ncclSystemError; \
-      INFO_LOC(NCCL_ALL, "-> %d (%s)", RES, strerror(errno)); \
+      ERR(ncclSystemError, "-> %d (%s)", RES, strerror(errno)); \
       goto label; \
     } \
   } while (0)
@@ -129,7 +177,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   do { \
     if ((statement) == value) { \
       /* Print the back trace*/ \
-      INFO_LOC(NCCL_ALL, "-> %d (%s)", ncclSystemError, strerror(errno)); \
+      ERR(ncclSystemError, "-> %d (%s)", ncclSystemError, strerror(errno)); \
       return ncclSystemError; \
     } \
   } while (0)
@@ -139,7 +187,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
     if ((statement) == value) { \
       /* Print the back trace*/ \
       RES = ncclSystemError; \
-      INFO_LOC(NCCL_ALL, "-> %d (%s)", RES, strerror(errno)); \
+      ERR(ncclSystemError, "-> %d (%s)", RES, strerror(errno)); \
       goto label; \
     } \
   } while (0)
@@ -150,7 +198,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
     ncclResult_t RES = call; \
     if (RES != ncclSuccess && RES != ncclInProgress) { \
       /* Print the back trace*/ \
-      if (ncclDebugNoWarn == 0) INFO_LOC(NCCL_ALL, "-> %d", RES); \
+      if (ncclDebugNoWarn == 0) WARN("-> %d", RES); \
       return RES; \
     } \
   } while (0)
@@ -160,7 +208,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
     RES = call; \
     if (RES != ncclSuccess && RES != ncclInProgress) { \
       /* Print the back trace*/ \
-      if (ncclDebugNoWarn == 0) INFO_LOC(NCCL_ALL, "-> %d", RES); \
+      if (ncclDebugNoWarn == 0) WARN("-> %d", RES); \
       goto label; \
     } \
   } while (0)
@@ -171,7 +219,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   do { \
     ncclResult_t TMPRES = call; \
     if (TMPRES != ncclSuccess && TMPRES != ncclInProgress) { \
-      if (ncclDebugNoWarn == 0) INFO_LOC(NCCL_ALL, "-> %d", TMPRES); \
+      if (ncclDebugNoWarn == 0) WARN("-> %d (%s)", TMPRES, ncclCodeToString(TMPRES)); \
       if (RES == ncclSuccess) RES = TMPRES; \
     } \
   } while (0)
@@ -198,7 +246,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
     uint32_t* tmpAbortFlag = (abortFlagPtr); \
     ncclResult_t RES = call; \
     if (RES != ncclSuccess && RES != ncclInProgress) { \
-      if (ncclDebugNoWarn == 0) INFO_LOC(NCCL_ALL, "-> %d", RES); \
+      if (ncclDebugNoWarn == 0) WARN("-> %d", RES); \
       return ncclInternalError; \
     } \
     if (COMPILER_ATOMIC_LOAD(tmpAbortFlag, std::memory_order_acquire)) NEQCHECK(*tmpAbortFlag, 0); \
@@ -209,7 +257,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
     uint32_t* tmpAbortFlag = (abortFlagPtr); \
     RES = call; \
     if (RES != ncclSuccess && RES != ncclInProgress) { \
-      if (ncclDebugNoWarn == 0) INFO_LOC(NCCL_ALL, "-> %d", RES); \
+      if (ncclDebugNoWarn == 0) WARN("-> %d", RES); \
       goto label; \
     } \
     if (COMPILER_ATOMIC_LOAD(tmpAbortFlag, std::memory_order_acquire)) NEQCHECKGOTO(*tmpAbortFlag, 0, RES, label); \
@@ -218,7 +266,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
 #define NCCLCHECKTHREAD(a, args) \
   do { \
     if (((args)->ret = (a)) != ncclSuccess && (args)->ret != ncclInProgress) { \
-      INFO_LOC(NCCL_INIT, "-> %d [Async thread]", (args)->ret); \
+      WARN("-> %d [Async thread]", (args)->ret); \
       return args; \
     } \
   } while (0)
@@ -227,7 +275,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   do { \
     cudaError_t err = (a); \
     if (err != cudaSuccess) { \
-      INFO_LOC(NCCL_INIT, "-> %d [Async thread]", (int)(err)); \
+      ERR(ncclUnhandledCudaError, "Cuda failure '%s' [Async thread]", cudaGetErrorString(err)); \
       args->ret = ncclUnhandledCudaError; \
       return args; \
     } \

--- a/comms/ncclx/v2_31/src/include/comm.h
+++ b/comms/ncclx/v2_31/src/include/comm.h
@@ -36,6 +36,28 @@
 #include "gin/gin_host_win_stub.h"
 #endif
 
+// [META] NCCLX state on ncclComm and its dependencies.
+#include <optional>
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/utils/colltrace/AlgoStats.h"
+#include "comms/utils/colltrace/CollTraceInterface.h"
+#include "comms/ctran/memory/SlabAllocator.h"
+#include "comms/ctran/memory/memCacheAllocator.h"
+#include "comms/utils/commSpecs.h"
+
+// Forward declarations of ncclx classes to avoid circular dependencies
+class ICtran;
+namespace meta::comms {
+class IBootstrap;
+} // namespace meta::comms
+namespace ncclx {
+class CommStateX;
+} // namespace ncclx
+namespace ncclx::transport {
+class TransportProxy;
+} // namespace ncclx::transport
+
 #if CUDART_VERSION < 9000
 struct cudaLaunchParams {
   void* func;
@@ -391,6 +413,14 @@ struct ncclKernelPlan {
   void* groupApiEventHandle;
   void* kernelLaunchEventHandle;
   void* groupEventHandle;
+
+  // [META] Pointer of a hashmap to store the connection information of peers;
+  // the usage is in transportConnect.cc
+  std::shared_ptr<void> peerReconnInfoMap{nullptr};
+  // buffer keys used in plan, used to reserve and release buffers
+  std::vector<std::string> bufKeys;
+  // pointer to be used to synchronize with the kernel for the current plan
+  uint64_t* channelsReadyPtr{nullptr};
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -539,6 +569,10 @@ struct ncclKernelPlanner {
   struct ncclIntruQueue<struct ncclKernelPlan, &ncclKernelPlan::next> planQueue;
   // First of the unlaunched kernels in `planQueue`
   struct ncclKernelPlan* unlaunchedPlansHead;
+  // [META] track number of channels that need to be initialized in current plan
+  int nMaxChannelsNeedInit{0};
+  // [META] track number of channels each algorithm needs to connect in current plan
+  std::array<int, NCCL_NUM_ALGORITHMS> algoMaxChannelsNeedConnect{0};
 };
 
 #define NCCL_MAGIC 0x0280028002800280 // Nickel atomic number is 28.
@@ -603,6 +637,21 @@ struct ncclComm {
   bool runtimeConn; // if dynamic connection is supported
   bool directMode; // if any process manages more than one local rank
   int cuMemSupport;
+
+  // [META] NCCLX supports storing channel metadata on the pinned host memory.
+  // See the description of NCCL_CHANNEL_METADATA_LOCATION for details
+  bool channelMetadataOnHost{false};
+  // if channels can/will be setup lazily for this communicator
+  bool lazySetupChannels{false};
+  // number of channels that are initialized and ready for use
+  int nChannelsReady{0};
+  // number of channels that are connected for each algorithm
+  std::array<int, NCCL_NUM_ALGORITHMS> algoConnectedChannels{0};
+  // metadata to be used for initializing channels lazily if enabled
+  std::optional<struct ncclKernelCommAndChannels*> devCommAndChans{std::nullopt};
+  std::optional<std::vector<int>> rings{std::nullopt};
+  // Slab Allocator for baseline initChannel metadata allocation
+  std::unique_ptr<ncclx::memory::SlabAllocator> slabAllocator{nullptr};
 
   uint64_t magic; // Magic number for all network communication. Not a security key -- only goal is to detect
                   // mismatches.
@@ -834,6 +883,29 @@ struct ncclComm {
 
   struct ncclDevrState devrState; // The symmetric runtime state
   struct ncclSymkState symkState; // The symmetric kernels state (built on previous)
+  int* rackSerials{nullptr};
+
+  /**
+   * NCCLX specific state
+   */
+  struct CommLogData logMetaData;
+  std::shared_ptr<meta::comms::colltrace::ICollTrace> newCollTrace;
+  std::shared_ptr<meta::comms::colltrace::AlgoStats> algoStats;
+  std::shared_ptr<meta::comms::IBootstrap> ctranBootstrap;
+  std::shared_ptr<ncclx::memory::memCacheAllocator> memCache{nullptr};
+  std::vector<std::string> connSetupBufKeys;
+  std::shared_ptr<ncclx::transport::TransportProxy> transportProxy_;
+
+  // This is the only bridge between ctran and baseline code
+  bool useCtran_{false}; // Ctran per-communicator control; set at init entry functions
+  std::unique_ptr<CtranComm> ctranComm_;
+
+  // [META:PAT_AVG] per-communicator control; set at init entry functions
+  // When enabled, forces PAT algorithm with ncclDevPatSumPostDiv for ReduceScatter with ncclAvg
+  bool usePatAvg_{false};
+
+  // Disable local transports (P2P and SHM); forces NET for all connections
+  bool noLocal_{false};
 
   struct ncclMemManager* memManager;  // Memory manager
   struct ncclIntruQueue<struct ncclMemManagerTask, &ncclMemManagerTask::next> suspendTaskQueue;
@@ -842,9 +914,13 @@ struct ncclComm {
   uint64_t endMagic;
 };
 
-static_assert(offsetof(struct ncclComm, startMagic) == 0, "startMagic must be the first field of ncclComm");
-static_assert(offsetof(struct ncclComm, endMagic) == sizeof(struct ncclComm) - sizeof(uint64_t),
-              "endMagic must be the last field of ncclComm");
+// [META] ncclComm now holds std::shared_ptr / std::unique_ptr / std::optional
+// members, so it is no longer standard-layout and offsetof() on it is not
+// portable. The invariant still holds by construction: startMagic is the first
+// declared field and endMagic the last.
+// static_assert(offsetof(struct ncclComm, startMagic) == 0, "startMagic must be the first field of ncclComm");
+// static_assert(offsetof(struct ncclComm, endMagic) == sizeof(struct ncclComm) - sizeof(uint64_t),
+//               "endMagic must be the last field of ncclComm");
 
 enum ncclLaunchMode {
   ncclLaunchModeInvalid = 0,
@@ -953,6 +1029,28 @@ static inline ncclRedOp_t ncclUserRedOpMangle(ncclComm* comm, ncclRedOp_t op) {
 
 ncclResult_t ncclCommEnsureReady(ncclComm_t comm);
 ncclResult_t ncclCommSetAsyncError(ncclComm_t comm, ncclResult_t nextState);
+
+// [META] record how many interNode/intraNode connections are made in one
+// ncclTransportP2pConnect call
+struct connectionSummary {
+  int intraSend = 0;
+  int intraRecv = 0;
+  int interSend = 0;
+  int interRecv = 0;
+
+  std::string toString() {
+    std::ostringstream oss;
+    oss << "intraSends: " << intraSend << " intraRecvs: " << intraRecv << " interSends: " << interSend
+        << " interRecvs: " << interRecv;
+    return oss.str();
+  }
+};
+
+// [META] Check whether we should skip NCCL internal resource destroy (i.e.,
+// ncclCommAbort has been called with COMM_ABORT_SCOPE == none or job). This
+// allows any destructors automatically triggered by process termination to
+// skip resource cleanup and leak check.
+bool skipDestroy();
 
 // Process-wide NCCL_CTA_POLICY env override, or NCCL_CONFIG_UNDEF_INT when unset/invalid.
 int ncclGetEnvCtaPolicy();

--- a/comms/ncclx/v2_31/src/include/debug.h
+++ b/comms/ncclx/v2_31/src/include/debug.h
@@ -11,6 +11,7 @@
 #include "nccl.h"
 #include "nccl_common.h"
 #include <stdio.h>
+#include <string_view>
 #include <thread>
 #include "compiler.h"
 
@@ -43,12 +44,30 @@ void ncclDebugLogInternal(ncclDebugLogLevel level, unsigned long flags, const ch
                           const char* fmt, ...);
 #endif
 
+/* Same signature and behaviour as ncclDebugLogInternal, kept as a separate
+ * symbol because the shared (version-independent) Meta code under
+ * comms/ncclx/meta/ links against this name across v2_29/v2_30/v2_31.
+ */
+void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char* file, const char* func, int line,
+                      const char* fmt, ...) __attribute__((format(printf, 6, 7)));
+
+/* Root-cause error log. Carries the ncclResult_t, so it can write the Scuba
+ * error record and set ncclGetLastError() state at the origin site rather than
+ * at every propagating check-macro layer. Defined in
+ * comms/ncclx/meta/logger/DebugExt.cc.
+ */
+void ncclMetaDebugLogError(ncclResult_t code, unsigned long flags, const char* file, const char* func, int line,
+                           const char* fmt, ...) __attribute__((format(printf, 6, 7)));
+
+void ncclSetMyThreadLoggingName(std::string_view name);
+
 // Let code temporarily downgrade WARN into INFO
 extern thread_local int ncclDebugNoWarn;
 extern char ncclLastError[];
 
-#define VERSION(...) ncclDebugLogInternal(NCCL_LOG_VERSION, NCCL_ALL, nullptr, nullptr, 0, __VA_ARGS__)
+#define VERSION(...) ncclDebugLogInternal(NCCL_LOG_VERSION, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
 #define WARN(...) ncclDebugLogInternal(NCCL_LOG_WARN, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define ERR(code, ...) ncclMetaDebugLogError((code), NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
 
 #define NOWARN(EXPR, FLAGS) \
   do { \
@@ -62,7 +81,7 @@ extern char ncclLastError[];
   do { \
     int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
     if ((level >= NCCL_LOG_INFO && ((FLAGS) & ncclDebugMask)) || (level < 0)) \
-      ncclDebugLogInternal(NCCL_LOG_INFO, (FLAGS), nullptr, nullptr, 0, __VA_ARGS__); \
+      ncclDebugLogInternal(NCCL_LOG_INFO, (FLAGS), __FILE__, __func__, __LINE__, __VA_ARGS__); \
   } while (0)
 
 #define INFO_LOC_FN(FLAGS, file, line, fn, fmt, ...) \
@@ -73,7 +92,7 @@ extern char ncclLastError[];
   do { \
     int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
     if ((level >= NCCL_LOG_TRACE && (NCCL_CALL & ncclDebugMask)) || (level < 0)) { \
-      ncclDebugLogInternal(NCCL_LOG_TRACE, NCCL_CALL, nullptr, __func__, __LINE__, __VA_ARGS__); \
+      ncclDebugLogInternal(NCCL_LOG_TRACE, NCCL_CALL, __FILE__, __func__, __LINE__, __VA_ARGS__); \
     } \
   } while (0)
 
@@ -82,7 +101,7 @@ extern char ncclLastError[];
   do { \
     int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
     if ((level >= NCCL_LOG_TRACE && ((FLAGS) & ncclDebugMask)) || (level < 0)) { \
-      ncclDebugLogInternal(NCCL_LOG_TRACE, (FLAGS), nullptr, __func__, __LINE__, __VA_ARGS__); \
+      ncclDebugLogInternal(NCCL_LOG_TRACE, (FLAGS), __FILE__, __func__, __LINE__, __VA_ARGS__); \
     } \
   } while (0)
 #define TRACE_LOC_FN(FLAGS, file, line, fn, fmt, ...) \
@@ -93,6 +112,19 @@ extern char ncclLastError[];
 #define TRACE_LOC_FN(FLAGS, file, line, fn, fmt, ...)
 #define TRACE_LOC(FLAGS, fmt, ...)
 #endif
+
+#define NCCL_NAMED_THREAD_START(threadName) \
+  do { \
+    ncclSetMyThreadLoggingName(threadName); \
+    INFO(NCCL_INIT, "[NCCL THREAD] Starting %s thread at %s", threadName, __func__); \
+  } while (0)
+
+#define NCCL_NAMED_THREAD_START_EXT(threadName, rank, commHash, commDesc) \
+  do { \
+    ncclSetMyThreadLoggingName(threadName); \
+    INFO(NCCL_INIT, "[NCCL THREAD] Starting %s thread for rank %d commHash %lx commDesc %s at %s", threadName, rank, \
+         commHash, commDesc.c_str(), __func__); \
+  } while (0)
 
 void ncclSetThreadName(std::thread& thread, const char* fmt, ...);
 #ifdef __cplusplus

--- a/comms/ncclx/v2_31/src/include/nccl_common.h
+++ b/comms/ncclx/v2_31/src/include/nccl_common.h
@@ -27,10 +27,11 @@ typedef SSIZE_T ssize_t;
 typedef enum {
   NCCL_LOG_NONE = 0,
   NCCL_LOG_VERSION = 1,
-  NCCL_LOG_WARN = 2,
-  NCCL_LOG_INFO = 3,
-  NCCL_LOG_ABORT = 4,
-  NCCL_LOG_TRACE = 5
+  NCCL_LOG_ERROR = 2,
+  NCCL_LOG_WARN = 3,
+  NCCL_LOG_INFO = 4,
+  NCCL_LOG_ABORT = 5,
+  NCCL_LOG_TRACE = 6
 } ncclDebugLogLevel;
 
 typedef enum {

--- a/comms/ncclx/v2_31/src/include/param.h
+++ b/comms/ncclx/v2_31/src/include/param.h
@@ -30,4 +30,6 @@ int64_t ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, i
     return cache; \
   }
 
+void initNcclLogger();
+
 #endif

--- a/comms/ncclx/v2_31/src/include/param/param.h
+++ b/comms/ncclx/v2_31/src/include/param/param.h
@@ -38,8 +38,8 @@
   namespace key_guards { \
   struct guard_##key {}; \
   }; \
-  extern constexpr char name##Key[] = #key; \
-  ncclParam<type> name{name##Key, default, parser, #type, flags, desc};
+  NCCL_PARAM_COMPILER_EXPORT_SYMBOL extern constexpr char name##Key[] = #key; \
+  NCCL_PARAM_COMPILER_EXPORT_SYMBOL ncclParam<type> name{name##Key, default, parser, #type, flags, desc};
 
 // Usage: USE_NCCL_PARAM(name, type)
 // name and type must match the DEFINE_NCCL_PARAM.

--- a/comms/ncclx/v2_31/src/include/param/param_registry.h
+++ b/comms/ncclx/v2_31/src/include/param/param_registry.h
@@ -18,7 +18,7 @@
 
 // C-linkage singleton accessor — exported as "ncclParamRegistryInstance"
 // Returns a process-wide RegistryState so map and mutex share identity across DSOs.
-extern "C" void* ncclParamRegistryInstance();
+extern "C" NCCL_PARAM_COMPILER_EXPORT_SYMBOL void* ncclParamRegistryInstance();
 
 // ncclParamRegistry is a global singleton list of all parameters. Parameters
 // defined through the DEFINE_NCCL_PARAM macro are automatically registered here

--- a/comms/ncclx/v2_31/src/include/param/utils.h
+++ b/comms/ncclx/v2_31/src/include/param/utils.h
@@ -32,8 +32,15 @@
 
 // Compiler detection macros
 #if defined(__GNUC__) || defined(__clang__)
+// Default visibility is required for the param registry's cross-DSO contract (see
+// param_registry.h): the fbcode Buck build compiles with -fvisibility=hidden and applies no
+// linker version script, so without this the accessor is hidden and each DSO that statically
+// links NCCLX gets its own registry. Upstream instead relies on its Makefile libnccl.map
+// ("global: nccl*"), which the Buck build does not use.
+#define NCCL_PARAM_COMPILER_EXPORT_SYMBOL __attribute__((visibility("default")))
 #define NCCL_PARAM_COMPILER_EXPECT(x, v) __builtin_expect((x), (v))
 #elif defined(_MSC_VER)
+#define NCCL_PARAM_COMPILER_EXPORT_SYMBOL
 #define NCCL_PARAM_COMPILER_EXPECT(x, v) (x)
 #else
 #error "Unsupported compiler"
@@ -54,8 +61,8 @@ constexpr ncclParamTypeId_t ncclParamTypeIdOf() noexcept {
   else return NCCL_PARAM_TYPE_RAW;
 }
 
-extern "C" const char* ncclParamEnvPluginGet(const char* key, bool env_init);
-extern "C" bool ncclParamIsCacheDisabled(const char* key);
+extern "C" NCCL_PARAM_COMPILER_EXPORT_SYMBOL const char* ncclParamEnvPluginGet(const char* key, bool env_init);
+extern "C" NCCL_PARAM_COMPILER_EXPORT_SYMBOL bool ncclParamIsCacheDisabled(const char* key);
 
 namespace nccl {
 namespace param {

--- a/comms/ncclx/v2_31/src/include/socket.h
+++ b/comms/ncclx/v2_31/src/include/socket.h
@@ -11,6 +11,8 @@
 #include "nccl.h"
 #include "os.h"
 
+#include <string>
+
 #if !defined(__CUDA_ARCH__)
 /* Ensure full socket types are visible when this header is included from .cu or other TU without os.h socket context. */
 #if defined(NCCL_OS_WINDOWS)
@@ -123,7 +125,9 @@ ncclResult_t ncclSocketInit(struct ncclSocket* sock, const union ncclSocketAddre
 ncclResult_t ncclSocketListen(struct ncclSocket* sock);
 ncclResult_t ncclSocketGetAddr(struct ncclSocket* sock, union ncclSocketAddress* addr);
 // Connect to sock->addr. sock->socketDescriptor is set after a successful call.
-ncclResult_t ncclSocketConnect(struct ncclSocket* sock);
+// localIfName, when set, binds the client socket to that interface (SO_BINDTODEVICE);
+// NCCL_CLIENT_SOCKET_IFNAME supplies the default.
+ncclResult_t ncclSocketConnect(struct ncclSocket* sock, const char* localIfName = nullptr);
 // Return socket connection state.
 ncclResult_t ncclSocketReady(struct ncclSocket* sock, int* running);
 // Accept an incoming connection from listenSock->socketDescriptor and keep the file descriptor in
@@ -147,4 +151,9 @@ ncclResult_t ncclSocketTryRecv(struct ncclSocket* sock, void* ptr, int size, int
 ncclResult_t ncclSocketShutdown(struct ncclSocket* sock, int how);
 ncclResult_t ncclSocketClose(struct ncclSocket* sock, bool wait = false);
 uint16_t ncclSocketToPort(union ncclSocketAddress* addr);
+// Numeric-host rendering of an address, used to match NCCL_SOCKET_IPADDR_PREFIX.
+// Despite the name (kept as-is from v2_30 so the two trees stay diffable), this handles both
+// AF_INET and AF_INET6 and returns the numeric form for either. Returns an empty string if the
+// address cannot be rendered.
+std::string ncclSocketToIPv6String(union ncclSocketAddress* addr);
 #endif

--- a/comms/ncclx/v2_31/src/init.cc
+++ b/comms/ncclx/v2_31/src/init.cc
@@ -450,7 +450,7 @@ ncclResult_t ncclCommEnsureReady(ncclComm_t comm) {
   } else {
     NCCLCHECK(ncclCommGetAsyncError(comm, &ret));
     if (ret == ncclInProgress) {
-      WARN("Attempt to use communicator before the previous operation returned ncclSuccess");
+      ERR(ncclInvalidArgument, "Attempt to use communicator before the previous operation returned ncclSuccess");
       ret = ncclInvalidArgument;
       goto exit;
     }
@@ -463,11 +463,11 @@ exit:
 
 static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, int ndev, int rank) {
   if (ndev < 1) {
-    WARN("invalid device count (%d) requested", ndev);
+    ERR(ncclInvalidArgument, "invalid device count (%d) requested", ndev);
     return ncclInvalidArgument;
   }
   if (rank >= ndev || rank < 0) {
-    WARN("rank %d exceeds ndev=%d", rank, ndev);
+    ERR(ncclInvalidArgument, "rank %d exceeds ndev=%d", rank, ndev);
     return ncclInvalidArgument;
   }
 
@@ -509,7 +509,7 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
 
   if (parent && parent->shareResources) {
     if (parent->ncclNet != comm->ncclNet) {
-      WARN("Split shares resources, but parent comm netName %s is different from child comm netName %s",
+      ERR(ncclInvalidUsage, "Split shares resources, but parent comm netName %s is different from child comm netName %s",
            parent->ncclNet->name, comm->ncclNet->name);
       return ncclInvalidUsage;
     }
@@ -959,7 +959,7 @@ static ncclResult_t ncclP2pSchedule(struct ncclComm* comm) {
   int groupCount = 0;
   for (int n = 0; n < comm->nNodes; ++n) {
     if (0 != comm->nodeRanks[n].localRanks % groupSize) {
-      WARN("nLocals = %d should be a diviser of the number of ranks in node %d = %d", groupSize, n,
+      ERR(ncclInternalError, "nLocals = %d should be a diviser of the number of ranks in node %d = %d", groupSize, n,
            comm->nodeRanks[n].localRanks);
       return ncclInternalError;
     }
@@ -972,7 +972,7 @@ static ncclResult_t ncclP2pSchedule(struct ncclComm* comm) {
     if (n < comm->node) group += nGroupsInNode;
   }
   if (groupCount != nGroups) {
-    WARN("Group creation failed: %d vs %d", groupCount, nGroups);
+    ERR(ncclInternalError, "Group creation failed: %d vs %d", groupCount, nGroups);
     return ncclInternalError;
   }
   INFO(NCCL_GRAPH, "%s: group size used is %d", __func__, groupSize);
@@ -1006,7 +1006,7 @@ static ncclResult_t ncclP2pSchedule(struct ncclComm* comm) {
   free(groupToLocal);
 
   if (round != comm->nRanks) {
-    WARN("P2p schedule creation has bugs.");
+    ERR(ncclInternalError, "P2p schedule creation has bugs.");
     return ncclInternalError;
   }
   return ncclSuccess;
@@ -1120,7 +1120,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     }
 
     if (comm->peerInfo[i].version != comm->peerInfo[rank].version) {
-      WARN("Mismatched NCCL version detected : rank %d version %d rank %d version %d", i, comm->peerInfo[i].version,
+      ERR(ncclInvalidUsage, "Mismatched NCCL version detected : rank %d version %d rank %d version %d", i, comm->peerInfo[i].version,
            rank, comm->peerInfo[rank].version);
       ret = ncclInvalidUsage;
       goto fail;
@@ -1194,7 +1194,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     TRACE(NCCL_INIT, "pidHash[%d] %lx intraProcRank %d intraProcRanks %d intraProcRank0 %d", rank,
           comm->peerInfo[rank].pidHash, intraProcRank, intraProcRanks, intraProcRank0);
     if (intraProcRank == -1 || intraProcRank0 == -1 || comm->peerInfo[intraProcRank0].comm == NULL) {
-      WARN("Failed to determine intra proc ranks rank %d hostHash %lx pidHash %lx intraProcRank %d intraProcRanks %d "
+      ERR(ncclInternalError, "Failed to determine intra proc ranks rank %d hostHash %lx pidHash %lx intraProcRank %d intraProcRanks %d "
            "intraProcRank0 %d",
            rank, comm->peerInfo[rank].hostHash, comm->peerInfo[rank].pidHash, intraProcRank, intraProcRanks,
            intraProcRank0);
@@ -1425,7 +1425,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
              "NCCL_IGNORE_NET_MISMATCH.",
              minLocalNetCount, maxLocalNetCount);
       } else {
-        WARN("Detected mixed local Net device counts across ranks (min %d, max %d). Set NCCL_IGNORE_NET_MISMATCH=1 to "
+        ERR(ncclSystemError, "Detected mixed local Net device counts across ranks (min %d, max %d). Set NCCL_IGNORE_NET_MISMATCH=1 to "
              "continue.",
              minLocalNetCount, maxLocalNetCount);
         ret = ncclSystemError;
@@ -1448,7 +1448,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
              "NCCL_IGNORE_COLLNET_MISMATCH.",
              minLocalCollNetCount, maxLocalCollNetCount);
       } else {
-        WARN("Detected mixed local CollNet device counts across ranks (min %d, max %d). Set "
+        ERR(ncclSystemError, "Detected mixed local CollNet device counts across ranks (min %d, max %d). Set "
              "NCCL_IGNORE_COLLNET_MISMATCH=1 to continue.",
              minLocalCollNetCount, maxLocalCollNetCount);
         ret = ncclSystemError;
@@ -1501,7 +1501,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   TRACE(NCCL_INIT, "hostHash[%d] %lx localRank %d localRanks %d localRank0 %d", rank, comm->peerInfo[rank].hostHash,
         comm->localRank, comm->localRanks, comm->localRankToRank[0]);
   if (comm->localRank == -1 || comm->localRankToRank[0] == -1 || comm->localRanks == 0) {
-    WARN("Failed to determine local ranks rank %d hostHash %lx pidHash %lx localRank %d localRanks %d localRank0 %d",
+    ERR(ncclInternalError, "Failed to determine local ranks rank %d hostHash %lx pidHash %lx localRank %d localRanks %d localRank0 %d",
          rank, comm->peerInfo[rank].hostHash, comm->peerInfo[rank].pidHash, comm->localRank, comm->localRanks,
          comm->localRankToRank[0]);
     ret = ncclInternalError;
@@ -2398,7 +2398,7 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t* config) {
     realSize = realSize > sizeof(ncclConfig_t) ? sizeof(ncclConfig_t) : realSize;
     memcpy((void*)internalConfigPtr, (void*)config, realSize);
     if (internalConfigPtr->magic != NCCL_API_MAGIC) {
-      WARN("ncclConfig_t argument not initialized via NCCL_CONFIG_INITIALIZER");
+      ERR(ncclInvalidArgument, "ncclConfig_t argument not initialized via NCCL_CONFIG_INITIALIZER");
       ret = ncclInvalidArgument;
       goto fail;
     }
@@ -2454,13 +2454,13 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t* config) {
   /* check input config attributes, -1 means user-undefined and we should use default value from NCCL. */
   if (internalConfigPtr->blocking != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->blocking != 0 &&
       internalConfigPtr->blocking != 1) {
-    WARN("Invalid config blocking attribute value %d", internalConfigPtr->blocking);
+    ERR(ncclInvalidArgument, "Invalid config blocking attribute value %d", internalConfigPtr->blocking);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->cgaClusterSize != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->cgaClusterSize < 0) {
-    WARN("Invalid config cgaClusterSize attribute value %d", internalConfigPtr->cgaClusterSize);
+    ERR(ncclInvalidArgument, "Invalid config cgaClusterSize attribute value %d", internalConfigPtr->cgaClusterSize);
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -2469,7 +2469,7 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t* config) {
       (internalConfigPtr->maxCTAs != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->maxCTAs <= 0) ||
       (internalConfigPtr->minCTAs != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->maxCTAs != NCCL_CONFIG_UNDEF_INT &&
        internalConfigPtr->minCTAs > internalConfigPtr->maxCTAs)) {
-    WARN("Invalid config min/max channels attribute value %d/%d", internalConfigPtr->minCTAs,
+    ERR(ncclInvalidArgument, "Invalid config min/max channels attribute value %d/%d", internalConfigPtr->minCTAs,
          internalConfigPtr->maxCTAs);
     ret = ncclInvalidArgument;
     goto fail;
@@ -2477,21 +2477,21 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t* config) {
 
   if (internalConfigPtr->splitShare != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->splitShare != 0 &&
       internalConfigPtr->splitShare != 1) {
-    WARN("Invalid config splitShare attribute value %d", internalConfigPtr->splitShare);
+    ERR(ncclInvalidArgument, "Invalid config splitShare attribute value %d", internalConfigPtr->splitShare);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->collnetEnable != NCCL_CONFIG_UNDEF_INT &&
       (internalConfigPtr->collnetEnable < 0 || internalConfigPtr->collnetEnable > 1)) {
-    WARN("Invalid config collnetEnable attribute value %d", internalConfigPtr->collnetEnable);
+    ERR(ncclInvalidArgument, "Invalid config collnetEnable attribute value %d", internalConfigPtr->collnetEnable);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->CTAPolicy != NCCL_CONFIG_UNDEF_INT) {
     if (!ctaPolicyIsValid(internalConfigPtr->CTAPolicy)) {
-      WARN("Invalid config policy attribute value %d", internalConfigPtr->CTAPolicy);
+      ERR(ncclInvalidArgument, "Invalid config policy attribute value %d", internalConfigPtr->CTAPolicy);
       ret = ncclInvalidArgument;
       goto fail;
     }
@@ -2499,27 +2499,27 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t* config) {
 
   if (internalConfigPtr->shrinkShare != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->shrinkShare != 0 &&
       internalConfigPtr->shrinkShare != 1) {
-    WARN("Invalid config shrinkShare attribute value %d", internalConfigPtr->shrinkShare);
+    ERR(ncclInvalidArgument, "Invalid config shrinkShare attribute value %d", internalConfigPtr->shrinkShare);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->nvlsCTAs != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->nvlsCTAs <= 0) {
-    WARN("Invalid config nvlsCTAs attribute value %d", internalConfigPtr->nvlsCTAs);
+    ERR(ncclInvalidArgument, "Invalid config nvlsCTAs attribute value %d", internalConfigPtr->nvlsCTAs);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->nChannelsPerNetPeer != NCCL_CONFIG_UNDEF_INT &&
       (internalConfigPtr->nChannelsPerNetPeer <= 0 || internalConfigPtr->nChannelsPerNetPeer > MAXCHANNELS)) {
-    WARN("Invalid config nChannelsPerNetPeer attribute value %d", internalConfigPtr->nChannelsPerNetPeer);
+    ERR(ncclInvalidArgument, "Invalid config nChannelsPerNetPeer attribute value %d", internalConfigPtr->nChannelsPerNetPeer);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->nvlinkCentricSched != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->nvlinkCentricSched != 0 &&
       internalConfigPtr->nvlinkCentricSched != 1) {
-    WARN("Invalid config nvlinkCentricSched attribute value %d", internalConfigPtr->nvlinkCentricSched);
+    ERR(ncclInvalidArgument, "Invalid config nvlinkCentricSched attribute value %d", internalConfigPtr->nvlinkCentricSched);
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -2532,7 +2532,7 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t* config) {
   }
 
   if (internalConfigPtr->numRmaCtx != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->numRmaCtx < 0) {
-    WARN("Invalid config numRmaCtx attribute value %d", internalConfigPtr->numRmaCtx);
+    ERR(ncclInvalidArgument, "Invalid config numRmaCtx attribute value %d", internalConfigPtr->numRmaCtx);
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -2544,7 +2544,7 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t* config) {
   }
 
   if (internalConfigPtr->maxP2pPeers != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->maxP2pPeers <= 0) {
-    WARN("Invalid config maxP2pPeers attribute value %d", internalConfigPtr->maxP2pPeers);
+    ERR(ncclInvalidArgument, "Invalid config maxP2pPeers attribute value %d", internalConfigPtr->maxP2pPeers);
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -2666,7 +2666,7 @@ static void ncclCommInitJobFree(void* _job) {
 static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId, ncclUniqueId* commId, int myrank,
                                         int cudaDev, ncclConfig_t* config, const char funcName[]) {
   if (nId <= 0 || nId > nranks) {
-    WARN("improper usage of ncclCommInitRank: nId = %d, nranks=%d", nId, nranks);
+    ERR(ncclInvalidArgument, "improper usage of ncclCommInitRank: nId = %d, nranks=%d", nId, nranks);
     return ncclInvalidArgument;
   }
   ncclResult_t res = ncclSuccess;
@@ -2687,7 +2687,7 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   NCCLCHECKGOTO(PtrCheck(newcomm, "CommInitRank", "newcomm"), res, fail);
   NCCLCHECKGOTO(PtrCheck(config, "CommInitRank", "config"), res, fail);
   if (nranks < 1 || myrank < 0 || myrank >= nranks) {
-    WARN("Invalid rank requested : %d/%d", myrank, nranks);
+    ERR(ncclInvalidArgument, "Invalid rank requested : %d/%d", myrank, nranks);
     res = ncclInvalidArgument;
     goto fail;
   }
@@ -2798,7 +2798,7 @@ ncclResult_t ncclCommInitAll(ncclComm_t* comms, int ndev, const int* devlist) {
   CUDACHECK(cudaGetDevice(&oldDev));
   NCCLCHECKGOTO(PtrCheck(comms, "CommInitAll", "comms"), ret, fail);
   if (ndev < 0) {
-    WARN("Invalid device count requested : %d", ndev);
+    ERR(ncclInvalidArgument, "Invalid device count requested : %d", ndev);
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -2809,7 +2809,7 @@ ncclResult_t ncclCommInitAll(ncclComm_t* comms, int ndev, const int* devlist) {
     for (int i = 0; i < ndev; ++i) {
       /* invalid device check. */
       if (devlist[i] < 0 || devlist[i] >= totalnDev) {
-        WARN("Invalid device %d (totalnDev=%d)", devlist[i], totalnDev);
+        ERR(ncclInvalidArgument, "Invalid device %d (totalnDev=%d)", devlist[i], totalnDev);
         ret = ncclInvalidArgument;
         goto fail;
       }
@@ -2849,7 +2849,7 @@ fail:
 
 ncclResult_t ncclCommSetAsyncError(ncclComm_t comm, ncclResult_t nextState) {
   if (nextState < 0 || nextState >= ncclNumResults || comm == NULL) {
-    WARN("ncclCommSetAsyncError: error comm %p sets state %d", comm, nextState);
+    ERR(ncclInvalidArgument, "ncclCommSetAsyncError: error comm %p sets state %d", comm, nextState);
     return ncclInvalidArgument;
   }
 
@@ -3153,7 +3153,7 @@ ncclResult_t ncclCommDestroy(ncclComm_t comm) {
   NCCLCHECK(ncclGroupStartInternal());
   // Try and prevent a double free of the comm struct (user error)
   if (comm->rank == -1 || comm->nRanks == -1 || comm->cudaDev == -1 || comm->busId == -1) {
-    WARN("comm %p has already been destroyed", comm);
+    ERR(ncclInvalidArgument, "comm %p has already been destroyed", comm);
     return ncclInvalidArgument;
   }
 
@@ -3511,11 +3511,11 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
 
   if (newcomm == NULL) return ncclInvalidArgument;
   if (nRanks <= 0) {
-    WARN("ncclCommGrow: total ranks must be positive, got %d", nRanks);
+    ERR(ncclInvalidArgument, "ncclCommGrow: total ranks must be positive, got %d", nRanks);
     return ncclInvalidArgument;
   }
   if (comm && nRanks <= comm->nRanks) {
-    WARN("ncclCommGrow: total ranks %d is less than current ranks %d", nRanks, comm->nRanks);
+    ERR(ncclInvalidArgument, "ncclCommGrow: total ranks %d is less than current ranks %d", nRanks, comm->nRanks);
     return ncclInvalidArgument;
   }
 
@@ -3533,7 +3533,7 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
     NCCLCHECKGOTO(CommCheck(comm, __func__, "comm"), res, exit);
     NCCLCHECKGOTO(ncclCommEnsureReady(comm), res, exit);
     if (rank != -1) {
-      WARN("ncclCommGrow: existing ranks must pass rank=-1, got %d", rank);
+      ERR(ncclInvalidArgument, "ncclCommGrow: existing ranks must pass rank=-1, got %d", rank);
       res = ncclInvalidArgument;
       goto exit;
     }
@@ -3547,7 +3547,7 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
       NCCLCHECKGOTO(bcastGrowHandle(&recvHandle, comm, /*isRoot=*/false), res, exit);
       // verify the magic is the same as the one computed by the root
       if (recvHandle.magic != hashCombine(comm->magic, comm->childCount)) {
-        WARN("ncclCommGrow: magic mismatch computed by the root, got %lx expected %lx", recvHandle.magic,
+        ERR(ncclInvalidArgument, "ncclCommGrow: magic mismatch computed by the root, got %lx expected %lx", recvHandle.magic,
              hashCombine(comm->magic, comm->childCount));
         res = ncclInvalidArgument;
         goto exit;
@@ -3557,17 +3557,17 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
   } else {
     // New ranks: validate parameters
     if (rank < 0) {
-      WARN("ncclCommGrow: new ranks must pass valid rank >= 0, got %d", rank);
+      ERR(ncclInvalidArgument, "ncclCommGrow: new ranks must pass valid rank >= 0, got %d", rank);
       res = ncclInvalidArgument;
       goto exit;
     }
     if (uniqueId == NULL) {
-      WARN("ncclCommGrow: new ranks must pass non-NULL uniqueId");
+      ERR(ncclInvalidArgument, "ncclCommGrow: new ranks must pass non-NULL uniqueId");
       res = ncclInvalidArgument;
       goto exit;
     }
     if (rank >= nRanks) {
-      WARN("ncclCommGrow: new rank %d exceeds total ranks %d", rank, nRanks);
+      ERR(ncclInvalidArgument, "ncclCommGrow: new rank %d exceeds total ranks %d", rank, nRanks);
       res = ncclInvalidArgument;
       goto exit;
     }

--- a/comms/ncclx/v2_31/src/mem_manager.cc
+++ b/comms/ncclx/v2_31/src/mem_manager.cc
@@ -134,7 +134,7 @@ static ncclResult_t ncclMemTrackInternal(struct ncclMemManager* manager, void* p
   if (ncclParamMemManagerDisable()) return ncclSuccess;
   if (manager == nullptr || ptr == nullptr) return ncclInternalError;
   if (!COMPILER_ATOMIC_LOAD(&manager->initialized, std::memory_order_acquire)) {
-    WARN("MemManager: Cannot track allocation ptr=%p, manager not initialized", ptr);
+    ERR(ncclInternalError, "MemManager: Cannot track allocation ptr=%p, manager not initialized", ptr);
     return ncclInternalError;
   }
 
@@ -153,7 +153,7 @@ static ncclResult_t ncclMemTrackInternal(struct ncclMemManager* manager, void* p
   // Scratch/Offload: create linked list entry
   ncclDynMemEntry* entry = (ncclDynMemEntry*)malloc(sizeof(ncclDynMemEntry));
   if (entry == nullptr) {
-    WARN("MemManager: Failed to allocate memory entry");
+    ERR(ncclSystemError, "MemManager: Failed to allocate memory entry");
     return ncclSystemError;
   }
 
@@ -240,7 +240,7 @@ ncclResult_t ncclMemUntrackDynamic(struct ncclMemManager* manager, void* ptr, st
 
   // Atomic check to avoid locking destroyed mutex
   if (!COMPILER_ATOMIC_LOAD(&manager->initialized, std::memory_order_acquire)) {
-    WARN("MemManager: Cannot untrack allocation ptr=%p, manager not initialized", ptr);
+    ERR(ncclInternalError, "MemManager: Cannot untrack allocation ptr=%p, manager not initialized", ptr);
     return ncclInternalError;
   }
 
@@ -356,7 +356,7 @@ ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* pt
   if (ncclParamMemManagerDisable()) return ncclSuccess;
   if (manager == nullptr || ptr == nullptr) return ncclInternalError;
   if (!COMPILER_ATOMIC_LOAD(&manager->initialized, std::memory_order_acquire)) {
-    WARN("MemManager: Cannot mark export for ptr=%p, manager not initialized", ptr);
+    ERR(ncclInternalError, "MemManager: Cannot mark export for ptr=%p, manager not initialized", ptr);
     return ncclInternalError;
   }
   std::lock_guard<std::mutex> lock(manager->lock);
@@ -368,7 +368,7 @@ ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* pt
   }
 
   if (entry == nullptr) {
-    WARN("MemManager: Cannot mark export for ptr=%p - not found in tracked entries. "
+    ERR(ncclInternalError, "MemManager: Cannot mark export for ptr=%p - not found in tracked entries. "
          "Only dynamic memory (scratch/offload) needs export tracking for suspend/resume.",
          ptr);
     return ncclInternalError;
@@ -376,14 +376,14 @@ ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* pt
 
   // Verify this is a local entry, not an imported one
   if (entry->isImportedFromPeer) {
-    WARN("MemManager: Cannot mark export for ptr=%p - this is an imported buffer, not a local one", ptr);
+    ERR(ncclInternalError, "MemManager: Cannot mark export for ptr=%p - this is an imported buffer, not a local one", ptr);
     return ncclInternalError;
   }
 
   // Check if peer already exists
   for (int i = 0; i < entry->desc.local.numExportedPeers; i++) {
     if (entry->desc.local.exportedPeerRanks[i] == peerRank) {
-      WARN("MemManager: Buffer ptr=%p already exported to peer rank %d", ptr, peerRank);
+      ERR(ncclInternalError, "MemManager: Buffer ptr=%p already exported to peer rank %d", ptr, peerRank);
       return ncclInternalError;
     }
   }
@@ -417,7 +417,7 @@ ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* pt
  */
 ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
   if (ncclParamMemManagerDisable()) {
-    WARN("MemManager: Suspend failed, memory manager is disabled");
+    ERR(ncclInvalidUsage, "MemManager: Suspend failed, memory manager is disabled");
     return ncclInvalidUsage;
   }
   if (comm == nullptr) return ncclInvalidArgument;
@@ -425,7 +425,7 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
   ncclMemManager* manager = comm->memManager;
 
   if (manager->released) {
-    WARN("MemManager: Already suspended");
+    ERR(ncclInvalidUsage, "MemManager: Already suspended");
     return ncclInvalidUsage;
   }
 
@@ -483,7 +483,7 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
     if (entry->memType == ncclMemOffload) {
       NCCLCHECKGOTO(ncclCudaHostCalloc((char**)&entry->cpuBackup, entry->size), ret, fail);
       if (entry->cpuBackup == nullptr) {
-        WARN("MemManager: Failed to allocate CPU backup for offload");
+        ERR(ncclSystemError, "MemManager: Failed to allocate CPU backup for offload");
         ret = ncclSystemError;
         goto fail;
       }
@@ -493,7 +493,7 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
       if (err != cudaSuccess) {
         ncclCudaHostFree(entry->cpuBackup);
         entry->cpuBackup = nullptr;
-        WARN("MemManager: Failed to copy to CPU backup: %s", cudaGetErrorString(err));
+        ERR(ncclUnhandledCudaError, "MemManager: Failed to copy to CPU backup: %s", cudaGetErrorString(err));
         ret = ncclUnhandledCudaError;
         goto fail;
       }
@@ -549,7 +549,7 @@ fail:
  */
 ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
   if (ncclParamMemManagerDisable()) {
-    WARN("MemManager: Resume failed, memory manager is disabled");
+    ERR(ncclInvalidUsage, "MemManager: Resume failed, memory manager is disabled");
     return ncclInvalidUsage;
   }
   if (comm == nullptr) return ncclInvalidArgument;
@@ -557,7 +557,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
   ncclMemManager* manager = comm->memManager;
 
   if (!manager->released) {
-    WARN("MemManager: Not in suspended state");
+    ERR(ncclInvalidUsage, "MemManager: Not in suspended state");
     return ncclInvalidUsage;
   }
 
@@ -632,7 +632,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
     if (entry->memType == ncclMemOffload && entry->cpuBackup != NULL) {
       cudaError_t err = cudaMemcpy(entry->ptr, entry->cpuBackup, entry->size, cudaMemcpyHostToDevice);
       if (err != cudaSuccess) {
-        WARN("MemManager: Failed to restore from CPU backup: %s (backup preserved)", cudaGetErrorString(err));
+        ERR(ncclUnhandledCudaError, "MemManager: Failed to restore from CPU backup: %s (backup preserved)", cudaGetErrorString(err));
         ret = ncclUnhandledCudaError;
         goto fail;
       }
@@ -647,7 +647,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
       CUresult exportRet = CUPFN(cuMemExportToShareableHandle(&entry->desc.local.shareableHandle.fabricHandle,
                                                               newHandle, CU_MEM_HANDLE_TYPE_FABRIC, 0));
       if (exportRet != CUDA_SUCCESS) {
-        WARN("MemManager: cuMemExportToShareableHandle (FABRIC) failed for ptr=%p", entry->ptr);
+        ERR(ncclUnhandledCudaError, "MemManager: cuMemExportToShareableHandle (FABRIC) failed for ptr=%p", entry->ptr);
         CUCHECKIGNORE(cuMemUnmap((CUdeviceptr)entry->ptr, entry->size));
         CUCHECKIGNORE(cuMemRelease(newHandle));
         entry->handle = 0;
@@ -700,7 +700,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
     // Allocate buffer for all counts
     allCounts = (int*)malloc(comm->nRanks * sizeof(int));
     if (allCounts == nullptr) {
-      WARN("MemManager: Failed to allocate allCounts");
+      ERR(ncclSystemError, "MemManager: Failed to allocate allCounts");
       return ncclSystemError;
     }
     memset(allCounts, 0, comm->nRanks * sizeof(int));
@@ -1006,13 +1006,13 @@ ncclResult_t ncclCommSuspend(ncclComm_t comm, int flags) {
 
   if (flags & NCCL_SUSPEND_MEM) {
     if (ncclParamMemManagerDisable()) {
-      WARN("MemManager: Suspend not supported, memory manager is disabled");
+      ERR(ncclInvalidUsage, "MemManager: Suspend not supported, memory manager is disabled");
       ret = ncclInvalidUsage;
       goto fail;
     }
     // Check if manager is shared
     if (comm->memManager && comm->memManager->refCount > 1) {
-      WARN("Memory suspend not supported with split_share communicators (refCount=%d)", comm->memManager->refCount);
+      ERR(ncclInvalidUsage, "Memory suspend not supported with split_share communicators (refCount=%d)", comm->memManager->refCount);
       ret = ncclInvalidUsage;
       goto fail;
     }
@@ -1057,13 +1057,13 @@ ncclResult_t ncclCommResume(ncclComm_t comm) {
   CUDACHECKGOTO(cudaSetDevice(comm->cudaDev), ret, fail);
 
   if (ncclParamMemManagerDisable()) {
-    WARN("MemManager: Resume not supported, memory manager is disabled");
+    ERR(ncclInvalidUsage, "MemManager: Resume not supported, memory manager is disabled");
     ret = ncclInvalidUsage;
     goto fail;
   }
   // Check if manager is shared
   if (comm->memManager && comm->memManager->refCount > 1) {
-    WARN("Memory resume not supported with split_share communicators (refCount=%d)", comm->memManager->refCount);
+    ERR(ncclInvalidUsage, "Memory resume not supported with split_share communicators (refCount=%d)", comm->memManager->refCount);
     ret = ncclInvalidUsage;
     goto fail;
   }
@@ -1102,7 +1102,7 @@ ncclResult_t ncclCommMemStats(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t*
   if (value == nullptr) return ncclInvalidArgument;
 
   if (ncclParamMemManagerDisable()) {
-    WARN("MemManager: MemStats not supported, memory manager is disabled");
+    ERR(ncclInvalidUsage, "MemManager: MemStats not supported, memory manager is disabled");
     return ncclInvalidUsage;
   }
 

--- a/comms/ncclx/v2_31/src/misc/argcheck.cc
+++ b/comms/ncclx/v2_31/src/misc/argcheck.cc
@@ -13,7 +13,7 @@ ncclResult_t CudaPtrCheck(const void* pointer, struct ncclComm* comm, const char
   cudaPointerAttributes attr;
   cudaError_t err = cudaPointerGetAttributes(&attr, pointer);
   if (err != cudaSuccess || attr.devicePointer == NULL) {
-    WARN("%s : %s %p is not a valid pointer", opname, ptrname, pointer);
+    ERR(ncclInvalidArgument, "%s : %s %p is not a valid pointer", opname, ptrname, pointer);
     return ncclInvalidArgument;
   }
 #if CUDART_VERSION >= 10000
@@ -21,7 +21,7 @@ ncclResult_t CudaPtrCheck(const void* pointer, struct ncclComm* comm, const char
 #else
   if (attr.memoryType == cudaMemoryTypeDevice && attr.device != comm->cudaDev) {
 #endif
-    WARN("%s : %s allocated on device %d mismatchs with NCCL device %d", opname, ptrname, attr.device, comm->cudaDev);
+    ERR(ncclInvalidArgument, "%s : %s allocated on device %d mismatchs with NCCL device %d", opname, ptrname, attr.device, comm->cudaDev);
     return ncclInvalidArgument;
   }
   return ncclSuccess;
@@ -29,7 +29,7 @@ ncclResult_t CudaPtrCheck(const void* pointer, struct ncclComm* comm, const char
 
 ncclResult_t PtrCheck(const void* ptr, const char* opname, const char* ptrname) {
   if (ptr == NULL) {
-    WARN("%s : %s argument is NULL", opname, ptrname);
+    ERR(ncclInvalidArgument, "%s : %s argument is NULL", opname, ptrname);
     return ncclInvalidArgument;
   }
   return ncclSuccess;
@@ -38,7 +38,7 @@ ncclResult_t PtrCheck(const void* ptr, const char* opname, const char* ptrname) 
 ncclResult_t CommCheck(struct ncclComm* comm, const char* opname, const char* ptrname) {
   NCCLCHECK(PtrCheck(comm, opname, ptrname));
   if (comm->startMagic != NCCL_MAGIC || comm->endMagic != NCCL_MAGIC) {
-    WARN("Error: corrupted comm object detected");
+    ERR(ncclInvalidArgument, "Error: corrupted comm object detected");
     return ncclInvalidArgument;
   }
   return ncclSuccess;
@@ -101,7 +101,7 @@ static ncclResult_t registrationCheck(struct ncclInfo* info) {
     if (cmpBufInfo[0].isSymRegistered != bufInfo[infoIdx].isSymRegistered ||
         cmpBufInfo[1].isSymRegistered != bufInfo[infoIdx + 1].isSymRegistered) {
       if (comm->rank == 0) {
-        WARN("Coll %s size %ld symmetric registration check failed on rank %d: sendReg %d recvReg %d mismatch with "
+        ERR(ncclInvalidArgument, "Coll %s size %ld symmetric registration check failed on rank %d: sendReg %d recvReg %d mismatch with "
              "rank 0 sendReg %d recvReg %d",
              info->opName, size, r, bufInfo[infoIdx].isSymRegistered, bufInfo[infoIdx + 1].isSymRegistered,
              cmpBufInfo[0].isSymRegistered, cmpBufInfo[1].isSymRegistered);
@@ -133,7 +133,7 @@ static ncclResult_t registrationCheck(struct ncclInfo* info) {
     if (cmpBufInfo[0].isSymRegistered) {
       if (sendWinMismatch) {
         if (comm->rank == 0) {
-          WARN("Coll %s size %ld symmetric registration check failed on rank %d: send buffer window (0x%lx) mismatch "
+          ERR(ncclInvalidArgument, "Coll %s size %ld symmetric registration check failed on rank %d: send buffer window (0x%lx) mismatch "
                "with rank 0 (0x%lx)",
                info->opName, size, sendWinMismatchRank, bufInfo[sendWinMismatchRank * 2].bigOffset,
                cmpBufInfo[0].bigOffset);
@@ -143,7 +143,7 @@ static ncclResult_t registrationCheck(struct ncclInfo* info) {
       }
       if (sendUserMismatch) {
         if (comm->rank == 0) {
-          WARN("Coll %s size %ld symmetric registration check failed on rank %d: send buffer user offset (0x%lx) "
+          ERR(ncclInvalidArgument, "Coll %s size %ld symmetric registration check failed on rank %d: send buffer user offset (0x%lx) "
                "mismatch with rank 0 (0x%lx)",
                info->opName, size, sendUserMismatchRank, bufInfo[sendUserMismatchRank * 2].userOffset,
                cmpBufInfo[0].userOffset);
@@ -159,7 +159,7 @@ static ncclResult_t registrationCheck(struct ncclInfo* info) {
     if (cmpBufInfo[1].isSymRegistered) {
       if (recvWinMismatch) {
         if (comm->rank == 0) {
-          WARN("Coll %s size %ld symmetric registration check failed on rank %d: recv buffer window (0x%lx) mismatch "
+          ERR(ncclInvalidArgument, "Coll %s size %ld symmetric registration check failed on rank %d: recv buffer window (0x%lx) mismatch "
                "with rank 0 (0x%lx)",
                info->opName, size, recvWinMismatchRank, bufInfo[recvWinMismatchRank * 2 + 1].bigOffset,
                cmpBufInfo[1].bigOffset);
@@ -169,7 +169,7 @@ static ncclResult_t registrationCheck(struct ncclInfo* info) {
       }
       if (recvUserMismatch) {
         if (comm->rank == 0) {
-          WARN("Coll %s size %ld symmetric registration check failed on rank %d: recv buffer user offset (0x%lx) "
+          ERR(ncclInvalidArgument, "Coll %s size %ld symmetric registration check failed on rank %d: recv buffer user offset (0x%lx) "
                "mismatch with rank 0 (0x%lx)",
                info->opName, size, recvUserMismatchRank, bufInfo[recvUserMismatchRank * 2 + 1].userOffset,
                cmpBufInfo[1].userOffset);
@@ -201,11 +201,11 @@ ncclResult_t ncclArgsGlobalCheck(struct ncclArgsInfo* argsInfo) {
 ncclResult_t ArgsCheck(struct ncclInfo* info) {
   // First, the easy ones
   if (info->root < 0 || info->root >= info->comm->nRanks) {
-    WARN("%s : invalid root %d (root should be in the 0..%d range)", info->opName, info->root, info->comm->nRanks);
+    ERR(ncclInvalidArgument, "%s : invalid root %d (root should be in the 0..%d range)", info->opName, info->root, info->comm->nRanks);
     return ncclInvalidArgument;
   }
   if (info->datatype < 0 || info->datatype >= ncclNumTypes) {
-    WARN("%s : invalid type %d", info->opName, info->datatype);
+    ERR(ncclInvalidArgument, "%s : invalid type %d", info->opName, info->datatype);
     return ncclInvalidArgument;
   }
 
@@ -214,13 +214,13 @@ ncclResult_t ArgsCheck(struct ncclInfo* info) {
   // just as a reminder.
   // coverity[result_independent_of_operands]
   if (info->op < 0 || ncclMaxRedOp < info->op) {
-    WARN("%s : invalid reduction operation %d", info->opName, info->op);
+    ERR(ncclInvalidArgument, "%s : invalid reduction operation %d", info->opName, info->op);
     return ncclInvalidArgument;
   }
   int opIx = int(ncclUserRedOpMangle(info->comm, info->op)) - int(ncclNumOps);
   if (ncclNumOps <= info->op &&
       (info->comm->userRedOpCapacity <= opIx || info->comm->userRedOps[opIx].freeNext != -1)) {
-    WARN("%s : reduction operation %d unknown to this communicator", info->opName, info->op);
+    ERR(ncclInvalidArgument, "%s : reduction operation %d unknown to this communicator", info->opName, info->op);
     return ncclInvalidArgument;
   }
 

--- a/comms/ncclx/v2_31/src/misc/cudawrap.cc
+++ b/comms/ncclx/v2_31/src/misc/cudawrap.cc
@@ -194,7 +194,7 @@ bool ncclCudaLaunchBlocking = false;
                                                           cudaEnableDefault, &driverStatus)); \
     if (res != cudaSuccess || driverStatus != cudaDriverEntryPointSuccess) { \
       if (!ignore) { \
-        WARN("Retrieve %s version %d failed with %d status %d", #symbol, version, res, driverStatus); \
+        ERR(ncclSystemError, "Retrieve %s version %d failed with %d status %d", #symbol, version, res, driverStatus); \
         return ncclSystemError; \
       } \
     } \
@@ -206,7 +206,7 @@ bool ncclCudaLaunchBlocking = false;
     res = CUDACLEARERROR(cudaGetDriverEntryPoint(#symbol, (void**)(&pfn_##symbol), cudaEnableDefault, &driverStatus)); \
     if (res != cudaSuccess || driverStatus != cudaDriverEntryPointSuccess) { \
       if (!ignore) { \
-        WARN("Retrieve %s failed with %d status %d", #symbol, res, driverStatus); \
+        ERR(ncclSystemError, "Retrieve %s failed with %d status %d", #symbol, res, driverStatus); \
         return ncclSystemError; \
       } \
     } \
@@ -217,7 +217,7 @@ bool ncclCudaLaunchBlocking = false;
     res = CUDACLEARERROR(cudaGetDriverEntryPoint(#symbol, (void**)(&pfn_##symbol), cudaEnableDefault)); \
     if (res != cudaSuccess) { \
       if (!ignore) { \
-        WARN("Retrieve %s failed with %d", #symbol, res); \
+        ERR(ncclSystemError, "Retrieve %s failed with %d", #symbol, res); \
         return ncclSystemError; \
       } \
     } \
@@ -325,7 +325,7 @@ static void initOnceFunc() {
 
 #if CUDART_VERSION >= 11030
   if (cudaPfnFuncLoader()) {
-    WARN("CUDA some PFN functions not found in the library");
+    ERR(ncclSystemError, "CUDA some PFN functions not found in the library");
     goto error;
   }
 #endif

--- a/comms/ncclx/v2_31/src/misc/gdrwrap.cc
+++ b/comms/ncclx/v2_31/src/misc/gdrwrap.cc
@@ -494,7 +494,7 @@ std::mutex& getGdrMutex() {
     cast = (void**)&funcptr; \
     tmp = ncclOsDlsym(handle, symbol); \
     if (tmp == NULL) { \
-      WARN("ncclOsDlsym failed on %s - %s", symbol, ncclOsDlerror()); \
+      ERR(ncclSystemError, "ncclOsDlsym failed on %s - %s", symbol, ncclOsDlerror()); \
       goto teardown; \
     } \
     *cast = tmp; \
@@ -584,7 +584,7 @@ static const char* ncclGdrBackendName() {
 
 static ncclResult_t ncclGdrUnavailable(const char* op) {
   if (gdrOps == NULL) {
-    WARN("GDRCOPY lib wrapper not initialized.");
+    ERR(ncclInternalError, "GDRCOPY lib wrapper not initialized.");
   } else {
     INFO(NCCL_INIT, "%s not available for %s backend", op, ncclGdrBackendName());
   }
@@ -593,7 +593,7 @@ static ncclResult_t ncclGdrUnavailable(const char* op) {
 
 gdr_t wrap_gdr_open(void) {
   if (gdrOps == NULL || gdrOps->open == NULL) {
-    WARN("GDRCOPY lib wrapper not initialized.");
+    ERR(ncclInternalError, "GDRCOPY lib wrapper not initialized.");
     return NULL;
   }
   gdr_t handle = gdrOps->open();
@@ -609,7 +609,7 @@ ncclResult_t wrap_gdr_close(gdr_t g) {
   if (gdrOps == NULL || gdrOps->close == NULL) return ncclGdrUnavailable("close");
   int ret = gdrOps->close(g);
   if (ret != 0) {
-    WARN("gdr_close() failed: %d", ret);
+    ERR(ncclSystemError, "gdr_close() failed: %d", ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -621,7 +621,7 @@ ncclResult_t wrap_gdr_pin_buffer(gdr_t g, unsigned long addr, size_t size, uint6
   int ret;
   GDRLOCKCALL(gdrOps->pinBuffer(g, addr, size, p2p_token, va_space, handle), ret);
   if (ret != 0) {
-    WARN("gdr_pin_buffer(addr %lx, size %zu) failed: %d", addr, size, ret);
+    ERR(ncclSystemError, "gdr_pin_buffer(addr %lx, size %zu) failed: %d", addr, size, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -647,14 +647,14 @@ bool ncclGdrPinV2Available(void) {
 
 ncclResult_t wrap_gdr_pin_buffer_v2(gdr_t g, unsigned long addr, size_t size, uint32_t flags, gdr_mh_t* handle) {
   if (!ncclGdrPinV2Available()) {
-    WARN("gdr_pin_buffer_v2 not available; GDRCopy >= 2.5 required");
+    ERR(ncclInternalError, "gdr_pin_buffer_v2 not available; GDRCopy >= 2.5 required");
     return ncclInternalError;
   }
   if (gdrOps == NULL || gdrOps->pinBufferV2 == NULL) return ncclGdrUnavailable("pin_buffer_v2");
   int ret;
   GDRLOCKCALL(gdrOps->pinBufferV2(g, addr, size, flags, handle), ret);
   if (ret != 0) {
-    WARN("gdr_pin_buffer_v2(addr %lx, size %zu, flags %u) failed: %d", addr, size, flags, ret);
+    ERR(ncclSystemError, "gdr_pin_buffer_v2(addr %lx, size %zu, flags %u) failed: %d", addr, size, flags, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -665,7 +665,7 @@ ncclResult_t wrap_gdr_unpin_buffer(gdr_t g, gdr_mh_t handle) {
   int ret;
   GDRLOCKCALL(gdrOps->unpinBuffer(g, handle), ret);
   if (ret != 0) {
-    WARN("gdr_unpin_buffer(handle %lx) failed: %d", handle.h, ret);
+    ERR(ncclSystemError, "gdr_unpin_buffer(handle %lx) failed: %d", handle.h, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -676,7 +676,7 @@ ncclResult_t wrap_gdr_get_info(gdr_t g, gdr_mh_t handle, gdr_info_t* info) {
   int ret;
   GDRLOCKCALL(gdrOps->getInfo(g, handle, info), ret);
   if (ret != 0) {
-    WARN("gdr_get_info(handle %lx) failed: %d", handle.h, ret);
+    ERR(ncclSystemError, "gdr_get_info(handle %lx) failed: %d", handle.h, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -687,7 +687,7 @@ ncclResult_t wrap_gdr_map(gdr_t g, gdr_mh_t handle, void** va, size_t size) {
   int ret;
   GDRLOCKCALL(gdrOps->map(g, handle, va, size), ret);
   if (ret != 0) {
-    WARN("gdr_map(handle %lx, size %zu) failed: %d", handle.h, size, ret);
+    ERR(ncclSystemError, "gdr_map(handle %lx, size %zu) failed: %d", handle.h, size, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -698,7 +698,7 @@ ncclResult_t wrap_gdr_unmap(gdr_t g, gdr_mh_t handle, void* va, size_t size) {
   int ret;
   GDRLOCKCALL(gdrOps->unmap(g, handle, va, size), ret);
   if (ret != 0) {
-    WARN("gdr_unmap(handle %lx, va %p, size %zu) failed: %d", handle.h, va, size, ret);
+    ERR(ncclSystemError, "gdr_unmap(handle %lx, va %p, size %zu) failed: %d", handle.h, va, size, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -759,7 +759,7 @@ ncclResult_t wrap_gdr_copy_to_mapping(gdr_mh_t handle, void* map_d_ptr, const vo
   int ret;
   GDRLOCKCALL(gdrOps->copyToMapping(handle, map_d_ptr, h_ptr, size), ret);
   if (ret != 0) {
-    WARN("gdr_copy_to_mapping(handle %lx, map_d_ptr %p, h_ptr %p, size %zu) failed: %d", handle.h, map_d_ptr, h_ptr,
+    ERR(ncclSystemError, "gdr_copy_to_mapping(handle %lx, map_d_ptr %p, h_ptr %p, size %zu) failed: %d", handle.h, map_d_ptr, h_ptr,
          size, ret);
     return ncclSystemError;
   }
@@ -771,7 +771,7 @@ ncclResult_t wrap_gdr_copy_from_mapping(gdr_mh_t handle, void* h_ptr, const void
   int ret;
   GDRLOCKCALL(gdrOps->copyFromMapping(handle, h_ptr, map_d_ptr, size), ret);
   if (ret != 0) {
-    WARN("gdr_copy_from_mapping(handle %lx, h_ptr %p, map_d_ptr %p, size %zu) failed: %d", handle.h, h_ptr, map_d_ptr,
+    ERR(ncclSystemError, "gdr_copy_from_mapping(handle %lx, h_ptr %p, map_d_ptr %p, size %zu) failed: %d", handle.h, h_ptr, map_d_ptr,
          size, ret);
     return ncclSystemError;
   }

--- a/comms/ncclx/v2_31/src/misc/ibvsymbols.cc
+++ b/comms/ncclx/v2_31/src/misc/ibvsymbols.cc
@@ -93,7 +93,7 @@ ncclResult_t buildIbvSymbols(struct ncclIbvSymbols* ibvSymbols) {
     cast = (void**)&funcptr; \
     tmp = dlvsym(handle, symbol, IBVERBS_VERSION); \
     if (tmp == NULL) { \
-      WARN("dlvsym failed on %s - %s version %s", symbol, dlerror(), IBVERBS_VERSION); \
+      ERR(ncclSystemError, "dlvsym failed on %s - %s version %s", symbol, dlerror(), IBVERBS_VERSION); \
       goto teardown; \
     } \
     *cast = tmp; \

--- a/comms/ncclx/v2_31/src/misc/ibvwrap.cc
+++ b/comms/ncclx/v2_31/src/misc/ibvwrap.cc
@@ -31,7 +31,7 @@ ncclResult_t wrap_ibv_symbols(void) {
 /* CHECK_NOT_NULL: helper macro to check for NULL symbol */
 #define CHECK_NOT_NULL(container, internal_name) \
   if (container.internal_name == NULL) { \
-    WARN("lib wrapper not initialized."); \
+    ERR(ncclInternalError, "lib wrapper not initialized."); \
     return ncclInternalError; \
   }
 
@@ -39,7 +39,7 @@ ncclResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name); \
   retval = container.call; \
   if (retval == error_retval) { \
-    WARN("Call to " name " failed with error %s", strerror(errno)); \
+    ERR(ncclSystemError, "Call to " name " failed with error %s", strerror(errno)); \
     return ncclSystemError; \
   } \
   return ncclSuccess;
@@ -48,7 +48,7 @@ ncclResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name); \
   retval = container.call; \
   if (retval == error_retval) { \
-    WARN("Call to " name " failed"); \
+    ERR(ncclSystemError, "Call to " name " failed"); \
     return ncclSystemError; \
   } \
   return ncclSuccess;
@@ -65,7 +65,7 @@ ncclResult_t wrap_ibv_symbols(void) {
     *supported = 0; \
     return ncclSuccess; \
   } else if (ret != success_retval) { \
-    WARN("Call to " name " failed with error %s errno %d", strerror(ret), ret); \
+    ERR(ncclSystemError, "Call to " name " failed with error %s errno %d", strerror(ret), ret); \
     *supported = 1; \
     return ncclSystemError; \
   } \
@@ -76,7 +76,7 @@ ncclResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name); \
   int ret = container.call; \
   if (ret != success_retval) { \
-    WARN("Call to " name " failed with error %s errno %d", strerror(ret), ret); \
+    ERR(ncclSystemError, "Call to " name " failed with error %s errno %d", strerror(ret), ret); \
     return ncclSystemError; \
   } \
   return ncclSuccess;
@@ -85,7 +85,7 @@ ncclResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name); \
   int ret = container.call; \
   if (ret == error_retval) { \
-    WARN("Call to " name " failed"); \
+    ERR(ncclSystemError, "Call to " name " failed"); \
     return ncclSystemError; \
   } \
   return ncclSuccess;
@@ -120,7 +120,7 @@ ncclResult_t wrap_ibv_free_device_list(struct ibv_device** list) {
 
 const char* wrap_ibv_get_device_name(struct ibv_device* device) {
   if (ibvSymbols.ibv_internal_get_device_name == NULL) {
-    WARN("lib wrapper not initialized.");
+    ERR(ncclInternalError, "lib wrapper not initialized.");
     exit(-1);
   }
   return ibvSymbols.ibv_internal_get_device_name(device);
@@ -202,7 +202,7 @@ ncclResult_t wrap_ibv_reg_mr(struct ibv_mr** ret, struct ibv_pd* pd, void* addr,
 
 struct ibv_mr* wrap_direct_ibv_reg_mr(struct ibv_pd* pd, void* addr, size_t length, int access) {
   if (ibvSymbols.ibv_internal_reg_mr == NULL) {
-    WARN("lib wrapper not initialized.");
+    ERR(ncclInternalError, "lib wrapper not initialized.");
     return NULL;
   }
   return ibvSymbols.ibv_internal_reg_mr(pd, addr, length, access);
@@ -377,7 +377,7 @@ ncclResult_t wrap_ibv_modify_qp(struct ibv_qp* qp, struct ibv_qp_attr* attr, int
   } while (IBV_MQP_RETRY_ERRNO_ALL(ret) && attempts < maxCnt);
   if (ret != 0) {
     ibvModifyQpLog(qp, attr->qp_state, attr, attr_mask, qpMsg, sizeof(qpMsg));
-    WARN("Call to ibv_modify_qp failed with %d %s, %s", ret, strerror(ret), qpMsg);
+    ERR(ncclSystemError, "Call to ibv_modify_qp failed with %d %s, %s", ret, strerror(ret), qpMsg);
     printIbModifyQpHint(ret);
     return ncclSystemError;
   }

--- a/comms/ncclx/v2_31/src/misc/mlx5dvsymbols.cc
+++ b/comms/ncclx/v2_31/src/misc/mlx5dvsymbols.cc
@@ -52,7 +52,7 @@ ncclResult_t buildMlx5dvSymbols(struct ncclMlx5dvSymbols* mlx5dvSymbols) {
     cast = (void**)&funcptr; \
     tmp = dlvsym(handle, symbol, MLX5DV_VERSION); \
     if (tmp == NULL) { \
-      WARN("dlvsym failed on %s - %s version %s", symbol, dlerror(), MLX5DV_VERSION); \
+      ERR(ncclSystemError, "dlvsym failed on %s - %s version %s", symbol, dlerror(), MLX5DV_VERSION); \
       goto teardown; \
     } \
     *cast = tmp; \

--- a/comms/ncclx/v2_31/src/misc/mlx5dvwrap.cc
+++ b/comms/ncclx/v2_31/src/misc/mlx5dvwrap.cc
@@ -29,7 +29,7 @@ ncclResult_t wrap_mlx5dv_symbols(void) {
 /* CHECK_NOT_NULL: helper macro to check for NULL symbol */
 #define CHECK_NOT_NULL(container, internal_name) \
   if (container.internal_name == NULL) { \
-    WARN("NET/MLX5: lib wrapper not initialized."); \
+    ERR(ncclInternalError, "NET/MLX5: lib wrapper not initialized."); \
     return ncclInternalError; \
   }
 
@@ -37,7 +37,7 @@ ncclResult_t wrap_mlx5dv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name); \
   retval = container.call; \
   if (retval == error_retval) { \
-    WARN("NET/MLX5: Call to " name " failed with error %s", strerror(errno)); \
+    ERR(ncclSystemError, "NET/MLX5: Call to " name " failed with error %s", strerror(errno)); \
     return ncclSystemError; \
   } \
   return ncclSuccess;
@@ -46,7 +46,7 @@ ncclResult_t wrap_mlx5dv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name); \
   int ret = container.call; \
   if (ret != success_retval) { \
-    WARN("NET/MLX5: Call to " name " failed with error %s", strerror(errno)); \
+    ERR(ncclSystemError, "NET/MLX5: Call to " name " failed with error %s", strerror(errno)); \
     return ncclSystemError; \
   } \
   return ncclSuccess;

--- a/comms/ncclx/v2_31/src/misc/nvmlwrap.cc
+++ b/comms/ncclx/v2_31/src/misc/nvmlwrap.cc
@@ -148,7 +148,7 @@ ncclResult_t ncclNvmlEnsureInitialized() {
 #endif
   nvmlReturn_t res1 = (have_v2 ? pfn_nvmlInit_v2 : pfn_nvmlInit)();
   if (res1 != NVML_SUCCESS) {
-    WARN("nvmlInit%s() failed: %s", have_v2 ? "_v2" : "", pfn_nvmlErrorString(res1));
+    ERR(ncclSystemError, "nvmlInit%s() failed: %s", have_v2 ? "_v2" : "", pfn_nvmlErrorString(res1));
     initResult = ncclSystemError;
     return initResult;
   }
@@ -156,14 +156,14 @@ ncclResult_t ncclNvmlEnsureInitialized() {
   unsigned int ndev;
   res1 = (have_v2 ? pfn_nvmlDeviceGetCount_v2 : pfn_nvmlDeviceGetCount)(&ndev);
   if (res1 != NVML_SUCCESS) {
-    WARN("nvmlDeviceGetCount%s() failed: %s", have_v2 ? "_v2" : "", pfn_nvmlErrorString(res1));
+    ERR(ncclSystemError, "nvmlDeviceGetCount%s() failed: %s", have_v2 ? "_v2" : "", pfn_nvmlErrorString(res1));
     initResult = ncclSystemError;
     return initResult;
   }
 
   ncclNvmlDeviceCount = int(ndev);
   if (ncclNvmlMaxDevices < ncclNvmlDeviceCount) {
-    WARN("nvmlDeviceGetCount() reported more devices (%d) than the internal maximum (ncclNvmlMaxDevices=%d)",
+    ERR(ncclInternalError, "nvmlDeviceGetCount() reported more devices (%d) than the internal maximum (ncclNvmlMaxDevices=%d)",
          ncclNvmlDeviceCount, ncclNvmlMaxDevices);
     initResult = ncclInternalError;
     return initResult;
@@ -172,7 +172,7 @@ ncclResult_t ncclNvmlEnsureInitialized() {
   for (int a = 0; a < ncclNvmlDeviceCount; a++) {
     res1 = pfn_nvmlDeviceGetHandleByIndex(a, &ncclNvmlDevices[a].handle);
     if (res1 != NVML_SUCCESS) {
-      WARN("nvmlDeviceGetHandleByIndex(%d) failed: %s", int(a), pfn_nvmlErrorString(res1));
+      ERR(ncclSystemError, "nvmlDeviceGetHandleByIndex(%d) failed: %s", int(a), pfn_nvmlErrorString(res1));
       initResult = ncclSystemError;
       return initResult;
     }
@@ -180,7 +180,7 @@ ncclResult_t ncclNvmlEnsureInitialized() {
     res1 = pfn_nvmlDeviceGetCudaComputeCapability(ncclNvmlDevices[a].handle, &ncclNvmlDevices[a].computeCapabilityMajor,
                                                   &ncclNvmlDevices[a].computeCapabilityMinor);
     if (res1 != NVML_SUCCESS) {
-      WARN("nvmlDeviceGetCudaComputeCapability(%d) failed: %s", int(a), pfn_nvmlErrorString(res1));
+      ERR(ncclSystemError, "nvmlDeviceGetCudaComputeCapability(%d) failed: %s", int(a), pfn_nvmlErrorString(res1));
       initResult = ncclSystemError;
       return initResult;
     }
@@ -193,14 +193,14 @@ ncclResult_t ncclNvmlEnsureInitialized() {
 
       res1 = pfn_nvmlDeviceGetP2PStatus(da, db, NVML_P2P_CAPS_INDEX_READ, &ncclNvmlDevicePairs[a][b].p2pStatusRead);
       if (res1 != NVML_SUCCESS) {
-        WARN("nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_READ) failed: %s", a, b, pfn_nvmlErrorString(res1));
+        ERR(ncclSystemError, "nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_READ) failed: %s", a, b, pfn_nvmlErrorString(res1));
         initResult = ncclSystemError;
         return initResult;
       }
 
       res1 = pfn_nvmlDeviceGetP2PStatus(da, db, NVML_P2P_CAPS_INDEX_WRITE, &ncclNvmlDevicePairs[a][b].p2pStatusWrite);
       if (res1 != NVML_SUCCESS) {
-        WARN("nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_READ) failed: %s", a, b, pfn_nvmlErrorString(res1));
+        ERR(ncclSystemError, "nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_READ) failed: %s", a, b, pfn_nvmlErrorString(res1));
         initResult = ncclSystemError;
         return initResult;
       }
@@ -215,7 +215,7 @@ ncclResult_t ncclNvmlEnsureInitialized() {
   do { \
     nvmlReturn_t e44241808 = pfn_##name(__VA_ARGS__); \
     if (e44241808 != NVML_SUCCESS) { \
-      WARN(#name "() failed: %s", pfn_nvmlErrorString(e44241808)); \
+      ERR(ncclSystemError, #name "() failed: %s", pfn_nvmlErrorString(e44241808)); \
       return ncclSystemError; \
     } \
   } while (0)

--- a/comms/ncclx/v2_31/src/misc/param.cc
+++ b/comms/ncclx/v2_31/src/misc/param.cc
@@ -20,6 +20,17 @@
 #include <unordered_set>
 #include "os.h"
 
+#include "cuda_runtime_api.h"
+
+#include <folly/synchronization/CallOnce.h>
+
+#include "comms/utils/InitFolly.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/SpdlogLogger.h"
+#include "meta/NcclxLogger.h"
+
 const char* userHomeDir() {
   return getenv("HOME");
 }
@@ -67,8 +78,19 @@ static void initEnvFunc() {
 }
 
 void initEnv() {
-  static std::once_flag once;
-  std::call_once(once, initEnvFunc);
+  // folly::call_once, not std::call_once: initFolly()/ncclCvarInit() can throw,
+  // and std::call_once deadlocks rather than retrying on a throwing callable.
+  static folly::once_flag once;
+  folly::call_once(once, [] {
+    meta::comms::initFolly();
+    ncclCvarInit();
+    // As early as the sink can be registered: it is configured from the
+    // NCCL_DEBUG* cvars, so it cannot precede ncclCvarInit(). Anything logged
+    // before this point goes to an unconfigured logger and is lost, so keep
+    // initEnvFunc() -- which reads conf files and can warn -- after it.
+    initNcclLogger();
+    initEnvFunc();
+  });
 }
 
 static void ncclGetCachePolicy(char const* env, int8_t* noCache) {
@@ -108,4 +130,20 @@ int64_t ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, i
 const char* ncclGetEnv(const char* name) {
   ncclInitEnv();
   return ncclEnvPluginGetEnv(name);
+}
+
+void initNcclLogger() {
+  // Shared CollTrace code still emits raw XLOG under comms.utils.
+  meta::comms::logger::initCommLogging();
+  meta::comms::logger::configureSpdlogLogger(
+    ncclx::logging::kNcclxLoggerName, "NCCL", meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
+    []() {
+      int cudaDev = -1;
+      (void)cudaGetDevice(&cudaDev);
+      return cudaDev;
+    },
+    [](std::string_view message) { meta::comms::logger::setLastError(std::string{message}, {}); },
+    NCCL_DEBUG_LOGGING_ASYNC);
+  meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName)
+    .set_level(meta::comms::logger::loggerLevelToSpdlogLevel(meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
 }

--- a/comms/ncclx/v2_31/src/misc/socket.cc
+++ b/comms/ncclx/v2_31/src/misc/socket.cc
@@ -16,6 +16,8 @@
 #include <atomic>
 #include <mutex>
 
+#include "comms/utils/cvars/nccl_cvars.h"
+
 NCCL_PARAM(RetryCnt, "SOCKET_RETRY_CNT", 34);
 NCCL_PARAM(RetryTimeOut, "SOCKET_RETRY_SLEEP_MSEC", 100);
 NCCL_PARAM(PollTimeOut, "SOCKET_POLL_TIMEOUT_MSEC", 0);
@@ -73,6 +75,19 @@ static ncclResult_t socketWait(int op, struct ncclSocket* sock, void* ptr, int s
     }
   }
   return ncclSuccess;
+}
+
+std::string ncclSocketToIPv6String(union ncclSocketAddress* addr) {
+  const struct sockaddr* saddr = &addr->sa;
+  // getnameinfo rejects a salen larger than the family's sockaddr on strict implementations.
+  const socklen_t salen = (saddr->sa_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
+  char host[NI_MAXHOST] = {0};
+  // On failure return empty rather than the uninitialized buffer, so a prefix comparison cannot
+  // match on garbage.
+  if (getnameinfo(saddr, salen, host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST) != 0) {
+    return {};
+  }
+  return {host};
 }
 
 uint16_t ncclSocketToPort(union ncclSocketAddress* addr) {
@@ -457,7 +472,7 @@ ncclResult_t ncclSocketReady(struct ncclSocket* sock, int* running) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclSocketConnect(struct ncclSocket* sock) {
+ncclResult_t ncclSocketConnect(struct ncclSocket* sock, const char* localIfName) {
 #ifdef ENABLE_TRACE
   char line[SOCKET_NAME_MAXLEN + 1];
 #endif
@@ -477,6 +492,20 @@ ncclResult_t ncclSocketConnect(struct ncclSocket* sock) {
     return ncclInternalError;
   }
   TRACE(NCCL_INIT | NCCL_NET, "Connecting to socket %s", ncclSocketToString(&sock->addr, line));
+
+  if (!NCCL_CLIENT_SOCKET_IFNAME.empty() && localIfName == nullptr) {
+    localIfName = NCCL_CLIENT_SOCKET_IFNAME.c_str();
+  }
+  // bind client socket to specified interface
+  if (localIfName != nullptr) {
+    // Zero-initialize and force termination: the name comes from a user-supplied cvar, and
+    // strncpy does not terminate when it is IFNAMSIZ or longer.
+    ifreq ifr{};
+    strncpy(ifr.ifr_name, localIfName, sizeof(ifr.ifr_name) - 1);
+    ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = '\0';
+    SYSCHECK(setsockopt(sock->socketDescriptor, SOL_SOCKET, SO_BINDTODEVICE, &ifr, sizeof(ifr)), "setsockopt");
+    INFO(NCCL_INIT, "ncclSocketConnect bind to interface %s", ifr.ifr_name);
+  }
 
   sock->state = ncclSocketStateConnecting;
   sock->finalizeCounter = 0;
@@ -591,6 +620,19 @@ ncclResult_t ncclSocketInit(struct ncclSocket* sock, const union ncclSocketAddre
     // in case of error, we close the descriptor before returning as it's unclear if the caller has to
     // use ncclSocketClose for cleanup
     NCCLCHECKGOTO(ncclOsSocketResetFd(sock), ret, fail);
+    if (NCCL_SOCKET_TOS_CONFIG != -1) {
+      // referenced D77281608
+      if (family == AF_INET6) {
+        // For IPv6 set the traffic class field
+        SYSCHECK(setsockopt(sock->socketDescriptor, IPPROTO_IPV6, IPV6_TCLASS, (char*)&NCCL_SOCKET_TOS_CONFIG,
+                            sizeof(int)),
+                 "setsockopt");
+      } else {
+        // For IPv4 set the TOS field
+        SYSCHECK(setsockopt(sock->socketDescriptor, IPPROTO_IP, IP_TOS, (char*)&NCCL_SOCKET_TOS_CONFIG, sizeof(int)),
+                 "setsockopt");
+      }
+    }
   } else {
     memset(&sock->addr, 0, sizeof(union ncclSocketAddress));
   }

--- a/comms/ncclx/v2_31/src/misc/socket.cc
+++ b/comms/ncclx/v2_31/src/misc/socket.cc
@@ -55,7 +55,7 @@ static ncclResult_t socketProgress(int op, struct ncclSocket* sock, void* ptr, i
       return ncclSuccess;
     } else {
       char line[SOCKET_NAME_MAXLEN + 1];
-      WARN("socketProgress: Connection closed by remote peer %s",
+      ERR(ncclRemoteError, "socketProgress: Connection closed by remote peer %s",
            ncclSocketToString(&sock->addr, line, /*numericHostForm*/ 0));
       return ncclRemoteError;
     }
@@ -91,7 +91,7 @@ ncclResult_t ncclSocketShutdown(struct ncclSocket* sock, int how) {
 
 ncclResult_t ncclSocketGetFd(struct ncclSocket* sock, ncclSocketDescriptor* socketDescriptor) {
   if (sock == NULL) {
-    WARN("ncclSocketGetFd: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketGetFd: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (socketDescriptor) *socketDescriptor = sock->socketDescriptor;
@@ -100,7 +100,7 @@ ncclResult_t ncclSocketGetFd(struct ncclSocket* sock, ncclSocketDescriptor* sock
 
 ncclResult_t ncclSocketSetFd(ncclSocketDescriptor socketDescriptor, struct ncclSocket* sock) {
   if (sock == NULL) {
-    WARN("ncclSocketSetFd: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketSetFd: pass NULL socket");
     return ncclInvalidArgument;
   }
   sock->socketDescriptor = socketDescriptor;
@@ -109,11 +109,11 @@ ncclResult_t ncclSocketSetFd(ncclSocketDescriptor socketDescriptor, struct ncclS
 
 ncclResult_t ncclSocketListen(struct ncclSocket* sock) {
   if (sock == NULL) {
-    WARN("ncclSocketListen: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketListen: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (!ncclOsSocketIsValid(sock)) {
-    WARN("ncclSocketListen: socket is invalid");
+    ERR(ncclInvalidArgument, "ncclSocketListen: socket is invalid");
     return ncclInvalidArgument;
   }
 
@@ -233,7 +233,7 @@ ncclResult_t ncclFindInterfaces(char* ifNames, union ncclSocketAddress* ifAddrs,
 
 ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char* ip_port_pair) {
   if (!(ip_port_pair && strlen(ip_port_pair) > 1)) {
-    WARN("Net : string is null");
+    ERR(ncclInvalidArgument, "Net : string is null");
     return ncclInvalidArgument;
   }
 
@@ -243,7 +243,7 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
     struct netIf ni;
     // parse <ip_or_hostname>:<port> string, expect one pair
     if (parseStringList(ip_port_pair, &ni, 1) != 1) {
-      WARN("Net : No valid <IPv4_or_hostname>:<port> pair found");
+      ERR(ncclInvalidArgument, "Net : No valid <IPv4_or_hostname>:<port> pair found");
       return ncclInvalidArgument;
     }
 
@@ -254,7 +254,7 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
     hints.ai_socktype = SOCK_STREAM;
 
     if ((rv = getaddrinfo(ni.prefix, NULL, &hints, &p)) != 0) {
-      WARN("Net : error encountered when getting address info : %s", gai_strerror(rv));
+      ERR(ncclInvalidArgument, "Net : error encountered when getting address info : %s", gai_strerror(rv));
       return ncclInvalidArgument;
     }
 
@@ -273,7 +273,7 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
       sin6.sin6_flowinfo = 0;                          // needed by IPv6, but possibly obsolete
       sin6.sin6_scope_id = 0;                          // should be global scope, set to 0
     } else {
-      WARN("Net : unsupported IP family");
+      ERR(ncclInvalidArgument, "Net : unsupported IP family");
       freeaddrinfo(p);
       return ncclInvalidArgument;
     }
@@ -287,7 +287,7 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
       if (ip_port_pair[i] == ']') break;
     }
     if (i == len) {
-      WARN("Net : No valid [IPv6]:port pair found");
+      ERR(ncclInvalidArgument, "Net : No valid [IPv6]:port pair found");
       return ncclInvalidArgument;
     }
     bool global_scope = (j == -1 ? true : false);     // If no % found, global scope; otherwise, link scope
@@ -316,7 +316,7 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
 
 ncclResult_t ncclSocketGetAddr(struct ncclSocket* sock, union ncclSocketAddress* addr) {
   if (sock == NULL) {
-    WARN("ncclSocketGetAddr: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketGetAddr: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (sock->state != ncclSocketStateReady) return ncclInternalError;
@@ -390,7 +390,7 @@ static ncclResult_t socketFinalizeAccept(struct ncclSocket* sock) {
 
 ncclResult_t ncclSocketPollConnect(struct ncclSocket* sock) {
   if (sock == NULL) {
-    WARN("ncclSocketPollConnect: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketPollConnect: pass NULL socket");
     return ncclInvalidArgument;
   }
   NCCLCHECK(ncclOsSocketPollConnect(sock));
@@ -445,7 +445,7 @@ ncclResult_t ncclSocketReady(struct ncclSocket* sock, int* running) {
     return ncclSuccess;
   }
   if (sock->state == ncclSocketStateError || sock->state == ncclSocketStateClosed) {
-    WARN("ncclSocketReady: unexpected socket state %d", sock->state);
+    ERR(ncclRemoteError, "ncclSocketReady: unexpected socket state %d", sock->state);
     return ncclRemoteError;
   }
   *running = (sock->state == ncclSocketStateReady) ? 1 : 0;
@@ -463,11 +463,11 @@ ncclResult_t ncclSocketConnect(struct ncclSocket* sock) {
 #endif
 
   if (sock == NULL) {
-    WARN("ncclSocketConnect: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketConnect: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (!ncclOsSocketIsValid(sock)) {
-    WARN("ncclSocketConnect: socket is invalid");
+    ERR(ncclInvalidArgument, "ncclSocketConnect: socket is invalid");
     return ncclInvalidArgument;
   }
 
@@ -507,7 +507,7 @@ ncclResult_t ncclSocketAccept(struct ncclSocket* sock, struct ncclSocket* listen
   ncclResult_t ret = ncclSuccess;
 
   if (listenSock == NULL || sock == NULL) {
-    WARN("ncclSocketAccept: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketAccept: pass NULL socket");
     ret = ncclInvalidArgument;
     goto exit;
   }
@@ -582,7 +582,7 @@ ncclResult_t ncclSocketInit(struct ncclSocket* sock, const union ncclSocketAddre
     family = sock->addr.sa.sa_family;
     if (family != AF_INET && family != AF_INET6) {
       char line[SOCKET_NAME_MAXLEN + 1];
-      WARN("ncclSocketInit: connecting to address %s with family %d is neither AF_INET(%d) nor AF_INET6(%d)",
+      ERR(ncclInternalError, "ncclSocketInit: connecting to address %s with family %d is neither AF_INET(%d) nor AF_INET6(%d)",
            ncclSocketToString(&sock->addr, line), family, AF_INET, AF_INET6);
       ret = ncclInternalError;
       goto exit;
@@ -603,7 +603,7 @@ fail:
 
 ncclResult_t ncclSocketProgress(int op, struct ncclSocket* sock, void* ptr, int size, int* offset, int* closed) {
   if (sock == NULL) {
-    WARN("ncclSocketProgress: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketProgress: pass NULL socket");
     return ncclInvalidArgument;
   }
   NCCLCHECK(socketProgress(op, sock, ptr, size, offset, closed));
@@ -612,7 +612,7 @@ ncclResult_t ncclSocketProgress(int op, struct ncclSocket* sock, void* ptr, int 
 
 ncclResult_t ncclSocketWait(int op, struct ncclSocket* sock, void* ptr, int size, int* offset) {
   if (sock == NULL) {
-    WARN("ncclSocketWait: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketWait: pass NULL socket");
     return ncclInvalidArgument;
   }
   NCCLCHECK(socketWait(op, sock, ptr, size, offset));
@@ -622,11 +622,11 @@ ncclResult_t ncclSocketWait(int op, struct ncclSocket* sock, void* ptr, int size
 ncclResult_t ncclSocketSend(struct ncclSocket* sock, void* ptr, int size) {
   int offset = 0;
   if (sock == NULL) {
-    WARN("ncclSocketSend: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketSend: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (sock->state != ncclSocketStateReady) {
-    WARN("ncclSocketSend: socket state (%d) is not ready", sock->state);
+    ERR(ncclInternalError, "ncclSocketSend: socket state (%d) is not ready", sock->state);
     return ncclInternalError;
   }
   NCCLCHECK(socketWait(NCCL_SOCKET_SEND, sock, ptr, size, &offset));
@@ -636,11 +636,11 @@ ncclResult_t ncclSocketSend(struct ncclSocket* sock, void* ptr, int size) {
 ncclResult_t ncclSocketRecv(struct ncclSocket* sock, void* ptr, int size) {
   int offset = 0;
   if (sock == NULL) {
-    WARN("ncclSocketRecv: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketRecv: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (sock->state != ncclSocketStateReady && sock->state != ncclSocketStateTerminating) {
-    WARN("ncclSocketRecv: socket state (%d) is not ready", sock->state);
+    ERR(ncclInternalError, "ncclSocketRecv: socket state (%d) is not ready", sock->state);
     return ncclInternalError;
   }
   NCCLCHECK(socketWait(NCCL_SOCKET_RECV, sock, ptr, size, &offset));
@@ -651,12 +651,12 @@ ncclResult_t ncclSocketSendRecv(struct ncclSocket* sendSock, void* sendPtr, int 
                                 void* recvPtr, int recvSize) {
   int sendOffset = 0, recvOffset = 0;
   if (sendSock == NULL || recvSock == NULL) {
-    WARN("ncclSocketSendRecv: invalid socket %p/%p", sendSock, recvSock);
+    ERR(ncclInternalError, "ncclSocketSendRecv: invalid socket %p/%p", sendSock, recvSock);
     return ncclInternalError;
   }
   if (sendSock->state != ncclSocketStateReady ||
       (recvSock->state != ncclSocketStateReady && recvSock->state != ncclSocketStateTerminating)) {
-    WARN("ncclSocketSendRecv: socket state (%d/%d) is not ready", sendSock->state, recvSock->state);
+    ERR(ncclInternalError, "ncclSocketSendRecv: socket state (%d/%d) is not ready", sendSock->state, recvSock->state);
     return ncclInternalError;
   }
   while (sendOffset < sendSize || recvOffset < recvSize) {
@@ -668,13 +668,13 @@ ncclResult_t ncclSocketSendRecv(struct ncclSocket* sendSock, void* sendPtr, int 
 
 ncclResult_t ncclSocketMultiOp(struct ncclSocketOp* ops, int numOps) {
   if (ops == NULL || numOps <= 0) {
-    WARN("ncclSocketMultiOp: invalid arguments ops=%p numOps=%d", ops, numOps);
+    ERR(ncclInvalidArgument, "ncclSocketMultiOp: invalid arguments ops=%p numOps=%d", ops, numOps);
     return ncclInvalidArgument;
   }
 
   for (int i = 0; i < numOps; i++) {
     if (ops[i].sock == NULL) {
-      WARN("ncclSocketMultiOp: invalid socket at index %d", i);
+      ERR(ncclInvalidArgument, "ncclSocketMultiOp: invalid socket at index %d", i);
       return ncclInvalidArgument;
     }
     ops[i].offset = 0;
@@ -693,7 +693,7 @@ ncclResult_t ncclSocketMultiOp(struct ncclSocketOp* ops, int numOps) {
 ncclResult_t ncclSocketTryRecv(struct ncclSocket* sock, void* ptr, int size, int* closed, bool blocking) {
   int offset = 0;
   if (sock == NULL) {
-    WARN("ncclSocketTryRecv: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketTryRecv: pass NULL socket");
     return ncclInvalidArgument;
   }
   *closed = 0;

--- a/comms/ncclx/v2_31/src/misc/strongstream.cc
+++ b/comms/ncclx/v2_31/src/misc/strongstream.cc
@@ -103,7 +103,7 @@ ncclResult_t ncclCudaGetCapturingGraph(struct ncclCudaGraph* graph, cudaStream_t
     graph->graphUsageMode = graphUsageMode;
 #endif
     if (status != cudaStreamCaptureStatusNone) {
-      WARN("NCCL cannot be captured in a graph if either it wasn't built with CUDA runtime >= 11.3 or if the installed "
+      ERR(ncclInvalidUsage, "NCCL cannot be captured in a graph if either it wasn't built with CUDA runtime >= 11.3 or if the installed "
            "CUDA driver < R465.");
       return ncclInvalidUsage;
     }
@@ -349,7 +349,7 @@ ncclResult_t ncclStrongStreamRelease(struct ncclCudaGraph graph, struct ncclStro
         CUDACHECK(cudaEventRecord(ss->serialEvent, ss->liveStream));
       }
       if (ss->liveAcquiredBy != localThreadId() && ncclParamLaunchRaceFatal()) {
-        WARN("%s", launchRaceFatalMsg);
+        ERR(ncclInvalidUsage, "%s", launchRaceFatalMsg);
         return ncclInvalidUsage;
       }
     } else {
@@ -362,7 +362,7 @@ ncclResult_t ncclStrongStreamRelease(struct ncclCudaGraph graph, struct ncclStro
       NCCLCHECK(recordEventOnStream(graph, ss->serialEvent, cap->captureStream, /*updateFrontier=*/true));
 
       if (cap->acquiredBy != localThreadId() && ncclParamLaunchRaceFatal()) {
-        WARN("%s", launchRaceFatalMsg);
+        ERR(ncclInvalidUsage, "%s", launchRaceFatalMsg);
         return ncclInvalidUsage;
       }
     }

--- a/comms/ncclx/v2_31/src/misc/utils.cc
+++ b/comms/ncclx/v2_31/src/misc/utils.cc
@@ -406,15 +406,15 @@ ncclResult_t ncclIntruAddressMapInsert_untyped(struct ncclIntruAddressMap_untype
                                                int nextFieldOffset, uintptr_t key, void* object) {
   // Runtime validation
   if (map == nullptr) {
-    WARN("Intrusive address map pointer is NULL");
+    ERR(ncclInvalidUsage, "Intrusive address map pointer is NULL");
     return ncclInvalidUsage;
   }
   if (object == nullptr) {
-    WARN("Object pointer is NULL");
+    ERR(ncclInvalidUsage, "Object pointer is NULL");
     return ncclInvalidUsage;
   }
   if (keySize <= 0 || keySize > (int)sizeof(uintptr_t)) {
-    WARN("Invalid key size %d (must be 0 < keySize <= %zu)", keySize, sizeof(uintptr_t));
+    ERR(ncclInvalidUsage, "Invalid key size %d (must be 0 < keySize <= %zu)", keySize, sizeof(uintptr_t));
     return ncclInvalidUsage;
   }
 
@@ -426,7 +426,7 @@ ncclResult_t ncclIntruAddressMapInsert_untyped(struct ncclIntruAddressMap_untype
     map->table = (void**)calloc(tableEntries, sizeof(void*));
     if (map->table == nullptr) {
       map->hbits = 0; // Reset on failure
-      WARN("Intrusive address map initialization failed: calloc(%zu entries) returned null", tableEntries);
+      ERR(ncclSystemError, "Intrusive address map initialization failed: calloc(%zu entries) returned null", tableEntries);
       return ncclSystemError;
     }
   }
@@ -443,7 +443,7 @@ ncclResult_t ncclIntruAddressMapInsert_untyped(struct ncclIntruAddressMap_untype
     // Allocate a new table (don't use realloc to avoid data corruption during rehashing)
     void** newTable = (void**)malloc(newSize * sizeof(void*));
     if (newTable == nullptr) {
-      WARN("Intrusive address map resize failed: malloc(%d entries) returned null", newSize);
+      ERR(ncclSystemError, "Intrusive address map resize failed: malloc(%d entries) returned null", newSize);
       return ncclSystemError;
     }
 
@@ -495,15 +495,15 @@ ncclResult_t ncclIntruAddressMapFind_untyped(struct ncclIntruAddressMap_untyped*
                                              int nextFieldOffset, uintptr_t key, void** object) {
   // Runtime validation
   if (map == nullptr) {
-    WARN("Intrusive address map pointer is NULL");
+    ERR(ncclInvalidUsage, "Intrusive address map pointer is NULL");
     return ncclInvalidUsage;
   }
   if (object == nullptr) {
-    WARN("Output object pointer is NULL");
+    ERR(ncclInvalidUsage, "Output object pointer is NULL");
     return ncclInvalidUsage;
   }
   if (keySize <= 0 || keySize > (int)sizeof(uintptr_t)) {
-    WARN("Invalid key size %d (must be 0 < keySize <= %zu)", keySize, sizeof(uintptr_t));
+    ERR(ncclInvalidUsage, "Invalid key size %d (must be 0 < keySize <= %zu)", keySize, sizeof(uintptr_t));
     return ncclInvalidUsage;
   }
 
@@ -534,11 +534,11 @@ ncclResult_t ncclIntruAddressMapRemove_untyped(struct ncclIntruAddressMap_untype
                                                int nextFieldOffset, uintptr_t key) {
   // Runtime validation
   if (map == nullptr) {
-    WARN("Intrusive address map pointer is NULL");
+    ERR(ncclInvalidUsage, "Intrusive address map pointer is NULL");
     return ncclInvalidUsage;
   }
   if (keySize <= 0 || keySize > (int)sizeof(uintptr_t)) {
-    WARN("Invalid key size %d (must be 0 < keySize <= %zu)", keySize, sizeof(uintptr_t));
+    ERR(ncclInvalidUsage, "Invalid key size %d (must be 0 < keySize <= %zu)", keySize, sizeof(uintptr_t));
     return ncclInvalidUsage;
   }
 

--- a/comms/ncclx/v2_31/src/mnnvl.cc
+++ b/comms/ncclx/v2_31/src/mnnvl.cc
@@ -66,7 +66,7 @@ ncclResult_t ncclMnnvlCheck(struct ncclComm* comm) {
       ncclCuMemAlloc(&ptr, &handle, CU_MEM_HANDLE_TYPE_FABRIC, CUDA_IPC_MIN, comm->memManager, ncclMemOffload);
     if (ret != ncclSuccess) {
       // Return an error if this is a MNNVL capable system but FABRIC handles are not supported
-      WARN("MNNVL (cliqueSize %d) is available but not working on this system. Check the IMEX channel configuration "
+      ERR(ncclSystemError, "MNNVL (cliqueSize %d) is available but not working on this system. Check the IMEX channel configuration "
            "(/dev/nvidia-caps-imex-channels). Set NCCL_MNNVL_ENABLE=0 to ignore this issue.",
            comm->clique.size);
       return ncclSystemError;
@@ -78,7 +78,7 @@ ncclResult_t ncclMnnvlCheck(struct ncclComm* comm) {
       (void)pfn_cuGetErrorString(err, &errStr);
       NCCLCHECK(ncclCuMemFree(ptr, comm->memManager));
       // Return an error if this is a MNNVL capable system but it's not working
-      WARN("MNNVL (cliqueSize %d) is available but not working on this system. Check the IMEX configuration "
+      ERR(ncclSystemError, "MNNVL (cliqueSize %d) is available but not working on this system. Check the IMEX configuration "
            "(nvidia-imex-ctl -N). Set NCCL_MNNVL_ENABLE=0 to ignore this issue.",
            comm->clique.size);
       return ncclSystemError;

--- a/comms/ncclx/v2_31/src/nccl.h.in
+++ b/comms/ncclx/v2_31/src/nccl.h.in
@@ -1074,6 +1074,74 @@ void pncclParamDumpAll(void);
 
 #ifdef __cplusplus
 
+// [META] CollTrace lifecycle feed and algorithm-statistics dump. Declared
+// outside extern "C" so the C++ container signatures work.
+#include <cstdint>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace ncclx::colltrace {
+
+inline constexpr uint64_t kInvalidReplayId = UINT64_MAX;
+
+enum class LifecycleEventType : uint8_t {
+  Enqueue,
+  Start,
+  End,
+};
+
+struct LifecycleEvent {
+  uint64_t replayId{kInvalidReplayId};
+  uint64_t commId{0};
+  // Stable one-based submission identity. Zero is reserved for no record.
+  // Matches getLatestCollTraceCollectiveId().
+  uint64_t collId{0};
+  // One-based per-execution identity. Differs from collId for graph replays.
+  uint64_t executionCollId{0};
+  LifecycleEventType eventType{LifecycleEventType::Enqueue};
+  double timestamp{0};
+};
+
+// Returns the process-local communicator identity used by lifecycle events.
+// Returns ncclInvalidArgument for a null communicator or ncclInvalidUsage if
+// the lifecycle feed is disabled.
+ncclResult_t getCollTraceCommId(ncclComm_t comm, uint64_t& commId);
+
+// Returns the latest one-based collective ID submitted on this communicator.
+// Writes zero and returns ncclSuccess if no collective has been submitted on
+// this communicator. Returns ncclInvalidArgument for a null communicator or
+// ncclInvalidUsage if the lifecycle feed is disabled.
+ncclResult_t getLatestCollTraceCollectiveId(ncclComm_t comm, uint64_t& collId);
+
+// Destructively drains lifecycle events across all lifecycle-enabled
+// communicators in this process. This call blocks until every registered
+// colltrace instance finishes a flush. Events are ordered by timestamp.
+ncclResult_t drainUnreadLifecycleEvents(std::vector<LifecycleEvent>& events);
+
+} // namespace ncclx::colltrace
+
+// NCCL_HAS_DUMP_ALGO_STAT controls whether dumpAlgoStat() is available.
+// To disable (e.g., when using a shim with a
+// different ncclComm layout), compile with -DNCCL_HAS_DUMP_ALGO_STAT=0.
+#if !defined(NCCL_HAS_DUMP_ALGO_STAT)
+#define NCCL_HAS_DUMP_ALGO_STAT
+#elif NCCL_HAS_DUMP_ALGO_STAT == 0
+#undef NCCL_HAS_DUMP_ALGO_STAT
+#endif
+
+#ifdef NCCL_HAS_DUMP_ALGO_STAT
+namespace ncclx::colltrace {
+
+// Dump collective algorithm statistics for a communicator.
+// Output map format: collective name -> algorithm name -> call count.
+// Requires NCCL_COLLTRACE=algostat to be enabled.
+// Clears and populates the output map. Empty if algostat not enabled or comm is null.
+void dumpAlgoStat(ncclComm_t comm, std::unordered_map<std::string, std::unordered_map<std::string, int64_t>>& algoStatMap);
+
+} // namespace ncclx::colltrace
+#endif // NCCL_HAS_DUMP_ALGO_STAT
+
 namespace ncclx {
 
 /*

--- a/comms/ncclx/v2_31/src/nccl.h.in
+++ b/comms/ncclx/v2_31/src/nccl.h.in
@@ -61,6 +61,11 @@
 #endif
 
 #ifdef __cplusplus
+// [NCCLX] Needed by ncclx::Hints below, which is declared inside the extern "C"
+// region so that C++ entry points can take it by reference.
+#include <initializer_list>
+#include <string>
+#include <unordered_map>
 extern "C" {
 #endif
 
@@ -151,6 +156,34 @@ typedef struct ncclConfig_v23100 {
   int numRmaSig;
   int rmaEagerInit;
   int hostCftMode;
+
+  //
+  // [NCCLX] Attributes following here are specific to NCCLX
+  //
+  // Appended after the last upstream member, matching v2_29/v2_30. The struct is
+  // versioned and append-only, so upstream's own members keep their offsets; only
+  // sizeof() grows, and NCCLX is the only reader of the fields below.
+  //
+
+  // communicator process group information.
+  const char* commDesc{nullptr};
+
+  // commSplit group ranks information
+  int* splitGroupRanks;
+  int splitGroupSize;
+
+  // control the fast init features
+  int fastInitMode{NCCL_CONFIG_UNDEF_INT};
+
+  // Opaque pointer to an ncclx::Hints object.  When non-null, NCCLX
+  // will read key-value pairs from this object and apply them to
+  // config fields that are still at their undefined defaults.
+  void* hints{NCCL_CONFIG_UNDEF_PTR};
+
+  // Internal field -- do not access directly.  This would be private
+  // if ncclConfig_t were a C++ class.  Populated by NCCLX during
+  // communicator creation; users must not read or write this field.
+  void* ncclxConfig{NCCL_CONFIG_UNDEF_PTR};
 } ncclConfig_t;
 
 /* Config initializer must be assigned to initialize config structure when it is created.
@@ -181,6 +214,12 @@ typedef struct ncclConfig_v23100 {
   NCCL_CONFIG_UNDEF_INT,                    /* numRmaSig */             \
   NCCL_CONFIG_UNDEF_INT,                    /* rmaEagerInit */          \
   NCCL_CONFIG_UNDEF_INT,                    /* hostCftMode */          \
+  NCCL_CONFIG_UNDEF_PTR,                    /* commDesc */              \
+  NCCL_CONFIG_UNDEF_PTR,                    /* splitGroupRanks */       \
+  NCCL_CONFIG_UNDEF_INT,                    /* splitGroupSize */        \
+  NCCL_CONFIG_UNDEF_INT,                    /* fastInitMode */          \
+  NCCL_CONFIG_UNDEF_PTR,                    /* hints */                 \
+  NCCL_CONFIG_UNDEF_PTR,                    /* ncclxConfig */           \
 }
 
 /* A single vendor-specific option expressed as a key-value pair. Multiple options can be
@@ -496,6 +535,13 @@ typedef enum { ncclSum        = 0,
                 * maintain ABI compatibility. */
                ncclMaxRedOp   = 0x7fffffff>>(32-8*sizeof(ncclRedOp_dummy_t))
              } ncclRedOp_t;
+
+/* [NCCLX] Comparison operation selector.
+ * Type-only dependency: shared meta/wrapper/MetaFactory.h maps this onto
+ * commCmpOp_t, so every version dir must declare it. The RMA signal API that
+ * consumes it (ncclWaitSignal and friends) is a separate row and is not ported
+ * here. */
+typedef enum { ncclCmpEQ = 0, ncclCmpGE = 1, ncclCmpLE = 2, ncclNumCmpOps = 3} ncclCmpOp_t;
 
 /* Data types */
 typedef enum { ncclInt8       = 0, ncclChar       = 0,
@@ -904,6 +950,28 @@ ncclResult_t pncclGroupEnd();
 ncclResult_t  ncclGroupSimulateEnd(ncclSimInfo_t* simInfo);
 ncclResult_t pncclGroupSimulateEnd(ncclSimInfo_t* simInfo);
 
+#ifdef __cplusplus
+namespace ncclx {
+typedef std::unordered_map<std::string, std::string> kvType;
+/*
+* NCCL hints object - Allows us to set hints (key, value) in the form
+* of strings, to be used by other operations.
+*/
+class Hints {
+    public:
+        Hints();
+        explicit Hints(std::initializer_list<std::pair<std::string, std::string>> init);
+        ncclResult_t set(const std::string& key, const std::string& val);
+        ncclResult_t get(const std::string& key, std::string& val) const;
+
+    private:
+        kvType kv;
+};
+
+} // namespace ncclx
+
+#endif
+
 /*
  * Parameter access
  *
@@ -1002,6 +1070,33 @@ void pncclParamDumpAll(void);
 
 #ifdef __cplusplus
 } // end extern "C"
+#endif
+
+#ifdef __cplusplus
+
+namespace ncclx {
+
+/*
+ * Set per-communicator configuration
+ *
+ * Update mutable configuration fields on a live communicator. Only
+ * algorithm-selection hint keys (sendrecvAlgo, allgatherAlgo, allreduceAlgo,
+ * alltoallvAlgo, rmaAlgo) may be changed after communicator creation.
+ *
+ * The config parameter must be initialized with NCCL_CONFIG_INITIALIZER. All
+ * flat ncclConfig_t fields must remain at their undefined defaults; only the
+ * hints pointer is read. Setting any flat field or any non-algo hint key
+ * returns ncclInvalidUsage. Passing an uninitialized config (missing magic)
+ * returns ncclInvalidArgument.
+ *
+ * The caller must ensure no concurrent collective or config update is in
+ * progress on the same communicator.
+ */
+// [META:COMM_SET_CONFIG]
+ncclResult_t commSetConfig(ncclComm_t comm, const ncclConfig_t* config);
+
+} // namespace ncclx
+
 #endif
 
 #endif // end include guard

--- a/comms/ncclx/v2_31/src/os/linux.cc
+++ b/comms/ncclx/v2_31/src/os/linux.cc
@@ -28,6 +28,8 @@
 #include "utils.h"
 #include "checks.h"
 #include "param.h"
+
+#include "comms/utils/cvars/nccl_cvars.h"
 #include <pthread.h>
 #include <sys/resource.h>
 #include <sys/syscall.h>
@@ -416,6 +418,18 @@ ncclResult_t ncclOsFindInterfaces(const char* prefixList, char* names, union ncc
     // check against user specified interfaces
     if (!(matchIfList(interface->ifa_name, -1, userIfs, nUserIfs, searchExact) ^ searchNot)) {
       continue;
+    }
+
+    // Only render the address when the filter is actually configured. v2_30 did this
+    // unconditionally, costing a getnameinfo and an INFO line per interface on every job,
+    // including the overwhelming majority that never set the prefix.
+    if (!NCCL_SOCKET_IPADDR_PREFIX.empty()) {
+      const auto addrString = ncclSocketToIPv6String((union ncclSocketAddress*)interface->ifa_addr);
+      if (addrString.compare(0, NCCL_SOCKET_IPADDR_PREFIX.length(), NCCL_SOCKET_IPADDR_PREFIX)) {
+        continue;
+      }
+      INFO(NCCL_INIT, "NCCL_SOCKET_IPADDR_PREFIX %s, current addrString %s", NCCL_SOCKET_IPADDR_PREFIX.c_str(),
+           addrString.c_str());
     }
 
     // Check that this interface has not already been saved

--- a/comms/ncclx/v2_31/src/os/linux.cc
+++ b/comms/ncclx/v2_31/src/os/linux.cc
@@ -195,13 +195,13 @@ ncclResult_t ncclOsSocketTryAccept(struct ncclSocket* sock) {
     /* per accept's man page, for linux sockets, the following errors might be already pending errors
      * and should be considered as EAGAIN. To avoid infinite loop in case of errors, we use the retry count*/
     if (++sock->errorRetries == ncclParamRetryCnt()) {
-      WARN("ncclOsSocketTryAccept: exceeded error retry count after %d attempts, %s", sock->errorRetries,
+      ERR(ncclSystemError, "ncclOsSocketTryAccept: exceeded error retry count after %d attempts, %s", sock->errorRetries,
            strerror(errno));
       return ncclSystemError;
     }
     INFO(NCCL_NET | NCCL_INIT, "Call to accept returned %s, retrying", strerror(errno));
   } else if (errno != EINTR && errno != EAGAIN && errno != EWOULDBLOCK) {
-    WARN("ncclOsSocketTryAccept: Accept failed: %s", strerror(errno));
+    ERR(ncclSystemError, "ncclOsSocketTryAccept: Accept failed: %s", strerror(errno));
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -216,7 +216,7 @@ ncclResult_t ncclOsSocketSetFlags(struct ncclSocket* sock) {
   int flags;
   int rcvBuf, sndBuf;
   if (!ncclOsSocketIsValid(sock)) {
-    WARN("ncclOsSocketSetFlags: invalid socket");
+    ERR(ncclInvalidArgument, "ncclOsSocketSetFlags: invalid socket");
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -285,7 +285,7 @@ static ncclResult_t socketConnectCheck(struct ncclSocket* sock, int errCode, con
     if (sock->customRetry == 0) {
       if (sock->errorRetries++ == ncclParamRetryCnt()) {
         sock->state = ncclSocketStateError;
-        WARN("%s: connect to %s returned %s, exceeded error retry count after %d attempts", funcName,
+        ERR(ncclRemoteError, "%s: connect to %s returned %s, exceeded error retry count after %d attempts", funcName,
              ncclSocketToString(&sock->addr, line), strerror(errCode), sock->errorRetries);
         return ncclRemoteError;
       }
@@ -299,7 +299,7 @@ static ncclResult_t socketConnectCheck(struct ncclSocket* sock, int errCode, con
     sock->state = ncclSocketStateConnecting;
   } else {
     sock->state = ncclSocketStateError;
-    WARN("%s: connect to %s failed : %s", funcName, ncclSocketToString(&sock->addr, line), strerror(errCode));
+    ERR(ncclSystemError, "%s: connect to %s failed : %s", funcName, ncclSocketToString(&sock->addr, line), strerror(errCode));
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -325,7 +325,7 @@ ncclResult_t ncclOsSocketPollConnect(struct ncclSocket* sock) {
   if (ret == 0 || (ret < 0 && errno == EINTR)) {
     return ncclSuccess;
   } else if (ret < 0) {
-    WARN("ncclOsSocketPollConnect to %s failed with error %s", ncclSocketToString(&sock->addr, line), strerror(errno));
+    ERR(ncclSystemError, "ncclOsSocketPollConnect to %s failed with error %s", ncclSocketToString(&sock->addr, line), strerror(errno));
     return ncclSystemError;
   }
 
@@ -359,7 +359,7 @@ ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr,
         return ncclSuccess;
       }
       if (errno != EINTR && errno != EWOULDBLOCK && errno != EAGAIN) {
-        WARN("ncclOsSocketProgressOpt: Call to %s %s failed : %s", (op == NCCL_SOCKET_RECV ? "recv from" : "send to"),
+        ERR(ncclRemoteError, "ncclOsSocketProgressOpt: Call to %s %s failed : %s", (op == NCCL_SOCKET_RECV ? "recv from" : "send to"),
              ncclSocketToString(&sock->addr, line), strerror(errno));
         return ncclRemoteError;
       } else {
@@ -597,7 +597,7 @@ ncclAffinity ncclOsCpuAnd(const ncclAffinity& a, const ncclAffinity& b) {
 ncclResult_t ncclOsGetAffinity(ncclAffinity* affinity) {
   int result = sched_getaffinity(0, sizeof(ncclAffinity), affinity);
   if (result == -1) {
-    WARN("sched_getaffinity failed with error: %s", strerror(errno));
+    ERR(ncclSystemError, "sched_getaffinity failed with error: %s", strerror(errno));
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -606,7 +606,7 @@ ncclResult_t ncclOsGetAffinity(ncclAffinity* affinity) {
 ncclResult_t ncclOsSetAffinity(const ncclAffinity& affinity) {
   int result = sched_setaffinity(0, sizeof(ncclAffinity), &affinity);
   if (result == -1) {
-    WARN("sched_setaffinity failed with error: %s", strerror(errno));
+    ERR(ncclSystemError, "sched_setaffinity failed with error: %s", strerror(errno));
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -621,7 +621,7 @@ ncclResult_t ncclOsNvmlOpen(ncclOsLibraryHandle* handle) {
 
   *handle = ncclOsDlopen("libnvidia-ml.so.1");
   if (*handle == nullptr) {
-    WARN("Failed to open libnvidia-ml.so.1: %s", ncclOsDlerror());
+    ERR(ncclSystemError, "Failed to open libnvidia-ml.so.1: %s", ncclOsDlerror());
     return ncclSystemError;
   }
 
@@ -643,7 +643,7 @@ ncclResult_t ncclOsGetPciPath(const char* busId, char** path) {
   memcpylower(busPath + sizeof("/sys/class/pci_bus/0000:00/../../") - 1, busId, BUSID_SIZE - 1);
   *path = realpath(busPath, NULL);
   if (*path == NULL) {
-    WARN("Could not find real path of %s", busPath);
+    ERR(ncclSystemError, "Could not find real path of %s", busPath);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -786,7 +786,7 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize, vo
           INFO(NCCL_ALL, "mkstemp: Failed to create %s, error: %s (%d) - retrying", shmPath, strerror(errno), errno);
           goto retry_mkstemp;
         }
-        WARN("Error: failed to create shared memory file %s, error %s (%d)", shmPath, strerror(errno), errno);
+        ERR(ncclSystemError, "Error: failed to create shared memory file %s, error %s (%d)", shmPath, strerror(errno), errno);
         ret = ncclSystemError;
         goto fail;
       }
@@ -801,7 +801,7 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize, vo
              strerror(errno), errno);
         goto retry_fallocate;
       }
-      WARN("Error: failed to extend %s to %ld bytes, error: %s (%d)", shmPath, realShmSize, strerror(errno), errno);
+      ERR(ncclSystemError, "Error: failed to extend %s to %ld bytes, error: %s (%d)", shmPath, realShmSize, strerror(errno), errno);
       ret = ncclSystemError;
       goto fail;
     }
@@ -812,7 +812,7 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize, vo
 
   hptr = (char*)mmap(NULL, realShmSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
   if (hptr == MAP_FAILED) {
-    WARN("Error: Could not map %s size %zu, error: %s (%d)", shmPath, realShmSize, strerror(errno), errno);
+    ERR(ncclSystemError, "Error: Could not map %s size %zu, error: %s (%d)", shmPath, realShmSize, strerror(errno), errno);
     ret = ncclSystemError;
     hptr = NULL;
     goto fail;

--- a/comms/ncclx/v2_31/src/os/linux_ipcsocket.cc
+++ b/comms/ncclx/v2_31/src/os/linux_ipcsocket.cc
@@ -37,7 +37,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket* handle, int rank, uint64_t hash, v
   handle->fd = NCCL_INVALID_SOCKET;
   handle->socketName[0] = '\0';
   if ((fd = socket(AF_UNIX, SOCK_DGRAM, 0)) < 0) {
-    WARN("UDS: Socket creation error : %s (%d)", strerror(errno), errno);
+    ERR(ncclSystemError, "UDS: Socket creation error : %s (%d)", strerror(errno), errno);
     return ncclSystemError;
   }
 
@@ -47,7 +47,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket* handle, int rank, uint64_t hash, v
   // Create unique name for the socket.
   int len = snprintf(temp, NCCL_IPC_SOCKNAME_LEN, NCCL_IPC_SOCKNAME_STR, rank, hash);
   if (len > (int)(sizeof(cliaddr.sun_path) - 1)) {
-    WARN("UDS: Cannot bind provided name to socket. Name too large");
+    ERR(ncclInternalError, "UDS: Cannot bind provided name to socket. Name too large");
     close(fd);
     return ncclInternalError;
   }
@@ -65,7 +65,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket* handle, int rank, uint64_t hash, v
     cliaddr.sun_path[0] = '\0'; // Linux abstract socket trick
   }
   if (bind(fd, (struct sockaddr*)&cliaddr, sizeof(cliaddr)) < 0) {
-    WARN("UDS: Binding to socket %s failed : %s (%d)", temp, strerror(errno), errno);
+    ERR(ncclSystemError, "UDS: Binding to socket %s failed : %s (%d)", temp, strerror(errno), errno);
     close(fd);
     return ncclSystemError;
   }
@@ -86,7 +86,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket* handle, int rank, uint64_t hash, v
 
 ncclResult_t ncclIpcSocketGetFd(struct ncclIpcSocket* handle, int* fd) {
   if (handle == NULL) {
-    WARN("ncclIpcSocketGetFd: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclIpcSocketGetFd: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (fd) *fd = handle->fd;
@@ -139,7 +139,7 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
 
   while ((ret = recvmsg(handle->fd, &msg, 0)) <= 0) {
     if (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
-      WARN("UDS: Receiving data over socket failed : %d", errno);
+      ERR(ncclSystemError, "UDS: Receiving data over socket failed : %d", errno);
       return ncclSystemError;
     }
     if (handle->abortFlag && COMPILER_ATOMIC_LOAD(handle->abortFlag, std::memory_order_acquire))
@@ -149,13 +149,13 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
   if (recvFd != NULL) {
     if (((cmptr = CMSG_FIRSTHDR(&msg)) != NULL) && (cmptr->cmsg_len == CMSG_LEN(sizeof(int)))) {
       if ((cmptr->cmsg_level != SOL_SOCKET) || (cmptr->cmsg_type != SCM_RIGHTS)) {
-        WARN("UDS: Receiving data over socket failed");
+        ERR(ncclSystemError, "UDS: Receiving data over socket failed");
         return ncclSystemError;
       }
 
       memmove(recvFd, CMSG_DATA(cmptr), sizeof(*recvFd));
     } else {
-      WARN("UDS: Receiving data over socket %s failed", handle->socketName);
+      ERR(ncclSystemError, "UDS: Receiving data over socket %s failed", handle->socketName);
       return ncclSystemError;
     }
     TRACE(NCCL_INIT | NCCL_P2P, "UDS: Got recvFd %d from socket %s", *recvFd, handle->socketName);
@@ -189,7 +189,7 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
 
   int len = snprintf(temp, NCCL_IPC_SOCKNAME_LEN, NCCL_IPC_SOCKNAME_STR, rank, hash);
   if (len > (sizeof(cliaddr.sun_path) - 1)) {
-    WARN("UDS: Cannot connect to provided name for socket. Name too large");
+    ERR(ncclInternalError, "UDS: Cannot connect to provided name for socket. Name too large");
     return ncclInternalError;
   }
   strcpy(cliaddr.sun_path, temp);
@@ -230,7 +230,7 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
   ssize_t sendResult;
   while ((sendResult = sendmsg(handle->fd, &msg, 0)) < 0) {
     if (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
-      WARN("UDS: Sending data over socket %s failed : %s (%d)", temp, strerror(errno), errno);
+      ERR(ncclSystemError, "UDS: Sending data over socket %s failed : %s (%d)", temp, strerror(errno), errno);
       return ncclSystemError;
     }
     if (handle->abortFlag && COMPILER_ATOMIC_LOAD(handle->abortFlag, std::memory_order_acquire))

--- a/comms/ncclx/v2_31/src/os/windows.cc
+++ b/comms/ncclx/v2_31/src/os/windows.cc
@@ -159,7 +159,7 @@ ncclResult_t ncclOsInitialize() {
   WSADATA wsaData;
   int result = WSAStartup(MAKEWORD(2, 2), &wsaData);
   if (result != 0) {
-    WARN("WSAStartup failed with error: %d", result);
+    ERR(ncclSystemError, "WSAStartup failed with error: %d", result);
     return ncclSystemError;
   }
   INFO(NCCL_INIT | NCCL_NET, "WSAStartup succeeded, Winsock version %d.%d", LOBYTE(wsaData.wVersion),
@@ -209,7 +209,7 @@ ncclResult_t ncclOsSocketTryAccept(struct ncclSocket* sock) {
     if (wsaError == WSAEINPROGRESS) {
       // Connection in progress, retry with backoff
       if (++sock->errorRetries == ncclParamRetryCnt()) {
-        WARN("ncclOsSocketTryAccept: exceeded error retry count after %d attempts, %s", sock->errorRetries,
+        ERR(ncclSystemError, "ncclOsSocketTryAccept: exceeded error retry count after %d attempts, %s", sock->errorRetries,
              getWSAErrorMessage(wsaError));
         return ncclSystemError;
       }
@@ -217,7 +217,7 @@ ncclResult_t ncclOsSocketTryAccept(struct ncclSocket* sock) {
     } else if (wsaError != WSAEINTR && wsaError != WSAEWOULDBLOCK) {
       // WSAEWOULDBLOCK (10035) is expected for non-blocking accept - means no pending connection yet
       // WSAEINTR means interrupted, both are normal and we just return success to try again later
-      WARN("ncclOsSocketTryAccept: Accept failed: %s", getWSAErrorMessage(wsaError));
+      ERR(ncclSystemError, "ncclOsSocketTryAccept: Accept failed: %s", getWSAErrorMessage(wsaError));
       return ncclSystemError;
     }
   }
@@ -233,7 +233,7 @@ ncclResult_t ncclOsSocketSetFlags(struct ncclSocket* sock) {
   int sndBuf, rcvBuf;
   /* Set socket as non-blocking if async or if we need to be able to abort */
   if (!ncclOsSocketIsValid(sock)) {
-    WARN("ncclOsSocketSetFlags: invalid socket");
+    ERR(ncclInvalidArgument, "ncclOsSocketSetFlags: invalid socket");
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -241,7 +241,7 @@ ncclResult_t ncclOsSocketSetFlags(struct ncclSocket* sock) {
     u_long mode = 1;
     int iResult = ioctlsocket(sock->socketDescriptor, FIONBIO, &mode);
     if (iResult != NO_ERROR) {
-      WARN("ncclOsSocketSetFlags: ioctlsocket failed with error: %ld", iResult);
+      ERR(ncclSystemError, "ncclOsSocketSetFlags: ioctlsocket failed with error: %ld", iResult);
       ret = ncclSystemError;
       goto fail;
     }
@@ -281,7 +281,7 @@ ncclResult_t ncclOsSocketResetFd(struct ncclSocket* sock) {
   newSocket = socket(sock->addr.sa.sa_family, SOCK_STREAM, 0);
   if (newSocket == INVALID_SOCKET) {
     int wsaError = WSAGetLastError();
-    WARN("ncclOsSocketResetFd: socket() failed with error %d: %s", wsaError, getWSAErrorMessage(wsaError));
+    ERR(ncclSystemError, "ncclOsSocketResetFd: socket() failed with error %d: %s", wsaError, getWSAErrorMessage(wsaError));
     ret = ncclSystemError;
     goto cleanup;
   }
@@ -315,7 +315,7 @@ static ncclResult_t socketConnectCheck(struct ncclSocket* sock, int errCode, con
     if (sock->customRetry == 0) {
       if (sock->errorRetries++ == ncclParamRetryCnt()) {
         sock->state = ncclSocketStateError;
-        WARN("%s: connect to %s returned %s, exceeded error retry count after %d attempts", funcName,
+        ERR(ncclRemoteError, "%s: connect to %s returned %s, exceeded error retry count after %d attempts", funcName,
              ncclSocketToString(&sock->addr, line), getWSAErrorMessage(errCode), sock->errorRetries);
         return ncclRemoteError;
       }
@@ -329,7 +329,7 @@ static ncclResult_t socketConnectCheck(struct ncclSocket* sock, int errCode, con
     sock->state = ncclSocketStateConnecting;
   } else {
     sock->state = ncclSocketStateError;
-    WARN("%s: connect to %s failed : %s", funcName, ncclSocketToString(&sock->addr, line), getWSAErrorMessage(errCode));
+    ERR(ncclSystemError, "%s: connect to %s failed : %s", funcName, ncclSocketToString(&sock->addr, line), getWSAErrorMessage(errCode));
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -356,7 +356,7 @@ ncclResult_t ncclOsSocketPollConnect(struct ncclSocket* sock) {
     return ncclSuccess;
   } else if (ret < 0) {
     int wsaError = WSAGetLastError();
-    WARN("ncclOsSocketPollConnect to %s failed with error %s", ncclSocketToString(&sock->addr, line),
+    ERR(ncclSystemError, "ncclOsSocketPollConnect to %s failed with error %s", ncclSocketToString(&sock->addr, line),
          getWSAErrorMessage(wsaError));
     return ncclSystemError;
   }
@@ -377,7 +377,7 @@ ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr,
     u_long mode = !block;
     int iResult = ioctlsocket(sock->socketDescriptor, FIONBIO, &mode);
     if (iResult != NO_ERROR) {
-      WARN("ncclOsSocketProgressOpt: ioctlsocket failed with error: %ld", iResult);
+      ERR(ncclSystemError, "ncclOsSocketProgressOpt: ioctlsocket failed with error: %ld", iResult);
       return ncclSystemError;
     }
     sock->socketBlockingMode = block;
@@ -399,7 +399,7 @@ ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr,
       // WSAEINPROGRESS (10036) means operation is in progress
       // WSAEINTR means interrupted by signal
       if (wsaError != WSAEWOULDBLOCK && wsaError != WSAEINPROGRESS && wsaError != WSAEINTR) {
-        WARN("ncclOsSocketProgressOpt: Call to %s %s failed : %d (%s)",
+        ERR(ncclRemoteError, "ncclOsSocketProgressOpt: Call to %s %s failed : %d (%s)",
              (op == NCCL_SOCKET_RECV ? "recv from" : "send to"), ncclSocketToString(&sock->addr, line), wsaError,
              getWSAErrorMessage(wsaError));
         return ncclRemoteError;
@@ -435,21 +435,21 @@ ncclResult_t ncclOsFindInterfaces(const char* prefixList, char* names, union ncc
   ULONG bufferSize = 0;
   DWORD result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL, NULL, &bufferSize);
   if (result != ERROR_BUFFER_OVERFLOW) {
-    WARN("GetAdaptersAddresses failed with error: %ld", result);
+    ERR(ncclSystemError, "GetAdaptersAddresses failed with error: %ld", result);
     ret = ncclSystemError;
     goto exit;
   }
 
   IP_ADAPTER_ADDRESSES* adapterAddresses = (IP_ADAPTER_ADDRESSES*)malloc(bufferSize);
   if (adapterAddresses == NULL) {
-    WARN("Failed to allocate memory for adapter addresses");
+    ERR(ncclSystemError, "Failed to allocate memory for adapter addresses");
     ret = ncclSystemError;
     goto exit;
   }
 
   result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL, adapterAddresses, &bufferSize);
   if (result != NO_ERROR) {
-    WARN("GetAdaptersAddresses failed with error: %ld", result);
+    ERR(ncclSystemError, "GetAdaptersAddresses failed with error: %ld", result);
     ret = ncclSystemError;
     goto exit;
   }
@@ -599,21 +599,21 @@ ncclResult_t ncclFindInterfaceMatchSubnet(char* ifName, union ncclSocketAddress*
   ULONG bufferSize = 0;
   DWORD result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL, NULL, &bufferSize);
   if (result != ERROR_BUFFER_OVERFLOW) {
-    WARN("GetAdaptersAddresses failed with error: %ld", result);
+    ERR(ncclSystemError, "GetAdaptersAddresses failed with error: %ld", result);
     ret = ncclSystemError;
     goto exit;
   }
 
   IP_ADAPTER_ADDRESSES* adapterAddresses = (IP_ADAPTER_ADDRESSES*)malloc(bufferSize);
   if (adapterAddresses == NULL) {
-    WARN("Failed to allocate memory for adapter addresses");
+    ERR(ncclSystemError, "Failed to allocate memory for adapter addresses");
     ret = ncclSystemError;
     goto exit;
   }
 
   result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL, adapterAddresses, &bufferSize);
   if (result != NO_ERROR) {
-    WARN("GetAdaptersAddresses failed with error: %ld", result);
+    ERR(ncclSystemError, "GetAdaptersAddresses failed with error: %ld", result);
     free(adapterAddresses);
     ret = ncclSystemError;
     goto exit;
@@ -727,7 +727,7 @@ ncclResult_t ncclOsGetAffinity(ncclAffinity* affinity) {
   DWORD_PTR processAffinityMask, systemAffinityMask;
   BOOL result = GetProcessAffinityMask(GetCurrentProcess(), &processAffinityMask, &systemAffinityMask);
   if (result == FALSE) {
-    WARN("GetProcessAffinityMask failed with error: %ld", GetLastError());
+    ERR(ncclSystemError, "GetProcessAffinityMask failed with error: %ld", GetLastError());
     return ncclSystemError;
   }
   *affinity = processAffinityMask;
@@ -737,7 +737,7 @@ ncclResult_t ncclOsGetAffinity(ncclAffinity* affinity) {
 ncclResult_t ncclOsSetAffinity(const ncclAffinity& affinity) {
   BOOL result = SetProcessAffinityMask(GetCurrentProcess(), affinity);
   if (result == FALSE) {
-    WARN("SetProcessAffinityMask failed with error: %ld", GetLastError());
+    ERR(ncclSystemError, "SetProcessAffinityMask failed with error: %ld", GetLastError());
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -764,7 +764,7 @@ ncclResult_t ncclOsNvmlOpen(ncclOsLibraryHandle* handle) {
 
   if (*handle == nullptr) {
     DWORD err = GetLastError();
-    WARN("Failed to load nvml.dll, error code: %lu", err);
+    ERR(ncclSystemError, "Failed to load nvml.dll, error code: %lu", err);
     return ncclSystemError;
   }
 
@@ -860,7 +860,7 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize, vo
                                   shmPath);                // name of mapping object
 
     if (hMapFile == NULL) {
-      WARN("Error: failed to create shared memory mapping %s, error code: %lu", shmPath, GetLastError());
+      ERR(ncclSystemError, "Error: failed to create shared memory mapping %s, error code: %lu", shmPath, GetLastError());
       ret = ncclSystemError;
       goto fail;
     }
@@ -873,7 +873,7 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize, vo
                                 shmPath);              // name of mapping object
 
     if (hMapFile == NULL) {
-      WARN("Error: failed to open shared memory mapping %s, error code: %lu", shmPath, GetLastError());
+      ERR(ncclSystemError, "Error: failed to open shared memory mapping %s, error code: %lu", shmPath, GetLastError());
       ret = ncclSystemError;
       goto fail;
     }
@@ -887,7 +887,7 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize, vo
                               realShmSize);        // number of bytes to map
 
   if (hptr == NULL) {
-    WARN("Error: Could not map view of file %s size %zu, error code: %lu", shmPath, realShmSize, GetLastError());
+    ERR(ncclSystemError, "Error: Could not map view of file %s size %zu, error code: %lu", shmPath, realShmSize, GetLastError());
     ret = ncclSystemError;
     goto fail;
   }

--- a/comms/ncclx/v2_31/src/os/windows_ipcsocket.cc
+++ b/comms/ncclx/v2_31/src/os/windows_ipcsocket.cc
@@ -43,7 +43,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket* handle, int rank, uint64_t hash, v
   char pipeName[NCCL_IPC_SOCKNAME_LEN];
   int len = snprintf(pipeName, NCCL_IPC_SOCKNAME_LEN, NCCL_IPC_PIPENAME_STR, rank, hash);
   if (len >= NCCL_IPC_SOCKNAME_LEN) {
-    WARN("IPC: Pipe name too long");
+    ERR(ncclInternalError, "IPC: Pipe name too long");
     return ncclInternalError;
   }
 
@@ -63,7 +63,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket* handle, int rank, uint64_t hash, v
   );
 
   if (hPipe == INVALID_HANDLE_VALUE) {
-    WARN("IPC: Failed to create named pipe %s: error %d", pipeName, GetLastError());
+    ERR(ncclSystemError, "IPC: Failed to create named pipe %s: error %d", pipeName, GetLastError());
     return ncclSystemError;
   }
 
@@ -78,7 +78,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket* handle, int rank, uint64_t hash, v
 
 ncclResult_t ncclIpcSocketGetFd(struct ncclIpcSocket* handle, int* fd) {
   if (handle == NULL) {
-    WARN("ncclIpcSocketGetFd: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclIpcSocketGetFd: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (fd) *fd = (int)handle->fd;
@@ -100,7 +100,7 @@ ncclResult_t ncclIpcSocketClose(ncclIpcSocket* handle) {
 
 ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, int* recvFd) {
   if (handle == NULL || handle->fd == NCCL_INVALID_SOCKET) {
-    WARN("IPC: Invalid socket handle");
+    ERR(ncclInvalidArgument, "IPC: Invalid socket handle");
     return ncclInvalidArgument;
   }
 
@@ -114,7 +114,7 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
   // Wait for client to connect
   BOOL connected = ConnectNamedPipe(hPipe, NULL);
   if (!connected && GetLastError() != ERROR_PIPE_CONNECTED) {
-    WARN("IPC: Failed to connect named pipe: error %d", GetLastError());
+    ERR(ncclSystemError, "IPC: Failed to connect named pipe: error %d", GetLastError());
     return ncclSystemError;
   }
 
@@ -132,13 +132,13 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
     if (error == ERROR_NO_DATA || error == ERROR_BROKEN_PIPE) {
       // Check abort flag
       if (handle->abortFlag && COMPILER_ATOMIC_LOAD(handle->abortFlag, std::memory_order_acquire)) {
-        WARN("IPC: Operation aborted");
+        ERR(ncclInternalError, "IPC: Operation aborted");
         return ncclInternalError;
       }
       continue;
     }
 
-    WARN("IPC: ReadFile failed: error %d", error);
+    ERR(ncclSystemError, "IPC: ReadFile failed: error %d", error);
     return ncclSystemError;
   }
 
@@ -162,7 +162,7 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
     );
 
     if (!dupSuccess) {
-      WARN("IPC: DuplicateHandle failed: error %d", GetLastError());
+      ERR(ncclSystemError, "IPC: DuplicateHandle failed: error %d", GetLastError());
       return ncclSystemError;
     }
 
@@ -183,7 +183,7 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
   char pipeName[NCCL_IPC_SOCKNAME_LEN];
   int len = snprintf(pipeName, NCCL_IPC_SOCKNAME_LEN, NCCL_IPC_PIPENAME_STR, rank, hash);
   if (len >= NCCL_IPC_SOCKNAME_LEN) {
-    WARN("IPC: Pipe name too long");
+    ERR(ncclInternalError, "IPC: Pipe name too long");
     return ncclInternalError;
   }
 
@@ -207,13 +207,13 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
 
     DWORD error = GetLastError();
     if (error != ERROR_PIPE_BUSY && error != ERROR_FILE_NOT_FOUND) {
-      WARN("IPC: Failed to connect to pipe %s: error %d", pipeName, error);
+      ERR(ncclSystemError, "IPC: Failed to connect to pipe %s: error %d", pipeName, error);
       return ncclSystemError;
     }
 
     // Check abort flag
     if (handle && handle->abortFlag && COMPILER_ATOMIC_LOAD(handle->abortFlag, std::memory_order_acquire)) {
-      WARN("IPC: Operation aborted");
+      ERR(ncclInternalError, "IPC: Operation aborted");
       return ncclInternalError;
     }
   }
@@ -223,7 +223,7 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
   // Set pipe to message mode
   DWORD mode = PIPE_READMODE_MESSAGE;
   if (!SetNamedPipeHandleState(hPipe, &mode, NULL, NULL)) {
-    WARN("IPC: SetNamedPipeHandleState failed: error %d", GetLastError());
+    ERR(ncclSystemError, "IPC: SetNamedPipeHandleState failed: error %d", GetLastError());
     CloseHandle(hPipe);
     return ncclSystemError;
   }
@@ -247,7 +247,7 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
   BOOL success = WriteFile(hPipe, &msg, sizeof(msg), &bytesWritten, NULL);
 
   if (!success || bytesWritten != sizeof(msg)) {
-    WARN("IPC: WriteFile failed: error %d, wrote %d of %zu bytes", GetLastError(), bytesWritten, sizeof(msg));
+    ERR(ncclSystemError, "IPC: WriteFile failed: error %d, wrote %d of %zu bytes", GetLastError(), bytesWritten, sizeof(msg));
     CloseHandle(hPipe);
     return ncclSystemError;
   }

--- a/comms/ncclx/v2_31/src/param/param.cc
+++ b/comms/ncclx/v2_31/src/param/param.cc
@@ -20,7 +20,7 @@ using ncclStringSet = std::unordered_set<std::string>;
 DEFINE_NCCL_PARAM(ncclParamNoCacheStr, const char*, NCCL_NO_CACHE, nullptr, NCCL_PARAM_FLAG_CACHED, NCCL_PARAM_DEFAULT,
                   "Comma-separated list of param keys to disable caching (or ALL)");
 
-extern "C" bool ncclParamIsCacheDisabled(const char* key) {
+extern "C" NCCL_PARAM_COMPILER_EXPORT_SYMBOL bool ncclParamIsCacheDisabled(const char* key) {
   // Short-circuit for NCCL_NO_CACHE itself to prevent circular dependency
   if (std::strcmp(key, "NCCL_NO_CACHE") == 0) return false;
 
@@ -44,7 +44,7 @@ extern "C" bool ncclParamIsCacheDisabled(const char* key) {
 // a single symbol instead of requiring ncclInitEnv + ncclEnvPluginGetEnv
 // to be exported.
 #include "env.h"
-extern "C" const char* ncclParamEnvPluginGet(const char* key, bool env_init) {
+extern "C" NCCL_PARAM_COMPILER_EXPORT_SYMBOL const char* ncclParamEnvPluginGet(const char* key, bool env_init) {
   if (env_init) {
     // regular parameters will init env plugins before reading env
     ncclInitEnv();

--- a/comms/ncclx/v2_31/src/param/param_registry.cc
+++ b/comms/ncclx/v2_31/src/param/param_registry.cc
@@ -8,7 +8,7 @@
 #include "param/param_registry.h"
 #include "debug.h"
 
-extern "C" void* ncclParamRegistryInstance() {
+extern "C" NCCL_PARAM_COMPILER_EXPORT_SYMBOL void* ncclParamRegistryInstance() {
   static ncclParamRegistry::registryState state;
   return &state;
 }

--- a/comms/ncclx/v2_31/src/param/param_registry.cc
+++ b/comms/ncclx/v2_31/src/param/param_registry.cc
@@ -17,7 +17,7 @@ ncclResult_t ncclParamRegistry::add(std::string key, ncclParamInfo_t info, ncclP
   auto& reg = state();
   std::lock_guard<std::mutex> lock(reg.mtx);
   if (reg.map.find(key) != reg.map.end()) {
-    WARN("PARAM: Duplicate registration for key \"%s\", ignoring.", key.c_str());
+    ERR(ncclInternalError, "PARAM: Duplicate registration for key \"%s\", ignoring.", key.c_str());
     return ncclInternalError;
   }
   reg.map[key] = {info, param};

--- a/comms/ncclx/v2_31/src/plugin/net.cc
+++ b/comms/ncclx/v2_31/src/plugin/net.cc
@@ -150,12 +150,12 @@ ncclResult_t ncclNetCheckDeviceVersion(struct ncclComm* comm, ncclNet_t* net, in
       INFO(NCCL_INIT, "Using NCCL_NET_DEVICE_UNPACK net plugin version %d", props.netDeviceVersion);
       return ncclSuccess;
     } else {
-      WARN("NCCL_DEVICE_UNPACK plugin has incompatible version %d, this NCCL build is compatible with %d, not using it",
+      ERR(ncclInternalError, "NCCL_DEVICE_UNPACK plugin has incompatible version %d, this NCCL build is compatible with %d, not using it",
            props.netDeviceVersion, NCCL_NET_DEVICE_UNPACK_VERSION);
       return ncclInternalError;
     }
   default:
-    WARN("Unknown device code index %d", type);
+    ERR(ncclInternalError, "Unknown device code index %d", type);
     return ncclInternalError;
   }
 
@@ -346,7 +346,7 @@ ncclResult_t ncclNetInit(struct ncclComm* comm) {
     }
   }
   if (ncclNetPluginInitialized) return ncclSuccess;
-  WARN("Failed to initialize any NET plugin");
+  ERR(ncclInvalidUsage, "Failed to initialize any NET plugin");
   return ncclInvalidUsage;
 }
 

--- a/comms/ncclx/v2_31/src/proxy.cc
+++ b/comms/ncclx/v2_31/src/proxy.cc
@@ -75,7 +75,7 @@ static ncclResult_t expectedProxyResponseStore(struct ncclProxyState* state, voi
       }
 
       if (elem->done) {
-        WARN("Storing response for already completed opId=%p", opId);
+        ERR(ncclInternalError, "Storing response for already completed opId=%p", opId);
         return ncclInternalError;
       }
 
@@ -90,7 +90,7 @@ static ncclResult_t expectedProxyResponseStore(struct ncclProxyState* state, voi
     elem = elem->next;
   }
 
-  WARN("Proxy response for opId=%p doesn't match any expected response", opId);
+  ERR(ncclInternalError, "Proxy response for opId=%p doesn't match any expected response", opId);
   return ncclInternalError;
 }
 
@@ -157,7 +157,7 @@ static ncclResult_t expectedProxyResponseRemove(struct ncclProxyState* state, vo
     prev = elem;
     elem = elem->next;
   }
-  WARN("Couldn't find opId=%p", opId);
+  ERR(ncclInternalError, "Couldn't find opId=%p", opId);
   return ncclInternalError;
 }
 
@@ -197,9 +197,9 @@ static ncclResult_t asyncProxyOpDequeue(struct ncclProxyLocalPeer* peer, ncclPro
     elem = elem->next;
   }
   if (op) {
-    WARN("Attempting to dequeue nonexistent async opId=%p", op->opId);
+    ERR(ncclInternalError, "Attempting to dequeue nonexistent async opId=%p", op->opId);
   } else {
-    WARN("Attempting to dequeue null operation");
+    ERR(ncclInternalError, "Attempting to dequeue null operation");
   }
   return ncclInternalError;
 }
@@ -253,7 +253,7 @@ ncclResult_t getOpIndex(struct ncclProxyArgs* op, struct ncclProxyProgressState*
     pool = pool->next;
     p++;
   }
-  WARN("Could not find pool of op %p", op);
+  ERR(ncclInternalError, "Could not find pool of op %p", op);
   return ncclInternalError;
 }
 
@@ -368,7 +368,7 @@ ncclResult_t dumpProxyState(struct ncclProxyProgressState* state) {
 static ncclResult_t ncclProxyOpToArgs(struct ncclProxyOp* op, struct ncclProxyArgs* args, int subIndex) {
   struct ncclProxySubArgs* sub = args->subs + subIndex;
   if (subIndex >= NCCL_PROXY_MAX_SUBS) {
-    WARN("Proxy append out of bounds");
+    ERR(ncclInternalError, "Proxy append out of bounds");
     return ncclInternalError;
   }
   // memset(sub, 0, sizeof(struct ncclProxySubArgs));
@@ -401,11 +401,11 @@ static ncclResult_t ncclProxyOpToArgs(struct ncclProxyOp* op, struct ncclProxyAr
     if ((args->sliceSteps != op->sliceSteps) || (args->chunkSteps != op->chunkSteps) ||
         (args->protocol != op->protocol) || (args->dtype != op->dtype) || (args->redOp != op->redOp) ||
         (args->coll != op->coll)) {
-      WARN("Proxy append mismatch");
+      ERR(ncclInternalError, "Proxy append mismatch");
       return ncclInternalError;
     }
     if (args->state != ncclProxyOpReady) {
-      WARN("Proxy append on running operation");
+      ERR(ncclInternalError, "Proxy append on running operation");
       return ncclInternalError;
     }
     goto exit;
@@ -538,7 +538,7 @@ static ncclResult_t ncclLocalOpAppend(struct ncclComm* comm, struct ncclProxyCon
       }
     }
     if (lastOp == -1) {
-      WARN("Unable to post incomplete proxy op chain %d..%d (opCount %ld)", proxyOps->nextOps, proxyOps->nextOpsEnd,
+      ERR(ncclInternalError, "Unable to post incomplete proxy op chain %d..%d (opCount %ld)", proxyOps->nextOps, proxyOps->nextOpsEnd,
            lastOpCount);
       return ncclInternalError;
     }
@@ -560,7 +560,7 @@ static ncclResult_t SaveProxy(struct ncclComm* comm, struct ncclChannel* channel
   struct ncclChannelPeer* peerComm = channel->peers[peer];
   struct ncclConnector* connector = type == proxyRecv ? peerComm->recv + connIndex : peerComm->send + connIndex;
   if (connector->transportComm == NULL) {
-    WARN("Rank %d has no transport for %s peer %d on channel %d/%d", comm->rank, type == proxyRecv ? "recv" : "send",
+    ERR(ncclInternalError, "Rank %d has no transport for %s peer %d on channel %d/%d", comm->rank, type == proxyRecv ? "recv" : "send",
          peer, channel->id, connIndex);
     return ncclInternalError;
   }
@@ -1370,7 +1370,7 @@ ncclResult_t ncclPollProxyResponse(struct ncclComm* comm, struct ncclProxyConnec
   struct ncclProxyState* sharedProxyState = comm->proxyState;
   // Receive the connection pointer from the Proxy
   if (COMPILER_ATOMIC_LOAD(comm->abortFlag, std::memory_order_acquire)) {
-    WARN("Comm %p is in abort state", comm);
+    ERR(ncclInternalError, "Comm %p is in abort state", comm);
     return ncclInternalError;
   }
   if (sharedProxyState->peerSocks == NULL) return ncclInternalError;
@@ -1384,7 +1384,7 @@ ncclResult_t ncclPollProxyResponse(struct ncclComm* comm, struct ncclProxyConnec
     ncclProxyRpcResponseHeader resp = {0};
     int offset = 0;
     if (ncclSuccess != ncclSocketProgress(NCCL_SOCKET_RECV, sock, &resp, sizeof(resp), &offset)) {
-      WARN("Socket recv failed while polling for opId=%p", opId);
+      ERR(ncclInternalError, "Socket recv failed while polling for opId=%p", opId);
       return ncclInternalError;
     }
 

--- a/comms/ncclx/v2_31/src/ras/client_support.cc
+++ b/comms/ncclx/v2_31/src/ras/client_support.cc
@@ -707,7 +707,7 @@ static ncclResult_t rasClientRun(struct rasClient* client, bool* closed) {
     client->status = RAS_CLIENT_FINISHED;
     break;
   default:
-    WARN("Invalid client status %d", client->status);
+    ERR(ncclInternalError, "Invalid client status %d", client->status);
     ret = ncclInternalError;
     goto exit;
   }

--- a/comms/ncclx/v2_31/src/ras/ras.cc
+++ b/comms/ncclx/v2_31/src/ras/ras.cc
@@ -257,7 +257,7 @@ static ncclResult_t rasLocalHandle(bool* terminate) {
     INFO(NCCL_RAS, "RAS handling local termination request");
     *terminate = true;
   } else {
-    WARN("RAS received unknown notification type %d", msg.type);
+    ERR(ncclInternalError, "RAS received unknown notification type %d", msg.type);
     return ncclInternalError;
   }
 
@@ -422,7 +422,7 @@ ncclResult_t rasMsgHandle(struct rasMsg* msg, struct rasSocket* sock) {
   } else if (msg->type == RAS_MSG_COLLRESP) {
     NCCLCHECK(rasMsgHandleCollResp(msg, sock));
   } else {
-    WARN("RAS received unknown message type (%d) from %s", msg->type, ncclSocketToString(&sock->sock.addr, rasLine));
+    ERR(ncclInternalError, "RAS received unknown message type (%d) from %s", msg->type, ncclSocketToString(&sock->sock.addr, rasLine));
     return ncclInternalError;
   }
 
@@ -446,7 +446,7 @@ static ncclResult_t rasMsgHandleConnInit(const struct rasMsg* msg, struct rasSoc
 
   if (msg->connInit.ncclVersion != NCCL_VERSION_CODE) {
     // Close any such sockets immediately!  This is basically unrecoverable...
-    WARN("NCCL version mismatch with remote peer %s (local: %s, remote %s)",
+    ERR(ncclInvalidUsage, "NCCL version mismatch with remote peer %s (local: %s, remote %s)",
          ncclSocketToString(&sock->sock.addr, rasLine),
          ncclVersionToString(NCCL_VERSION_CODE, versionLocal, sizeof(versionLocal)),
          ncclVersionToString(msg->connInit.ncclVersion, versionRemote, sizeof(versionRemote)));

--- a/comms/ncclx/v2_31/src/register/register.cc
+++ b/comms/ncclx/v2_31/src/register/register.cc
@@ -184,7 +184,7 @@ static ncclResult_t commDeregister(struct ncclComm* comm, bool isGraph, struct n
   CUDACHECK(cudaSetDevice(comm->cudaDev));
   for (slot = 0; slot < cache->population && cache->slots[slot] != reg; slot++);
   if (slot == cache->population) {
-    WARN("Deregister: Could not find handle");
+    ERR(ncclInvalidUsage, "Deregister: Could not find handle");
     return ncclInvalidUsage;
   }
   if (isGraph) --reg->graphRefs;

--- a/comms/ncclx/v2_31/src/rma/rma_ce.cc
+++ b/comms/ncclx/v2_31/src/rma/rma_ce.cc
@@ -209,7 +209,7 @@ static ncclResult_t ncclRmaCePutLaunchPersist(struct ncclComm* comm, struct nccl
       NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, task->peerWinHost, task->peerWinOffset, peerLsaRank, &peerBuff), ret,
                     fail);
       if (peerBuff == NULL) {
-        WARN("RMA CE: peerBuff is NULL after ncclDevrGetLsaRankPtr");
+        ERR(ncclInvalidArgument, "RMA CE: peerBuff is NULL after ncclDevrGetLsaRankPtr");
         ret = ncclInvalidArgument;
         goto fail;
       }
@@ -307,7 +307,7 @@ static ncclResult_t ncclRmaCePutLaunchNonPersist(struct ncclComm* comm, struct n
                                             &peerBuff),
                       ret, fail);
         if (peerBuff == NULL) {
-          WARN("RMA CE: peerBuff is NULL after ncclDevrGetLsaRankPtr");
+          ERR(ncclInvalidArgument, "RMA CE: peerBuff is NULL after ncclDevrGetLsaRankPtr");
           ret = ncclInvalidArgument;
           goto fail;
         }
@@ -389,7 +389,7 @@ fail:
 
 ncclResult_t ncclRmaCePutLaunch(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream) {
   if (!comm->rmaState.rmaCeState.initialized) {
-    WARN("RMA CE is not initialized");
+    ERR(ncclInternalError, "RMA CE is not initialized");
     return ncclInternalError;
   }
 
@@ -406,7 +406,7 @@ ncclResult_t ncclRmaCeWaitLaunch(struct ncclComm* comm, struct ncclKernelPlan* p
 
   // Make sure the RMA CE is initialized
   if (!comm->rmaState.rmaCeState.initialized) {
-    WARN("RMA CE is not initialized");
+    ERR(ncclInternalError, "RMA CE is not initialized");
     return ncclInternalError;
   }
 

--- a/comms/ncclx/v2_31/src/rma/rma_proxy_launch.cc
+++ b/comms/ncclx/v2_31/src/rma/rma_proxy_launch.cc
@@ -562,7 +562,7 @@ ncclResult_t ncclRmaProxyPutLaunch(struct ncclComm* comm, struct ncclKernelPlan*
   ncclResult_t ret = ncclSuccess;
 
   if (!comm->rmaState.rmaProxyState.connected) {
-    WARN("RMA proxy is not connected");
+    ERR(ncclInternalError, "RMA proxy is not connected");
     return ncclInternalError;
   }
 
@@ -665,7 +665,7 @@ ncclResult_t ncclRmaProxyWaitLaunch(struct ncclComm* comm, struct ncclKernelPlan
   ncclResult_t ret = ncclSuccess;
 
   if (!comm->rmaState.rmaProxyState.connected) {
-    WARN("RMA proxy is not connected");
+    ERR(ncclInternalError, "RMA proxy is not connected");
     return ncclInternalError;
   }
 

--- a/comms/ncclx/v2_31/src/transport.cc
+++ b/comms/ncclx/v2_31/src/transport.cc
@@ -38,7 +38,7 @@ static ncclResult_t selectTransport(struct ncclComm* comm, struct ncclTopoGraph*
       return ncclSuccess;
     }
   }
-  WARN("No transport found for rank %d[%lx] -> rank %d[%lx]", myInfo->rank, myInfo->busId, peerInfo->rank,
+  ERR(ncclSystemError, "No transport found for rank %d[%lx] -> rank %d[%lx]", myInfo->rank, myInfo->busId, peerInfo->rank,
        peerInfo->busId);
   return ncclSystemError;
 }

--- a/comms/ncclx/v2_31/src/transport/coll_net.cc
+++ b/comms/ncclx/v2_31/src/transport/coll_net.cc
@@ -479,7 +479,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
                                      void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   ncclResult_t ret = ncclSuccess;
   if (reqSize != sizeof(struct collNetConnectArgs)) {
-    WARN("sendProxyConnect: reqSize is %d != %ld", reqSize, sizeof(struct collNetConnectArgs));
+    ERR(ncclInternalError, "sendProxyConnect: reqSize is %d != %ld", reqSize, sizeof(struct collNetConnectArgs));
     return ncclInternalError;
   }
   struct collNetConnectArgs* args = (struct collNetConnectArgs*)reqBuff;
@@ -499,7 +499,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
 
   // Collnet connect is allowed to fail. Gracefully handle that case by returning NULL to the caller.
   if (respSize != sizeof(struct connectMap*)) {
-    WARN("sendProxyConnect: respSize is %d != %ld", respSize, sizeof(void*));
+    ERR(ncclInternalError, "sendProxyConnect: respSize is %d != %ld", respSize, sizeof(void*));
     return ncclInternalError;
   }
   if (resources->collNetComm == NULL) {
@@ -576,7 +576,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
                                      void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   ncclResult_t ret = ncclSuccess;
   if (reqSize != sizeof(struct collNetConnectArgs)) {
-    WARN("recvProxyConnect: reqSize is %d != %ld", reqSize, sizeof(struct collNetConnectArgs));
+    ERR(ncclInternalError, "recvProxyConnect: reqSize is %d != %ld", reqSize, sizeof(struct collNetConnectArgs));
     return ncclInternalError;
   }
   struct collNetConnectArgs* args = (struct collNetConnectArgs*)reqBuff;
@@ -590,7 +590,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
 
   // Collnet connect is allowed to fail. Gracefully handle that case by returning NULL to the caller.
   if (respSize != sizeof(struct connectMap*)) {
-    WARN("sendProxyConnect: respSize is %d != %ld", respSize, sizeof(void*));
+    ERR(ncclInternalError, "sendProxyConnect: respSize is %d != %ld", respSize, sizeof(void*));
     return ncclInternalError;
   }
   if (resources->collNetComm == NULL) {
@@ -660,7 +660,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) info->mhandles[p] = resources->mhandles[p];
 
   if (respSize != sizeof(struct connectMap*)) {
-    WARN("recvProxyConnect: respSize is %d != %ld", respSize, sizeof(void*));
+    ERR(ncclInternalError, "recvProxyConnect: respSize is %d != %ld", respSize, sizeof(void*));
     return ncclInternalError;
   }
   *((struct connectMap**)respBuff) = &resources->map;
@@ -1024,7 +1024,7 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
             int sendBeg = calcRegionOffset(args, 0, s, sub->received, 0);
             int sendEnd = calcRegionOffset(args, 0, s, sub->received, 1);
             if (sendEnd - sendBeg != connFifo[buffSlot].size) {
-              WARN("CollNet sizes: want=%d got=%ld", sendEnd - sendBeg, connFifo[buffSlot].size);
+              ERR(ncclInternalError, "CollNet sizes: want=%d got=%ld", sendEnd - sendBeg, connFifo[buffSlot].size);
               return ncclInternalError;
             }
           }

--- a/comms/ncclx/v2_31/src/transport/net.cc
+++ b/comms/ncclx/v2_31/src/transport/net.cc
@@ -492,7 +492,7 @@ static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* conne
       if (err == cudaErrorPeerAccessAlreadyEnabled) {
         cudaGetLastError();
       } else if (err != cudaSuccess) {
-        WARN("failed to peer with device %d: %d %s", map->cudaDev, err, cudaGetErrorString(err));
+        ERR(ncclInternalError, "failed to peer with device %d: %d %s", map->cudaDev, err, cudaGetErrorString(err));
         return ncclInternalError;
       }
     }
@@ -667,7 +667,7 @@ static ncclResult_t sharedNetBuffersInit(struct ncclProxyState* proxyState, int 
                                          int sameProcess, int nChannels, char** gpuPtr, char** cpuPtr, ssize_t* size,
                                          ncclIpcDesc* ipcDesc) {
   if (cuda == 0 && sameProcess == 0) {
-    WARN("PXN should not use host buffers for data");
+    ERR(ncclInternalError, "PXN should not use host buffers for data");
     return ncclInternalError;
   }
   struct ncclProxyProgressState* progressState = &proxyState->progressState;

--- a/comms/ncclx/v2_31/src/transport/net_ib/common.cc
+++ b/comms/ncclx/v2_31/src/transport/net_ib/common.cc
@@ -32,7 +32,7 @@ extern int ncclParamIbResiliencyPortFailover();
 
 ncclResult_t ncclIbStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName) {
   if (ncclParamIbAsyncEvents() && COMPILER_ATOMIC_LOAD(&stat->fatalErrorCount, std::memory_order_relaxed)) {
-    WARN("communicator encountered a fatal error (detected in %s)", funcName);
+    ERR(ncclSystemError, "communicator encountered a fatal error (detected in %s)", funcName);
     return ncclSystemError;
   }
   return ncclSuccess;

--- a/comms/ncclx/v2_31/src/transport/net_ib/connect.cc
+++ b/comms/ncclx/v2_31/src/transport/net_ib/connect.cc
@@ -234,7 +234,7 @@ static ncclResult_t ncclIbRoceGetVersionNum(const char* deviceName, int portNum,
 
   int fd = open(roceTypePath, O_RDONLY);
   if (fd == -1) {
-    WARN("NET/IB: open failed in ncclIbRoceGetVersionNum: %s", strerror(errno));
+    ERR(ncclSystemError, "NET/IB: open failed in ncclIbRoceGetVersionNum: %s", strerror(errno));
     return ncclSystemError;
   }
   int ret = read(fd, gidRoceVerStr, 15);
@@ -244,7 +244,7 @@ static ncclResult_t ncclIbRoceGetVersionNum(const char* deviceName, int portNum,
     // In containerized environments, read could return EINVAL if the GID index is not mapped to the
     // container sysfs. In this case return ncclSuccess and let the caller move to next GID index.
     if (errno == EINVAL) return ncclSuccess;
-    WARN("NET/IB: read failed in ncclIbRoceGetVersionNum: %s", strerror(errno));
+    ERR(ncclSystemError, "NET/IB: read failed in ncclIbRoceGetVersionNum: %s", strerror(errno));
     return ncclSystemError;
   }
 
@@ -850,7 +850,7 @@ ncclResult_t ncclIbConnectImpl(void* ctx, int dev, void* opaqueHandle, void** se
   if (stage->state == ncclIbCommStateConnecting) goto ib_connect;
   if (stage->state == ncclIbCommStateConnected) goto ib_send_ready;
   if (stage->state != ncclIbCommStateStart) {
-    WARN("Error: trying to connect already connected sendComm");
+    ERR(ncclInternalError, "Error: trying to connect already connected sendComm");
     return ncclInternalError;
   }
   stage->buffer = NULL;
@@ -872,7 +872,7 @@ ib_connect_check:
   // IB Setup
   struct ncclIbMergedDev* mergedDev;
   if (dev >= ncclNMergedIbDevs) {
-    WARN("NET/IB : Trying to use non-existent virtual device %d", dev);
+    ERR(ncclInternalError, "NET/IB : Trying to use non-existent virtual device %d", dev);
     return ncclInternalError;
   }
 
@@ -1013,7 +1013,7 @@ ib_recv_dev_list:
     if (link_layer == IBV_LINK_LAYER_UNSPECIFIED) link_layer = devInfo->link_layer;
     if (link_layer != devInfo->link_layer) {
       int ibDev0 = comm->devs[0].base.ibDevN;
-      WARN("NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
+      ERR(ncclInternalError, "NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
            "only one link type using NCCL_IB_HCA",
            commDev->base.ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0,
            ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
@@ -1068,7 +1068,7 @@ ib_connect:
     link_layer = ncclIbDevs[ibDev0].portAttr.link_layer;
     for (int i = 0; i < remMeta.ndevs; i++) {
       if (remMeta.devs[i].link_layer != link_layer) {
-        WARN("NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one "
+        ERR(ncclInternalError, "NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one "
              "link type using NCCL_IB_HCA",
              NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum,
              NCCL_IB_LLSTR(link_layer));
@@ -1435,7 +1435,7 @@ ncclResult_t ncclIbAcceptImpl(void* listenComm, void** recvComm, ncclNetDeviceHa
   if (stage->state == ncclIbCommStateSend) goto ib_send;
   if (stage->state == ncclIbCommStatePendingReady) goto ib_recv_ready;
   if (stage->state != ncclIbCommStateStart) {
-    WARN("Listencomm in unknown state %d", stage->state);
+    ERR(ncclInternalError, "Listencomm in unknown state %d", stage->state);
     return ncclInternalError;
   }
 
@@ -1468,7 +1468,7 @@ ib_recv_dev_list:
   ncclNetVDeviceProps_t remoteVProps;
   memcpy(&remoteVProps, stage->buffer, sizeof(ncclNetVDeviceProps_t));
   if (lComm->dev >= ncclNMergedIbDevs) {
-    WARN("NET/IB : Trying to use non-existent virtual device %d", lComm->dev);
+    ERR(ncclInternalError, "NET/IB : Trying to use non-existent virtual device %d", lComm->dev);
     return ncclInternalError;
   }
 
@@ -1576,7 +1576,7 @@ ib_recv:
     if (link_layer == IBV_LINK_LAYER_UNSPECIFIED) link_layer = ibDev->portAttr.link_layer;
     if (link_layer != ibDev->portAttr.link_layer) {
       int ibDev0 = rComm->devs[0].base.ibDevN;
-      WARN("NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
+      ERR(ncclInternalError, "NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
            "only one link type using NCCL_IB_HCA",
            ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0,
            ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
@@ -1589,7 +1589,7 @@ ib_recv:
   for (int i = 0; i < remMeta.ndevs; i++) {
     if (remMeta.devs[i].link_layer != link_layer) {
       int ibDev0 = rComm->devs[0].base.ibDevN;
-      WARN("NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one link "
+      ERR(ncclInternalError, "NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one link "
            "type using NCCL_IB_HCA",
            NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum,
            NCCL_IB_LLSTR(link_layer));

--- a/comms/ncclx/v2_31/src/transport/net_ib/gdaki/gin_host_gdaki.cc
+++ b/comms/ncclx/v2_31/src/transport/net_ib/gdaki/gin_host_gdaki.cc
@@ -33,7 +33,7 @@
     doca_error_t err = call; \
     if (err != DOCA_SUCCESS) { \
       /* Print the back trace*/ \
-      WARN("DOCA failure %d", err); \
+      ERR(ncclSystemError, "DOCA failure %d", err); \
       return ncclSystemError; \
     } \
   } while (0)
@@ -43,7 +43,7 @@
     doca_error_t err = call; \
     if (err != DOCA_SUCCESS) { \
       /* Print the back trace*/ \
-      WARN("DOCA failure %d", err); \
+      ERR(ncclSystemError, "DOCA failure %d", err); \
       RES = ncclSystemError; \
       goto label; \
     } \
@@ -278,7 +278,7 @@ public:
 
   ncclResult_t allocate_elements(unsigned int num_elements, unsigned int* out_start_idx) {
     if (this->next_unused_idx + num_elements > this->num_elements) {
-      WARN("Not enough space to get elements");
+      ERR(ncclInvalidUsage, "Not enough space to get elements");
       return ncclInvalidUsage;
     }
 
@@ -765,7 +765,7 @@ ncclResult_t ncclGinGdakiCreateContext(void* collComm, ncclGinConfig_t* config, 
           goto retry_create_qp_group_list_hl;
         }
 
-        WARN("DOCA Error %d", docaStatus);
+        ERR(ncclSystemError, "DOCA Error %d", docaStatus);
         status = ncclSystemError;
         goto out;
       }
@@ -801,7 +801,7 @@ ncclResult_t ncclGinGdakiCreateContext(void* collComm, ncclGinConfig_t* config, 
           goto retry_create_qp_list_hl;
         }
 
-        WARN("DOCA Error %d", docaStatus);
+        ERR(ncclSystemError, "DOCA Error %d", docaStatus);
         status = ncclSystemError;
         goto out;
       }

--- a/comms/ncclx/v2_31/src/transport/net_ib/gin.cc
+++ b/comms/ncclx/v2_31/src/transport/net_ib/gin.cc
@@ -39,7 +39,7 @@ static ncclResult_t ncclGinIbGdrGpuSupport(bool gdaki) {
   CUCHECK(cuDeviceGetAttribute(&dmaBufSupportOnDevice, CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED, cudaDev));
   if (dmaBufSupportOnDevice == 1) return ncclSuccess;
 
-  WARN("Unable to use GIN: Peermem is not supported, and device %d does not support DMA-BUF.", cudaDev);
+  ERR(ncclInvalidUsage, "Unable to use GIN: Peermem is not supported, and device %d does not support DMA-BUF.", cudaDev);
   return ncclInvalidUsage;
 }
 
@@ -258,7 +258,7 @@ ncclResult_t ncclGinIbGdakiGetGinProperties(ncclGinProperties_t* ginProps) {
 ncclResult_t ncclGinIbGdakiGetProperties(int dev, ncclNetProperties_t* props) {
   std::lock_guard<std::mutex> lock(ncclGinIbGdakiLockMutex);
   if (dev >= ncclGinIbGdakiNDevs) {
-    WARN("NET/IB : Requested properties for GIN GDAKI NIC %d, only %d GIN GDAKI NICs have been created", dev,
+    ERR(ncclInvalidUsage, "NET/IB : Requested properties for GIN GDAKI NIC %d, only %d GIN GDAKI NICs have been created", dev,
          ncclGinIbGdakiNDevs);
     return ncclInvalidUsage;
   }

--- a/comms/ncclx/v2_31/src/transport/net_ib/init.cc
+++ b/comms/ncclx/v2_31/src/transport/net_ib/init.cc
@@ -201,12 +201,12 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   }
 
   if (props->ndevs == 0) {
-    WARN("NET/IB : Can't make virtual NIC with 0 devices");
+    ERR(ncclInvalidUsage, "NET/IB : Can't make virtual NIC with 0 devices");
     return ncclInvalidUsage;
   }
 
   if (ncclNMergedIbDevs == MAX_IB_VDEVS) {
-    WARN("NET/IB : Cannot allocate any more virtual devices (%d)", MAX_IB_VDEVS);
+    ERR(ncclInvalidUsage, "NET/IB : Cannot allocate any more virtual devices (%d)", MAX_IB_VDEVS);
     return ncclInvalidUsage;
   }
 
@@ -242,12 +242,12 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   ncclIbDev* dev0 = ncclIbDevs + props->devs[0];
   for (int i = 1; i < props->ndevs; i++) {
     if (props->devs[i] >= ncclNIbDevs) {
-      WARN("NET/IB : Cannot use physical device %d, max %d", props->devs[i], ncclNIbDevs);
+      ERR(ncclInvalidUsage, "NET/IB : Cannot use physical device %d, max %d", props->devs[i], ncclNIbDevs);
       return ncclInvalidUsage;
     }
     ncclIbDev* dev = ncclIbDevs + props->devs[i];
     if (dev->link != dev0->link) {
-      WARN("NET/IB : Attempted to merge incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
+      ERR(ncclInvalidUsage, "NET/IB : Attempted to merge incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
            "only one link type using NCCL_IB_HCA",
            props->devs[0], dev0->devName, dev0->portNum, NCCL_IB_LLSTR(dev0->link), props->devs[i], dev->devName,
            dev->portNum, NCCL_IB_LLSTR(dev->link));
@@ -304,7 +304,7 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       ncclNMergedIbDevs = 0;
       NCCLCHECK(ncclFindInterfaces(ncclIbIfName, &ncclIbIfAddr, MAX_IF_NAME_SIZE, 1, &nIpIfs));
       if (nIpIfs != 1) {
-        WARN("NET/IB : No IP interface found.");
+        ERR(ncclInternalError, "NET/IB : No IP interface found.");
         ret = ncclInternalError;
         goto fail;
       }
@@ -573,7 +573,7 @@ ncclResult_t ncclIbGetPhysProperties(int dev, ncclNetProperties_t* props) {
 
 ncclResult_t ncclIbGetProperties(int dev, ncclNetProperties_t* props) {
   if (dev >= ncclNMergedIbDevs) {
-    WARN("NET/IB : Requested properties for vNic %d, only %d vNics have been created", dev, ncclNMergedIbDevs);
+    ERR(ncclInvalidUsage, "NET/IB : Requested properties for vNic %d, only %d vNics have been created", dev, ncclNMergedIbDevs);
     return ncclInvalidUsage;
   }
   struct ncclIbMergedDev* mergedDev = ncclIbMergedDevs + dev;

--- a/comms/ncclx/v2_31/src/transport/net_ib/p2p.cc
+++ b/comms/ncclx/v2_31/src/transport/net_ib/p2p.cc
@@ -30,7 +30,7 @@ ncclResult_t ncclIbGetRequest(struct ncclIbNetCommBase* base, struct ncclIbReque
       return ncclSuccess;
     }
   }
-  WARN("NET/IB : unable to allocate requests");
+  ERR(ncclInternalError, "NET/IB : unable to allocate requests");
   *req = NULL;
   return ncclInternalError;
 }
@@ -276,7 +276,7 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
                          void** request) {
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
   if (comm->base.ready == 0) {
-    WARN("NET/IB: ncclIbIsend() called when comm->base.ready == 0");
+    ERR(ncclInternalError, "NET/IB: ncclIbIsend() called when comm->base.ready == 0");
     *request = NULL;
     return ncclInternalError;
   }
@@ -311,7 +311,7 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
       char line[SOCKET_NAME_MAXLEN + 1];
       union ncclSocketAddress addr;
       ncclSocketGetAddr(&comm->base.sock, &addr);
-      WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x", r, nreqs,
+      ERR(ncclInternalError, "NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x", r, nreqs,
            tag, ncclSocketToString(&addr, line), slots[r].size, slots[r].addr, slots[r].rkeys[0]);
       return ncclInternalError;
     }
@@ -458,7 +458,7 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
                          void** request) {
   struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
   if (comm->base.ready == 0) {
-    WARN("NET/IB: ncclIbIrecv() called when comm->base.ready == 0");
+    ERR(ncclInternalError, "NET/IB: ncclIbIrecv() called when comm->base.ready == 0");
     *request = NULL;
     return ncclInternalError;
   }
@@ -832,7 +832,7 @@ static inline ncclResult_t ncclIbCompletionEventProcess(struct ncclIbNetCommBase
     for (int j = 0; j < req->nreqs; j++) {
       sendReq = sendComm->sendReqs[slot][j];
       if (!commBase->resiliency && (sendReq->events[devIndex] <= 0)) {
-        WARN("NET/IB: sendReq(%p)->events={%d,%d,%d,%d}, devIndex=%d, reqIdx=%d <= 0", sendReq, sendReq->events[0],
+        ERR(ncclInternalError, "NET/IB: sendReq(%p)->events={%d,%d,%d,%d}, devIndex=%d, reqIdx=%d <= 0", sendReq, sendReq->events[0],
              sendReq->events[1], sendReq->events[2], sendReq->events[3], devIndex, j);
         return ncclInternalError;
       }

--- a/comms/ncclx/v2_31/src/transport/net_ib/reg.cc
+++ b/comms/ncclx/v2_31/src/transport/net_ib/reg.cc
@@ -116,7 +116,7 @@ ncclResult_t ncclIbDeregMrInternal(ncclIbNetCommDevBase* base, ibv_mr* mhandle) 
       return ncclSuccess;
     }
   }
-  WARN("NET/IB: could not find mr %p inside cache of %d entries", mhandle, cache->population);
+  ERR(ncclInternalError, "NET/IB: could not find mr %p inside cache of %d entries", mhandle, cache->population);
   return ncclInternalError;
 }
 

--- a/comms/ncclx/v2_31/src/transport/net_socket.cc
+++ b/comms/ncclx/v2_31/src/transport/net_socket.cc
@@ -61,7 +61,7 @@ ncclResult_t ncclNetSocketInit(void** ctx, uint64_t commId, ncclNetCommConfig_t*
     union ncclSocketAddress addrs[MAX_IFS];
     NCCLCHECKGOTO(ncclFindInterfaces(names, addrs, MAX_IF_NAME_SIZE, MAX_IFS, &ncclNetIfs), ret, fail);
     if (ncclNetIfs <= 0) {
-      WARN("NET/Socket : no interface found");
+      ERR(ncclInternalError, "NET/Socket : no interface found");
       ret = ncclInternalError;
       goto fail;
     } else {
@@ -415,7 +415,7 @@ fail:
 ncclResult_t ncclNetSocketListen(void* ctx, int dev, void* opaqueHandle, void** listenComm) {
   if (dev < 0 || dev >= ncclNetIfs) {
     // data transfer socket is based on specified dev
-    WARN("NET/Socket : ncclNetSocketListen dev=%d ncclNetIfs=%d", dev, ncclNetIfs);
+    ERR(ncclInternalError, "NET/Socket : ncclNetSocketListen dev=%d ncclNetIfs=%d", dev, ncclNetIfs);
     return ncclInternalError;
   }
   ncclResult_t ret = ncclSuccess;
@@ -562,7 +562,7 @@ ncclResult_t ncclNetSocketGetRequest(struct ncclNetSocketComm* comm, int op, voi
       return ncclSuccess;
     }
   }
-  WARN("NET/Socket : unable to allocate requests");
+  ERR(ncclInternalError, "NET/Socket : unable to allocate requests");
   return ncclInternalError;
 }
 
@@ -603,7 +603,7 @@ ncclResult_t ncclNetSocketGetTask(struct ncclNetSocketComm* comm, struct ncclPro
     res->threadCond.notify_one();
     return ncclSuccess;
   }
-  WARN("NET/Socket : unable to allocate subtasks");
+  ERR(ncclInternalError, "NET/Socket : unable to allocate subtasks");
   return ncclInternalError;
 }
 
@@ -616,7 +616,7 @@ ncclResult_t ncclNetSocketTest(void* request, int* done, int* size) {
   *done = 0;
   struct ncclNetSocketRequest* r = (struct ncclNetSocketRequest*)request;
   if (r == NULL) {
-    WARN("NET/Socket : test called with NULL request");
+    ERR(ncclInternalError, "NET/Socket : test called with NULL request");
     return ncclInternalError;
   }
   if (r->used == 1) { /* try to send/recv size (+ inline data if any) */
@@ -640,7 +640,7 @@ ncclResult_t ncclNetSocketTest(void* request, int* done, int* size) {
         char line[SOCKET_NAME_MAXLEN + 1];
         union ncclSocketAddress addr;
         NCCLCHECK(ncclSocketGetAddr(r->ctrlSock, &addr));
-        WARN("NET/Socket : peer %s message truncated : receiving %d bytes instead of %d. If you believe your socket "
+        ERR(ncclInvalidUsage, "NET/Socket : peer %s message truncated : receiving %d bytes instead of %d. If you believe your socket "
              "network is in a healthy state, "
              "there may be a mismatch in collective sizes or environment settings (e.g. NCCL_PROTO, NCCL_ALGO) between "
              "ranks",

--- a/comms/ncclx/v2_31/src/transport/nvls.cc
+++ b/comms/ncclx/v2_31/src/transport/nvls.cc
@@ -373,7 +373,7 @@ static ncclResult_t nvlsAllocateMem(struct ncclComm* comm, const CUmemAccessDesc
   if (err != CUDA_SUCCESS) {
     const char* errStr;
     (void)pfn_cuGetErrorString(err, &errStr);    // Fail the job as NVLS support is not functional
-    WARN("Failed to bind NVLink SHARP (NVLS) Multicast memory of size %ld : CUDA error %d '%s'.\nThis is usually "
+    ERR(ncclUnhandledCudaError, "Failed to bind NVLink SHARP (NVLS) Multicast memory of size %ld : CUDA error %d '%s'.\nThis is usually "
          "caused by a system or configuration error in the Fabric Manager or NVSwitches.\nDisable NVLS "
          "(NCCL_NVLS_ENABLE=0) if you wish to avoid this error in the future.",
          ucsize, err, errStr);

--- a/comms/ncclx/v2_31/src/transport/p2p.cc
+++ b/comms/ncclx/v2_31/src/transport/p2p.cc
@@ -355,7 +355,7 @@ static ncclResult_t p2pMap(struct ncclComm* comm, struct ncclProxyConnector* pro
       if (err == cudaErrorPeerAccessAlreadyEnabled) {
         cudaGetLastError();
       } else if (err != cudaSuccess) {
-        WARN("failed to peer with device %d(=%lx): %d %s", peerInfo->cudaDev, peerInfo->busId, err,
+        ERR(ncclInternalError, "failed to peer with device %d(=%lx): %d %s", peerInfo->cudaDev, peerInfo->busId, err,
              cudaGetErrorString(err));
         return ncclInternalError;
       }

--- a/comms/ncclx/v2_31/src/transport/shm.cc
+++ b/comms/ncclx/v2_31/src/transport/shm.cc
@@ -305,7 +305,7 @@ static void initShmLocality() {
 ncclResult_t ncclShmAllocateShareableBuffer(size_t size, bool legacy, ncclShmIpcDesc_t* desc, void** hptr,
                                             void** dptr) {
   if (desc == NULL || hptr == NULL) {
-    WARN("Invalid argument desc %p, hptr %p", desc, hptr);
+    ERR(ncclInvalidArgument, "Invalid argument desc %p, hptr %p", desc, hptr);
     return ncclInvalidArgument;
   }
 #if CUDART_VERSION >= 12020
@@ -358,7 +358,7 @@ ncclResult_t ncclShmAllocateShareableBuffer(size_t size, bool legacy, ncclShmIpc
 ncclResult_t ncclShmImportShareableBuffer(struct ncclComm* comm, int proxyRank, ncclShmIpcDesc_t* desc, void** hptr,
                                           void** dptr, ncclShmIpcDesc_t* descOut) {
   if (comm == NULL || desc == NULL || hptr == NULL || descOut == NULL) {
-    WARN("Invalid argument comm %p, desc %p, hptr %p, descOut %p", comm, desc, hptr, descOut);
+    ERR(ncclInvalidArgument, "Invalid argument comm %p, desc %p, hptr %p, descOut %p", comm, desc, hptr, descOut);
     return ncclInvalidArgument;
   }
 #if CUDART_VERSION >= 12020

--- a/comms/ncclx/v2_31/src/tuning/cost_model.cc
+++ b/comms/ncclx/v2_31/src/tuning/cost_model.cc
@@ -47,7 +47,7 @@ static ncclResult_t parseList(const char* str, const char* const prefixElems[], 
         // It makes no sense for any entry other than the first to not have a prefix,
         // because then all the prefixes before the prefix-less entry would be
         // overwritten.
-        WARN("All entries except the first must have a prefix: \"%s\"", str);
+        ERR(ncclInvalidUsage, "All entries except the first must have a prefix: \"%s\"", str);
         ret = ncclInvalidUsage;
         goto fail;
       }
@@ -84,7 +84,7 @@ static ncclResult_t parseList(const char* str, const char* const prefixElems[], 
           }
         }
         if (e == nelems) {
-          WARN("Unrecognized element token \"%s\" when parsing \"%s\"", elem, str);
+          ERR(ncclInvalidUsage, "Unrecognized element token \"%s\" when parsing \"%s\"", elem, str);
           ret = ncclInvalidUsage;
           goto fail;
         }
@@ -94,7 +94,7 @@ static ncclResult_t parseList(const char* str, const char* const prefixElems[], 
       tokStr = nullptr;
     }
     if (!foundPrefix) {
-      WARN("Unrecognized prefix token \"%s\" when parsing \"%s\"", prefix, str);
+      ERR(ncclInvalidUsage, "Unrecognized prefix token \"%s\" when parsing \"%s\"", prefix, str);
       ret = ncclInvalidUsage;
       goto fail;
     }


### PR DESCRIPTION
Summary:

**This diff is drafted so the decision is cheap, not because the decision is made.** Do not land
until the open question below is answered. See D117227084 for the full analysis.

Restores `NCCL_PARAM_COMPILER_EXPORT_SYMBOL` to v2_31, the one symbol from the CVARs row that
upstream 2.31 does not already supply. Seven sites across five files, mirroring v2_30:

- `include/param/utils.h` — the macro definition in both compiler branches, plus the two
  `extern "C"` declarations
- `include/param/param_registry.h` — the `ncclParamRegistryInstance` declaration
- `include/param/param.h` — both symbols generated by `DEFINE_NCCL_PARAM`
- `param/param.cc`, `param/param_registry.cc` — the three definitions

Upstream's 2.31 signatures are preserved throughout, notably
`ncclParamEnvPluginGet(const char* key, bool env_init)` rather than v2_30's one-argument form.

# Why this might be needed

`include/param/param_registry.h` states the contract, and the wording is upstream's own:

> The underlying state (RegistryState) is held behind a C-linkage accessor
> (ncclParamRegistryInstance) so that all DSOs in the process share a single map and mutex,
> **even when NCCL is statically linked into multiple libraries.**

The symbol is exported to be *interposed*, not to be called by name. Upstream satisfies this
through its Makefile `libnccl.map` (`global: nccl*;`), which the symbol matches by prefix. The
fbcode Buck build uses no version script and compiles with `-fvisibility=hidden`
(`nccl_build_config.bzl:135`), so neither mechanism applies and the accessor is hidden. v2_30
bridged that gap with this attribute; v2_31 lost it.

The trigger condition exists in our tree: `//comms/torchcomms/ncclx:_comms_ncclx` is a
`cpp_python_extension` that statically links `//comms/ncclx:nccl` via `ncclx-api` /
`ncclx-global-api`, and it loads alongside `//comms/torchcomms:_comms` in one Python process.
v2_30's `src/version.script` already names `_comms_ncclx` as a cross-`.so` caller for the Scuba
error loggers.

# The open question

Whether a torchcomms + NCCLX process actually ends up with more than one copy of the param
registry. A single copy makes hidden visibility harmless, since the accessor call resolves within
the DSO. Two or more copies means params registered in one are invisible in another, and the
`"PARAM: Duplicate registration for key"` warning that would reveal it does not fire either.

Note this cannot be settled by code search: interposition produces no by-name references. An
earlier full-repo sweep found zero callers, which is consistent with either answer.

If the answer is "one copy", abandon this diff and keep D117227084 with its reasoning corrected.

Reviewed By: shr

Differential Revision: D117238276
