### PR TITLE
Optimize registered Tree AllReduce for striped IB (#3781)

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3421,8 +3421,8 @@ cvars:
    default     : 1
    description : |-
      Number of independent Phase-2 IB progress groups per physical CUDA block
-     in MCCL fused AllReduce. Ring supports 1, 2, 4, and 10; Tree supports 1
-     and 2. The default preserves the existing full-block protocol.
+     in MCCL fused AllReduce. Ring and Tree support 1, 2, 4, and 10. The
+     default preserves the existing full-block protocol.
 
  - name        : MCCL_MAX_NCHANNELS
    type        : int


### PR DESCRIPTION
Summary:

Extend the fused Tree AllReduce registered path with the Ring optimizations needed for efficient ppn=1 operation.

- Preserve requested Tree virtual stripe counts for S1, S2, S4, and S10 and cap blocks by the available IB groups.
- Use a separately registered `sendbuff` for out-of-place Tree reduce input, avoiding the Phase-1 staging copy when eligible.
- Separate registered-send posting from phase-boundary draining so reduce and broadcast progress remain pipelined.
- Retain staged fallback behavior when input registration is unavailable.

S20 support is intentionally excluded because it did not improve performance and increases device specialization/build cost.

Reviewed By: rmahidhar

Differential Revision: D117295780


