### PR TITLE
Add CudaLog and LoggerRuntime to the RCCL OSS CMake src list

### DIFF
--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -1090,6 +1090,8 @@ set(COMMON_FILES
   comms/utils/logger/BackendTopologyUtil.h
   comms/utils/logger/CommsLogFormatter.cc
   comms/utils/logger/CommsLogFormatter.h
+  comms/utils/logger/CudaLog.cc
+  comms/utils/logger/CudaLog.h
   comms/utils/logger/DataSink.h
   comms/utils/logger/DataTable.cc
   comms/utils/logger/DataTable.h
@@ -1105,6 +1107,8 @@ set(COMMON_FILES
   comms/utils/logger/EventsScubaUtil.h
   comms/utils/logger/Logger.cc
   comms/utils/logger/Logger.h
+  comms/utils/logger/LoggerRuntime.cc
+  comms/utils/logger/LoggerRuntime.h
   comms/utils/logger/LoggingFormat.cc
   comms/utils/logger/LoggingFormat.h
   comms/utils/logger/LogTypes.cc


### PR DESCRIPTION
Summary:
The `xlformers_llama4_amd_conda` conveyor build has been broken since D116694639
landed. `import torch` fails at first `dlopen` of the freshly built RCCLX:

```
ImportError: .../site-packages/torch/lib/../../../../librccl.so.1:
  undefined symbol: _ZN4meta5comms6logger17shouldLogFromCudaERKNS1_17CommsSpdlogLoggerENS1_12CudaLogLevelE
```

which demangles to `meta::comms::logger::shouldLogFromCuda(CommsSpdlogLogger const&, CudaLogLevel)`.

D116694639 added `comms/utils/logger/CudaLog.{h,cc}` and `comms/utils/logger/LoggerRuntime.{h,cc}`,
and routed the DDA algo managers through the new `COMMS_CUDA_LOG` macro. The
`comms/utils/**` portion of the RCCL OSS build is an explicit source list (unlike
`comms/ctran/**` and `comms/prims/**`, which are globbed), and neither new file was
added to it.

Compilation still succeeds because `CMAKE_CXX_FLAGS` carries `-idirafter ${FBCODE_DIR}`,
so the headers resolve; and `librccl.so` is not linked with `-Wl,--no-undefined`, so
the missing definitions are not diagnosed at link time either. The first symptom is
therefore a runtime `ImportError`, ~2h48m into the conda build.

Two distinct gaps are fixed here:

| File | Referenced from | Missing symbol |
| --- | --- | --- |
| `comms/utils/logger/CudaLog.cc` | `COMMS_CUDA_LOG` in `comms/common/algorithms/**/*AlgoManager.cu`, `AlgoFactory.cu` | `shouldLogFromCuda`, `tryGetSpdlogLoggerForCuda`, `logFromCuda` |
| `comms/utils/logger/LoggerRuntime.cc` | `comms/utils/logger/Logger.cc` (already in the list) | `initCommLoggerRuntime`, `shutdownCommLoggerRuntime` |

Only the first undefined symbol is reported by the dynamic linker, so `LoggerRuntime.cc`
would have broken the very next build had it been fixed alone.

**Please keep both entries.** `LoggerRuntime.cc` is not incidental cleanup: D116694643
(`[comms-simplification][defolly][9/11]`) adds
`#include "comms/utils/logger/LoggerRuntime.h"` to `comms/ctran/utils/LogInit.cc`, which
the OSS build compiles via the `CTRAN_SOURCES` glob. That is a second, independent
consumer of `initCommLoggerRuntime` / `shutdownCommLoggerRuntime`. Trimming this diff to
just `CudaLog.cc` — the only symbol the failure log names — would leave the conda build
green until D116694643 lands, and then break it again the same way.

Reviewed By: srinathb-meta

Differential Revision: D117299545


