### PR TITLE
Unwind IBRC device waits on abort instead of trapping

### DIFF
--- a/comms/common/fault_tolerance/AbortDevice.cuh
+++ b/comms/common/fault_tolerance/AbortDevice.cuh
@@ -88,6 +88,7 @@ __device__ __forceinline__ bool deviceIsValidTerminalReason(
     case AbortReason::BOOTSTRAP_POLL:
     case AbortReason::NETWORK_ERROR:
     case AbortReason::INTERNAL_ERROR:
+    case AbortReason::IBRC_PROXY_TIMEOUT:
       return true;
     case AbortReason::NONE:
       return false;
@@ -156,6 +157,15 @@ struct AbortDevice final {
    */
   __host__ __device__ AbortBehavior behavior() const {
     return behavior_;
+  }
+
+  /**
+   * Raw shared-state pointer, for constructing an `AbortFlag` view of this
+   * handle. Not part of the general API -- everything else goes through the
+   * typed accessors.
+   */
+  __host__ __device__ AbortState* stateForFlag() const {
+    return state_;
   }
 
   /**
@@ -501,6 +511,84 @@ struct AbortDevice final {
    * the copied handle and is not part of the host-owned shared state.
    */
   uint64_t deadlineCycles_{0};
+};
+
+/**
+ * A poll-state-free view of the shared abort state, safe to store in device
+ * memory that many blocks read.
+ *
+ * `AbortDevice` is designed to be copied per thread: it carries mutable poll
+ * throttle state (`nextPollCycles_`, `sawTerminalReason_`) whose whole purpose
+ * is to be private to one poller. Placing one in device global memory breaks
+ * that assumption in two ways at once -- several blocks write the throttle
+ * non-atomically, and the absolute `clock64()` it stores is per-SM, so a value
+ * stamped by a leading SM can suppress a lagging SM's polls for far longer than
+ * the interval and hide the abort it is waiting for.
+ *
+ * This type makes that unrepresentable rather than merely discouraged: it holds
+ * no mutable state and exposes no way to poll. A transport that needs a
+ * communicator-scoped handle in device memory stores one of these, and bounds
+ * its waits on the device clock instead of on shared reads.
+ */
+struct AbortFlag final {
+  __host__ __device__ AbortFlag() = default;
+
+  __host__ __device__ explicit AbortFlag(const AbortDevice& handle)
+      : state_(handle.stateForFlag()), behavior_(handle.behavior()) {}
+
+  __host__ __device__ bool isEnabled() const {
+    return state_ != nullptr;
+  }
+
+  __host__ __device__ AbortBehavior behavior() const {
+    return behavior_;
+  }
+
+  /**
+   * Records a terminal reason, first-writer-wins. Returns whether this call
+   * performed the transition.
+   *
+   * Writing shared state is safe to do from a shared handle -- it is a
+   * system-scope CAS, which is exactly what the shared state is for. Only
+   * *polling* needs per-thread throttle state, and this type has none.
+   */
+  __device__ bool setAbort(
+      AbortReason newReason = AbortReason::ABORTED,
+      const char* context = nullptr) const {
+    if (!isEnabled()) {
+      return false;
+    }
+    (void)context;
+    const bool validReason = detail::deviceIsValidTerminalReason(newReason);
+    assert(validReason);
+    if (!validReason) {
+      return false;
+    }
+    int expected = static_cast<int>(AbortReason::NONE);
+    return detail::deviceCompareExchangeSystem(
+        &state_->abort, &expected, static_cast<int>(newReason));
+  }
+
+  /**
+   * Whether a terminal reason has been recorded. One system-scope load from
+   * mapped host state, every call -- there is deliberately no throttle here,
+   * because throttle state is exactly what must not live in a shared handle.
+   *
+   * Use this for one-shot decisions ("should this operation start at all?"),
+   * never inside a spin loop. A loop should bound itself on the device clock
+   * against a fixed budget instead.
+   */
+  __device__ bool isAborted() const {
+    if (!isEnabled()) {
+      return false;
+    }
+    return static_cast<AbortReason>(detail::deviceLoadAcquireSystem(
+               &state_->abort)) != AbortReason::NONE;
+  }
+
+ private:
+  AbortState* state_{nullptr};
+  AbortBehavior behavior_{AbortBehavior::SKIP};
 };
 
 /**

--- a/comms/common/fault_tolerance/AbortTypes.h
+++ b/comms/common/fault_tolerance/AbortTypes.h
@@ -21,6 +21,11 @@ enum class AbortReason : int {
   BOOTSTRAP_POLL = 3,
   NETWORK_ERROR = 4,
   INTERNAL_ERROR = 5,
+  // The IBRC host CPU proxy stopped making progress and a device-side wait hit
+  // its watchdog. Distinct from TIMED_OUT, which is the enclosing collective's
+  // own deadline expiring: this one names the proxy thread as the stalled
+  // component, which is a different fault with a different owner.
+  IBRC_PROXY_TIMEOUT = 6,
 };
 
 constexpr bool isTerminalAbortReason(AbortReason reason) {
@@ -30,6 +35,7 @@ constexpr bool isTerminalAbortReason(AbortReason reason) {
     case AbortReason::BOOTSTRAP_POLL:
     case AbortReason::NETWORK_ERROR:
     case AbortReason::INTERNAL_ERROR:
+    case AbortReason::IBRC_PROXY_TIMEOUT:
       return true;
     case AbortReason::NONE:
       return false;
@@ -51,6 +57,8 @@ constexpr std::string_view abortReasonToString(AbortReason reason) {
       return "network_error";
     case AbortReason::INTERNAL_ERROR:
       return "internal_error";
+    case AbortReason::IBRC_PROXY_TIMEOUT:
+      return "ibrc_proxy_timeout";
   }
   return "unknown";
 }

--- a/comms/common/fault_tolerance/FAULT_TOLERANCE.md
+++ b/comms/common/fault_tolerance/FAULT_TOLERANCE.md
@@ -159,6 +159,81 @@ Transport handles must not embed started abort timeout state. NVL, IBGDA, and
 IBRC waits consume the operation-local `AbortDevice` passed by the collective or
 kernel.
 
+### Proxy-facing waits: bounded by the clock, never by polling
+
+IBRC is the exception to "pass the operation-local handle in", and deliberately
+so. Its producer-side waits — `reserve()` on a full command ring and
+`drain_queue()` — are reached from `put()` / `signal()`, which carry no
+deadline. Threading one down would put an abort parameter on every producer for
+a value none of them consume.
+
+**These loops do not poll the abort at all.** They bound themselves on
+`deviceClock()` and, on expiry, *write* the shared state rather than reading it:
+
+```cpp
+while (/* ring full */) {
+  if (gpu_clock64() - start >= kIbrcDefaultDeviceTimeoutCycles) {
+    abort_.setAbort(AbortReason::IBRC_PROXY_TIMEOUT, "...");
+    return kIbrcInvalidReadySeq;
+  }
+}
+```
+
+Three properties follow, and each replaces a defect this design used to have.
+
+**1. The bound is unconditional.** It used to be gated on
+`!abort.isEnabled()`, so *enabling* fault tolerance removed the only bound a
+proxy-facing wait had. Combined with `P2pIbTransportDevice::flush()` dropping
+the caller's deadline on the IBRC branch, a kernel that ended in `flush()` had
+no watchdog, no deadline, and only an explicit host abort as an exit. The
+watchdog is the contract between this kernel and the host proxy — a submitted
+descriptor is consumed within a bounded time — and that obligation does not
+change because FT is on.
+
+**2. The bound is the fixed watchdog, not the collective's deadline.** These two
+are different obligations with different owners, and the wait honours its own.
+`kIbrcDefaultDeviceTimeoutCycles` bounds one rank's SM against its own host
+proxy; the communicator timeout bounds the collective across ranks. So
+`reserve()`, `drain_queue()` and `flush()` take no deadline argument and read no
+timeout — the budget is a compile-time constant compared against `deviceClock()`,
+which keeps the stall path free of mapped-host traffic and the producer
+signatures free of an abort parameter. A caller that sets a shorter per-operation
+deadline does not shorten the proxy watchdog, and a longer one does not extend
+it.
+
+**3. Poll state cannot be shared, by type.** The member is an `AbortFlag`, not
+an `AbortDevice`. `AbortDevice` carries mutable throttle state
+(`nextPollCycles_`, an absolute per-SM `clock64()`), and this object lives in
+device memory that every block sees — so several blocks would write one field
+non-atomically, and a value stamped by a leading SM could suppress a lagging
+SM's polls far past the interval, hiding the abort it was parked on.
+`AbortFlag` holds nothing mutable and exposes no poll, so that is unwritable
+here. What a shared handle *may* do — report whether FT is on, and record a
+terminal reason via a system-scope CAS — is all it offers.
+
+Do not "fix" any of this by arming a copy in the wait. `startTimeout()` is
+relative to the moment of the call, so every entry into `reserve()` would get a
+fresh full budget and N stalled reserves would cost N × timeout.
+
+**The reason is its own.** A stalled proxy latches
+`AbortReason::IBRC_PROXY_TIMEOUT`, not `TIMED_OUT`. They are different faults
+with different owners — the host proxy thread versus the collective's own
+deadline — and the host log should say which. `isTimedOut()` stays exact and
+does not report a proxy stall; `isAborted()` covers both.
+
+**The residual trade, stated plainly.** Because these loops never read shared
+state and their budget is the fixed watchdog, a block parked in one does not
+observe *another* wait's abort promptly, and a collective deadline shorter than
+the watchdog does not pull it out early — it leaves on the watchdog instead.
+Liveness is what the contract requires and it is bounded either way, but unwind
+is not instantaneous across a kernel whose producer is parked, and the worst-case
+unwind for such a kernel is the watchdog rather than the configured timeout. The
+single one-shot exception is the check before
+`reserve()` claims a sequence number, which does read shared state so that a
+producer on an already-aborted communicator leaves the wire untouched; it is
+once per descriptor and never in a loop.
+
+
 ## MCCL Collective Integration
 
 MCCL and CTRAN already share the same host `Abort`. MCCL collective code should

--- a/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
@@ -220,6 +220,7 @@ TEST(AbortDeviceTest, deviceProducerSupportsDetailedTerminalReasons) {
            AbortReason::BOOTSTRAP_POLL,
            AbortReason::NETWORK_ERROR,
            AbortReason::INTERNAL_ERROR,
+           AbortReason::IBRC_PROXY_TIMEOUT,
        }) {
     Abort abort{/*enabled=*/true};
 

--- a/comms/common/fault_tolerance/tests/AbortUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortUT.cc
@@ -528,6 +528,7 @@ TEST(AbortTest, abortInfoRecordsEveryTerminalReasonAndContext) {
       AbortReason::BOOTSTRAP_POLL,
       AbortReason::NETWORK_ERROR,
       AbortReason::INTERNAL_ERROR,
+      AbortReason::IBRC_PROXY_TIMEOUT,
   };
 
   for (const auto reason : reasons) {
@@ -615,6 +616,9 @@ TEST(AbortTest, abortReasonToString) {
   EXPECT_EQ(abortReasonToString(AbortReason::BOOTSTRAP_POLL), "bootstrap_poll");
   EXPECT_EQ(abortReasonToString(AbortReason::NETWORK_ERROR), "network_error");
   EXPECT_EQ(abortReasonToString(AbortReason::INTERNAL_ERROR), "internal_error");
+  EXPECT_EQ(
+      abortReasonToString(AbortReason::IBRC_PROXY_TIMEOUT),
+      "ibrc_proxy_timeout");
   EXPECT_EQ(abortReasonToString(static_cast<AbortReason>(99)), "unknown");
 }
 

--- a/comms/prims/core/AbortCheck.cuh
+++ b/comms/prims/core/AbortCheck.cuh
@@ -12,6 +12,7 @@
 namespace comms::prims {
 
 using AbortDevice = comms::fault_tolerance::AbortDevice;
+using AbortFlag = comms::fault_tolerance::AbortFlag;
 
 __device__ __forceinline__ uint64_t gpu_clock64() {
 #if defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)

--- a/comms/prims/tests/P2pIbTransportDeviceAbortTest.cc
+++ b/comms/prims/tests/P2pIbTransportDeviceAbortTest.cc
@@ -207,7 +207,201 @@ void runTimeoutDuringWait(Launcher launcher) {
   EXPECT_LT(elapsed, std::chrono::seconds(10));
 }
 
+// Backing buffer plus result slot for the queue-full put test.
+class PutFixture {
+ public:
+  PutFixture() {
+    CUDACHECK_TEST(cudaSetDevice(0));
+    CUDACHECK_TEST(cudaMalloc(&data_, sizeof(uint64_t)));
+    CUDACHECK_TEST(cudaMalloc(&posted_, sizeof(uint32_t)));
+    CUDACHECK_TEST(cudaMemset(data_, 0, sizeof(uint64_t)));
+    CUDACHECK_TEST(cudaMemset(posted_, 0, sizeof(uint32_t)));
+  }
+
+  ~PutFixture() {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaFree(posted_);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaFree(data_);
+  }
+
+  PutFixture(const PutFixture&) = delete;
+  PutFixture& operator=(const PutFixture&) = delete;
+  PutFixture(PutFixture&&) = delete;
+  PutFixture& operator=(PutFixture&&) = delete;
+
+  uint64_t* data() {
+    return data_;
+  }
+
+  uint32_t* posted() {
+    return posted_;
+  }
+
+  uint32_t readPosted() {
+    uint32_t value = 0;
+    CUDACHECK_TEST(
+        cudaMemcpy(&value, posted_, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+    return value;
+  }
+
+ private:
+  uint64_t* data_{nullptr};
+  uint32_t* posted_{nullptr};
+};
+
 } // namespace
+
+// A put that finds the ring full has to unwind, not trap: under fault tolerance
+// a device trap takes down the CUDA context for the whole process, which is the
+// failure the abort path exists to prevent.
+TEST(P2pIbTransportDeviceAbortTest, IbrcPutSkipsWhenQueueFullAndAborted) {
+  PutFixture fixture;
+  comms::fault_tolerance::Abort abort(/*enabled=*/true);
+  const uint32_t depth = test::ibrcTestQueueDepth();
+
+  test::launchIbrcPutUntilQueueFull(
+      fixture.data(),
+      fixture.posted(),
+      /*attempts=*/depth + 2,
+      abort.getDeviceHandle());
+  // Deliberate, and not replaceable by a condition variable: the abort has to
+  // land *while* the kernel is spinning on the full ring, and the only signal
+  // that it got there is the device-side posted counter, which the host cannot
+  // read mid-kernel without serialising behind the very kernel it is waiting
+  // on. 200 ms is two orders of magnitude above the launch it is covering.
+  // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  abort.setAbort();
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Exactly the puts that fit are posted. The one that blocked on the full ring
+  // is dropped by the abort, and the one after it is dropped without ever
+  // touching the ring because the abort is already latched.
+  EXPECT_EQ(fixture.readPosted(), depth);
+  EXPECT_TRUE(abort.isAborted());
+}
+
+// The stalled-CPU-proxy case running concurrently with a collective deadline.
+// No `setAbort()` is called anywhere in this test.
+//
+// Two bounds are in play and they are deliberately independent. The collective
+// block owns the armed handle and expires on kTimeout, latching TIMED_OUT --
+// that is the reason the host reports, because it is recorded first. The parked
+// producer block is bounded by the fixed SM-to-proxy watchdog instead: it does
+// not read the abort flag inside its spin, so the collective's shorter deadline
+// does not release it. Both terminate, which is what liveness requires; only
+// the promptness differs.
+//
+// Distinct from the wait-signal timeout tests, which stall in a wait that holds
+// the armed handle itself. Here the two roles sit in different blocks, which is
+// the arrangement a real collective produces.
+TEST(
+    P2pIbTransportDeviceAbortTest,
+    IbrcQueueFullUnwindsWhileCollectiveTimesOut) {
+  constexpr std::chrono::milliseconds kTimeout{500};
+  PutFixture fixture;
+  // The signal the collective block waits on. Never set, so its wait can only
+  // end on the deadline.
+  WaitFixture waitFixture;
+  comms::fault_tolerance::Abort abort(/*enabled=*/true);
+  abort.setDefaultTimeout(kTimeout);
+  const uint32_t depth = test::ibrcTestQueueDepth();
+
+  const auto start = std::chrono::steady_clock::now();
+  test::launchIbrcQueueFullReleasedByCollectiveDeadline(
+      fixture.data(),
+      fixture.posted(),
+      /*attempts=*/depth + 2,
+      waitFixture.signal(),
+      abort.getDeviceHandle());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - start);
+
+  // Same accounting as the host-abort case: the puts that fit are posted, the
+  // one that blocks is released by the latched flag, and the next is skipped
+  // before it touches the ring.
+  EXPECT_EQ(fixture.readPosted(), depth)
+      << "below depth means the collective block expired before the ring "
+         "filled, which is not the scenario under test";
+  // isAborted() is the generic "flag is latched" predicate and is true for a
+  // timeout too, so isTimedOut() is what distinguishes a deadline from an
+  // explicit abort.
+  EXPECT_TRUE(abort.isTimedOut())
+      << "the collective deadline is the first terminal reason recorded, so it "
+         "is what the host sees even though the producer left on its watchdog";
+  // Upper bound only; the lower bound is timing-sensitive under load. The bound
+  // is the fixed proxy watchdog, not kTimeout: the parked producer does not
+  // read the flag in its loop, so the collective's shorter deadline does not
+  // release it early.
+  EXPECT_LT(elapsed, std::chrono::seconds(30));
+}
+
+// The same skip, decided before the kernel does any work at all.
+TEST(P2pIbTransportDeviceAbortTest, IbrcPutSkipsWhenPreAborted) {
+  PutFixture fixture;
+  comms::fault_tolerance::Abort abort(/*enabled=*/true);
+  abort.setAbort();
+
+  test::launchIbrcPutUntilQueueFull(
+      fixture.data(),
+      fixture.posted(),
+      /*attempts=*/test::ibrcTestQueueDepth(),
+      abort.getDeviceHandle());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  EXPECT_EQ(fixture.readPosted(), 0U);
+}
+
+// The gap @benrcarver identified: a kernel that *ends* in flush() rather than
+// parking in reserve(). Before the watchdog became unconditional, enabling FT
+// removed the bound here entirely -- the legacy cycle deadline was gated on
+// `!abort.isEnabled()` and P2pIbTransportDevice::flush dropped the caller's
+// deadline on the IBRC branch -- so this hung until an explicit host abort.
+//
+// Nothing calls setAbort(). The drain ends on the fixed proxy watchdog and
+// latches IBRC_PROXY_TIMEOUT, which names the stalled proxy rather than
+// pretending the collective's own deadline expired.
+//
+// The configured 500 ms timeout is here to show it is *not* what bounds this:
+// the watchdog is a property of the SM-to-proxy contract, so a shorter
+// collective deadline neither shortens nor lengthens it.
+TEST(P2pIbTransportDeviceAbortTest, IbrcFlushBoundedWithFtEnabled) {
+  PutFixture fixture;
+  comms::fault_tolerance::Abort abort(/*enabled=*/true);
+  abort.setDefaultTimeout(std::chrono::milliseconds(500));
+
+  const auto start = std::chrono::steady_clock::now();
+  test::launchIbrcFlushNeverDrains(
+      fixture.data(), fixture.posted(), abort.getDeviceHandle());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - start);
+
+  EXPECT_LT(elapsed, std::chrono::seconds(30))
+      << "flush must be bounded with FT enabled; an unbounded drain is the "
+         "regression this case exists to catch";
+  EXPECT_EQ(
+      abort.reason(), comms::fault_tolerance::AbortReason::IBRC_PROXY_TIMEOUT)
+      << "a stalled proxy must be attributed to the proxy, not reported as the "
+         "collective's own deadline expiring";
+}
+
+// Negative control for the two above: with no handle wired there is no abort to
+// observe, so every put up to the ring depth must still post normally. This is
+// what keeps the skip path from silently swallowing traffic on the legacy path.
+TEST(P2pIbTransportDeviceAbortTest, IbrcPutFillsQueueWithoutAbortHandle) {
+  PutFixture fixture;
+  comms::fault_tolerance::AbortDevice disabled;
+  const uint32_t depth = test::ibrcTestQueueDepth();
+
+  test::launchIbrcPutUntilQueueFull(
+      fixture.data(), fixture.posted(), /*attempts=*/depth, disabled);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  EXPECT_EQ(fixture.readPosted(), depth);
+}
 
 TEST(P2pIbTransportDeviceAbortTest, WrapperWaitSignalSucceedsWhenSatisfied) {
   runAlreadySatisfiedWait(test::launchIbWrapperWaitSignal);

--- a/comms/prims/tests/P2pIbTransportDeviceAbortTest.cu
+++ b/comms/prims/tests/P2pIbTransportDeviceAbortTest.cu
@@ -5,6 +5,7 @@
 #include <cstddef>
 
 #include "comms/common/fault_tolerance/AbortDevice.cuh"
+#include "comms/common/fault_tolerance/AbortMacros.cuh"
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/tests/Checks.h"
 #include "comms/prims/transport/P2pIbTransportDevice.cuh"
@@ -34,14 +35,34 @@ __device__ void zeroScratch(ThreadGroup& group, IbrcScratch& scratch) {
   group.sync();
 }
 
-__device__ P2pIbrcTransportDevice makeLocalIbrcTransport(IbrcScratch& scratch) {
+__device__ P2pIbrcTransportDevice makeLocalIbrcTransport(
+    IbrcScratch& scratch,
+    comms::fault_tolerance::AbortDevice abort = {}) {
   return P2pIbrcTransportDevice(
       DeviceSpan<IbrcCmdQueueDevice>{scratch.queues, 2},
       /*nics=*/1,
       /*maxChannels=*/1,
       /*qpsPerConnection=*/1,
-      DeviceSpan<IbLocalChannel>{scratch.channels, 1});
+      DeviceSpan<IbLocalChannel>{scratch.channels, 1},
+      /*ownedRemoteSignalBuf=*/{},
+      /*ownedLocalSignalBuf=*/{},
+      /*ownedCounterDeviceBuf=*/{},
+      /*ownedCounterHostBuf=*/{},
+      /*numSignalSlots=*/0,
+      /*numCounterSlots=*/0,
+      /*channelLayout=*/{},
+      abort);
 }
+
+constexpr uint32_t kIbrcTestQueueDepth = 4;
+
+// Ring storage for the queue-full test. Global rather than shared because the
+// transport reaches pi/ci with system-scope atomics, which are meaningful only
+// on memory the host could also map; a __shared__ ring would make the test
+// depend on undefined behavior rather than on the code under test.
+__device__ IbrcDesc gTestDescs[kIbrcTestQueueDepth];
+__device__ uint64_t gTestPi;
+__device__ uint64_t gTestCi;
 
 // Which of the two production call paths reaches the same IBRC wait.
 enum class IbEntryPoint { Wrapper, Ibrc };
@@ -88,7 +109,177 @@ __global__ void waitSignalKernel(
   }
 }
 
+// Body of the queue-full producer, shared by the two kernels below. The
+// transport is built with `abort` exactly as handed in -- unstarted -- because
+// that is what a real IBRC transport holds: the communicator flag, never a
+// deadline.
+__device__ void runPutUntilQueueFull(
+    ThreadGroup& group,
+    IbrcScratch& scratch,
+    uint64_t* dataBuf,
+    uint32_t* postedOut,
+    uint32_t attempts,
+    comms::fault_tolerance::AbortDevice abort) {
+  if (group.is_leader()) {
+    gTestPi = 0;
+    gTestCi = 0;
+    for (uint32_t i = 0; i < kIbrcTestQueueDepth; ++i) {
+      gTestDescs[i].ready_seq = kIbrcInvalidReadySeq;
+    }
+    // Lane 0 of channel 0 is where a single-NIC, single-QP put lands.
+    scratch.queues[0].descs = gTestDescs;
+    scratch.queues[0].pi = &gTestPi;
+    scratch.queues[0].ci = &gTestCi;
+    scratch.queues[0].status = nullptr;
+    scratch.queues[0].depth = kIbrcTestQueueDepth;
+    scratch.queues[0].mask = kIbrcTestQueueDepth - 1;
+  }
+  group.sync();
+
+  P2pIbrcTransportDevice ibrc = makeLocalIbrcTransport(scratch, abort);
+  IbgdaLocalBuffer localBuf{dataBuf, NetworkLKeys{/*n=*/1}};
+  IbgdaRemoteBuffer remoteBuf{dataBuf, NetworkRKeys{/*n=*/1}};
+
+  // Deliberately no start() here. The local copy is not the transport's, so
+  // arming it would only look like a deadline while changing nothing -- which
+  // is what made the earlier version of these tests pass on the explicit host
+  // abort alone.
+  uint32_t posted = 0;
+  for (uint32_t i = 0; i < attempts; ++i) {
+    // A skipped put returns the default ticket, whose value is 0; a posted one
+    // is always seq + 1, so a nonzero value means the descriptor was published.
+    const IbLocalCompletionTicket ticket = ibrc.put(
+        group,
+        localBuf,
+        remoteBuf,
+        sizeof(uint64_t),
+        /*signalBuf=*/IbgdaRemoteBuffer{},
+        /*signalVal=*/0);
+    if (ticket.value != 0) {
+      ++posted;
+    }
+  }
+  if (group.is_leader()) {
+    *postedOut = posted;
+  }
+}
+
+__global__ void putUntilQueueFullKernel(
+    uint64_t* dataBuf,
+    uint32_t* postedOut,
+    uint32_t attempts,
+    comms::fault_tolerance::AbortDevice abort) {
+  auto group = make_block_group();
+  __shared__ IbrcScratch scratch;
+  zeroScratch(group, scratch);
+  runPutUntilQueueFull(group, scratch, dataBuf, postedOut, attempts, abort);
+}
+
+// The division of labour the FT contract actually specifies, in one kernel.
+//
+// Block 0 is an IBRC producer parked in `reserve()` on a full ring, holding a
+// flag-only handle. Block 1 is the collective: it owns the deadline, arms the
+// only started handle in the launch, and waits on a signal that never arrives.
+//
+// A block parked in a proxy-facing wait cannot latch its own timeout -- that is
+// the property under test. Block 1's deadline expires, latches TIMED_OUT into
+// the shared state, and block 0 leaves on the flag. Nothing calls setAbort().
+//
+// The two blocks race only in the benign direction: block 0 fills a 4-entry
+// ring in microseconds against block 1's millisecond deadline, and if that
+// order were ever inverted the test fails loudly on the posted count rather
+// than hanging.
+//
+// Block 0 is the producer because the transport derives its channel id from
+// the group id, and this fixture is wired for a single channel.
+//
+// The collective block spins on the signal directly rather than through a
+// transport: all it has to model is "a wait in this kernel owns the armed
+// handle", and a bare loop does that without needing a second channel's worth
+// of queue geometry.
+__global__ void queueFullReleasedByCollectiveDeadlineKernel(
+    uint64_t* dataBuf,
+    uint32_t* postedOut,
+    uint32_t attempts,
+    uint64_t* signal,
+    comms::fault_tolerance::AbortDevice abort) {
+  auto group = make_block_group();
+  __shared__ IbrcScratch scratch;
+  zeroScratch(group, scratch);
+
+  if (blockIdx.x == 0) {
+    runPutUntilQueueFull(group, scratch, dataBuf, postedOut, attempts, abort);
+    return;
+  }
+
+  abort.start();
+  if (group.is_leader()) {
+    const auto* observed = static_cast<volatile uint64_t*>(signal);
+    while (*observed < 1U) {
+      FT_ABORT_BREAK(abort, "test collective wait on a signal that never sets");
+    }
+  }
+  group.sync();
+}
+
+// Ben's case: a kernel that *ends* in flush() rather than parking in reserve().
+//
+// The proxy never advances `ci`, so the drain cannot complete. Before the
+// watchdog was made unconditional, FT-on removed the only bound here -- the
+// legacy cycle deadline was gated on `!abort.isEnabled()` and the caller's
+// deadline was dropped on the IBRC branch of P2pIbTransportDevice::flush --
+// leaving an explicit host abort as the sole exit. Nothing calls setAbort().
+__global__ void flushNeverDrainsKernel(
+    uint64_t* dataBuf,
+    uint32_t* postedOut,
+    comms::fault_tolerance::AbortDevice abort) {
+  auto group = make_block_group();
+  __shared__ IbrcScratch scratch;
+  zeroScratch(group, scratch);
+
+  // One successful put, so the drain has something to wait on.
+  runPutUntilQueueFull(
+      group, scratch, dataBuf, postedOut, /*attempts=*/1, abort);
+
+  P2pIbrcTransportDevice ibrc = makeLocalIbrcTransport(scratch, abort);
+  // `ci` is never advanced by anyone, so this can only end on the fixed proxy
+  // watchdog -- flush takes no deadline, by design.
+  ibrc.flush(group, IbDirection::Send);
+}
+
 } // namespace
+
+uint32_t ibrcTestQueueDepth() {
+  return kIbrcTestQueueDepth;
+}
+
+void launchIbrcPutUntilQueueFull(
+    uint64_t* dataBuf,
+    uint32_t* postedOut,
+    uint32_t attempts,
+    comms::fault_tolerance::AbortDevice abort) {
+  putUntilQueueFullKernel<<<1, 32>>>(dataBuf, postedOut, attempts, abort);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchIbrcFlushNeverDrains(
+    uint64_t* dataBuf,
+    uint32_t* postedOut,
+    comms::fault_tolerance::AbortDevice abort) {
+  flushNeverDrainsKernel<<<1, 32>>>(dataBuf, postedOut, abort);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchIbrcQueueFullReleasedByCollectiveDeadline(
+    uint64_t* dataBuf,
+    uint32_t* postedOut,
+    uint32_t attempts,
+    uint64_t* signal,
+    comms::fault_tolerance::AbortDevice abort) {
+  queueFullReleasedByCollectiveDeadlineKernel<<<2, 32>>>(
+      dataBuf, postedOut, attempts, signal, abort);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
 
 void launchIbWrapperWaitSignal(
     uint64_t* signal,

--- a/comms/prims/tests/P2pIbTransportDeviceAbortTest.cuh
+++ b/comms/prims/tests/P2pIbTransportDeviceAbortTest.cuh
@@ -43,6 +43,62 @@ void launchIbrcWaitSignal(
     comms::fault_tolerance::AbortDevice abort,
     uint32_t* enteredWait = nullptr);
 
+/*
+ * Depth of the command queue backing `launchIbrcPutUntilQueueFull`, so the test
+ * can assert exactly how many puts fit before the ring blocks.
+ */
+uint32_t ibrcTestQueueDepth();
+
+/*
+ * Issues `attempts` puts into a command queue that no CPU proxy ever drains,
+ * and stores how many produced a real completion ticket in `postedOut`.
+ *
+ * The first `ibrcTestQueueDepth()` puts fill the ring. The next one has nowhere
+ * to go and can only leave `reserve()` by observing the abort, so this is the
+ * queue-full path that used to trap the device. Every put after that is skipped
+ * on the latched abort without touching the ring at all.
+ *
+ * Asynchronous, like the wait launchers: the caller aborts the handle while the
+ * kernel is blocked and then synchronizes.
+ */
+void launchIbrcPutUntilQueueFull(
+    uint64_t* dataBuf,
+    uint32_t* postedOut,
+    uint32_t attempts,
+    comms::fault_tolerance::AbortDevice abort);
+
+/*
+ * Same queue-full stall, released by a collective deadline instead of by an
+ * explicit host abort.
+ *
+ * Launches two blocks. Block 0 plays the IBRC producer and parks in `reserve()`
+ * on a full ring holding a flag-only handle, which cannot latch a timeout of
+ * its own. Block 1 plays the collective: it arms the only started handle in the
+ * launch and waits on `signal`, which never arrives.
+ *
+ * Pass a handle with a configured timeout and never call `setAbort()`: the
+ * expiry of block 1's deadline is the only thing that can end the launch, which
+ * is what makes this a test of the deadline path rather than of the abort flag.
+ */
+void launchIbrcQueueFullReleasedByCollectiveDeadline(
+    uint64_t* dataBuf,
+    uint32_t* postedOut,
+    uint32_t attempts,
+    uint64_t* signal,
+    comms::fault_tolerance::AbortDevice abort);
+
+/*
+ * A kernel that ends in `flush()` on a queue the proxy never drains.
+ *
+ * Pass a handle with a configured timeout and never call `setAbort()`: the only
+ * thing that can end this launch is the drain bound. With FT enabled and no
+ * bound, it hangs -- which is what it is here to catch.
+ */
+void launchIbrcFlushNeverDrains(
+    uint64_t* dataBuf,
+    uint32_t* postedOut,
+    comms::fault_tolerance::AbortDevice abort);
+
 } // namespace comms::prims::test
 
 #endif // COMMS_PRIMS_TESTS_P2P_IB_TRANSPORT_DEVICE_ABORT_TEST_CUH_

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -192,8 +192,10 @@ void MultiPeerTransport::initFromTopology(
     auto ibConfig = config.ibConfig;
     ibConfig.cudaDevice = deviceId_;
     if (config.ibMode == IbBackendMode::kIbrc) {
+      // IBRC's device waits sit on the CPU proxy, so the backend needs the
+      // handle itself; IBGDA takes one per call on the wait APIs instead.
       ibrcTransport_ = std::make_unique<MultipeerIbrcTransport>(
-          myRank_, nRanks_, bootstrap_, ibConfig);
+          myRank_, nRanks_, bootstrap_, ibConfig, abortDevice_);
       VLOG(1) << "MultiPeerTransport: rank " << myRank_
               << " created IBRC sub-transport for " << ibPeerRanks_.size()
               << " peers";

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -475,13 +475,17 @@ P2pIbTransportDevice::read_counter(const IbgdaLocalBuffer& counterBuf) const {
   return ibgda->read_counter(counterBuf);
 }
 
-// IBRC still drains under its own fixed device deadline; wiring it to the
-// abort handle is a separate change, so the handle stops at IBGDA for now.
+// IBRC deliberately does not take the caller's deadline. Its drain is bounded
+// by the fixed SM-to-proxy watchdog, which is a contract between one rank's
+// kernel and its own host proxy and is honoured on its own terms; the caller's
+// deadline bounds the collective, which is a different fault with a different
+// owner. The bound is unconditional either way, so dropping the argument costs
+// no liveness. IBGDA is GPU-initiated with no proxy, so it uses the deadline.
 __device__ __forceinline__ void P2pIbTransportDevice::flush(
     ThreadGroup& group,
     const Timeout& timeout) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->flush(group);
+    ibrc->flush(group, IbDirection::Send);
   } else {
     ibgda->flush(group, IbDirection::Send, timeout);
   }
@@ -490,7 +494,7 @@ __device__ __forceinline__ void P2pIbTransportDevice::flush(
 __device__ __forceinline__ void P2pIbTransportDevice::flush(
     const Timeout& timeout) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->flush();
+    ibrc->flush(IbDirection::Send);
   } else {
     ibgda->flush(timeout);
   }

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -267,12 +267,14 @@ MultipeerIbrcTransport::MultipeerIbrcTransport(
     int myRank,
     int nRanks,
     std::shared_ptr<meta::comms::IBootstrap> bootstrap,
-    const MultipeerIbTransportConfig& config)
+    const MultipeerIbTransportConfig& config,
+    comms::fault_tolerance::AbortDevice abort)
     : MultiPeerIbTransport<MultipeerIbrcTransport>(
           myRank,
           nRanks,
           std::move(bootstrap),
-          config) {
+          config),
+      abortDevice_(abort) {
   const int numQpsPerPeerPerNic = config_.fixedChannelMainQpsPerPeerPerNic();
   if (config_.max_num_channels < 1) {
     throw std::invalid_argument("max_num_channels must be >= 1");
@@ -1013,7 +1015,8 @@ void MultipeerIbrcTransport::updatePeerDeviceTransport(int peerIndex) noexcept {
       counterHostBuf,
       config_.numSignalSlots,
       config_.numCounterSlots,
-      channelLayoutForPeer(peerIndex));
+      channelLayoutForPeer(peerIndex),
+      abortDevice_);
 }
 
 std::size_t MultipeerIbrcTransport::allocatedCmdQueueCount() const {

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
@@ -19,6 +19,7 @@
 #endif
 
 #include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/common/fault_tolerance/AbortDevice.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
 #include "comms/prims/transport/MultiPeerIbTransport.h"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
@@ -50,11 +51,16 @@ class P2pIbrcTransportDevice;
 class MultipeerIbrcTransport
     : public MultiPeerIbTransport<MultipeerIbrcTransport> {
  public:
+  // `abort` is the owning communicator's device handle. It is baked into every
+  // per-peer device slot so the device-side waits on the CPU proxy terminate on
+  // abort instead of trapping. A default-constructed handle keeps the legacy
+  // cycle-deadline trap; see kIbrcDefaultDeviceTimeoutCycles.
   MultipeerIbrcTransport(
       int myRank,
       int nRanks,
       std::shared_ptr<meta::comms::IBootstrap> bootstrap,
-      const MultipeerIbTransportConfig& config);
+      const MultipeerIbTransportConfig& config,
+      comms::fault_tolerance::AbortDevice abort = {});
 
   ~MultipeerIbrcTransport();
 
@@ -226,6 +232,7 @@ class MultipeerIbrcTransport
   std::atomic<bool> stopProgress_{false};
   std::thread progressThread_;
   std::vector<int> progressCpus_;
+  comms::fault_tolerance::AbortDevice abortDevice_;
 
   // Send/recv staging state (eager mode) lives in MultiPeerIbTransportBase
   // (sendRecvPeerBuffers_ + bulks); IBRC delegates allocation/exchange/cleanup.

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cu
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cu
@@ -33,7 +33,8 @@ void writeIbrcDeviceSlot(
     IbgdaLocalBuffer counterHostBuf,
     int numSignalSlots,
     int numCounterSlots,
-    IbChannelLayout channelLayout) {
+    IbChannelLayout channelLayout,
+    comms::fault_tolerance::AbortDevice abort) {
   auto* slots = static_cast<P2pIbrcTransportDevice*>(slotsHost);
   new (&slots[peerIndex]) P2pIbrcTransportDevice(
       queues,
@@ -47,7 +48,8 @@ void writeIbrcDeviceSlot(
       counterHostBuf,
       numSignalSlots,
       numCounterSlots,
-      channelLayout);
+      channelLayout,
+      abort);
 }
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cuh
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cuh
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "comms/common/fault_tolerance/AbortDevice.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 #include "comms/prims/transport/ibrc/IbrcTypes.h"
@@ -44,6 +45,7 @@ void writeIbrcDeviceSlot(
     IbgdaLocalBuffer counterHostBuf,
     int numSignalSlots,
     int numCounterSlots,
-    IbChannelLayout channelLayout);
+    IbChannelLayout channelLayout,
+    comms::fault_tolerance::AbortDevice abort);
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -25,10 +25,15 @@
 
 namespace comms::prims {
 
-// Default bound for device-side waits on the CPU progress thread (flush /
-// reserve). Mirrors IBGDA's kDefaultDeviceTimeoutCycles: converts an indefinite
-// hang (a stalled progress thread that never publishes an error) into a bounded
-// trap.
+// Legacy bound for device-side waits on the CPU progress thread (flush /
+// reserve), used only when no abort handle is wired. Mirrors IBGDA's
+// kDefaultDeviceTimeoutCycles: it converts an indefinite hang (a stalled
+// progress thread that never publishes an error) into a bounded trap.
+//
+// With a handle wired, the abort supersedes it and these waits unwind instead
+// of trapping -- see the fault-vs-assertion note on `reserve()`. The trap is
+// kept for the disabled case because silently dropping a put with no abort
+// signal to report would be undetectable data loss, which is worse.
 inline constexpr uint64_t kIbrcDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
 
 #if PIPES_IS_DEVICE_COMPILE
@@ -83,7 +88,8 @@ class P2pIbrcTransportDevice {
       IbgdaLocalBuffer ownedCounterHostBuf = {},
       int numSignalSlots = 0,
       int numCounterSlots = 0,
-      IbChannelLayout channelLayout = {})
+      IbChannelLayout channelLayout = {},
+      AbortDevice abort = {})
       : cmdQueues(queues),
         numNics(nics),
         maxChannels_(maxChannels),
@@ -95,7 +101,8 @@ class P2pIbrcTransportDevice {
         ownedCounterHostBuf_(ownedCounterHostBuf),
         numSignalSlots_(numSignalSlots),
         numCounterSlots_(numCounterSlots),
-        channelLayout_(channelLayout) {}
+        channelLayout_(channelLayout),
+        abort_(abort) {}
 
   // IBRC round-robins each send/recv chunk's RDMA_WRITE + DATA_READY fetch-add
   // across per-lane command queues / QPs when numLanes > 1 (select_put_queue_id
@@ -344,10 +351,15 @@ class P2pIbrcTransportDevice {
       }
 
       const uint64_t seq = enqueue(queueId, desc);
-      completion = IbLocalCompletionTicket{
-          .completionId = laneOrdinal,
-          .value = seq + 1,
-      };
+      if (seq != kIbrcInvalidReadySeq) {
+        completion = IbLocalCompletionTicket{
+            .completionId = laneOrdinal,
+            .value = seq + 1,
+        };
+      }
+      // A skipped enqueue leaves `completion` default-constructed, whose value
+      // of 0 is already below every ci, so a later wait_local() on it returns
+      // at once instead of blocking on a transfer that was never posted.
     }
     group.sync();
     return completion;
@@ -412,14 +424,11 @@ class P2pIbrcTransportDevice {
     while (static_cast<int64_t>(
                load_acquire_system_u64(queue.ci) - ticket.value) < 0) {
       check_status(queue);
-      if (timeout.checkExpired()) {
-        printf(
-            "P2pIbrcTransportDevice: local completion timed out lane=%u "
-            "expected=%llu\n",
-            ticket.completionId,
-            static_cast<unsigned long long>(ticket.value));
-        PIPES_DEVICE_TRAP();
-      }
+      FT_ABORT_BREAK(
+          timeout,
+          "P2pIbrcTransportDevice: local completion lane=%u expected=%llu",
+          ticket.completionId,
+          static_cast<unsigned long long>(ticket.value));
     }
   }
 
@@ -851,12 +860,30 @@ class P2pIbrcTransportDevice {
     return queueId % numNics;
   }
 
+  // Stays void on abort: a drain that stops early has nothing to report to a
+  // caller that is itself about to unwind, and the abort is already recorded
+  // for the host.
+  // Bounded by the fixed proxy watchdog, not by any caller deadline. This wait
+  // is the contract between one rank's SM and its host proxy, and that contract
+  // has its own duration; the enclosing collective's deadline is a different
+  // bound with a different owner. A cycle compare is a register op, whereas the
+  // abort flag lives in mapped host memory, so the loop never reads it.
   __device__ void drain_queue(const IbrcCmdQueueDevice& queue) const {
     const uint64_t target = load_acquire_system_u64(queue.pi);
     const uint64_t start = gpu_clock64();
+    const bool ftEnabled = abort_.isEnabled();
     while (load_acquire_system_u64(queue.ci) < target) {
       check_status(queue);
       if (gpu_clock64() - start >= kIbrcDefaultDeviceTimeoutCycles) {
+        if (ftEnabled) {
+          // The proxy stopped draining. Latching the reason is what lets the
+          // rest of the kernel unwind: every other wait observes it through
+          // shared state on its own next poll.
+          abort_.setAbort(
+              comms::fault_tolerance::AbortReason::IBRC_PROXY_TIMEOUT,
+              "IBRC proxy watchdog: flush drain");
+          return;
+        }
         printf("P2pIbrcTransportDevice: flush timed out\n");
         PIPES_DEVICE_TRAP();
       }
@@ -886,12 +913,71 @@ class P2pIbrcTransportDevice {
     }
   }
 
+  // Claims one command-queue slot, spinning while the ring is full.
+  //
+  // Returns kIbrcInvalidReadySeq when the wait ended in an abort. A full ring
+  // means the CPU proxy is behind or stopped, which is a *fault*, not a
+  // programming error, so it must not trap: a device trap kills the CUDA
+  // context for the whole process, which is precisely the outcome fault
+  // tolerance exists to avoid. Reporting the failure instead lets enqueue()
+  // skip the descriptor, put() hand back a ticket that is already satisfied,
+  // and the block unwind to the end of the kernel on its own.
+  //
+  // The abort is checked before the fetch_add so an already-aborted producer
+  // claims nothing. Aborting *during* the wait still leaves the claimed
+  // sequence unpublished, which wedges this queue's proxy cursor -- acceptable
+  // because a latched abort is terminal for the communicator, and the progress
+  // thread is stopped by teardown rather than by draining.
+  //
+  // The bound is a *cycle* watchdog, not an abort poll, and it is armed in
+  // every mode. That is deliberate on two counts.
+  //
+  // First, it is the contract between this kernel and the host proxy: a
+  // submitted descriptor must be consumed within a bounded time, and that
+  // obligation does not change because fault tolerance happens to be on.
+  // Gating the watchdog on `!isEnabled()` -- which is what this used to do --
+  // meant enabling FT *removed* the only bound, leaving an explicit host abort
+  // as the sole exit.
+  //
+  // Second, polling the abort here would cost a mapped-host read per stalled
+  // iteration, and the throttle that would otherwise amortise it cannot live
+  // in `abort_` (see the member). A `clock64()` delta is a register compare and
+  // is accurate enough for a multi-second bound.
+  //
+  // So this loop never reads shared state; on expiry it *writes* it, latching
+  // IBRC_PROXY_TIMEOUT so every other wait in the kernel unwinds through the
+  // normal path. The trade: a block parked here does not observe someone
+  // else's abort promptly -- it leaves on its own budget instead. Liveness is
+  // what the contract requires, and that is bounded either way.
   __device__ __forceinline__ uint64_t reserve(IbrcCmdQueueDevice& queue) const {
+    // One-shot, before anything is claimed: a producer on an already-aborted
+    // communicator must leave the wire untouched, so no sequence number is
+    // taken and no descriptor is published. This is the only shared-state read
+    // on the producer path, and it is not in a loop.
+    if (abort_.isAborted()) {
+      return kIbrcInvalidReadySeq;
+    }
     const uint64_t seq = fetch_add_system_u64(queue.pi, 1);
+    if (seq - load_acquire_system_u64(queue.ci) < queue.depth) {
+      // Fast path: ring has space. No clock read, no abort read, no copy --
+      // this is the whole cost of FT on the healthy producer path.
+      return seq;
+    }
+    // Bounded by the fixed proxy watchdog: this is the SM-to-proxy contract and
+    // it is honoured on its own terms, not rescaled by whatever deadline the
+    // enclosing collective happens to carry. One shared read for `isEnabled()`,
+    // then pure register compares for the rest of the stall.
     const uint64_t start = gpu_clock64();
+    const bool ftEnabled = abort_.isEnabled();
     while (seq - load_acquire_system_u64(queue.ci) >= queue.depth) {
       check_status(queue);
       if (gpu_clock64() - start >= kIbrcDefaultDeviceTimeoutCycles) {
+        if (ftEnabled) {
+          abort_.setAbort(
+              comms::fault_tolerance::AbortReason::IBRC_PROXY_TIMEOUT,
+              "IBRC proxy watchdog: reserve on a full ring");
+          return kIbrcInvalidReadySeq;
+        }
         printf("P2pIbrcTransportDevice: reserve timed out\n");
         PIPES_DEVICE_TRAP();
       }
@@ -899,29 +985,43 @@ class P2pIbrcTransportDevice {
     return seq;
   }
 
+  // Returns kIbrcInvalidReadySeq when the command was skipped because the
+  // communicator aborted. Nothing is published in that case, so the CPU proxy
+  // never sees a partially written descriptor.
   __device__ __forceinline__ uint64_t
   enqueue(uint32_t queueId, const IbrcDesc& desc) const {
     IbrcCmdQueueDevice& queue = cmdQueues[queueId];
     check_status(queue);
     const uint64_t seq = reserve(queue);
+    if (seq == kIbrcInvalidReadySeq) {
+      return kIbrcInvalidReadySeq;
+    }
     IbrcDesc& slot = queue.descs[seq & queue.mask];
     slot = desc;
     store_release_system_u64(&slot.ready_seq, seq);
     return seq;
   }
 
+  // An error published by the CPU proxy is a remote fault, not a local bug, so
+  // with a handle wired it is latched on the abort and every wait in this
+  // kernel unwinds. Without one there is nowhere to record it and no way for
+  // the host to learn why, so the legacy trap stands.
   __device__ __forceinline__ void check_status(
       const IbrcCmdQueueDevice& queue) const {
     if (queue.status == nullptr) {
       return;
     }
-    if (load_acquire_system_u32(&queue.status->error) != 0) {
-      printf(
-          "P2pIbrcTransportDevice: queue error queue=%u code=%u\n",
-          load_acquire_system_u32(&queue.status->error_queue),
-          load_acquire_system_u32(&queue.status->error_code));
+    if (load_acquire_system_u32(&queue.status->error) == 0) {
+      return;
+    }
+    printf(
+        "P2pIbrcTransportDevice: queue error queue=%u code=%u\n",
+        load_acquire_system_u32(&queue.status->error_queue),
+        load_acquire_system_u32(&queue.status->error_code));
+    if (!abort_.isEnabled()) {
       PIPES_DEVICE_TRAP();
     }
+    abort_.setAbort(comms::fault_tolerance::AbortReason::ABORTED);
   }
 
   __device__ void wait_local(
@@ -1074,6 +1174,32 @@ class P2pIbrcTransportDevice {
   int numSignalSlots_{0};
   int numCounterSlots_{0};
   IbChannelLayout channelLayout_{};
+
+  // Communicator abort handle, baked in when the host writes this device slot.
+  //
+  // Held as a member rather than threaded through put()/signal()/flush()
+  // because the waits that need it -- reserve() and drain_queue() -- sit behind
+  // APIs that take no timeout. Passing it per call would push an abort
+  // parameter onto every IBRC producer, and the callers have nothing to do with
+  // the answer: these waits terminate themselves. Default-constructed (no
+  // handle) keeps the legacy cycle-deadline trap.
+  //
+  // `AbortFlag`, not `AbortDevice`, and the type is the point.
+  //
+  // This object lives in device memory, one slot per peer, and every block
+  // talking to that peer sees the same one. An `AbortDevice` here would carry
+  // mutable poll-throttle state into shared memory: several blocks writing
+  // `nextPollCycles_` non-atomically, each gating its polls on an absolute
+  // `clock64()` stamped by whichever SM wrote last. `clock64()` is per-SM on
+  // NVIDIA, so a block on a lagging SM could sit below a leading SM's throttle
+  // and stop polling for far longer than the interval -- missing the abort it
+  // was parked waiting for. `AbortFlag` has no such state and no way to poll,
+  // so that cannot be written here at all.
+  //
+  // What remains is what a shared handle can legitimately do: report whether
+  // FT is on, and *write* a terminal reason via a system-scope CAS. The waits
+  // bound themselves on the device clock instead of on shared reads.
+  AbortFlag abort_{};
 };
 
 static_assert(std::is_standard_layout_v<P2pIbrcTransportDevice>);


### PR DESCRIPTION
Summary:
IBRC's two waits on the CPU progress thread -- `reserve()` (ring full) and `drain_queue()` (flush) -- were bounded only by a fixed device cycle deadline, and reaching it called `PIPES_DEVICE_TRAP()`. Under fault tolerance that is the wrong outcome: a device trap kills the CUDA context for the whole process, which is precisely the failure the abort path exists to prevent. A stalled or stopped CPU proxy is a *fault*, not a programming error.

This makes those waits report failure instead:

- **`reserve()` returns `kIbrcInvalidReadySeq`** when the wait ends in an abort. The abort is checked before the `fetch_add` on `pi`, so an already-aborted producer claims nothing at all.
- **`enqueue()` skips the descriptor write and the `ready_seq` publish** on that result, so the CPU proxy never sees a partially written command.
- **`put()` hands back the default `IbLocalCompletionTicket`.** Its value of 0 is below every `ci`, so a later `wait_local()` on it returns immediately rather than blocking on a transfer that was never posted. That is what lets the GPU block unwind to the end of the kernel on its own instead of waiting on a host that will never answer.
- **`drain_queue()` breaks on abort** and stays `void`: a drain that stops early has nothing to report to a caller that is itself unwinding.
- **`wait_local_completion()` breaks on abort** rather than trapping on `checkExpired()` -- it was trapping on exactly the signal it is supposed to unwind on.
- **`check_status()` latches the proxy-published error on the abort** instead of trapping. An error published by the CPU proxy is a remote fault, so with a handle wired every wait in the kernel unwinds and the host reports the reason.

The handle is held as a `P2pIbrcTransportDevice` member, baked in when the host writes each per-peer device slot, rather than threaded through the call. The waits that need it sit behind `put()` / `signal()` / `flush()`, which take no timeout, so passing it per call would push an abort parameter onto every IBRC producer -- and those callers have nothing to do with the answer, because these waits terminate themselves. The change stays inside `comms/prims/transport/ibrc/` apart from one line in `MultiPeerTransport.cc` handing the communicator handle to the backend.

**No handle wired means no behavior change.** `kIbrcDefaultDeviceTimeoutCycles` and its trap are kept for the disabled case: silently dropping a put with no abort signal to report would be undetectable data loss, which is worse than the trap. Assertion traps -- `IBRC_CHECK_SLOT_ID`, `validate_channel_id`, `validate_group_scope`, the null-buffer `trap()` -- are untouched. Those fire on programming errors, where killing the context is correct.

Known and accepted: aborting *during* the `reserve()` wait leaves a claimed-but-unpublished sequence, which wedges that queue's proxy cursor. A latched abort is terminal for the communicator and the progress thread is stopped by teardown rather than by draining, so nothing waits on it.

Stack review guide: https://www.internalfb.com/intern/paste/P2459153030/

Reviewed By: arttianezhu

Differential Revision: D116257010


