### PR TITLE
Add common registered launch support

### DIFF
--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -212,6 +212,7 @@ TEST_F(MultimemNvlTransportTestFixture, SignalFreeConfigurationConstructs) {
   EXPECT_TRUE(handle.internalMultimemSignals.empty());
   EXPECT_EQ(handle.pipelineDepth, 0);
   EXPECT_EQ(handle.maxChannels, 1);
+  EXPECT_EQ(handle.maxBlocks, 0);
   EXPECT_EQ(handle.signalsPerChannel, 0);
   ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 }
@@ -743,14 +744,20 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
 
   constexpr std::size_t kDataBytes = 8192;
   constexpr uint32_t kUserSignals = 2;
-  const uint64_t internalSignals = multimem_staging_signals_per_channel(
+  // Keep these distinct so the test fails if handle.maxBlocks is accidentally
+  // wired from maxChannels.
+  constexpr std::size_t kMaxChannels = 2;
+  constexpr std::size_t kMaxBlocks = 1;
+  const uint64_t signalsPerChannel = multimem_staging_signals_per_channel(
       static_cast<uint32_t>(numRanks), /*pipelineDepth=*/1);
+  const uint64_t internalSignals = kMaxChannels * signalsPerChannel;
+
+  auto config =
+      makeConfig(kDataBytes, kUserSignals, /*pipelineDepth=*/1, kMaxChannels);
+  config.maxBlocks = kMaxBlocks;
 
   MultimemNvlTransport transport(
-      bootstrap,
-      globalRank,
-      identityRankMap(numRanks),
-      makeConfig(kDataBytes, kUserSignals, 1, 1));
+      bootstrap, globalRank, identityRankMap(numRanks), config);
 
   transport.exchange();
   auto handle = transport.getDeviceTransport();
@@ -767,8 +774,9 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
   EXPECT_EQ(handle.internalLocalSignals.size(), internalSignals);
   EXPECT_EQ(handle.internalMultimemSignals.size(), internalSignals);
   EXPECT_EQ(handle.pipelineDepth, 1);
-  EXPECT_EQ(handle.maxChannels, 1);
-  EXPECT_EQ(handle.signalsPerChannel, internalSignals);
+  EXPECT_EQ(handle.maxChannels, kMaxChannels);
+  EXPECT_EQ(handle.maxBlocks, kMaxBlocks);
+  EXPECT_EQ(handle.signalsPerChannel, signalsPerChannel);
   EXPECT_TRUE(handle.internalUnicastSignalsByRank.empty());
 
   EXPECT_EQ(transport.getAllocatedDataBufferSize(), kDataBytes);
@@ -815,6 +823,7 @@ TEST_F(MultimemNvlTransportTestFixture, ExchangeSupportsDataOnlyConfiguration) {
   EXPECT_TRUE(handle.internalMultimemSignals.empty());
   EXPECT_EQ(handle.pipelineDepth, 0);
   EXPECT_EQ(handle.maxChannels, 1);
+  EXPECT_EQ(handle.maxBlocks, 0);
   EXPECT_EQ(handle.signalsPerChannel, 0);
   EXPECT_EQ(transport.getAllocatedSignalBufferSize(), 0);
 

--- a/comms/prims/transport/nvl/MultimemNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.cc
@@ -286,6 +286,7 @@ MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
       .nvlRanks = nvlRanks_,
       .pipelineDepth = static_cast<uint32_t>(config_.pipelineDepth),
       .maxChannels = static_cast<uint32_t>(config_.maxChannels),
+      .maxBlocks = static_cast<uint32_t>(config_.maxBlocks),
       .signalsPerChannel = signalsPerChannel_,
       .internalUnicastSignalsByRank = internalUnicastSignalsByRank_
           ? DeviceSpan<SignalState*>(

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -78,6 +78,7 @@ struct MultimemNvlTransportDevice {
   int nvlRanks{1};
   uint32_t pipelineDepth{0};
   uint32_t maxChannels{0};
+  uint32_t maxBlocks{0};
   uint32_t signalsPerChannel{0};
   // Indexed by NVL-local destination rank. Each entry addresses the base of
   // that destination's internal signal slots through its unicast mapping.


### PR DESCRIPTION
Summary:
## Core implementation

Add shared registered NVLMM helpers that validate one identity-mapped NVL team, lazily initialize the existing multimem transport, and return its cached device handle.
Expose the configured transport block limit to host launchers and compute a bounded unsigned default CTA count.
Use unsigned launch geometry and the existing `TiledBuffer` partitioning helper for device tiles.

## Background

Registered ReduceScatter, AllGather, and AllReduce share the same topology, transport, and launch-geometry requirements.
Keeping those checks in one common layer prevents each collective from independently interpreting communicator and transport state.
Accumulation selection is intentionally not communicator state and is introduced later as a per-operation option.

Reviewed By: dboyda

Differential Revision: D116405701


