### PR TITLE
Add block-scoped NVL aggregate barrier (#3785)

### DIFF
--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cu
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cu
@@ -48,7 +48,8 @@ __global__ void nvlSignalTrapKernel(
   uint32_t signalsPerChannel =
       static_cast<uint32_t>(multimem_staging_signals_per_channel(
           static_cast<uint64_t>(nvlRanks), pipelineDepth));
-  if (testCase == NvlSignalTrapCase::SignalsPerChannelMismatch) {
+  if (testCase == NvlSignalTrapCase::SignalsPerChannelMismatch ||
+      testCase == NvlSignalTrapCase::BlockBarrierSignalsPerChannelMismatch) {
     --signalsPerChannel;
   }
   MultimemNvlTransportDevice transport{
@@ -138,6 +139,13 @@ __global__ void nvlSignalTrapKernel(
     return;
   }
   auto group = make_block_group();
+  if (testCase == NvlSignalTrapCase::BlockBarrierNon1DBlock ||
+      testCase == NvlSignalTrapCase::BlockBarrierDuplicateChannelOwner ||
+      testCase == NvlSignalTrapCase::BlockBarrierNon1DGrid ||
+      testCase == NvlSignalTrapCase::BlockBarrierSignalsPerChannelMismatch) {
+    nvl_signal_detail::validate_block_barrier(transport, /*channel=*/0, group);
+    return;
+  }
   if (testCase == NvlSignalTrapCase::PerPeerDuplicateChannelOwner ||
       testCase == NvlSignalTrapCase::PerPeerNon1DBlock) {
     signal_publish<
@@ -267,6 +275,7 @@ dim3 signal_trap_threads(NvlSignalTrapCase testCase) {
     case NvlSignalTrapCase::DuplicateChannelOwner:
       return dim3(2 * kWarpSize);
     case NvlSignalTrapCase::PerPeerNon1DBlock:
+    case NvlSignalTrapCase::BlockBarrierNon1DBlock:
       return dim3(kNvlSignalSmallPerPeerThreads, 2);
     case NvlSignalTrapCase::AggregateDepthTooLarge:
     case NvlSignalTrapCase::ArrivalCountMismatch:
@@ -282,8 +291,10 @@ dim3 signal_trap_threads(NvlSignalTrapCase testCase) {
 dim3 signal_trap_blocks(NvlSignalTrapCase testCase) {
   switch (testCase) {
     case NvlSignalTrapCase::PerPeerDuplicateChannelOwner:
+    case NvlSignalTrapCase::BlockBarrierDuplicateChannelOwner:
       return dim3(2);
     case NvlSignalTrapCase::AggregateNon1DGrid:
+    case NvlSignalTrapCase::BlockBarrierNon1DGrid:
       return dim3(1, 2);
     default:
       return dim3(1);

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
@@ -27,6 +27,10 @@ enum class NvlSignalTrapCase : uint32_t {
   AggregateNon1DGrid,
   PerPeerDuplicateChannelOwner,
   PerPeerNon1DBlock,
+  BlockBarrierNon1DBlock,
+  BlockBarrierDuplicateChannelOwner,
+  BlockBarrierNon1DGrid,
+  BlockBarrierSignalsPerChannelMismatch,
 };
 
 enum class NvlSignalRankBoundaryWaitPolicy : uint32_t {

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -1684,6 +1684,91 @@ TEST_F(
 
 TEST_F(
     MultimemNvlTransportTestFixture,
+    BlockAggregateBarrierOrdersEveryWarpAcrossRepeatedEpochs) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  constexpr uint32_t kChannels = 2;
+  constexpr uint32_t kPipelineDepth = 4;
+  constexpr uint32_t kEpochs = 3;
+  constexpr uint32_t kThreads = 128;
+  constexpr std::size_t kElementCount = kChannels * kEpochs * kThreads;
+  auto bootstrap = makeBootstrap("mmnvl_block_aggregate_barrier");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(
+          kElementCount * sizeof(int32_t),
+          /*userSignalCount=*/0,
+          kPipelineDepth,
+          kChannels));
+  transport.exchange();
+
+  int32_t* deviceReducedValues = nullptr;
+  uint64_t* deviceSignalValues = nullptr;
+  constexpr std::size_t kSignalValueCount = 2 * kChannels * kPipelineDepth;
+  CUDACHECK_TEST(
+      cudaMalloc(&deviceReducedValues, kElementCount * sizeof(int32_t)));
+  CUDACHECK_TEST(
+      cudaMalloc(&deviceSignalValues, kSignalValueCount * sizeof(uint64_t)));
+  test::launchBlockAggregateBarrier(
+      transport.getDeviceTransport(),
+      kChannels,
+      kEpochs,
+      deviceReducedValues,
+      deviceSignalValues);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int32_t> reducedValues(kElementCount);
+  std::vector<uint64_t> signalValues(kSignalValueCount);
+  CUDACHECK_TEST(cudaMemcpy(
+      reducedValues.data(),
+      deviceReducedValues,
+      kElementCount * sizeof(int32_t),
+      cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaMemcpy(
+      signalValues.data(),
+      deviceSignalValues,
+      kSignalValueCount * sizeof(uint64_t),
+      cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaFree(deviceReducedValues));
+  CUDACHECK_TEST(cudaFree(deviceSignalValues));
+
+  const int32_t rankSum = numRanks * (numRanks + 1) / 2;
+  for (uint32_t epoch = 0; epoch < kEpochs; ++epoch) {
+    for (uint32_t channel = 0; channel < kChannels; ++channel) {
+      const int32_t expected =
+          rankSum + numRanks * static_cast<int32_t>(10 * epoch + 100 * channel);
+      const std::size_t offset =
+          (static_cast<std::size_t>(epoch) * kChannels + channel) * kThreads;
+      EXPECT_EQ(
+          std::vector<int32_t>(
+              reducedValues.begin() + offset,
+              reducedValues.begin() + offset + kThreads),
+          std::vector<int32_t>(kThreads, expected));
+    }
+  }
+  const uint64_t expectedSignalValue =
+      static_cast<uint64_t>(kEpochs * numRanks);
+  for (uint32_t channel = 0; channel < kChannels; ++channel) {
+    const std::size_t outputBase =
+        static_cast<std::size_t>(channel) * 2 * kPipelineDepth;
+    EXPECT_EQ(signalValues[outputBase], expectedSignalValue);
+    EXPECT_EQ(signalValues[outputBase + kPipelineDepth], expectedSignalValue);
+    for (uint32_t lane = 1; lane < kPipelineDepth; ++lane) {
+      EXPECT_EQ(signalValues[outputBase + lane], 0);
+      EXPECT_EQ(signalValues[outputBase + kPipelineDepth + lane], 0);
+    }
+  }
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
     UniformSignalPerPeerRoundTripUsesAggregateAck) {
   if (numRanks < 3) {
     GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -404,6 +404,41 @@ __global__ void initializeAggregateSignalsKernel(
   }
 }
 
+__global__ void blockAggregateBarrierKernel(
+    MultimemNvlTransportDevice transport,
+    uint32_t epochs,
+    int32_t* reducedValues,
+    uint64_t* signalValues) {
+  auto block = make_block_group();
+  auto* local = reinterpret_cast<int32_t*>(transport.localData);
+  const auto* multicast =
+      reinterpret_cast<const int32_t*>(transport.multimemData);
+  for (uint32_t epoch = 0; epoch < epochs; ++epoch) {
+    const std::size_t offset =
+        (static_cast<std::size_t>(epoch) * gridDim.x + blockIdx.x) * blockDim.x;
+    local[offset + threadIdx.x] = transport.nvlRank + 1 +
+        static_cast<int32_t>(10 * epoch + 100 * blockIdx.x);
+    nvl_block_barrier(
+        transport, static_cast<uint32_t>(blockIdx.x), block, AbortDevice{});
+    multimem::load_reduce_at<int32_t>(
+        block, reducedValues + offset, multicast + offset, blockDim.x);
+  }
+
+  block.sync();
+  if (threadIdx.x < transport.pipelineDepth) {
+    const uint64_t signalId =
+        static_cast<uint64_t>(blockIdx.x) * transport.signalsPerChannel +
+        static_cast<uint64_t>(3 * transport.nvlRanks) +
+        static_cast<uint64_t>(4 * threadIdx.x);
+    const std::size_t outputBase =
+        static_cast<std::size_t>(blockIdx.x) * 2 * transport.pipelineDepth;
+    signalValues[outputBase + threadIdx.x] =
+        transport.internalLocalSignals[signalId].load();
+    signalValues[outputBase + transport.pipelineDepth + threadIdx.x] =
+        transport.internalLocalSignals[signalId + 1].load();
+  }
+}
+
 __global__ void perPeerWaitOnlyKernel(
     MultimemNvlTransportDevice transport,
     uint64_t roundValue,
@@ -828,6 +863,18 @@ void launchInitializeAggregateSignals(
     cudaStream_t stream) {
   initializeAggregateSignalsKernel<<<1, 32, 0, stream>>>(
       transport, counterValue, epochValue);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchBlockAggregateBarrier(
+    MultimemNvlTransportDevice transport,
+    uint32_t channels,
+    uint32_t epochs,
+    int32_t* reducedValues,
+    uint64_t* signalValues,
+    cudaStream_t stream) {
+  blockAggregateBarrierKernel<<<channels, 128, 0, stream>>>(
+      transport, epochs, reducedValues, signalValues);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -182,6 +182,14 @@ void launchInitializeAggregateSignals(
     uint64_t epochValue,
     cudaStream_t stream = nullptr);
 
+void launchBlockAggregateBarrier(
+    MultimemNvlTransportDevice transport,
+    uint32_t channels,
+    uint32_t epochs,
+    int32_t* reducedValues,
+    uint64_t* signalValues,
+    cudaStream_t stream = nullptr);
+
 void launchFillReductionInput(
     MultimemNvlTransportDevice transport,
     MultimemReductionTestType type,

--- a/comms/prims/transport/nvl/MultimemNvlSignal.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlSignal.cuh
@@ -529,6 +529,57 @@ __device__ __forceinline__ void validate_aggregate(
 #endif
 }
 
+__device__ __forceinline__ void validate_block_barrier(
+    const MultimemNvlTransportDevice& transport,
+    uint32_t channel,
+    const ThreadGroup& block) {
+#if defined(__CUDA_ARCH__)
+  const bool validRankCount = transport.nvlRanks > 0 &&
+      nvl_signal_rank_count_supported(
+                                  static_cast<uint32_t>(transport.nvlRanks));
+  const uint64_t expectedSignalsPerChannel = validRankCount
+      ? multimem_staging_signals_per_channel(
+            static_cast<uint64_t>(transport.nvlRanks), transport.pipelineDepth)
+      : 0;
+  const uint64_t requiredSignals =
+      static_cast<uint64_t>(transport.maxChannels) *
+      transport.signalsPerChannel;
+  if (blockDim.y != 1 || blockDim.z != 1 || gridDim.y != 1 || gridDim.z != 1 ||
+      block.scope != SyncScope::BLOCK || block.group_size != blockDim.x ||
+      block.group_size < kWarpSize || block.group_size % kWarpSize != 0 ||
+      block.group_id != channel || !validRankCount ||
+      transport.pipelineDepth == 0 || channel >= transport.maxChannels ||
+      transport.signalsPerChannel != expectedSignalsPerChannel ||
+      requiredSignals > transport.internalLocalSignals.size() ||
+      requiredSignals > transport.internalMultimemSignals.size()) {
+    printf(
+        "NVL block barrier invalid geometry: block=(%u,%u,%u) "
+        "grid=(%u,%u,%u) groupId=%u groupSize=%u ranks=%d "
+        "channel=%u maxChannels=%u pipelineDepth=%u "
+        "signalsPerChannel=%u expectedSignalsPerChannel=%llu\n",
+        static_cast<unsigned>(blockDim.x),
+        static_cast<unsigned>(blockDim.y),
+        static_cast<unsigned>(blockDim.z),
+        static_cast<unsigned>(gridDim.x),
+        static_cast<unsigned>(gridDim.y),
+        static_cast<unsigned>(gridDim.z),
+        static_cast<unsigned>(block.group_id),
+        static_cast<unsigned>(block.group_size),
+        transport.nvlRanks,
+        static_cast<unsigned>(channel),
+        static_cast<unsigned>(transport.maxChannels),
+        static_cast<unsigned>(transport.pipelineDepth),
+        static_cast<unsigned>(transport.signalsPerChannel),
+        static_cast<unsigned long long>(expectedSignalsPerChannel));
+    __trap();
+  }
+#else
+  (void)transport;
+  (void)channel;
+  (void)block;
+#endif
+}
+
 } // namespace nvl_signal_detail
 
 /**
@@ -751,6 +802,45 @@ __device__ __forceinline__ void signal_publish_and_wait(
       transport, round, participants, group);
   nvl_signal_detail::signal_wait_impl<access, topology, phase, waitPolicy>(
       transport, round, participants, group, abortDevice);
+}
+
+/**
+ * Synchronizes one CUDA block with the same channel block on every NVL rank.
+ *
+ * Every NVL rank must enter this barrier for the same channel in the same
+ * sequence. The barrier consumes the channel's aggregate Ready lane zero and
+ * must not be called from rank-local or otherwise divergent control flow.
+ *
+ * The first block synchronization makes every thread's prior writes visible
+ * to the leader. The leader publishes one release-add through lane zero of the
+ * channel's aggregate counter, waits for every NVL rank, and advances the
+ * local epoch. The final block synchronization makes the acquire wait visible
+ * to the remaining threads.
+ */
+__device__ __forceinline__ void nvl_block_barrier(
+    const MultimemNvlTransportDevice& transport,
+    uint32_t channel,
+    ThreadGroup& block,
+    const AbortDevice& abortDevice = AbortDevice{}) {
+  nvl_signal_detail::validate_block_barrier(transport, channel, block);
+
+  comms::device::fence_acq_rel_sys();
+  block.sync();
+  if (block.is_leader()) {
+    const StageRound round{.channel = channel, .value = 1};
+    const uint64_t signalId =
+        nvl_signal_detail::aggregate_counter_id<NvlSignalPhase::Ready>(
+            transport, round, /*lane=*/0);
+    auto* counter = transport.internalLocalSignals.data() + signalId;
+    auto* epoch = counter + 1;
+    const uint64_t expected =
+        epoch->load() + static_cast<uint64_t>(transport.nvlRanks);
+    transport.template signal_internal_scalar_prefenced<SignalOp::SIGNAL_ADD>(
+        signalId, 1);
+    nvl_signal_detail::wait_until_reached(*counter, expected, abortDevice);
+    epoch->store(expected);
+  }
+  block.sync();
 }
 
 } // namespace comms::prims


### PR DESCRIPTION
Summary:

## Core implementation

Add `nvl_block_barrier` over the existing multicast aggregate counter and epoch layout.
Publish every block thread's prior system-scope writes before the block leader signals and waits through aggregate lane zero.
Use the final block synchronization to make the acquired remote state available to every thread.
Validate one-dimensional launch geometry, one block owner per channel, signal storage, and the shared NVL72 rank-count contract before accessing the protocol.
Avoid the generic warp-wide pipeline-lane protocol, so each block barrier uses one counter, one epoch, one release add, and one acquire wait.

## Background

Registered NVLMM collectives need corresponding CUDA blocks on every NVL rank to agree before and after block-wide data work.
The block adapter reuses the aggregate counter layout while avoiding the generic warp-wide pipeline-lane protocol and without reserving another signal prefix.

Reviewed By: dboyda

Differential Revision: D116410173


