### PR TITLE
Port memcache and slab allocator

### DIFF
--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -11,6 +11,8 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/algoconf/AlgoStrConv.h"
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <sstream>
 #include <stdexcept>

--- a/comms/ncclx/meta/baseline_modification_docs/per_comm_config_buffersize_ib.md
+++ b/comms/ncclx/meta/baseline_modification_docs/per_comm_config_buffersize_ib.md
@@ -112,6 +112,28 @@ comm->ctx = ctx; // [NCCLX-PerCommConfig] store ctx for ncclIbAccept
 
 **Why in baseline**: `ncclIbConnect` and `ncclIbAccept` are where QPs are created and `splitDataOnQps`/`nqps`/`cqSize` are computed. The values must be set at connection time.
 
+### 6. `src/transport/net_ib/gin.cc` — Extended IB ctx allocation (GIN path)
+
+**Include added**: `meta/transport/NcclxIbNetCommConfig.h`
+
+**Function**: `ncclGinIbInitType()`
+
+**Change**: Same ctx upgrade as `ncclIbInit()`. The GIN backend routes through `ncclIbListen`/`ncclIbConnect`/`ncclIbAccept`, which now cast `ctx` to `ncclx::NcclxIbNetCommConfig*`. Allocating a plain `ncclNetCommConfig_t` here would make those casts read past the allocation, so the ctx must be allocated as `NcclxIbNetCommConfig`.
+
+```cpp
+// [NCCLX-PerCommConfig] Allocate NcclxIbNetCommConfig (not ncclNetCommConfig_t)
+auto* ncclxConfig = new (std::nothrow) ncclx::NcclxIbNetCommConfig();
+if (ncclxConfig == nullptr) return ncclSystemError;
+ncclxConfig->trafficClass = NCCL_NET_TRAFFIC_CLASS_UNDEF;
+*ctx = ncclxConfig;
+```
+
+**Function**: `ncclGinIbFinalize()`
+
+**Change**: Uses `delete static_cast<ncclx::NcclxIbNetCommConfig*>(ctx)` instead of `free(ctx)`.
+
+**Why in baseline**: GIN allocates its own IB ctx and passes it into the shared IB transport entry points, so it must match the ctx type those entry points expect.
+
 ## NCCLX meta/ Files (not baseline)
 
 These files contain the NCCLX-side logic and are not part of NCCL baseline:
@@ -138,3 +160,4 @@ To remove per-comm config from the baseline:
 3. `src/transport/net_ib/init.cc`: Revert `ncclIbInit()` to allocate `ncclNetCommConfig_t` via `ncclCalloc`; revert `ncclIbFinalize()` to `free(ctx)`; remove meta/ includes
 4. `src/transport/net_ib/common.h`: Remove `void* ctx` from `ncclIbListenComm`
 5. `src/transport/net_ib/connect.cc`: Remove `NcclxIbNetCommConfig.h` include; remove `comm->ctx = ctx` in `ncclIbListen`; remove `ncclxIbCommInit` calls; revert `qpsPerConn`/`qpsPerConnAccept` to use `ncclParamIbQpsPerConn()` directly; revert ctx cast to `ncclNetCommConfig_t*`
+6. `src/transport/net_ib/gin.cc`: Remove the `NcclxIbNetCommConfig.h` include; revert `ncclGinIbInitType()` to allocate `ncclNetCommConfig_t` via `ncclCalloc`; revert `ncclGinIbFinalize()` to `free(ctx)`

--- a/comms/ncclx/meta/baseline_modification_docs/structured_logging_baseline.md
+++ b/comms/ncclx/meta/baseline_modification_docs/structured_logging_baseline.md
@@ -1,0 +1,149 @@
+# Structured Logging (spdlog + Scuba): Baseline Modifications
+
+## Background
+
+NCCLX routes every NCCL log line through Meta's shared comms logging stack
+(`comms/utils/logger/**`) instead of upstream's `vfprintf(ncclDebugFile, ...)`.
+That gives NCCL logs the same spdlog sink, formatter, and `NCCL_DEBUG_FILE`
+handling as CTRAN, and fans root-cause errors out to the
+`nccl_structured_logging` Scuba table.
+
+Two things are layered on top of the plain redirect:
+
+- A dedicated root-cause error macro `ERR(code, ...)`, which carries the
+  `ncclResult_t`. Upstream signals errors with `WARN(...); return code;`, so the
+  code is lost at the log site and the root-cause message is indistinguishable
+  from ordinary non-fatal warnings. `ERR` records the Scuba error record and
+  `ncclGetLastError()` state exactly once, at the origin, instead of at every
+  propagating check-macro layer.
+- A `NCCL_LOG_ERROR` severity between `NCCL_LOG_VERSION` and `NCCL_LOG_WARN`, so
+  oncall automation that keys off ERROR severity can find the real root cause.
+
+Design rationale and the cleanup plan live in
+[`comms/ncclx/docs/error_logging.md`](../../docs/error_logging.md).
+
+## Versions Affected
+
+v2_29, v2_30, v2_31
+
+## What is shared, and what has to be forked
+
+Most of the machinery is version-independent and needs no port:
+
+| Concern | Lives in |
+|---|---|
+| spdlog sink, formatter, async/file routing | `comms/utils/logger/SpdlogLogger.{h,cc}` |
+| Scuba error record | `comms/utils/logger/LoggingFormat.cc` (`logErrorToScuba`) |
+| `ncclGetLastError()` state, native stack | `comms/utils/logger/{LoggingFormat,ErrorStackUtil}.cc` |
+| `ERR` implementation (`ncclMetaDebugLogError`) | `comms/ncclx/meta/logger/DebugExt.cc` |
+| Level mapping + sink entry point (`writeNcclLog`) | `comms/ncclx/meta/logger/NcclDebugLog.h` |
+
+Only the five upstream-derived files below are forked per version.
+
+## Baseline Files Modified
+
+### 1. `src/include/nccl_common.h` — new severity
+
+**Change**: Inserted `NCCL_LOG_ERROR = 2` into `ncclDebugLogLevel`, renumbering
+`WARN`/`INFO`/`ABORT`/`TRACE` to 3/4/5/6.
+
+**Why in baseline**: `ncclDebugLogLevel` is the type every logging entry point
+takes, including the shared `writeNcclLog` switch in `meta/logger/`. The shared
+code does not compile against a version that lacks `NCCL_LOG_ERROR`.
+
+**Caveat**: the enumerator values are part of the `ncclDebugLogger_t` ABI passed
+to net/tuner plugins. A plugin compiled against pristine upstream headers will
+read a shifted level. This is accepted, and matches v2_29/v2_30.
+
+### 2. `src/include/debug.h` — macros and declarations
+
+**Change**: Declared `ncclMetaDebugLog`, `ncclMetaDebugLogError`, and
+`ncclSetMyThreadLoggingName`; added the `ERR(code, ...)` macro and the
+`NCCL_NAMED_THREAD_START[_EXT]` helpers; changed `VERSION`, `INFO`, `TRACE_CALL`,
+and `TRACE` to pass `__FILE__, __func__, __LINE__` where upstream passes
+`nullptr, nullptr, 0`.
+
+**Why in baseline**: these are the macros every call site in the tree expands.
+
+**2.31 note**: upstream 2.31 introduced `ncclDebugLogInternal(level, flags, file,
+func, line, fmt, ...)` — the same signature Meta had forked `ncclMetaDebugLog`
+for. v2_31 therefore keeps upstream's function in the macros and only widens the
+arguments, rather than repointing every macro at a parallel symbol as v2_30 does.
+`ncclMetaDebugLog` survives as a second entry point into the same funnel purely
+because the shared `meta/logger/DebugExt.cc` links against that name across all
+three versions.
+
+### 3. `src/debug.cc` — the funnel
+
+**Change**: Replaced the tail of `ncclDebugLogV()` — timestamp/hostname/pid/tid
+prefixing and `vfprintf` — with a `vsnprintf` of the caller's message followed by
+`ncclx::logging::writeNcclLog(level, file, func, line, message)`. The sink owns
+the line prefix and the output destination. Also: `NCCL_LOG_ERROR` joins
+`NCCL_LOG_WARN` in the `ncclDebugNoWarn` downgrade and the `ncclLastError` save;
+`ncclDebugInit()` publishes the subsystem mask via
+`meta::comms::logger::setSubSystemMask()`; and `ncclMetaDebugLog` /
+`ncclSetMyThreadLoggingName` are defined here.
+
+**Why in baseline**: upstream has no registerable log sink — `ncclDebugLogV`
+writes to `ncclDebugFile` directly, and `ncclDebugLogger_t` points the other way
+(NCCL to plugins). Redirecting the output requires editing this function.
+
+**Deliberately left in place**: `ncclDebugInit()` still parses
+`NCCL_DEBUG_TIMESTAMP_LEVELS` / `NCCL_DEBUG_TIMESTAMP_FORMAT` /
+`NCCL_DEBUG_FILE` and still caches `hostname`/`pid`, even though the sink now
+supplies those. Keeping the upstream parsing intact keeps the fork to one
+function and keeps the published params honest.
+
+### 4. `src/include/checks.h` — check macros
+
+**Change**: Added `ncclCodeToString()`; converted the root-cause check macros
+(`CUDACHECK[GOTO]`, `SYSCHECK[GOTO]`, `PTHREADCHECK[GOTO]`, `NEQCHECK[GOTO]`,
+`EQCHECK[GOTO]`, `CUDACHECKTHREAD`) from `WARN`/`INFO_LOC` to `ERR(code, ...)`;
+raised the propagation macros (`NCCLCHECK[GOTO]`, `NCCLWAIT[GOTO]`,
+`NCCLCHECKIGNORE`, `NCCLCHECKTHREAD`) from `INFO_LOC` to `WARN` so the
+propagation chain stays visible without `NCCL_DEBUG=INFO`; and added
+`CHECKABORT` and `CUDACHECKABORT`, which shared `meta/` code calls and so must
+exist in every version dir. `v2_30`'s `SYSCHECKVAL` is deliberately not ported:
+nothing in `v2_31/src`, `meta/`, or any consumer references it.
+
+**Why in baseline**: `checks.h` is where the bulk of NCCL's error reporting
+actually happens, so converting it here covers most call sites without touching
+them individually.
+
+**2.31 note**: upstream 2.31 added `INFO_LOC`, which prepends `file:line (func)`
+to the message. Since the sink now carries source location in the log record,
+converted macros use 2.31's shorter message text rather than v2_30's explicit
+`"%s:%d -> %d"` spelling.
+
+### 5. `src/misc/param.cc`, `src/include/param.h` — sink registration
+
+**Change**: Added `initNcclLogger()` and called it from `initEnv()`, alongside
+`meta::comms::initFolly()` and `ncclCvarInit()`.
+
+**Why in baseline**: `initEnv()` is the one-time init hook upstream already runs
+before any logging is configured. Registration has to happen there or the first
+log lines are lost.
+
+**Why it is not covered by CTRAN or MCCL initializing spdlog**:
+`getSpdlogLogger(name)` is a name-keyed registry. CTRAN registers
+`"comms.ctran"`; `writeNcclLog` looks up `"comms.ncclx"`. An unregistered name
+is lazily default-constructed — no file sink, no `"NCCL"` prefix, no cudaDev
+thread context, no `setLastError` hook — so the logs go nowhere quietly. Only
+`initCommLogging()` is genuinely shared, and it is `folly::once`-guarded.
+
+**Known duplication**: `initNcclLogger()` is near-identical to
+`comms/ctran/utils/LogInit.cc`, differing only in the logger name and prefix
+(four copies across ctran + v2_29 + v2_30 + v2_31). Hoisting a
+`configureDomainLogger(name, prefix)` helper into `comms/utils/logger` would
+collapse all four; that is a shared-code refactor, tracked separately.
+
+## Upstreaming
+
+Two asks would retire almost all of the above, and both still hold against
+upstream 2.31:
+
+1. A result-code-carrying error macro (`ERR(code, ...)` / `WARNRET(code, ...)`),
+   which removes the `debug.h` and `checks.h` forks and the per-rebase call-site
+   conversions.
+2. A registerable logging callback in `ncclDebugLog`, which removes the
+   `debug.cc` fork entirely.

--- a/comms/ncclx/v2_31/src/allocator.cc
+++ b/comms/ncclx/v2_31/src/allocator.cc
@@ -225,14 +225,14 @@ ncclResult_t ncclSpaceAlloc(struct ncclSpace* a, int64_t limit, int64_t size, in
     }
     i += 2; // Next empty segment
   }
-  WARN("Allocation failed. No suitable space found to accommodate size=0x%lx within limit=0x%lx", (long)size,
+  ERR(ncclInternalError, "Allocation failed. No suitable space found to accommodate size=0x%lx within limit=0x%lx", (long)size,
        (long)limit);
   return ncclInternalError;
 }
 
 ncclResult_t ncclSpaceFree(struct ncclSpace* a, int64_t offset, int64_t size) {
   if (a->count == 0 || a->cuts[a->count - 1] <= offset) {
-    WARN("No allocation found at offset=0x%lx", (long)offset);
+    ERR(ncclInternalError, "No allocation found at offset=0x%lx", (long)offset);
     return ncclInternalError;
   }
 
@@ -244,7 +244,7 @@ ncclResult_t ncclSpaceFree(struct ncclSpace* a, int64_t offset, int64_t size) {
   int64_t hi = a->cuts[i];
 
   if (offset < lo || hi < offset + size) {
-    WARN("Given size=0x%lx extends beyond allocation.", (long)size);
+    ERR(ncclInternalError, "Given size=0x%lx extends beyond allocation.", (long)size);
     return ncclInternalError;
   }
 
@@ -423,7 +423,7 @@ ncclResult_t ncclShadowPoolFree(struct ncclShadowPool* pool, void* devObj, cudaS
   struct ncclShadowObject** pobj = &pool->table[b];
   while (true) {
     if (*pobj == nullptr) {
-      WARN("Device object does not exist in shadow pool.");
+      ERR(ncclInternalError, "Device object does not exist in shadow pool.");
       return ncclInternalError;
     }
     if ((*pobj)->devObj == devObj) break;
@@ -456,7 +456,7 @@ ncclResult_t ncclShadowPoolToHost(struct ncclShadowPool* pool, void* devObj, voi
   struct ncclShadowObject* obj = pool->table[b];
   while (true) {
     if (obj == nullptr) {
-      WARN("Device object does not exist in shadow pool.");
+      ERR(ncclInternalError, "Device object does not exist in shadow pool.");
       return ncclInternalError;
     }
     if (obj->devObj == devObj) break;

--- a/comms/ncclx/v2_31/src/bootstrap.cc
+++ b/comms/ncclx/v2_31/src/bootstrap.cc
@@ -111,19 +111,19 @@ ncclResult_t bootstrapNetInit() {
       if (env) {
         union ncclSocketAddress remoteAddr;
         if (ncclSocketGetAddrFromString(&remoteAddr, env) != ncclSuccess) {
-          WARN("Invalid NCCL_COMM_ID, please use format: <ipv4>:<port> or [<ipv6>]:<port> or <hostname>:<port>");
+          ERR(ncclInvalidArgument, "Invalid NCCL_COMM_ID, please use format: <ipv4>:<port> or [<ipv6>]:<port> or <hostname>:<port>");
           return ncclInvalidArgument;
         }
         NCCLCHECK(ncclFindInterfaceMatchSubnet(bootstrapNetIfName, &bootstrapNetIfAddr, &remoteAddr, MAX_IF_NAME_SIZE,
                                                &nIfs));
         if (nIfs <= 0) {
-          WARN("NET/Socket : No usable listening interface found");
+          ERR(ncclSystemError, "NET/Socket : No usable listening interface found");
           return ncclSystemError;
         }
       } else {
         NCCLCHECK(ncclFindInterfaces(bootstrapNetIfName, &bootstrapNetIfAddr, MAX_IF_NAME_SIZE, 1, &nIfs));
         if (nIfs <= 0) {
-          WARN("Bootstrap : no socket interface found");
+          ERR(ncclInvalidUsage, "Bootstrap : no socket interface found");
           return ncclInvalidUsage;
         }
       }
@@ -221,7 +221,7 @@ static ncclResult_t socketRecv(struct ncclSocket* sock, void* data, int size) {
   int recvSize;
   NCCLCHECK(ncclSocketRecv(sock, &recvSize, sizeof(int)));
   if (recvSize > size) {
-    WARN("Message truncated : received %d bytes instead of %d", recvSize, size);
+    ERR(ncclInternalError, "Message truncated : received %d bytes instead of %d", recvSize, size);
     return ncclInternalError;
   }
   int actualSize = std::min(recvSize, size);
@@ -233,7 +233,7 @@ static ncclResult_t socketSendRecv(struct ncclSocket* sendSock, void* sendData, 
   int senderRecvSize;
   NCCLCHECK(ncclSocketSendRecv(sendSock, &sendSize, sizeof(int), recvSock, &senderRecvSize, sizeof(int)));
   if (senderRecvSize > recvSize) {
-    WARN("Message truncated : received %d bytes instead of %d", senderRecvSize, recvSize);
+    ERR(ncclInternalError, "Message truncated : received %d bytes instead of %d", senderRecvSize, recvSize);
     return ncclInternalError;
   }
   NCCLCHECK(ncclSocketSendRecv(sendSock, sendData, sendSize, recvSock, recvData, std::min(recvSize, senderRecvSize)));
@@ -246,7 +246,7 @@ static ncclResult_t socketDoubleSendRecv(struct ncclSocketOp ops[4]) {
   NCCLCHECK(ncclSocketSendRecv(ops[0].sock, &ops[0].size, sizeof(int), ops[1].sock, &senderRecvSize1, sizeof(int)));
   NCCLCHECK(ncclSocketSendRecv(ops[2].sock, &ops[2].size, sizeof(int), ops[3].sock, &senderRecvSize2, sizeof(int)));
   if (senderRecvSize1 > ops[1].size || senderRecvSize2 > ops[3].size) {
-    WARN("Message truncated : received %d,%d bytes instead of %d,%d", senderRecvSize1, senderRecvSize2, ops[1].size,
+    ERR(ncclInternalError, "Message truncated : received %d,%d bytes instead of %d,%d", senderRecvSize1, senderRecvSize2, ops[1].size,
          ops[3].size);
     return ncclInternalError;
   }
@@ -332,7 +332,7 @@ static void* bootstrapRoot(void* rargs) {
     }
 
     if (nranks != info.nranks || nroots != info.nroots || iroot != info.iroot || offset != info.offset) {
-      WARN("Bootstrap Root : mismatch in info from procs, nranks %d vs %d, nroots %d vs %d, iroot %d vs %d, offset %d "
+      ERR(ncclInternalError, "Bootstrap Root : mismatch in info from procs, nranks %d vs %d, nroots %d vs %d, iroot %d vs %d, offset %d "
            "vs %d",
            nranks, info.nranks, nroots, info.nroots, iroot, info.iroot, offset, info.offset);
       goto out;
@@ -340,12 +340,12 @@ static void* bootstrapRoot(void* rargs) {
 
     localId = localIdFromRoot(info.rank, iroot, nranks, nroots, offset);
     if (localId < 0 || localId >= nrecv) {
-      WARN("Bootstrap Root : localId %d is out of range", localId);
+      ERR(ncclInternalError, "Bootstrap Root : localId %d is out of range", localId);
       goto out;
     }
     if (memcmp(&zeroAddress, &rankAddressesRoot[localId], sizeof(union ncclSocketAddress)) != 0 ||
         memcmp(&zeroInfo, &rankInfo[localId], sizeof(union ringConnectInfo)) != 0) {
-      WARN("Bootstrap Root : rank %d of %d ranks has already checked in", info.rank, nranks);
+      ERR(ncclInternalError, "Bootstrap Root : rank %d of %d ranks has already checked in", info.rank, nranks);
       goto out;
     }
     // if the previous has already checked in, send the newly received handle, if not save the handle for later
@@ -434,13 +434,13 @@ ncclResult_t bootstrapGetUniqueId(struct ncclBootstrapHandle* handle, struct ncc
   if (env) {
     // If comm is provided (grow operation), NCCL_COMM_ID should not be set
     if (comm) {
-      WARN("ncclCommGetUniqueId should not be called when NCCL_COMM_ID is set");
+      ERR(ncclInvalidUsage, "ncclCommGetUniqueId should not be called when NCCL_COMM_ID is set");
       return ncclInvalidUsage;
     }
     // Normal init: use NCCL_COMM_ID from environment
     INFO(NCCL_ENV, "NCCL_COMM_ID set by environment to %s", env);
     if (ncclSocketGetAddrFromString(&handle->addr, env) != ncclSuccess) {
-      WARN("Invalid NCCL_COMM_ID, please use format: <ipv4>:<port> or [<ipv6>]:<port> or <hostname>:<port>");
+      ERR(ncclInvalidArgument, "Invalid NCCL_COMM_ID, please use format: <ipv4>:<port> or [<ipv6>]:<port> or <hostname>:<port>");
       return ncclInvalidArgument;
     }
     handle->magic = NCCL_MAGIC;
@@ -461,7 +461,7 @@ ncclResult_t bootstrapGetUniqueId(struct ncclBootstrapHandle* handle, struct ncc
 
 ncclResult_t bcastGrowHandle(struct ncclBootstrapHandle* handle, struct ncclComm* parent, bool isRoot) {
   if (!parent || !handle) {
-    WARN("bcastGrowHandle: parent comm and handle must be provided");
+    ERR(ncclInvalidArgument, "bcastGrowHandle: parent comm and handle must be provided");
     return ncclInvalidArgument;
   }
 
@@ -574,9 +574,9 @@ static ncclResult_t netGetDevice(int rank, struct ncclComm* comm, int* dev) {
         }
         if (devOOB == -1) {
           if (!searchNot) {
-            WARN("no device found matching %s%s, verify NCCL_OOB_NET_IFNAME", searchExact ? "exactly " : "", userIfEnv);
+            ERR(ncclInvalidArgument, "no device found matching %s%s, verify NCCL_OOB_NET_IFNAME", searchExact ? "exactly " : "", userIfEnv);
           } else {
-            WARN("no device found after excluding %s%s, verify NCCL_OOB_NET_IFNAME", searchExact ? "exactly " : "",
+            ERR(ncclInvalidArgument, "no device found after excluding %s%s, verify NCCL_OOB_NET_IFNAME", searchExact ? "exactly " : "",
                  userIfEnv);
           }
           return ncclInvalidArgument;
@@ -702,7 +702,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
   } else if (parent != NULL) {
     comm->magic = state->magic = hashCombine(parent->magic, parent->childCount);
   } else {
-    WARN("bootstrapInit: handles and parent are NULL");
+    ERR(ncclSystemError, "bootstrapInit: handles and parent are NULL");
     return ncclSystemError;
   }
 
@@ -737,7 +737,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
       if (handles != NULL) {
         offset = BOOTSTRAP_HANDLE(handles, 0)->nRanks - 1;
       } else {
-        WARN("bootstrapInit: handles and parent are NULL");
+        ERR(ncclSystemError, "bootstrapInit: handles and parent are NULL");
         return ncclSystemError;
       }
     }
@@ -1316,7 +1316,7 @@ ncclResult_t bootstrapClose(void* commState) {
   if (state->unexpectedConnections != NULL) {
     unexpectedFree(state);
     if (COMPILER_ATOMIC_LOAD(state->abortFlag, std::memory_order_acquire) == 0) {
-      WARN("Unexpected connections are not empty");
+      ERR(ncclInternalError, "Unexpected connections are not empty");
       return ncclInternalError;
     }
   }

--- a/comms/ncclx/v2_31/src/channel.cc
+++ b/comms/ncclx/v2_31/src/channel.cc
@@ -10,6 +10,25 @@
 #include "gdrwrap.h"
 #include "transport.h"
 
+#include "comms/ctran/memory/SlabAllocator.h"
+#include "meta/wrapper/MetaFactory.h"
+
+template <typename T>
+static ncclResult_t ncclxChannelCallocAsync(
+    T** ptr,
+    size_t nelem,
+    cudaStream_t stream,
+    struct ncclComm* comm,
+    const char* callsite) {
+  if (comm->slabAllocator) {
+    return metaCommToNccl(comm->slabAllocator->cuCallocAsync(
+        reinterpret_cast<void**>(ptr), nelem * sizeof(T), stream, callsite, &comm->logMetaData));
+  }
+
+  // [META:MEMCACHE_SLAB] Retain NCCL's suspend/resume tracking when slab allocation is disabled.
+  return ncclCudaCallocAsync(ptr, nelem, stream, comm->memManager, ncclMemOffload);
+}
+
 ncclResult_t initChannel(struct ncclComm* comm, int channelId) {
   struct ncclChannel* channel = &comm->channels[channelId];
   if (channel->id != -1) return ncclSuccess;
@@ -41,12 +60,22 @@ ncclResult_t initChannel(struct ncclComm* comm, int channelId) {
 
   if (channel->devPeers == NULL) {
     if (sharedRes->devPeers[channelId] == NULL) {
-      NCCLCHECK(ncclCudaCallocAsync(sharedRes->devPeers + channelId, sharedRes->tpNRanks, deviceStream,
-                                    comm->memManager, ncclMemOffload));
+      if (comm->channelMetadataOnHost) {
+        NCCLCHECK(ncclCudaHostCalloc(sharedRes->devPeers + channelId, sharedRes->tpNRanks));
+      } else {
+        NCCLCHECK(ncclxChannelCallocAsync(sharedRes->devPeers + channelId, sharedRes->tpNRanks, deviceStream, comm,
+                                          "initChannnelSharedResDevPeers"));
+      }
     }
     /* channel->devPeers is not shared, so just free it when calling commFree() */
-    NCCLCHECK(ncclCudaCallocAsync(&channel->devPeers, nPeers, deviceStream, comm->memManager, ncclMemOffload));
-    ncclCommPushCudaFree(comm, channel->devPeers);
+    if (comm->channelMetadataOnHost) {
+      NCCLCHECK(ncclCudaHostCalloc(&channel->devPeers, nPeers));
+      ncclCommPushCudaHostFree(comm, channel->devPeers);
+    } else {
+      NCCLCHECK(ncclxChannelCallocAsync(&channel->devPeers, nPeers, deviceStream, comm,
+                                        "initChannnelDevPeers"));
+      if (!comm->slabAllocator) ncclCommPushCudaFree(comm, channel->devPeers);
+    }
     NCCLCHECK(ncclCalloc(&channel->devPeersHostPtr, nPeers));
     for (int r = 0; r < nRanks; r++) {
       uintptr_t addr = (uintptr_t)(comm->sharedRes->devPeers[channelId] + comm->topParentRanks[r]);
@@ -57,8 +86,14 @@ ncclResult_t initChannel(struct ncclComm* comm, int channelId) {
 
   channel->ring.userRanks = ncclMemoryStackAlloc<int>(&comm->memPermanent, nRanks);
   channel->ring.rankToIndex = ncclMemoryStackAlloc<int>(&comm->memPermanent, nRanks);
-  NCCLCHECK(ncclCudaCallocAsync(&channel->devRingUserRanks, nRanks, deviceStream, comm->memManager, ncclMemOffload));
-  ncclCommPushCudaFree(comm, channel->devRingUserRanks);
+  if (comm->channelMetadataOnHost) {
+    NCCLCHECK(ncclCudaHostCalloc(&channel->devRingUserRanks, nRanks));
+    ncclCommPushCudaHostFree(comm, channel->devRingUserRanks);
+  } else {
+    NCCLCHECK(ncclxChannelCallocAsync(&channel->devRingUserRanks, nRanks, deviceStream, comm,
+                                      "initChannneldevRingUserRanks"));
+    if (!comm->slabAllocator) ncclCommPushCudaFree(comm, channel->devRingUserRanks);
+  }
 
   /* guarantee addr has been copied into channel->devPeers */
   NCCLCHECK(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &sharedRes->deviceStream,

--- a/comms/ncclx/v2_31/src/collectives.cc
+++ b/comms/ncclx/v2_31/src/collectives.cc
@@ -12,6 +12,12 @@
 #include "nccl.h"
 #include "nvtx_payload_schemas.h"
 
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/ExtUtils.h"
+#include "meta/NcclxConfig.h"
+#include "meta/wrapper/MetaFactory.h"
+
 const char* ncclFuncToString(ncclFunc_t fn) {
   switch (fn) {
   case ncclFuncAllGather:
@@ -143,9 +149,19 @@ NCCL_API(ncclResult_t, ncclAllGather, const void* sendbuff, void* recvbuff, size
          ncclComm_t comm, cudaStream_t stream);
 ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcount, ncclDataType_t datatype,
                            ncclComm_t comm, cudaStream_t stream) {
+  if (sendcount == 0) return ncclSuccess;
+  SetCudaDevRAII setCudaDev(comm->cudaDev);
   // Just pass the size of one message and not the total bytes sent/received.
   NVTX3_FUNC_WITH_PARAMS(AllGather, NcclNvtxParamsAllGather,
                          NVTX3_PAYLOAD(comm ? comm->commHash : 0, sendcount * ncclTypeSize(datatype)));
+
+  const auto algo = NCCLX_CONFIG_FIELD(comm->config, allgatherAlgo);
+  if (algo != NCCL_ALLGATHER_ALGO::orig &&
+      ctranAllGatherSupport(comm->ctranComm_.get(), algo, stream, recvbuff,
+                           sendcount * comm->nRanks * ncclTypeSize(datatype))) {
+    return metaCommToNccl(ctranAllGather(sendbuff, recvbuff, sendcount, ncclToMetaComm(datatype),
+                                         comm->ctranComm_.get(), stream, algo));
+  }
   return ncclAllGatherConfigImpl(sendbuff, recvbuff, sendcount, datatype, comm, stream, nullptr);
 }
 
@@ -175,8 +191,25 @@ NCCL_API(ncclResult_t, ncclAlltoAll, const void* sendbuff, void* recvbuff, size_
          ncclComm* comm, cudaStream_t stream);
 ncclResult_t ncclAlltoAll(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, ncclComm* comm,
                           cudaStream_t stream) {
+  if (count == 0) return ncclSuccess;
+  SetCudaDevRAII setCudaDev(comm->cudaDev);
   NVTX3_FUNC_WITH_PARAMS(AlltoAll, NcclNvtxParamsAlltoAll,
                          NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype)));
+
+  NCCLCHECK(CudaPtrCheck(sendbuff, comm, "sendbuff", "ncclAlltoAll"));
+  NCCLCHECK(CudaPtrCheck(recvbuff, comm, "recvbuff", "ncclAlltoAll"));
+  if (sendbuff == recvbuff) {
+    ERR(ncclInvalidArgument, "Found sendbuff %p == recvbuff %p. In-place ncclAlltoAll is not supported.", sendbuff,
+        recvbuff);
+    return ncclInvalidArgument;
+  }
+
+  const auto algo = NCCLX_CONFIG_FIELD(comm->config, alltoallAlgo);
+  if (algo != NCCL_ALLTOALL_ALGO::orig &&
+      ctranAllToAllSupport(count, ncclToMetaComm(datatype), comm->ctranComm_.get(), algo, stream, recvbuff)) {
+    return metaCommToNccl(
+        ctranAllToAll(sendbuff, recvbuff, count, ncclToMetaComm(datatype), comm->ctranComm_.get(), stream, algo));
+  }
   return ncclAlltoAllConfigImpl(sendbuff, recvbuff, count, datatype, comm, stream, nullptr);
 }
 
@@ -205,6 +238,12 @@ NCCL_API(ncclResult_t, ncclAllReduce, const void* sendbuff, void* recvbuff, size
          ncclRedOp_t op, ncclComm* comm, cudaStream_t stream);
 ncclResult_t ncclAllReduce(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, ncclRedOp_t op,
                            ncclComm* comm, cudaStream_t stream) {
+  const auto algo = NCCLX_CONFIG_FIELD(comm->config, allreduceAlgo);
+  if (algo != NCCL_ALLREDUCE_ALGO::orig && ctranAllReduceSupport(comm->ctranComm_.get(), algo)) {
+    return metaCommToNccl(ctranAllReduce(sendbuff, recvbuff, count, ncclToMetaComm(datatype), ncclToMetaComm(op),
+                                         comm->ctranComm_.get(), stream, algo));
+  }
+
   NVTX3_FUNC_WITH_PARAMS(AllReduce, NcclNvtxParamsAllReduce,
                          NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), op));
   return ncclAllReduceConfigImpl(sendbuff, recvbuff, count, datatype, op, comm, stream, nullptr);
@@ -235,6 +274,14 @@ NCCL_API(ncclResult_t, ncclBroadcast, const void* sendbuff, void* recvbuff, size
          int root, ncclComm_t comm, cudaStream_t stream);
 ncclResult_t ncclBroadcast(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root,
                            ncclComm_t comm, cudaStream_t stream) {
+  if (count == 0) return ncclSuccess;
+  SetCudaDevRAII setCudaDev(comm->cudaDev);
+  if (NCCL_BROADCAST_ALGO != NCCL_BROADCAST_ALGO::orig &&
+      ctranBroadcastSupport(comm->ctranComm_.get(), NCCL_BROADCAST_ALGO)) {
+    return metaCommToNccl(ctranBroadcast(sendbuff, recvbuff, count, ncclToMetaComm(datatype), root,
+                                         comm->ctranComm_.get(), stream, NCCL_BROADCAST_ALGO));
+  }
+
   NVTX3_FUNC_WITH_PARAMS(Broadcast, NcclNvtxParamsBroadcast,
                          NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), root));
   return ncclBroadcastConfigImpl(sendbuff, recvbuff, count, datatype, root, comm, stream, nullptr);
@@ -333,8 +380,16 @@ NCCL_API(ncclResult_t, ncclReduceScatter, const void* sendbuff, void* recvbuff, 
          ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream);
 ncclResult_t ncclReduceScatter(const void* sendbuff, void* recvbuff, size_t recvcount, ncclDataType_t datatype,
                                ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
+  SetCudaDevRAII setCudaDev(comm->cudaDev);
   NVTX3_FUNC_WITH_PARAMS(ReduceScatter, NcclNvtxParamsReduceScatter,
                          NVTX3_PAYLOAD(comm ? comm->commHash : 0, recvcount * ncclTypeSize(datatype), op));
+
+  if (NCCL_REDUCESCATTER_ALGO != NCCL_REDUCESCATTER_ALGO::orig &&
+      ctranReduceScatterSupport(comm->ctranComm_.get(), NCCL_REDUCESCATTER_ALGO)) {
+    return metaCommToNccl(ctranReduceScatter(sendbuff, recvbuff, recvcount, ncclToMetaComm(datatype),
+                                             ncclToMetaComm(op), comm->ctranComm_.get(), stream,
+                                             NCCL_REDUCESCATTER_ALGO));
+  }
   return ncclReduceScatterConfigImpl(sendbuff, recvbuff, recvcount, datatype, op, comm, stream, nullptr);
 }
 
@@ -378,10 +433,9 @@ ncclResult_t ncclScatterConfig(const void* sendbuff, void* recvbuff, size_t coun
   return ncclScatterConfigImpl(sendbuff, recvbuff, count, datatype, root, comm, stream, config);
 }
 
-NCCL_API(ncclResult_t, ncclSend, const void* sendbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
-         cudaStream_t stream);
-ncclResult_t ncclSend(const void* sendbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
-                      cudaStream_t stream) {
+static ncclResult_t baseSend(const void* sendbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
+                             cudaStream_t stream) {
+  ctranGroupTrackDefaultOp(comm->ctranComm_.get());
   NVTX3_FUNC_WITH_PARAMS(Send, NcclNvtxParamsSendRecv,
                          NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), peer));
 
@@ -397,13 +451,37 @@ ncclResult_t ncclSend(const void* sendbuff, size_t count, ncclDataType_t datatyp
                           stream, /* Args */
                           1,
                           1};
-  return ncclEnqueueCheck(&info);
+  ncclResult_t ret;
+  NCCLCHECK(ncclGroupStart());
+  NCCLCHECKGOTO(ncclEnqueueCheck(&info), ret, exit);
+exit:
+  NCCLCHECK(ncclGroupEnd());
+  return ret;
 }
 
-NCCL_API(ncclResult_t, ncclRecv, void* recvbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
+NCCL_API(ncclResult_t, ncclSend, const void* sendbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
          cudaStream_t stream);
-ncclResult_t ncclRecv(void* recvbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
+ncclResult_t ncclSend(const void* sendbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
                       cudaStream_t stream) {
+  if (count == 0) return ncclSuccess;
+  SetCudaDevRAII setCudaDev(comm->cudaDev);
+
+  const auto algo = NCCLX_CONFIG_FIELD(comm->config, sendrecvAlgo);
+  if (algo != NCCL_SENDRECV_ALGO::orig && ctranSendRecvSupport(peer, comm->ctranComm_.get(), algo, stream)) {
+    ncclResult_t ret;
+    NCCLCHECK(ncclGroupStart());
+    ret = metaCommToNccl(
+        ctranSend(sendbuff, count, ncclToMetaComm(datatype), peer, comm->ctranComm_.get(), stream, algo));
+    NCCLCHECK(ncclGroupEnd());
+    return ret;
+  }
+
+  return baseSend(sendbuff, count, datatype, peer, comm, stream);
+}
+
+static ncclResult_t baseRecv(void* recvbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
+                             cudaStream_t stream) {
+  ctranGroupTrackDefaultOp(comm->ctranComm_.get());
   NVTX3_FUNC_WITH_PARAMS(Recv, NcclNvtxParamsSendRecv,
                          NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), peer));
 
@@ -419,7 +497,32 @@ ncclResult_t ncclRecv(void* recvbuff, size_t count, ncclDataType_t datatype, int
                           stream, /* Args */
                           1,
                           1};
-  return ncclEnqueueCheck(&info);
+  ncclResult_t ret;
+  NCCLCHECK(ncclGroupStart());
+  NCCLCHECKGOTO(ncclEnqueueCheck(&info), ret, exit);
+exit:
+  NCCLCHECK(ncclGroupEnd());
+  return ret;
+}
+
+NCCL_API(ncclResult_t, ncclRecv, void* recvbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
+         cudaStream_t stream);
+ncclResult_t ncclRecv(void* recvbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
+                      cudaStream_t stream) {
+  if (count == 0) return ncclSuccess;
+  SetCudaDevRAII setCudaDev(comm->cudaDev);
+
+  const auto algo = NCCLX_CONFIG_FIELD(comm->config, sendrecvAlgo);
+  if (algo != NCCL_SENDRECV_ALGO::orig && ctranSendRecvSupport(peer, comm->ctranComm_.get(), algo, stream)) {
+    ncclResult_t ret;
+    NCCLCHECK(ncclGroupStart());
+    ret = metaCommToNccl(
+        ctranRecv(recvbuff, count, ncclToMetaComm(datatype), peer, comm->ctranComm_.get(), stream, algo));
+    NCCLCHECK(ncclGroupEnd());
+    return ret;
+  }
+
+  return baseRecv(recvbuff, count, datatype, peer, comm, stream);
 }
 
 NCCL_API(ncclResult_t, ncclPutSignal, const void* localbuff, size_t count, ncclDataType_t datatype, int peer,

--- a/comms/ncclx/v2_31/src/debug.cc
+++ b/comms/ncclx/v2_31/src/debug.cc
@@ -19,7 +19,10 @@
 #include "os.h"
 #include "utils.h"
 #include "env.h"
-#include <cinttypes>
+#include <vector>
+
+#include "comms/utils/logger/LoggingFormat.h"
+#include "meta/logger/NcclDebugLog.h"
 
 #define NCCL_DEBUG_RESET_TRIGGERED (-2)
 
@@ -39,13 +42,12 @@ static std::mutex ncclDebugMutex;
 static std::chrono::steady_clock::time_point ncclEpoch;
 static bool ncclWarnSetDebugInfo = false;
 
-static thread_local int tid = -1;
-
 // clang-format off
 DEFINE_NCCL_PARAM(ncclParamDebugLevel, ncclDebugLogLevel, NCCL_DEBUG, NCCL_LOG_NONE,
                   NCCL_PARAM_FLAG_PUBLISHED | NCCL_PARAM_FLAG_NO_ENVPLUGIN_INIT,
                   ncclParamOneOf<ncclDebugLogLevel>(makeOptions(
                     makeOption("VERSION", NCCL_LOG_VERSION, "Prints the NCCL version info only"),
+                    makeOption("ERROR", NCCL_LOG_ERROR, "Prints only root-cause error messages (ERR)."),
                     makeOption("WARN", NCCL_LOG_WARN, "Prints only messages indicating a fatal error."),
                     makeOption("INFO", NCCL_LOG_INFO, "Prints debug message"),
                     makeOption("ABORT", NCCL_LOG_ABORT, ""),
@@ -86,13 +88,14 @@ DEFINE_NCCL_PARAM(ncclParamDebugTimestampLevel, uint32_t, NCCL_DEBUG_TIMESTAMP_L
                   NCCL_PARAM_FLAG_PUBLISHED | NCCL_PARAM_FLAG_NO_ENVPLUGIN_INIT,
                   ncclParamBitsetOf<uint32_t>(
                     makeOptions(makeOption("VERSION", (1u << NCCL_LOG_VERSION), "on NCCL version info message"),
+                                makeOption("ERROR", (1u << NCCL_LOG_ERROR), "on Root-cause error message"),
                                 makeOption("WARN", (1u << NCCL_LOG_WARN), "on Explicit error message"),
                                 makeOption("INFO", (1u << NCCL_LOG_INFO), "on Debug message"),
                                 makeOption("ABORT", (1u << NCCL_LOG_ABORT), ""),
                                 makeOption("TRACE", (1u << NCCL_LOG_TRACE), "on Replayable trace message"),
                                 makeOption("ALL",
-                                           (1u << NCCL_LOG_VERSION | 1u << NCCL_LOG_WARN | 1u << NCCL_LOG_INFO |
-                                            1u << NCCL_LOG_ABORT | 1u << NCCL_LOG_TRACE),
+                                           (1u << NCCL_LOG_VERSION | 1u << NCCL_LOG_ERROR | 1u << NCCL_LOG_WARN |
+                                            1u << NCCL_LOG_INFO | 1u << NCCL_LOG_ABORT | 1u << NCCL_LOG_TRACE),
                                            "on All messages"))),
                   "Set which log lines get a timestamp depending upon the level of the log");
 
@@ -248,6 +251,10 @@ static void ncclDebugInit() {
 
   ncclEpoch = std::chrono::steady_clock::now();
   ncclDebugMask = ncclParamDebugSubsys();
+
+  // NCCLX -> Enable CTRAN subsystems logging as per NCCL_DEBUG_SUBSYS
+  meta::comms::logger::setSubSystemMask(ncclDebugMask);
+
   COMPILER_ATOMIC_STORE(&ncclDebugLevel, tempNcclDebugLevel, std::memory_order_release);
 }
 
@@ -255,13 +262,13 @@ static void ncclDebugLogV(ncclDebugLogLevel level, unsigned long flags, const ch
                           const char* fmt, va_list vargs) {
   int gotLevel = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire);
 
-  if (ncclDebugNoWarn != 0 && level == NCCL_LOG_WARN) {
+  if (ncclDebugNoWarn != 0 && (level == NCCL_LOG_WARN || level == NCCL_LOG_ERROR)) {
     level = NCCL_LOG_INFO;
     flags = ncclDebugNoWarn;
   }
 
-  // Save the last error (WARN) as a human readable string
-  if (level == NCCL_LOG_WARN) {
+  // Save the last error (ERR/WARN) as a human readable string
+  if (level == NCCL_LOG_WARN || level == NCCL_LOG_ERROR) {
     std::lock_guard<std::mutex> lock(ncclDebugMutex);
     va_list vcopy;
     va_copy(vcopy, vargs);
@@ -273,108 +280,63 @@ static void ncclDebugLogV(ncclDebugLogLevel level, unsigned long flags, const ch
     return;
   }
 
-  std::lock_guard<std::mutex> lock(ncclDebugMutex);
-  if (ncclDebugLevel < 0) ncclDebugInit();
-  if (ncclDebugLevel < level || ((flags & ncclDebugMask) == 0)) {
+  /* The mutex guards ncclDebugInit() and the level/mask read only. Upstream
+   * also holds it across the vfprintf; the sink below is thread-safe and can
+   * block on a synchronous file write, so formatting and emitting stay outside
+   * it — holding it there would serialize all logging and would deadlock if
+   * anything under the sink ever logged back through NCCL.
+   */
+  bool escalateToInfo = false;
+  {
+    std::lock_guard<std::mutex> lock(ncclDebugMutex);
+    /* Atomic even under the lock: the escalation store below deliberately runs
+     * outside it, so the mutex alone does not order these reads against it.
+     */
+    int curLevel = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire);
+    if (curLevel < 0) {
+      ncclDebugInit();
+      curLevel = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire);
+    }
+    if (curLevel < level || ((flags & ncclDebugMask) == 0)) {
+      return;
+    }
+    escalateToInfo = ncclWarnSetDebugInfo && level == NCCL_LOG_WARN;
+  }
+
+  if (escalateToInfo) {
+    COMPILER_ATOMIC_STORE(&ncclDebugLevel, static_cast<int>(NCCL_LOG_INFO), std::memory_order_release);
+  }
+
+  /* NCCLX: hand the message to the Meta sink instead of prefixing and
+   * vfprintf-ing it here. The sink owns the line prefix (timestamp, host, pid,
+   * tid, severity) and the output destination, and additionally fans errors
+   * out to Scuba, so only the call site's own message is formatted below.
+   */
+  /* Stack buffer sized as upstream's, with a heap fallback only when the
+   * message overflows it. Formatting twice unconditionally would double
+   * format-string parsing on every INFO/TRACE line, which is a hot path.
+   */
+  char stackBuf[1024];
+  va_list vcopy;
+  va_copy(vcopy, vargs);
+  const int msgLen = std::vsnprintf(stackBuf, sizeof(stackBuf), fmt, vcopy);
+  va_end(vcopy);
+  if (msgLen < 0) {
     return;
   }
 
-  if (tid == -1) {
-    tid = ncclOsGetTid();
+  const char* message = stackBuf;
+  std::vector<char> heapBuf;
+  if (static_cast<size_t>(msgLen) >= sizeof(stackBuf)) {
+    heapBuf.resize(static_cast<size_t>(msgLen) + 1); // +1 for null terminator
+    va_copy(vcopy, vargs);
+    std::vsnprintf(heapBuf.data(), heapBuf.size(), fmt, vcopy);
+    va_end(vcopy);
+    message = heapBuf.data();
   }
 
-  char buffer[1024];
-  size_t len = 0;
-
-  // WARNs come with an extra newline at the beginning.
-  if (level == NCCL_LOG_WARN) {
-    buffer[len++] = '\n';
-  }
-
-  // Add the timestamp to the buffer if they are turned on for this level.
-  if (ncclDebugTimestampLevels & (1 << level)) {
-    if (ncclDebugTimestampFormat[0] != '\0') {
-      struct timespec ts;
-      clockRealtime(&ts);
-      time_t nowTimeT = ts.tv_sec;
-      long nowNs = ts.tv_nsec;
-      std::tm nowTm;
-      ncclOsLocaltime(&nowTimeT, &nowTm);
-
-      // Add the subseconds portion if it is part of the format.
-      char localTimestampFormat[sizeof(ncclDebugTimestampFormat)];
-      const char* pformat = ncclDebugTimestampFormat;
-      if (ncclDebugTimestampSubsecondsStart != -1) {
-        pformat = localTimestampFormat;   // Need to use the local version which has subseconds
-        memcpy(localTimestampFormat, ncclDebugTimestampFormat, ncclDebugTimestampSubsecondsStart);
-        snprintf(localTimestampFormat + ncclDebugTimestampSubsecondsStart, ncclDebugTimestampSubsecondDigits + 1,
-                 "%0*" PRIu64, ncclDebugTimestampSubsecondDigits,
-                 (uint64_t)(nowNs / (1000000000L / ncclDebugTimestampMaxSubseconds)));
-        strcpy(localTimestampFormat + ncclDebugTimestampSubsecondsStart + ncclDebugTimestampSubsecondDigits,
-               ncclDebugTimestampFormat + ncclDebugTimestampSubsecondsStart + ncclDebugTimestampSubsecondDigits);
-      }
-
-      // Format the time. If it runs out of space, fall back on a simpler format.
-      int adv = std::strftime(buffer + len, sizeof(buffer) - len, pformat, &nowTm);
-      if (adv == 0 && ncclDebugTimestampFormat[0] != '\0') {
-        // Ran out of space. Fall back on the default. This should never fail.
-        adv = std::strftime(buffer + len, sizeof(buffer) - len, "[%F %T] ", &nowTm);
-      }
-      len += adv;
-    }
-  }
-  len = std::min(len, sizeof(buffer) - 1);  // prevent overflows
-
-  // Add hostname, pid and tid portion of the log line.
-  if (level != NCCL_LOG_VERSION) {
-    len += snprintf(buffer + len, sizeof(buffer) - len, "%s:%d:%d ", hostname, pid, tid);
-    len = std::min(len, sizeof(buffer) - 1);  // prevent overflows
-  }
-
-  int cudaDev = 0;
-  if (!(level == NCCL_LOG_TRACE && flags == NCCL_CALL)) {
-    (void)cudaGetDevice(&cudaDev);
-  }
-
-  const char* fileStr = file ? file : "<unknown>";
-  const char* funcStr = func ? func : "<unknown>";
-
-  // Add level specific formatting. The format string from the call site is incorporated into this prefix.
-  if (level == NCCL_LOG_WARN) {
-    if (func && func[0]) {
-      len += snprintf(buffer + len, sizeof(buffer) - len, "[%d] %s:%d (%s) NCCL WARN %s\n", cudaDev, fileStr, line,
-                      funcStr, fmt);
-    } else {
-      len += snprintf(buffer + len, sizeof(buffer) - len, "[%d] %s:%d NCCL WARN %s\n", cudaDev, fileStr, line, fmt);
-    }
-    if (ncclWarnSetDebugInfo) {
-      COMPILER_ATOMIC_STORE(&ncclDebugLevel, static_cast<int>(NCCL_LOG_INFO), std::memory_order_release);
-    }
-  } else if (level == NCCL_LOG_INFO) {
-    len += snprintf(buffer + len, sizeof(buffer) - len, "[%d] NCCL INFO %s\n", cudaDev, fmt);
-  } else if (level == NCCL_LOG_TRACE && flags == NCCL_CALL) {
-    len += snprintf(buffer + len, sizeof(buffer) - len, "NCCL CALL %s\n", fmt);
-  } else if (level == NCCL_LOG_TRACE) {
-    auto delta = std::chrono::steady_clock::now() - ncclEpoch;
-    double timestamp = std::chrono::duration_cast<std::chrono::duration<double>>(delta).count() * 1000;
-    len += snprintf(buffer + len, sizeof(buffer) - len, "[%d] %f %s:%d NCCL TRACE %s\n", cudaDev, timestamp, funcStr,
-                    line, fmt);
-  } else {
-    len += snprintf(buffer + len, sizeof(buffer) - len, "%s\n", fmt);
-  }
-
-  // If the prefixed format string overflows, make sure it is still terminated with a newline.
-  if (len > sizeof(buffer) - 1) {
-    // snprintf already placed a \0 at sizeof(buffer)-1
-    buffer[sizeof(buffer) - 2] = '\n';
-  }
-
-  // Add the message as given by the call site.
-  // The call site's format string has been incorporated into `buffer` along with our prefix.
-  va_list vcopy;
-  va_copy(vcopy, vargs);
-  (void)vfprintf(ncclDebugFile, buffer, vcopy);
-  va_end(vcopy);
+  ncclx::logging::writeNcclLog(level, file ? file : "", func ? func : "", line,
+                               std::string_view(message, static_cast<size_t>(msgLen)));
 }
 
 // Internal only Common logging function used by the INFO, WARN and TRACE macros
@@ -384,6 +346,21 @@ void ncclDebugLogInternal(ncclDebugLogLevel level, unsigned long flags, const ch
   va_start(vargs, fmt);
   ncclDebugLogV(level, flags, file, func, line, fmt, vargs);
   va_end(vargs);
+}
+
+/* Same funnel as ncclDebugLogInternal, under the name the shared Meta code in
+ * comms/ncclx/meta/ links against across ncclx versions.
+ */
+void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char* file, const char* func, int line,
+                      const char* fmt, ...) {
+  va_list vargs;
+  va_start(vargs, fmt);
+  ncclDebugLogV(level, flags, file, func, line, fmt, vargs);
+  va_end(vargs);
+}
+
+void ncclSetMyThreadLoggingName(std::string_view name) {
+  meta::comms::logger::initThreadMetaData(name);
 }
 
 /* Exported ABI logging function exported to the dynamically loadable Net

--- a/comms/ncclx/v2_31/src/dev_runtime.cc
+++ b/comms/ncclx/v2_31/src/dev_runtime.cc
@@ -49,7 +49,7 @@ static ncclResult_t getNcclVersionCompat(int version, struct ncclDevCommCompat**
 
   if (version > NCCL_VERSION_CODE && ncclParamEnableVersionCheck()) {
     char compiledBuf[16], runtimeBuf[16];
-    WARN("NCCL library is too old. This application was compiled with NCCL version %s, but is running with NCCL "
+    ERR(ncclInvalidUsage, "NCCL library is too old. This application was compiled with NCCL version %s, but is running with NCCL "
          "library version %s.",
          ncclVersionToString(version, compiledBuf, sizeof(compiledBuf)),
          ncclVersionToString(NCCL_VERSION_CODE, runtimeBuf, sizeof(runtimeBuf)));
@@ -65,7 +65,7 @@ static ncclResult_t getNcclVersionCompat(int version, struct ncclDevCommCompat**
   }
   if (devCompat == nullptr) {
     char compiledBuf[16], runtimeBuf[16];
-    WARN("NCCL library is not backwards compatible. This application was compiled with NCCL version %s, but is running "
+    ERR(ncclInvalidUsage, "NCCL library is not backwards compatible. This application was compiled with NCCL version %s, but is running "
          "with NCCL library version %s.",
          ncclVersionToString(version, compiledBuf, sizeof(compiledBuf)),
          ncclVersionToString(NCCL_VERSION_CODE, runtimeBuf, sizeof(runtimeBuf)));
@@ -443,7 +443,7 @@ ncclResult_t symTeamObtain(struct ncclComm* comm, struct ncclTeam team, bool mul
 
   if (multimem) {
     if (!comm->nvlsSupport) {
-      WARN("Multicast support requested for team but none available on system.");
+      ERR(ncclInvalidArgument, "Multicast support requested for team but none available on system.");
       ret = ncclInvalidArgument;
       goto fail;
     } else {
@@ -1018,7 +1018,7 @@ ncclResult_t ncclDevrWindowRegisterInGroup(struct ncclComm* comm, void* userPtr,
 
   memOffset = reinterpret_cast<CUdeviceptr>(userPtr) - memAddr;
   if (memOffset % NCCL_WIN_REQUIRED_ALIGNMENT != 0) {
-    WARN("Window address must be suitably aligned.");
+    ERR(ncclInvalidArgument, "Window address must be suitably aligned.");
     ret = ncclInvalidArgument;
     goto fail_locReg;
   }
@@ -1274,18 +1274,18 @@ ncclResult_t ncclDevrCommCreateInternal(struct ncclComm* comm, struct ncclDevCom
 
   bool requestedGinResources = ncclGinResourcesRequested(reqs);
   if (requestedGinResources && requestedConnectionType == NCCL_GIN_CONNECTION_NONE) {
-    WARN("User requested GIN resources but did not request GIN to be enabled!");
+    ERR(ncclInvalidArgument, "User requested GIN resources but did not request GIN to be enabled!");
     return ncclInvalidArgument;
   }
 
   if (requestedConnectionType != NCCL_GIN_CONNECTION_NONE) {
     if (comm->globalGinSupport == NCCL_GIN_CONNECTION_NONE) {
-      WARN("User requested GIN but not all ranks in the communicator support GIN");
+      ERR(ncclInvalidArgument, "User requested GIN but not all ranks in the communicator support GIN");
       return ncclInvalidArgument;
     }
     if (requestedConnectionType == NCCL_GIN_CONNECTION_FULL) {
       if (comm->globalGinSupport == NCCL_GIN_CONNECTION_RAIL) {
-        WARN("User requested GIN connection type NCCL_GIN_CONNECTION_FULL but the communicator supports only "
+        ERR(ncclInvalidArgument, "User requested GIN connection type NCCL_GIN_CONNECTION_FULL but the communicator supports only "
              "NCCL_GIN_CONNECTION_RAIL");
         return ncclInvalidArgument;
       }
@@ -1713,7 +1713,7 @@ ncclResult_t ncclCommQueryProperties(ncclComm_t comm, ncclCommProperties_t* prop
   NCCLCHECK(ncclCommEnsureReady(comm));
 
   if (props->magic != NCCL_API_MAGIC) {
-    WARN("Cannot get communicator properties: ncclCommProperties_t argument must be initialized via "
+    ERR(ncclInvalidUsage, "Cannot get communicator properties: ncclCommProperties_t argument must be initialized via "
          "NCCL_COMM_PROPERTIES_INITIALIZER");
     return ncclInvalidUsage;
   }
@@ -1768,7 +1768,7 @@ ncclResult_t ncclDevCommCreate(ncclComm_t comm, struct ncclDevCommRequirements c
   NCCLCHECK(CommCheck(comm, __func__, "comm"));
   NCCLCHECK(PtrCheck(reqs, __func__, "reqs"));
   if (reqs->magic != NCCL_API_MAGIC) {
-    WARN("Cannot create device communicator: ncclDevCommRequirements_t argument must be initialized via "
+    ERR(ncclInvalidUsage, "Cannot create device communicator: ncclDevCommRequirements_t argument must be initialized via "
          "NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER");
     return ncclInvalidUsage;
   }
@@ -1791,7 +1791,7 @@ ncclResult_t ncclDevCommCreate(ncclComm_t comm, struct ncclDevCommRequirements c
   NCCLCHECK(ncclGroupStartInternal());
 
   if (!comm->symmetricSupport) {
-    WARN("Communicator does not support symmetric memory!");
+    ERR(ncclInvalidUsage, "Communicator does not support symmetric memory!");
     ret = ncclInvalidUsage;
     goto fail;
   }
@@ -1926,7 +1926,7 @@ ncclResult_t ncclWinGetUserPtr(struct ncclComm* comm, struct ncclWindow_vidmem* 
 
   winHost = (struct ncclDevrWindow*)winDevHost->winHost;
   if (winHost == nullptr) {
-    WARN("window has a NULL user pointer");
+    ERR(ncclInternalError, "window has a NULL user pointer");
     return ncclInternalError;
   }
 
@@ -1938,7 +1938,7 @@ ncclResult_t ncclDevrWorldToLsaRank(struct ncclComm* comm, int peerWorldRank, in
   ncclTeam_t worldTeam = ncclTeamWorld(comm);
   ncclTeam_t lsaTeam = ncclTeamLsa(comm);
   if (!ncclTeamRankIsMember(lsaTeam, worldTeam, peerWorldRank)) {
-    WARN("ncclDevrWorldToLsaRank: world rank %d is not a member of the LSA team", peerWorldRank);
+    ERR(ncclInternalError, "ncclDevrWorldToLsaRank: world rank %d is not a member of the LSA team", peerWorldRank);
     return ncclInternalError;
   }
   *peerLsaRank = ncclTeamRankToTeam(lsaTeam, worldTeam, peerWorldRank);
@@ -1993,7 +1993,7 @@ ncclResult_t ncclDevrGetLsaTeamPtrMC(struct ncclComm* comm, struct ncclDevrWindo
   if (winHost == nullptr || outPtr == nullptr) return ncclInternalError;
 
   if (!comm->nvlsSupport) {
-    WARN("Multimem pointer requested but system does not support multimem.");
+    ERR(ncclInvalidUsage, "Multimem pointer requested but system does not support multimem.");
     return ncclInvalidUsage;
   }
 
@@ -2016,7 +2016,7 @@ ncclResult_t findCommAndHostWindowFromDeviceWindow(ncclWindow_t devWindow, ncclC
   std::lock_guard<std::mutex> lock(ncclWindowMapMutex);
   NCCLCHECK(ncclIntruAddressMapFind(&ncclWindowMap, devWindow, &winHost));
   if (winHost == nullptr) {
-    WARN("Could not find communicator matching window %p (map hbits=%d count=%d)", devWindow, ncclWindowMap.base.hbits,
+    ERR(ncclInvalidArgument, "Could not find communicator matching window %p (map hbits=%d count=%d)", devWindow, ncclWindowMap.base.hbits,
          ncclWindowMap.base.count);
     return ncclInvalidArgument;
   }
@@ -2034,7 +2034,7 @@ ncclResult_t ncclGetMultimemDevicePointer(ncclWindow_t window, size_t offset, nc
   NCCLCHECK(PtrCheck(window, __func__, "window"));
   NCCLCHECK(PtrCheck(outPtr, __func__, "outPtr"));
   if (multimem.mcBasePtr == nullptr) {
-    WARN("MCBasePtr %p needs to be valid.", multimem.mcBasePtr);
+    ERR(ncclInvalidArgument, "MCBasePtr %p needs to be valid.", multimem.mcBasePtr);
     return ncclInvalidArgument;
   }
 
@@ -2084,7 +2084,7 @@ ncclResult_t ncclGetLsaDevicePointer(ncclWindow_t window, size_t offset, int lsa
 
   devr = &comm->devrState;
   if (lsaRank < 0 || lsaRank >= devr->lsaSize) {
-    WARN("The provided lsaRank %d is not in the valid lsaSize of [0,%d] for the provided window %p.", lsaRank,
+    ERR(ncclInvalidArgument, "The provided lsaRank %d is not in the valid lsaSize of [0,%d] for the provided window %p.", lsaRank,
          devr->lsaSize, window);
     return ncclInvalidArgument; // In this case the user should know what the lsa size is.
   }
@@ -2110,7 +2110,7 @@ ncclResult_t ncclGetPeerDevicePointer(ncclWindow_t window, size_t offset, int pe
   NCCLCHECK(findCommAndHostWindowFromDeviceWindow(window, &comm, &winHost));
   // Validate peer rank is within bounds
   if (peer < 0 || peer >= comm->nRanks) {
-    WARN("peer %d is not within valid range of ranks %d.", peer, comm->nRanks);
+    ERR(ncclInvalidArgument, "peer %d is not within valid range of ranks %d.", peer, comm->nRanks);
     return ncclInvalidArgument;
   }
 

--- a/comms/ncclx/v2_31/src/dev_runtime_segments.cc
+++ b/comms/ncclx/v2_31/src/dev_runtime_segments.cc
@@ -46,7 +46,7 @@ ncclResult_t ncclDevrCheckRegistrationSupport(void* userPtr, size_t userSize, st
   ncclResult_t ret = ncclSuccess;
   if (hasSysmemSegment) {
     if (!ncclParamElasticBufferRegister()) {
-      WARN("VA represented by {userPtr = %p, size = %zu} contains CPU-backed physical segments, but "
+      ERR(ncclInvalidArgument, "VA represented by {userPtr = %p, size = %zu} contains CPU-backed physical segments, but "
            "NCCL_ELASTIC_BUFFER_REGISTER is set to 0. Please set NCCL_ELASTIC_BUFFER_REGISTER=1 and retry window "
            "registration",
            userPtr, userSize);
@@ -60,7 +60,7 @@ ncclResult_t ncclDevrCheckRegistrationSupport(void* userPtr, size_t userSize, st
                                        comm->cudaDev),
                   ret, exit);
       if (!multiNodeLsaSupported) {
-        WARN("VA represented by {userPtr = %p, size = %zu} contains CPU-backed physical segments, but the LSA team "
+        ERR(ncclInvalidArgument, "VA represented by {userPtr = %p, size = %zu} contains CPU-backed physical segments, but the LSA team "
              "does not support multi-node IPC on CPU-backed buffers. Please retry by setting NCCL_MNNVL_ENABLE=0",
              userPtr, userSize);
         ret = ncclInvalidArgument;

--- a/comms/ncclx/v2_31/src/devcomm/devcomm_v22902.cc
+++ b/comms/ncclx/v2_31/src/devcomm/devcomm_v22902.cc
@@ -106,7 +106,7 @@ static ncclResult_t ncclDevCommRequirementsFilter_v22902(ncclComm_t comm, ncclDe
   }
   if (userRequestedGin) {
     char compiledBuf[16], runtimeBuf[16];
-    WARN("The application was compiled with too old version of NCCL. It was compiled with NCCL version %s, but is "
+    ERR(ncclInvalidUsage, "The application was compiled with too old version of NCCL. It was compiled with NCCL version %s, but is "
          "running with NCCL library version %s. Because of its use of GIN device kernels, it needs to be recompiled, "
          "preferably with the same NCCL version that it will be running with.",
          ncclVersionToString(reqs->version, compiledBuf, sizeof(compiledBuf)),

--- a/comms/ncclx/v2_31/src/devcomm/devcomm_v22907.cc
+++ b/comms/ncclx/v2_31/src/devcomm/devcomm_v22907.cc
@@ -86,7 +86,7 @@ static ncclResult_t ncclDevCommRequirementsFilter_v22907(ncclComm_t comm, ncclDe
   }
   if (requestedGinResources && (reqs->ginConnectionType != NCCL_GIN_CONNECTION_NONE || reqs->ginForceEnable)) {
     char compiledBuf[16], runtimeBuf[16];
-    WARN("The application was compiled with too old version of NCCL. It was compiled with NCCL version %s, but is "
+    ERR(ncclInvalidUsage, "The application was compiled with too old version of NCCL. It was compiled with NCCL version %s, but is "
          "running with NCCL library version %s. Because of its use of GIN device kernels, it needs to be recompiled, "
          "preferably with the same NCCL version that it will be running with.",
          ncclVersionToString(reqs->version, compiledBuf, sizeof(compiledBuf)),

--- a/comms/ncclx/v2_31/src/device/common.cu
+++ b/comms/ncclx/v2_31/src/device/common.cu
@@ -9,7 +9,11 @@
 #include "collectives.h"
 #include "common.h"
 #include "nccl_device.h"
-#include "comm.h"
+// [META] Upstream 2.31 includes "comm.h" here; nothing in this file uses it.
+// NCCLX adds host-only C++ members to ncclComm (folly-backed colltrace, ctran
+// and allocator types), which nvcc cannot parse, so pulling comm.h into a
+// device translation unit breaks the build. v2_29/v2_30 were unaffected because
+// their device/common.cu does not include it. Upstreaming candidate.
 
 __shared__ ncclShmemData ncclShmem;
 #if __CUDA_ARCH__ < 700

--- a/comms/ncclx/v2_31/src/enqueue/enqueue.cc
+++ b/comms/ncclx/v2_31/src/enqueue/enqueue.cc
@@ -110,7 +110,7 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
   }
 
   if (ncclShmemDynamicSize(cudaArch) > maxDynamicSmem) {
-    WARN("cudaArch %d dynamic smem %d exceeds device/fn maxSharedMem %d", cudaArch, ncclShmemDynamicSize(cudaArch),
+    ERR(ncclSystemError, "cudaArch %d dynamic smem %d exceeds device/fn maxSharedMem %d", cudaArch, ncclShmemDynamicSize(cudaArch),
          maxDynamicSmem);
     return ncclSystemError;
   }
@@ -1245,11 +1245,11 @@ static ncclResult_t scheduleP2pTasksToPlan(struct ncclComm* comm, int* p2pEpoch,
 
       if (sendRank == comm->rank) {
         if (send != nullptr && recv == nullptr) {
-          WARN("Trying to send to self without a matching recv");
+          ERR(ncclInvalidUsage, "Trying to send to self without a matching recv");
           return ncclInvalidUsage;
         }
         if (send == nullptr && recv != nullptr) {
-          WARN("Trying to recv to self without a matching send");
+          ERR(ncclInvalidUsage, "Trying to recv to self without a matching send");
           return ncclInvalidUsage;
         }
       }
@@ -2197,7 +2197,7 @@ static ncclResult_t calcCollChunking(struct ncclComm* comm, struct ncclTaskColl*
                                                             ncclPatternRingTwice;
     break;
   default:
-    WARN("Unknown pattern for collective %d algorithm %d", info->func, info->algorithm);
+    ERR(ncclInternalError, "Unknown pattern for collective %d algorithm %d", info->func, info->algorithm);
     return ncclInternalError;
   }
 
@@ -2345,7 +2345,7 @@ static ncclResult_t calcCollChunking(struct ncclComm* comm, struct ncclTaskColl*
     nchunksPerLoop = comm->channels[0].nvls.nHeads;
     break;
   default:
-    WARN("Unknown pattern %d", pattern);
+    ERR(ncclInternalError, "Unknown pattern %d", pattern);
     return ncclInternalError;
   }
 
@@ -2412,7 +2412,7 @@ static ncclResult_t calcCollChunking(struct ncclComm* comm, struct ncclTaskColl*
         proxyOp->loopOffset = 0;
       }
     } else {
-      WARN("Net registration invalid algorithm %s", ncclAlgoToString(info->algorithm));
+      ERR(ncclInternalError, "Net registration invalid algorithm %s", ncclAlgoToString(info->algorithm));
       return ncclInternalError;
     }
 
@@ -2459,7 +2459,7 @@ static ncclResult_t calcCollChunking(struct ncclComm* comm, struct ncclTaskColl*
   case ncclPatternSend:
   case ncclPatternRecv:
   default:
-    WARN("Unknown pattern %d", pattern);
+    ERR(ncclInternalError, "Unknown pattern %d", pattern);
     return ncclInternalError;
   }
 
@@ -2563,7 +2563,7 @@ static ncclResult_t hostToDevRedOp(ncclDevRedOpFull* opFull, ncclRedOp_t op, ncc
     int ix = int(ncclUserRedOpMangle(comm, op)) - int(ncclNumOps);
     ncclUserRedOp* user = &comm->userRedOps[ix];
     if (datatype != user->datatype) {
-      WARN("Data type supplied to user-created ncclRedOp_t does not match type "
+      ERR(ncclInvalidArgument, "Data type supplied to user-created ncclRedOp_t does not match type "
            "given to reduction operation");
       return ncclInvalidArgument;
     }
@@ -2584,7 +2584,7 @@ ncclResult_t ncclPlannerSetCapturingGraph(struct ncclComm* comm, struct ncclInfo
         struct ncclCudaGraph graph;
         NCCLCHECK(ncclCudaGetCapturingGraph(&graph, info->stream, comm->config.graphUsageMode));
         if (planner->streams != nullptr && !ncclCudaGraphSame(planner->capturingGraph, graph)) {
-          WARN("Streams given to a communicator within a NCCL group must either be all uncaptured or all captured by "
+          ERR(ncclInvalidUsage, "Streams given to a communicator within a NCCL group must either be all uncaptured or all captured by "
                "the same graph.");
           return ncclInvalidUsage;
         }
@@ -2890,14 +2890,14 @@ static ncclResult_t rmaTaskAppend(struct ncclComm* comm, struct ncclInfo* info) 
   void const* srcBuff = info->sendbuff;
 
   if (!comm->hostRmaSupport) {
-    WARN("One sided RMA: host RMA is not supported in this communicator.");
+    ERR(ncclInvalidArgument, "One sided RMA: host RMA is not supported in this communicator.");
     return ncclInvalidArgument;
   }
 
   int driverVersion;
   NCCLCHECK(ncclCudaDriverVersion(&driverVersion));
   if (driverVersion < 12050) {
-    WARN("One-sided RMA requires CUDA driver 12.5 or later (found %d.%d).", driverVersion / 1000,
+    ERR(ncclInvalidUsage, "One-sided RMA requires CUDA driver 12.5 or later (found %d.%d).", driverVersion / 1000,
          (driverVersion % 1000) / 10);
     return ncclInvalidUsage;
   }
@@ -2917,7 +2917,7 @@ static ncclResult_t rmaTaskAppend(struct ncclComm* comm, struct ncclInfo* info) 
 
   // Check if flags is valid
   if (info->flags != 0) {
-    WARN("Flags %u is invalid (must be 0)", info->flags);
+    ERR(ncclInvalidArgument, "Flags %u is invalid (must be 0)", info->flags);
     return ncclInvalidArgument;
   }
 
@@ -2929,7 +2929,7 @@ static ncclResult_t rmaTaskAppend(struct ncclComm* comm, struct ncclInfo* info) 
   if (info->coll == ncclFuncPutSignal) {
     // Validate peer window with detailed debugging
     if (info->peerWin == NULL) {
-      WARN("ncclPutSignal: peerWin is NULL");
+      ERR(ncclInvalidArgument, "ncclPutSignal: peerWin is NULL");
       return ncclInvalidArgument;
     }
 
@@ -2939,12 +2939,12 @@ static ncclResult_t rmaTaskAppend(struct ncclComm* comm, struct ncclInfo* info) 
 
     // Validate source buffer and window
     if (srcBuff == NULL) {
-      WARN("ncclPutSignal: srcBuff is NULL");
+      ERR(ncclInvalidArgument, "ncclPutSignal: srcBuff is NULL");
       return ncclInvalidArgument;
     }
     NCCLCHECK(ncclDevrFindWindow(comm, srcBuff, &srcWinHost));
     if (srcWinHost == NULL || !(srcWinHost->winFlags & NCCL_WIN_COLL_SYMMETRIC)) {
-      WARN("ncclPutSignal: srcWinHost is not in a valid symmetric window");
+      ERR(ncclInvalidArgument, "ncclPutSignal: srcWinHost is not in a valid symmetric window");
       return ncclInvalidArgument;
     }
     srcWinOffset = (char*)srcBuff - (char*)srcWinHost->userPtr;
@@ -2953,29 +2953,29 @@ static ncclResult_t rmaTaskAppend(struct ncclComm* comm, struct ncclInfo* info) 
     bool hasSysmemSegment = ncclDevrWindowHasSysmemSegment(srcWinHost) || ncclDevrWindowHasSysmemSegment(peerWinHost);
 
     if (isMultiSegment) {
-      WARN("ncclPutSignal currently does not support VAs backed by multiple physical cuMem segments");
+      ERR(ncclInvalidArgument, "ncclPutSignal currently does not support VAs backed by multiple physical cuMem segments");
       return ncclInvalidArgument;
     }
     if (hasSysmemSegment) {
-      WARN("ncclPutSignal currently does not support VAs with host-backed cuMem segments");
+      ERR(ncclInvalidArgument, "ncclPutSignal currently does not support VAs with host-backed cuMem segments");
       return ncclInvalidArgument;
     }
   } else if (info->coll == ncclFuncSignal) {
     // Check if count is valid
     if (info->count != 0) {
-      WARN("ncclSignal: count must be 0");
+      ERR(ncclInvalidArgument, "ncclSignal: count must be 0");
       return ncclInvalidArgument;
     }
   } else if (info->coll == ncclFuncWaitSignal) {
     // Check if signalDescs is valid
     if (info->signalDescs == NULL || info->nDesc == 0) {
-      WARN("ncclWaitSignal: invalid arguments");
+      ERR(ncclInvalidArgument, "ncclWaitSignal: invalid arguments");
       return ncclInvalidArgument;
     }
     // Validate each descriptor
     for (int i = 0; i < info->nDesc; i++) {
       if (info->signalDescs[i].opCnt <= 0) {
-        WARN("ncclWaitSignal: descriptor %d has invalid opCnt %d", i, info->signalDescs[i].opCnt);
+        ERR(ncclInvalidArgument, "ncclWaitSignal: descriptor %d has invalid opCnt %d", i, info->signalDescs[i].opCnt);
         return ncclInvalidArgument;
       }
       if (info->signalDescs[i].sigIdx < 0 || info->signalDescs[i].sigIdx >= comm->config.numRmaSig) {
@@ -3152,7 +3152,7 @@ static ncclResult_t rawTaskAppend(struct ncclComm* comm, struct ncclInfo* info) 
       put->stream = info->stream;
     } else {
       if (info->count != 0) {
-        WARN("ncclSignal: count must be 0");
+        ERR(ncclInvalidArgument, "ncclSignal: count must be 0");
         return ncclInvalidArgument;
       }
       struct ncclRawTaskSignal* sig = &t->rma.rmaOp.signal;
@@ -3165,12 +3165,12 @@ static ncclResult_t rawTaskAppend(struct ncclComm* comm, struct ncclInfo* info) 
     ncclIntruQueueEnqueue(&rtq->genericQueue, t);
   } else if (info->coll == ncclFuncWaitSignal) {
     if (info->nDesc <= 0 || info->signalDescs == NULL) {
-      WARN("ncclWaitSignal: invalid arguments");
+      ERR(ncclInvalidArgument, "ncclWaitSignal: invalid arguments");
       return ncclInvalidArgument;
     }
     for (int i = 0; i < info->nDesc; i++) {
       if (info->signalDescs[i].opCnt <= 0) {
-        WARN("ncclWaitSignal: descriptor %d has invalid opCnt %d", i, info->signalDescs[i].opCnt);
+        ERR(ncclInvalidArgument, "ncclWaitSignal: descriptor %d has invalid opCnt %d", i, info->signalDescs[i].opCnt);
         return ncclInvalidArgument;
       }
       if (info->signalDescs[i].sigIdx < 0 || info->signalDescs[i].sigIdx >= comm->config.numRmaSig) {
@@ -3205,7 +3205,7 @@ static ncclResult_t rawTaskAppend(struct ncclComm* comm, struct ncclInfo* info) 
     if (info->datatype == ncclFloat8e4m3 || info->datatype == ncclFloat8e5m2) {
       if (comm->minCompCap < 90 &&
           (info->coll == ncclFuncReduce || info->coll == ncclFuncReduceScatter || info->coll == ncclFuncAllReduce)) {
-        WARN("FP8 reduction support begins with sm90 capable devices.");
+        ERR(ncclInvalidArgument, "FP8 reduction support begins with sm90 capable devices.");
         return ncclInvalidArgument;
       }
     }
@@ -3269,7 +3269,7 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
     if (info->datatype == ncclFloat8e4m3 || info->datatype == ncclFloat8e5m2) {
       if (comm->minCompCap < 90 && info->coll != ncclFuncAllGather && info->coll != ncclFuncBroadcast &&
           info->coll != ncclFuncAlltoAll && info->coll != ncclFuncScatter && info->coll != ncclFuncGather) {
-        WARN("FP8 reduction support begins with sm90 capable devices.");
+        ERR(ncclInvalidArgument, "FP8 reduction support begins with sm90 capable devices.");
         return ncclInvalidArgument;
       }
     }
@@ -3477,7 +3477,7 @@ ncclResult_t ncclRedOpCreatePreMulSum(ncclRedOp_t* op, void* scalar, ncclDataTyp
 NCCL_API(ncclResult_t, ncclRedOpDestroy, ncclRedOp_t op, ncclComm_t comm);
 ncclResult_t ncclRedOpDestroy(ncclRedOp_t op, ncclComm_t comm) {
   if (0 <= int(op) && int(op) < int(ncclNumOps)) {
-    WARN("ncclRedOpDestroy : operator is a NCCL builtin.");
+    ERR(ncclInvalidArgument, "ncclRedOpDestroy : operator is a NCCL builtin.");
     return ncclInvalidArgument;
   }
   // int(ncclMaxRedOp) < int(op) will always be false due to the sizes of
@@ -3485,17 +3485,17 @@ ncclResult_t ncclRedOpDestroy(ncclRedOp_t op, ncclComm_t comm) {
   // just as a reminder.
   // coverity[result_independent_of_operands]
   if (int(op) < 0 || int(ncclMaxRedOp) < int(op)) {
-    WARN("ncclRedOpDestroy :  operator is garbage.");
+    ERR(ncclInvalidArgument, "ncclRedOpDestroy :  operator is garbage.");
     return ncclInvalidArgument;
   }
   if (comm == NULL) {
-    WARN("ncclRedOpDestroy : invalid communicator passed.");
+    ERR(ncclInvalidArgument, "ncclRedOpDestroy : invalid communicator passed.");
     return ncclInvalidArgument;
   }
 
   int ix = int(ncclUserRedOpMangle(comm, op)) - int(ncclNumOps);
   if (comm->userRedOpCapacity <= ix || comm->userRedOps[ix].freeNext != -1) {
-    WARN("ncclRedOpDestroy : operator unknown to this communicator.");
+    ERR(ncclInvalidArgument, "ncclRedOpDestroy : operator unknown to this communicator.");
     return ncclInvalidArgument;
   }
   // push to free list

--- a/comms/ncclx/v2_31/src/enqueue/task_prep/task_posttuning.cc
+++ b/comms/ncclx/v2_31/src/enqueue/task_prep/task_posttuning.cc
@@ -326,14 +326,14 @@ static ncclResult_t postTuneRmaTaskAppend(struct ncclComm* comm, const struct nc
   }
 
   if (!comm->hostRmaSupport) {
-    WARN("One sided RMA: host RMA is not supported in this communicator.");
+    ERR(ncclInvalidArgument, "One sided RMA: host RMA is not supported in this communicator.");
     return ncclInvalidArgument;
   }
 
   int driverVersion;
   NCCLCHECK(ncclCudaDriverVersion(&driverVersion));
   if (driverVersion < 12050) {
-    WARN("One-sided RMA requires CUDA driver 12.5 or later (found %d.%d).", driverVersion / 1000,
+    ERR(ncclInvalidUsage, "One-sided RMA requires CUDA driver 12.5 or later (found %d.%d).", driverVersion / 1000,
          (driverVersion % 1000) / 10);
     return ncclInvalidUsage;
   }
@@ -346,7 +346,7 @@ static ncclResult_t postTuneRmaTaskAppend(struct ncclComm* comm, const struct nc
 
   // Check if flags is valid
   if (flags != 0) {
-    WARN("Flags %u is invalid (must be 0)", flags);
+    ERR(ncclInvalidArgument, "Flags %u is invalid (must be 0)", flags);
     return ncclInvalidArgument;
   }
 
@@ -367,7 +367,7 @@ static ncclResult_t postTuneRmaTaskAppend(struct ncclComm* comm, const struct nc
   if (func == ncclFuncPutSignal) {
     // Validate peer window with detailed debugging
     if (peerWin == NULL) {
-      WARN("ncclPutSignal: peerWin is NULL");
+      ERR(ncclInvalidArgument, "ncclPutSignal: peerWin is NULL");
       return ncclInvalidArgument;
     }
 
@@ -377,12 +377,12 @@ static ncclResult_t postTuneRmaTaskAppend(struct ncclComm* comm, const struct nc
 
     // Validate source buffer and window
     if (srcBuff == NULL) {
-      WARN("ncclPutSignal: srcBuff is NULL");
+      ERR(ncclInvalidArgument, "ncclPutSignal: srcBuff is NULL");
       return ncclInvalidArgument;
     }
     NCCLCHECK(ncclDevrFindWindow(comm, srcBuff, &srcWinHost));
     if (srcWinHost == NULL || !(srcWinHost->winFlags & NCCL_WIN_COLL_SYMMETRIC)) {
-      WARN("ncclPutSignal: srcWinHost is not in a valid symmetric window");
+      ERR(ncclInvalidArgument, "ncclPutSignal: srcWinHost is not in a valid symmetric window");
       return ncclInvalidArgument;
     }
     srcWinOffset = (char*)srcBuff - (char*)srcWinHost->userPtr;
@@ -391,23 +391,23 @@ static ncclResult_t postTuneRmaTaskAppend(struct ncclComm* comm, const struct nc
     bool hasSysmemSegment = ncclDevrWindowHasSysmemSegment(srcWinHost) || ncclDevrWindowHasSysmemSegment(peerWinHost);
 
     if (isMultiSegment) {
-      WARN("ncclPutSignal currently does not support VAs backed by multiple physical cuMem segments");
+      ERR(ncclInvalidArgument, "ncclPutSignal currently does not support VAs backed by multiple physical cuMem segments");
       return ncclInvalidArgument;
     }
     if (hasSysmemSegment) {
-      WARN("ncclPutSignal currently does not support VAs with host-backed cuMem segments");
+      ERR(ncclInvalidArgument, "ncclPutSignal currently does not support VAs with host-backed cuMem segments");
       return ncclInvalidArgument;
     }
   } else if (func == ncclFuncWaitSignal) {
     // Check if signalDescs is valid
     if (signalDescs == NULL || nDesc == 0) {
-      WARN("ncclWaitSignal: invalid arguments");
+      ERR(ncclInvalidArgument, "ncclWaitSignal: invalid arguments");
       return ncclInvalidArgument;
     }
     // Validate each descriptor
     for (int i = 0; i < nDesc; i++) {
       if (signalDescs[i].opCnt <= 0) {
-        WARN("ncclWaitSignal: descriptor %d has invalid opCnt %d", i, signalDescs[i].opCnt);
+        ERR(ncclInvalidArgument, "ncclWaitSignal: descriptor %d has invalid opCnt %d", i, signalDescs[i].opCnt);
         return ncclInvalidArgument;
       }
       if (signalDescs[i].sigIdx < 0 || signalDescs[i].sigIdx >= comm->config.numRmaSig) {

--- a/comms/ncclx/v2_31/src/gin/gin_host.cc
+++ b/comms/ncclx/v2_31/src/gin/gin_host.cc
@@ -97,19 +97,19 @@ ncclResult_t ncclGinConnectOnce(struct ncclComm* comm) {
 
   ncclResult_t ret = ncclSuccess;
   if (ncclParamGinEnable() == 0) {
-    WARN("GIN is disabled.");
+    ERR(ncclInternalError, "GIN is disabled.");
     return ncclInternalError;
   }
 
   if (!ginState->supported) {
-    WARN("GIN not supported.");
+    ERR(ncclInvalidUsage, "GIN not supported.");
     return ncclInvalidUsage;
   }
 
   ginState->ginConnectionType = comm->globalGinSupport;
 
   if (!comm->symmetricSupport) {
-    WARN("Communicator does not support symmetric memory!");
+    ERR(ncclInternalError, "Communicator does not support symmetric memory!");
     return ncclInternalError;
   }
 
@@ -149,7 +149,7 @@ ncclResult_t ncclGinConnectOnce(struct ncclComm* comm) {
 
     NCCLCHECKGOTO(backend->ncclGin->devices(&ndev), ret, fail);
     if (ndev <= 0) {
-      WARN("No GIN-capable devices found.");
+      ERR(ncclInternalError, "No GIN-capable devices found.");
       ret = ncclInternalError;
       goto fail;
     }
@@ -449,7 +449,7 @@ ncclResult_t ncclGinDevCommFree(struct ncclComm* comm, struct ncclDevComm const*
   struct ncclGinStateDevComm *dc = ginState->devComms, *prevDc = NULL;
   while (1) {
     if (dc == NULL) {
-      WARN("Dev comm not found\n");
+      ERR(ncclInternalError, "Dev comm not found\n");
       return ncclInternalError;
     }
     if (dc->devHandles[0]->handle == devComm->ginHandles[0]) break;
@@ -509,7 +509,7 @@ ncclResult_t ncclGinRegister(struct ncclComm* comm, void* address, size_t size,
       // Multi-segment GIN registration requires DMABUF support on all GIN connections
       for (int commIdx = 0; commIdx < backend->ginCommCount; commIdx++) {
         if (!(backend->ginProps[commIdx].ptrSupport & NCCL_PTR_DMABUF)) {
-          WARN(
+          ERR(ncclInvalidArgument, 
             "Window registration of addresses that span multiple physical segments requires DMABUF support with GIN.");
           return ncclInvalidArgument;
         }
@@ -520,7 +520,7 @@ ncclResult_t ncclGinRegister(struct ncclComm* comm, void* address, size_t size,
       NCCLCHECK(backend->ncclGin->regMrSym(backend->ginComms[commIdx], address, size, memType, mrFlags,
                                            &ginHostWins[slot], &ginDevWins[slot]));
       if (ginHostWins[slot] == NULL) {
-        WARN("rank %d - GIN Symmetric register failed: buff %p, size %ld", comm->rank, address, size);
+        ERR(ncclSystemError, "rank %d - GIN Symmetric register failed: buff %p, size %ld", comm->rank, address, size);
         return ncclSystemError;
       }
     }

--- a/comms/ncclx/v2_31/src/gin/gin_host_proxy.cc
+++ b/comms/ncclx/v2_31/src/gin/gin_host_proxy.cc
@@ -270,7 +270,7 @@ static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx* ctx, struct ginProxyH
     void* dstHandle = (void*)(uint64_t)gfd->qword[ncclGinProxyGfdDstHandle].dstHandle.dstHandle;
     uint64_t size = gfd->qword[ncclGinProxyGfdHeader].header.size;
     if (!rmaBackend->iget) {
-      WARN("GIN plugin does not support GET");
+      ERR(ncclInvalidUsage, "GIN plugin does not support GET");
       return ncclInvalidUsage;
     }
     NCCLCHECK(rmaBackend->iget(ctx->rmaCtx, hostGpuCtx->contextId, srcOff, srcHandle, size, dstOff, dstHandle,
@@ -280,7 +280,7 @@ static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx* ctx, struct ginProxyH
 
   if (extractOp(gfd) & ncclGinProxyOpFlush) {
     if (!rmaBackend->iflush) {
-      WARN("GIN plugin does not support FLUSH");
+      ERR(ncclInvalidUsage, "GIN plugin does not support FLUSH");
       return ncclInvalidUsage;
     }
     NCCLCHECK(rmaBackend->iflush(ctx->rmaCtx, hostGpuCtx->contextId, ctx->signalsGinHandle, targetRank,

--- a/comms/ncclx/v2_31/src/graph/connect.cc
+++ b/comms/ncclx/v2_31/src/graph/connect.cc
@@ -128,7 +128,7 @@ static ncclResult_t setTreeDown(struct ncclTree* tree, int* indexes, int d) {
   int x = 0;
   while (x < NCCL_MAX_TREE_ARITY && tree->down[x] >= 0) x++;
   if (x == NCCL_MAX_TREE_ARITY) {
-    WARN("Internal error : tree already has %d children (%d %d %d)", x, tree->down[0], tree->down[1], tree->down[2]);
+    ERR(ncclInternalError, "Internal error : tree already has %d children (%d %d %d)", x, tree->down[0], tree->down[1], tree->down[2]);
     return ncclInternalError;
   }
   tree->down[x] = indexes[d];

--- a/comms/ncclx/v2_31/src/graph/paths.cc
+++ b/comms/ncclx/v2_31/src/graph/paths.cc
@@ -29,7 +29,7 @@ static ncclResult_t getPath(struct ncclTopoSystem* system, struct ncclTopoNode* 
       return ncclSuccess;
     }
   }
-  WARN("Could not find node of type %d id %lx", t, id);
+  ERR(ncclInternalError, "Could not find node of type %d id %lx", t, id);
   return ncclInternalError;
 }
 
@@ -120,7 +120,7 @@ static ncclResult_t ncclTopoSetPaths(struct ncclTopoNode* baseNode, struct ncclT
             }
           }
           if (reverseLink == nullptr) {
-            WARN("Failed to find reverse path from remNode %d/%lx nlinks %d to node %d/%lx", remNode->type, remNode->id,
+            ERR(ncclInternalError, "Failed to find reverse path from remNode %d/%lx nlinks %d to node %d/%lx", remNode->type, remNode->id,
                  remNode->nlinks, node->type, node->id);
             return ncclInternalError;
           }
@@ -206,7 +206,7 @@ ncclResult_t ncclGetLocalCpu(struct ncclTopoSystem* system, int gpu, int* cpu) {
   int localCpus[NCCL_TOPO_MAX_NODES], count;
   NCCLCHECK(ncclTopoGetLocal(system, GPU, gpu, CPU, localCpus, &count, NULL));
   if (count == 0) {
-    WARN("Error : could not find CPU close to GPU %d", gpu);
+    ERR(ncclInternalError, "Error : could not find CPU close to GPU %d", gpu);
     return ncclInternalError;
   }
   struct ncclTopoLinkList* paths = system->nodes[GPU].nodes[gpu].paths[CPU];
@@ -420,7 +420,7 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
         if (!good) {
           if (!ncclParamIgnoreDisabledP2p()) {
             if (path->type <= PATH_NVB) {
-              WARN("P2P is disabled between NVLINK connected GPUs %d and %d. This should not be the case given their "
+              ERR(ncclUnhandledCudaError, "P2P is disabled between NVLINK connected GPUs %d and %d. This should not be the case given their "
                    "connectivity, and is probably due to a hardware issue. If you still want to proceed, you can set "
                    "NCCL_IGNORE_DISABLED_P2P=1.",
                    indexes[i - 1], indexes[i - 0]);
@@ -684,7 +684,7 @@ ncclResult_t ncclTopoGetIntermediateRank(struct ncclTopoSystem* system, int rank
       }
     }
     if (node->type != GPU) {
-      WARN("Could not find intermediate GPU between GPU rank %d and NIC %lx", rank, netId);
+      ERR(ncclInternalError, "Could not find intermediate GPU between GPU rank %d and NIC %lx", rank, netId);
       return ncclInternalError;
     }
     NCCLCHECK(ncclTopoDevToRank(system, NCCL_TOPO_ID_SYSTEM_ID(node->id), node->gpu.dev, /*warn=*/true,
@@ -925,7 +925,7 @@ ncclResult_t ncclTopoTrimSystem(struct ncclTopoSystem* system, struct ncclComm* 
       else gpu = NULL;
     }
     if (gpu == NULL) {
-      WARN("Could not find id %lx", ids[i]);
+      ERR(ncclInternalError, "Could not find id %lx", ids[i]);
       ret = ncclInternalError;
       goto fail;
     }

--- a/comms/ncclx/v2_31/src/graph/paths.cc
+++ b/comms/ncclx/v2_31/src/graph/paths.cc
@@ -13,6 +13,8 @@
 #include "channel.h"
 #include "transport.h"
 #include "device.h"
+#include "meta/DeviceRackSerial.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 
 // Pre-compute GPU->NIC, GPU->GPU and NIC->GPU paths
 
@@ -393,6 +395,20 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
 
   // Compute the PCI distance and compare with the p2pLevel.
   if (path->type <= p2pLevel) *p2p = 1;
+
+  // [META] Check if multi-NVLink P2P is disabled and handle rack serial matching
+  if (NCCL_MNNVL_TRUNK_DISABLE && mnnvl) {
+    INFO(NCCL_GRAPH, "NCCL_MNNVL_TRUNK_DISABLE enabled");
+
+    if (comm->peerInfo[rank1].rackSerial[0] != '\0' && comm->peerInfo[rank2].rackSerial[0] != '\0') {
+      *p2p = ncclx::isSameRackSerial(comm->peerInfo[rank1].rackSerial, comm->peerInfo[rank2].rackSerial);
+      INFO(NCCL_GRAPH,
+           "P2P is set to %d based on rack serial match/unmatch rank1: %d rank2: %d rackSerial1: %s rackSerial2: %s",
+           *p2p, rank1, rank2, comm->peerInfo[rank1].rackSerial, comm->peerInfo[rank2].rackSerial);
+    } else {
+      WARN("No rack serial information available, skipping rack serial check");
+    }
+  }
 
   // Use parent pointer comparison to handle multi-rank-per-GPU case:
   // Different topology indices (g1 != g2) may point to the same physical GPU

--- a/comms/ncclx/v2_31/src/graph/rings.cc
+++ b/comms/ncclx/v2_31/src/graph/rings.cc
@@ -48,7 +48,7 @@ ncclResult_t ncclBuildRings(int nrings, int* rings, int rank, int nranks, int* p
     snprintf(prefix, sizeof(prefix), "Channel %02d/%02d :", r, nrings);
     if (rank == 0) dumpLine(rings + r * nranks, nranks, prefix);
     if (current != rank) {
-      WARN("Error : ring %d does not loop back to start (%d != %d)", r, current, rank);
+      ERR(ncclInternalError, "Error : ring %d does not loop back to start (%d != %d)", r, current, rank);
       ret = ncclInternalError;
       goto end;
     }
@@ -61,7 +61,7 @@ ncclResult_t ncclBuildRings(int nrings, int* rings, int rank, int nranks, int* p
         continue;
       }
       if ((bits & mask) == 0) {
-        WARN("Error : ring %d does not contain rank %d", r, i);
+        ERR(ncclInternalError, "Error : ring %d does not contain rank %d", r, i);
         ret = ncclInternalError;
         goto end;
       }

--- a/comms/ncclx/v2_31/src/graph/search.cc
+++ b/comms/ncclx/v2_31/src/graph/search.cc
@@ -71,7 +71,7 @@ static ncclResult_t findRevLink(struct ncclTopoNode* node1, struct ncclTopoNode*
       return ncclSuccess;
     }
   }
-  WARN("Could not find rev link for %d/%ld -> %d/%ld", node1->type, node1->id, node2->type, node2->id);
+  ERR(ncclInternalError, "Could not find rev link for %d/%ld -> %d/%ld", node1->type, node1->id, node2->type, node2->id);
   return ncclInternalError;
 }
 
@@ -133,7 +133,7 @@ static ncclResult_t ncclTopoFollowPath(struct ncclTopoSystem* system, struct ncc
   struct ncclTopoNode* node2 = system->nodes[type2].nodes + index2;
 
   if (node1->paths[type2] == nullptr || node2->paths[type1] == nullptr) {
-    WARN("No path computed to go from %s/%d to %s/%d", topoNodeTypeStr[type1], index1, topoNodeTypeStr[type2], index2);
+    ERR(ncclInternalError, "No path computed to go from %s/%d to %s/%d", topoNodeTypeStr[type1], index1, topoNodeTypeStr[type2], index2);
     return ncclInternalError;
   }
 
@@ -227,7 +227,7 @@ static ncclResult_t getGpuIndex(struct ncclTopoSystem* system, int rank, int* in
       return ncclSuccess;
     }
   }
-  WARN("Could not find gpu rank %d", rank);
+  ERR(ncclInternalError, "Could not find gpu rank %d", rank);
   return ncclInternalError;
 }
 
@@ -238,7 +238,7 @@ static ncclResult_t getNetIndex(struct ncclTopoSystem* system, int64_t id, int* 
       return ncclSuccess;
     }
   }
-  WARN("Could not find net id %lx", id);
+  ERR(ncclInternalError, "Could not find net id %lx", id);
   return ncclInternalError;
 }
 
@@ -947,7 +947,7 @@ ncclResult_t ncclTopoGetChannelFromXml(struct ncclXmlNode* xmlChannel, int c, st
           }
         }
         if (rank == -1) {
-          WARN("XML Import Channel : dev %ld not found.", dev);
+          ERR(ncclSystemError, "XML Import Channel : dev %ld not found.", dev);
           return ncclSystemError;
         }
       }
@@ -1017,7 +1017,7 @@ ncclResult_t ncclTopoGetXmlFromChannel(struct ncclTopoGraph* graph, int c, struc
       }
     }
     if (dev == -1) {
-      WARN("XML Export Channel : rank %d not found.", intra[g]);
+      ERR(ncclInternalError, "XML Export Channel : rank %d not found.", intra[g]);
       return ncclInternalError;
     }
     NCCLCHECK(xmlSetAttrLong(node, "dev", dev));

--- a/comms/ncclx/v2_31/src/graph/topo.cc
+++ b/comms/ncclx/v2_31/src/graph/topo.cc
@@ -103,7 +103,7 @@ ncclResult_t ncclTopoGetNode(struct ncclTopoSystem* system, struct ncclTopoNode*
 
 ncclResult_t ncclTopoCreateNode(struct ncclTopoSystem* system, struct ncclTopoNode** node, int type, uint64_t id) {
   if (system->nodes[type].count == NCCL_TOPO_MAX_NODES) {
-    WARN("Error : tried to create too many nodes of type %d", type);
+    ERR(ncclInternalError, "Error : tried to create too many nodes of type %d", type);
     return ncclInternalError;
   }
   struct ncclTopoNode* n = system->nodes[type].nodes + system->nodes[type].count;
@@ -179,7 +179,7 @@ ncclResult_t ncclTopoConnectNodes(struct ncclTopoNode* node, struct ncclTopoNode
     if (link->remNode == remNode && link->type == type) break;
   }
   if (link - node->links == NCCL_TOPO_MAX_LINKS) {
-    WARN("Error : too many Topo links (max %d)", NCCL_TOPO_MAX_LINKS);
+    ERR(ncclInternalError, "Error : too many Topo links (max %d)", NCCL_TOPO_MAX_LINKS);
     return ncclInternalError;
   }
   if (link->remNode == NULL) node->nlinks++;
@@ -244,7 +244,7 @@ ncclResult_t ncclTopoFlattenBcmSwitches(struct ncclTopoSystem* system) {
           if (remNode == pciSwitch) continue;
           // Add link from parent PCI switch -> PCI device
           if (pciSwitch->nlinks == NCCL_TOPO_MAX_LINKS) {
-            WARN("Error : too many Topo links (max %d)", NCCL_TOPO_MAX_LINKS);
+            ERR(ncclInternalError, "Error : too many Topo links (max %d)", NCCL_TOPO_MAX_LINKS);
             ret = ncclInternalError;
             goto fail;
           }
@@ -919,7 +919,7 @@ ncclResult_t ncclTopoAddPciLinks(struct ncclXmlNode* node, struct ncclTopoSystem
     pBusId = NCCL_TOPO_ID(systemId, pBusId);
     NCCLCHECK(ncclTopoGetNode(system, &pci, PCI, pBusId));
     if (pci == NULL) {
-      WARN("Add PCI Link error : could not find PCI SW %lx", pBusId);
+      ERR(ncclInternalError, "Add PCI Link error : could not find PCI SW %lx", pBusId);
       return ncclInternalError;
     }
     struct ncclTopoNode* remote = NULL;
@@ -1014,7 +1014,7 @@ ncclResult_t ncclTopoGetSystemFromXml(struct ncclXml* xml, struct ncclTopoSystem
   while (systemId < system->nHosts && system->hostHashes[systemId] != localHostHash) systemId++;
   system->systemId = systemId;
   if (systemId == system->nHosts) {
-    WARN("localHostHash = 0x%lx not found in the list of system hostHashes", localHostHash);
+    ERR(ncclInvalidArgument, "localHostHash = 0x%lx not found in the list of system hostHashes", localHostHash);
     return ncclInvalidArgument;
   }
 
@@ -1281,7 +1281,7 @@ ncclResult_t ncclTopoMakeUniqueBusId(struct ncclXml* xml, char* busId, struct nc
     i++;
   }
 
-  WARN("TOPO/NET : Couldn't generate unique busId after %d tries", i);
+  ERR(ncclInternalError, "TOPO/NET : Couldn't generate unique busId after %d tries", i);
   return ncclInternalError;
 }
 
@@ -1312,7 +1312,7 @@ ncclResult_t ncclTopoMakePciParent(struct ncclXml* xml, struct ncclXmlNode** par
   if (newBusId == NULL) {
     const char* name;
     NCCLCHECK(xmlGetAttr(physNetNode, "name", &name));
-    WARN("TOPO/NET : Can't find busId of child 0 %s", name);
+    ERR(ncclInternalError, "TOPO/NET : Can't find busId of child 0 %s", name);
     return ncclInternalError;
   }
 
@@ -1322,7 +1322,7 @@ ncclResult_t ncclTopoMakePciParent(struct ncclXml* xml, struct ncclXmlNode** par
 ncclResult_t ncclTopoMakeVnic(struct ncclXml* xml, struct ncclTopoNetInfo* netInfo, ncclNetVDeviceProps_t* vProps,
                               struct ncclXmlNode** physNetNodes) {
   if (vProps->ndevs > netInfo->maxDevsPerNic) {
-    WARN("TOPO/NET : Tried to merge too many NICs. %d > %d", vProps->ndevs, netInfo->maxDevsPerNic);
+    ERR(ncclInternalError, "TOPO/NET : Tried to merge too many NICs. %d > %d", vProps->ndevs, netInfo->maxDevsPerNic);
     return ncclInternalError;
   }
 
@@ -1378,13 +1378,13 @@ ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* net
     }
 
     if (vProps.ndevs != nUserIfs) {
-      WARN("TOPO/NET : Only matched %d devices, %d requested from %s", vProps.ndevs, nUserIfs, semi);
+      ERR(ncclInvalidUsage, "TOPO/NET : Only matched %d devices, %d requested from %s", vProps.ndevs, nUserIfs, semi);
       ret = ncclInvalidUsage;
       goto fail;
     }
 
     if (vProps.ndevs > netInfo->maxDevsPerNic) {
-      WARN("Specified fused NIC %s which has too many devices (%d). Max %d", semi, vProps.ndevs,
+      ERR(ncclInvalidUsage, "Specified fused NIC %s which has too many devices (%d). Max %d", semi, vProps.ndevs,
            netInfo->maxDevsPerNic);
       ret = ncclInvalidUsage;
       goto fail;
@@ -1397,7 +1397,7 @@ ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* net
         placedDevs[vProps.devs[i]] = 1;
       }
     } else {
-      WARN("TOPO/NET : Could not force merge NICs %s. Please specify a valid NCCL_NET_FORCE_MERGE string.", semi);
+      ERR(ncclInvalidUsage, "TOPO/NET : Could not force merge NICs %s. Please specify a valid NCCL_NET_FORCE_MERGE string.", semi);
       ret = ncclInvalidUsage;
       goto fail;
     }
@@ -1454,7 +1454,7 @@ ncclResult_t ncclTopoAutoMerge(struct ncclXml* xml, struct ncclTopoNetInfo* netI
       }
 
       if (vProps.ndevs > netInfo->maxDevsPerNic) {
-        WARN("TOPO/NET : Tried to merge too many NICs. %d > %d", vProps.ndevs, netInfo->maxDevsPerNic);
+        ERR(ncclInternalError, "TOPO/NET : Tried to merge too many NICs. %d > %d", vProps.ndevs, netInfo->maxDevsPerNic);
         return ncclInternalError;
       }
 
@@ -2009,7 +2009,7 @@ ncclResult_t ncclTopoGetLocal(struct ncclTopoSystem* system, int type, int index
     }
     if (paths[i].bw == maxBw && paths[i].type == minType) {
       if (count == NCCL_TOPO_MAX_NODES) {
-        WARN("Error : ran out of room to store found nodes in ncclTopoGetLocal."
+        ERR(ncclInternalError, "Error : ran out of room to store found nodes in ncclTopoGetLocal."
              " Filled %d of type %d, starting from index %d of type %d.",
              NCCL_TOPO_MAX_NODES, resultType, index, type);
         return ncclInternalError;
@@ -2078,7 +2078,7 @@ ncclResult_t ncclTopoGetNetDevsPolicy(enum netDevsPolicy* policy, int* policyNum
   static std::once_flag onceFlag;
   std::call_once(onceFlag, getNetDevsPolicyOnce);
   if (netDevsPolicy == NETDEVS_POLICY_MAX && netDevsPolicyNum <= 0) {
-    WARN("Invalid number of network devices = %d for policy MAX", netDevsPolicyNum);
+    ERR(ncclInternalError, "Invalid number of network devices = %d for policy MAX", netDevsPolicyNum);
     return ncclInternalError;
   }
   if (policy) *policy = netDevsPolicy;
@@ -2097,7 +2097,7 @@ ncclResult_t ncclTopoGetLocalNetType(struct ncclTopoSystem* system, int type, in
   int localNetCount;
   NCCLCHECK(ncclTopoGetLocal(system, GPU, gpu, type, localNets, &localNetCount, NULL));
   if (localNetCount == 0) {
-    WARN("Could not find any local path from gpu %d to net.", gpu);
+    ERR(ncclInternalError, "Could not find any local path from gpu %d to net.", gpu);
     return ncclInternalError;
   }
 

--- a/comms/ncclx/v2_31/src/graph/xml.cc
+++ b/comms/ncclx/v2_31/src/graph/xml.cc
@@ -37,7 +37,7 @@ struct xmlHandler {
 
 ncclResult_t xmlGetChar(FILE* file, char* c) {
   if (fread(c, 1, 1, file) == 0) {
-    WARN("XML Parse : Unexpected EOF");
+    ERR(ncclInternalError, "XML Parse : Unexpected EOF");
     return ncclInternalError;
   }
   return ncclSuccess;
@@ -53,7 +53,7 @@ ncclResult_t xmlGetValue(FILE* file, char* value, char* last) {
       value[o] = c;
       if (o == MAX_STR_LEN - 1) {
         value[o] = '\0';
-        WARN("Error : value %s too long (max %d)", value, MAX_STR_LEN);
+        ERR(ncclInternalError, "Error : value %s too long (max %d)", value, MAX_STR_LEN);
         return ncclInternalError;
       }
       o++;
@@ -63,7 +63,7 @@ ncclResult_t xmlGetValue(FILE* file, char* value, char* last) {
     *last = c;
     return ncclSuccess;
 #else
-    WARN("XML Parse : Expected (double) quote.");
+    ERR(ncclInternalError, "XML Parse : Expected (double) quote.");
     return ncclInternalError;
 #endif
   }
@@ -74,7 +74,7 @@ ncclResult_t xmlGetValue(FILE* file, char* value, char* last) {
     value[o] = c;
     if (o == MAX_STR_LEN - 1) {
       value[o] = '\0';
-      WARN("Error : value %s too long (max %d)", value, MAX_STR_LEN);
+      ERR(ncclInternalError, "Error : value %s too long (max %d)", value, MAX_STR_LEN);
       return ncclInternalError;
     }
     o++;
@@ -93,7 +93,7 @@ ncclResult_t xmlGetToken(FILE* file, char* name, char* value, char* last) {
     if (c == '=') {
       ptr[o] = '\0';
       if (value == NULL) {
-        WARN("XML Parse : Unexpected value with name %s", ptr);
+        ERR(ncclInternalError, "XML Parse : Unexpected value with name %s", ptr);
         return ncclInternalError;
       }
       return xmlGetValue(file, value, last);
@@ -101,7 +101,7 @@ ncclResult_t xmlGetToken(FILE* file, char* name, char* value, char* last) {
     ptr[o] = c;
     if (o == MAX_STR_LEN - 1) {
       ptr[o] = '\0';
-      WARN("Error : name %s too long (max %d)", ptr, MAX_STR_LEN);
+      ERR(ncclInternalError, "Error : name %s too long (max %d)", ptr, MAX_STR_LEN);
       return ncclInternalError;
     }
     o++;
@@ -131,7 +131,7 @@ ncclResult_t xmlSkipComment(FILE* file, char* start, char next) {
   while (strcmp(end, "-->") != 0) {
     int c;
     if (fread(&c, 1, 1, file) != 1) {
-      WARN("XML Parse error : unterminated comment");
+      ERR(ncclInternalError, "XML Parse error : unterminated comment");
       return ncclInternalError;
     }
     SHIFT_APPEND(end, c);
@@ -146,7 +146,7 @@ ncclResult_t xmlGetNode(FILE* file, struct ncclXmlNode* node) {
     if (fread(&c, 1, 1, file) == 0) return ncclSuccess;
   }
   if (c != '<') {
-    WARN("XML Parse error : expecting '<', got '%c'", c);
+    ERR(ncclInternalError, "XML Parse error : expecting '<', got '%c'", c);
     return ncclInternalError;
   }
   // Read XML element name
@@ -164,7 +164,7 @@ ncclResult_t xmlGetNode(FILE* file, struct ncclXmlNode* node) {
     // Re-read the name, we got '/' in the first call
     NCCLCHECK(xmlGetToken(file, node->name, NULL, &c));
     if (c != '>') {
-      WARN("XML Parse error : unexpected trailing %c in closing tag %s", c, node->name);
+      ERR(ncclInternalError, "XML Parse error : unexpected trailing %c in closing tag %s", c, node->name);
       return ncclInternalError;
     }
     return ncclSuccess;
@@ -188,7 +188,7 @@ ncclResult_t xmlGetNode(FILE* file, struct ncclXmlNode* node) {
     NCCLCHECK(xmlGetToken(file, str, NULL, &c));
   }
   if (c != '>') {
-    WARN("XML Parse : expected >, got '%c'", c);
+    ERR(ncclInternalError, "XML Parse : expected >, got '%c'", c);
     return ncclInternalError;
   }
   return ncclSuccess;
@@ -199,7 +199,7 @@ ncclResult_t xmlLoadSub(FILE* file, struct ncclXml* xml, struct ncclXmlNode* hea
   if (head && head->type == NODE_TYPE_SINGLE) return ncclSuccess;
   while (1) {
     if (xml->maxIndex == xml->maxNodes) {
-      WARN("Error : XML parser is limited to %d nodes", xml->maxNodes);
+      ERR(ncclInternalError, "Error : XML parser is limited to %d nodes", xml->maxNodes);
       return ncclInternalError;
     }
     struct ncclXmlNode* node = xml->nodes + xml->maxIndex;
@@ -207,7 +207,7 @@ ncclResult_t xmlLoadSub(FILE* file, struct ncclXml* xml, struct ncclXmlNode* hea
     NCCLCHECK(xmlGetNode(file, node));
     if (node->type == NODE_TYPE_NONE) {
       if (head) {
-        WARN("XML Parse : unterminated %s", head->name);
+        ERR(ncclInternalError, "XML Parse : unterminated %s", head->name);
         return ncclInternalError;
       } else {
         // All done
@@ -216,7 +216,7 @@ ncclResult_t xmlLoadSub(FILE* file, struct ncclXml* xml, struct ncclXmlNode* hea
     }
     if (head && node->type == NODE_TYPE_CLOSE) {
       if (strcmp(node->name, head->name) != 0) {
-        WARN("XML Mismatch : %s / %s", head->name, node->name);
+        ERR(ncclInternalError, "XML Mismatch : %s / %s", head->name, node->name);
         return ncclInternalError;
       }
       return ncclSuccess;
@@ -226,7 +226,7 @@ ncclResult_t xmlLoadSub(FILE* file, struct ncclXml* xml, struct ncclXmlNode* hea
       if (strcmp(node->name, handlers[h].name) == 0) {
         if (head) {
           if (head->nSubs == MAX_SUBS) {
-            WARN("Error : XML parser is limited to %d subnodes", MAX_SUBS);
+            ERR(ncclInternalError, "Error : XML parser is limited to %d subnodes", MAX_SUBS);
             return ncclInternalError;
           }
           head->subs[head->nSubs++] = node;
@@ -391,7 +391,7 @@ ncclResult_t ncclTopoXmlLoadSystem(FILE* file, struct ncclXml* xml, struct ncclX
   int version;
   NCCLCHECK(xmlGetAttrInt(head, "version", &version));
   if (version != NCCL_TOPO_XML_VERSION) {
-    WARN("XML Topology has wrong version %d, %d needed", version, NCCL_TOPO_XML_VERSION);
+    ERR(ncclInvalidUsage, "XML Topology has wrong version %d, %d needed", version, NCCL_TOPO_XML_VERSION);
     return ncclInvalidUsage;
   }
   const char* name;
@@ -475,7 +475,7 @@ ncclResult_t ncclTopoGetXmlFromCpu(struct ncclXmlNode* cpuNode, struct ncclXml* 
     const char* numaId;
     NCCLCHECK(xmlGetAttr(cpuNode, "numaid", &numaId));
     if (numaId == NULL) {
-      WARN("GetXmlFromCpu : could not find CPU numa ID.");
+      ERR(ncclInternalError, "GetXmlFromCpu : could not find CPU numa ID.");
       return ncclInternalError;
     }
     // Set affinity using OS-specific implementation
@@ -870,7 +870,7 @@ ncclResult_t ncclTopoGetXmlFromSys(struct ncclXmlNode* pciNode, struct ncclXml* 
       }
     }
     if (parent->nSubs == MAX_SUBS) {
-      WARN("Error : XML parser is limited to %d subnodes", MAX_SUBS);
+      ERR(ncclInternalError, "Error : XML parser is limited to %d subnodes", MAX_SUBS);
       ret = ncclInternalError;
       goto exit;
     }
@@ -1232,7 +1232,7 @@ ncclResult_t ncclTopoXmlGraphLoadGraphs(FILE* file, struct ncclXml* xmlGraph, st
   int version;
   NCCLCHECK(xmlGetAttrInt(head, "version", &version));
   if (version != NCCL_GRAPH_XML_VERSION) {
-    WARN("XML Graph has wrong version %d, %d needed", version, NCCL_GRAPH_XML_VERSION);
+    ERR(ncclInvalidUsage, "XML Graph has wrong version %d, %d needed", version, NCCL_GRAPH_XML_VERSION);
     return ncclInvalidUsage;
   }
   const char* name;
@@ -1248,7 +1248,7 @@ ncclResult_t ncclTopoXmlGraphLoadGraphs(FILE* file, struct ncclXml* xmlGraph, st
 ncclResult_t ncclTopoGetXmlGraphFromFile(const char* xmlGraphFile, struct ncclXml* xml) {
   FILE* file = fopen(xmlGraphFile, "r");
   if (file == NULL) {
-    WARN("Could not open XML graph file %s : %s", xmlGraphFile, strerror(errno));
+    ERR(ncclSystemError, "Could not open XML graph file %s : %s", xmlGraphFile, strerror(errno));
     return ncclSystemError;
   }
   struct xmlHandler handlers[] = {{"graphs", ncclTopoXmlGraphLoadGraphs}};

--- a/comms/ncclx/v2_31/src/group.cc
+++ b/comms/ncclx/v2_31/src/group.cc
@@ -23,6 +23,9 @@
 #include <thread>
 #include "os.h"
 
+#include "comms/ctran/Ctran.h"
+#include "meta/wrapper/MetaFactory.h"
+
 #define GROUP_MAX_RECLAIM_STEPS 10
 
 thread_local int ncclGroupDepth = 0; // depth of ncclGroupStart nesting
@@ -1046,6 +1049,8 @@ ncclResult_t ncclGroupEndInternal(ncclSimInfo_t* simInfo) {
   }
 
   if ((--ncclGroupDepth) > 0) goto exit;
+
+  NCCLCHECKGOTO(metaCommToNccl(ctranGroupEndHook()), ret, fail);
 
   if ((ret = ncclGroupError) != ncclSuccess) goto fail;
 

--- a/comms/ncclx/v2_31/src/group.cc
+++ b/comms/ncclx/v2_31/src/group.cc
@@ -59,7 +59,7 @@ ncclResult_t ncclAsyncLaunch(struct ncclAsyncJob* job, ncclResult_t (*func)(stru
       /* first met communicator */
       ncclGroupBlocking = comm->config.blocking;
     } else if (ncclGroupBlocking != comm->config.blocking) {
-      WARN("Blocking and nonblocking communicators are not allowed in the same group.");
+      ERR(ncclInvalidArgument, "Blocking and nonblocking communicators are not allowed in the same group.");
       ret = ncclInvalidArgument;
     }
     if (ret == ncclSuccess) {
@@ -449,7 +449,7 @@ ncclResult_t doLaunches(struct ncclComm* head, int taskType) {
       // We have entered barriers but are aborting without leaving them. Thus
       // these comms are permanently trashed. We need a good mechanism for
       // tracking and reporting that.
-      WARN("Either none or all communicators in a ncclGroup() can be CUDA graph captured.");
+      ERR(ncclInvalidUsage, "Either none or all communicators in a ncclGroup() can be CUDA graph captured.");
       result = ncclInvalidUsage;
       goto failure;
     }
@@ -1033,7 +1033,7 @@ ncclResult_t ncclGroupEndInternal(ncclSimInfo_t* simInfo) {
   internalSimInfo.magic = 0;
 
   if (ncclGroupDepth == 0) {
-    WARN("ncclGroupEnd: not in a group call.");
+    ERR(ncclInvalidUsage, "ncclGroupEnd: not in a group call.");
     ret = ncclInvalidUsage;
     goto exit;
   }
@@ -1054,7 +1054,7 @@ ncclResult_t ncclGroupEndInternal(ncclSimInfo_t* simInfo) {
     realSize = realSize > sizeof(ncclSimInfo_t) ? sizeof(ncclSimInfo_t) : realSize;
     memcpy((void*)&internalSimInfo, (void*)simInfo, realSize);
     if (internalSimInfo.magic != 0x74685283) {
-      WARN("ncclSimInfo_t argument not initialized via NCCL_SIM_INFO_INITIALIZER");
+      ERR(ncclInvalidArgument, "ncclSimInfo_t argument not initialized via NCCL_SIM_INFO_INITIALIZER");
       ret = ncclInvalidArgument;
       goto fail;
     }

--- a/comms/ncclx/v2_31/src/include/checks.h
+++ b/comms/ncclx/v2_31/src/include/checks.h
@@ -10,12 +10,38 @@
 
 #include "debug.h"
 
+constexpr const char* ncclCodeToString(ncclResult_t code) {
+  switch (code) {
+  case ncclSuccess:
+    return "no error";
+  case ncclUnhandledCudaError:
+    return "unhandled cuda error (run with NCCL_DEBUG=INFO for details)";
+  case ncclSystemError:
+    return "unhandled system error (run with NCCL_DEBUG=INFO for details)";
+  case ncclInternalError:
+    return "internal error - please report this issue to the NCCL developers";
+  case ncclInvalidArgument:
+    return "invalid argument (run with NCCL_DEBUG=WARN for details)";
+  case ncclInvalidUsage:
+    return "invalid usage (run with NCCL_DEBUG=WARN for details)";
+  case ncclRemoteError:
+    return "remote process exited or there was a network error";
+  case ncclInProgress:
+    return "NCCL operation in progress";
+  case ncclTimeout:
+    return "NCCL operation timed out";
+  case ncclNumResults:
+  default:
+    return "unknown result code";
+  }
+}
+
 // Check CUDA RT calls
 #define CUDACHECK(cmd) \
   do { \
     cudaError_t err = cmd; \
     if (err != cudaSuccess) { \
-      WARN("Cuda failure '%s'", cudaGetErrorString(err)); \
+      ERR(ncclUnhandledCudaError, "Cuda failure '%s'", cudaGetErrorString(err)); \
       (void)cudaGetLastError(); \
       return ncclUnhandledCudaError; \
     } \
@@ -25,12 +51,34 @@
   do { \
     cudaError_t err = cmd; \
     if (err != cudaSuccess) { \
-      WARN("Cuda failure '%s'", cudaGetErrorString(err)); \
+      ERR(ncclUnhandledCudaError, "Cuda failure '%s'", cudaGetErrorString(err)); \
       (void)cudaGetLastError(); \
       RES = ncclUnhandledCudaError; \
       goto label; \
     } \
   } while (false)
+
+// Use of abort should be aware of potential memory leak risk
+// and place a signal handler to catch it and trigger termination processing
+#define CUDACHECKABORT(cmd) \
+  do { \
+    cudaError_t err = cmd; \
+    if (err != cudaSuccess) { \
+      ERR(ncclUnhandledCudaError, "Cuda failure '%s'", cudaGetErrorString(err)); \
+      abort(); \
+    } \
+  } while (false)
+
+// fmt is required: WARN expands to a printf-format function, so an
+// argument-less CHECKABORT would expand to a format-less WARN.
+#define CHECKABORT(statement, fmt, ...) \
+  do { \
+    if (!(statement)) { \
+      WARN("Check failed: %s", #statement); \
+      WARN(fmt, ##__VA_ARGS__); \
+      abort(); \
+    } \
+  } while (0)
 
 // Report failure but clear error and continue
 #define CUDACHECKIGNORE(cmd) \
@@ -60,7 +108,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
     int retval; \
     SYSCHECKSYNC((statement), name, retval); \
     if (retval == -1) { \
-      WARN("Call to " name " failed: %s", strerror(errno)); \
+      ERR(ncclSystemError, "Call to " name " failed: %s", strerror(errno)); \
       return ncclSystemError; \
     } \
   } while (false)
@@ -80,7 +128,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
     int retval; \
     SYSCHECKSYNC((statement), name, retval); \
     if (retval == -1) { \
-      WARN("Call to " name " failed: %s", strerror(errno)); \
+      ERR(ncclSystemError, "Call to " name " failed: %s", strerror(errno)); \
       RES = ncclSystemError; \
       goto label; \
     } \
@@ -91,7 +139,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   do { \
     int retval = (statement); \
     if (retval != 0) { \
-      WARN("Call to " name " failed: %s", strerror(retval)); \
+      ERR(ncclSystemError, "Call to " name " failed: %s", strerror(retval)); \
       return ncclSystemError; \
     } \
   } while (0)
@@ -100,7 +148,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   do { \
     int retval = (statement); \
     if (retval != 0) { \
-      WARN("Call to " name " failed: %s", strerror(retval)); \
+      ERR(ncclSystemError, "Call to " name " failed: %s", strerror(retval)); \
       RES = ncclSystemError; \
       goto label; \
     } \
@@ -110,7 +158,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   do { \
     if ((statement) != value) { \
       /* Print the back trace*/ \
-      INFO_LOC(NCCL_ALL, "-> %d (%s)", ncclSystemError, strerror(errno)); \
+      ERR(ncclSystemError, "-> %d (%s)", ncclSystemError, strerror(errno)); \
       return ncclSystemError; \
     } \
   } while (0)
@@ -120,7 +168,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
     if ((statement) != value) { \
       /* Print the back trace*/ \
       RES = ncclSystemError; \
-      INFO_LOC(NCCL_ALL, "-> %d (%s)", RES, strerror(errno)); \
+      ERR(ncclSystemError, "-> %d (%s)", RES, strerror(errno)); \
       goto label; \
     } \
   } while (0)
@@ -129,7 +177,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   do { \
     if ((statement) == value) { \
       /* Print the back trace*/ \
-      INFO_LOC(NCCL_ALL, "-> %d (%s)", ncclSystemError, strerror(errno)); \
+      ERR(ncclSystemError, "-> %d (%s)", ncclSystemError, strerror(errno)); \
       return ncclSystemError; \
     } \
   } while (0)
@@ -139,7 +187,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
     if ((statement) == value) { \
       /* Print the back trace*/ \
       RES = ncclSystemError; \
-      INFO_LOC(NCCL_ALL, "-> %d (%s)", RES, strerror(errno)); \
+      ERR(ncclSystemError, "-> %d (%s)", RES, strerror(errno)); \
       goto label; \
     } \
   } while (0)
@@ -150,7 +198,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
     ncclResult_t RES = call; \
     if (RES != ncclSuccess && RES != ncclInProgress) { \
       /* Print the back trace*/ \
-      if (ncclDebugNoWarn == 0) INFO_LOC(NCCL_ALL, "-> %d", RES); \
+      if (ncclDebugNoWarn == 0) WARN("-> %d", RES); \
       return RES; \
     } \
   } while (0)
@@ -160,7 +208,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
     RES = call; \
     if (RES != ncclSuccess && RES != ncclInProgress) { \
       /* Print the back trace*/ \
-      if (ncclDebugNoWarn == 0) INFO_LOC(NCCL_ALL, "-> %d", RES); \
+      if (ncclDebugNoWarn == 0) WARN("-> %d", RES); \
       goto label; \
     } \
   } while (0)
@@ -171,7 +219,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   do { \
     ncclResult_t TMPRES = call; \
     if (TMPRES != ncclSuccess && TMPRES != ncclInProgress) { \
-      if (ncclDebugNoWarn == 0) INFO_LOC(NCCL_ALL, "-> %d", TMPRES); \
+      if (ncclDebugNoWarn == 0) WARN("-> %d (%s)", TMPRES, ncclCodeToString(TMPRES)); \
       if (RES == ncclSuccess) RES = TMPRES; \
     } \
   } while (0)
@@ -198,7 +246,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
     uint32_t* tmpAbortFlag = (abortFlagPtr); \
     ncclResult_t RES = call; \
     if (RES != ncclSuccess && RES != ncclInProgress) { \
-      if (ncclDebugNoWarn == 0) INFO_LOC(NCCL_ALL, "-> %d", RES); \
+      if (ncclDebugNoWarn == 0) WARN("-> %d", RES); \
       return ncclInternalError; \
     } \
     if (COMPILER_ATOMIC_LOAD(tmpAbortFlag, std::memory_order_acquire)) NEQCHECK(*tmpAbortFlag, 0); \
@@ -209,7 +257,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
     uint32_t* tmpAbortFlag = (abortFlagPtr); \
     RES = call; \
     if (RES != ncclSuccess && RES != ncclInProgress) { \
-      if (ncclDebugNoWarn == 0) INFO_LOC(NCCL_ALL, "-> %d", RES); \
+      if (ncclDebugNoWarn == 0) WARN("-> %d", RES); \
       goto label; \
     } \
     if (COMPILER_ATOMIC_LOAD(tmpAbortFlag, std::memory_order_acquire)) NEQCHECKGOTO(*tmpAbortFlag, 0, RES, label); \
@@ -218,7 +266,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
 #define NCCLCHECKTHREAD(a, args) \
   do { \
     if (((args)->ret = (a)) != ncclSuccess && (args)->ret != ncclInProgress) { \
-      INFO_LOC(NCCL_INIT, "-> %d [Async thread]", (args)->ret); \
+      WARN("-> %d [Async thread]", (args)->ret); \
       return args; \
     } \
   } while (0)
@@ -227,7 +275,7 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   do { \
     cudaError_t err = (a); \
     if (err != cudaSuccess) { \
-      INFO_LOC(NCCL_INIT, "-> %d [Async thread]", (int)(err)); \
+      ERR(ncclUnhandledCudaError, "Cuda failure '%s' [Async thread]", cudaGetErrorString(err)); \
       args->ret = ncclUnhandledCudaError; \
       return args; \
     } \

--- a/comms/ncclx/v2_31/src/include/comm.h
+++ b/comms/ncclx/v2_31/src/include/comm.h
@@ -36,6 +36,28 @@
 #include "gin/gin_host_win_stub.h"
 #endif
 
+// [META] NCCLX state on ncclComm and its dependencies.
+#include <optional>
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/utils/colltrace/AlgoStats.h"
+#include "comms/utils/colltrace/CollTraceInterface.h"
+#include "comms/ctran/memory/SlabAllocator.h"
+#include "comms/ctran/memory/memCacheAllocator.h"
+#include "comms/utils/commSpecs.h"
+
+// Forward declarations of ncclx classes to avoid circular dependencies
+class ICtran;
+namespace meta::comms {
+class IBootstrap;
+} // namespace meta::comms
+namespace ncclx {
+class CommStateX;
+} // namespace ncclx
+namespace ncclx::transport {
+class TransportProxy;
+} // namespace ncclx::transport
+
 #if CUDART_VERSION < 9000
 struct cudaLaunchParams {
   void* func;
@@ -391,6 +413,14 @@ struct ncclKernelPlan {
   void* groupApiEventHandle;
   void* kernelLaunchEventHandle;
   void* groupEventHandle;
+
+  // [META] Pointer of a hashmap to store the connection information of peers;
+  // the usage is in transportConnect.cc
+  std::shared_ptr<void> peerReconnInfoMap{nullptr};
+  // buffer keys used in plan, used to reserve and release buffers
+  std::vector<std::string> bufKeys;
+  // pointer to be used to synchronize with the kernel for the current plan
+  uint64_t* channelsReadyPtr{nullptr};
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -539,6 +569,10 @@ struct ncclKernelPlanner {
   struct ncclIntruQueue<struct ncclKernelPlan, &ncclKernelPlan::next> planQueue;
   // First of the unlaunched kernels in `planQueue`
   struct ncclKernelPlan* unlaunchedPlansHead;
+  // [META] track number of channels that need to be initialized in current plan
+  int nMaxChannelsNeedInit{0};
+  // [META] track number of channels each algorithm needs to connect in current plan
+  std::array<int, NCCL_NUM_ALGORITHMS> algoMaxChannelsNeedConnect{0};
 };
 
 #define NCCL_MAGIC 0x0280028002800280 // Nickel atomic number is 28.
@@ -603,6 +637,21 @@ struct ncclComm {
   bool runtimeConn; // if dynamic connection is supported
   bool directMode; // if any process manages more than one local rank
   int cuMemSupport;
+
+  // [META] NCCLX supports storing channel metadata on the pinned host memory.
+  // See the description of NCCL_CHANNEL_METADATA_LOCATION for details
+  bool channelMetadataOnHost{false};
+  // if channels can/will be setup lazily for this communicator
+  bool lazySetupChannels{false};
+  // number of channels that are initialized and ready for use
+  int nChannelsReady{0};
+  // number of channels that are connected for each algorithm
+  std::array<int, NCCL_NUM_ALGORITHMS> algoConnectedChannels{0};
+  // metadata to be used for initializing channels lazily if enabled
+  std::optional<struct ncclKernelCommAndChannels*> devCommAndChans{std::nullopt};
+  std::optional<std::vector<int>> rings{std::nullopt};
+  // Slab Allocator for baseline initChannel metadata allocation
+  std::unique_ptr<ncclx::memory::SlabAllocator> slabAllocator{nullptr};
 
   uint64_t magic; // Magic number for all network communication. Not a security key -- only goal is to detect
                   // mismatches.
@@ -834,6 +883,29 @@ struct ncclComm {
 
   struct ncclDevrState devrState; // The symmetric runtime state
   struct ncclSymkState symkState; // The symmetric kernels state (built on previous)
+  int* rackSerials{nullptr};
+
+  /**
+   * NCCLX specific state
+   */
+  struct CommLogData logMetaData;
+  std::shared_ptr<meta::comms::colltrace::ICollTrace> newCollTrace;
+  std::shared_ptr<meta::comms::colltrace::AlgoStats> algoStats;
+  std::shared_ptr<meta::comms::IBootstrap> ctranBootstrap;
+  std::shared_ptr<ncclx::memory::memCacheAllocator> memCache{nullptr};
+  std::vector<std::string> connSetupBufKeys;
+  std::shared_ptr<ncclx::transport::TransportProxy> transportProxy_;
+
+  // This is the only bridge between ctran and baseline code
+  bool useCtran_{false}; // Ctran per-communicator control; set at init entry functions
+  std::unique_ptr<CtranComm> ctranComm_;
+
+  // [META:PAT_AVG] per-communicator control; set at init entry functions
+  // When enabled, forces PAT algorithm with ncclDevPatSumPostDiv for ReduceScatter with ncclAvg
+  bool usePatAvg_{false};
+
+  // Disable local transports (P2P and SHM); forces NET for all connections
+  bool noLocal_{false};
 
   struct ncclMemManager* memManager;  // Memory manager
   struct ncclIntruQueue<struct ncclMemManagerTask, &ncclMemManagerTask::next> suspendTaskQueue;
@@ -842,9 +914,13 @@ struct ncclComm {
   uint64_t endMagic;
 };
 
-static_assert(offsetof(struct ncclComm, startMagic) == 0, "startMagic must be the first field of ncclComm");
-static_assert(offsetof(struct ncclComm, endMagic) == sizeof(struct ncclComm) - sizeof(uint64_t),
-              "endMagic must be the last field of ncclComm");
+// [META] ncclComm now holds std::shared_ptr / std::unique_ptr / std::optional
+// members, so it is no longer standard-layout and offsetof() on it is not
+// portable. The invariant still holds by construction: startMagic is the first
+// declared field and endMagic the last.
+// static_assert(offsetof(struct ncclComm, startMagic) == 0, "startMagic must be the first field of ncclComm");
+// static_assert(offsetof(struct ncclComm, endMagic) == sizeof(struct ncclComm) - sizeof(uint64_t),
+//               "endMagic must be the last field of ncclComm");
 
 enum ncclLaunchMode {
   ncclLaunchModeInvalid = 0,
@@ -953,6 +1029,28 @@ static inline ncclRedOp_t ncclUserRedOpMangle(ncclComm* comm, ncclRedOp_t op) {
 
 ncclResult_t ncclCommEnsureReady(ncclComm_t comm);
 ncclResult_t ncclCommSetAsyncError(ncclComm_t comm, ncclResult_t nextState);
+
+// [META] record how many interNode/intraNode connections are made in one
+// ncclTransportP2pConnect call
+struct connectionSummary {
+  int intraSend = 0;
+  int intraRecv = 0;
+  int interSend = 0;
+  int interRecv = 0;
+
+  std::string toString() {
+    std::ostringstream oss;
+    oss << "intraSends: " << intraSend << " intraRecvs: " << intraRecv << " interSends: " << interSend
+        << " interRecvs: " << interRecv;
+    return oss.str();
+  }
+};
+
+// [META] Check whether we should skip NCCL internal resource destroy (i.e.,
+// ncclCommAbort has been called with COMM_ABORT_SCOPE == none or job). This
+// allows any destructors automatically triggered by process termination to
+// skip resource cleanup and leak check.
+bool skipDestroy();
 
 // Process-wide NCCL_CTA_POLICY env override, or NCCL_CONFIG_UNDEF_INT when unset/invalid.
 int ncclGetEnvCtaPolicy();

--- a/comms/ncclx/v2_31/src/include/debug.h
+++ b/comms/ncclx/v2_31/src/include/debug.h
@@ -11,6 +11,7 @@
 #include "nccl.h"
 #include "nccl_common.h"
 #include <stdio.h>
+#include <string_view>
 #include <thread>
 #include "compiler.h"
 
@@ -43,12 +44,30 @@ void ncclDebugLogInternal(ncclDebugLogLevel level, unsigned long flags, const ch
                           const char* fmt, ...);
 #endif
 
+/* Same signature and behaviour as ncclDebugLogInternal, kept as a separate
+ * symbol because the shared (version-independent) Meta code under
+ * comms/ncclx/meta/ links against this name across v2_29/v2_30/v2_31.
+ */
+void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char* file, const char* func, int line,
+                      const char* fmt, ...) __attribute__((format(printf, 6, 7)));
+
+/* Root-cause error log. Carries the ncclResult_t, so it can write the Scuba
+ * error record and set ncclGetLastError() state at the origin site rather than
+ * at every propagating check-macro layer. Defined in
+ * comms/ncclx/meta/logger/DebugExt.cc.
+ */
+void ncclMetaDebugLogError(ncclResult_t code, unsigned long flags, const char* file, const char* func, int line,
+                           const char* fmt, ...) __attribute__((format(printf, 6, 7)));
+
+void ncclSetMyThreadLoggingName(std::string_view name);
+
 // Let code temporarily downgrade WARN into INFO
 extern thread_local int ncclDebugNoWarn;
 extern char ncclLastError[];
 
-#define VERSION(...) ncclDebugLogInternal(NCCL_LOG_VERSION, NCCL_ALL, nullptr, nullptr, 0, __VA_ARGS__)
+#define VERSION(...) ncclDebugLogInternal(NCCL_LOG_VERSION, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
 #define WARN(...) ncclDebugLogInternal(NCCL_LOG_WARN, NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define ERR(code, ...) ncclMetaDebugLogError((code), NCCL_ALL, __FILE__, __func__, __LINE__, __VA_ARGS__)
 
 #define NOWARN(EXPR, FLAGS) \
   do { \
@@ -62,7 +81,7 @@ extern char ncclLastError[];
   do { \
     int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
     if ((level >= NCCL_LOG_INFO && ((FLAGS) & ncclDebugMask)) || (level < 0)) \
-      ncclDebugLogInternal(NCCL_LOG_INFO, (FLAGS), nullptr, nullptr, 0, __VA_ARGS__); \
+      ncclDebugLogInternal(NCCL_LOG_INFO, (FLAGS), __FILE__, __func__, __LINE__, __VA_ARGS__); \
   } while (0)
 
 #define INFO_LOC_FN(FLAGS, file, line, fn, fmt, ...) \
@@ -73,7 +92,7 @@ extern char ncclLastError[];
   do { \
     int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
     if ((level >= NCCL_LOG_TRACE && (NCCL_CALL & ncclDebugMask)) || (level < 0)) { \
-      ncclDebugLogInternal(NCCL_LOG_TRACE, NCCL_CALL, nullptr, __func__, __LINE__, __VA_ARGS__); \
+      ncclDebugLogInternal(NCCL_LOG_TRACE, NCCL_CALL, __FILE__, __func__, __LINE__, __VA_ARGS__); \
     } \
   } while (0)
 
@@ -82,7 +101,7 @@ extern char ncclLastError[];
   do { \
     int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
     if ((level >= NCCL_LOG_TRACE && ((FLAGS) & ncclDebugMask)) || (level < 0)) { \
-      ncclDebugLogInternal(NCCL_LOG_TRACE, (FLAGS), nullptr, __func__, __LINE__, __VA_ARGS__); \
+      ncclDebugLogInternal(NCCL_LOG_TRACE, (FLAGS), __FILE__, __func__, __LINE__, __VA_ARGS__); \
     } \
   } while (0)
 #define TRACE_LOC_FN(FLAGS, file, line, fn, fmt, ...) \
@@ -93,6 +112,19 @@ extern char ncclLastError[];
 #define TRACE_LOC_FN(FLAGS, file, line, fn, fmt, ...)
 #define TRACE_LOC(FLAGS, fmt, ...)
 #endif
+
+#define NCCL_NAMED_THREAD_START(threadName) \
+  do { \
+    ncclSetMyThreadLoggingName(threadName); \
+    INFO(NCCL_INIT, "[NCCL THREAD] Starting %s thread at %s", threadName, __func__); \
+  } while (0)
+
+#define NCCL_NAMED_THREAD_START_EXT(threadName, rank, commHash, commDesc) \
+  do { \
+    ncclSetMyThreadLoggingName(threadName); \
+    INFO(NCCL_INIT, "[NCCL THREAD] Starting %s thread for rank %d commHash %lx commDesc %s at %s", threadName, rank, \
+         commHash, commDesc.c_str(), __func__); \
+  } while (0)
 
 void ncclSetThreadName(std::thread& thread, const char* fmt, ...);
 #ifdef __cplusplus

--- a/comms/ncclx/v2_31/src/include/nccl_common.h
+++ b/comms/ncclx/v2_31/src/include/nccl_common.h
@@ -27,10 +27,11 @@ typedef SSIZE_T ssize_t;
 typedef enum {
   NCCL_LOG_NONE = 0,
   NCCL_LOG_VERSION = 1,
-  NCCL_LOG_WARN = 2,
-  NCCL_LOG_INFO = 3,
-  NCCL_LOG_ABORT = 4,
-  NCCL_LOG_TRACE = 5
+  NCCL_LOG_ERROR = 2,
+  NCCL_LOG_WARN = 3,
+  NCCL_LOG_INFO = 4,
+  NCCL_LOG_ABORT = 5,
+  NCCL_LOG_TRACE = 6
 } ncclDebugLogLevel;
 
 typedef enum {

--- a/comms/ncclx/v2_31/src/include/param.h
+++ b/comms/ncclx/v2_31/src/include/param.h
@@ -30,4 +30,6 @@ int64_t ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, i
     return cache; \
   }
 
+void initNcclLogger();
+
 #endif

--- a/comms/ncclx/v2_31/src/include/transport.h
+++ b/comms/ncclx/v2_31/src/include/transport.h
@@ -20,6 +20,8 @@
 #define TRANSPORT_NET 2
 #define TRANSPORT_COLLNET 3
 
+constexpr auto kMaxRackSerialLen = 63; // [META] for DeviceRackSerial string support
+
 #include "proxy.h"
 #include "comm.h"
 #include "bootstrap.h"
@@ -62,6 +64,7 @@ struct ncclPeerInfo {
   bool rmaPluginAvailable;
   bool cuMemGdrSupport;
   int mloPart; // MLOPart partition index, or -1 if not an MLOPart GPU
+  char rackSerial[kMaxRackSerialLen + 1]; // [META] string-based rack serial
 };
 
 #define CONNECT_SIZE 256

--- a/comms/ncclx/v2_31/src/init.cc
+++ b/comms/ncclx/v2_31/src/init.cc
@@ -6,6 +6,7 @@
  *************************************************************************/
 
 #include "nccl.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "channel.h"
 #include "nvmlwrap.h"
 #include "gdrwrap.h"
@@ -284,6 +285,14 @@ void ncclCommPushCudaGdrFree(struct ncclComm* comm, void* handle) {
   comm->destructorHead = dtor;
 }
 
+// [META:PER_COMM_CONFIG] Release the canonical ncclx::Config owned by the comm.
+static void ncclxCommFree(ncclComm_t comm) {
+  if (comm->config.ncclxConfig != nullptr) {
+    delete static_cast<ncclx::Config*>(comm->config.ncclxConfig);
+    comm->config.ncclxConfig = nullptr;
+  }
+}
+
 static ncclResult_t commFree(ncclComm_t comm) {
   int abort = 0;
   /* commFree() should not involve any sync among ranks. */
@@ -388,6 +397,7 @@ static ncclResult_t commFree(ncclComm_t comm) {
   free(comm->topParentRanks);
   free(comm->topParentLocalRanks);
   free(comm->gproxyConn);
+  ncclxCommFree(comm);
 
   NCCLCHECK(ncclRegCleanup(comm));
 
@@ -2377,8 +2387,25 @@ static ncclResult_t envConfigOverride(ncclComm_t comm) {
   return ret;
 }
 
+// [META:PER_COMM_CONFIG] ncclConfig_t carries an owning pointer to an
+// ncclx::Config, so a bytewise copy would leave parent and child sharing one
+// object and double-free it. Clone it instead.
+static void deepCopyCommConfig(ncclConfig_t* dst, const ncclConfig_t* src) {
+  *dst = *src;
+  // parseCommConfig copies individual fields to comm->config but never sets
+  // size, magic, or version, so they remain 0 from the original ncclCalloc.
+  // Restore them here so the copied config passes parseCommConfig's magic
+  // validation in the child comm.
+  dst->size = sizeof(ncclConfig_t);
+  dst->magic = NCCL_API_MAGIC;
+  dst->version = NCCL_VERSION(NCCL_MAJOR, NCCL_MINOR, NCCL_PATCH);
+  if (src->ncclxConfig) {
+    dst->ncclxConfig = new ncclx::Config(*static_cast<ncclx::Config*>(src->ncclxConfig));
+  }
+}
+
 static ncclResult_t copyCommConfig(ncclComm_t childComm, ncclComm_t parnet) {
-  memcpy(&childComm->config, &parnet->config, sizeof(ncclConfig_t));
+  deepCopyCommConfig(&childComm->config, &parnet->config);
   NCCLCHECK(envConfigOverride(childComm));
   return ncclSuccess;
 }
@@ -2631,6 +2658,9 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t* config) {
   comm->config.numRmaSig = internalConfigPtr->numRmaSig;
   comm->config.rmaEagerInit = internalConfigPtr->rmaEagerInit;
   comm->config.hostCftMode = internalConfigPtr->hostCftMode;
+  // [META:PER_COMM_CONFIG] Hand the parsed ncclx::Config to the comm. Ownership
+  // transfers here: ncclxCommFree() deletes it in commFree().
+  comm->config.ncclxConfig = internalConfigPtr->ncclxConfig;
   NCCLCHECKGOTO(envConfigOverride(comm), ret, fail);
 
   // Resolve to system default (serialize) if neither user config nor env var set it.
@@ -2765,6 +2795,7 @@ ncclResult_t ncclCommInitRank(ncclComm_t* newcomm, int nranks, ncclUniqueId comm
 
   int cudaDev;
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  NCCLCHECK(ncclxParseCommConfig(&config)); // [META:PER_COMM_CONFIG]
   CUDACHECK(cudaGetDevice(&cudaDev));
 
   NCCLCHECK(ncclGroupStartInternal());
@@ -2833,6 +2864,13 @@ ncclResult_t ncclCommInitAll(ncclComm_t* comms, int ndev, const int* devlist) {
     // Ignore return codes .. we need to call ncclGroupEnd to clean up anyway
     int dev = devlist ? devlist[i] : i;
     CUDACHECKGOTO(cudaSetDevice(dev), ret, fail);
+    // [META:PER_COMM_CONFIG] Parse per iteration, not once outside the loop.
+    // parseCommConfig transfers ownership of the ncclx::Config to the comm and
+    // ncclxCommFree() deletes it, so a single parsed config shared across ndev
+    // comms would be freed ndev times. (v2_30 parses once outside the loop and
+    // has that double free.)
+    config = NCCL_CONFIG_INITIALIZER;
+    NCCLCHECKGOTO(ncclxParseCommConfig(&config), ret, fail);
     ncclCommInitRankDev(comms + i, ndev, 1, &uniqueId, i, dev, &config, __func__);
   }
   NCCLCHECKGOTO(ncclGroupEndInternal(), ret, fail);
@@ -2874,8 +2912,14 @@ ncclResult_t ncclCommInitRankConfig(ncclComm_t* newcomm, int nranks, ncclUniqueI
   (void)ncclCudaLibraryInit();
   CUDACHECK(cudaGetDevice(&cudaDev));
 
-  if (config == NULL) internalConfigPtr = &internalConfig;
-  else internalConfigPtr = config;
+  // [META:PER_COMM_CONFIG] Always go through the local copy so the parsed
+  // ncclx::Config is not written into the caller's struct.
+  if (config != NULL) {
+    internalConfig = *config;
+    internalConfig.ncclxConfig = NCCL_CONFIG_UNDEF_PTR;
+  }
+  NCCLCHECKGOTO(ncclxParseCommConfig(&internalConfig), ret, fail);
+  internalConfigPtr = &internalConfig;
   NCCLCHECKGOTO(ncclCommInitRankDev(newcomm, nranks, 1, &commId, myrank, cudaDev, internalConfigPtr, __func__), ret,
                 fail);
 
@@ -2911,8 +2955,14 @@ ncclResult_t ncclCommInitRankScalable(ncclComm_t* newcomm, int nranks, int myran
   (void)ncclCudaLibraryInit();
   CUDACHECK(cudaGetDevice(&cudaDev));
 
-  if (config == NULL) internalConfigPtr = &internalConfig;
-  else internalConfigPtr = config;
+  // [META:PER_COMM_CONFIG] Always go through the local copy so the parsed
+  // ncclx::Config is not written into the caller's struct.
+  if (config != NULL) {
+    internalConfig = *config;
+    internalConfig.ncclxConfig = NCCL_CONFIG_UNDEF_PTR;
+  }
+  NCCLCHECKGOTO(ncclxParseCommConfig(&internalConfig), ret, fail);
+  internalConfigPtr = &internalConfig;
   NCCLCHECKGOTO(ncclCommInitRankDev(newcomm, nranks, nId, commId, myrank, cudaDev, internalConfigPtr, __func__), ret,
                 fail);
 
@@ -3353,6 +3403,9 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
   struct ncclCommInitRankAsyncJob* job = NULL;
   struct ncclComm* childComm = NCCL_COMM_NULL;
   ncclResult_t res = ncclSuccess;
+  // [META:PER_COMM_CONFIG] Declared here rather than at the use site so the
+  // gotos below do not jump over its initialization.
+  ncclConfig_t childInternalConfig;
 
   int oldDev;
   CUDACHECK(cudaGetDevice(&oldDev));
@@ -3405,9 +3458,17 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
       *childComm->abortFlagRefCount = 1;
     }
     if (config == NULL) {
+      // copyCommConfig deep-copies, so the child inherits the parent's
+      // ncclx::Config (allgatherAlgo and friends) with its own copy.
       NCCLCHECKGOTO(copyCommConfig(childComm, comm), res, fail);
     } else {
-      NCCLCHECKGOTO(parseCommConfig(childComm, config), res, fail);
+      // [META:PER_COMM_CONFIG] Parse into a local copy: ncclxParseCommConfig
+      // allocates an ncclx::Config and stores the pointer in the struct it is
+      // given, and the caller's config is not ours to mutate or own.
+      childInternalConfig = *config;
+      childInternalConfig.ncclxConfig = NCCL_CONFIG_UNDEF_PTR;
+      NCCLCHECKGOTO(ncclxParseCommConfig(&childInternalConfig), res, fail);
+      NCCLCHECKGOTO(parseCommConfig(childComm, &childInternalConfig), res, fail);
     }
 
     /* start with ncclInternalError and will be changed to ncclSuccess if init succeeds. */
@@ -3524,6 +3585,9 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
   struct ncclCommInitRankAsyncJob* job = NULL;
   ncclComm_t newComm = NULL;
   struct ncclBootstrapHandle recvHandle;
+  // [META:PER_COMM_CONFIG] Declared up here so the gotos below do not jump over
+  // its initialization.
+  ncclConfig_t growInternalConfig;
 
   *newcomm = NULL; // Initialize output parameter early in case of early errors
 
@@ -3601,9 +3665,19 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
 
   // Configure the new communicator
   if (isExistingRank && config == NULL) {
+    // Deep copy, so the grown comm gets its own ncclx::Config.
     NCCLCHECKGOTO(copyCommConfig(newComm, comm), res, fail);
   } else {
-    NCCLCHECKGOTO(parseCommConfig(newComm, config), res, fail);
+    // [META:PER_COMM_CONFIG] New ranks without a config start from defaults;
+    // either way parse into a local copy rather than the caller's struct.
+    if (config != NULL) {
+      growInternalConfig = *config;
+    } else {
+      growInternalConfig = NCCL_CONFIG_INITIALIZER;
+    }
+    growInternalConfig.ncclxConfig = NCCL_CONFIG_UNDEF_PTR;
+    NCCLCHECKGOTO(ncclxParseCommConfig(&growInternalConfig), res, fail);
+    NCCLCHECKGOTO(parseCommConfig(newComm, &growInternalConfig), res, fail);
   }
 
   newComm->initState = ncclInProgress;

--- a/comms/ncclx/v2_31/src/init.cc
+++ b/comms/ncclx/v2_31/src/init.cc
@@ -9,6 +9,8 @@
 #include "meta/NcclxConfig.h" // @manual
 #include "meta/NcclxPerCommConfig.h" // @manual
 #include "meta/DeviceRackSerial.h" // @manual
+#include "meta/transport/transportExt.h" // @manual
+#include "comms/ctran/memory/SlabAllocator.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "channel.h"
 #include "nvmlwrap.h"
@@ -50,6 +52,7 @@
 #include "meta/wrapper/MetaFactory.h"
 
 #include <cinttypes>
+#include <memory>
 #include <string>
 
 #define STR2(v) #v
@@ -371,7 +374,13 @@ static ncclResult_t commFree(ncclComm_t comm) {
       NCCLCHECK(ncclGinFinalize(comm));
       for (int c = 0; c < MAXCHANNELS; c++) {
         if (comm->sharedRes->peers[c]) free(comm->sharedRes->peers[c]);
-        if (comm->sharedRes->devPeers[c]) ncclCudaFree(comm->sharedRes->devPeers[c], comm->memManager);
+        if (comm->sharedRes->devPeers[c]) {
+          if (comm->channelMetadataOnHost) {
+            ncclCudaHostFree(comm->sharedRes->devPeers[c]);
+          } else if (!comm->slabAllocator) {
+            ncclCudaFree(comm->sharedRes->devPeers[c], comm->memManager);
+          }
+        }
       }
       free(comm->sharedRes->tpRankToLocalRank);
       NCCLCHECK(ncclStrongStreamDestruct(&comm->sharedRes->hostStream));
@@ -2069,6 +2078,13 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   comm->logMetaData.commDesc = NCCLX_CONFIG_FIELD(comm->config, commDesc);
   comm->logMetaData.rank = comm->rank;
   comm->logMetaData.nRanks = comm->nRanks;
+
+  // [META:MEMCACHE_SLAB] Select channel metadata allocation before initChannel runs.
+  if (NCCL_MEM_USE_SLAB_ALLOCATOR) {
+    comm->slabAllocator = std::make_unique<ncclx::memory::SlabAllocator>();
+  }
+  comm->channelMetadataOnHost =
+      ncclx::getChannelMetadataLoc() == NCCL_CHANNEL_METADATA_LOCATION::host;
 
   NCCLCHECKGOTO(initTransportsRank(comm, job->parent, timers), res, fail);
 

--- a/comms/ncclx/v2_31/src/init.cc
+++ b/comms/ncclx/v2_31/src/init.cc
@@ -450,7 +450,7 @@ ncclResult_t ncclCommEnsureReady(ncclComm_t comm) {
   } else {
     NCCLCHECK(ncclCommGetAsyncError(comm, &ret));
     if (ret == ncclInProgress) {
-      WARN("Attempt to use communicator before the previous operation returned ncclSuccess");
+      ERR(ncclInvalidArgument, "Attempt to use communicator before the previous operation returned ncclSuccess");
       ret = ncclInvalidArgument;
       goto exit;
     }
@@ -463,11 +463,11 @@ exit:
 
 static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, int ndev, int rank) {
   if (ndev < 1) {
-    WARN("invalid device count (%d) requested", ndev);
+    ERR(ncclInvalidArgument, "invalid device count (%d) requested", ndev);
     return ncclInvalidArgument;
   }
   if (rank >= ndev || rank < 0) {
-    WARN("rank %d exceeds ndev=%d", rank, ndev);
+    ERR(ncclInvalidArgument, "rank %d exceeds ndev=%d", rank, ndev);
     return ncclInvalidArgument;
   }
 
@@ -509,7 +509,7 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
 
   if (parent && parent->shareResources) {
     if (parent->ncclNet != comm->ncclNet) {
-      WARN("Split shares resources, but parent comm netName %s is different from child comm netName %s",
+      ERR(ncclInvalidUsage, "Split shares resources, but parent comm netName %s is different from child comm netName %s",
            parent->ncclNet->name, comm->ncclNet->name);
       return ncclInvalidUsage;
     }
@@ -959,7 +959,7 @@ static ncclResult_t ncclP2pSchedule(struct ncclComm* comm) {
   int groupCount = 0;
   for (int n = 0; n < comm->nNodes; ++n) {
     if (0 != comm->nodeRanks[n].localRanks % groupSize) {
-      WARN("nLocals = %d should be a diviser of the number of ranks in node %d = %d", groupSize, n,
+      ERR(ncclInternalError, "nLocals = %d should be a diviser of the number of ranks in node %d = %d", groupSize, n,
            comm->nodeRanks[n].localRanks);
       return ncclInternalError;
     }
@@ -972,7 +972,7 @@ static ncclResult_t ncclP2pSchedule(struct ncclComm* comm) {
     if (n < comm->node) group += nGroupsInNode;
   }
   if (groupCount != nGroups) {
-    WARN("Group creation failed: %d vs %d", groupCount, nGroups);
+    ERR(ncclInternalError, "Group creation failed: %d vs %d", groupCount, nGroups);
     return ncclInternalError;
   }
   INFO(NCCL_GRAPH, "%s: group size used is %d", __func__, groupSize);
@@ -1006,7 +1006,7 @@ static ncclResult_t ncclP2pSchedule(struct ncclComm* comm) {
   free(groupToLocal);
 
   if (round != comm->nRanks) {
-    WARN("P2p schedule creation has bugs.");
+    ERR(ncclInternalError, "P2p schedule creation has bugs.");
     return ncclInternalError;
   }
   return ncclSuccess;
@@ -1120,7 +1120,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     }
 
     if (comm->peerInfo[i].version != comm->peerInfo[rank].version) {
-      WARN("Mismatched NCCL version detected : rank %d version %d rank %d version %d", i, comm->peerInfo[i].version,
+      ERR(ncclInvalidUsage, "Mismatched NCCL version detected : rank %d version %d rank %d version %d", i, comm->peerInfo[i].version,
            rank, comm->peerInfo[rank].version);
       ret = ncclInvalidUsage;
       goto fail;
@@ -1194,7 +1194,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     TRACE(NCCL_INIT, "pidHash[%d] %lx intraProcRank %d intraProcRanks %d intraProcRank0 %d", rank,
           comm->peerInfo[rank].pidHash, intraProcRank, intraProcRanks, intraProcRank0);
     if (intraProcRank == -1 || intraProcRank0 == -1 || comm->peerInfo[intraProcRank0].comm == NULL) {
-      WARN("Failed to determine intra proc ranks rank %d hostHash %lx pidHash %lx intraProcRank %d intraProcRanks %d "
+      ERR(ncclInternalError, "Failed to determine intra proc ranks rank %d hostHash %lx pidHash %lx intraProcRank %d intraProcRanks %d "
            "intraProcRank0 %d",
            rank, comm->peerInfo[rank].hostHash, comm->peerInfo[rank].pidHash, intraProcRank, intraProcRanks,
            intraProcRank0);
@@ -1425,7 +1425,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
              "NCCL_IGNORE_NET_MISMATCH.",
              minLocalNetCount, maxLocalNetCount);
       } else {
-        WARN("Detected mixed local Net device counts across ranks (min %d, max %d). Set NCCL_IGNORE_NET_MISMATCH=1 to "
+        ERR(ncclSystemError, "Detected mixed local Net device counts across ranks (min %d, max %d). Set NCCL_IGNORE_NET_MISMATCH=1 to "
              "continue.",
              minLocalNetCount, maxLocalNetCount);
         ret = ncclSystemError;
@@ -1448,7 +1448,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
              "NCCL_IGNORE_COLLNET_MISMATCH.",
              minLocalCollNetCount, maxLocalCollNetCount);
       } else {
-        WARN("Detected mixed local CollNet device counts across ranks (min %d, max %d). Set "
+        ERR(ncclSystemError, "Detected mixed local CollNet device counts across ranks (min %d, max %d). Set "
              "NCCL_IGNORE_COLLNET_MISMATCH=1 to continue.",
              minLocalCollNetCount, maxLocalCollNetCount);
         ret = ncclSystemError;
@@ -1501,7 +1501,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   TRACE(NCCL_INIT, "hostHash[%d] %lx localRank %d localRanks %d localRank0 %d", rank, comm->peerInfo[rank].hostHash,
         comm->localRank, comm->localRanks, comm->localRankToRank[0]);
   if (comm->localRank == -1 || comm->localRankToRank[0] == -1 || comm->localRanks == 0) {
-    WARN("Failed to determine local ranks rank %d hostHash %lx pidHash %lx localRank %d localRanks %d localRank0 %d",
+    ERR(ncclInternalError, "Failed to determine local ranks rank %d hostHash %lx pidHash %lx localRank %d localRanks %d localRank0 %d",
          rank, comm->peerInfo[rank].hostHash, comm->peerInfo[rank].pidHash, comm->localRank, comm->localRanks,
          comm->localRankToRank[0]);
     ret = ncclInternalError;
@@ -2398,7 +2398,7 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t* config) {
     realSize = realSize > sizeof(ncclConfig_t) ? sizeof(ncclConfig_t) : realSize;
     memcpy((void*)internalConfigPtr, (void*)config, realSize);
     if (internalConfigPtr->magic != NCCL_API_MAGIC) {
-      WARN("ncclConfig_t argument not initialized via NCCL_CONFIG_INITIALIZER");
+      ERR(ncclInvalidArgument, "ncclConfig_t argument not initialized via NCCL_CONFIG_INITIALIZER");
       ret = ncclInvalidArgument;
       goto fail;
     }
@@ -2454,13 +2454,13 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t* config) {
   /* check input config attributes, -1 means user-undefined and we should use default value from NCCL. */
   if (internalConfigPtr->blocking != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->blocking != 0 &&
       internalConfigPtr->blocking != 1) {
-    WARN("Invalid config blocking attribute value %d", internalConfigPtr->blocking);
+    ERR(ncclInvalidArgument, "Invalid config blocking attribute value %d", internalConfigPtr->blocking);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->cgaClusterSize != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->cgaClusterSize < 0) {
-    WARN("Invalid config cgaClusterSize attribute value %d", internalConfigPtr->cgaClusterSize);
+    ERR(ncclInvalidArgument, "Invalid config cgaClusterSize attribute value %d", internalConfigPtr->cgaClusterSize);
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -2469,7 +2469,7 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t* config) {
       (internalConfigPtr->maxCTAs != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->maxCTAs <= 0) ||
       (internalConfigPtr->minCTAs != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->maxCTAs != NCCL_CONFIG_UNDEF_INT &&
        internalConfigPtr->minCTAs > internalConfigPtr->maxCTAs)) {
-    WARN("Invalid config min/max channels attribute value %d/%d", internalConfigPtr->minCTAs,
+    ERR(ncclInvalidArgument, "Invalid config min/max channels attribute value %d/%d", internalConfigPtr->minCTAs,
          internalConfigPtr->maxCTAs);
     ret = ncclInvalidArgument;
     goto fail;
@@ -2477,21 +2477,21 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t* config) {
 
   if (internalConfigPtr->splitShare != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->splitShare != 0 &&
       internalConfigPtr->splitShare != 1) {
-    WARN("Invalid config splitShare attribute value %d", internalConfigPtr->splitShare);
+    ERR(ncclInvalidArgument, "Invalid config splitShare attribute value %d", internalConfigPtr->splitShare);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->collnetEnable != NCCL_CONFIG_UNDEF_INT &&
       (internalConfigPtr->collnetEnable < 0 || internalConfigPtr->collnetEnable > 1)) {
-    WARN("Invalid config collnetEnable attribute value %d", internalConfigPtr->collnetEnable);
+    ERR(ncclInvalidArgument, "Invalid config collnetEnable attribute value %d", internalConfigPtr->collnetEnable);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->CTAPolicy != NCCL_CONFIG_UNDEF_INT) {
     if (!ctaPolicyIsValid(internalConfigPtr->CTAPolicy)) {
-      WARN("Invalid config policy attribute value %d", internalConfigPtr->CTAPolicy);
+      ERR(ncclInvalidArgument, "Invalid config policy attribute value %d", internalConfigPtr->CTAPolicy);
       ret = ncclInvalidArgument;
       goto fail;
     }
@@ -2499,27 +2499,27 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t* config) {
 
   if (internalConfigPtr->shrinkShare != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->shrinkShare != 0 &&
       internalConfigPtr->shrinkShare != 1) {
-    WARN("Invalid config shrinkShare attribute value %d", internalConfigPtr->shrinkShare);
+    ERR(ncclInvalidArgument, "Invalid config shrinkShare attribute value %d", internalConfigPtr->shrinkShare);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->nvlsCTAs != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->nvlsCTAs <= 0) {
-    WARN("Invalid config nvlsCTAs attribute value %d", internalConfigPtr->nvlsCTAs);
+    ERR(ncclInvalidArgument, "Invalid config nvlsCTAs attribute value %d", internalConfigPtr->nvlsCTAs);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->nChannelsPerNetPeer != NCCL_CONFIG_UNDEF_INT &&
       (internalConfigPtr->nChannelsPerNetPeer <= 0 || internalConfigPtr->nChannelsPerNetPeer > MAXCHANNELS)) {
-    WARN("Invalid config nChannelsPerNetPeer attribute value %d", internalConfigPtr->nChannelsPerNetPeer);
+    ERR(ncclInvalidArgument, "Invalid config nChannelsPerNetPeer attribute value %d", internalConfigPtr->nChannelsPerNetPeer);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
   if (internalConfigPtr->nvlinkCentricSched != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->nvlinkCentricSched != 0 &&
       internalConfigPtr->nvlinkCentricSched != 1) {
-    WARN("Invalid config nvlinkCentricSched attribute value %d", internalConfigPtr->nvlinkCentricSched);
+    ERR(ncclInvalidArgument, "Invalid config nvlinkCentricSched attribute value %d", internalConfigPtr->nvlinkCentricSched);
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -2532,7 +2532,7 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t* config) {
   }
 
   if (internalConfigPtr->numRmaCtx != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->numRmaCtx < 0) {
-    WARN("Invalid config numRmaCtx attribute value %d", internalConfigPtr->numRmaCtx);
+    ERR(ncclInvalidArgument, "Invalid config numRmaCtx attribute value %d", internalConfigPtr->numRmaCtx);
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -2544,7 +2544,7 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t* config) {
   }
 
   if (internalConfigPtr->maxP2pPeers != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->maxP2pPeers <= 0) {
-    WARN("Invalid config maxP2pPeers attribute value %d", internalConfigPtr->maxP2pPeers);
+    ERR(ncclInvalidArgument, "Invalid config maxP2pPeers attribute value %d", internalConfigPtr->maxP2pPeers);
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -2666,7 +2666,7 @@ static void ncclCommInitJobFree(void* _job) {
 static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId, ncclUniqueId* commId, int myrank,
                                         int cudaDev, ncclConfig_t* config, const char funcName[]) {
   if (nId <= 0 || nId > nranks) {
-    WARN("improper usage of ncclCommInitRank: nId = %d, nranks=%d", nId, nranks);
+    ERR(ncclInvalidArgument, "improper usage of ncclCommInitRank: nId = %d, nranks=%d", nId, nranks);
     return ncclInvalidArgument;
   }
   ncclResult_t res = ncclSuccess;
@@ -2687,7 +2687,7 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   NCCLCHECKGOTO(PtrCheck(newcomm, "CommInitRank", "newcomm"), res, fail);
   NCCLCHECKGOTO(PtrCheck(config, "CommInitRank", "config"), res, fail);
   if (nranks < 1 || myrank < 0 || myrank >= nranks) {
-    WARN("Invalid rank requested : %d/%d", myrank, nranks);
+    ERR(ncclInvalidArgument, "Invalid rank requested : %d/%d", myrank, nranks);
     res = ncclInvalidArgument;
     goto fail;
   }
@@ -2798,7 +2798,7 @@ ncclResult_t ncclCommInitAll(ncclComm_t* comms, int ndev, const int* devlist) {
   CUDACHECK(cudaGetDevice(&oldDev));
   NCCLCHECKGOTO(PtrCheck(comms, "CommInitAll", "comms"), ret, fail);
   if (ndev < 0) {
-    WARN("Invalid device count requested : %d", ndev);
+    ERR(ncclInvalidArgument, "Invalid device count requested : %d", ndev);
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -2809,7 +2809,7 @@ ncclResult_t ncclCommInitAll(ncclComm_t* comms, int ndev, const int* devlist) {
     for (int i = 0; i < ndev; ++i) {
       /* invalid device check. */
       if (devlist[i] < 0 || devlist[i] >= totalnDev) {
-        WARN("Invalid device %d (totalnDev=%d)", devlist[i], totalnDev);
+        ERR(ncclInvalidArgument, "Invalid device %d (totalnDev=%d)", devlist[i], totalnDev);
         ret = ncclInvalidArgument;
         goto fail;
       }
@@ -2849,7 +2849,7 @@ fail:
 
 ncclResult_t ncclCommSetAsyncError(ncclComm_t comm, ncclResult_t nextState) {
   if (nextState < 0 || nextState >= ncclNumResults || comm == NULL) {
-    WARN("ncclCommSetAsyncError: error comm %p sets state %d", comm, nextState);
+    ERR(ncclInvalidArgument, "ncclCommSetAsyncError: error comm %p sets state %d", comm, nextState);
     return ncclInvalidArgument;
   }
 
@@ -3153,7 +3153,7 @@ ncclResult_t ncclCommDestroy(ncclComm_t comm) {
   NCCLCHECK(ncclGroupStartInternal());
   // Try and prevent a double free of the comm struct (user error)
   if (comm->rank == -1 || comm->nRanks == -1 || comm->cudaDev == -1 || comm->busId == -1) {
-    WARN("comm %p has already been destroyed", comm);
+    ERR(ncclInvalidArgument, "comm %p has already been destroyed", comm);
     return ncclInvalidArgument;
   }
 
@@ -3511,11 +3511,11 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
 
   if (newcomm == NULL) return ncclInvalidArgument;
   if (nRanks <= 0) {
-    WARN("ncclCommGrow: total ranks must be positive, got %d", nRanks);
+    ERR(ncclInvalidArgument, "ncclCommGrow: total ranks must be positive, got %d", nRanks);
     return ncclInvalidArgument;
   }
   if (comm && nRanks <= comm->nRanks) {
-    WARN("ncclCommGrow: total ranks %d is less than current ranks %d", nRanks, comm->nRanks);
+    ERR(ncclInvalidArgument, "ncclCommGrow: total ranks %d is less than current ranks %d", nRanks, comm->nRanks);
     return ncclInvalidArgument;
   }
 
@@ -3533,7 +3533,7 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
     NCCLCHECKGOTO(CommCheck(comm, __func__, "comm"), res, exit);
     NCCLCHECKGOTO(ncclCommEnsureReady(comm), res, exit);
     if (rank != -1) {
-      WARN("ncclCommGrow: existing ranks must pass rank=-1, got %d", rank);
+      ERR(ncclInvalidArgument, "ncclCommGrow: existing ranks must pass rank=-1, got %d", rank);
       res = ncclInvalidArgument;
       goto exit;
     }
@@ -3547,7 +3547,7 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
       NCCLCHECKGOTO(bcastGrowHandle(&recvHandle, comm, /*isRoot=*/false), res, exit);
       // verify the magic is the same as the one computed by the root
       if (recvHandle.magic != hashCombine(comm->magic, comm->childCount)) {
-        WARN("ncclCommGrow: magic mismatch computed by the root, got %lx expected %lx", recvHandle.magic,
+        ERR(ncclInvalidArgument, "ncclCommGrow: magic mismatch computed by the root, got %lx expected %lx", recvHandle.magic,
              hashCombine(comm->magic, comm->childCount));
         res = ncclInvalidArgument;
         goto exit;
@@ -3557,17 +3557,17 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
   } else {
     // New ranks: validate parameters
     if (rank < 0) {
-      WARN("ncclCommGrow: new ranks must pass valid rank >= 0, got %d", rank);
+      ERR(ncclInvalidArgument, "ncclCommGrow: new ranks must pass valid rank >= 0, got %d", rank);
       res = ncclInvalidArgument;
       goto exit;
     }
     if (uniqueId == NULL) {
-      WARN("ncclCommGrow: new ranks must pass non-NULL uniqueId");
+      ERR(ncclInvalidArgument, "ncclCommGrow: new ranks must pass non-NULL uniqueId");
       res = ncclInvalidArgument;
       goto exit;
     }
     if (rank >= nRanks) {
-      WARN("ncclCommGrow: new rank %d exceeds total ranks %d", rank, nRanks);
+      ERR(ncclInvalidArgument, "ncclCommGrow: new rank %d exceeds total ranks %d", rank, nRanks);
       res = ncclInvalidArgument;
       goto exit;
     }

--- a/comms/ncclx/v2_31/src/init.cc
+++ b/comms/ncclx/v2_31/src/init.cc
@@ -45,7 +45,12 @@
 #include "rma/rma.h"
 #include "tuning.h"
 
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/utils/SkipDestroyUtil.h"
+#include "meta/wrapper/MetaFactory.h"
+
 #include <cinttypes>
+#include <string>
 
 #define STR2(v) #v
 #define STR(v) STR2(v)
@@ -2059,11 +2064,21 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   }
   comm->cudaArch = cudaArch;
 
+  comm->logMetaData.commId = commIdHash;
+  comm->logMetaData.commHash = comm->commHash;
+  comm->logMetaData.commDesc = NCCLX_CONFIG_FIELD(comm->config, commDesc);
+  comm->logMetaData.rank = comm->rank;
+  comm->logMetaData.nRanks = comm->nRanks;
+
   NCCLCHECKGOTO(initTransportsRank(comm, job->parent, timers), res, fail);
 
   // update communicator state
   comm->initState = ncclSuccess;
   timers[TIMER_INIT_TOTAL] = clockNano() - timers[TIMER_INIT_TOTAL];
+
+  if (comm->useCtran_) {
+    NCCLCHECKGOTO(createCtranComm(comm), res, fail);
+  }
 
   // Trace this call for replay tool
   if (job->parent) {
@@ -2748,6 +2763,9 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   NCCLCHECKGOTO(ncclCudaHostCalloc(&comm->abortFlagDev, 1), res, fail);
   NCCLCHECKGOTO(ncclCalloc(&comm->abortFlagRefCount, 1), res, fail);
   comm->startMagic = comm->endMagic = NCCL_MAGIC; // Used to detect comm corruption.
+  comm->useCtran_ = NCCLX_CONFIG_FIELD(*config, useCtran);
+  comm->usePatAvg_ = NCCLX_CONFIG_FIELD(*config, usePatAvg);
+  comm->noLocal_ = NCCLX_CONFIG_FIELD(*config, noLocal);
   *comm->abortFlagRefCount = 1;
   for (int i = 0; i < ncclGroupTaskTypeNum; i++) {
     comm->groupNext[i] = reinterpret_cast<struct ncclComm*>(NCCL_COMM_GROUP_INVALID);
@@ -3009,6 +3027,8 @@ static ncclResult_t commDestroySync(struct ncclAsyncJob* job_) {
   ncclResult_t ret = ncclSuccess;
 
   CUDACHECKGOTO(cudaSetDevice(comm->cudaDev), ret, fail);
+
+  NCCLCHECKGOTO(destroyCtranComm(comm), ret, fail);
 
   TRACE(NCCL_DESTROY, "Destroying comm %p rank %d abortFlag %d asyncResult %d", comm, comm->rank, *comm->abortFlag,
         comm->asyncResult);
@@ -3364,9 +3384,37 @@ fail:
   goto exit;
 }
 
+static bool skipDestroyFlag = false;
+
+bool skipDestroy() {
+  return skipDestroyFlag;
+}
+
+static void commAbortLog(ncclComm_t comm, const std::string& abortScope) {
+  if (comm == nullptr) {
+    INFO(NCCL_INIT, "comm %p - Abort %s", comm, abortScope.c_str());
+  } else {
+    INFO(NCCL_INIT, "comm %p commHash %lx commDesc %s rank %d nRanks %d cudaDev %d busId %lx - Abort %s", comm,
+         comm->commHash, NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str(), comm->rank, comm->nRanks, comm->cudaDev,
+         comm->busId, abortScope.c_str());
+  }
+}
+
 NCCL_API(ncclResult_t, ncclCommAbort, ncclComm_t comm);
 ncclResult_t ncclCommAbort(ncclComm_t comm) {
   NVTX3_RANGE(NcclNvtxParamsCommAbort);
+
+  if (NCCL_COMM_ABORT_SCOPE != NCCL_COMM_ABORT_SCOPE::comm) {
+    skipDestroyFlag = true;
+    ctran::utils::setSkipDestroyCtran(skipDestroyFlag);
+  }
+  if (NCCL_COMM_ABORT_SCOPE == NCCL_COMM_ABORT_SCOPE::none) {
+    commAbortLog(comm, "SKIP");
+    return ncclSuccess;
+  } else if (NCCL_COMM_ABORT_SCOPE == NCCL_COMM_ABORT_SCOPE::job) {
+    commAbortLog(comm, "EXIT");
+    exit(1);
+  }
 
   if (comm == NULL) {
     return ncclSuccess;
@@ -3494,6 +3542,9 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
 
     /* start with ncclInternalError and will be changed to ncclSuccess if init succeeds. */
     childComm->initState = ncclInternalError;
+    childComm->useCtran_ = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
+    childComm->usePatAvg_ = NCCLX_CONFIG_FIELD(childComm->config, usePatAvg);
+    childComm->noLocal_ = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
   }
 
   NEW_NOTHROW_GOTO(job, ncclCommInitRankAsyncJob, res, fail);
@@ -3701,6 +3752,10 @@ ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqu
     NCCLCHECKGOTO(parseCommConfig(newComm, &growInternalConfig), res, fail);
   }
 
+  newComm->useCtran_ = NCCLX_CONFIG_FIELD(newComm->config, useCtran);
+  newComm->usePatAvg_ = NCCLX_CONFIG_FIELD(newComm->config, usePatAvg);
+  newComm->noLocal_ = NCCLX_CONFIG_FIELD(newComm->config, noLocal);
+
   newComm->initState = ncclInProgress;
   *newcomm = newComm;
 
@@ -3864,6 +3919,14 @@ ncclResult_t ncclCommGetAsyncError(ncclComm_t comm, ncclResult_t* asyncError) {
   if (*asyncError == ncclSuccess && comm->groupJob) {
     NCCLCHECK(ncclGroupJobComplete(comm->groupJob));
     comm->groupJob = NULL;
+  }
+
+  if (NCCL_CTRAN_ENABLE && ctranInitialized(comm->ctranComm_.get()) &&
+      (*asyncError == ncclSuccess || *asyncError == ncclInProgress)) {
+    const auto ctranAsyncError = metaCommToNccl(comm->ctranComm_->getAsyncResult());
+    if (ctranAsyncError != ncclSuccess) {
+      *asyncError = ctranAsyncError;
+    }
   }
   return ncclSuccess;
 }

--- a/comms/ncclx/v2_31/src/init.cc
+++ b/comms/ncclx/v2_31/src/init.cc
@@ -8,6 +8,8 @@
 #include "nccl.h"
 #include "meta/NcclxConfig.h" // @manual
 #include "meta/NcclxPerCommConfig.h" // @manual
+#include "meta/DeviceRackSerial.h" // @manual
+#include "comms/utils/cvars/nccl_cvars.h"
 #include "channel.h"
 #include "nvmlwrap.h"
 #include "gdrwrap.h"
@@ -832,6 +834,14 @@ static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, u
       }
       INFO(NCCL_INIT, "MNNVL busId 0x%lx fabric UUID %lx.%lx cliqueId 0x%x state %d healthMask 0x%x", info->busId,
            uuid0, uuid1, info->fabricInfo.cliqueId, info->fabricInfo.state, info->fabricInfo.healthMask);
+      // [META] Load rack serial for MNNVL trunk disable (string-based, supports alphanumeric serials)
+      if (NCCL_MNNVL_TRUNK_DISABLE) {
+        if (ncclx::loadRackSerial(NCCL_TOPO_FILE_PATH, info->rackSerial, sizeof(info->rackSerial))) {
+          INFO(NCCL_INIT, "Loaded rack serial: %s", info->rackSerial);
+        } else {
+          WARN("No rack serial information available, skipping rack serial check");
+        }
+      }
     }
   }
 

--- a/comms/ncclx/v2_31/src/init.cc
+++ b/comms/ncclx/v2_31/src/init.cc
@@ -7,6 +7,7 @@
 
 #include "nccl.h"
 #include "meta/NcclxConfig.h" // @manual
+#include "meta/NcclxPerCommConfig.h" // @manual
 #include "channel.h"
 #include "nvmlwrap.h"
 #include "gdrwrap.h"
@@ -885,6 +886,16 @@ static ncclResult_t computeBuffSizes(struct ncclComm* comm) {
 
   for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
     comm->buffSizes[p] = envs[p] != -2 ? envs[p] : defaults[p];
+  }
+
+  // [NCCLX-PerCommConfig] Validate and apply per-comm overrides
+  NCCLCHECK(ncclxValidatePerCommConfig(comm->config));
+  if (comm->config.ncclxConfig) {
+    auto& configBuffSize = NCCLX_CONFIG_FIELD(comm->config, ncclBuffSize);
+    if (configBuffSize.has_value()) {
+      comm->buffSizes[NCCL_PROTO_SIMPLE] = configBuffSize.value();
+      INFO(NCCL_INIT, "Per-comm SIMPLE buffSize overridden to %d", configBuffSize.value());
+    }
   }
 
   if (comm->nNodes > 1) {

--- a/comms/ncclx/v2_31/src/mem_manager.cc
+++ b/comms/ncclx/v2_31/src/mem_manager.cc
@@ -134,7 +134,7 @@ static ncclResult_t ncclMemTrackInternal(struct ncclMemManager* manager, void* p
   if (ncclParamMemManagerDisable()) return ncclSuccess;
   if (manager == nullptr || ptr == nullptr) return ncclInternalError;
   if (!COMPILER_ATOMIC_LOAD(&manager->initialized, std::memory_order_acquire)) {
-    WARN("MemManager: Cannot track allocation ptr=%p, manager not initialized", ptr);
+    ERR(ncclInternalError, "MemManager: Cannot track allocation ptr=%p, manager not initialized", ptr);
     return ncclInternalError;
   }
 
@@ -153,7 +153,7 @@ static ncclResult_t ncclMemTrackInternal(struct ncclMemManager* manager, void* p
   // Scratch/Offload: create linked list entry
   ncclDynMemEntry* entry = (ncclDynMemEntry*)malloc(sizeof(ncclDynMemEntry));
   if (entry == nullptr) {
-    WARN("MemManager: Failed to allocate memory entry");
+    ERR(ncclSystemError, "MemManager: Failed to allocate memory entry");
     return ncclSystemError;
   }
 
@@ -240,7 +240,7 @@ ncclResult_t ncclMemUntrackDynamic(struct ncclMemManager* manager, void* ptr, st
 
   // Atomic check to avoid locking destroyed mutex
   if (!COMPILER_ATOMIC_LOAD(&manager->initialized, std::memory_order_acquire)) {
-    WARN("MemManager: Cannot untrack allocation ptr=%p, manager not initialized", ptr);
+    ERR(ncclInternalError, "MemManager: Cannot untrack allocation ptr=%p, manager not initialized", ptr);
     return ncclInternalError;
   }
 
@@ -356,7 +356,7 @@ ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* pt
   if (ncclParamMemManagerDisable()) return ncclSuccess;
   if (manager == nullptr || ptr == nullptr) return ncclInternalError;
   if (!COMPILER_ATOMIC_LOAD(&manager->initialized, std::memory_order_acquire)) {
-    WARN("MemManager: Cannot mark export for ptr=%p, manager not initialized", ptr);
+    ERR(ncclInternalError, "MemManager: Cannot mark export for ptr=%p, manager not initialized", ptr);
     return ncclInternalError;
   }
   std::lock_guard<std::mutex> lock(manager->lock);
@@ -368,7 +368,7 @@ ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* pt
   }
 
   if (entry == nullptr) {
-    WARN("MemManager: Cannot mark export for ptr=%p - not found in tracked entries. "
+    ERR(ncclInternalError, "MemManager: Cannot mark export for ptr=%p - not found in tracked entries. "
          "Only dynamic memory (scratch/offload) needs export tracking for suspend/resume.",
          ptr);
     return ncclInternalError;
@@ -376,14 +376,14 @@ ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* pt
 
   // Verify this is a local entry, not an imported one
   if (entry->isImportedFromPeer) {
-    WARN("MemManager: Cannot mark export for ptr=%p - this is an imported buffer, not a local one", ptr);
+    ERR(ncclInternalError, "MemManager: Cannot mark export for ptr=%p - this is an imported buffer, not a local one", ptr);
     return ncclInternalError;
   }
 
   // Check if peer already exists
   for (int i = 0; i < entry->desc.local.numExportedPeers; i++) {
     if (entry->desc.local.exportedPeerRanks[i] == peerRank) {
-      WARN("MemManager: Buffer ptr=%p already exported to peer rank %d", ptr, peerRank);
+      ERR(ncclInternalError, "MemManager: Buffer ptr=%p already exported to peer rank %d", ptr, peerRank);
       return ncclInternalError;
     }
   }
@@ -417,7 +417,7 @@ ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* pt
  */
 ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
   if (ncclParamMemManagerDisable()) {
-    WARN("MemManager: Suspend failed, memory manager is disabled");
+    ERR(ncclInvalidUsage, "MemManager: Suspend failed, memory manager is disabled");
     return ncclInvalidUsage;
   }
   if (comm == nullptr) return ncclInvalidArgument;
@@ -425,7 +425,7 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
   ncclMemManager* manager = comm->memManager;
 
   if (manager->released) {
-    WARN("MemManager: Already suspended");
+    ERR(ncclInvalidUsage, "MemManager: Already suspended");
     return ncclInvalidUsage;
   }
 
@@ -483,7 +483,7 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
     if (entry->memType == ncclMemOffload) {
       NCCLCHECKGOTO(ncclCudaHostCalloc((char**)&entry->cpuBackup, entry->size), ret, fail);
       if (entry->cpuBackup == nullptr) {
-        WARN("MemManager: Failed to allocate CPU backup for offload");
+        ERR(ncclSystemError, "MemManager: Failed to allocate CPU backup for offload");
         ret = ncclSystemError;
         goto fail;
       }
@@ -493,7 +493,7 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
       if (err != cudaSuccess) {
         ncclCudaHostFree(entry->cpuBackup);
         entry->cpuBackup = nullptr;
-        WARN("MemManager: Failed to copy to CPU backup: %s", cudaGetErrorString(err));
+        ERR(ncclUnhandledCudaError, "MemManager: Failed to copy to CPU backup: %s", cudaGetErrorString(err));
         ret = ncclUnhandledCudaError;
         goto fail;
       }
@@ -549,7 +549,7 @@ fail:
  */
 ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
   if (ncclParamMemManagerDisable()) {
-    WARN("MemManager: Resume failed, memory manager is disabled");
+    ERR(ncclInvalidUsage, "MemManager: Resume failed, memory manager is disabled");
     return ncclInvalidUsage;
   }
   if (comm == nullptr) return ncclInvalidArgument;
@@ -557,7 +557,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
   ncclMemManager* manager = comm->memManager;
 
   if (!manager->released) {
-    WARN("MemManager: Not in suspended state");
+    ERR(ncclInvalidUsage, "MemManager: Not in suspended state");
     return ncclInvalidUsage;
   }
 
@@ -632,7 +632,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
     if (entry->memType == ncclMemOffload && entry->cpuBackup != NULL) {
       cudaError_t err = cudaMemcpy(entry->ptr, entry->cpuBackup, entry->size, cudaMemcpyHostToDevice);
       if (err != cudaSuccess) {
-        WARN("MemManager: Failed to restore from CPU backup: %s (backup preserved)", cudaGetErrorString(err));
+        ERR(ncclUnhandledCudaError, "MemManager: Failed to restore from CPU backup: %s (backup preserved)", cudaGetErrorString(err));
         ret = ncclUnhandledCudaError;
         goto fail;
       }
@@ -647,7 +647,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
       CUresult exportRet = CUPFN(cuMemExportToShareableHandle(&entry->desc.local.shareableHandle.fabricHandle,
                                                               newHandle, CU_MEM_HANDLE_TYPE_FABRIC, 0));
       if (exportRet != CUDA_SUCCESS) {
-        WARN("MemManager: cuMemExportToShareableHandle (FABRIC) failed for ptr=%p", entry->ptr);
+        ERR(ncclUnhandledCudaError, "MemManager: cuMemExportToShareableHandle (FABRIC) failed for ptr=%p", entry->ptr);
         CUCHECKIGNORE(cuMemUnmap((CUdeviceptr)entry->ptr, entry->size));
         CUCHECKIGNORE(cuMemRelease(newHandle));
         entry->handle = 0;
@@ -700,7 +700,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
     // Allocate buffer for all counts
     allCounts = (int*)malloc(comm->nRanks * sizeof(int));
     if (allCounts == nullptr) {
-      WARN("MemManager: Failed to allocate allCounts");
+      ERR(ncclSystemError, "MemManager: Failed to allocate allCounts");
       return ncclSystemError;
     }
     memset(allCounts, 0, comm->nRanks * sizeof(int));
@@ -1006,13 +1006,13 @@ ncclResult_t ncclCommSuspend(ncclComm_t comm, int flags) {
 
   if (flags & NCCL_SUSPEND_MEM) {
     if (ncclParamMemManagerDisable()) {
-      WARN("MemManager: Suspend not supported, memory manager is disabled");
+      ERR(ncclInvalidUsage, "MemManager: Suspend not supported, memory manager is disabled");
       ret = ncclInvalidUsage;
       goto fail;
     }
     // Check if manager is shared
     if (comm->memManager && comm->memManager->refCount > 1) {
-      WARN("Memory suspend not supported with split_share communicators (refCount=%d)", comm->memManager->refCount);
+      ERR(ncclInvalidUsage, "Memory suspend not supported with split_share communicators (refCount=%d)", comm->memManager->refCount);
       ret = ncclInvalidUsage;
       goto fail;
     }
@@ -1057,13 +1057,13 @@ ncclResult_t ncclCommResume(ncclComm_t comm) {
   CUDACHECKGOTO(cudaSetDevice(comm->cudaDev), ret, fail);
 
   if (ncclParamMemManagerDisable()) {
-    WARN("MemManager: Resume not supported, memory manager is disabled");
+    ERR(ncclInvalidUsage, "MemManager: Resume not supported, memory manager is disabled");
     ret = ncclInvalidUsage;
     goto fail;
   }
   // Check if manager is shared
   if (comm->memManager && comm->memManager->refCount > 1) {
-    WARN("Memory resume not supported with split_share communicators (refCount=%d)", comm->memManager->refCount);
+    ERR(ncclInvalidUsage, "Memory resume not supported with split_share communicators (refCount=%d)", comm->memManager->refCount);
     ret = ncclInvalidUsage;
     goto fail;
   }
@@ -1102,7 +1102,7 @@ ncclResult_t ncclCommMemStats(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t*
   if (value == nullptr) return ncclInvalidArgument;
 
   if (ncclParamMemManagerDisable()) {
-    WARN("MemManager: MemStats not supported, memory manager is disabled");
+    ERR(ncclInvalidUsage, "MemManager: MemStats not supported, memory manager is disabled");
     return ncclInvalidUsage;
   }
 

--- a/comms/ncclx/v2_31/src/misc/argcheck.cc
+++ b/comms/ncclx/v2_31/src/misc/argcheck.cc
@@ -13,7 +13,7 @@ ncclResult_t CudaPtrCheck(const void* pointer, struct ncclComm* comm, const char
   cudaPointerAttributes attr;
   cudaError_t err = cudaPointerGetAttributes(&attr, pointer);
   if (err != cudaSuccess || attr.devicePointer == NULL) {
-    WARN("%s : %s %p is not a valid pointer", opname, ptrname, pointer);
+    ERR(ncclInvalidArgument, "%s : %s %p is not a valid pointer", opname, ptrname, pointer);
     return ncclInvalidArgument;
   }
 #if CUDART_VERSION >= 10000
@@ -21,7 +21,7 @@ ncclResult_t CudaPtrCheck(const void* pointer, struct ncclComm* comm, const char
 #else
   if (attr.memoryType == cudaMemoryTypeDevice && attr.device != comm->cudaDev) {
 #endif
-    WARN("%s : %s allocated on device %d mismatchs with NCCL device %d", opname, ptrname, attr.device, comm->cudaDev);
+    ERR(ncclInvalidArgument, "%s : %s allocated on device %d mismatchs with NCCL device %d", opname, ptrname, attr.device, comm->cudaDev);
     return ncclInvalidArgument;
   }
   return ncclSuccess;
@@ -29,7 +29,7 @@ ncclResult_t CudaPtrCheck(const void* pointer, struct ncclComm* comm, const char
 
 ncclResult_t PtrCheck(const void* ptr, const char* opname, const char* ptrname) {
   if (ptr == NULL) {
-    WARN("%s : %s argument is NULL", opname, ptrname);
+    ERR(ncclInvalidArgument, "%s : %s argument is NULL", opname, ptrname);
     return ncclInvalidArgument;
   }
   return ncclSuccess;
@@ -38,7 +38,7 @@ ncclResult_t PtrCheck(const void* ptr, const char* opname, const char* ptrname) 
 ncclResult_t CommCheck(struct ncclComm* comm, const char* opname, const char* ptrname) {
   NCCLCHECK(PtrCheck(comm, opname, ptrname));
   if (comm->startMagic != NCCL_MAGIC || comm->endMagic != NCCL_MAGIC) {
-    WARN("Error: corrupted comm object detected");
+    ERR(ncclInvalidArgument, "Error: corrupted comm object detected");
     return ncclInvalidArgument;
   }
   return ncclSuccess;
@@ -101,7 +101,7 @@ static ncclResult_t registrationCheck(struct ncclInfo* info) {
     if (cmpBufInfo[0].isSymRegistered != bufInfo[infoIdx].isSymRegistered ||
         cmpBufInfo[1].isSymRegistered != bufInfo[infoIdx + 1].isSymRegistered) {
       if (comm->rank == 0) {
-        WARN("Coll %s size %ld symmetric registration check failed on rank %d: sendReg %d recvReg %d mismatch with "
+        ERR(ncclInvalidArgument, "Coll %s size %ld symmetric registration check failed on rank %d: sendReg %d recvReg %d mismatch with "
              "rank 0 sendReg %d recvReg %d",
              info->opName, size, r, bufInfo[infoIdx].isSymRegistered, bufInfo[infoIdx + 1].isSymRegistered,
              cmpBufInfo[0].isSymRegistered, cmpBufInfo[1].isSymRegistered);
@@ -133,7 +133,7 @@ static ncclResult_t registrationCheck(struct ncclInfo* info) {
     if (cmpBufInfo[0].isSymRegistered) {
       if (sendWinMismatch) {
         if (comm->rank == 0) {
-          WARN("Coll %s size %ld symmetric registration check failed on rank %d: send buffer window (0x%lx) mismatch "
+          ERR(ncclInvalidArgument, "Coll %s size %ld symmetric registration check failed on rank %d: send buffer window (0x%lx) mismatch "
                "with rank 0 (0x%lx)",
                info->opName, size, sendWinMismatchRank, bufInfo[sendWinMismatchRank * 2].bigOffset,
                cmpBufInfo[0].bigOffset);
@@ -143,7 +143,7 @@ static ncclResult_t registrationCheck(struct ncclInfo* info) {
       }
       if (sendUserMismatch) {
         if (comm->rank == 0) {
-          WARN("Coll %s size %ld symmetric registration check failed on rank %d: send buffer user offset (0x%lx) "
+          ERR(ncclInvalidArgument, "Coll %s size %ld symmetric registration check failed on rank %d: send buffer user offset (0x%lx) "
                "mismatch with rank 0 (0x%lx)",
                info->opName, size, sendUserMismatchRank, bufInfo[sendUserMismatchRank * 2].userOffset,
                cmpBufInfo[0].userOffset);
@@ -159,7 +159,7 @@ static ncclResult_t registrationCheck(struct ncclInfo* info) {
     if (cmpBufInfo[1].isSymRegistered) {
       if (recvWinMismatch) {
         if (comm->rank == 0) {
-          WARN("Coll %s size %ld symmetric registration check failed on rank %d: recv buffer window (0x%lx) mismatch "
+          ERR(ncclInvalidArgument, "Coll %s size %ld symmetric registration check failed on rank %d: recv buffer window (0x%lx) mismatch "
                "with rank 0 (0x%lx)",
                info->opName, size, recvWinMismatchRank, bufInfo[recvWinMismatchRank * 2 + 1].bigOffset,
                cmpBufInfo[1].bigOffset);
@@ -169,7 +169,7 @@ static ncclResult_t registrationCheck(struct ncclInfo* info) {
       }
       if (recvUserMismatch) {
         if (comm->rank == 0) {
-          WARN("Coll %s size %ld symmetric registration check failed on rank %d: recv buffer user offset (0x%lx) "
+          ERR(ncclInvalidArgument, "Coll %s size %ld symmetric registration check failed on rank %d: recv buffer user offset (0x%lx) "
                "mismatch with rank 0 (0x%lx)",
                info->opName, size, recvUserMismatchRank, bufInfo[recvUserMismatchRank * 2 + 1].userOffset,
                cmpBufInfo[1].userOffset);
@@ -201,11 +201,11 @@ ncclResult_t ncclArgsGlobalCheck(struct ncclArgsInfo* argsInfo) {
 ncclResult_t ArgsCheck(struct ncclInfo* info) {
   // First, the easy ones
   if (info->root < 0 || info->root >= info->comm->nRanks) {
-    WARN("%s : invalid root %d (root should be in the 0..%d range)", info->opName, info->root, info->comm->nRanks);
+    ERR(ncclInvalidArgument, "%s : invalid root %d (root should be in the 0..%d range)", info->opName, info->root, info->comm->nRanks);
     return ncclInvalidArgument;
   }
   if (info->datatype < 0 || info->datatype >= ncclNumTypes) {
-    WARN("%s : invalid type %d", info->opName, info->datatype);
+    ERR(ncclInvalidArgument, "%s : invalid type %d", info->opName, info->datatype);
     return ncclInvalidArgument;
   }
 
@@ -214,13 +214,13 @@ ncclResult_t ArgsCheck(struct ncclInfo* info) {
   // just as a reminder.
   // coverity[result_independent_of_operands]
   if (info->op < 0 || ncclMaxRedOp < info->op) {
-    WARN("%s : invalid reduction operation %d", info->opName, info->op);
+    ERR(ncclInvalidArgument, "%s : invalid reduction operation %d", info->opName, info->op);
     return ncclInvalidArgument;
   }
   int opIx = int(ncclUserRedOpMangle(info->comm, info->op)) - int(ncclNumOps);
   if (ncclNumOps <= info->op &&
       (info->comm->userRedOpCapacity <= opIx || info->comm->userRedOps[opIx].freeNext != -1)) {
-    WARN("%s : reduction operation %d unknown to this communicator", info->opName, info->op);
+    ERR(ncclInvalidArgument, "%s : reduction operation %d unknown to this communicator", info->opName, info->op);
     return ncclInvalidArgument;
   }
 

--- a/comms/ncclx/v2_31/src/misc/cudawrap.cc
+++ b/comms/ncclx/v2_31/src/misc/cudawrap.cc
@@ -12,6 +12,8 @@
 #include "cudawrap.h"
 #include <mutex>
 
+#include "comms/ctran/utils/CudaWrap.h"
+
 // This env var (NCCL_CUMEM_ENABLE) toggles cuMem API usage
 NCCL_PARAM(CuMemEnable, "CUMEM_ENABLE", -2);
 NCCL_PARAM(CuMemHostEnable, "CUMEM_HOST_ENABLE", -1);
@@ -354,6 +356,8 @@ error:
 
 ncclResult_t ncclCudaLibraryInit() {
   std::call_once(initOnceFlag, initOnceFunc);
+  const auto res = ctran::utils::commCudaLibraryInit();
+  if (res != commSuccess) return ncclSystemError;
   return initResult;
 }
 

--- a/comms/ncclx/v2_31/src/misc/cudawrap.cc
+++ b/comms/ncclx/v2_31/src/misc/cudawrap.cc
@@ -194,7 +194,7 @@ bool ncclCudaLaunchBlocking = false;
                                                           cudaEnableDefault, &driverStatus)); \
     if (res != cudaSuccess || driverStatus != cudaDriverEntryPointSuccess) { \
       if (!ignore) { \
-        WARN("Retrieve %s version %d failed with %d status %d", #symbol, version, res, driverStatus); \
+        ERR(ncclSystemError, "Retrieve %s version %d failed with %d status %d", #symbol, version, res, driverStatus); \
         return ncclSystemError; \
       } \
     } \
@@ -206,7 +206,7 @@ bool ncclCudaLaunchBlocking = false;
     res = CUDACLEARERROR(cudaGetDriverEntryPoint(#symbol, (void**)(&pfn_##symbol), cudaEnableDefault, &driverStatus)); \
     if (res != cudaSuccess || driverStatus != cudaDriverEntryPointSuccess) { \
       if (!ignore) { \
-        WARN("Retrieve %s failed with %d status %d", #symbol, res, driverStatus); \
+        ERR(ncclSystemError, "Retrieve %s failed with %d status %d", #symbol, res, driverStatus); \
         return ncclSystemError; \
       } \
     } \
@@ -217,7 +217,7 @@ bool ncclCudaLaunchBlocking = false;
     res = CUDACLEARERROR(cudaGetDriverEntryPoint(#symbol, (void**)(&pfn_##symbol), cudaEnableDefault)); \
     if (res != cudaSuccess) { \
       if (!ignore) { \
-        WARN("Retrieve %s failed with %d", #symbol, res); \
+        ERR(ncclSystemError, "Retrieve %s failed with %d", #symbol, res); \
         return ncclSystemError; \
       } \
     } \
@@ -325,7 +325,7 @@ static void initOnceFunc() {
 
 #if CUDART_VERSION >= 11030
   if (cudaPfnFuncLoader()) {
-    WARN("CUDA some PFN functions not found in the library");
+    ERR(ncclSystemError, "CUDA some PFN functions not found in the library");
     goto error;
   }
 #endif

--- a/comms/ncclx/v2_31/src/misc/gdrwrap.cc
+++ b/comms/ncclx/v2_31/src/misc/gdrwrap.cc
@@ -494,7 +494,7 @@ std::mutex& getGdrMutex() {
     cast = (void**)&funcptr; \
     tmp = ncclOsDlsym(handle, symbol); \
     if (tmp == NULL) { \
-      WARN("ncclOsDlsym failed on %s - %s", symbol, ncclOsDlerror()); \
+      ERR(ncclSystemError, "ncclOsDlsym failed on %s - %s", symbol, ncclOsDlerror()); \
       goto teardown; \
     } \
     *cast = tmp; \
@@ -584,7 +584,7 @@ static const char* ncclGdrBackendName() {
 
 static ncclResult_t ncclGdrUnavailable(const char* op) {
   if (gdrOps == NULL) {
-    WARN("GDRCOPY lib wrapper not initialized.");
+    ERR(ncclInternalError, "GDRCOPY lib wrapper not initialized.");
   } else {
     INFO(NCCL_INIT, "%s not available for %s backend", op, ncclGdrBackendName());
   }
@@ -593,7 +593,7 @@ static ncclResult_t ncclGdrUnavailable(const char* op) {
 
 gdr_t wrap_gdr_open(void) {
   if (gdrOps == NULL || gdrOps->open == NULL) {
-    WARN("GDRCOPY lib wrapper not initialized.");
+    ERR(ncclInternalError, "GDRCOPY lib wrapper not initialized.");
     return NULL;
   }
   gdr_t handle = gdrOps->open();
@@ -609,7 +609,7 @@ ncclResult_t wrap_gdr_close(gdr_t g) {
   if (gdrOps == NULL || gdrOps->close == NULL) return ncclGdrUnavailable("close");
   int ret = gdrOps->close(g);
   if (ret != 0) {
-    WARN("gdr_close() failed: %d", ret);
+    ERR(ncclSystemError, "gdr_close() failed: %d", ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -621,7 +621,7 @@ ncclResult_t wrap_gdr_pin_buffer(gdr_t g, unsigned long addr, size_t size, uint6
   int ret;
   GDRLOCKCALL(gdrOps->pinBuffer(g, addr, size, p2p_token, va_space, handle), ret);
   if (ret != 0) {
-    WARN("gdr_pin_buffer(addr %lx, size %zu) failed: %d", addr, size, ret);
+    ERR(ncclSystemError, "gdr_pin_buffer(addr %lx, size %zu) failed: %d", addr, size, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -647,14 +647,14 @@ bool ncclGdrPinV2Available(void) {
 
 ncclResult_t wrap_gdr_pin_buffer_v2(gdr_t g, unsigned long addr, size_t size, uint32_t flags, gdr_mh_t* handle) {
   if (!ncclGdrPinV2Available()) {
-    WARN("gdr_pin_buffer_v2 not available; GDRCopy >= 2.5 required");
+    ERR(ncclInternalError, "gdr_pin_buffer_v2 not available; GDRCopy >= 2.5 required");
     return ncclInternalError;
   }
   if (gdrOps == NULL || gdrOps->pinBufferV2 == NULL) return ncclGdrUnavailable("pin_buffer_v2");
   int ret;
   GDRLOCKCALL(gdrOps->pinBufferV2(g, addr, size, flags, handle), ret);
   if (ret != 0) {
-    WARN("gdr_pin_buffer_v2(addr %lx, size %zu, flags %u) failed: %d", addr, size, flags, ret);
+    ERR(ncclSystemError, "gdr_pin_buffer_v2(addr %lx, size %zu, flags %u) failed: %d", addr, size, flags, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -665,7 +665,7 @@ ncclResult_t wrap_gdr_unpin_buffer(gdr_t g, gdr_mh_t handle) {
   int ret;
   GDRLOCKCALL(gdrOps->unpinBuffer(g, handle), ret);
   if (ret != 0) {
-    WARN("gdr_unpin_buffer(handle %lx) failed: %d", handle.h, ret);
+    ERR(ncclSystemError, "gdr_unpin_buffer(handle %lx) failed: %d", handle.h, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -676,7 +676,7 @@ ncclResult_t wrap_gdr_get_info(gdr_t g, gdr_mh_t handle, gdr_info_t* info) {
   int ret;
   GDRLOCKCALL(gdrOps->getInfo(g, handle, info), ret);
   if (ret != 0) {
-    WARN("gdr_get_info(handle %lx) failed: %d", handle.h, ret);
+    ERR(ncclSystemError, "gdr_get_info(handle %lx) failed: %d", handle.h, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -687,7 +687,7 @@ ncclResult_t wrap_gdr_map(gdr_t g, gdr_mh_t handle, void** va, size_t size) {
   int ret;
   GDRLOCKCALL(gdrOps->map(g, handle, va, size), ret);
   if (ret != 0) {
-    WARN("gdr_map(handle %lx, size %zu) failed: %d", handle.h, size, ret);
+    ERR(ncclSystemError, "gdr_map(handle %lx, size %zu) failed: %d", handle.h, size, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -698,7 +698,7 @@ ncclResult_t wrap_gdr_unmap(gdr_t g, gdr_mh_t handle, void* va, size_t size) {
   int ret;
   GDRLOCKCALL(gdrOps->unmap(g, handle, va, size), ret);
   if (ret != 0) {
-    WARN("gdr_unmap(handle %lx, va %p, size %zu) failed: %d", handle.h, va, size, ret);
+    ERR(ncclSystemError, "gdr_unmap(handle %lx, va %p, size %zu) failed: %d", handle.h, va, size, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -759,7 +759,7 @@ ncclResult_t wrap_gdr_copy_to_mapping(gdr_mh_t handle, void* map_d_ptr, const vo
   int ret;
   GDRLOCKCALL(gdrOps->copyToMapping(handle, map_d_ptr, h_ptr, size), ret);
   if (ret != 0) {
-    WARN("gdr_copy_to_mapping(handle %lx, map_d_ptr %p, h_ptr %p, size %zu) failed: %d", handle.h, map_d_ptr, h_ptr,
+    ERR(ncclSystemError, "gdr_copy_to_mapping(handle %lx, map_d_ptr %p, h_ptr %p, size %zu) failed: %d", handle.h, map_d_ptr, h_ptr,
          size, ret);
     return ncclSystemError;
   }
@@ -771,7 +771,7 @@ ncclResult_t wrap_gdr_copy_from_mapping(gdr_mh_t handle, void* h_ptr, const void
   int ret;
   GDRLOCKCALL(gdrOps->copyFromMapping(handle, h_ptr, map_d_ptr, size), ret);
   if (ret != 0) {
-    WARN("gdr_copy_from_mapping(handle %lx, h_ptr %p, map_d_ptr %p, size %zu) failed: %d", handle.h, h_ptr, map_d_ptr,
+    ERR(ncclSystemError, "gdr_copy_from_mapping(handle %lx, h_ptr %p, map_d_ptr %p, size %zu) failed: %d", handle.h, h_ptr, map_d_ptr,
          size, ret);
     return ncclSystemError;
   }

--- a/comms/ncclx/v2_31/src/misc/ibvsymbols.cc
+++ b/comms/ncclx/v2_31/src/misc/ibvsymbols.cc
@@ -93,7 +93,7 @@ ncclResult_t buildIbvSymbols(struct ncclIbvSymbols* ibvSymbols) {
     cast = (void**)&funcptr; \
     tmp = dlvsym(handle, symbol, IBVERBS_VERSION); \
     if (tmp == NULL) { \
-      WARN("dlvsym failed on %s - %s version %s", symbol, dlerror(), IBVERBS_VERSION); \
+      ERR(ncclSystemError, "dlvsym failed on %s - %s version %s", symbol, dlerror(), IBVERBS_VERSION); \
       goto teardown; \
     } \
     *cast = tmp; \

--- a/comms/ncclx/v2_31/src/misc/ibvwrap.cc
+++ b/comms/ncclx/v2_31/src/misc/ibvwrap.cc
@@ -31,7 +31,7 @@ ncclResult_t wrap_ibv_symbols(void) {
 /* CHECK_NOT_NULL: helper macro to check for NULL symbol */
 #define CHECK_NOT_NULL(container, internal_name) \
   if (container.internal_name == NULL) { \
-    WARN("lib wrapper not initialized."); \
+    ERR(ncclInternalError, "lib wrapper not initialized."); \
     return ncclInternalError; \
   }
 
@@ -39,7 +39,7 @@ ncclResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name); \
   retval = container.call; \
   if (retval == error_retval) { \
-    WARN("Call to " name " failed with error %s", strerror(errno)); \
+    ERR(ncclSystemError, "Call to " name " failed with error %s", strerror(errno)); \
     return ncclSystemError; \
   } \
   return ncclSuccess;
@@ -48,7 +48,7 @@ ncclResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name); \
   retval = container.call; \
   if (retval == error_retval) { \
-    WARN("Call to " name " failed"); \
+    ERR(ncclSystemError, "Call to " name " failed"); \
     return ncclSystemError; \
   } \
   return ncclSuccess;
@@ -65,7 +65,7 @@ ncclResult_t wrap_ibv_symbols(void) {
     *supported = 0; \
     return ncclSuccess; \
   } else if (ret != success_retval) { \
-    WARN("Call to " name " failed with error %s errno %d", strerror(ret), ret); \
+    ERR(ncclSystemError, "Call to " name " failed with error %s errno %d", strerror(ret), ret); \
     *supported = 1; \
     return ncclSystemError; \
   } \
@@ -76,7 +76,7 @@ ncclResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name); \
   int ret = container.call; \
   if (ret != success_retval) { \
-    WARN("Call to " name " failed with error %s errno %d", strerror(ret), ret); \
+    ERR(ncclSystemError, "Call to " name " failed with error %s errno %d", strerror(ret), ret); \
     return ncclSystemError; \
   } \
   return ncclSuccess;
@@ -85,7 +85,7 @@ ncclResult_t wrap_ibv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name); \
   int ret = container.call; \
   if (ret == error_retval) { \
-    WARN("Call to " name " failed"); \
+    ERR(ncclSystemError, "Call to " name " failed"); \
     return ncclSystemError; \
   } \
   return ncclSuccess;
@@ -120,7 +120,7 @@ ncclResult_t wrap_ibv_free_device_list(struct ibv_device** list) {
 
 const char* wrap_ibv_get_device_name(struct ibv_device* device) {
   if (ibvSymbols.ibv_internal_get_device_name == NULL) {
-    WARN("lib wrapper not initialized.");
+    ERR(ncclInternalError, "lib wrapper not initialized.");
     exit(-1);
   }
   return ibvSymbols.ibv_internal_get_device_name(device);
@@ -202,7 +202,7 @@ ncclResult_t wrap_ibv_reg_mr(struct ibv_mr** ret, struct ibv_pd* pd, void* addr,
 
 struct ibv_mr* wrap_direct_ibv_reg_mr(struct ibv_pd* pd, void* addr, size_t length, int access) {
   if (ibvSymbols.ibv_internal_reg_mr == NULL) {
-    WARN("lib wrapper not initialized.");
+    ERR(ncclInternalError, "lib wrapper not initialized.");
     return NULL;
   }
   return ibvSymbols.ibv_internal_reg_mr(pd, addr, length, access);
@@ -377,7 +377,7 @@ ncclResult_t wrap_ibv_modify_qp(struct ibv_qp* qp, struct ibv_qp_attr* attr, int
   } while (IBV_MQP_RETRY_ERRNO_ALL(ret) && attempts < maxCnt);
   if (ret != 0) {
     ibvModifyQpLog(qp, attr->qp_state, attr, attr_mask, qpMsg, sizeof(qpMsg));
-    WARN("Call to ibv_modify_qp failed with %d %s, %s", ret, strerror(ret), qpMsg);
+    ERR(ncclSystemError, "Call to ibv_modify_qp failed with %d %s, %s", ret, strerror(ret), qpMsg);
     printIbModifyQpHint(ret);
     return ncclSystemError;
   }

--- a/comms/ncclx/v2_31/src/misc/mlx5dvsymbols.cc
+++ b/comms/ncclx/v2_31/src/misc/mlx5dvsymbols.cc
@@ -52,7 +52,7 @@ ncclResult_t buildMlx5dvSymbols(struct ncclMlx5dvSymbols* mlx5dvSymbols) {
     cast = (void**)&funcptr; \
     tmp = dlvsym(handle, symbol, MLX5DV_VERSION); \
     if (tmp == NULL) { \
-      WARN("dlvsym failed on %s - %s version %s", symbol, dlerror(), MLX5DV_VERSION); \
+      ERR(ncclSystemError, "dlvsym failed on %s - %s version %s", symbol, dlerror(), MLX5DV_VERSION); \
       goto teardown; \
     } \
     *cast = tmp; \

--- a/comms/ncclx/v2_31/src/misc/mlx5dvwrap.cc
+++ b/comms/ncclx/v2_31/src/misc/mlx5dvwrap.cc
@@ -29,7 +29,7 @@ ncclResult_t wrap_mlx5dv_symbols(void) {
 /* CHECK_NOT_NULL: helper macro to check for NULL symbol */
 #define CHECK_NOT_NULL(container, internal_name) \
   if (container.internal_name == NULL) { \
-    WARN("NET/MLX5: lib wrapper not initialized."); \
+    ERR(ncclInternalError, "NET/MLX5: lib wrapper not initialized."); \
     return ncclInternalError; \
   }
 
@@ -37,7 +37,7 @@ ncclResult_t wrap_mlx5dv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name); \
   retval = container.call; \
   if (retval == error_retval) { \
-    WARN("NET/MLX5: Call to " name " failed with error %s", strerror(errno)); \
+    ERR(ncclSystemError, "NET/MLX5: Call to " name " failed with error %s", strerror(errno)); \
     return ncclSystemError; \
   } \
   return ncclSuccess;
@@ -46,7 +46,7 @@ ncclResult_t wrap_mlx5dv_symbols(void) {
   CHECK_NOT_NULL(container, internal_name); \
   int ret = container.call; \
   if (ret != success_retval) { \
-    WARN("NET/MLX5: Call to " name " failed with error %s", strerror(errno)); \
+    ERR(ncclSystemError, "NET/MLX5: Call to " name " failed with error %s", strerror(errno)); \
     return ncclSystemError; \
   } \
   return ncclSuccess;

--- a/comms/ncclx/v2_31/src/misc/nvmlwrap.cc
+++ b/comms/ncclx/v2_31/src/misc/nvmlwrap.cc
@@ -148,7 +148,7 @@ ncclResult_t ncclNvmlEnsureInitialized() {
 #endif
   nvmlReturn_t res1 = (have_v2 ? pfn_nvmlInit_v2 : pfn_nvmlInit)();
   if (res1 != NVML_SUCCESS) {
-    WARN("nvmlInit%s() failed: %s", have_v2 ? "_v2" : "", pfn_nvmlErrorString(res1));
+    ERR(ncclSystemError, "nvmlInit%s() failed: %s", have_v2 ? "_v2" : "", pfn_nvmlErrorString(res1));
     initResult = ncclSystemError;
     return initResult;
   }
@@ -156,14 +156,14 @@ ncclResult_t ncclNvmlEnsureInitialized() {
   unsigned int ndev;
   res1 = (have_v2 ? pfn_nvmlDeviceGetCount_v2 : pfn_nvmlDeviceGetCount)(&ndev);
   if (res1 != NVML_SUCCESS) {
-    WARN("nvmlDeviceGetCount%s() failed: %s", have_v2 ? "_v2" : "", pfn_nvmlErrorString(res1));
+    ERR(ncclSystemError, "nvmlDeviceGetCount%s() failed: %s", have_v2 ? "_v2" : "", pfn_nvmlErrorString(res1));
     initResult = ncclSystemError;
     return initResult;
   }
 
   ncclNvmlDeviceCount = int(ndev);
   if (ncclNvmlMaxDevices < ncclNvmlDeviceCount) {
-    WARN("nvmlDeviceGetCount() reported more devices (%d) than the internal maximum (ncclNvmlMaxDevices=%d)",
+    ERR(ncclInternalError, "nvmlDeviceGetCount() reported more devices (%d) than the internal maximum (ncclNvmlMaxDevices=%d)",
          ncclNvmlDeviceCount, ncclNvmlMaxDevices);
     initResult = ncclInternalError;
     return initResult;
@@ -172,7 +172,7 @@ ncclResult_t ncclNvmlEnsureInitialized() {
   for (int a = 0; a < ncclNvmlDeviceCount; a++) {
     res1 = pfn_nvmlDeviceGetHandleByIndex(a, &ncclNvmlDevices[a].handle);
     if (res1 != NVML_SUCCESS) {
-      WARN("nvmlDeviceGetHandleByIndex(%d) failed: %s", int(a), pfn_nvmlErrorString(res1));
+      ERR(ncclSystemError, "nvmlDeviceGetHandleByIndex(%d) failed: %s", int(a), pfn_nvmlErrorString(res1));
       initResult = ncclSystemError;
       return initResult;
     }
@@ -180,7 +180,7 @@ ncclResult_t ncclNvmlEnsureInitialized() {
     res1 = pfn_nvmlDeviceGetCudaComputeCapability(ncclNvmlDevices[a].handle, &ncclNvmlDevices[a].computeCapabilityMajor,
                                                   &ncclNvmlDevices[a].computeCapabilityMinor);
     if (res1 != NVML_SUCCESS) {
-      WARN("nvmlDeviceGetCudaComputeCapability(%d) failed: %s", int(a), pfn_nvmlErrorString(res1));
+      ERR(ncclSystemError, "nvmlDeviceGetCudaComputeCapability(%d) failed: %s", int(a), pfn_nvmlErrorString(res1));
       initResult = ncclSystemError;
       return initResult;
     }
@@ -193,14 +193,14 @@ ncclResult_t ncclNvmlEnsureInitialized() {
 
       res1 = pfn_nvmlDeviceGetP2PStatus(da, db, NVML_P2P_CAPS_INDEX_READ, &ncclNvmlDevicePairs[a][b].p2pStatusRead);
       if (res1 != NVML_SUCCESS) {
-        WARN("nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_READ) failed: %s", a, b, pfn_nvmlErrorString(res1));
+        ERR(ncclSystemError, "nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_READ) failed: %s", a, b, pfn_nvmlErrorString(res1));
         initResult = ncclSystemError;
         return initResult;
       }
 
       res1 = pfn_nvmlDeviceGetP2PStatus(da, db, NVML_P2P_CAPS_INDEX_WRITE, &ncclNvmlDevicePairs[a][b].p2pStatusWrite);
       if (res1 != NVML_SUCCESS) {
-        WARN("nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_READ) failed: %s", a, b, pfn_nvmlErrorString(res1));
+        ERR(ncclSystemError, "nvmlDeviceGetP2PStatus(%d,%d,NVML_P2P_CAPS_INDEX_READ) failed: %s", a, b, pfn_nvmlErrorString(res1));
         initResult = ncclSystemError;
         return initResult;
       }
@@ -215,7 +215,7 @@ ncclResult_t ncclNvmlEnsureInitialized() {
   do { \
     nvmlReturn_t e44241808 = pfn_##name(__VA_ARGS__); \
     if (e44241808 != NVML_SUCCESS) { \
-      WARN(#name "() failed: %s", pfn_nvmlErrorString(e44241808)); \
+      ERR(ncclSystemError, #name "() failed: %s", pfn_nvmlErrorString(e44241808)); \
       return ncclSystemError; \
     } \
   } while (0)

--- a/comms/ncclx/v2_31/src/misc/param.cc
+++ b/comms/ncclx/v2_31/src/misc/param.cc
@@ -20,6 +20,17 @@
 #include <unordered_set>
 #include "os.h"
 
+#include "cuda_runtime_api.h"
+
+#include <folly/synchronization/CallOnce.h>
+
+#include "comms/utils/InitFolly.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/SpdlogLogger.h"
+#include "meta/NcclxLogger.h"
+
 const char* userHomeDir() {
   return getenv("HOME");
 }
@@ -67,8 +78,19 @@ static void initEnvFunc() {
 }
 
 void initEnv() {
-  static std::once_flag once;
-  std::call_once(once, initEnvFunc);
+  // folly::call_once, not std::call_once: initFolly()/ncclCvarInit() can throw,
+  // and std::call_once deadlocks rather than retrying on a throwing callable.
+  static folly::once_flag once;
+  folly::call_once(once, [] {
+    meta::comms::initFolly();
+    ncclCvarInit();
+    // As early as the sink can be registered: it is configured from the
+    // NCCL_DEBUG* cvars, so it cannot precede ncclCvarInit(). Anything logged
+    // before this point goes to an unconfigured logger and is lost, so keep
+    // initEnvFunc() -- which reads conf files and can warn -- after it.
+    initNcclLogger();
+    initEnvFunc();
+  });
 }
 
 static void ncclGetCachePolicy(char const* env, int8_t* noCache) {
@@ -108,4 +130,20 @@ int64_t ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, i
 const char* ncclGetEnv(const char* name) {
   ncclInitEnv();
   return ncclEnvPluginGetEnv(name);
+}
+
+void initNcclLogger() {
+  // Shared CollTrace code still emits raw XLOG under comms.utils.
+  meta::comms::logger::initCommLogging();
+  meta::comms::logger::configureSpdlogLogger(
+    ncclx::logging::kNcclxLoggerName, "NCCL", meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str()),
+    []() {
+      int cudaDev = -1;
+      (void)cudaGetDevice(&cudaDev);
+      return cudaDev;
+    },
+    [](std::string_view message) { meta::comms::logger::setLastError(std::string{message}, {}); },
+    NCCL_DEBUG_LOGGING_ASYNC);
+  meta::comms::logger::getSpdlogLogger(ncclx::logging::kNcclxLoggerName)
+    .set_level(meta::comms::logger::loggerLevelToSpdlogLevel(meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)));
 }

--- a/comms/ncclx/v2_31/src/misc/socket.cc
+++ b/comms/ncclx/v2_31/src/misc/socket.cc
@@ -55,7 +55,7 @@ static ncclResult_t socketProgress(int op, struct ncclSocket* sock, void* ptr, i
       return ncclSuccess;
     } else {
       char line[SOCKET_NAME_MAXLEN + 1];
-      WARN("socketProgress: Connection closed by remote peer %s",
+      ERR(ncclRemoteError, "socketProgress: Connection closed by remote peer %s",
            ncclSocketToString(&sock->addr, line, /*numericHostForm*/ 0));
       return ncclRemoteError;
     }
@@ -91,7 +91,7 @@ ncclResult_t ncclSocketShutdown(struct ncclSocket* sock, int how) {
 
 ncclResult_t ncclSocketGetFd(struct ncclSocket* sock, ncclSocketDescriptor* socketDescriptor) {
   if (sock == NULL) {
-    WARN("ncclSocketGetFd: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketGetFd: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (socketDescriptor) *socketDescriptor = sock->socketDescriptor;
@@ -100,7 +100,7 @@ ncclResult_t ncclSocketGetFd(struct ncclSocket* sock, ncclSocketDescriptor* sock
 
 ncclResult_t ncclSocketSetFd(ncclSocketDescriptor socketDescriptor, struct ncclSocket* sock) {
   if (sock == NULL) {
-    WARN("ncclSocketSetFd: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketSetFd: pass NULL socket");
     return ncclInvalidArgument;
   }
   sock->socketDescriptor = socketDescriptor;
@@ -109,11 +109,11 @@ ncclResult_t ncclSocketSetFd(ncclSocketDescriptor socketDescriptor, struct ncclS
 
 ncclResult_t ncclSocketListen(struct ncclSocket* sock) {
   if (sock == NULL) {
-    WARN("ncclSocketListen: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketListen: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (!ncclOsSocketIsValid(sock)) {
-    WARN("ncclSocketListen: socket is invalid");
+    ERR(ncclInvalidArgument, "ncclSocketListen: socket is invalid");
     return ncclInvalidArgument;
   }
 
@@ -233,7 +233,7 @@ ncclResult_t ncclFindInterfaces(char* ifNames, union ncclSocketAddress* ifAddrs,
 
 ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char* ip_port_pair) {
   if (!(ip_port_pair && strlen(ip_port_pair) > 1)) {
-    WARN("Net : string is null");
+    ERR(ncclInvalidArgument, "Net : string is null");
     return ncclInvalidArgument;
   }
 
@@ -243,7 +243,7 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
     struct netIf ni;
     // parse <ip_or_hostname>:<port> string, expect one pair
     if (parseStringList(ip_port_pair, &ni, 1) != 1) {
-      WARN("Net : No valid <IPv4_or_hostname>:<port> pair found");
+      ERR(ncclInvalidArgument, "Net : No valid <IPv4_or_hostname>:<port> pair found");
       return ncclInvalidArgument;
     }
 
@@ -254,7 +254,7 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
     hints.ai_socktype = SOCK_STREAM;
 
     if ((rv = getaddrinfo(ni.prefix, NULL, &hints, &p)) != 0) {
-      WARN("Net : error encountered when getting address info : %s", gai_strerror(rv));
+      ERR(ncclInvalidArgument, "Net : error encountered when getting address info : %s", gai_strerror(rv));
       return ncclInvalidArgument;
     }
 
@@ -273,7 +273,7 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
       sin6.sin6_flowinfo = 0;                          // needed by IPv6, but possibly obsolete
       sin6.sin6_scope_id = 0;                          // should be global scope, set to 0
     } else {
-      WARN("Net : unsupported IP family");
+      ERR(ncclInvalidArgument, "Net : unsupported IP family");
       freeaddrinfo(p);
       return ncclInvalidArgument;
     }
@@ -287,7 +287,7 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
       if (ip_port_pair[i] == ']') break;
     }
     if (i == len) {
-      WARN("Net : No valid [IPv6]:port pair found");
+      ERR(ncclInvalidArgument, "Net : No valid [IPv6]:port pair found");
       return ncclInvalidArgument;
     }
     bool global_scope = (j == -1 ? true : false);     // If no % found, global scope; otherwise, link scope
@@ -316,7 +316,7 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
 
 ncclResult_t ncclSocketGetAddr(struct ncclSocket* sock, union ncclSocketAddress* addr) {
   if (sock == NULL) {
-    WARN("ncclSocketGetAddr: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketGetAddr: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (sock->state != ncclSocketStateReady) return ncclInternalError;
@@ -390,7 +390,7 @@ static ncclResult_t socketFinalizeAccept(struct ncclSocket* sock) {
 
 ncclResult_t ncclSocketPollConnect(struct ncclSocket* sock) {
   if (sock == NULL) {
-    WARN("ncclSocketPollConnect: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketPollConnect: pass NULL socket");
     return ncclInvalidArgument;
   }
   NCCLCHECK(ncclOsSocketPollConnect(sock));
@@ -445,7 +445,7 @@ ncclResult_t ncclSocketReady(struct ncclSocket* sock, int* running) {
     return ncclSuccess;
   }
   if (sock->state == ncclSocketStateError || sock->state == ncclSocketStateClosed) {
-    WARN("ncclSocketReady: unexpected socket state %d", sock->state);
+    ERR(ncclRemoteError, "ncclSocketReady: unexpected socket state %d", sock->state);
     return ncclRemoteError;
   }
   *running = (sock->state == ncclSocketStateReady) ? 1 : 0;
@@ -463,11 +463,11 @@ ncclResult_t ncclSocketConnect(struct ncclSocket* sock) {
 #endif
 
   if (sock == NULL) {
-    WARN("ncclSocketConnect: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketConnect: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (!ncclOsSocketIsValid(sock)) {
-    WARN("ncclSocketConnect: socket is invalid");
+    ERR(ncclInvalidArgument, "ncclSocketConnect: socket is invalid");
     return ncclInvalidArgument;
   }
 
@@ -507,7 +507,7 @@ ncclResult_t ncclSocketAccept(struct ncclSocket* sock, struct ncclSocket* listen
   ncclResult_t ret = ncclSuccess;
 
   if (listenSock == NULL || sock == NULL) {
-    WARN("ncclSocketAccept: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketAccept: pass NULL socket");
     ret = ncclInvalidArgument;
     goto exit;
   }
@@ -582,7 +582,7 @@ ncclResult_t ncclSocketInit(struct ncclSocket* sock, const union ncclSocketAddre
     family = sock->addr.sa.sa_family;
     if (family != AF_INET && family != AF_INET6) {
       char line[SOCKET_NAME_MAXLEN + 1];
-      WARN("ncclSocketInit: connecting to address %s with family %d is neither AF_INET(%d) nor AF_INET6(%d)",
+      ERR(ncclInternalError, "ncclSocketInit: connecting to address %s with family %d is neither AF_INET(%d) nor AF_INET6(%d)",
            ncclSocketToString(&sock->addr, line), family, AF_INET, AF_INET6);
       ret = ncclInternalError;
       goto exit;
@@ -603,7 +603,7 @@ fail:
 
 ncclResult_t ncclSocketProgress(int op, struct ncclSocket* sock, void* ptr, int size, int* offset, int* closed) {
   if (sock == NULL) {
-    WARN("ncclSocketProgress: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketProgress: pass NULL socket");
     return ncclInvalidArgument;
   }
   NCCLCHECK(socketProgress(op, sock, ptr, size, offset, closed));
@@ -612,7 +612,7 @@ ncclResult_t ncclSocketProgress(int op, struct ncclSocket* sock, void* ptr, int 
 
 ncclResult_t ncclSocketWait(int op, struct ncclSocket* sock, void* ptr, int size, int* offset) {
   if (sock == NULL) {
-    WARN("ncclSocketWait: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketWait: pass NULL socket");
     return ncclInvalidArgument;
   }
   NCCLCHECK(socketWait(op, sock, ptr, size, offset));
@@ -622,11 +622,11 @@ ncclResult_t ncclSocketWait(int op, struct ncclSocket* sock, void* ptr, int size
 ncclResult_t ncclSocketSend(struct ncclSocket* sock, void* ptr, int size) {
   int offset = 0;
   if (sock == NULL) {
-    WARN("ncclSocketSend: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketSend: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (sock->state != ncclSocketStateReady) {
-    WARN("ncclSocketSend: socket state (%d) is not ready", sock->state);
+    ERR(ncclInternalError, "ncclSocketSend: socket state (%d) is not ready", sock->state);
     return ncclInternalError;
   }
   NCCLCHECK(socketWait(NCCL_SOCKET_SEND, sock, ptr, size, &offset));
@@ -636,11 +636,11 @@ ncclResult_t ncclSocketSend(struct ncclSocket* sock, void* ptr, int size) {
 ncclResult_t ncclSocketRecv(struct ncclSocket* sock, void* ptr, int size) {
   int offset = 0;
   if (sock == NULL) {
-    WARN("ncclSocketRecv: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketRecv: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (sock->state != ncclSocketStateReady && sock->state != ncclSocketStateTerminating) {
-    WARN("ncclSocketRecv: socket state (%d) is not ready", sock->state);
+    ERR(ncclInternalError, "ncclSocketRecv: socket state (%d) is not ready", sock->state);
     return ncclInternalError;
   }
   NCCLCHECK(socketWait(NCCL_SOCKET_RECV, sock, ptr, size, &offset));
@@ -651,12 +651,12 @@ ncclResult_t ncclSocketSendRecv(struct ncclSocket* sendSock, void* sendPtr, int 
                                 void* recvPtr, int recvSize) {
   int sendOffset = 0, recvOffset = 0;
   if (sendSock == NULL || recvSock == NULL) {
-    WARN("ncclSocketSendRecv: invalid socket %p/%p", sendSock, recvSock);
+    ERR(ncclInternalError, "ncclSocketSendRecv: invalid socket %p/%p", sendSock, recvSock);
     return ncclInternalError;
   }
   if (sendSock->state != ncclSocketStateReady ||
       (recvSock->state != ncclSocketStateReady && recvSock->state != ncclSocketStateTerminating)) {
-    WARN("ncclSocketSendRecv: socket state (%d/%d) is not ready", sendSock->state, recvSock->state);
+    ERR(ncclInternalError, "ncclSocketSendRecv: socket state (%d/%d) is not ready", sendSock->state, recvSock->state);
     return ncclInternalError;
   }
   while (sendOffset < sendSize || recvOffset < recvSize) {
@@ -668,13 +668,13 @@ ncclResult_t ncclSocketSendRecv(struct ncclSocket* sendSock, void* sendPtr, int 
 
 ncclResult_t ncclSocketMultiOp(struct ncclSocketOp* ops, int numOps) {
   if (ops == NULL || numOps <= 0) {
-    WARN("ncclSocketMultiOp: invalid arguments ops=%p numOps=%d", ops, numOps);
+    ERR(ncclInvalidArgument, "ncclSocketMultiOp: invalid arguments ops=%p numOps=%d", ops, numOps);
     return ncclInvalidArgument;
   }
 
   for (int i = 0; i < numOps; i++) {
     if (ops[i].sock == NULL) {
-      WARN("ncclSocketMultiOp: invalid socket at index %d", i);
+      ERR(ncclInvalidArgument, "ncclSocketMultiOp: invalid socket at index %d", i);
       return ncclInvalidArgument;
     }
     ops[i].offset = 0;
@@ -693,7 +693,7 @@ ncclResult_t ncclSocketMultiOp(struct ncclSocketOp* ops, int numOps) {
 ncclResult_t ncclSocketTryRecv(struct ncclSocket* sock, void* ptr, int size, int* closed, bool blocking) {
   int offset = 0;
   if (sock == NULL) {
-    WARN("ncclSocketTryRecv: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclSocketTryRecv: pass NULL socket");
     return ncclInvalidArgument;
   }
   *closed = 0;

--- a/comms/ncclx/v2_31/src/misc/strongstream.cc
+++ b/comms/ncclx/v2_31/src/misc/strongstream.cc
@@ -103,7 +103,7 @@ ncclResult_t ncclCudaGetCapturingGraph(struct ncclCudaGraph* graph, cudaStream_t
     graph->graphUsageMode = graphUsageMode;
 #endif
     if (status != cudaStreamCaptureStatusNone) {
-      WARN("NCCL cannot be captured in a graph if either it wasn't built with CUDA runtime >= 11.3 or if the installed "
+      ERR(ncclInvalidUsage, "NCCL cannot be captured in a graph if either it wasn't built with CUDA runtime >= 11.3 or if the installed "
            "CUDA driver < R465.");
       return ncclInvalidUsage;
     }
@@ -349,7 +349,7 @@ ncclResult_t ncclStrongStreamRelease(struct ncclCudaGraph graph, struct ncclStro
         CUDACHECK(cudaEventRecord(ss->serialEvent, ss->liveStream));
       }
       if (ss->liveAcquiredBy != localThreadId() && ncclParamLaunchRaceFatal()) {
-        WARN("%s", launchRaceFatalMsg);
+        ERR(ncclInvalidUsage, "%s", launchRaceFatalMsg);
         return ncclInvalidUsage;
       }
     } else {
@@ -362,7 +362,7 @@ ncclResult_t ncclStrongStreamRelease(struct ncclCudaGraph graph, struct ncclStro
       NCCLCHECK(recordEventOnStream(graph, ss->serialEvent, cap->captureStream, /*updateFrontier=*/true));
 
       if (cap->acquiredBy != localThreadId() && ncclParamLaunchRaceFatal()) {
-        WARN("%s", launchRaceFatalMsg);
+        ERR(ncclInvalidUsage, "%s", launchRaceFatalMsg);
         return ncclInvalidUsage;
       }
     }

--- a/comms/ncclx/v2_31/src/misc/utils.cc
+++ b/comms/ncclx/v2_31/src/misc/utils.cc
@@ -406,15 +406,15 @@ ncclResult_t ncclIntruAddressMapInsert_untyped(struct ncclIntruAddressMap_untype
                                                int nextFieldOffset, uintptr_t key, void* object) {
   // Runtime validation
   if (map == nullptr) {
-    WARN("Intrusive address map pointer is NULL");
+    ERR(ncclInvalidUsage, "Intrusive address map pointer is NULL");
     return ncclInvalidUsage;
   }
   if (object == nullptr) {
-    WARN("Object pointer is NULL");
+    ERR(ncclInvalidUsage, "Object pointer is NULL");
     return ncclInvalidUsage;
   }
   if (keySize <= 0 || keySize > (int)sizeof(uintptr_t)) {
-    WARN("Invalid key size %d (must be 0 < keySize <= %zu)", keySize, sizeof(uintptr_t));
+    ERR(ncclInvalidUsage, "Invalid key size %d (must be 0 < keySize <= %zu)", keySize, sizeof(uintptr_t));
     return ncclInvalidUsage;
   }
 
@@ -426,7 +426,7 @@ ncclResult_t ncclIntruAddressMapInsert_untyped(struct ncclIntruAddressMap_untype
     map->table = (void**)calloc(tableEntries, sizeof(void*));
     if (map->table == nullptr) {
       map->hbits = 0; // Reset on failure
-      WARN("Intrusive address map initialization failed: calloc(%zu entries) returned null", tableEntries);
+      ERR(ncclSystemError, "Intrusive address map initialization failed: calloc(%zu entries) returned null", tableEntries);
       return ncclSystemError;
     }
   }
@@ -443,7 +443,7 @@ ncclResult_t ncclIntruAddressMapInsert_untyped(struct ncclIntruAddressMap_untype
     // Allocate a new table (don't use realloc to avoid data corruption during rehashing)
     void** newTable = (void**)malloc(newSize * sizeof(void*));
     if (newTable == nullptr) {
-      WARN("Intrusive address map resize failed: malloc(%d entries) returned null", newSize);
+      ERR(ncclSystemError, "Intrusive address map resize failed: malloc(%d entries) returned null", newSize);
       return ncclSystemError;
     }
 
@@ -495,15 +495,15 @@ ncclResult_t ncclIntruAddressMapFind_untyped(struct ncclIntruAddressMap_untyped*
                                              int nextFieldOffset, uintptr_t key, void** object) {
   // Runtime validation
   if (map == nullptr) {
-    WARN("Intrusive address map pointer is NULL");
+    ERR(ncclInvalidUsage, "Intrusive address map pointer is NULL");
     return ncclInvalidUsage;
   }
   if (object == nullptr) {
-    WARN("Output object pointer is NULL");
+    ERR(ncclInvalidUsage, "Output object pointer is NULL");
     return ncclInvalidUsage;
   }
   if (keySize <= 0 || keySize > (int)sizeof(uintptr_t)) {
-    WARN("Invalid key size %d (must be 0 < keySize <= %zu)", keySize, sizeof(uintptr_t));
+    ERR(ncclInvalidUsage, "Invalid key size %d (must be 0 < keySize <= %zu)", keySize, sizeof(uintptr_t));
     return ncclInvalidUsage;
   }
 
@@ -534,11 +534,11 @@ ncclResult_t ncclIntruAddressMapRemove_untyped(struct ncclIntruAddressMap_untype
                                                int nextFieldOffset, uintptr_t key) {
   // Runtime validation
   if (map == nullptr) {
-    WARN("Intrusive address map pointer is NULL");
+    ERR(ncclInvalidUsage, "Intrusive address map pointer is NULL");
     return ncclInvalidUsage;
   }
   if (keySize <= 0 || keySize > (int)sizeof(uintptr_t)) {
-    WARN("Invalid key size %d (must be 0 < keySize <= %zu)", keySize, sizeof(uintptr_t));
+    ERR(ncclInvalidUsage, "Invalid key size %d (must be 0 < keySize <= %zu)", keySize, sizeof(uintptr_t));
     return ncclInvalidUsage;
   }
 

--- a/comms/ncclx/v2_31/src/mnnvl.cc
+++ b/comms/ncclx/v2_31/src/mnnvl.cc
@@ -66,7 +66,7 @@ ncclResult_t ncclMnnvlCheck(struct ncclComm* comm) {
       ncclCuMemAlloc(&ptr, &handle, CU_MEM_HANDLE_TYPE_FABRIC, CUDA_IPC_MIN, comm->memManager, ncclMemOffload);
     if (ret != ncclSuccess) {
       // Return an error if this is a MNNVL capable system but FABRIC handles are not supported
-      WARN("MNNVL (cliqueSize %d) is available but not working on this system. Check the IMEX channel configuration "
+      ERR(ncclSystemError, "MNNVL (cliqueSize %d) is available but not working on this system. Check the IMEX channel configuration "
            "(/dev/nvidia-caps-imex-channels). Set NCCL_MNNVL_ENABLE=0 to ignore this issue.",
            comm->clique.size);
       return ncclSystemError;
@@ -78,7 +78,7 @@ ncclResult_t ncclMnnvlCheck(struct ncclComm* comm) {
       (void)pfn_cuGetErrorString(err, &errStr);
       NCCLCHECK(ncclCuMemFree(ptr, comm->memManager));
       // Return an error if this is a MNNVL capable system but it's not working
-      WARN("MNNVL (cliqueSize %d) is available but not working on this system. Check the IMEX configuration "
+      ERR(ncclSystemError, "MNNVL (cliqueSize %d) is available but not working on this system. Check the IMEX configuration "
            "(nvidia-imex-ctl -N). Set NCCL_MNNVL_ENABLE=0 to ignore this issue.",
            comm->clique.size);
       return ncclSystemError;

--- a/comms/ncclx/v2_31/src/nccl.h.in
+++ b/comms/ncclx/v2_31/src/nccl.h.in
@@ -1074,6 +1074,74 @@ void pncclParamDumpAll(void);
 
 #ifdef __cplusplus
 
+// [META] CollTrace lifecycle feed and algorithm-statistics dump. Declared
+// outside extern "C" so the C++ container signatures work.
+#include <cstdint>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace ncclx::colltrace {
+
+inline constexpr uint64_t kInvalidReplayId = UINT64_MAX;
+
+enum class LifecycleEventType : uint8_t {
+  Enqueue,
+  Start,
+  End,
+};
+
+struct LifecycleEvent {
+  uint64_t replayId{kInvalidReplayId};
+  uint64_t commId{0};
+  // Stable one-based submission identity. Zero is reserved for no record.
+  // Matches getLatestCollTraceCollectiveId().
+  uint64_t collId{0};
+  // One-based per-execution identity. Differs from collId for graph replays.
+  uint64_t executionCollId{0};
+  LifecycleEventType eventType{LifecycleEventType::Enqueue};
+  double timestamp{0};
+};
+
+// Returns the process-local communicator identity used by lifecycle events.
+// Returns ncclInvalidArgument for a null communicator or ncclInvalidUsage if
+// the lifecycle feed is disabled.
+ncclResult_t getCollTraceCommId(ncclComm_t comm, uint64_t& commId);
+
+// Returns the latest one-based collective ID submitted on this communicator.
+// Writes zero and returns ncclSuccess if no collective has been submitted on
+// this communicator. Returns ncclInvalidArgument for a null communicator or
+// ncclInvalidUsage if the lifecycle feed is disabled.
+ncclResult_t getLatestCollTraceCollectiveId(ncclComm_t comm, uint64_t& collId);
+
+// Destructively drains lifecycle events across all lifecycle-enabled
+// communicators in this process. This call blocks until every registered
+// colltrace instance finishes a flush. Events are ordered by timestamp.
+ncclResult_t drainUnreadLifecycleEvents(std::vector<LifecycleEvent>& events);
+
+} // namespace ncclx::colltrace
+
+// NCCL_HAS_DUMP_ALGO_STAT controls whether dumpAlgoStat() is available.
+// To disable (e.g., when using a shim with a
+// different ncclComm layout), compile with -DNCCL_HAS_DUMP_ALGO_STAT=0.
+#if !defined(NCCL_HAS_DUMP_ALGO_STAT)
+#define NCCL_HAS_DUMP_ALGO_STAT
+#elif NCCL_HAS_DUMP_ALGO_STAT == 0
+#undef NCCL_HAS_DUMP_ALGO_STAT
+#endif
+
+#ifdef NCCL_HAS_DUMP_ALGO_STAT
+namespace ncclx::colltrace {
+
+// Dump collective algorithm statistics for a communicator.
+// Output map format: collective name -> algorithm name -> call count.
+// Requires NCCL_COLLTRACE=algostat to be enabled.
+// Clears and populates the output map. Empty if algostat not enabled or comm is null.
+void dumpAlgoStat(ncclComm_t comm, std::unordered_map<std::string, std::unordered_map<std::string, int64_t>>& algoStatMap);
+
+} // namespace ncclx::colltrace
+#endif // NCCL_HAS_DUMP_ALGO_STAT
+
 namespace ncclx {
 
 /*

--- a/comms/ncclx/v2_31/src/nccl.h.in
+++ b/comms/ncclx/v2_31/src/nccl.h.in
@@ -456,11 +456,14 @@ ncclResult_t pncclCommCuDevice(const ncclComm_t comm, int* device);
 ncclResult_t  ncclCommUserRank(const ncclComm_t comm, int* rank);
 ncclResult_t pncclCommUserRank(const ncclComm_t comm, int* rank);
 
-/* Register CUDA buffer for zero-copy operation */
+/* Handle-based registration for zero-copy operation.
+ * Consider using ncclGlobalRegisterWithPtr for new code - it supports both single and
+ * multi-segment buffers without requiring handle management. */
 ncclResult_t  ncclCommRegister(const ncclComm_t comm, void* buff, size_t size, void** handle);
 ncclResult_t pncclCommRegister(const ncclComm_t comm, void* buff, size_t size, void** handle);
 
-/* Deregister CUDA buffer */
+/* Handle-based deregistration.
+ * Consider using ncclGlobalDeregisterWithPtr for new code. */
 ncclResult_t  ncclCommDeregister(const ncclComm_t comm, void* handle);
 ncclResult_t pncclCommDeregister(const ncclComm_t comm, void* handle);
 
@@ -504,6 +507,23 @@ typedef enum {
  */
 ncclResult_t  ncclCommMemStats(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value);
 ncclResult_t pncclCommMemStats(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value);
+
+/* Pointer-based registration for all buffer types - no handle returned.
+ * Supports both single-segment and multi-segment (expandable) buffers.
+ * Use ncclGlobalDeregisterWithPtr(buf, len) to deregister.
+ * "Global" because registration is stored in a global RegCache, not per-comm.
+ * Does not require a communicator - uses global backends set by first comm.
+ * cudaDev is auto-detected from the buffer pointer. */
+ncclResult_t  ncclGlobalRegisterWithPtr(void* buff, size_t size);
+ncclResult_t pncclGlobalRegisterWithPtr(void* buff, size_t size);
+
+/* Pointer-based deregistration for all buffer types.
+ * Uses pinRange to discover all physical segments and frees each.
+ * "Global" because registration is stored in a global RegCache, not per-comm.
+ * Does not require a communicator - uses global backends set by first comm.
+ * cudaDev is auto-detected from the buffer pointer. */
+ncclResult_t  ncclGlobalDeregisterWithPtr(void* buff, size_t size);
+ncclResult_t pncclGlobalDeregisterWithPtr(void* buff, size_t size);
 
 /* Register memory window  */
 ncclResult_t  ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, ncclWindow_t* win, int winFlags);

--- a/comms/ncclx/v2_31/src/nccl.h.in
+++ b/comms/ncclx/v2_31/src/nccl.h.in
@@ -61,6 +61,11 @@
 #endif
 
 #ifdef __cplusplus
+// [NCCLX] Needed by ncclx::Hints below, which is declared inside the extern "C"
+// region so that C++ entry points can take it by reference.
+#include <initializer_list>
+#include <string>
+#include <unordered_map>
 extern "C" {
 #endif
 
@@ -151,6 +156,34 @@ typedef struct ncclConfig_v23100 {
   int numRmaSig;
   int rmaEagerInit;
   int hostCftMode;
+
+  //
+  // [NCCLX] Attributes following here are specific to NCCLX
+  //
+  // Appended after the last upstream member, matching v2_29/v2_30. The struct is
+  // versioned and append-only, so upstream's own members keep their offsets; only
+  // sizeof() grows, and NCCLX is the only reader of the fields below.
+  //
+
+  // communicator process group information.
+  const char* commDesc{nullptr};
+
+  // commSplit group ranks information
+  int* splitGroupRanks;
+  int splitGroupSize;
+
+  // control the fast init features
+  int fastInitMode{NCCL_CONFIG_UNDEF_INT};
+
+  // Opaque pointer to an ncclx::Hints object.  When non-null, NCCLX
+  // will read key-value pairs from this object and apply them to
+  // config fields that are still at their undefined defaults.
+  void* hints{NCCL_CONFIG_UNDEF_PTR};
+
+  // Internal field -- do not access directly.  This would be private
+  // if ncclConfig_t were a C++ class.  Populated by NCCLX during
+  // communicator creation; users must not read or write this field.
+  void* ncclxConfig{NCCL_CONFIG_UNDEF_PTR};
 } ncclConfig_t;
 
 /* Config initializer must be assigned to initialize config structure when it is created.
@@ -181,6 +214,12 @@ typedef struct ncclConfig_v23100 {
   NCCL_CONFIG_UNDEF_INT,                    /* numRmaSig */             \
   NCCL_CONFIG_UNDEF_INT,                    /* rmaEagerInit */          \
   NCCL_CONFIG_UNDEF_INT,                    /* hostCftMode */          \
+  NCCL_CONFIG_UNDEF_PTR,                    /* commDesc */              \
+  NCCL_CONFIG_UNDEF_PTR,                    /* splitGroupRanks */       \
+  NCCL_CONFIG_UNDEF_INT,                    /* splitGroupSize */        \
+  NCCL_CONFIG_UNDEF_INT,                    /* fastInitMode */          \
+  NCCL_CONFIG_UNDEF_PTR,                    /* hints */                 \
+  NCCL_CONFIG_UNDEF_PTR,                    /* ncclxConfig */           \
 }
 
 /* A single vendor-specific option expressed as a key-value pair. Multiple options can be
@@ -496,6 +535,13 @@ typedef enum { ncclSum        = 0,
                 * maintain ABI compatibility. */
                ncclMaxRedOp   = 0x7fffffff>>(32-8*sizeof(ncclRedOp_dummy_t))
              } ncclRedOp_t;
+
+/* [NCCLX] Comparison operation selector.
+ * Type-only dependency: shared meta/wrapper/MetaFactory.h maps this onto
+ * commCmpOp_t, so every version dir must declare it. The RMA signal API that
+ * consumes it (ncclWaitSignal and friends) is a separate row and is not ported
+ * here. */
+typedef enum { ncclCmpEQ = 0, ncclCmpGE = 1, ncclCmpLE = 2, ncclNumCmpOps = 3} ncclCmpOp_t;
 
 /* Data types */
 typedef enum { ncclInt8       = 0, ncclChar       = 0,
@@ -904,6 +950,28 @@ ncclResult_t pncclGroupEnd();
 ncclResult_t  ncclGroupSimulateEnd(ncclSimInfo_t* simInfo);
 ncclResult_t pncclGroupSimulateEnd(ncclSimInfo_t* simInfo);
 
+#ifdef __cplusplus
+namespace ncclx {
+typedef std::unordered_map<std::string, std::string> kvType;
+/*
+* NCCL hints object - Allows us to set hints (key, value) in the form
+* of strings, to be used by other operations.
+*/
+class Hints {
+    public:
+        Hints();
+        explicit Hints(std::initializer_list<std::pair<std::string, std::string>> init);
+        ncclResult_t set(const std::string& key, const std::string& val);
+        ncclResult_t get(const std::string& key, std::string& val) const;
+
+    private:
+        kvType kv;
+};
+
+} // namespace ncclx
+
+#endif
+
 /*
  * Parameter access
  *
@@ -1002,6 +1070,33 @@ void pncclParamDumpAll(void);
 
 #ifdef __cplusplus
 } // end extern "C"
+#endif
+
+#ifdef __cplusplus
+
+namespace ncclx {
+
+/*
+ * Set per-communicator configuration
+ *
+ * Update mutable configuration fields on a live communicator. Only
+ * algorithm-selection hint keys (sendrecvAlgo, allgatherAlgo, allreduceAlgo,
+ * alltoallvAlgo, rmaAlgo) may be changed after communicator creation.
+ *
+ * The config parameter must be initialized with NCCL_CONFIG_INITIALIZER. All
+ * flat ncclConfig_t fields must remain at their undefined defaults; only the
+ * hints pointer is read. Setting any flat field or any non-algo hint key
+ * returns ncclInvalidUsage. Passing an uninitialized config (missing magic)
+ * returns ncclInvalidArgument.
+ *
+ * The caller must ensure no concurrent collective or config update is in
+ * progress on the same communicator.
+ */
+// [META:COMM_SET_CONFIG]
+ncclResult_t commSetConfig(ncclComm_t comm, const ncclConfig_t* config);
+
+} // namespace ncclx
+
 #endif
 
 #endif // end include guard

--- a/comms/ncclx/v2_31/src/os/linux.cc
+++ b/comms/ncclx/v2_31/src/os/linux.cc
@@ -195,13 +195,13 @@ ncclResult_t ncclOsSocketTryAccept(struct ncclSocket* sock) {
     /* per accept's man page, for linux sockets, the following errors might be already pending errors
      * and should be considered as EAGAIN. To avoid infinite loop in case of errors, we use the retry count*/
     if (++sock->errorRetries == ncclParamRetryCnt()) {
-      WARN("ncclOsSocketTryAccept: exceeded error retry count after %d attempts, %s", sock->errorRetries,
+      ERR(ncclSystemError, "ncclOsSocketTryAccept: exceeded error retry count after %d attempts, %s", sock->errorRetries,
            strerror(errno));
       return ncclSystemError;
     }
     INFO(NCCL_NET | NCCL_INIT, "Call to accept returned %s, retrying", strerror(errno));
   } else if (errno != EINTR && errno != EAGAIN && errno != EWOULDBLOCK) {
-    WARN("ncclOsSocketTryAccept: Accept failed: %s", strerror(errno));
+    ERR(ncclSystemError, "ncclOsSocketTryAccept: Accept failed: %s", strerror(errno));
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -216,7 +216,7 @@ ncclResult_t ncclOsSocketSetFlags(struct ncclSocket* sock) {
   int flags;
   int rcvBuf, sndBuf;
   if (!ncclOsSocketIsValid(sock)) {
-    WARN("ncclOsSocketSetFlags: invalid socket");
+    ERR(ncclInvalidArgument, "ncclOsSocketSetFlags: invalid socket");
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -285,7 +285,7 @@ static ncclResult_t socketConnectCheck(struct ncclSocket* sock, int errCode, con
     if (sock->customRetry == 0) {
       if (sock->errorRetries++ == ncclParamRetryCnt()) {
         sock->state = ncclSocketStateError;
-        WARN("%s: connect to %s returned %s, exceeded error retry count after %d attempts", funcName,
+        ERR(ncclRemoteError, "%s: connect to %s returned %s, exceeded error retry count after %d attempts", funcName,
              ncclSocketToString(&sock->addr, line), strerror(errCode), sock->errorRetries);
         return ncclRemoteError;
       }
@@ -299,7 +299,7 @@ static ncclResult_t socketConnectCheck(struct ncclSocket* sock, int errCode, con
     sock->state = ncclSocketStateConnecting;
   } else {
     sock->state = ncclSocketStateError;
-    WARN("%s: connect to %s failed : %s", funcName, ncclSocketToString(&sock->addr, line), strerror(errCode));
+    ERR(ncclSystemError, "%s: connect to %s failed : %s", funcName, ncclSocketToString(&sock->addr, line), strerror(errCode));
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -325,7 +325,7 @@ ncclResult_t ncclOsSocketPollConnect(struct ncclSocket* sock) {
   if (ret == 0 || (ret < 0 && errno == EINTR)) {
     return ncclSuccess;
   } else if (ret < 0) {
-    WARN("ncclOsSocketPollConnect to %s failed with error %s", ncclSocketToString(&sock->addr, line), strerror(errno));
+    ERR(ncclSystemError, "ncclOsSocketPollConnect to %s failed with error %s", ncclSocketToString(&sock->addr, line), strerror(errno));
     return ncclSystemError;
   }
 
@@ -359,7 +359,7 @@ ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr,
         return ncclSuccess;
       }
       if (errno != EINTR && errno != EWOULDBLOCK && errno != EAGAIN) {
-        WARN("ncclOsSocketProgressOpt: Call to %s %s failed : %s", (op == NCCL_SOCKET_RECV ? "recv from" : "send to"),
+        ERR(ncclRemoteError, "ncclOsSocketProgressOpt: Call to %s %s failed : %s", (op == NCCL_SOCKET_RECV ? "recv from" : "send to"),
              ncclSocketToString(&sock->addr, line), strerror(errno));
         return ncclRemoteError;
       } else {
@@ -597,7 +597,7 @@ ncclAffinity ncclOsCpuAnd(const ncclAffinity& a, const ncclAffinity& b) {
 ncclResult_t ncclOsGetAffinity(ncclAffinity* affinity) {
   int result = sched_getaffinity(0, sizeof(ncclAffinity), affinity);
   if (result == -1) {
-    WARN("sched_getaffinity failed with error: %s", strerror(errno));
+    ERR(ncclSystemError, "sched_getaffinity failed with error: %s", strerror(errno));
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -606,7 +606,7 @@ ncclResult_t ncclOsGetAffinity(ncclAffinity* affinity) {
 ncclResult_t ncclOsSetAffinity(const ncclAffinity& affinity) {
   int result = sched_setaffinity(0, sizeof(ncclAffinity), &affinity);
   if (result == -1) {
-    WARN("sched_setaffinity failed with error: %s", strerror(errno));
+    ERR(ncclSystemError, "sched_setaffinity failed with error: %s", strerror(errno));
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -621,7 +621,7 @@ ncclResult_t ncclOsNvmlOpen(ncclOsLibraryHandle* handle) {
 
   *handle = ncclOsDlopen("libnvidia-ml.so.1");
   if (*handle == nullptr) {
-    WARN("Failed to open libnvidia-ml.so.1: %s", ncclOsDlerror());
+    ERR(ncclSystemError, "Failed to open libnvidia-ml.so.1: %s", ncclOsDlerror());
     return ncclSystemError;
   }
 
@@ -643,7 +643,7 @@ ncclResult_t ncclOsGetPciPath(const char* busId, char** path) {
   memcpylower(busPath + sizeof("/sys/class/pci_bus/0000:00/../../") - 1, busId, BUSID_SIZE - 1);
   *path = realpath(busPath, NULL);
   if (*path == NULL) {
-    WARN("Could not find real path of %s", busPath);
+    ERR(ncclSystemError, "Could not find real path of %s", busPath);
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -786,7 +786,7 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize, vo
           INFO(NCCL_ALL, "mkstemp: Failed to create %s, error: %s (%d) - retrying", shmPath, strerror(errno), errno);
           goto retry_mkstemp;
         }
-        WARN("Error: failed to create shared memory file %s, error %s (%d)", shmPath, strerror(errno), errno);
+        ERR(ncclSystemError, "Error: failed to create shared memory file %s, error %s (%d)", shmPath, strerror(errno), errno);
         ret = ncclSystemError;
         goto fail;
       }
@@ -801,7 +801,7 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize, vo
              strerror(errno), errno);
         goto retry_fallocate;
       }
-      WARN("Error: failed to extend %s to %ld bytes, error: %s (%d)", shmPath, realShmSize, strerror(errno), errno);
+      ERR(ncclSystemError, "Error: failed to extend %s to %ld bytes, error: %s (%d)", shmPath, realShmSize, strerror(errno), errno);
       ret = ncclSystemError;
       goto fail;
     }
@@ -812,7 +812,7 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize, vo
 
   hptr = (char*)mmap(NULL, realShmSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
   if (hptr == MAP_FAILED) {
-    WARN("Error: Could not map %s size %zu, error: %s (%d)", shmPath, realShmSize, strerror(errno), errno);
+    ERR(ncclSystemError, "Error: Could not map %s size %zu, error: %s (%d)", shmPath, realShmSize, strerror(errno), errno);
     ret = ncclSystemError;
     hptr = NULL;
     goto fail;

--- a/comms/ncclx/v2_31/src/os/linux_ipcsocket.cc
+++ b/comms/ncclx/v2_31/src/os/linux_ipcsocket.cc
@@ -37,7 +37,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket* handle, int rank, uint64_t hash, v
   handle->fd = NCCL_INVALID_SOCKET;
   handle->socketName[0] = '\0';
   if ((fd = socket(AF_UNIX, SOCK_DGRAM, 0)) < 0) {
-    WARN("UDS: Socket creation error : %s (%d)", strerror(errno), errno);
+    ERR(ncclSystemError, "UDS: Socket creation error : %s (%d)", strerror(errno), errno);
     return ncclSystemError;
   }
 
@@ -47,7 +47,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket* handle, int rank, uint64_t hash, v
   // Create unique name for the socket.
   int len = snprintf(temp, NCCL_IPC_SOCKNAME_LEN, NCCL_IPC_SOCKNAME_STR, rank, hash);
   if (len > (int)(sizeof(cliaddr.sun_path) - 1)) {
-    WARN("UDS: Cannot bind provided name to socket. Name too large");
+    ERR(ncclInternalError, "UDS: Cannot bind provided name to socket. Name too large");
     close(fd);
     return ncclInternalError;
   }
@@ -65,7 +65,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket* handle, int rank, uint64_t hash, v
     cliaddr.sun_path[0] = '\0'; // Linux abstract socket trick
   }
   if (bind(fd, (struct sockaddr*)&cliaddr, sizeof(cliaddr)) < 0) {
-    WARN("UDS: Binding to socket %s failed : %s (%d)", temp, strerror(errno), errno);
+    ERR(ncclSystemError, "UDS: Binding to socket %s failed : %s (%d)", temp, strerror(errno), errno);
     close(fd);
     return ncclSystemError;
   }
@@ -86,7 +86,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket* handle, int rank, uint64_t hash, v
 
 ncclResult_t ncclIpcSocketGetFd(struct ncclIpcSocket* handle, int* fd) {
   if (handle == NULL) {
-    WARN("ncclIpcSocketGetFd: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclIpcSocketGetFd: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (fd) *fd = handle->fd;
@@ -139,7 +139,7 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
 
   while ((ret = recvmsg(handle->fd, &msg, 0)) <= 0) {
     if (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
-      WARN("UDS: Receiving data over socket failed : %d", errno);
+      ERR(ncclSystemError, "UDS: Receiving data over socket failed : %d", errno);
       return ncclSystemError;
     }
     if (handle->abortFlag && COMPILER_ATOMIC_LOAD(handle->abortFlag, std::memory_order_acquire))
@@ -149,13 +149,13 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
   if (recvFd != NULL) {
     if (((cmptr = CMSG_FIRSTHDR(&msg)) != NULL) && (cmptr->cmsg_len == CMSG_LEN(sizeof(int)))) {
       if ((cmptr->cmsg_level != SOL_SOCKET) || (cmptr->cmsg_type != SCM_RIGHTS)) {
-        WARN("UDS: Receiving data over socket failed");
+        ERR(ncclSystemError, "UDS: Receiving data over socket failed");
         return ncclSystemError;
       }
 
       memmove(recvFd, CMSG_DATA(cmptr), sizeof(*recvFd));
     } else {
-      WARN("UDS: Receiving data over socket %s failed", handle->socketName);
+      ERR(ncclSystemError, "UDS: Receiving data over socket %s failed", handle->socketName);
       return ncclSystemError;
     }
     TRACE(NCCL_INIT | NCCL_P2P, "UDS: Got recvFd %d from socket %s", *recvFd, handle->socketName);
@@ -189,7 +189,7 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
 
   int len = snprintf(temp, NCCL_IPC_SOCKNAME_LEN, NCCL_IPC_SOCKNAME_STR, rank, hash);
   if (len > (sizeof(cliaddr.sun_path) - 1)) {
-    WARN("UDS: Cannot connect to provided name for socket. Name too large");
+    ERR(ncclInternalError, "UDS: Cannot connect to provided name for socket. Name too large");
     return ncclInternalError;
   }
   strcpy(cliaddr.sun_path, temp);
@@ -230,7 +230,7 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
   ssize_t sendResult;
   while ((sendResult = sendmsg(handle->fd, &msg, 0)) < 0) {
     if (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
-      WARN("UDS: Sending data over socket %s failed : %s (%d)", temp, strerror(errno), errno);
+      ERR(ncclSystemError, "UDS: Sending data over socket %s failed : %s (%d)", temp, strerror(errno), errno);
       return ncclSystemError;
     }
     if (handle->abortFlag && COMPILER_ATOMIC_LOAD(handle->abortFlag, std::memory_order_acquire))

--- a/comms/ncclx/v2_31/src/os/windows.cc
+++ b/comms/ncclx/v2_31/src/os/windows.cc
@@ -159,7 +159,7 @@ ncclResult_t ncclOsInitialize() {
   WSADATA wsaData;
   int result = WSAStartup(MAKEWORD(2, 2), &wsaData);
   if (result != 0) {
-    WARN("WSAStartup failed with error: %d", result);
+    ERR(ncclSystemError, "WSAStartup failed with error: %d", result);
     return ncclSystemError;
   }
   INFO(NCCL_INIT | NCCL_NET, "WSAStartup succeeded, Winsock version %d.%d", LOBYTE(wsaData.wVersion),
@@ -209,7 +209,7 @@ ncclResult_t ncclOsSocketTryAccept(struct ncclSocket* sock) {
     if (wsaError == WSAEINPROGRESS) {
       // Connection in progress, retry with backoff
       if (++sock->errorRetries == ncclParamRetryCnt()) {
-        WARN("ncclOsSocketTryAccept: exceeded error retry count after %d attempts, %s", sock->errorRetries,
+        ERR(ncclSystemError, "ncclOsSocketTryAccept: exceeded error retry count after %d attempts, %s", sock->errorRetries,
              getWSAErrorMessage(wsaError));
         return ncclSystemError;
       }
@@ -217,7 +217,7 @@ ncclResult_t ncclOsSocketTryAccept(struct ncclSocket* sock) {
     } else if (wsaError != WSAEINTR && wsaError != WSAEWOULDBLOCK) {
       // WSAEWOULDBLOCK (10035) is expected for non-blocking accept - means no pending connection yet
       // WSAEINTR means interrupted, both are normal and we just return success to try again later
-      WARN("ncclOsSocketTryAccept: Accept failed: %s", getWSAErrorMessage(wsaError));
+      ERR(ncclSystemError, "ncclOsSocketTryAccept: Accept failed: %s", getWSAErrorMessage(wsaError));
       return ncclSystemError;
     }
   }
@@ -233,7 +233,7 @@ ncclResult_t ncclOsSocketSetFlags(struct ncclSocket* sock) {
   int sndBuf, rcvBuf;
   /* Set socket as non-blocking if async or if we need to be able to abort */
   if (!ncclOsSocketIsValid(sock)) {
-    WARN("ncclOsSocketSetFlags: invalid socket");
+    ERR(ncclInvalidArgument, "ncclOsSocketSetFlags: invalid socket");
     ret = ncclInvalidArgument;
     goto fail;
   }
@@ -241,7 +241,7 @@ ncclResult_t ncclOsSocketSetFlags(struct ncclSocket* sock) {
     u_long mode = 1;
     int iResult = ioctlsocket(sock->socketDescriptor, FIONBIO, &mode);
     if (iResult != NO_ERROR) {
-      WARN("ncclOsSocketSetFlags: ioctlsocket failed with error: %ld", iResult);
+      ERR(ncclSystemError, "ncclOsSocketSetFlags: ioctlsocket failed with error: %ld", iResult);
       ret = ncclSystemError;
       goto fail;
     }
@@ -281,7 +281,7 @@ ncclResult_t ncclOsSocketResetFd(struct ncclSocket* sock) {
   newSocket = socket(sock->addr.sa.sa_family, SOCK_STREAM, 0);
   if (newSocket == INVALID_SOCKET) {
     int wsaError = WSAGetLastError();
-    WARN("ncclOsSocketResetFd: socket() failed with error %d: %s", wsaError, getWSAErrorMessage(wsaError));
+    ERR(ncclSystemError, "ncclOsSocketResetFd: socket() failed with error %d: %s", wsaError, getWSAErrorMessage(wsaError));
     ret = ncclSystemError;
     goto cleanup;
   }
@@ -315,7 +315,7 @@ static ncclResult_t socketConnectCheck(struct ncclSocket* sock, int errCode, con
     if (sock->customRetry == 0) {
       if (sock->errorRetries++ == ncclParamRetryCnt()) {
         sock->state = ncclSocketStateError;
-        WARN("%s: connect to %s returned %s, exceeded error retry count after %d attempts", funcName,
+        ERR(ncclRemoteError, "%s: connect to %s returned %s, exceeded error retry count after %d attempts", funcName,
              ncclSocketToString(&sock->addr, line), getWSAErrorMessage(errCode), sock->errorRetries);
         return ncclRemoteError;
       }
@@ -329,7 +329,7 @@ static ncclResult_t socketConnectCheck(struct ncclSocket* sock, int errCode, con
     sock->state = ncclSocketStateConnecting;
   } else {
     sock->state = ncclSocketStateError;
-    WARN("%s: connect to %s failed : %s", funcName, ncclSocketToString(&sock->addr, line), getWSAErrorMessage(errCode));
+    ERR(ncclSystemError, "%s: connect to %s failed : %s", funcName, ncclSocketToString(&sock->addr, line), getWSAErrorMessage(errCode));
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -356,7 +356,7 @@ ncclResult_t ncclOsSocketPollConnect(struct ncclSocket* sock) {
     return ncclSuccess;
   } else if (ret < 0) {
     int wsaError = WSAGetLastError();
-    WARN("ncclOsSocketPollConnect to %s failed with error %s", ncclSocketToString(&sock->addr, line),
+    ERR(ncclSystemError, "ncclOsSocketPollConnect to %s failed with error %s", ncclSocketToString(&sock->addr, line),
          getWSAErrorMessage(wsaError));
     return ncclSystemError;
   }
@@ -377,7 +377,7 @@ ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr,
     u_long mode = !block;
     int iResult = ioctlsocket(sock->socketDescriptor, FIONBIO, &mode);
     if (iResult != NO_ERROR) {
-      WARN("ncclOsSocketProgressOpt: ioctlsocket failed with error: %ld", iResult);
+      ERR(ncclSystemError, "ncclOsSocketProgressOpt: ioctlsocket failed with error: %ld", iResult);
       return ncclSystemError;
     }
     sock->socketBlockingMode = block;
@@ -399,7 +399,7 @@ ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr,
       // WSAEINPROGRESS (10036) means operation is in progress
       // WSAEINTR means interrupted by signal
       if (wsaError != WSAEWOULDBLOCK && wsaError != WSAEINPROGRESS && wsaError != WSAEINTR) {
-        WARN("ncclOsSocketProgressOpt: Call to %s %s failed : %d (%s)",
+        ERR(ncclRemoteError, "ncclOsSocketProgressOpt: Call to %s %s failed : %d (%s)",
              (op == NCCL_SOCKET_RECV ? "recv from" : "send to"), ncclSocketToString(&sock->addr, line), wsaError,
              getWSAErrorMessage(wsaError));
         return ncclRemoteError;
@@ -435,21 +435,21 @@ ncclResult_t ncclOsFindInterfaces(const char* prefixList, char* names, union ncc
   ULONG bufferSize = 0;
   DWORD result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL, NULL, &bufferSize);
   if (result != ERROR_BUFFER_OVERFLOW) {
-    WARN("GetAdaptersAddresses failed with error: %ld", result);
+    ERR(ncclSystemError, "GetAdaptersAddresses failed with error: %ld", result);
     ret = ncclSystemError;
     goto exit;
   }
 
   IP_ADAPTER_ADDRESSES* adapterAddresses = (IP_ADAPTER_ADDRESSES*)malloc(bufferSize);
   if (adapterAddresses == NULL) {
-    WARN("Failed to allocate memory for adapter addresses");
+    ERR(ncclSystemError, "Failed to allocate memory for adapter addresses");
     ret = ncclSystemError;
     goto exit;
   }
 
   result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL, adapterAddresses, &bufferSize);
   if (result != NO_ERROR) {
-    WARN("GetAdaptersAddresses failed with error: %ld", result);
+    ERR(ncclSystemError, "GetAdaptersAddresses failed with error: %ld", result);
     ret = ncclSystemError;
     goto exit;
   }
@@ -599,21 +599,21 @@ ncclResult_t ncclFindInterfaceMatchSubnet(char* ifName, union ncclSocketAddress*
   ULONG bufferSize = 0;
   DWORD result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL, NULL, &bufferSize);
   if (result != ERROR_BUFFER_OVERFLOW) {
-    WARN("GetAdaptersAddresses failed with error: %ld", result);
+    ERR(ncclSystemError, "GetAdaptersAddresses failed with error: %ld", result);
     ret = ncclSystemError;
     goto exit;
   }
 
   IP_ADAPTER_ADDRESSES* adapterAddresses = (IP_ADAPTER_ADDRESSES*)malloc(bufferSize);
   if (adapterAddresses == NULL) {
-    WARN("Failed to allocate memory for adapter addresses");
+    ERR(ncclSystemError, "Failed to allocate memory for adapter addresses");
     ret = ncclSystemError;
     goto exit;
   }
 
   result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, NULL, adapterAddresses, &bufferSize);
   if (result != NO_ERROR) {
-    WARN("GetAdaptersAddresses failed with error: %ld", result);
+    ERR(ncclSystemError, "GetAdaptersAddresses failed with error: %ld", result);
     free(adapterAddresses);
     ret = ncclSystemError;
     goto exit;
@@ -727,7 +727,7 @@ ncclResult_t ncclOsGetAffinity(ncclAffinity* affinity) {
   DWORD_PTR processAffinityMask, systemAffinityMask;
   BOOL result = GetProcessAffinityMask(GetCurrentProcess(), &processAffinityMask, &systemAffinityMask);
   if (result == FALSE) {
-    WARN("GetProcessAffinityMask failed with error: %ld", GetLastError());
+    ERR(ncclSystemError, "GetProcessAffinityMask failed with error: %ld", GetLastError());
     return ncclSystemError;
   }
   *affinity = processAffinityMask;
@@ -737,7 +737,7 @@ ncclResult_t ncclOsGetAffinity(ncclAffinity* affinity) {
 ncclResult_t ncclOsSetAffinity(const ncclAffinity& affinity) {
   BOOL result = SetProcessAffinityMask(GetCurrentProcess(), affinity);
   if (result == FALSE) {
-    WARN("SetProcessAffinityMask failed with error: %ld", GetLastError());
+    ERR(ncclSystemError, "SetProcessAffinityMask failed with error: %ld", GetLastError());
     return ncclSystemError;
   }
   return ncclSuccess;
@@ -764,7 +764,7 @@ ncclResult_t ncclOsNvmlOpen(ncclOsLibraryHandle* handle) {
 
   if (*handle == nullptr) {
     DWORD err = GetLastError();
-    WARN("Failed to load nvml.dll, error code: %lu", err);
+    ERR(ncclSystemError, "Failed to load nvml.dll, error code: %lu", err);
     return ncclSystemError;
   }
 
@@ -860,7 +860,7 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize, vo
                                   shmPath);                // name of mapping object
 
     if (hMapFile == NULL) {
-      WARN("Error: failed to create shared memory mapping %s, error code: %lu", shmPath, GetLastError());
+      ERR(ncclSystemError, "Error: failed to create shared memory mapping %s, error code: %lu", shmPath, GetLastError());
       ret = ncclSystemError;
       goto fail;
     }
@@ -873,7 +873,7 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize, vo
                                 shmPath);              // name of mapping object
 
     if (hMapFile == NULL) {
-      WARN("Error: failed to open shared memory mapping %s, error code: %lu", shmPath, GetLastError());
+      ERR(ncclSystemError, "Error: failed to open shared memory mapping %s, error code: %lu", shmPath, GetLastError());
       ret = ncclSystemError;
       goto fail;
     }
@@ -887,7 +887,7 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize, vo
                               realShmSize);        // number of bytes to map
 
   if (hptr == NULL) {
-    WARN("Error: Could not map view of file %s size %zu, error code: %lu", shmPath, realShmSize, GetLastError());
+    ERR(ncclSystemError, "Error: Could not map view of file %s size %zu, error code: %lu", shmPath, realShmSize, GetLastError());
     ret = ncclSystemError;
     goto fail;
   }

--- a/comms/ncclx/v2_31/src/os/windows_ipcsocket.cc
+++ b/comms/ncclx/v2_31/src/os/windows_ipcsocket.cc
@@ -43,7 +43,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket* handle, int rank, uint64_t hash, v
   char pipeName[NCCL_IPC_SOCKNAME_LEN];
   int len = snprintf(pipeName, NCCL_IPC_SOCKNAME_LEN, NCCL_IPC_PIPENAME_STR, rank, hash);
   if (len >= NCCL_IPC_SOCKNAME_LEN) {
-    WARN("IPC: Pipe name too long");
+    ERR(ncclInternalError, "IPC: Pipe name too long");
     return ncclInternalError;
   }
 
@@ -63,7 +63,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket* handle, int rank, uint64_t hash, v
   );
 
   if (hPipe == INVALID_HANDLE_VALUE) {
-    WARN("IPC: Failed to create named pipe %s: error %d", pipeName, GetLastError());
+    ERR(ncclSystemError, "IPC: Failed to create named pipe %s: error %d", pipeName, GetLastError());
     return ncclSystemError;
   }
 
@@ -78,7 +78,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket* handle, int rank, uint64_t hash, v
 
 ncclResult_t ncclIpcSocketGetFd(struct ncclIpcSocket* handle, int* fd) {
   if (handle == NULL) {
-    WARN("ncclIpcSocketGetFd: pass NULL socket");
+    ERR(ncclInvalidArgument, "ncclIpcSocketGetFd: pass NULL socket");
     return ncclInvalidArgument;
   }
   if (fd) *fd = (int)handle->fd;
@@ -100,7 +100,7 @@ ncclResult_t ncclIpcSocketClose(ncclIpcSocket* handle) {
 
 ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, int* recvFd) {
   if (handle == NULL || handle->fd == NCCL_INVALID_SOCKET) {
-    WARN("IPC: Invalid socket handle");
+    ERR(ncclInvalidArgument, "IPC: Invalid socket handle");
     return ncclInvalidArgument;
   }
 
@@ -114,7 +114,7 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
   // Wait for client to connect
   BOOL connected = ConnectNamedPipe(hPipe, NULL);
   if (!connected && GetLastError() != ERROR_PIPE_CONNECTED) {
-    WARN("IPC: Failed to connect named pipe: error %d", GetLastError());
+    ERR(ncclSystemError, "IPC: Failed to connect named pipe: error %d", GetLastError());
     return ncclSystemError;
   }
 
@@ -132,13 +132,13 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
     if (error == ERROR_NO_DATA || error == ERROR_BROKEN_PIPE) {
       // Check abort flag
       if (handle->abortFlag && COMPILER_ATOMIC_LOAD(handle->abortFlag, std::memory_order_acquire)) {
-        WARN("IPC: Operation aborted");
+        ERR(ncclInternalError, "IPC: Operation aborted");
         return ncclInternalError;
       }
       continue;
     }
 
-    WARN("IPC: ReadFile failed: error %d", error);
+    ERR(ncclSystemError, "IPC: ReadFile failed: error %d", error);
     return ncclSystemError;
   }
 
@@ -162,7 +162,7 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
     );
 
     if (!dupSuccess) {
-      WARN("IPC: DuplicateHandle failed: error %d", GetLastError());
+      ERR(ncclSystemError, "IPC: DuplicateHandle failed: error %d", GetLastError());
       return ncclSystemError;
     }
 
@@ -183,7 +183,7 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
   char pipeName[NCCL_IPC_SOCKNAME_LEN];
   int len = snprintf(pipeName, NCCL_IPC_SOCKNAME_LEN, NCCL_IPC_PIPENAME_STR, rank, hash);
   if (len >= NCCL_IPC_SOCKNAME_LEN) {
-    WARN("IPC: Pipe name too long");
+    ERR(ncclInternalError, "IPC: Pipe name too long");
     return ncclInternalError;
   }
 
@@ -207,13 +207,13 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
 
     DWORD error = GetLastError();
     if (error != ERROR_PIPE_BUSY && error != ERROR_FILE_NOT_FOUND) {
-      WARN("IPC: Failed to connect to pipe %s: error %d", pipeName, error);
+      ERR(ncclSystemError, "IPC: Failed to connect to pipe %s: error %d", pipeName, error);
       return ncclSystemError;
     }
 
     // Check abort flag
     if (handle && handle->abortFlag && COMPILER_ATOMIC_LOAD(handle->abortFlag, std::memory_order_acquire)) {
-      WARN("IPC: Operation aborted");
+      ERR(ncclInternalError, "IPC: Operation aborted");
       return ncclInternalError;
     }
   }
@@ -223,7 +223,7 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
   // Set pipe to message mode
   DWORD mode = PIPE_READMODE_MESSAGE;
   if (!SetNamedPipeHandleState(hPipe, &mode, NULL, NULL)) {
-    WARN("IPC: SetNamedPipeHandleState failed: error %d", GetLastError());
+    ERR(ncclSystemError, "IPC: SetNamedPipeHandleState failed: error %d", GetLastError());
     CloseHandle(hPipe);
     return ncclSystemError;
   }
@@ -247,7 +247,7 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, 
   BOOL success = WriteFile(hPipe, &msg, sizeof(msg), &bytesWritten, NULL);
 
   if (!success || bytesWritten != sizeof(msg)) {
-    WARN("IPC: WriteFile failed: error %d, wrote %d of %zu bytes", GetLastError(), bytesWritten, sizeof(msg));
+    ERR(ncclSystemError, "IPC: WriteFile failed: error %d, wrote %d of %zu bytes", GetLastError(), bytesWritten, sizeof(msg));
     CloseHandle(hPipe);
     return ncclSystemError;
   }

--- a/comms/ncclx/v2_31/src/param/param_registry.cc
+++ b/comms/ncclx/v2_31/src/param/param_registry.cc
@@ -17,7 +17,7 @@ ncclResult_t ncclParamRegistry::add(std::string key, ncclParamInfo_t info, ncclP
   auto& reg = state();
   std::lock_guard<std::mutex> lock(reg.mtx);
   if (reg.map.find(key) != reg.map.end()) {
-    WARN("PARAM: Duplicate registration for key \"%s\", ignoring.", key.c_str());
+    ERR(ncclInternalError, "PARAM: Duplicate registration for key \"%s\", ignoring.", key.c_str());
     return ncclInternalError;
   }
   reg.map[key] = {info, param};

--- a/comms/ncclx/v2_31/src/plugin/net.cc
+++ b/comms/ncclx/v2_31/src/plugin/net.cc
@@ -14,6 +14,9 @@
 #include <string.h>
 #include <errno.h>
 #include <mutex>
+
+// [NCCLX-PerCommConfig] RAII scope for passing comm config to net plugin init
+#include "meta/transport/NcclxNetPluginHelper.h"
 // #include <sys/types.h>
 // #include <sys/stat.h>
 // #include <unistd.h>
@@ -322,6 +325,11 @@ ncclResult_t ncclNetInit(struct ncclComm* comm) {
   bool ncclNetPluginInitialized = false;
   std::call_once(initPluginLibsOnceFlag, initPluginLibsOnceFunc);
   std::lock_guard<std::mutex> lock(netPluginMutex);
+
+  // [NCCLX-PerCommConfig] Make comm config available to ncclIbInit via side-channel.
+  // Scoped to this function, and read synchronously under the same mutex.
+  ncclx::NcclxCommConfigScope configScope(&comm->config);
+
   for (int pluginIndex = 0; pluginIndex < pluginCount; pluginIndex++) {
     if ((pluginIndex < (pluginCount - NCCL_NET_NUM_INTERNAL_PLUGINS)) &&
         (netPluginLibs[pluginIndex].ncclNetPluginState == ncclNetPluginStateLoadReady)) {

--- a/comms/ncclx/v2_31/src/plugin/net.cc
+++ b/comms/ncclx/v2_31/src/plugin/net.cc
@@ -150,12 +150,12 @@ ncclResult_t ncclNetCheckDeviceVersion(struct ncclComm* comm, ncclNet_t* net, in
       INFO(NCCL_INIT, "Using NCCL_NET_DEVICE_UNPACK net plugin version %d", props.netDeviceVersion);
       return ncclSuccess;
     } else {
-      WARN("NCCL_DEVICE_UNPACK plugin has incompatible version %d, this NCCL build is compatible with %d, not using it",
+      ERR(ncclInternalError, "NCCL_DEVICE_UNPACK plugin has incompatible version %d, this NCCL build is compatible with %d, not using it",
            props.netDeviceVersion, NCCL_NET_DEVICE_UNPACK_VERSION);
       return ncclInternalError;
     }
   default:
-    WARN("Unknown device code index %d", type);
+    ERR(ncclInternalError, "Unknown device code index %d", type);
     return ncclInternalError;
   }
 
@@ -346,7 +346,7 @@ ncclResult_t ncclNetInit(struct ncclComm* comm) {
     }
   }
   if (ncclNetPluginInitialized) return ncclSuccess;
-  WARN("Failed to initialize any NET plugin");
+  ERR(ncclInvalidUsage, "Failed to initialize any NET plugin");
   return ncclInvalidUsage;
 }
 

--- a/comms/ncclx/v2_31/src/proxy.cc
+++ b/comms/ncclx/v2_31/src/proxy.cc
@@ -75,7 +75,7 @@ static ncclResult_t expectedProxyResponseStore(struct ncclProxyState* state, voi
       }
 
       if (elem->done) {
-        WARN("Storing response for already completed opId=%p", opId);
+        ERR(ncclInternalError, "Storing response for already completed opId=%p", opId);
         return ncclInternalError;
       }
 
@@ -90,7 +90,7 @@ static ncclResult_t expectedProxyResponseStore(struct ncclProxyState* state, voi
     elem = elem->next;
   }
 
-  WARN("Proxy response for opId=%p doesn't match any expected response", opId);
+  ERR(ncclInternalError, "Proxy response for opId=%p doesn't match any expected response", opId);
   return ncclInternalError;
 }
 
@@ -157,7 +157,7 @@ static ncclResult_t expectedProxyResponseRemove(struct ncclProxyState* state, vo
     prev = elem;
     elem = elem->next;
   }
-  WARN("Couldn't find opId=%p", opId);
+  ERR(ncclInternalError, "Couldn't find opId=%p", opId);
   return ncclInternalError;
 }
 
@@ -197,9 +197,9 @@ static ncclResult_t asyncProxyOpDequeue(struct ncclProxyLocalPeer* peer, ncclPro
     elem = elem->next;
   }
   if (op) {
-    WARN("Attempting to dequeue nonexistent async opId=%p", op->opId);
+    ERR(ncclInternalError, "Attempting to dequeue nonexistent async opId=%p", op->opId);
   } else {
-    WARN("Attempting to dequeue null operation");
+    ERR(ncclInternalError, "Attempting to dequeue null operation");
   }
   return ncclInternalError;
 }
@@ -253,7 +253,7 @@ ncclResult_t getOpIndex(struct ncclProxyArgs* op, struct ncclProxyProgressState*
     pool = pool->next;
     p++;
   }
-  WARN("Could not find pool of op %p", op);
+  ERR(ncclInternalError, "Could not find pool of op %p", op);
   return ncclInternalError;
 }
 
@@ -368,7 +368,7 @@ ncclResult_t dumpProxyState(struct ncclProxyProgressState* state) {
 static ncclResult_t ncclProxyOpToArgs(struct ncclProxyOp* op, struct ncclProxyArgs* args, int subIndex) {
   struct ncclProxySubArgs* sub = args->subs + subIndex;
   if (subIndex >= NCCL_PROXY_MAX_SUBS) {
-    WARN("Proxy append out of bounds");
+    ERR(ncclInternalError, "Proxy append out of bounds");
     return ncclInternalError;
   }
   // memset(sub, 0, sizeof(struct ncclProxySubArgs));
@@ -401,11 +401,11 @@ static ncclResult_t ncclProxyOpToArgs(struct ncclProxyOp* op, struct ncclProxyAr
     if ((args->sliceSteps != op->sliceSteps) || (args->chunkSteps != op->chunkSteps) ||
         (args->protocol != op->protocol) || (args->dtype != op->dtype) || (args->redOp != op->redOp) ||
         (args->coll != op->coll)) {
-      WARN("Proxy append mismatch");
+      ERR(ncclInternalError, "Proxy append mismatch");
       return ncclInternalError;
     }
     if (args->state != ncclProxyOpReady) {
-      WARN("Proxy append on running operation");
+      ERR(ncclInternalError, "Proxy append on running operation");
       return ncclInternalError;
     }
     goto exit;
@@ -538,7 +538,7 @@ static ncclResult_t ncclLocalOpAppend(struct ncclComm* comm, struct ncclProxyCon
       }
     }
     if (lastOp == -1) {
-      WARN("Unable to post incomplete proxy op chain %d..%d (opCount %ld)", proxyOps->nextOps, proxyOps->nextOpsEnd,
+      ERR(ncclInternalError, "Unable to post incomplete proxy op chain %d..%d (opCount %ld)", proxyOps->nextOps, proxyOps->nextOpsEnd,
            lastOpCount);
       return ncclInternalError;
     }
@@ -560,7 +560,7 @@ static ncclResult_t SaveProxy(struct ncclComm* comm, struct ncclChannel* channel
   struct ncclChannelPeer* peerComm = channel->peers[peer];
   struct ncclConnector* connector = type == proxyRecv ? peerComm->recv + connIndex : peerComm->send + connIndex;
   if (connector->transportComm == NULL) {
-    WARN("Rank %d has no transport for %s peer %d on channel %d/%d", comm->rank, type == proxyRecv ? "recv" : "send",
+    ERR(ncclInternalError, "Rank %d has no transport for %s peer %d on channel %d/%d", comm->rank, type == proxyRecv ? "recv" : "send",
          peer, channel->id, connIndex);
     return ncclInternalError;
   }
@@ -1370,7 +1370,7 @@ ncclResult_t ncclPollProxyResponse(struct ncclComm* comm, struct ncclProxyConnec
   struct ncclProxyState* sharedProxyState = comm->proxyState;
   // Receive the connection pointer from the Proxy
   if (COMPILER_ATOMIC_LOAD(comm->abortFlag, std::memory_order_acquire)) {
-    WARN("Comm %p is in abort state", comm);
+    ERR(ncclInternalError, "Comm %p is in abort state", comm);
     return ncclInternalError;
   }
   if (sharedProxyState->peerSocks == NULL) return ncclInternalError;
@@ -1384,7 +1384,7 @@ ncclResult_t ncclPollProxyResponse(struct ncclComm* comm, struct ncclProxyConnec
     ncclProxyRpcResponseHeader resp = {0};
     int offset = 0;
     if (ncclSuccess != ncclSocketProgress(NCCL_SOCKET_RECV, sock, &resp, sizeof(resp), &offset)) {
-      WARN("Socket recv failed while polling for opId=%p", opId);
+      ERR(ncclInternalError, "Socket recv failed while polling for opId=%p", opId);
       return ncclInternalError;
     }
 

--- a/comms/ncclx/v2_31/src/ras/client_support.cc
+++ b/comms/ncclx/v2_31/src/ras/client_support.cc
@@ -707,7 +707,7 @@ static ncclResult_t rasClientRun(struct rasClient* client, bool* closed) {
     client->status = RAS_CLIENT_FINISHED;
     break;
   default:
-    WARN("Invalid client status %d", client->status);
+    ERR(ncclInternalError, "Invalid client status %d", client->status);
     ret = ncclInternalError;
     goto exit;
   }

--- a/comms/ncclx/v2_31/src/ras/ras.cc
+++ b/comms/ncclx/v2_31/src/ras/ras.cc
@@ -257,7 +257,7 @@ static ncclResult_t rasLocalHandle(bool* terminate) {
     INFO(NCCL_RAS, "RAS handling local termination request");
     *terminate = true;
   } else {
-    WARN("RAS received unknown notification type %d", msg.type);
+    ERR(ncclInternalError, "RAS received unknown notification type %d", msg.type);
     return ncclInternalError;
   }
 
@@ -422,7 +422,7 @@ ncclResult_t rasMsgHandle(struct rasMsg* msg, struct rasSocket* sock) {
   } else if (msg->type == RAS_MSG_COLLRESP) {
     NCCLCHECK(rasMsgHandleCollResp(msg, sock));
   } else {
-    WARN("RAS received unknown message type (%d) from %s", msg->type, ncclSocketToString(&sock->sock.addr, rasLine));
+    ERR(ncclInternalError, "RAS received unknown message type (%d) from %s", msg->type, ncclSocketToString(&sock->sock.addr, rasLine));
     return ncclInternalError;
   }
 
@@ -446,7 +446,7 @@ static ncclResult_t rasMsgHandleConnInit(const struct rasMsg* msg, struct rasSoc
 
   if (msg->connInit.ncclVersion != NCCL_VERSION_CODE) {
     // Close any such sockets immediately!  This is basically unrecoverable...
-    WARN("NCCL version mismatch with remote peer %s (local: %s, remote %s)",
+    ERR(ncclInvalidUsage, "NCCL version mismatch with remote peer %s (local: %s, remote %s)",
          ncclSocketToString(&sock->sock.addr, rasLine),
          ncclVersionToString(NCCL_VERSION_CODE, versionLocal, sizeof(versionLocal)),
          ncclVersionToString(msg->connInit.ncclVersion, versionRemote, sizeof(versionRemote)));

--- a/comms/ncclx/v2_31/src/register/register.cc
+++ b/comms/ncclx/v2_31/src/register/register.cc
@@ -13,7 +13,13 @@
 #include "transport.h"
 #include "group.h"
 
-NCCL_PARAM(LocalRegister, "LOCAL_REGISTER", 1);
+#include "comms/ctran/Ctran.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
+#include "meta/wrapper/MetaFactory.h"
+
+// conflict with ctran, disable for now.
+NCCL_PARAM(LocalRegister, "LOCAL_REGISTER", 0);
 
 ncclResult_t ncclRegLocalIsValid(struct ncclReg* reg, bool* isValid) {
   if (reg && isValid) {
@@ -153,12 +159,35 @@ ncclResult_t ncclRegCleanup(struct ncclComm* comm) {
 
 NCCL_API(ncclResult_t, ncclCommRegister, const ncclComm_t comm, void* buff, size_t size, void** handle);
 ncclResult_t ncclCommRegister(const ncclComm_t comm, void* buff, size_t size, void** handle) {
-  if (!ncclParamLocalRegister() || ncclP2pUsesMemcpy()) {
+  auto timerBegin = std::chrono::steady_clock::now();
+  // FIXME: we should eventually support hybrid registration.
+  // Disable it for now to avoid undefined behavior due to handle conflict.
+  if (NCCL_CTRAN_REGISTER != NCCL_CTRAN_REGISTER::none && ncclParamLocalRegister()) {
+    ERR(ncclInvalidUsage, "Invalid usage to turn on NCCL_CTRAN_REGISTER and NCCL_LOCAL_REGISTER at the same time.");
+    return metaCommToNccl(commInvalidUsage);
+  }
+
+  if (ctranInitialized(comm->ctranComm_.get()) && NCCL_CTRAN_REGISTER != NCCL_CTRAN_REGISTER::none) {
+    NCCLCHECK(metaCommToNccl(comm->ctranComm_->ctran_->commRegister(buff, size, handle)));
+  } else if (!ncclParamLocalRegister() || ncclP2pUsesMemcpy()) {
     *handle = NULL;
     INFO(NCCL_REG, "Skipping registration for buffer %p size %zi (LocalRegister=%ld, P2pUsesMemcpy=%d)", buff, size,
          ncclParamLocalRegister(), ncclP2pUsesMemcpy());
   } else {
     NCCLCHECK(ncclRegister(comm, buff, size, false, handle));
+  }
+
+  INFO(NCCL_ALLOC, "REGISTER: user registered buffer %p len %ld hdl %p with commHash %lx commDesc %s", buff, size,
+       *handle, comm->logMetaData.commHash, comm->logMetaData.commDesc.c_str());
+  if (NCCL_COMM_REGISTER_LOG_ENABLE) {
+    meta::comms::memtrace::recordReg(
+        comm->logMetaData,
+        "",
+        "ncclCommRegister",
+        reinterpret_cast<uintptr_t>(*handle),
+        size,
+        0,
+        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - timerBegin).count());
   }
   return ncclSuccess;
 }
@@ -201,11 +230,57 @@ exit:
 
 NCCL_API(ncclResult_t, ncclCommDeregister, const ncclComm_t comm, void* handle);
 ncclResult_t ncclCommDeregister(const ncclComm_t comm, void* handle) {
-  NCCLCHECK(commDeregister(comm, false, (struct ncclReg*)handle));
+  auto timerBegin = std::chrono::steady_clock::now();
+
+  // FIXME: we should eventually support hybrid registration.
+  // Disable it for now to avoid undefined behavior due to handle conflict.
+  if (NCCL_CTRAN_REGISTER != NCCL_CTRAN_REGISTER::none && ncclParamLocalRegister()) {
+    ERR(ncclInvalidUsage, "Invalid usage to turn on NCCL_CTRAN_REGISTER and NCCL_LOCAL_REGISTER at the same time.");
+    return metaCommToNccl(commInvalidUsage);
+  }
+
+  if ((ctranInitialized(comm->ctranComm_.get()) && NCCL_CTRAN_REGISTER != NCCL_CTRAN_REGISTER::none) ||
+      ncclParamLocalRegister()) {
+    NCCLCHECK(CommCheck(comm, "ncclCommRegister", "comm"));
+    NCCLCHECK(PtrCheck(handle, "ncclCommDeregister", "handle"));
+  }
+
+  if (ctranInitialized(comm->ctranComm_.get()) && NCCL_CTRAN_REGISTER != NCCL_CTRAN_REGISTER::none) {
+    NCCLCHECK(metaCommToNccl(comm->ctranComm_->ctran_->commDeregister(handle)));
+  } else if (ncclParamLocalRegister()) {
+    NCCLCHECK(commDeregister(comm, false, (struct ncclReg*)handle));
+  }
+
+  INFO(NCCL_ALLOC, "REGISTER: user deregistered hdl %p with commHash %lx commDesc %s", handle,
+       comm->logMetaData.commHash, comm->logMetaData.commDesc.c_str());
+  if (NCCL_COMM_REGISTER_LOG_ENABLE) {
+    meta::comms::memtrace::recordReg(
+        comm->logMetaData,
+        "",
+        "ncclCommDeregister",
+        reinterpret_cast<uintptr_t>(handle),
+        0,
+        0,
+        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - timerBegin).count());
+  }
   return ncclSuccess;
 }
 
 ncclResult_t ncclCommGraphDeregister(const ncclComm_t comm, struct ncclReg* handle) {
   NCCLCHECK(commDeregister(comm, true, handle));
   return ncclSuccess;
+}
+
+// Global pointer-based registration (no handle, no comm required).
+NCCL_API(ncclResult_t, ncclGlobalRegisterWithPtr, void* buff, size_t size);
+ncclResult_t ncclGlobalRegisterWithPtr(void* buff, size_t size) {
+  auto res = ctran::globalRegisterWithPtr(buff, size);
+  return metaCommToNccl(res);
+}
+
+// Global pointer-based deregistration (no handle, no comm required).
+NCCL_API(ncclResult_t, ncclGlobalDeregisterWithPtr, void* buff, size_t size);
+ncclResult_t ncclGlobalDeregisterWithPtr(void* buff, size_t size) {
+  auto res = ctran::globalDeregisterWithPtr(buff, size);
+  return metaCommToNccl(res);
 }

--- a/comms/ncclx/v2_31/src/register/register.cc
+++ b/comms/ncclx/v2_31/src/register/register.cc
@@ -184,7 +184,7 @@ static ncclResult_t commDeregister(struct ncclComm* comm, bool isGraph, struct n
   CUDACHECK(cudaSetDevice(comm->cudaDev));
   for (slot = 0; slot < cache->population && cache->slots[slot] != reg; slot++);
   if (slot == cache->population) {
-    WARN("Deregister: Could not find handle");
+    ERR(ncclInvalidUsage, "Deregister: Could not find handle");
     return ncclInvalidUsage;
   }
   if (isGraph) --reg->graphRefs;

--- a/comms/ncclx/v2_31/src/rma/rma_ce.cc
+++ b/comms/ncclx/v2_31/src/rma/rma_ce.cc
@@ -209,7 +209,7 @@ static ncclResult_t ncclRmaCePutLaunchPersist(struct ncclComm* comm, struct nccl
       NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, task->peerWinHost, task->peerWinOffset, peerLsaRank, &peerBuff), ret,
                     fail);
       if (peerBuff == NULL) {
-        WARN("RMA CE: peerBuff is NULL after ncclDevrGetLsaRankPtr");
+        ERR(ncclInvalidArgument, "RMA CE: peerBuff is NULL after ncclDevrGetLsaRankPtr");
         ret = ncclInvalidArgument;
         goto fail;
       }
@@ -307,7 +307,7 @@ static ncclResult_t ncclRmaCePutLaunchNonPersist(struct ncclComm* comm, struct n
                                             &peerBuff),
                       ret, fail);
         if (peerBuff == NULL) {
-          WARN("RMA CE: peerBuff is NULL after ncclDevrGetLsaRankPtr");
+          ERR(ncclInvalidArgument, "RMA CE: peerBuff is NULL after ncclDevrGetLsaRankPtr");
           ret = ncclInvalidArgument;
           goto fail;
         }
@@ -389,7 +389,7 @@ fail:
 
 ncclResult_t ncclRmaCePutLaunch(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream) {
   if (!comm->rmaState.rmaCeState.initialized) {
-    WARN("RMA CE is not initialized");
+    ERR(ncclInternalError, "RMA CE is not initialized");
     return ncclInternalError;
   }
 
@@ -406,7 +406,7 @@ ncclResult_t ncclRmaCeWaitLaunch(struct ncclComm* comm, struct ncclKernelPlan* p
 
   // Make sure the RMA CE is initialized
   if (!comm->rmaState.rmaCeState.initialized) {
-    WARN("RMA CE is not initialized");
+    ERR(ncclInternalError, "RMA CE is not initialized");
     return ncclInternalError;
   }
 

--- a/comms/ncclx/v2_31/src/rma/rma_proxy_launch.cc
+++ b/comms/ncclx/v2_31/src/rma/rma_proxy_launch.cc
@@ -562,7 +562,7 @@ ncclResult_t ncclRmaProxyPutLaunch(struct ncclComm* comm, struct ncclKernelPlan*
   ncclResult_t ret = ncclSuccess;
 
   if (!comm->rmaState.rmaProxyState.connected) {
-    WARN("RMA proxy is not connected");
+    ERR(ncclInternalError, "RMA proxy is not connected");
     return ncclInternalError;
   }
 
@@ -665,7 +665,7 @@ ncclResult_t ncclRmaProxyWaitLaunch(struct ncclComm* comm, struct ncclKernelPlan
   ncclResult_t ret = ncclSuccess;
 
   if (!comm->rmaState.rmaProxyState.connected) {
-    WARN("RMA proxy is not connected");
+    ERR(ncclInternalError, "RMA proxy is not connected");
     return ncclInternalError;
   }
 

--- a/comms/ncclx/v2_31/src/transport.cc
+++ b/comms/ncclx/v2_31/src/transport.cc
@@ -38,7 +38,7 @@ static ncclResult_t selectTransport(struct ncclComm* comm, struct ncclTopoGraph*
       return ncclSuccess;
     }
   }
-  WARN("No transport found for rank %d[%lx] -> rank %d[%lx]", myInfo->rank, myInfo->busId, peerInfo->rank,
+  ERR(ncclSystemError, "No transport found for rank %d[%lx] -> rank %d[%lx]", myInfo->rank, myInfo->busId, peerInfo->rank,
        peerInfo->busId);
   return ncclSystemError;
 }

--- a/comms/ncclx/v2_31/src/transport/coll_net.cc
+++ b/comms/ncclx/v2_31/src/transport/coll_net.cc
@@ -479,7 +479,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
                                      void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   ncclResult_t ret = ncclSuccess;
   if (reqSize != sizeof(struct collNetConnectArgs)) {
-    WARN("sendProxyConnect: reqSize is %d != %ld", reqSize, sizeof(struct collNetConnectArgs));
+    ERR(ncclInternalError, "sendProxyConnect: reqSize is %d != %ld", reqSize, sizeof(struct collNetConnectArgs));
     return ncclInternalError;
   }
   struct collNetConnectArgs* args = (struct collNetConnectArgs*)reqBuff;
@@ -499,7 +499,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
 
   // Collnet connect is allowed to fail. Gracefully handle that case by returning NULL to the caller.
   if (respSize != sizeof(struct connectMap*)) {
-    WARN("sendProxyConnect: respSize is %d != %ld", respSize, sizeof(void*));
+    ERR(ncclInternalError, "sendProxyConnect: respSize is %d != %ld", respSize, sizeof(void*));
     return ncclInternalError;
   }
   if (resources->collNetComm == NULL) {
@@ -576,7 +576,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
                                      void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   ncclResult_t ret = ncclSuccess;
   if (reqSize != sizeof(struct collNetConnectArgs)) {
-    WARN("recvProxyConnect: reqSize is %d != %ld", reqSize, sizeof(struct collNetConnectArgs));
+    ERR(ncclInternalError, "recvProxyConnect: reqSize is %d != %ld", reqSize, sizeof(struct collNetConnectArgs));
     return ncclInternalError;
   }
   struct collNetConnectArgs* args = (struct collNetConnectArgs*)reqBuff;
@@ -590,7 +590,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
 
   // Collnet connect is allowed to fail. Gracefully handle that case by returning NULL to the caller.
   if (respSize != sizeof(struct connectMap*)) {
-    WARN("sendProxyConnect: respSize is %d != %ld", respSize, sizeof(void*));
+    ERR(ncclInternalError, "sendProxyConnect: respSize is %d != %ld", respSize, sizeof(void*));
     return ncclInternalError;
   }
   if (resources->collNetComm == NULL) {
@@ -660,7 +660,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) info->mhandles[p] = resources->mhandles[p];
 
   if (respSize != sizeof(struct connectMap*)) {
-    WARN("recvProxyConnect: respSize is %d != %ld", respSize, sizeof(void*));
+    ERR(ncclInternalError, "recvProxyConnect: respSize is %d != %ld", respSize, sizeof(void*));
     return ncclInternalError;
   }
   *((struct connectMap**)respBuff) = &resources->map;
@@ -1024,7 +1024,7 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
             int sendBeg = calcRegionOffset(args, 0, s, sub->received, 0);
             int sendEnd = calcRegionOffset(args, 0, s, sub->received, 1);
             if (sendEnd - sendBeg != connFifo[buffSlot].size) {
-              WARN("CollNet sizes: want=%d got=%ld", sendEnd - sendBeg, connFifo[buffSlot].size);
+              ERR(ncclInternalError, "CollNet sizes: want=%d got=%ld", sendEnd - sendBeg, connFifo[buffSlot].size);
               return ncclInternalError;
             }
           }

--- a/comms/ncclx/v2_31/src/transport/net.cc
+++ b/comms/ncclx/v2_31/src/transport/net.cc
@@ -492,7 +492,7 @@ static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* conne
       if (err == cudaErrorPeerAccessAlreadyEnabled) {
         cudaGetLastError();
       } else if (err != cudaSuccess) {
-        WARN("failed to peer with device %d: %d %s", map->cudaDev, err, cudaGetErrorString(err));
+        ERR(ncclInternalError, "failed to peer with device %d: %d %s", map->cudaDev, err, cudaGetErrorString(err));
         return ncclInternalError;
       }
     }
@@ -667,7 +667,7 @@ static ncclResult_t sharedNetBuffersInit(struct ncclProxyState* proxyState, int 
                                          int sameProcess, int nChannels, char** gpuPtr, char** cpuPtr, ssize_t* size,
                                          ncclIpcDesc* ipcDesc) {
   if (cuda == 0 && sameProcess == 0) {
-    WARN("PXN should not use host buffers for data");
+    ERR(ncclInternalError, "PXN should not use host buffers for data");
     return ncclInternalError;
   }
   struct ncclProxyProgressState* progressState = &proxyState->progressState;

--- a/comms/ncclx/v2_31/src/transport/net_ib/common.cc
+++ b/comms/ncclx/v2_31/src/transport/net_ib/common.cc
@@ -32,7 +32,7 @@ extern int ncclParamIbResiliencyPortFailover();
 
 ncclResult_t ncclIbStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName) {
   if (ncclParamIbAsyncEvents() && COMPILER_ATOMIC_LOAD(&stat->fatalErrorCount, std::memory_order_relaxed)) {
-    WARN("communicator encountered a fatal error (detected in %s)", funcName);
+    ERR(ncclSystemError, "communicator encountered a fatal error (detected in %s)", funcName);
     return ncclSystemError;
   }
   return ncclSuccess;

--- a/comms/ncclx/v2_31/src/transport/net_ib/common.h
+++ b/comms/ncclx/v2_31/src/transport/net_ib/common.h
@@ -633,6 +633,7 @@ struct ncclIbListenComm {
   int dev;
   struct ncclSocket sock;
   struct ncclIbCommStage* stage;
+  void* ctx; // [NCCLX-PerCommConfig] per-comm config ctx, set by ncclIbListen
 };
 
 static inline void ncclIbCheckSpeedChanges(struct ncclIbSendComm* sendComm, struct ncclIbNetCommBase* base) {

--- a/comms/ncclx/v2_31/src/transport/net_ib/connect.cc
+++ b/comms/ncclx/v2_31/src/transport/net_ib/connect.cc
@@ -234,7 +234,7 @@ static ncclResult_t ncclIbRoceGetVersionNum(const char* deviceName, int portNum,
 
   int fd = open(roceTypePath, O_RDONLY);
   if (fd == -1) {
-    WARN("NET/IB: open failed in ncclIbRoceGetVersionNum: %s", strerror(errno));
+    ERR(ncclSystemError, "NET/IB: open failed in ncclIbRoceGetVersionNum: %s", strerror(errno));
     return ncclSystemError;
   }
   int ret = read(fd, gidRoceVerStr, 15);
@@ -244,7 +244,7 @@ static ncclResult_t ncclIbRoceGetVersionNum(const char* deviceName, int portNum,
     // In containerized environments, read could return EINVAL if the GID index is not mapped to the
     // container sysfs. In this case return ncclSuccess and let the caller move to next GID index.
     if (errno == EINVAL) return ncclSuccess;
-    WARN("NET/IB: read failed in ncclIbRoceGetVersionNum: %s", strerror(errno));
+    ERR(ncclSystemError, "NET/IB: read failed in ncclIbRoceGetVersionNum: %s", strerror(errno));
     return ncclSystemError;
   }
 
@@ -850,7 +850,7 @@ ncclResult_t ncclIbConnectImpl(void* ctx, int dev, void* opaqueHandle, void** se
   if (stage->state == ncclIbCommStateConnecting) goto ib_connect;
   if (stage->state == ncclIbCommStateConnected) goto ib_send_ready;
   if (stage->state != ncclIbCommStateStart) {
-    WARN("Error: trying to connect already connected sendComm");
+    ERR(ncclInternalError, "Error: trying to connect already connected sendComm");
     return ncclInternalError;
   }
   stage->buffer = NULL;
@@ -872,7 +872,7 @@ ib_connect_check:
   // IB Setup
   struct ncclIbMergedDev* mergedDev;
   if (dev >= ncclNMergedIbDevs) {
-    WARN("NET/IB : Trying to use non-existent virtual device %d", dev);
+    ERR(ncclInternalError, "NET/IB : Trying to use non-existent virtual device %d", dev);
     return ncclInternalError;
   }
 
@@ -1013,7 +1013,7 @@ ib_recv_dev_list:
     if (link_layer == IBV_LINK_LAYER_UNSPECIFIED) link_layer = devInfo->link_layer;
     if (link_layer != devInfo->link_layer) {
       int ibDev0 = comm->devs[0].base.ibDevN;
-      WARN("NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
+      ERR(ncclInternalError, "NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
            "only one link type using NCCL_IB_HCA",
            commDev->base.ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0,
            ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
@@ -1068,7 +1068,7 @@ ib_connect:
     link_layer = ncclIbDevs[ibDev0].portAttr.link_layer;
     for (int i = 0; i < remMeta.ndevs; i++) {
       if (remMeta.devs[i].link_layer != link_layer) {
-        WARN("NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one "
+        ERR(ncclInternalError, "NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one "
              "link type using NCCL_IB_HCA",
              NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum,
              NCCL_IB_LLSTR(link_layer));
@@ -1435,7 +1435,7 @@ ncclResult_t ncclIbAcceptImpl(void* listenComm, void** recvComm, ncclNetDeviceHa
   if (stage->state == ncclIbCommStateSend) goto ib_send;
   if (stage->state == ncclIbCommStatePendingReady) goto ib_recv_ready;
   if (stage->state != ncclIbCommStateStart) {
-    WARN("Listencomm in unknown state %d", stage->state);
+    ERR(ncclInternalError, "Listencomm in unknown state %d", stage->state);
     return ncclInternalError;
   }
 
@@ -1468,7 +1468,7 @@ ib_recv_dev_list:
   ncclNetVDeviceProps_t remoteVProps;
   memcpy(&remoteVProps, stage->buffer, sizeof(ncclNetVDeviceProps_t));
   if (lComm->dev >= ncclNMergedIbDevs) {
-    WARN("NET/IB : Trying to use non-existent virtual device %d", lComm->dev);
+    ERR(ncclInternalError, "NET/IB : Trying to use non-existent virtual device %d", lComm->dev);
     return ncclInternalError;
   }
 
@@ -1576,7 +1576,7 @@ ib_recv:
     if (link_layer == IBV_LINK_LAYER_UNSPECIFIED) link_layer = ibDev->portAttr.link_layer;
     if (link_layer != ibDev->portAttr.link_layer) {
       int ibDev0 = rComm->devs[0].base.ibDevN;
-      WARN("NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
+      ERR(ncclInternalError, "NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
            "only one link type using NCCL_IB_HCA",
            ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0,
            ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
@@ -1589,7 +1589,7 @@ ib_recv:
   for (int i = 0; i < remMeta.ndevs; i++) {
     if (remMeta.devs[i].link_layer != link_layer) {
       int ibDev0 = rComm->devs[0].base.ibDevN;
-      WARN("NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one link "
+      ERR(ncclInternalError, "NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one link "
            "type using NCCL_IB_HCA",
            NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum,
            NCCL_IB_LLSTR(link_layer));

--- a/comms/ncclx/v2_31/src/transport/net_ib/connect.cc
+++ b/comms/ncclx/v2_31/src/transport/net_ib/connect.cc
@@ -10,6 +10,9 @@
 #include "p2p.h"
 #include "p2p_resiliency.h"
 
+// [NCCLX-PerCommConfig] Per-comm IB config helpers
+#include "meta/transport/NcclxIbNetCommConfig.h"
+
 NCCL_PARAM(IbGidIndex, "IB_GID_INDEX", -1);
 NCCL_PARAM(IbRoutableFlidIbGidIndex, "IB_ROUTABLE_FLID_GID_INDEX", 1);
 NCCL_PARAM(IbRoceVersionNum, "IB_ROCE_VERSION_NUM", 2);
@@ -634,6 +637,7 @@ ncclResult_t ncclIbListen(void* ctx, int dev, void* opaqueHandle, void** listenC
   static_assert(sizeof(struct ncclIbHandle) < NCCL_NET_HANDLE_MAXSIZE, "ncclIbHandle size too large");
   memset(handle, 0, sizeof(struct ncclIbHandle));
   comm->dev = dev;
+  comm->ctx = ctx; // [NCCLX-PerCommConfig] store ctx for ncclIbAccept
   handle->magic = ncclSocketDefaultMagic();
   NCCLCHECKGOTO(ncclSocketInit(&comm->sock, &ncclIbIfAddr, handle->magic, ncclSocketTypeNetIb, NULL, 1), ret, fail);
   NCCLCHECKGOTO(ncclSocketListen(&comm->sock), ret, fail);
@@ -857,6 +861,8 @@ ncclResult_t ncclIbConnectImpl(void* ctx, int dev, void* opaqueHandle, void** se
 
   NCCLCHECK(ncclIbMalloc((void**)&comm, sizeof(struct ncclIbSendComm)));
   NCCLCHECKGOTO(ncclIbSendCommInit(comm), ret, fail);
+  // [NCCLX-PerCommConfig] Apply per-comm IB overrides (splitDataOnQps)
+  ncclx::ncclxIbCommInit(comm, ctx);
   NCCLCHECKGOTO(ncclIbStatsInit(&comm->base.stats), ret, fail);
   NCCLCHECKGOTO(ncclSocketInit(&comm->base.sock, &handle->connectAddr, handle->magic, ncclSocketTypeNetIb, NULL, 1),
                 ret, fail);
@@ -1132,7 +1138,12 @@ fail:
 
 ncclResult_t ncclIbConnect(void* ctx, int dev, void* opaqueHandle, void** sendComm,
                            ncclNetDeviceHandle_t** sendDevComm) {
-  return ncclIbConnectImpl(ctx, dev, opaqueHandle, sendComm, sendDevComm, ncclParamIbQpsPerConn(), ncclParamIbTc());
+  // [NCCLX-PerCommConfig] Resolve the per-comm qpsPerConnection override here.
+  // 2.31 takes nQpsPerDev as a parameter, so unlike v2_30 this needs no helper
+  // threaded through the goto-driven state machine in ncclIbConnectImpl.
+  return ncclIbConnectImpl(ctx, dev, opaqueHandle, sendComm, sendDevComm,
+                           ncclx::ibResolveQpsPerConnection((ncclx::NcclxIbNetCommConfig*)ctx, ncclParamIbQpsPerConn()),
+                           ncclParamIbTc());
 }
 
 NCCL_PARAM(IbWarnRailLocal, "IB_WARN_RAIL_LOCAL", 0);
@@ -1441,6 +1452,8 @@ ncclResult_t ncclIbAcceptImpl(void* listenComm, void** recvComm, ncclNetDeviceHa
 
   NCCLCHECK(ncclIbMalloc((void**)&rComm, sizeof(struct ncclIbRecvComm)));
   NCCLCHECKGOTO(ncclIbRecvCommInit(rComm), ret, fail);
+  // [NCCLX-PerCommConfig] Apply per-comm IB overrides (splitDataOnQps)
+  ncclx::ncclxIbCommInit(rComm, lComm->ctx);
   NCCLCHECKGOTO(ncclIbStatsInit(&rComm->base.stats), ret, fail);
   stage->comm = rComm;
   stage->state = ncclIbCommStateAccept;
@@ -1712,7 +1725,12 @@ fail:
 }
 
 ncclResult_t ncclIbAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle_t** recvDevComm) {
-  return ncclIbAcceptImpl(listenComm, recvComm, recvDevComm, ncclParamIbQpsPerConn());
+  // [NCCLX-PerCommConfig] Resolve the per-comm qpsPerConnection override from
+  // the ctx ncclIbListen stashed on the listen comm.
+  auto* lComm = (struct ncclIbListenComm*)listenComm;
+  return ncclIbAcceptImpl(listenComm, recvComm, recvDevComm,
+                          ncclx::ibResolveQpsPerConnection((ncclx::NcclxIbNetCommConfig*)lComm->ctx,
+                                                           ncclParamIbQpsPerConn()));
 }
 
 ncclResult_t ncclIbCloseSend(void* sendComm) {

--- a/comms/ncclx/v2_31/src/transport/net_ib/gdaki/gin_host_gdaki.cc
+++ b/comms/ncclx/v2_31/src/transport/net_ib/gdaki/gin_host_gdaki.cc
@@ -33,7 +33,7 @@
     doca_error_t err = call; \
     if (err != DOCA_SUCCESS) { \
       /* Print the back trace*/ \
-      WARN("DOCA failure %d", err); \
+      ERR(ncclSystemError, "DOCA failure %d", err); \
       return ncclSystemError; \
     } \
   } while (0)
@@ -43,7 +43,7 @@
     doca_error_t err = call; \
     if (err != DOCA_SUCCESS) { \
       /* Print the back trace*/ \
-      WARN("DOCA failure %d", err); \
+      ERR(ncclSystemError, "DOCA failure %d", err); \
       RES = ncclSystemError; \
       goto label; \
     } \
@@ -278,7 +278,7 @@ public:
 
   ncclResult_t allocate_elements(unsigned int num_elements, unsigned int* out_start_idx) {
     if (this->next_unused_idx + num_elements > this->num_elements) {
-      WARN("Not enough space to get elements");
+      ERR(ncclInvalidUsage, "Not enough space to get elements");
       return ncclInvalidUsage;
     }
 
@@ -765,7 +765,7 @@ ncclResult_t ncclGinGdakiCreateContext(void* collComm, ncclGinConfig_t* config, 
           goto retry_create_qp_group_list_hl;
         }
 
-        WARN("DOCA Error %d", docaStatus);
+        ERR(ncclSystemError, "DOCA Error %d", docaStatus);
         status = ncclSystemError;
         goto out;
       }
@@ -801,7 +801,7 @@ ncclResult_t ncclGinGdakiCreateContext(void* collComm, ncclGinConfig_t* config, 
           goto retry_create_qp_list_hl;
         }
 
-        WARN("DOCA Error %d", docaStatus);
+        ERR(ncclSystemError, "DOCA Error %d", docaStatus);
         status = ncclSystemError;
         goto out;
       }

--- a/comms/ncclx/v2_31/src/transport/net_ib/gin.cc
+++ b/comms/ncclx/v2_31/src/transport/net_ib/gin.cc
@@ -39,7 +39,7 @@ static ncclResult_t ncclGinIbGdrGpuSupport(bool gdaki) {
   CUCHECK(cuDeviceGetAttribute(&dmaBufSupportOnDevice, CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED, cudaDev));
   if (dmaBufSupportOnDevice == 1) return ncclSuccess;
 
-  WARN("Unable to use GIN: Peermem is not supported, and device %d does not support DMA-BUF.", cudaDev);
+  ERR(ncclInvalidUsage, "Unable to use GIN: Peermem is not supported, and device %d does not support DMA-BUF.", cudaDev);
   return ncclInvalidUsage;
 }
 
@@ -258,7 +258,7 @@ ncclResult_t ncclGinIbGdakiGetGinProperties(ncclGinProperties_t* ginProps) {
 ncclResult_t ncclGinIbGdakiGetProperties(int dev, ncclNetProperties_t* props) {
   std::lock_guard<std::mutex> lock(ncclGinIbGdakiLockMutex);
   if (dev >= ncclGinIbGdakiNDevs) {
-    WARN("NET/IB : Requested properties for GIN GDAKI NIC %d, only %d GIN GDAKI NICs have been created", dev,
+    ERR(ncclInvalidUsage, "NET/IB : Requested properties for GIN GDAKI NIC %d, only %d GIN GDAKI NICs have been created", dev,
          ncclGinIbGdakiNDevs);
     return ncclInvalidUsage;
   }

--- a/comms/ncclx/v2_31/src/transport/net_ib/gin.cc
+++ b/comms/ncclx/v2_31/src/transport/net_ib/gin.cc
@@ -7,8 +7,13 @@
 
 #include "common.h"
 
+#include <new>
+
 #include "gin/gin_host.h"
 #include "gin.h"
+// [NCCLX-PerCommConfig] Use NcclxIbNetCommConfig so ctx is compatible with
+// ncclIbListen/ncclIbConnect which cast ctx to NcclxIbNetCommConfig*.
+#include "meta/transport/NcclxIbNetCommConfig.h"
 
 const int NCCL_GIN_IB_ALLGATHER_TAG = 0xa0;
 const int NCCL_GIN_IB_ALLTOALL_TAG = 0xa1;
@@ -86,15 +91,19 @@ ncclResult_t ncclGinIbInitType(void** ctx, uint64_t commId, ncclDebugLogger_t lo
   NCCLCHECK(ncclGinIbGdrSupport(&gdrSupport, type == NCCL_GIN_TYPE_GDAKI));
   if (!gdrSupport) return ncclInternalError;
 
-  ncclNetCommConfig_t* netCommConfig = nullptr;
-  NCCLCHECK(ncclCalloc(&netCommConfig, 1));
-  netCommConfig->trafficClass = NCCL_NET_TRAFFIC_CLASS_UNDEF;
-  *ctx = netCommConfig;
+  // [NCCLX-PerCommConfig] Allocate NcclxIbNetCommConfig (not ncclNetCommConfig_t)
+  // so the ctx is type-compatible with ncclIbListen/ncclIbConnect, which cast
+  // ctx to NcclxIbNetCommConfig* to read per-comm IB overrides.
+  auto* ncclxConfig = new (std::nothrow) ncclx::NcclxIbNetCommConfig();
+  if (ncclxConfig == nullptr) return ncclSystemError;
+  ncclxConfig->trafficClass = NCCL_NET_TRAFFIC_CLASS_UNDEF;
+  *ctx = ncclxConfig;
   return ncclSuccess;
 }
 
 ncclResult_t ncclGinIbFinalize(void* ctx) {
-  if (ctx) free(ctx);
+  // [NCCLX-PerCommConfig] Match allocation in ncclGinIbInitType
+  delete static_cast<ncclx::NcclxIbNetCommConfig*>(ctx);
   return ncclIbFinalizeDevices();
 }
 

--- a/comms/ncclx/v2_31/src/transport/net_ib/init.cc
+++ b/comms/ncclx/v2_31/src/transport/net_ib/init.cc
@@ -201,12 +201,12 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   }
 
   if (props->ndevs == 0) {
-    WARN("NET/IB : Can't make virtual NIC with 0 devices");
+    ERR(ncclInvalidUsage, "NET/IB : Can't make virtual NIC with 0 devices");
     return ncclInvalidUsage;
   }
 
   if (ncclNMergedIbDevs == MAX_IB_VDEVS) {
-    WARN("NET/IB : Cannot allocate any more virtual devices (%d)", MAX_IB_VDEVS);
+    ERR(ncclInvalidUsage, "NET/IB : Cannot allocate any more virtual devices (%d)", MAX_IB_VDEVS);
     return ncclInvalidUsage;
   }
 
@@ -242,12 +242,12 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   ncclIbDev* dev0 = ncclIbDevs + props->devs[0];
   for (int i = 1; i < props->ndevs; i++) {
     if (props->devs[i] >= ncclNIbDevs) {
-      WARN("NET/IB : Cannot use physical device %d, max %d", props->devs[i], ncclNIbDevs);
+      ERR(ncclInvalidUsage, "NET/IB : Cannot use physical device %d, max %d", props->devs[i], ncclNIbDevs);
       return ncclInvalidUsage;
     }
     ncclIbDev* dev = ncclIbDevs + props->devs[i];
     if (dev->link != dev0->link) {
-      WARN("NET/IB : Attempted to merge incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
+      ERR(ncclInvalidUsage, "NET/IB : Attempted to merge incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
            "only one link type using NCCL_IB_HCA",
            props->devs[0], dev0->devName, dev0->portNum, NCCL_IB_LLSTR(dev0->link), props->devs[i], dev->devName,
            dev->portNum, NCCL_IB_LLSTR(dev->link));
@@ -304,7 +304,7 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       ncclNMergedIbDevs = 0;
       NCCLCHECK(ncclFindInterfaces(ncclIbIfName, &ncclIbIfAddr, MAX_IF_NAME_SIZE, 1, &nIpIfs));
       if (nIpIfs != 1) {
-        WARN("NET/IB : No IP interface found.");
+        ERR(ncclInternalError, "NET/IB : No IP interface found.");
         ret = ncclInternalError;
         goto fail;
       }
@@ -573,7 +573,7 @@ ncclResult_t ncclIbGetPhysProperties(int dev, ncclNetProperties_t* props) {
 
 ncclResult_t ncclIbGetProperties(int dev, ncclNetProperties_t* props) {
   if (dev >= ncclNMergedIbDevs) {
-    WARN("NET/IB : Requested properties for vNic %d, only %d vNics have been created", dev, ncclNMergedIbDevs);
+    ERR(ncclInvalidUsage, "NET/IB : Requested properties for vNic %d, only %d vNics have been created", dev, ncclNMergedIbDevs);
     return ncclInvalidUsage;
   }
   struct ncclIbMergedDev* mergedDev = ncclIbMergedDevs + dev;

--- a/comms/ncclx/v2_31/src/transport/net_ib/init.cc
+++ b/comms/ncclx/v2_31/src/transport/net_ib/init.cc
@@ -5,8 +5,14 @@
  * See LICENSE.txt for more license information
  *************************************************************************/
 
+#include <new>
+
 #include "common.h"
 #include "p2p_resiliency_recovery.h"
+// [NCCLX-PerCommConfig] Per-comm IB config via side-channel
+#include "meta/NcclxConfig.h"
+#include "meta/transport/NcclxIbNetCommConfig.h"
+#include "meta/transport/NcclxNetPluginHelper.h"
 
 NCCL_PARAM(IbPciRelaxedOrdering, "IB_PCI_RELAXED_ORDERING", 2);
 NCCL_PARAM(IbAdaptiveRouting, "IB_ADAPTIVE_ROUTING", -2);
@@ -526,14 +532,32 @@ fail:
 
 ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config, ncclDebugLogger_t logFunction,
                         ncclProfilerCallback_t profFunction) {
-  ncclResult_t ret = ncclSuccess;
-  ncclNetCommConfig_t* netCommConfig = nullptr;
   NCCLCHECK(ncclIbInitDevices(logFunction, profFunction));
   NCCLCHECK(ncclIbPortRecoveryThreadStart());
-  NCCLCHECK(ncclCalloc(&netCommConfig, 1));
-  netCommConfig->trafficClass = config->trafficClass;
-  *ctx = (void*)netCommConfig;
-  return ret;
+  // [NCCLX-PerCommConfig] Allocate extended ctx with per-comm IB overrides.
+  // NcclxIbNetCommConfig is a superset of ncclNetCommConfig_t, so the upstream
+  // readers of *ctx are unaffected; ncclIbFinalize deletes it as the same type.
+  // Use nothrow: ncclIbInit is a C-style plugin callback returning ncclResult_t,
+  // so a std::bad_alloc must not propagate up through exception-unsafe callers.
+  auto* ncclxConfig = new (std::nothrow) ncclx::NcclxIbNetCommConfig();
+  if (ncclxConfig == nullptr) return ncclSystemError;
+  ncclxConfig->trafficClass = config->trafficClass;
+
+  const ncclConfig_t* commConfig = ncclxGetCurrentCommConfig();
+  if (commConfig && commConfig->ncclxConfig) {
+    auto& ibSplit = NCCLX_CONFIG_FIELD(*commConfig, ibSplitDataOnQps);
+    if (ibSplit.has_value()) {
+      ncclxConfig->ibSplitDataOnQps = ibSplit.value();
+    }
+
+    auto& ibQps = NCCLX_CONFIG_FIELD(*commConfig, ibQpsPerConnection);
+    if (ibQps.has_value()) {
+      ncclxConfig->ibQpsPerConnection = ibQps.value();
+    }
+  }
+
+  *ctx = (void*)ncclxConfig;
+  return ncclSuccess;
 }
 
 ncclResult_t ncclIbDevices(int* ndev) {
@@ -588,7 +612,8 @@ ncclResult_t ncclIbGetProperties(int dev, ncclNetProperties_t* props) {
 }
 
 ncclResult_t ncclIbFinalize(void* ctx) {
-  free(ctx);
+  // [NCCLX-PerCommConfig] Free extended ctx (NcclxIbNetCommConfig, not ncclNetCommConfig_t)
+  delete static_cast<ncclx::NcclxIbNetCommConfig*>(ctx);
   NCCLCHECK(ncclIbPortRecoveryThreadStop());
   return ncclIbFinalizeDevices();
 }

--- a/comms/ncclx/v2_31/src/transport/net_ib/p2p.cc
+++ b/comms/ncclx/v2_31/src/transport/net_ib/p2p.cc
@@ -30,7 +30,7 @@ ncclResult_t ncclIbGetRequest(struct ncclIbNetCommBase* base, struct ncclIbReque
       return ncclSuccess;
     }
   }
-  WARN("NET/IB : unable to allocate requests");
+  ERR(ncclInternalError, "NET/IB : unable to allocate requests");
   *req = NULL;
   return ncclInternalError;
 }
@@ -276,7 +276,7 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
                          void** request) {
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
   if (comm->base.ready == 0) {
-    WARN("NET/IB: ncclIbIsend() called when comm->base.ready == 0");
+    ERR(ncclInternalError, "NET/IB: ncclIbIsend() called when comm->base.ready == 0");
     *request = NULL;
     return ncclInternalError;
   }
@@ -311,7 +311,7 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
       char line[SOCKET_NAME_MAXLEN + 1];
       union ncclSocketAddress addr;
       ncclSocketGetAddr(&comm->base.sock, &addr);
-      WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x", r, nreqs,
+      ERR(ncclInternalError, "NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x", r, nreqs,
            tag, ncclSocketToString(&addr, line), slots[r].size, slots[r].addr, slots[r].rkeys[0]);
       return ncclInternalError;
     }
@@ -458,7 +458,7 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
                          void** request) {
   struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
   if (comm->base.ready == 0) {
-    WARN("NET/IB: ncclIbIrecv() called when comm->base.ready == 0");
+    ERR(ncclInternalError, "NET/IB: ncclIbIrecv() called when comm->base.ready == 0");
     *request = NULL;
     return ncclInternalError;
   }
@@ -832,7 +832,7 @@ static inline ncclResult_t ncclIbCompletionEventProcess(struct ncclIbNetCommBase
     for (int j = 0; j < req->nreqs; j++) {
       sendReq = sendComm->sendReqs[slot][j];
       if (!commBase->resiliency && (sendReq->events[devIndex] <= 0)) {
-        WARN("NET/IB: sendReq(%p)->events={%d,%d,%d,%d}, devIndex=%d, reqIdx=%d <= 0", sendReq, sendReq->events[0],
+        ERR(ncclInternalError, "NET/IB: sendReq(%p)->events={%d,%d,%d,%d}, devIndex=%d, reqIdx=%d <= 0", sendReq, sendReq->events[0],
              sendReq->events[1], sendReq->events[2], sendReq->events[3], devIndex, j);
         return ncclInternalError;
       }

--- a/comms/ncclx/v2_31/src/transport/net_ib/reg.cc
+++ b/comms/ncclx/v2_31/src/transport/net_ib/reg.cc
@@ -116,7 +116,7 @@ ncclResult_t ncclIbDeregMrInternal(ncclIbNetCommDevBase* base, ibv_mr* mhandle) 
       return ncclSuccess;
     }
   }
-  WARN("NET/IB: could not find mr %p inside cache of %d entries", mhandle, cache->population);
+  ERR(ncclInternalError, "NET/IB: could not find mr %p inside cache of %d entries", mhandle, cache->population);
   return ncclInternalError;
 }
 

--- a/comms/ncclx/v2_31/src/transport/net_socket.cc
+++ b/comms/ncclx/v2_31/src/transport/net_socket.cc
@@ -61,7 +61,7 @@ ncclResult_t ncclNetSocketInit(void** ctx, uint64_t commId, ncclNetCommConfig_t*
     union ncclSocketAddress addrs[MAX_IFS];
     NCCLCHECKGOTO(ncclFindInterfaces(names, addrs, MAX_IF_NAME_SIZE, MAX_IFS, &ncclNetIfs), ret, fail);
     if (ncclNetIfs <= 0) {
-      WARN("NET/Socket : no interface found");
+      ERR(ncclInternalError, "NET/Socket : no interface found");
       ret = ncclInternalError;
       goto fail;
     } else {
@@ -415,7 +415,7 @@ fail:
 ncclResult_t ncclNetSocketListen(void* ctx, int dev, void* opaqueHandle, void** listenComm) {
   if (dev < 0 || dev >= ncclNetIfs) {
     // data transfer socket is based on specified dev
-    WARN("NET/Socket : ncclNetSocketListen dev=%d ncclNetIfs=%d", dev, ncclNetIfs);
+    ERR(ncclInternalError, "NET/Socket : ncclNetSocketListen dev=%d ncclNetIfs=%d", dev, ncclNetIfs);
     return ncclInternalError;
   }
   ncclResult_t ret = ncclSuccess;
@@ -562,7 +562,7 @@ ncclResult_t ncclNetSocketGetRequest(struct ncclNetSocketComm* comm, int op, voi
       return ncclSuccess;
     }
   }
-  WARN("NET/Socket : unable to allocate requests");
+  ERR(ncclInternalError, "NET/Socket : unable to allocate requests");
   return ncclInternalError;
 }
 
@@ -603,7 +603,7 @@ ncclResult_t ncclNetSocketGetTask(struct ncclNetSocketComm* comm, struct ncclPro
     res->threadCond.notify_one();
     return ncclSuccess;
   }
-  WARN("NET/Socket : unable to allocate subtasks");
+  ERR(ncclInternalError, "NET/Socket : unable to allocate subtasks");
   return ncclInternalError;
 }
 
@@ -616,7 +616,7 @@ ncclResult_t ncclNetSocketTest(void* request, int* done, int* size) {
   *done = 0;
   struct ncclNetSocketRequest* r = (struct ncclNetSocketRequest*)request;
   if (r == NULL) {
-    WARN("NET/Socket : test called with NULL request");
+    ERR(ncclInternalError, "NET/Socket : test called with NULL request");
     return ncclInternalError;
   }
   if (r->used == 1) { /* try to send/recv size (+ inline data if any) */
@@ -640,7 +640,7 @@ ncclResult_t ncclNetSocketTest(void* request, int* done, int* size) {
         char line[SOCKET_NAME_MAXLEN + 1];
         union ncclSocketAddress addr;
         NCCLCHECK(ncclSocketGetAddr(r->ctrlSock, &addr));
-        WARN("NET/Socket : peer %s message truncated : receiving %d bytes instead of %d. If you believe your socket "
+        ERR(ncclInvalidUsage, "NET/Socket : peer %s message truncated : receiving %d bytes instead of %d. If you believe your socket "
              "network is in a healthy state, "
              "there may be a mismatch in collective sizes or environment settings (e.g. NCCL_PROTO, NCCL_ALGO) between "
              "ranks",

--- a/comms/ncclx/v2_31/src/transport/nvls.cc
+++ b/comms/ncclx/v2_31/src/transport/nvls.cc
@@ -373,7 +373,7 @@ static ncclResult_t nvlsAllocateMem(struct ncclComm* comm, const CUmemAccessDesc
   if (err != CUDA_SUCCESS) {
     const char* errStr;
     (void)pfn_cuGetErrorString(err, &errStr);    // Fail the job as NVLS support is not functional
-    WARN("Failed to bind NVLink SHARP (NVLS) Multicast memory of size %ld : CUDA error %d '%s'.\nThis is usually "
+    ERR(ncclUnhandledCudaError, "Failed to bind NVLink SHARP (NVLS) Multicast memory of size %ld : CUDA error %d '%s'.\nThis is usually "
          "caused by a system or configuration error in the Fabric Manager or NVSwitches.\nDisable NVLS "
          "(NCCL_NVLS_ENABLE=0) if you wish to avoid this error in the future.",
          ucsize, err, errStr);

--- a/comms/ncclx/v2_31/src/transport/p2p.cc
+++ b/comms/ncclx/v2_31/src/transport/p2p.cc
@@ -355,7 +355,7 @@ static ncclResult_t p2pMap(struct ncclComm* comm, struct ncclProxyConnector* pro
       if (err == cudaErrorPeerAccessAlreadyEnabled) {
         cudaGetLastError();
       } else if (err != cudaSuccess) {
-        WARN("failed to peer with device %d(=%lx): %d %s", peerInfo->cudaDev, peerInfo->busId, err,
+        ERR(ncclInternalError, "failed to peer with device %d(=%lx): %d %s", peerInfo->cudaDev, peerInfo->busId, err,
              cudaGetErrorString(err));
         return ncclInternalError;
       }

--- a/comms/ncclx/v2_31/src/transport/shm.cc
+++ b/comms/ncclx/v2_31/src/transport/shm.cc
@@ -305,7 +305,7 @@ static void initShmLocality() {
 ncclResult_t ncclShmAllocateShareableBuffer(size_t size, bool legacy, ncclShmIpcDesc_t* desc, void** hptr,
                                             void** dptr) {
   if (desc == NULL || hptr == NULL) {
-    WARN("Invalid argument desc %p, hptr %p", desc, hptr);
+    ERR(ncclInvalidArgument, "Invalid argument desc %p, hptr %p", desc, hptr);
     return ncclInvalidArgument;
   }
 #if CUDART_VERSION >= 12020
@@ -358,7 +358,7 @@ ncclResult_t ncclShmAllocateShareableBuffer(size_t size, bool legacy, ncclShmIpc
 ncclResult_t ncclShmImportShareableBuffer(struct ncclComm* comm, int proxyRank, ncclShmIpcDesc_t* desc, void** hptr,
                                           void** dptr, ncclShmIpcDesc_t* descOut) {
   if (comm == NULL || desc == NULL || hptr == NULL || descOut == NULL) {
-    WARN("Invalid argument comm %p, desc %p, hptr %p, descOut %p", comm, desc, hptr, descOut);
+    ERR(ncclInvalidArgument, "Invalid argument comm %p, desc %p, hptr %p, descOut %p", comm, desc, hptr, descOut);
     return ncclInvalidArgument;
   }
 #if CUDART_VERSION >= 12020

--- a/comms/ncclx/v2_31/src/tuning/cost_model.cc
+++ b/comms/ncclx/v2_31/src/tuning/cost_model.cc
@@ -47,7 +47,7 @@ static ncclResult_t parseList(const char* str, const char* const prefixElems[], 
         // It makes no sense for any entry other than the first to not have a prefix,
         // because then all the prefixes before the prefix-less entry would be
         // overwritten.
-        WARN("All entries except the first must have a prefix: \"%s\"", str);
+        ERR(ncclInvalidUsage, "All entries except the first must have a prefix: \"%s\"", str);
         ret = ncclInvalidUsage;
         goto fail;
       }
@@ -84,7 +84,7 @@ static ncclResult_t parseList(const char* str, const char* const prefixElems[], 
           }
         }
         if (e == nelems) {
-          WARN("Unrecognized element token \"%s\" when parsing \"%s\"", elem, str);
+          ERR(ncclInvalidUsage, "Unrecognized element token \"%s\" when parsing \"%s\"", elem, str);
           ret = ncclInvalidUsage;
           goto fail;
         }
@@ -94,7 +94,7 @@ static ncclResult_t parseList(const char* str, const char* const prefixElems[], 
       tokStr = nullptr;
     }
     if (!foundPrefix) {
-      WARN("Unrecognized prefix token \"%s\" when parsing \"%s\"", prefix, str);
+      ERR(ncclInvalidUsage, "Unrecognized prefix token \"%s\" when parsing \"%s\"", prefix, str);
       ret = ncclInvalidUsage;
       goto fail;
     }


### PR DESCRIPTION
Summary:
Port the v2.30 channel metadata allocation policy to NCCLX 2.31.

Support pinned-host metadata when `NCCL_USE_MEM_CACHE` selects it and slab-backed device metadata when `NCCL_MEM_USE_SLAB_ALLOCATOR` is enabled. Preserve the native 2.31 `ncclMemManager` and `ncclMemOffload` path when slab allocation is disabled, and pair shared pinned-host metadata with `ncclCudaHostFree`.

Initialize the CTran CUDA driver wrappers from `ncclCudaLibraryInit()` so `SlabAllocator` can detect and use cuMem during communicator setup. The 2.31 shared library builds in opt mode and targeted lint is clean.

Differential Revision: D116990030
