### PR TITLE
Relax the cuda.core cap to cuda-core~=1.0

### DIFF
--- a/comms/ncclx/v2_30/bindings/nccl4py/pyproject.toml
+++ b/comms/ncclx/v2_30/bindings/nccl4py/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 dependencies = [
     "packaging",
     "numpy",
-    "cuda.core>=0.5.0,<1.0",
+    "cuda-core~=1.0",
     "cuda-pathfinder~=1.1",
 ]
 


### PR DESCRIPTION
Summary:
nccl4py's packaging metadata capped `cuda.core<1.0` — NVIDIA's pre-1.0 pin, imported verbatim with the NCCL 2.30 rebase. The cap makes the published nccl4py wheel unresolvable in any uv environment that also needs cuda-python 13.3.x (which requires `cuda-core~=1.0.0`); farm currently works around this by excluding nccl4py from its env entirely, which breaks the tclite backend and the clog v2 tuning query at runtime (`import nccl.bindings.ncclx` -> `ModuleNotFoundError`).

Relax the constraint to `cuda-core~=1.0`, matching what upstream NCCL 2.31 already ships.

This should not create any breakage:

- nccl4py's cuda.core usage surface is confined to `nccl/core/*.py`: `Device` (ctor / `set_current` / `device_id`), `Stream.from_handle(handle=)`, `Buffer.from_handle(ptr=, size=, mr=)`, `MemoryResource` subclassing (`allocate` / `deallocate` + `device_id` / `is_device_accessible` / `is_host_accessible`), `system.get_num_devices()`, and `cuda.core.utils` (`StridedMemoryView`, `args_viewable_as_strided_memory`). Every one of these exists with identical names and parameter lists in cuda-core 1.1.1 (what `~=1.0` resolves to).
- The only relocations in cuda-core 1.x are the typing helpers `IsStreamT` and `DevicePointerT` (moved in the cu12/cu13 package split); `typing.py` and `memory.py` already carry local fallbacks for exactly that case (a `Protocol` definition and `DevicePointerT = int`), so behavior is unchanged.
- The primary internal consumers (the tclite ncclx backend and the clog v2 tuning query) import only `nccl.bindings`, which has no cuda.core dependency at all.

Differential Revision: D117393909


