### PR TITLE
Wire AbortDevice into AllReduce Tree and Ring (#3790)

### DIFF
--- a/comms/prims/collectives/ReduceScatterDirectIbV2.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIbV2.cu
@@ -300,7 +300,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
             // slow peer never stops us polling the others.
             int ready = 0;
             bool finished = false;
-            while (ready < count && !finished) {
+            bool aborted = false;
+            while (ready < count && !finished && !aborted) {
               ready = 0;
               for (int i = 0; i < count; ++i) {
                 if (rviews[s][i].staging != nullptr) {
@@ -311,6 +312,17 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
                 auto transport = args.peers[rpeer_of[i]];
                 const auto st = transport.progress_recv_acquire_once(
                     solo, wire_bytes, max_sig, timeout, view);
+                // `Aborted` is terminal and must be handled explicitly. It used
+                // to fall through this chain: the acquire had already driven
+                // the slot to `Done` via abandon_progress_state(), so the NEXT
+                // acquire returned `Done`, the loop set `finished` and the
+                // collective reported ordinary completion over a partially
+                // reduced accumulator. Stopping here keeps "aborted" and
+                // "stream complete" distinguishable.
+                if (st == IbgdaSendRecvProgressStatus::Aborted) {
+                  aborted = true;
+                  break;
+                }
                 if (st == IbgdaSendRecvProgressStatus::Done) {
                   finished = true;
                   break;
@@ -321,7 +333,7 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
                 }
               }
             }
-            if (finished) {
+            if (finished || aborted) {
               s_nchunks = c;
               __threadfence_block();
               s_published = c;
@@ -339,7 +351,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
               const int ps = (c - 1) % kSlots;
               for (int i = 0; i < count; ++i) {
                 auto transport = args.peers[rpeer_of[i]];
-                transport.progress_recv_release_once(solo, rviews[ps][i]);
+                transport.progress_recv_release_once(
+                    solo, timeout, rviews[ps][i]);
                 rviews[ps][i] = detail::RecvChunkAcquisition{};
               }
               released = c - 1;
@@ -354,7 +367,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
             const int ds = d % kSlots;
             for (int i = 0; i < count; ++i) {
               auto transport = args.peers[rpeer_of[i]];
-              transport.progress_recv_release_once(solo, rviews[ds][i]);
+              transport.progress_recv_release_once(
+                  solo, timeout, rviews[ds][i]);
               rviews[ds][i] = detail::RecvChunkAcquisition{};
             }
             released = d;

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -777,11 +777,12 @@ template <typename>
 __device__ __forceinline__ void
 P2pIbTransportDevice::progress_recv_release_once(
     ThreadGroup& group,
+    const AbortDevice& timeout,
     const detail::RecvChunkAcquisition& view) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->progress_recv_release_once(group, view);
+    ibrc->progress_recv_release_once(group, timeout, view);
   } else {
-    ibgda->progress_recv_release_once(group, view);
+    ibgda->progress_recv_release_once(group, timeout, view);
   }
 }
 

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -101,6 +101,7 @@ template <typename Transport, typename Proto>
 __device__ __forceinline__ void progress_recv_release_once(
     Transport& transport,
     ThreadGroup& group,
+    const AbortDevice& timeout,
     const RecvChunkAcquisition& view);
 
 template <typename Transport>
@@ -428,6 +429,7 @@ struct P2pIbTransportDevice {
   template <typename = void>
   __device__ __forceinline__ void progress_recv_release_once(
       ThreadGroup& group,
+      const AbortDevice& timeout,
       const detail::RecvChunkAcquisition& view);
 
   template <

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -72,6 +72,36 @@ __device__ __forceinline__ void abandon_progress_state(
     IbChannelProgress& slot,
     IbChannelProgress& state);
 
+/*
+ * Where the abort is consulted on the ready path, and why it is not a
+ * standalone entry guard.
+ *
+ * Every abort check in this file used to hang off a wait, and each consults the
+ * abort only on its *not-ready* branch. So a call that found everything ready
+ * reached the put, the fused DATA_READY, or the SLOT_FREE credit having never
+ * looked at the abort -- and publishing any of those after an abort is what
+ * principle 4 forbids: a false signal releases a peer that is correctly blocked
+ * and stops it ever reaching its own deadline, so the fault reads to that peer
+ * as success.
+ *
+ * The obvious fix -- one guard at the top of each progress call -- adds a
+ * group-wide broadcast to every *healthy* attempt, and Tree scheduling and
+ * batched send/recv drive these in tight loops. Instead the verdict rides out
+ * through synchronization that already exists:
+ *
+ *   - `try_prepare_send_slot()` and both `progress_recv_ready()` overloads
+ *     already broadcast a readiness verdict; the leader now decides the abort
+ *     inside that same block and returns `kProgressAborted` through it.
+ *   - The pre-put `group.sync()` becomes a broadcast carrying the verdict,
+ *     which covers a call resuming at WaitSlotFree -- that path skips slot
+ *     preparation, and skips the SLOT_FREE wait entirely for a chunk inside the
+ *     pipeline depth.
+ *
+ * Net added barriers on the healthy path: zero, except LL's ready path, which
+ * had no existing broadcast to fold into and now pays the one the not-ready
+ * path already paid.
+ */
+
 template <typename Proto = protocol::Simple>
 __device__ __forceinline__ ProgressGeometry make_progress_geometry(
     const IbChannelLayout& channelLayout,
@@ -565,14 +595,30 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
       }
     }
 
+    // Last gate before the put and its fused DATA_READY.
+    //
+    // A call that *resumes* at WaitSlotFree skipped `try_prepare_send_slot`,
+    // and the SLOT_FREE wait above is itself skipped for any chunk inside the
+    // pipeline depth -- so on that path nothing has consulted the abort yet.
+    // This replaces the `group.sync()` that already stood here rather than
+    // adding a barrier: a broadcast is the same single synchronization, and it
+    // carries the verdict out with it.
+    uint32_t sendAborted = 0;
     if (group.is_leader()) {
       trace_allreduce_event(
           traceContext,
           PipesTraceEventType::kAllReduceSendSyncBegin,
           static_cast<uint8_t>(kPipesTraceQpLaneMask),
           chunk.wireBytes);
+      sendAborted =
+          FT_ABORT_CHECK(timeout, "send publish on an aborted communicator")
+          ? 1U
+          : 0U;
     }
-    group.sync();
+    if (group.broadcast<uint32_t>(sendAborted) != 0U) {
+      abandon_progress_state(group, progressSlot, state);
+      return IbgdaSendRecvProgressStatus::Aborted;
+    }
     if (group.is_leader()) {
       __threadfence_system();
       trace_allreduce_event(
@@ -770,7 +816,21 @@ progress_registered_send_once(
         (isFinalChunk ? protocol::Simple::wire_bytes(state.activeTailPadding)
                       : 0);
 
-    group.sync();
+    // Same gate as the plain send path, for the same reason: a resumed call
+    // entering at WaitSlotFree consulted nothing, and this replaces the
+    // `group.sync()` that already stood here rather than adding a barrier.
+    uint32_t sendAborted = 0;
+    if (group.is_leader()) {
+      sendAborted =
+          FT_ABORT_CHECK(
+              timeout, "registered send publish on an aborted communicator")
+          ? 1U
+          : 0U;
+    }
+    if (group.broadcast<uint32_t>(sendAborted) != 0U) {
+      abandon_progress_state(group, progressSlot, state);
+      return IbgdaRegisteredSendProgressStatus::Aborted;
+    }
     if (group.is_leader()) {
       __threadfence_system();
       ThreadGroup solo{
@@ -1101,42 +1161,51 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
   if (group.is_leader()) {
     unsigned long long current = 0;
     unsigned long long expected = 0;
-    ready = poll_recv_data_ready(
-                transport,
-                localChannel,
-                localDataReady,
-                waitCredit,
-                current,
-                expected)
-        ? 1U
-        : 0U;
-    if (!ready) {
-      if (fine_trace_enabled(traceContext) && traceState != nullptr &&
-          !traceState->dataReadyWaitOpen) {
+    // Asked before readiness, so the already-landed path is covered too. This
+    // function already broadcasts, so the check is free of extra barriers; a
+    // separate entry guard would add one to every healthy poll. Without it a
+    // chunk whose data had arrived went on to consume it and credit SLOT_FREE
+    // without ever consulting the abort.
+    if (FT_ABORT_CHECK(timeout, "recv progress on an aborted communicator")) {
+      ready = kProgressAborted;
+    } else {
+      ready = poll_recv_data_ready(
+                  transport,
+                  localChannel,
+                  localDataReady,
+                  waitCredit,
+                  current,
+                  expected)
+          ? 1U
+          : 0U;
+      if (!ready) {
+        if (fine_trace_enabled(traceContext) && traceState != nullptr &&
+            !traceState->dataReadyWaitOpen) {
+          trace_allreduce_event(
+              traceContext,
+              PipesTraceEventType::kAllReduceDataReadyWaitBegin,
+              qpLane,
+              waitCredit);
+          traceState->dataReadyWaitOpen = true;
+        }
+        if (FT_ABORT_CHECK(
+                timeout,
+                "progress_recv_once waiting for DATA_READY expected>=%llu, "
+                "current=%llu",
+                expected,
+                current)) {
+          ready = kProgressAborted;
+        }
+      } else if (
+          fine_trace_enabled(traceContext) && traceState != nullptr &&
+          traceState->dataReadyWaitOpen) {
         trace_allreduce_event(
             traceContext,
-            PipesTraceEventType::kAllReduceDataReadyWaitBegin,
+            PipesTraceEventType::kAllReduceDataReadyWaitEnd,
             qpLane,
             waitCredit);
-        traceState->dataReadyWaitOpen = true;
+        traceState->dataReadyWaitOpen = false;
       }
-      if (FT_ABORT_CHECK(
-              timeout,
-              "progress_recv_once waiting for DATA_READY expected>=%llu, "
-              "current=%llu",
-              expected,
-              current)) {
-        ready = kProgressAborted;
-      }
-    } else if (
-        fine_trace_enabled(traceContext) && traceState != nullptr &&
-        traceState->dataReadyWaitOpen) {
-      trace_allreduce_event(
-          traceContext,
-          PipesTraceEventType::kAllReduceDataReadyWaitEnd,
-          qpLane,
-          waitCredit);
-      traceState->dataReadyWaitOpen = false;
     }
   }
   // Broadcast makes the answer group-uniform, which is what lets abort ride out
@@ -1250,27 +1319,24 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
   // Packet geometry lives in LLImpl, which owns the format; this seam only
   // decides what to do with the verdict -- report not-ready on false, rather
   // than spin.
-  if (LLImpl<P>::all_flags_set(
-          group,
-          staging,
-          P::max_payload(chunk.wireBytes),
-          static_cast<typename P::FlagType>(chunk.flagVal))) {
-    if (group.is_leader()) {
-      // LL carries no DATA_READY, but its put still advanced the sender's
-      // IbQpState::cursor -- select_put_lane_ordinal() increments that cursor
-      // on every put regardless of protocol, and it is channel-scoped, not
-      // slot-scoped. recvDataReadyLaneCursor mirrors it, so the mirror has to
-      // advance here too: consuming an LL chunk without it leaves the two one
-      // chunk apart per LL transfer, and Simple's next receive on this channel
-      // then waits on a lane the sender never wrote. Matches the unconditional
-      // bump in poll_recv_data_ready() (a single lane makes it a no-op).
-      ++localChannel.recvDataReadyLaneCursor;
-    }
-    return kProgressReady;
-  }
+  // `all_flags_set` is group-collective, so every thread evaluates it; the
+  // verdict below is then decided once by the leader and broadcast.
+  const bool flagsSet = LLImpl<P>::all_flags_set(
+      group,
+      staging,
+      P::max_payload(chunk.wireBytes),
+      static_cast<typename P::FlagType>(chunk.flagVal));
   // Only the leader checks, so the answer has to be broadcast before it leaves:
   // a per-thread verdict here would split the group at the caller's next
   // collective step.
+  //
+  // The abort is asked *before* readiness, and the ready path now leaves
+  // through the same single broadcast as the not-ready path rather than
+  // returning early. Previously a chunk whose flags were already set returned
+  // `kProgressReady` without ever consulting the abort, and the caller went on
+  // to consume the packet and credit SLOT_FREE. One broadcast on every path is
+  // the floor here -- unlike Simple, LL's ready path had no existing barrier to
+  // fold into.
   uint32_t status = kProgressNotReady;
   if (group.is_leader()) {
     if (FT_ABORT_CHECK(
@@ -1280,6 +1346,17 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
             static_cast<unsigned long long>(chunk.flagVal),
             static_cast<unsigned long long>(chunk.wireBytes))) {
       status = kProgressAborted;
+    } else if (flagsSet) {
+      // LL carries no DATA_READY, but its put still advanced the sender's
+      // IbQpState::cursor -- select_put_lane_ordinal() increments that cursor
+      // on every put regardless of protocol, and it is channel-scoped, not
+      // slot-scoped. recvDataReadyLaneCursor mirrors it, so the mirror has to
+      // advance here too: consuming an LL chunk without it leaves the two one
+      // chunk apart per LL transfer, and Simple's next receive on this channel
+      // then waits on a lane the sender never wrote. Matches the unconditional
+      // bump in poll_recv_data_ready() (a single lane makes it a no-op).
+      ++localChannel.recvDataReadyLaneCursor;
+      status = kProgressReady;
     }
   }
   return group.broadcast<uint32_t>(status);
@@ -1679,9 +1756,29 @@ template <typename Transport, typename Proto>
 __device__ __forceinline__ void progress_recv_release_once(
     Transport& transport,
     ThreadGroup& group,
+    const AbortDevice& timeout,
     const RecvChunkAcquisition& view) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   if (view.staging == nullptr) {
+    return;
+  }
+  // SLOT_FREE is a peer-visible credit: it tells the sender this range has been
+  // consumed and may be overwritten. After an abort the consumption either did
+  // not happen or is not trustworthy, so crediting it releases a peer that is
+  // correctly blocked -- principle 4. This function had no abort parameter at
+  // all and signalled unconditionally, which is why the split-receive path
+  // stayed uncontained while the fused one was fixed.
+  //
+  // Leader-decides-and-broadcasts, because a subset skipping the signal while
+  // the rest enter `transport.signal()` would split the group.
+  uint32_t aborted = 0;
+  if (group.is_leader()) {
+    aborted =
+        FT_ABORT_CHECK(timeout, "recv slot release on an aborted communicator")
+        ? 1U
+        : 0U;
+  }
+  if (group.broadcast<uint32_t>(aborted) != 0U) {
     return;
   }
   auto& channelLayout = transport.channel_layout();
@@ -1692,6 +1789,7 @@ __device__ __forceinline__ void progress_recv_release_once(
 #else
   (void)transport;
   (void)group;
+  (void)timeout;
   (void)view;
 #endif
 }
@@ -2094,37 +2192,52 @@ __device__ __forceinline__ uint32_t try_prepare_send_slot(
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t ready = kProgressReady;
   if (group.is_leader()) {
-    auto& slot = transport.template local_channel_slot<P>(group.group_id)
-                     .sendCompletionSlots[slotId];
-    if (slot.generation != generation) {
-      uint64_t pending = slot.laneMask;
-      const uint32_t numLanes = transport.send_completion_lane_count();
-      for (uint32_t laneId = 0; laneId < numLanes; ++laneId) {
-        const uint64_t laneBit = 1ULL << laneId;
-        if ((pending & laneBit) == 0) {
-          continue;
+    // Consulted on the ready path too, not just when the slot is busy.
+    //
+    // This function already broadcasts its verdict, so folding the abort into
+    // it costs no extra barrier -- which is the whole point: a standalone entry
+    // guard would add a group-wide broadcast to every healthy progress attempt,
+    // and Tree scheduling and batched send/recv call this in tight loops.
+    //
+    // Checking only inside the not-ready branch below is what left the hole: a
+    // call that finds the slot already free never looked at the abort and went
+    // on to stage the payload and issue the put with its fused DATA_READY.
+    if (FT_ABORT_CHECK(
+            timeout, "send slot preparation on an aborted communicator")) {
+      ready = kProgressAborted;
+    } else {
+      auto& slot = transport.template local_channel_slot<P>(group.group_id)
+                       .sendCompletionSlots[slotId];
+      if (slot.generation != generation) {
+        uint64_t pending = slot.laneMask;
+        const uint32_t numLanes = transport.send_completion_lane_count();
+        for (uint32_t laneId = 0; laneId < numLanes; ++laneId) {
+          const uint64_t laneBit = 1ULL << laneId;
+          if ((pending & laneBit) == 0) {
+            continue;
+          }
+          const IbLocalCompletionTicket ticket{
+              .completionId = laneId,
+              .value = slot.values[laneId],
+          };
+          if (transport.is_local_completion_ready(group.group_id, ticket)) {
+            pending &= ~laneBit;
+          }
         }
-        const IbLocalCompletionTicket ticket{
-            .completionId = laneId,
-            .value = slot.values[laneId],
-        };
-        if (transport.is_local_completion_ready(group.group_id, ticket)) {
-          pending &= ~laneBit;
-        }
-      }
-      slot.laneMask = pending;
-      if (pending == 0) {
-        slot.generation = generation;
-      } else {
-        ready = kProgressNotReady;
-        if (FT_ABORT_CHECK(
-                timeout,
-                "send slot local completion timed out slot=%u generation=%llu "
-                "pending=0x%llx",
-                slotId,
-                static_cast<unsigned long long>(generation),
-                static_cast<unsigned long long>(pending))) {
-          ready = kProgressAborted;
+        slot.laneMask = pending;
+        if (pending == 0) {
+          slot.generation = generation;
+        } else {
+          ready = kProgressNotReady;
+          if (FT_ABORT_CHECK(
+                  timeout,
+                  "send slot local completion timed out slot=%u generation=%llu "
+                  "pending=0x%llx",
+                  slotId,
+                  static_cast<unsigned long long>(generation),
+                  static_cast<unsigned long long>(pending))) {
+            ready = kProgressAborted;
+          }
         }
       }
     }

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -2325,10 +2325,11 @@ class P2pIbgdaTransportDevice {
   template <typename = void>
   __device__ __forceinline__ void progress_recv_release_once(
       ThreadGroup& group,
+      const AbortDevice& timeout,
       const detail::RecvChunkAcquisition& view) {
     detail::
         progress_recv_release_once<P2pIbgdaTransportDevice, protocol::Simple>(
-            *this, group, view);
+            *this, group, timeout, view);
   }
 
   /**

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -702,10 +702,11 @@ class P2pIbrcTransportDevice {
   template <typename = void>
   __device__ __forceinline__ void progress_recv_release_once(
       ThreadGroup& group,
+      const AbortDevice& timeout,
       const detail::RecvChunkAcquisition& view) {
     detail::
         progress_recv_release_once<P2pIbrcTransportDevice, protocol::Simple>(
-            *this, group, view);
+            *this, group, timeout, view);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>


### PR DESCRIPTION
Summary:

Makes all three native AllReduce algorithms abortable. Before this, only
`Direct` carried the communicator abort handle; `Tree` and `Ring` kept just
`.transports.data()` from the device handle and default-constructed a disabled
`Timeout` in their device impls, so neither an explicit `abort()` nor a
`setTimeout()` deadline could ever unblock them.

Two independent gaps are fixed:

1. The abort *handle* now lives on `common::CommonKernArgs` rather than each
   algorithm's `KernArgs`, and `fillCommonKernArgs()` is its single writer. All
   three launchers pass `deviceHandle->abort`, so a new algorithm cannot forget
   it. `AllReduceIb{Tree,Ring}Impl.cuh` and the 3-arg `runAllReduceFused()`
   overload borrow that handle instead of default-constructing a disabled one -
   the overload feeds NVL phases 1 and 3, so the disabled handle was unbounding
   those too, not only phase 2.
2. `McclComm::allReduce` now resolves the collective timeout for every native
   algorithm, not just `Direct`. Wiring the handle alone is not enough: without
   this, `comm->setTimeout()` stays inert for Tree and Ring.

Tree and Ring keep the whole `MultiPeerDeviceHandle` in a `std::optional`
instead of extracting `.transports` inline, so "handle present but abort
dropped" is no longer representable.

Behavior notes:
- Tree and Ring now observe explicit aborts and timeouts. Previously they ran
  to completion or hung.
- No change for `Direct`, which was already wired.
- Disabled abort (`MCCL_ABORT_MODE=none`, or FT off) is unchanged: the handle
  is a no-op and every check short-circuits.

Changes in this update, from review:

- **Terminate the Tree lane loop on abort.** `phase2IbDualTree()` discarded the lane status with `(void)` and re-tested `lane.phase != Done`; an aborted lane never reaches `Done`, so the loop spun for the rest of the kernel. Each lane is now retired on `Aborted` as well. Both lane groups span the whole block, so the status is block-uniform; retiring the lane instead of breaking lets the sibling lane observe the abort on its own next poll and unwind the same way.
- **Handle `Aborted` in the Tree registered-send status switch.** `progressRegisteredLaneSend()` had no `case Aborted`, so it fell through to `return Waiting` and the caller retried forever. It now maps to `IbgdaSendRecvProgressStatus::Aborted`, which the phase handlers already propagate.
- **Terminate the Ring registered-send loops on abort.** `postRegisteredSend()` and `drainRegisteredSends()` had dropped the `status != Aborted` condition their Prims originals carry, so both `do/while` loops were unbounded on abort.
- **Route per-op timeouts through one validated helper.** Tree, Ring and Direct used `opts.timeout->count() > 0`, which made an explicit `0` indistinguishable from "no override" and passed any positive `int64` through unchecked. All three now call `mccl::collectives::applyOpTimeout()` (added in `D115656601`), which rejects negatives and values above `kMaxOpTimeoutMs` and treats `0ms` as an explicit "no deadline for this operation". Direct's `unsupportedReason()` now reports against the same constant, so `supported()` and `run()` cannot disagree.
- **Drop the dead parameter from `resolveCollectiveTimeout()`.** It stopped consulting the `Abort` when the comm-default fallback was removed; the reason it must not fall back is now on the declaration.
- **Default-initialize every `CommonKernArgs` member**, clearing 12 `cppcoreguidelines-pro-type-member-init` findings from `lint_root` that appeared once `abort{}` gained an initializer.

The three loop fixes are the ones that matter for liveness: under the non-blocking contract (`FAULT_TOLERANCE.md`) a wait terminating itself is the guarantee, and a loop that re-tests a condition abort can never satisfy defeats it.

Also in this update: **`McclComm::resolveCollectiveTimeout()` is deleted.** Dropping its unused `Abort` parameter (R21) left it returning its own argument, so the call site was doing a copy and an assignment to no effect:

```cpp
auto effectiveOpts = opts;
effectiveOpts.timeout = resolveCollectiveTimeout(opts.timeout);
return runAllReduce(effectiveOpts);   // -> return runAllReduce(opts);
```

The reason the per-op value must stay empty -- folding the communicator default in would snapshot it at launch and defeat the late-binding that lets `setTimeout()` reach an already-created device handle -- now sits as a comment where the decision is, not on a trivial static that existed to be unit-tested. Its three `McclCommCollectiveTimeoutTest` cases go with it, and `McclComm`'s test-only `public:` block is now empty and removed (the other two entries moved to `mccl::utils::detail` in `D115814486`).

That invariant is not left unguarded: `AllReduceFaultToleranceTest.DroppedRankTimeoutFailsCollective` in `D114905570` calls `setTimeout(100ms)` *after* the communicator is built and after warmup collectives, and only lapses at ~100 ms if the per-op override stayed empty and the device read the deadline from shared state at launch.

Analysis:

The build-speed regression reported on this diff is real but accepted. The signal is on
`fbcode//comms/mccl/collectives/allreduce:allreduce_fused_tree_device`, specifically
`cuda_cubin_lower_sm80 AllReduceIbTreeFloat32.cu (pic)`: `instruction_count` rose from
historical p90 `781,984,083,595` to `1,119,817,945,159` (`+43%`, action duration
`4m 2s`). I generated the Buck graph comparison for Phabricator version `419596312`; test
and control both had `1365` reachable nodes and `6167` directed edges, so this is not a
configured-graph fanout issue. The cost is inside CUDA lowering of the tree device TU.

Measured binary payload with
`buck2 build fbcode/mode/opt fbcode//comms/mccl/collectives/allreduce:allreduce_fused_tree_device --show-full-json-output`:

- `AllReduceIbTreeFloat32.cu.pic.o`: `6,795,336` B before, `7,311,016` B after (`+515,680` B, `+7.59%`).
- All materialized tree-device `.pic.o` objects: `123,713,432` B before, `133,028,096` B after (`+9,314,664` B, `+7.53%`).
- Thin archive `liballreduce_fused_tree_device.pic.a`: `3,232` B before and after.

The compile-time cost comes from keeping `FT_ABORT_CHECK` on the critical wait, publish,
and release paths in the header-only CUDA progress helpers. That intentionally preserves
both the production `SKIP` behavior needed for correctness/liveness and the `TRAP` path's
site-specific device logging when diagnosing aborts. We are keeping the regression because
correctness plus critical-path abort logging is the priority here.

Reviewed By: Scusemua, arttianezhu

Differential Revision: D115855240


