### PR TITLE
Rename GPE profiling logging cvar (#3797)

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -90,7 +90,9 @@ struct ctranConfig {
   std::string commDesc;
   std::vector<enum CommBackend> backends = {};
   ctranPrimsConfig primsConfig;
-  bool enableProfiler{NCCL_CTRAN_TRANSPORT_PROFILER};
+  // The creator supplies this; ctran does not read the sampling cvar
+  // itself, so a comm-split child inherits the parent's decision.
+  bool enableProfiler{false};
 
   bool operator==(const ctranConfig& other) const {
     return (

--- a/comms/ctran/tests/CtranAllReduceTest.cc
+++ b/comms/ctran/tests/CtranAllReduceTest.cc
@@ -271,12 +271,11 @@ INSTANTIATE_TEST_SUITE_P(
       return std::get<0>(info.param);
     });
 
-// Profiler test subclass: enables profiler in SetUp so ctran::Profiler is
+// Profiler test subclass: samples every collective so ctran::Profiler is
 // created during ctranInit, then injects MockAlgoProfilerReporter.
 class CtranAllReduceProfilerTest : public CtranAllReduceTest {
  protected:
   void SetUp() override {
-    setenv("NCCL_CTRAN_TRANSPORT_PROFILER", "1", 1);
     setenv("NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT", "1", 1);
     CtranAllReduceTest::SetUp();
   }

--- a/comms/ctran/tests/CtranDistAllgatherPTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherPTests.cc
@@ -91,7 +91,6 @@ class CtranAllgatherPTest : public ctran::CtranDistTestFixture {
 
   void SetUp() override {
     setenv("NCCL_CTRAN_ENABLE", "1", 0);
-    setenv("NCCL_CTRAN_TRANSPORT_PROFILER", "1", 0);
     setenv("NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT", "1", 0);
     CtranDistTestFixture::SetUp();
 

--- a/comms/ctran/tests/CtranDistAllgatherTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherTests.cc
@@ -36,7 +36,6 @@ class CtranAllgatherTest : public ctran::CtranDistTestFixture,
   ctran::test::VerifyAlgoStatsHelper algoStats_;
 
   void setUpWithEnvs(const ctran::CtranEnvs& envs = {}) {
-    setenv("NCCL_CTRAN_TRANSPORT_PROFILER", "1", 0);
     setenv("NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT", "1", 0);
     algoStats_.enable();
     ctran::CtranDistTestFixture::SetUp(envs);

--- a/comms/ctran/tests/CtranDistSendRecvUT.cc
+++ b/comms/ctran/tests/CtranDistSendRecvUT.cc
@@ -27,7 +27,6 @@ class CtranTestFixture : public ctran::CtranDistTestFixture,
     setenv("NCCL_COLLTRACE", "trace", 0);
     setenv("NCCL_COLLTRACE_RECORD_MAX", "-1", 0);
     setenv("NCCL_CTRAN_ENABLE", "1", 0);
-    setenv("NCCL_CTRAN_TRANSPORT_PROFILER", "1", 0);
     setenv("NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT", "1", 0);
     ctran::CtranDistTestFixture::SetUp(envs);
     srand(time(NULL));

--- a/comms/ctran/tests/CtranDistTestUtils.cc
+++ b/comms/ctran/tests/CtranDistTestUtils.cc
@@ -129,6 +129,8 @@ std::unique_ptr<CtranComm> CtranDistTestFixture::makeCtranComm(
   comm->logMetaData_.commDesc = commDesc;
   comm->logMetaData_.rank = globalRank;
   comm->logMetaData_.nRanks = numRanks;
+  // Mirrors the standalone-ctran-comm creator policy.
+  comm->config_.enableProfiler = NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT > 0;
 
   int cudaDev;
   CUDACHECK_TEST(cudaGetDevice(&cudaDev));

--- a/comms/ctran/tests/CtranTestUtils.cc
+++ b/comms/ctran/tests/CtranTestUtils.cc
@@ -517,6 +517,10 @@ std::unique_ptr<CtranComm> CtranStandaloneFixture::makeCtranComm(
       /*commRanksToWorldRanks=*/std::move(commRanksToWorldRanks),
       /*commDesc=*/std::string(kCommDesc));
 
+  // Mirrors the standalone-ctran-comm creator policy.
+  ctranComm->config_.enableProfiler =
+      NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT > 0;
+
   EXPECT_EQ(ctranInit(ctranComm.get()), commSuccess);
 
   CLOGF(INFO, "UT CTran initialized");
@@ -601,6 +605,10 @@ void initCtranCommMultiRank(PerRankState& state) {
       std::move(commRanksToWorldRanks),
       std::string{kMultiRankCommDesc});
   ctranComm->statex_->initRankStatesTopology(ctranComm->bootstrap_.get());
+
+  // Mirrors the standalone-ctran-comm creator policy.
+  ctranComm->config_.enableProfiler =
+      NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT > 0;
 
   FB_COMMCHECKTHROW_EX_NOCOMM(ctranInit(ctranComm));
 

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphAllToAllPCtgraphTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphAllToAllPCtgraphTest.cc
@@ -398,17 +398,13 @@ TEST_F(CudaGraphAllToAllPCtgraphIbConfig, CtgraphHonorsAllToAllIbConfig) {
 // Verifies the ctgraph AllToAllP path actually feeds the ctran::Profiler
 // (whose reporter writes to the `nccl_profiler_algo` Scuba table). Without
 // this, the instrumentation added in `ctranAllToAllPIbImpl` would compile
-// but silently no-op — the default test env sets
-// NCCL_CTRAN_TRANSPORT_PROFILER=false, so `comm->ctran_->profiler` is
-// nullptr and every CTRAN_PROFILER_IF block skips. This fixture flips both
-// knobs so the profiler is constructed AND every collective is traced,
-// then reads the accumulated profiler state after the graph replays.
+// but silently no-op. This fixture samples every collective so the profiler
+// is constructed, then reads its accumulated state after the graph replays.
 class CudaGraphAllToAllPCtgraphProfilerScuba : public CtranCudaGraphTestBase {
  protected:
   void SetUp() override {
     CtranDistTestFixture::SetUp(
         ctran::CtranEnvs{
-            {"NCCL_CTRAN_TRANSPORT_PROFILER", "true"},
             {"NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT", "1"},
         });
   }
@@ -477,7 +473,7 @@ TEST_F(
 
   ASSERT_NE(comm->ctran_, nullptr);
   ASSERT_NE(comm->ctran_->profiler, nullptr)
-      << "Profiler must be constructed when NCCL_CTRAN_TRANSPORT_PROFILER=true";
+      << "Profiler must be constructed when sampling is enabled";
   auto* profiler = comm->ctran_->profiler.get();
 
   // Post-condition set inside `ctranAllToAllPIbImpl`: on a traced collective

--- a/comms/ncclx/meta/tests/CommWithCtranTest.cc
+++ b/comms/ncclx/meta/tests/CommWithCtranTest.cc
@@ -73,6 +73,28 @@ TEST_F(CommWithCtranTest, CtranDisable) {
   EXPECT_FALSE(ctranAllToAllvSupport(nullptr));
 }
 
+TEST_F(CommWithCtranTest, ProfilerCreatedWhenSamplingWeightSet) {
+  // A regular NCCL comm must still construct the ctran profiler when the
+  // sampling cvar is on.
+  EnvRAII env(NCCL_CTRAN_ENABLE, true);
+
+  {
+    EnvRAII samplingWeightEnv(NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT, 1);
+    ncclx::test::NcclCommRAII comm{
+        globalRank, numRanks, localRank, bootstrap_.get()};
+    ASSERT_NE(comm->ctranComm_, nullptr);
+    ASSERT_NE(comm->ctranComm_->ctran_, nullptr);
+    EXPECT_NE(comm->ctranComm_->ctran_->profiler, nullptr);
+  }
+
+  {
+    EnvRAII samplingWeightEnv(NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT, 0);
+    ncclx::test::NcclCommRAII comm{
+        globalRank, numRanks, localRank, bootstrap_.get()};
+    EXPECT_EQ(comm->ctranComm_->ctran_->profiler, nullptr);
+  }
+}
+
 TEST_F(CommWithCtranTest, CtranCommInitialized) {
   EnvRAII env(NCCL_CTRAN_ENABLE, true);
   ncclx::test::NcclCommRAII comm{

--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -38,6 +38,7 @@ ctranConfig makeCtranConfigFrom(ncclComm* comm) {
   struct ctranConfig tconfig = {
       .blocking = comm->config.blocking,
       .commDesc = NCCLX_CONFIG_FIELD(comm->config, commDesc),
+      .enableProfiler = NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT > 0,
   };
   if (comm->config.ncclxConfig != nullptr) {
     const auto* ncclxCfg =

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3562,15 +3562,10 @@ cvars:
    type        : bool
    default     : true
    description : |-
-     Enable ctran transport profiling for MCCL. When true (and the rank
-     passes MCCL_FILTER_PROFILER_LOGGING_BY_RANKS), MCCL sets
-     comm_->config_.enableProfiler and injects BOTH
-     McclAlgoProfilerReporter and McclGpeProfilerReporter into
-     ctranInit. Algo rows land in mccl_operation_trace with
-     mcclop="ALGO_PROFILING"; GPE per-tracepoint rows land in the same
-     table with mcclop="GPE_PROFILING". Set to false to disable both
-     reporters from the MCCL level (CTRAN-side defaults for the GPE
-     profiler still apply per NCCL_CTRAN_GPE_PROFILING_ENABLE).
+     Enable construction of the MCCL GPE profiler reporter. When enabled,
+     the reporter can write GPE per-tracepoint rows to mccl_operation_trace
+     with mcclop="GPE_PROFILING". This does not control the CTRAN algorithm
+     profiler.
 
  - name        : MCCL_FORCE_SMALL_MSG_AR_RING
    type        : bool
@@ -3589,13 +3584,11 @@ cvars:
    default     : "0"
    description : |-
      Comma-separated list of global ranks allowed to write profiler
-     operation data to filter logs (mccl_operation_trace). Only effective
-     when MCCL_CTRAN_TRANSPORT_PROFILER is enabled (true by default),
-     which controls whether ctran profiling data flows to
-     mccl_operation_trace. This filter applies only to profiler
-     operation trace samples; other log types are not affected. When
-     this list is non-empty, only the specified ranks will have their
-     profiler samples written; all other ranks are silently skipped.
+     operation data to filter logs (mccl_operation_trace). This filter applies
+     to algorithm profiler construction and healthy GPE profiler rows; aborted
+     GPE rows bypass it. Other log types are not affected. When this list is
+     non-empty, only the specified ranks will have their profiler samples
+     written; all other ranks are silently skipped.
      Default: "0" (only rank 0 logs). Set to an empty string to allow
      all ranks to log.
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3558,7 +3558,7 @@ cvars:
      For example, setting MCCL_SCUBA_LOG_LEVEL=HIGH means only HIGH and
      CRITICAL priority logs will be forwarded to Scuba.
 
- - name        : MCCL_CTRAN_TRANSPORT_PROFILER
+ - name        : MCCL_CTRAN_GPE_PROFILING_LOGGING
    type        : bool
    default     : true
    description : |-


### PR DESCRIPTION
Summary:

Rename `MCCL_CTRAN_TRANSPORT_PROFILER` to `MCCL_CTRAN_GPE_PROFILING_LOGGING` now that this MCCL control only gates the GPE profiler reporter. Keep the CTRAN transport profiler cvar separate.

Reviewed By: shr

Differential Revision: D117386624


