### PR TITLE
Record the one-budget-per-kernel rule and per-collective FT status

### DIFF
--- a/comms/common/fault_tolerance/FAULT_TOLERANCE.md
+++ b/comms/common/fault_tolerance/FAULT_TOLERANCE.md
@@ -21,36 +21,51 @@ rules the detail exists to serve.
    `FT_ABORT_BREAK` / `FT_ABORT_RETURN` (`AbortMacros.cuh`); they terminate the
    loop themselves. Do not convert a `void` wait to `bool` just to report that
    it aborted.
-4. **Group uniformity idiom: leader polls, then broadcasts.** Use the existing
+4. **Never signal a peer for work you abandoned.** `FT_ABORT_BREAK` ends the
+   *spin* it is written in; it says nothing to the pipeline loop around it. A
+   loop that keeps going after its wait gave up will still issue the put, the
+   fused `DATA_READY`, and the `SLOT_FREE` credit for every remaining chunk. So
+   put a group-uniform `groupAborted()` break between the wait and the first
+   peer-visible side effect.
+
+   This is not about garbage output — that is contract-legal. It is that a false
+   signal **releases a peer that is correctly blocked and stops it ever reaching
+   its own deadline**, so the fault looks to that peer like a successful
+   collective. One rank's abort then silently suppresses fault detection on the
+   rest, which is the opposite of what this design is for. Measured at
+   `IB_ONLY_1x8` before this was fixed: only 5 of 7 survivors recorded
+   `TIMED_OUT` from their own deadline; the other two were spuriously completed
+   by the ranks that had. After: 7 of 7.
+5. **Group uniformity idiom: leader polls, then broadcasts.** Use the existing
    leader + `broadcast<uint32_t>` shape rather than adding a new reduction
    primitive for one call site.
-5. **Never derive a loop bound or an index from peer-written data.** Bounds come
+6. **Never derive a loop bound or an index from peer-written data.** Bounds come
    from local geometry or parameters. This is the assumption that lets a wait
    give up without unwinding the caller.
-6. **Do not store started deadline state in a transport object.** Transport
+7. **Do not store started deadline state in a transport object.** Transport
    handles outlive operations and are shared across blocks; copy the handle per
    block and call `startTimeout()` on the copy.
-7. **Keep abort polling off hot paths.** Gate the check behind a spin count so
+8. **Keep abort polling off hot paths.** Gate the check behind a spin count so
    it only engages once actually stalled, and prefer one poller per group over
    one per thread when the loop is per-thread.
-8. **Onboard every new or in-flight wait as it lands**, including
+9. **Onboard every new or in-flight wait as it lands**, including
    work-in-progress paths. A spin loop that reaches main without an abort check
    is a hang waiting to happen.
-9. **Per-operation timeouts come only from the collective API.** The
-   communicator deadline stays late-bound in shared state so `setTimeout()` is
-   observed by already-created device handles.
-10. **Validate a timeout's sign, not its size.** Choosing a sane magnitude is
+10. **Per-operation timeouts come only from the collective API.** The
+    communicator deadline stays late-bound in shared state so `setTimeout()` is
+    observed by already-created device handles.
+11. **Validate a timeout's sign, not its size.** Choosing a sane magnitude is
     the caller's job; `std::chrono` types already make unit mistakes unlikely.
     A negative value must be rejected, because at the `AbortDevice` layer it
     silently means "no override".
-11. **Fault tolerance is an MCCL-communicator feature.** Communicators created
+12. **Fault tolerance is an MCCL-communicator feature.** Communicators created
     through the NCCLX/CTRAN factory get a disabled `Abort`; see *Scope*.
-12. **Terminate the kernel cleanly; never trap to do it.** A trap takes the CUDA
+13. **Terminate the kernel cleanly; never trap to do it.** A trap takes the CUDA
     context down and loses every other stream on the device, which is a worse
     outcome than the hang it replaces. Abort must unwind to a normal kernel
     exit. `FT_DEVICE_TRAP()` stays reserved for the death tests that assert trap
     semantics deliberately.
-13. **Contain the abort path in the transport.** The transport leaves its
+14. **Contain the abort path in the transport.** The transport leaves its
     per-channel state releasable on abort -- an unwinding operation drives its
     progress slot to the terminal stage (`abandon_progress_state()`), so a
     kernel already queued on the same channel re-initializes without tripping
@@ -142,6 +157,76 @@ Do not store started timeout state in persistent transport objects. Transport
 device handles may live across calls and may be reused by many blocks. Storing a
 started deadline there would make timeout state shared across unrelated blocks,
 kernels, or operations.
+
+## Why the abort check is amortized
+
+This is the single most important performance property of the whole design, and
+it is easy to undo by accident, so it is worth stating with numbers.
+
+`AbortState` lives in **mapped pinned host memory** so that host and device see
+one abort reason. That is what makes the contract work, and it is also what
+makes a naive check ruinous: every read of the shared reason from the device is
+an uncached PCIe round trip. Spin loops call the check on *every iteration*, and
+in the LL small-message path that is up to 32 lanes x 2 loads per warp per
+iteration.
+
+So `checkExpired()` does not read shared state on most calls. It gates the read
+behind the free device clock:
+
+```cpp
+const uint64_t now = detail::deviceClock();
+const bool deadlineDue = deadlineCycles_ != 0 && now >= deadlineCycles_;
+if (!deadlineDue && now < nextPollCycles_) {
+  return false;          // register compare only -- no memory touched
+}
+nextPollCycles_ = now + pollIntervalCycles_;
+```
+
+`pollIntervalCycles_` is `cyclesPerMs_ / kAbortPollsPerMs` with
+`kAbortPollsPerMs = 100`, i.e. **100 shared reads per millisecond per handle**,
+independent of how fast the loop spins. Once a terminal reason has been seen,
+`sawTerminalReason_` answers from a register forever.
+
+### What it is worth
+
+Measured on 8x H100 (`devgpu012.mwg1`) with
+`comms/common/fault_tolerance/benchmarks:abort_bench`; full tables and
+methodology in that directory's `Perf.md`.
+
+| Row | Ungated | Gated | |
+|---|---:|---:|---|
+| `AbortDeviceIsAbortedLoadLoop` | 225.93ms / 100K polls | 4.87ms / 100K polls | 46x |
+| `AbortDeviceIsAbortedWithDeadlineLoadLoop` | 226.28ms / 100K polls | 4.88ms / 100K polls | 46x |
+
+That is ~2.26us per ungated poll against ~49ns gated. The
+`CudaAtomicDeviceLoadLoop` row corroborates the mechanism independently: a bare
+mapped-pinned load is 1.11us, so the ungated cost is simply "the shared read,
+every time".
+
+Two consequences worth internalizing:
+
+- **Arming a deadline is free.** The with-deadline row is within noise of the
+  no-deadline row (4.88ms vs 4.87ms) because the deadline is one more register
+  compare on the same gated path. There is no performance argument for leaving a
+  collective unarmed.
+- **The cost of an abort check is a property of the poll interval, not of the
+  loop.** A tighter spin loop does not make aborts more expensive. This is why
+  Principle 7 says to gate the check rather than to call it less often.
+
+### How to not undo it
+
+- Do not add work to `checkExpired()` before the gate. Anything above the
+  `now < nextPollCycles_` early return runs on every spin iteration of every
+  wait in the codebase.
+- Do not add a debug assertion to this path "just in case" -- it was considered
+  for the arm-site invariant and rejected for exactly this reason; a static
+  audit plus per-collective stall tests cover that without touching the gate.
+- Prefer one poller per group over one per thread when the loop is per-thread.
+  The gate is per-handle-copy, so N thread-local copies mean N times the shared
+  reads.
+- If you change `kAbortPollsPerMs`, re-run `abort_bench` and update both this
+  section and `Perf.md`. It trades abort-detection latency against shared-read
+  volume, and both numbers above move with it.
 
 ## MPT And Prims Integration
 
@@ -401,6 +486,64 @@ communicator" and "the collective forgot to pass the handle". Only the host can
 see both the communicator's `Abort` and the handle being launched, so only the
 host can tell those apart.
 
+### One budget per kernel
+
+`startTimeout()` computes `deadlineCycles_ = deviceClock() + timeoutMs *
+cyclesPerMs_` **at the moment it is called**. There is no host-settable absolute
+deadline, so a deadline is only ever as wide as the region between the `start()`
+that armed it and the wait that observes it.
+
+The rule that follows, and the one the table below audits:
+
+> **Exactly one `start()` per `__global__` kernel, at entry. Everything below it
+> takes the handle by reference.**
+
+A second `start()` anywhere downstream re-arms from the current clock, so the
+work after it gets a fresh full budget on top of whatever the work before it
+already spent. Two arm sites in one kernel means the kernel can take twice the
+deadline the caller asked for, and the effect is worst exactly when it matters
+least — when things are already running slowly.
+
+The accepted consequence: a collective that spans **two kernel launches gets two
+budgets**. That is deliberate. Closing it would need the host to stamp an
+absolute deadline into the handle, which means carrying a device-clock reference
+sample to convert `steady_clock` into the device cycle domain. Not worth it
+while one collective is one launch.
+
+### Per-collective FT status
+
+Onboarding is incremental. A collective that has not been onboarded carries a
+**disabled** handle, and `AbortDevice::checkExpired()` returns `false`
+immediately for those — so it is inert rather than wrong. What must never happen
+is an *enabled* handle that nothing armed: the waits would then observe explicit
+aborts but no deadline would ever fire.
+
+| Collective | Kernel(s) | Arm site | Status |
+| --- | --- | --- | --- |
+| AllReduce Direct | `AllReduceIbDirect.cu` | `args.timeout.start()` at entry, forwarded to the 4-arg `runAllReduceFused` | onboarded |
+| AllReduce Ring | `AllReduceIbRingImpl.cuh` | `runRing` arms at entry; passed to `runAllReduceFused` and `phase2IbRing` | onboarded |
+| AllReduce Tree | `AllReduceIbTreeImpl.cuh` | kernel entry; passed to `runAllReduceFused` and `TreePhase2` | onboarded |
+| SendRecv | `SendRecvLauncher.cu` | `abort.start()` at entry, threaded into every send/recv | onboarded |
+| ReduceScatter Ring | `RingReduceScatterKernel.cuh` | kernel entry | onboarded |
+| ReduceScatter Direct / DirectIbV2 | `prims/collectives/ReduceScatterDirect*.cu` | kernel entry | onboarded |
+| ReduceScatter DirectIb (`ctdirect_ib`) | `ctran/algos/ReduceScatterDirectIb.cc` | **none — `params.abort` is left default-constructed** | **not onboarded** |
+| AllGather Direct | `prims/collectives/AllGatherDirect.cu` | kernel entry, once in each of the three kernels | onboarded |
+| AllGather Ring | `prims/collectives/RingAllgather.cu` | kernel entry | onboarded |
+| AllToAllv (+ Ll128) | `prims/collectives/AllToAllv*.cu` | kernel entry | onboarded |
+
+Two things this audit turned up that are worth keeping written down:
+
+- `runAllReduceFused` has a **three-argument overload that arms a handle of its
+  own**. It exists for callers that have no handle to pass. A caller that has
+  already armed one must use the four-argument overload — using the short one
+  is the easiest way to end up with two budgets in a kernel, and it is how Tree
+  did before this was fixed.
+- `prims::collectives::all_gather` takes its `Timeout` **by value and arms it**.
+  That is correct for its current callers, which are all kernel entries handing
+  in an unarmed handle, but it means a collective that ever passes its own armed
+  handle would silently get it re-armed. Prefer taking it by reference if that
+  call site appears.
+
 ### What the caller sees
 
 - The collective completes; **output buffers are undefined** after an abort.
@@ -413,10 +556,22 @@ host can tell those apart.
 
 Fault tolerance is a **MCCL-communicator** feature. Communicators created
 through the NCCLX/CTRAN factory get a disabled `Abort`, so they have no device
-deadline and no abort observation; the `ctdirect_ib` ReduceScatter path is
-unbounded on those comms. This is an accepted limitation, not an oversight, and
-it is a regression against the pre-migration code, which applied
-`MCCL_ABORT_TIMEOUT_MS` unconditionally on that path. The debug diagnostic above
+deadline and no abort observation.
+
+`ctdirect_ib` ReduceScatter is unbounded on **more than those comms**, and the
+earlier wording here understated it. `McclComm::reduceScatter()` intercepts only
+`ctring_ib`, so an ordinary **FT-enabled** MCCL communicator that selects
+`ctdirect_ib` — via `NCCL_REDUCESCATTER_ALGO` or `ncclReduceScatterQuantize` —
+falls through to `ctranReduceScatter()` and reaches
+`ReduceScatterDirectIb.cc`, which deliberately leaves `params.abort`
+default-constructed. The kernel therefore arms a disabled handle and has neither
+the communicator's abort state nor its deadline, so peer loss is unbounded on a
+communicator whose owner asked for fault tolerance. Thanks to @benrcarver for
+catching that the status table and this section contradicted each other.
+
+Until that route is either plumbed or rejected under FT, the table above marks
+it **not onboarded**. This is a regression against the pre-migration code, which
+applied `MCCL_ABORT_TIMEOUT_MS` unconditionally on that path. The debug diagnostic above
 is scoped to FT-enabled communicators so it stays silent here and under
 `MCCL_ABORT_MODE=none`.
 

--- a/comms/prims/collectives/ReduceScatterDirectIbV2.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIbV2.cu
@@ -300,7 +300,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
             // slow peer never stops us polling the others.
             int ready = 0;
             bool finished = false;
-            while (ready < count && !finished) {
+            bool aborted = false;
+            while (ready < count && !finished && !aborted) {
               ready = 0;
               for (int i = 0; i < count; ++i) {
                 if (rviews[s][i].staging != nullptr) {
@@ -311,6 +312,17 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
                 auto transport = args.peers[rpeer_of[i]];
                 const auto st = transport.progress_recv_acquire_once(
                     solo, wire_bytes, max_sig, timeout, view);
+                // `Aborted` is terminal and must be handled explicitly. It used
+                // to fall through this chain: the acquire had already driven
+                // the slot to `Done` via abandon_progress_state(), so the NEXT
+                // acquire returned `Done`, the loop set `finished` and the
+                // collective reported ordinary completion over a partially
+                // reduced accumulator. Stopping here keeps "aborted" and
+                // "stream complete" distinguishable.
+                if (st == IbgdaSendRecvProgressStatus::Aborted) {
+                  aborted = true;
+                  break;
+                }
                 if (st == IbgdaSendRecvProgressStatus::Done) {
                   finished = true;
                   break;
@@ -321,7 +333,7 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
                 }
               }
             }
-            if (finished) {
+            if (finished || aborted) {
               s_nchunks = c;
               __threadfence_block();
               s_published = c;
@@ -339,7 +351,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
               const int ps = (c - 1) % kSlots;
               for (int i = 0; i < count; ++i) {
                 auto transport = args.peers[rpeer_of[i]];
-                transport.progress_recv_release_once(solo, rviews[ps][i]);
+                transport.progress_recv_release_once(
+                    solo, timeout, rviews[ps][i]);
                 rviews[ps][i] = detail::RecvChunkAcquisition{};
               }
               released = c - 1;
@@ -354,7 +367,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
             const int ds = d % kSlots;
             for (int i = 0; i < count; ++i) {
               auto transport = args.peers[rpeer_of[i]];
-              transport.progress_recv_release_once(solo, rviews[ds][i]);
+              transport.progress_recv_release_once(
+                  solo, timeout, rviews[ds][i]);
               rviews[ds][i] = detail::RecvChunkAcquisition{};
             }
             released = d;

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -777,11 +777,12 @@ template <typename>
 __device__ __forceinline__ void
 P2pIbTransportDevice::progress_recv_release_once(
     ThreadGroup& group,
+    const AbortDevice& timeout,
     const detail::RecvChunkAcquisition& view) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->progress_recv_release_once(group, view);
+    ibrc->progress_recv_release_once(group, timeout, view);
   } else {
-    ibgda->progress_recv_release_once(group, view);
+    ibgda->progress_recv_release_once(group, timeout, view);
   }
 }
 

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -101,6 +101,7 @@ template <typename Transport, typename Proto>
 __device__ __forceinline__ void progress_recv_release_once(
     Transport& transport,
     ThreadGroup& group,
+    const AbortDevice& timeout,
     const RecvChunkAcquisition& view);
 
 template <typename Transport>
@@ -428,6 +429,7 @@ struct P2pIbTransportDevice {
   template <typename = void>
   __device__ __forceinline__ void progress_recv_release_once(
       ThreadGroup& group,
+      const AbortDevice& timeout,
       const detail::RecvChunkAcquisition& view);
 
   template <

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -72,6 +72,36 @@ __device__ __forceinline__ void abandon_progress_state(
     IbChannelProgress& slot,
     IbChannelProgress& state);
 
+/*
+ * Where the abort is consulted on the ready path, and why it is not a
+ * standalone entry guard.
+ *
+ * Every abort check in this file used to hang off a wait, and each consults the
+ * abort only on its *not-ready* branch. So a call that found everything ready
+ * reached the put, the fused DATA_READY, or the SLOT_FREE credit having never
+ * looked at the abort -- and publishing any of those after an abort is what
+ * principle 4 forbids: a false signal releases a peer that is correctly blocked
+ * and stops it ever reaching its own deadline, so the fault reads to that peer
+ * as success.
+ *
+ * The obvious fix -- one guard at the top of each progress call -- adds a
+ * group-wide broadcast to every *healthy* attempt, and Tree scheduling and
+ * batched send/recv drive these in tight loops. Instead the verdict rides out
+ * through synchronization that already exists:
+ *
+ *   - `try_prepare_send_slot()` and both `progress_recv_ready()` overloads
+ *     already broadcast a readiness verdict; the leader now decides the abort
+ *     inside that same block and returns `kProgressAborted` through it.
+ *   - The pre-put `group.sync()` becomes a broadcast carrying the verdict,
+ *     which covers a call resuming at WaitSlotFree -- that path skips slot
+ *     preparation, and skips the SLOT_FREE wait entirely for a chunk inside the
+ *     pipeline depth.
+ *
+ * Net added barriers on the healthy path: zero, except LL's ready path, which
+ * had no existing broadcast to fold into and now pays the one the not-ready
+ * path already paid.
+ */
+
 template <typename Proto = protocol::Simple>
 __device__ __forceinline__ ProgressGeometry make_progress_geometry(
     const IbChannelLayout& channelLayout,
@@ -565,14 +595,30 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
       }
     }
 
+    // Last gate before the put and its fused DATA_READY.
+    //
+    // A call that *resumes* at WaitSlotFree skipped `try_prepare_send_slot`,
+    // and the SLOT_FREE wait above is itself skipped for any chunk inside the
+    // pipeline depth -- so on that path nothing has consulted the abort yet.
+    // This replaces the `group.sync()` that already stood here rather than
+    // adding a barrier: a broadcast is the same single synchronization, and it
+    // carries the verdict out with it.
+    uint32_t sendAborted = 0;
     if (group.is_leader()) {
       trace_allreduce_event(
           traceContext,
           PipesTraceEventType::kAllReduceSendSyncBegin,
           static_cast<uint8_t>(kPipesTraceQpLaneMask),
           chunk.wireBytes);
+      sendAborted =
+          FT_ABORT_CHECK(timeout, "send publish on an aborted communicator")
+          ? 1U
+          : 0U;
     }
-    group.sync();
+    if (group.broadcast<uint32_t>(sendAborted) != 0U) {
+      abandon_progress_state(group, progressSlot, state);
+      return IbgdaSendRecvProgressStatus::Aborted;
+    }
     if (group.is_leader()) {
       __threadfence_system();
       trace_allreduce_event(
@@ -770,7 +816,21 @@ progress_registered_send_once(
         (isFinalChunk ? protocol::Simple::wire_bytes(state.activeTailPadding)
                       : 0);
 
-    group.sync();
+    // Same gate as the plain send path, for the same reason: a resumed call
+    // entering at WaitSlotFree consulted nothing, and this replaces the
+    // `group.sync()` that already stood here rather than adding a barrier.
+    uint32_t sendAborted = 0;
+    if (group.is_leader()) {
+      sendAborted =
+          FT_ABORT_CHECK(
+              timeout, "registered send publish on an aborted communicator")
+          ? 1U
+          : 0U;
+    }
+    if (group.broadcast<uint32_t>(sendAborted) != 0U) {
+      abandon_progress_state(group, progressSlot, state);
+      return IbgdaRegisteredSendProgressStatus::Aborted;
+    }
     if (group.is_leader()) {
       __threadfence_system();
       ThreadGroup solo{
@@ -1101,42 +1161,51 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
   if (group.is_leader()) {
     unsigned long long current = 0;
     unsigned long long expected = 0;
-    ready = poll_recv_data_ready(
-                transport,
-                localChannel,
-                localDataReady,
-                waitCredit,
-                current,
-                expected)
-        ? 1U
-        : 0U;
-    if (!ready) {
-      if (fine_trace_enabled(traceContext) && traceState != nullptr &&
-          !traceState->dataReadyWaitOpen) {
+    // Asked before readiness, so the already-landed path is covered too. This
+    // function already broadcasts, so the check is free of extra barriers; a
+    // separate entry guard would add one to every healthy poll. Without it a
+    // chunk whose data had arrived went on to consume it and credit SLOT_FREE
+    // without ever consulting the abort.
+    if (FT_ABORT_CHECK(timeout, "recv progress on an aborted communicator")) {
+      ready = kProgressAborted;
+    } else {
+      ready = poll_recv_data_ready(
+                  transport,
+                  localChannel,
+                  localDataReady,
+                  waitCredit,
+                  current,
+                  expected)
+          ? 1U
+          : 0U;
+      if (!ready) {
+        if (fine_trace_enabled(traceContext) && traceState != nullptr &&
+            !traceState->dataReadyWaitOpen) {
+          trace_allreduce_event(
+              traceContext,
+              PipesTraceEventType::kAllReduceDataReadyWaitBegin,
+              qpLane,
+              waitCredit);
+          traceState->dataReadyWaitOpen = true;
+        }
+        if (FT_ABORT_CHECK(
+                timeout,
+                "progress_recv_once waiting for DATA_READY expected>=%llu, "
+                "current=%llu",
+                expected,
+                current)) {
+          ready = kProgressAborted;
+        }
+      } else if (
+          fine_trace_enabled(traceContext) && traceState != nullptr &&
+          traceState->dataReadyWaitOpen) {
         trace_allreduce_event(
             traceContext,
-            PipesTraceEventType::kAllReduceDataReadyWaitBegin,
+            PipesTraceEventType::kAllReduceDataReadyWaitEnd,
             qpLane,
             waitCredit);
-        traceState->dataReadyWaitOpen = true;
+        traceState->dataReadyWaitOpen = false;
       }
-      if (FT_ABORT_CHECK(
-              timeout,
-              "progress_recv_once waiting for DATA_READY expected>=%llu, "
-              "current=%llu",
-              expected,
-              current)) {
-        ready = kProgressAborted;
-      }
-    } else if (
-        fine_trace_enabled(traceContext) && traceState != nullptr &&
-        traceState->dataReadyWaitOpen) {
-      trace_allreduce_event(
-          traceContext,
-          PipesTraceEventType::kAllReduceDataReadyWaitEnd,
-          qpLane,
-          waitCredit);
-      traceState->dataReadyWaitOpen = false;
     }
   }
   // Broadcast makes the answer group-uniform, which is what lets abort ride out
@@ -1250,27 +1319,24 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
   // Packet geometry lives in LLImpl, which owns the format; this seam only
   // decides what to do with the verdict -- report not-ready on false, rather
   // than spin.
-  if (LLImpl<P>::all_flags_set(
-          group,
-          staging,
-          P::max_payload(chunk.wireBytes),
-          static_cast<typename P::FlagType>(chunk.flagVal))) {
-    if (group.is_leader()) {
-      // LL carries no DATA_READY, but its put still advanced the sender's
-      // IbQpState::cursor -- select_put_lane_ordinal() increments that cursor
-      // on every put regardless of protocol, and it is channel-scoped, not
-      // slot-scoped. recvDataReadyLaneCursor mirrors it, so the mirror has to
-      // advance here too: consuming an LL chunk without it leaves the two one
-      // chunk apart per LL transfer, and Simple's next receive on this channel
-      // then waits on a lane the sender never wrote. Matches the unconditional
-      // bump in poll_recv_data_ready() (a single lane makes it a no-op).
-      ++localChannel.recvDataReadyLaneCursor;
-    }
-    return kProgressReady;
-  }
+  // `all_flags_set` is group-collective, so every thread evaluates it; the
+  // verdict below is then decided once by the leader and broadcast.
+  const bool flagsSet = LLImpl<P>::all_flags_set(
+      group,
+      staging,
+      P::max_payload(chunk.wireBytes),
+      static_cast<typename P::FlagType>(chunk.flagVal));
   // Only the leader checks, so the answer has to be broadcast before it leaves:
   // a per-thread verdict here would split the group at the caller's next
   // collective step.
+  //
+  // The abort is asked *before* readiness, and the ready path now leaves
+  // through the same single broadcast as the not-ready path rather than
+  // returning early. Previously a chunk whose flags were already set returned
+  // `kProgressReady` without ever consulting the abort, and the caller went on
+  // to consume the packet and credit SLOT_FREE. One broadcast on every path is
+  // the floor here -- unlike Simple, LL's ready path had no existing barrier to
+  // fold into.
   uint32_t status = kProgressNotReady;
   if (group.is_leader()) {
     if (FT_ABORT_CHECK(
@@ -1280,6 +1346,17 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
             static_cast<unsigned long long>(chunk.flagVal),
             static_cast<unsigned long long>(chunk.wireBytes))) {
       status = kProgressAborted;
+    } else if (flagsSet) {
+      // LL carries no DATA_READY, but its put still advanced the sender's
+      // IbQpState::cursor -- select_put_lane_ordinal() increments that cursor
+      // on every put regardless of protocol, and it is channel-scoped, not
+      // slot-scoped. recvDataReadyLaneCursor mirrors it, so the mirror has to
+      // advance here too: consuming an LL chunk without it leaves the two one
+      // chunk apart per LL transfer, and Simple's next receive on this channel
+      // then waits on a lane the sender never wrote. Matches the unconditional
+      // bump in poll_recv_data_ready() (a single lane makes it a no-op).
+      ++localChannel.recvDataReadyLaneCursor;
+      status = kProgressReady;
     }
   }
   return group.broadcast<uint32_t>(status);
@@ -1679,9 +1756,29 @@ template <typename Transport, typename Proto>
 __device__ __forceinline__ void progress_recv_release_once(
     Transport& transport,
     ThreadGroup& group,
+    const AbortDevice& timeout,
     const RecvChunkAcquisition& view) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   if (view.staging == nullptr) {
+    return;
+  }
+  // SLOT_FREE is a peer-visible credit: it tells the sender this range has been
+  // consumed and may be overwritten. After an abort the consumption either did
+  // not happen or is not trustworthy, so crediting it releases a peer that is
+  // correctly blocked -- principle 4. This function had no abort parameter at
+  // all and signalled unconditionally, which is why the split-receive path
+  // stayed uncontained while the fused one was fixed.
+  //
+  // Leader-decides-and-broadcasts, because a subset skipping the signal while
+  // the rest enter `transport.signal()` would split the group.
+  uint32_t aborted = 0;
+  if (group.is_leader()) {
+    aborted =
+        FT_ABORT_CHECK(timeout, "recv slot release on an aborted communicator")
+        ? 1U
+        : 0U;
+  }
+  if (group.broadcast<uint32_t>(aborted) != 0U) {
     return;
   }
   auto& channelLayout = transport.channel_layout();
@@ -1692,6 +1789,7 @@ __device__ __forceinline__ void progress_recv_release_once(
 #else
   (void)transport;
   (void)group;
+  (void)timeout;
   (void)view;
 #endif
 }
@@ -2094,37 +2192,52 @@ __device__ __forceinline__ uint32_t try_prepare_send_slot(
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t ready = kProgressReady;
   if (group.is_leader()) {
-    auto& slot = transport.template local_channel_slot<P>(group.group_id)
-                     .sendCompletionSlots[slotId];
-    if (slot.generation != generation) {
-      uint64_t pending = slot.laneMask;
-      const uint32_t numLanes = transport.send_completion_lane_count();
-      for (uint32_t laneId = 0; laneId < numLanes; ++laneId) {
-        const uint64_t laneBit = 1ULL << laneId;
-        if ((pending & laneBit) == 0) {
-          continue;
+    // Consulted on the ready path too, not just when the slot is busy.
+    //
+    // This function already broadcasts its verdict, so folding the abort into
+    // it costs no extra barrier -- which is the whole point: a standalone entry
+    // guard would add a group-wide broadcast to every healthy progress attempt,
+    // and Tree scheduling and batched send/recv call this in tight loops.
+    //
+    // Checking only inside the not-ready branch below is what left the hole: a
+    // call that finds the slot already free never looked at the abort and went
+    // on to stage the payload and issue the put with its fused DATA_READY.
+    if (FT_ABORT_CHECK(
+            timeout, "send slot preparation on an aborted communicator")) {
+      ready = kProgressAborted;
+    } else {
+      auto& slot = transport.template local_channel_slot<P>(group.group_id)
+                       .sendCompletionSlots[slotId];
+      if (slot.generation != generation) {
+        uint64_t pending = slot.laneMask;
+        const uint32_t numLanes = transport.send_completion_lane_count();
+        for (uint32_t laneId = 0; laneId < numLanes; ++laneId) {
+          const uint64_t laneBit = 1ULL << laneId;
+          if ((pending & laneBit) == 0) {
+            continue;
+          }
+          const IbLocalCompletionTicket ticket{
+              .completionId = laneId,
+              .value = slot.values[laneId],
+          };
+          if (transport.is_local_completion_ready(group.group_id, ticket)) {
+            pending &= ~laneBit;
+          }
         }
-        const IbLocalCompletionTicket ticket{
-            .completionId = laneId,
-            .value = slot.values[laneId],
-        };
-        if (transport.is_local_completion_ready(group.group_id, ticket)) {
-          pending &= ~laneBit;
-        }
-      }
-      slot.laneMask = pending;
-      if (pending == 0) {
-        slot.generation = generation;
-      } else {
-        ready = kProgressNotReady;
-        if (FT_ABORT_CHECK(
-                timeout,
-                "send slot local completion timed out slot=%u generation=%llu "
-                "pending=0x%llx",
-                slotId,
-                static_cast<unsigned long long>(generation),
-                static_cast<unsigned long long>(pending))) {
-          ready = kProgressAborted;
+        slot.laneMask = pending;
+        if (pending == 0) {
+          slot.generation = generation;
+        } else {
+          ready = kProgressNotReady;
+          if (FT_ABORT_CHECK(
+                  timeout,
+                  "send slot local completion timed out slot=%u generation=%llu "
+                  "pending=0x%llx",
+                  slotId,
+                  static_cast<unsigned long long>(generation),
+                  static_cast<unsigned long long>(pending))) {
+            ready = kProgressAborted;
+          }
         }
       }
     }

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -2325,10 +2325,11 @@ class P2pIbgdaTransportDevice {
   template <typename = void>
   __device__ __forceinline__ void progress_recv_release_once(
       ThreadGroup& group,
+      const AbortDevice& timeout,
       const detail::RecvChunkAcquisition& view) {
     detail::
         progress_recv_release_once<P2pIbgdaTransportDevice, protocol::Simple>(
-            *this, group, view);
+            *this, group, timeout, view);
   }
 
   /**

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -702,10 +702,11 @@ class P2pIbrcTransportDevice {
   template <typename = void>
   __device__ __forceinline__ void progress_recv_release_once(
       ThreadGroup& group,
+      const AbortDevice& timeout,
       const detail::RecvChunkAcquisition& view) {
     detail::
         progress_recv_release_once<P2pIbrcTransportDevice, protocol::Simple>(
-            *this, group, view);
+            *this, group, timeout, view);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>


### PR DESCRIPTION
Summary:
An audit of every `startTimeout()` call site in `comms/mccl` and `comms/prims`
turned up a real defect and a rule that was being followed by convention
without being written down.

`startTimeout()` sets `deadlineCycles_ = deviceClock() + timeoutMs *
cyclesPerMs_` at the moment it is called, and there is no host-settable absolute
deadline. So a second `start()` below the first re-arms from the current clock
and hands the work after it a fresh full budget on top of whatever the work
before it already spent. AllReduce Tree was doing exactly that -- one handle
armed inside the three-argument `runAllReduceFused` for the NVL phases, another
armed inside `phase2IbDualTree` for Phase 2 -- so the kernel ran on two
independent budgets and could take up to twice the deadline the caller asked
for. Fixed in D115855240; this diff records the rule that makes it a rule
rather than a one-off fix.

Adds two sections to `FAULT_TOLERANCE.md`:

- **One budget per kernel.** Exactly one `start()` per `__global__` kernel, at
  entry; everything below takes the handle by reference. States the accepted
  consequence that a collective spanning two launches gets two budgets, and why
  closing that is not worth a device-clock reference sample today.
- **Per-collective FT status.** A table of every collective, its kernel, its arm
  site and whether it is onboarded, so incremental onboarding has a ledger
  instead of an oral tradition. All nine entries are currently onboarded with
  exactly one arm site each.

Also records the two traps the audit found: the three-argument
`runAllReduceFused` overload arms a handle of its own and must not be used by a
caller that already armed one, and `prims::collectives::all_gather` takes its
`Timeout` by value and arms it, which is fine for its current kernel-entry
callers but would silently re-arm a collective's handle if one were ever passed.

Deliberately not enforced with a runtime assertion. The natural place is
`AbortDevice::checkExpired()`, which is the steady-state polling path that
D115855241 exists to keep down to a register compare; adding a branch there
costs the hot path for a class of bug that a static audit plus per-collective
stall coverage already catches.

Reviewed By: Scusemua, arttianezhu

Differential Revision: D116659195


