### PR TITLE
Unwind IBGDA completion errors instead of trapping

### DIFF
--- a/comms/common/fault_tolerance/FAULT_TOLERANCE.md
+++ b/comms/common/fault_tolerance/FAULT_TOLERANCE.md
@@ -21,36 +21,51 @@ rules the detail exists to serve.
    `FT_ABORT_BREAK` / `FT_ABORT_RETURN` (`AbortMacros.cuh`); they terminate the
    loop themselves. Do not convert a `void` wait to `bool` just to report that
    it aborted.
-4. **Group uniformity idiom: leader polls, then broadcasts.** Use the existing
+4. **Never signal a peer for work you abandoned.** `FT_ABORT_BREAK` ends the
+   *spin* it is written in; it says nothing to the pipeline loop around it. A
+   loop that keeps going after its wait gave up will still issue the put, the
+   fused `DATA_READY`, and the `SLOT_FREE` credit for every remaining chunk. So
+   put a group-uniform `groupAborted()` break between the wait and the first
+   peer-visible side effect.
+
+   This is not about garbage output — that is contract-legal. It is that a false
+   signal **releases a peer that is correctly blocked and stops it ever reaching
+   its own deadline**, so the fault looks to that peer like a successful
+   collective. One rank's abort then silently suppresses fault detection on the
+   rest, which is the opposite of what this design is for. Measured at
+   `IB_ONLY_1x8` before this was fixed: only 5 of 7 survivors recorded
+   `TIMED_OUT` from their own deadline; the other two were spuriously completed
+   by the ranks that had. After: 7 of 7.
+5. **Group uniformity idiom: leader polls, then broadcasts.** Use the existing
    leader + `broadcast<uint32_t>` shape rather than adding a new reduction
    primitive for one call site.
-5. **Never derive a loop bound or an index from peer-written data.** Bounds come
+6. **Never derive a loop bound or an index from peer-written data.** Bounds come
    from local geometry or parameters. This is the assumption that lets a wait
    give up without unwinding the caller.
-6. **Do not store started deadline state in a transport object.** Transport
+7. **Do not store started deadline state in a transport object.** Transport
    handles outlive operations and are shared across blocks; copy the handle per
    block and call `startTimeout()` on the copy.
-7. **Keep abort polling off hot paths.** Gate the check behind a spin count so
+8. **Keep abort polling off hot paths.** Gate the check behind a spin count so
    it only engages once actually stalled, and prefer one poller per group over
    one per thread when the loop is per-thread.
-8. **Onboard every new or in-flight wait as it lands**, including
+9. **Onboard every new or in-flight wait as it lands**, including
    work-in-progress paths. A spin loop that reaches main without an abort check
    is a hang waiting to happen.
-9. **Per-operation timeouts come only from the collective API.** The
-   communicator deadline stays late-bound in shared state so `setTimeout()` is
-   observed by already-created device handles.
-10. **Validate a timeout's sign, not its size.** Choosing a sane magnitude is
+10. **Per-operation timeouts come only from the collective API.** The
+    communicator deadline stays late-bound in shared state so `setTimeout()` is
+    observed by already-created device handles.
+11. **Validate a timeout's sign, not its size.** Choosing a sane magnitude is
     the caller's job; `std::chrono` types already make unit mistakes unlikely.
     A negative value must be rejected, because at the `AbortDevice` layer it
     silently means "no override".
-11. **Fault tolerance is an MCCL-communicator feature.** Communicators created
+12. **Fault tolerance is an MCCL-communicator feature.** Communicators created
     through the NCCLX/CTRAN factory get a disabled `Abort`; see *Scope*.
-12. **Terminate the kernel cleanly; never trap to do it.** A trap takes the CUDA
+13. **Terminate the kernel cleanly; never trap to do it.** A trap takes the CUDA
     context down and loses every other stream on the device, which is a worse
     outcome than the hang it replaces. Abort must unwind to a normal kernel
     exit. `FT_DEVICE_TRAP()` stays reserved for the death tests that assert trap
     semantics deliberately.
-13. **Contain the abort path in the transport.** The transport leaves its
+14. **Contain the abort path in the transport.** The transport leaves its
     per-channel state releasable on abort -- an unwinding operation drives its
     progress slot to the terminal stage (`abandon_progress_state()`), so a
     kernel already queued on the same channel re-initializes without tripping
@@ -142,6 +157,76 @@ Do not store started timeout state in persistent transport objects. Transport
 device handles may live across calls and may be reused by many blocks. Storing a
 started deadline there would make timeout state shared across unrelated blocks,
 kernels, or operations.
+
+## Why the abort check is amortized
+
+This is the single most important performance property of the whole design, and
+it is easy to undo by accident, so it is worth stating with numbers.
+
+`AbortState` lives in **mapped pinned host memory** so that host and device see
+one abort reason. That is what makes the contract work, and it is also what
+makes a naive check ruinous: every read of the shared reason from the device is
+an uncached PCIe round trip. Spin loops call the check on *every iteration*, and
+in the LL small-message path that is up to 32 lanes x 2 loads per warp per
+iteration.
+
+So `checkExpired()` does not read shared state on most calls. It gates the read
+behind the free device clock:
+
+```cpp
+const uint64_t now = detail::deviceClock();
+const bool deadlineDue = deadlineCycles_ != 0 && now >= deadlineCycles_;
+if (!deadlineDue && now < nextPollCycles_) {
+  return false;          // register compare only -- no memory touched
+}
+nextPollCycles_ = now + pollIntervalCycles_;
+```
+
+`pollIntervalCycles_` is `cyclesPerMs_ / kAbortPollsPerMs` with
+`kAbortPollsPerMs = 100`, i.e. **100 shared reads per millisecond per handle**,
+independent of how fast the loop spins. Once a terminal reason has been seen,
+`sawTerminalReason_` answers from a register forever.
+
+### What it is worth
+
+Measured on 8x H100 (`devgpu012.mwg1`) with
+`comms/common/fault_tolerance/benchmarks:abort_bench`; full tables and
+methodology in that directory's `Perf.md`.
+
+| Row | Ungated | Gated | |
+|---|---:|---:|---|
+| `AbortDeviceIsAbortedLoadLoop` | 225.93ms / 100K polls | 4.87ms / 100K polls | 46x |
+| `AbortDeviceIsAbortedWithDeadlineLoadLoop` | 226.28ms / 100K polls | 4.88ms / 100K polls | 46x |
+
+That is ~2.26us per ungated poll against ~49ns gated. The
+`CudaAtomicDeviceLoadLoop` row corroborates the mechanism independently: a bare
+mapped-pinned load is 1.11us, so the ungated cost is simply "the shared read,
+every time".
+
+Two consequences worth internalizing:
+
+- **Arming a deadline is free.** The with-deadline row is within noise of the
+  no-deadline row (4.88ms vs 4.87ms) because the deadline is one more register
+  compare on the same gated path. There is no performance argument for leaving a
+  collective unarmed.
+- **The cost of an abort check is a property of the poll interval, not of the
+  loop.** A tighter spin loop does not make aborts more expensive. This is why
+  Principle 7 says to gate the check rather than to call it less often.
+
+### How to not undo it
+
+- Do not add work to `checkExpired()` before the gate. Anything above the
+  `now < nextPollCycles_` early return runs on every spin iteration of every
+  wait in the codebase.
+- Do not add a debug assertion to this path "just in case" -- it was considered
+  for the arm-site invariant and rejected for exactly this reason; a static
+  audit plus per-collective stall tests cover that without touching the gate.
+- Prefer one poller per group over one per thread when the loop is per-thread.
+  The gate is per-handle-copy, so N thread-local copies mean N times the shared
+  reads.
+- If you change `kAbortPollsPerMs`, re-run `abort_bench` and update both this
+  section and `Perf.md`. It trades abort-detection latency against shared-read
+  volume, and both numbers above move with it.
 
 ## MPT And Prims Integration
 
@@ -401,6 +486,64 @@ communicator" and "the collective forgot to pass the handle". Only the host can
 see both the communicator's `Abort` and the handle being launched, so only the
 host can tell those apart.
 
+### One budget per kernel
+
+`startTimeout()` computes `deadlineCycles_ = deviceClock() + timeoutMs *
+cyclesPerMs_` **at the moment it is called**. There is no host-settable absolute
+deadline, so a deadline is only ever as wide as the region between the `start()`
+that armed it and the wait that observes it.
+
+The rule that follows, and the one the table below audits:
+
+> **Exactly one `start()` per `__global__` kernel, at entry. Everything below it
+> takes the handle by reference.**
+
+A second `start()` anywhere downstream re-arms from the current clock, so the
+work after it gets a fresh full budget on top of whatever the work before it
+already spent. Two arm sites in one kernel means the kernel can take twice the
+deadline the caller asked for, and the effect is worst exactly when it matters
+least — when things are already running slowly.
+
+The accepted consequence: a collective that spans **two kernel launches gets two
+budgets**. That is deliberate. Closing it would need the host to stamp an
+absolute deadline into the handle, which means carrying a device-clock reference
+sample to convert `steady_clock` into the device cycle domain. Not worth it
+while one collective is one launch.
+
+### Per-collective FT status
+
+Onboarding is incremental. A collective that has not been onboarded carries a
+**disabled** handle, and `AbortDevice::checkExpired()` returns `false`
+immediately for those — so it is inert rather than wrong. What must never happen
+is an *enabled* handle that nothing armed: the waits would then observe explicit
+aborts but no deadline would ever fire.
+
+| Collective | Kernel(s) | Arm site | Status |
+| --- | --- | --- | --- |
+| AllReduce Direct | `AllReduceIbDirect.cu` | `args.timeout.start()` at entry, forwarded to the 4-arg `runAllReduceFused` | onboarded |
+| AllReduce Ring | `AllReduceIbRingImpl.cuh` | `runRing` arms at entry; passed to `runAllReduceFused` and `phase2IbRing` | onboarded |
+| AllReduce Tree | `AllReduceIbTreeImpl.cuh` | kernel entry; passed to `runAllReduceFused` and `TreePhase2` | onboarded |
+| SendRecv | `SendRecvLauncher.cu` | `abort.start()` at entry, threaded into every send/recv | onboarded |
+| ReduceScatter Ring | `RingReduceScatterKernel.cuh` | kernel entry | onboarded |
+| ReduceScatter Direct / DirectIbV2 | `prims/collectives/ReduceScatterDirect*.cu` | kernel entry | onboarded |
+| ReduceScatter DirectIb (`ctdirect_ib`) | `ctran/algos/ReduceScatterDirectIb.cc` | **none — `params.abort` is left default-constructed** | **not onboarded** |
+| AllGather Direct | `prims/collectives/AllGatherDirect.cu` | kernel entry, once in each of the three kernels | onboarded |
+| AllGather Ring | `prims/collectives/RingAllgather.cu` | kernel entry | onboarded |
+| AllToAllv (+ Ll128) | `prims/collectives/AllToAllv*.cu` | kernel entry | onboarded |
+
+Two things this audit turned up that are worth keeping written down:
+
+- `runAllReduceFused` has a **three-argument overload that arms a handle of its
+  own**. It exists for callers that have no handle to pass. A caller that has
+  already armed one must use the four-argument overload — using the short one
+  is the easiest way to end up with two budgets in a kernel, and it is how Tree
+  did before this was fixed.
+- `prims::collectives::all_gather` takes its `Timeout` **by value and arms it**.
+  That is correct for its current callers, which are all kernel entries handing
+  in an unarmed handle, but it means a collective that ever passes its own armed
+  handle would silently get it re-armed. Prefer taking it by reference if that
+  call site appears.
+
 ### What the caller sees
 
 - The collective completes; **output buffers are undefined** after an abort.
@@ -413,10 +556,22 @@ host can tell those apart.
 
 Fault tolerance is a **MCCL-communicator** feature. Communicators created
 through the NCCLX/CTRAN factory get a disabled `Abort`, so they have no device
-deadline and no abort observation; the `ctdirect_ib` ReduceScatter path is
-unbounded on those comms. This is an accepted limitation, not an oversight, and
-it is a regression against the pre-migration code, which applied
-`MCCL_ABORT_TIMEOUT_MS` unconditionally on that path. The debug diagnostic above
+deadline and no abort observation.
+
+`ctdirect_ib` ReduceScatter is unbounded on **more than those comms**, and the
+earlier wording here understated it. `McclComm::reduceScatter()` intercepts only
+`ctring_ib`, so an ordinary **FT-enabled** MCCL communicator that selects
+`ctdirect_ib` — via `NCCL_REDUCESCATTER_ALGO` or `ncclReduceScatterQuantize` —
+falls through to `ctranReduceScatter()` and reaches
+`ReduceScatterDirectIb.cc`, which deliberately leaves `params.abort`
+default-constructed. The kernel therefore arms a disabled handle and has neither
+the communicator's abort state nor its deadline, so peer loss is unbounded on a
+communicator whose owner asked for fault tolerance. Thanks to @benrcarver for
+catching that the status table and this section contradicted each other.
+
+Until that route is either plumbed or rejected under FT, the table above marks
+it **not onboarded**. This is a regression against the pre-migration code, which
+applied `MCCL_ABORT_TIMEOUT_MS` unconditionally on that path. The debug diagnostic above
 is scoped to FT-enabled communicators so it stays silent here and under
 `MCCL_ABORT_MODE=none`.
 

--- a/comms/prims/collectives/ReduceScatterDirectIbV2.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIbV2.cu
@@ -300,7 +300,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
             // slow peer never stops us polling the others.
             int ready = 0;
             bool finished = false;
-            while (ready < count && !finished) {
+            bool aborted = false;
+            while (ready < count && !finished && !aborted) {
               ready = 0;
               for (int i = 0; i < count; ++i) {
                 if (rviews[s][i].staging != nullptr) {
@@ -311,6 +312,17 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
                 auto transport = args.peers[rpeer_of[i]];
                 const auto st = transport.progress_recv_acquire_once(
                     solo, wire_bytes, max_sig, timeout, view);
+                // `Aborted` is terminal and must be handled explicitly. It used
+                // to fall through this chain: the acquire had already driven
+                // the slot to `Done` via abandon_progress_state(), so the NEXT
+                // acquire returned `Done`, the loop set `finished` and the
+                // collective reported ordinary completion over a partially
+                // reduced accumulator. Stopping here keeps "aborted" and
+                // "stream complete" distinguishable.
+                if (st == IbgdaSendRecvProgressStatus::Aborted) {
+                  aborted = true;
+                  break;
+                }
                 if (st == IbgdaSendRecvProgressStatus::Done) {
                   finished = true;
                   break;
@@ -321,7 +333,7 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
                 }
               }
             }
-            if (finished) {
+            if (finished || aborted) {
               s_nchunks = c;
               __threadfence_block();
               s_published = c;
@@ -339,7 +351,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
               const int ps = (c - 1) % kSlots;
               for (int i = 0; i < count; ++i) {
                 auto transport = args.peers[rpeer_of[i]];
-                transport.progress_recv_release_once(solo, rviews[ps][i]);
+                transport.progress_recv_release_once(
+                    solo, timeout, rviews[ps][i]);
                 rviews[ps][i] = detail::RecvChunkAcquisition{};
               }
               released = c - 1;
@@ -354,7 +367,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
             const int ds = d % kSlots;
             for (int i = 0; i < count; ++i) {
               auto transport = args.peers[rpeer_of[i]];
-              transport.progress_recv_release_once(solo, rviews[ds][i]);
+              transport.progress_recv_release_once(
+                  solo, timeout, rviews[ds][i]);
               rviews[ds][i] = detail::RecvChunkAcquisition{};
             }
             released = d;

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -9,12 +9,14 @@
 
 #include <memory>
 #include <string>
+#include <thread>
 #include <tuple>
 #include <vector>
 
 #ifdef __HIP_PLATFORM_AMD__
 #include "comms/prims/transport/amd/HipHostCompat.h"
 #endif
+#include "comms/common/fault_tolerance/Abort.h"
 #include "comms/prims/tests/MultipeerIbgdaTransportTest.h"
 #include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 #include "comms/prims/transport/ibgda/MultipeerIbgdaTransport.h"
@@ -1841,6 +1843,107 @@ TEST_F(
         << "at byte " << firstMismatch << ", expected "
         << static_cast<int>(expected[firstMismatch]) << ", got "
         << static_cast<int>(received[firstMismatch]);
+  }
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+#endif
+
+#ifndef __HIP_PLATFORM_AMD__
+TEST_F(
+    MultipeerIbgdaTransportTestFixture,
+    WarpProxyServiceLoopUnwindsOnMidFlightAbort) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+
+  // The existing warp-proxy tests all pass `testAbortDevice()`, a 60 s TRAP
+  // handle whose only possible exit is the watchdog taking the CUDA context
+  // down. That means none of them can tell a service loop that honours an
+  // abort from one that ignores it. This test supplies a real `SKIP`-mode
+  // abort with *no* deadline, so honouring it is the only way the kernel can
+  // ever finish.
+  constexpr std::size_t numChunks = 1024;
+  constexpr std::size_t maxSignalBytes = 1024;
+  constexpr int pipelineDepth = 16;
+  constexpr std::size_t perChannelSize =
+      static_cast<std::size_t>(pipelineDepth) * maxSignalBytes;
+  constexpr std::size_t nbytes = numChunks * maxSignalBytes;
+  // Depth 1 so the workers park on credit waits rather than running ahead into
+  // a deep command queue -- parked workers are what "mid-flight" has to mean
+  // for this to exercise anything.
+  constexpr uint32_t queueDepth = 1;
+  const bool isSender = globalRank == 0;
+  const int peerRank = isSender ? 1 : 0;
+
+  std::unique_ptr<MultipeerIbgdaTransport> transport;
+  try {
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .perChannelSize = perChannelSize,
+        .max_num_channels = 1,
+        .pipelineDepth = pipelineDepth,
+    };
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, numRanks, bootstrap, config);
+    transport->exchange();
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+
+  auto* peerTransport = transport->getP2pTransportDevice(peerRank);
+  DeviceBuffer dataBuffer(nbytes);
+  CUDACHECK_TEST(cudaMemset(dataBuffer.get(), 0, nbytes));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  if (isSender) {
+    // A bare `Abort` leaves `deadlineCycles_` at 0 -- "no deadline" -- so
+    // nothing but the explicit `setAbort()` below can end the kernel.
+    comms::fault_tolerance::Abort abort(
+        /*enabled=*/true, comms::fault_tolerance::AbortBehavior::SKIP);
+    test::launchWarpProxyStalledSend(
+        peerTransport,
+        dataBuffer.get(),
+        nbytes,
+        maxSignalBytes,
+        queueDepth,
+        abort.getDeviceHandle());
+
+    // The peer deliberately never runs its own proxy, so its slot-free credits
+    // never arrive and the sender parks in `wait_recv_ready` with
+    // `posted < tail`. Sleep first so the abort lands on a parked proxy rather
+    // than during setup.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    ASSERT_NE(cudaStreamQuery(nullptr), cudaSuccess)
+        << "warp proxy finished on its own; the peer must not be draining it, "
+        << "so this test would not be exercising a mid-flight abort";
+
+    const auto abortedAt = std::chrono::steady_clock::now();
+    EXPECT_TRUE(abort.setAbort(comms::fault_tolerance::AbortReason::ABORTED))
+        << "host lost the abort CAS -- something else aborted first";
+
+    // Poll rather than `cudaDeviceSynchronize()`: with no watchdog behind it, a
+    // service loop that ignores the abort would hang here forever and the test
+    // would report nothing at all. Polling turns that regression into a named
+    // failure before the harness kills the process.
+    constexpr auto kUnwindBudget = std::chrono::seconds(30);
+    cudaError_t status = cudaErrorNotReady;
+    while (status == cudaErrorNotReady &&
+           std::chrono::steady_clock::now() - abortedAt < kUnwindBudget) {
+      status = cudaStreamQuery(nullptr);
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    const auto unwindMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                              std::chrono::steady_clock::now() - abortedAt)
+                              .count();
+    ASSERT_EQ(status, cudaSuccess)
+        << "warp proxy service loop did not unwind " << unwindMs
+        << " ms after a mid-flight abort";
+
+    const auto info = abort.getAbortInfo();
+    ASSERT_TRUE(info.has_value());
+    EXPECT_EQ(info->reason, comms::fault_tolerance::AbortReason::ABORTED);
   }
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 }

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -126,6 +126,13 @@ class TestIbTransport {
     return ibrc_->getP2pTransportDeviceSlot(peerRank) != nullptr;
   }
 
+  // Raw IBGDA device pointer. Needed only where a test must reach
+  // IBGDA-specific state that the unified wrapper does not expose -- the
+  // channel layout, for the rkey-poisoning drain test. Null on IBRC.
+  P2pIbgdaTransportDevice* getIbgdaTransportDevice(int peerRank) {
+    return ibgda_ ? ibgda_->getP2pTransportDevice(peerRank) : nullptr;
+  }
+
   P2pIbTransportDevice getP2pTransportDevice(int peerRank) {
     if (ibgda_) {
       return P2pIbTransportDevice(ibgda_->getP2pTransportDevice(peerRank));
@@ -451,6 +458,281 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalBasic) {
 // =============================================================================
 // Group-Level Put/Signal Basic Test - Verifies explicit cooperative RDMA
 // =============================================================================
+
+/*
+ * The completion-error path, reached deterministically.
+ *
+ * Rank 0 posts an RDMA write with the peer's rkey corrupted. The NIC answers
+ * `REM_ACCESS_ERR`, and `flush()` picks it up inside `wait_local_on_qp`'s CQ
+ * poll -- the branch that used to fall straight out of the
+ * `while (status == EBUSY)` loop and report success from a `void` function.
+ *
+ * **Why a bad rkey and not a dead peer.** The AllReduce-level
+ * `DeadPeerCompletionErrorUnwinds` cannot reach this branch, and the
+ * measurement is in `D114905570`: with a 30 s deadline every survivor ran the
+ * deadline out (29937-30000 ms) and no completion error was ever polled. A dead
+ * peer's op does not complete with an error, it just does not complete, until
+ * IB retry exhaustion roughly a minute later. A remote access error is terminal
+ * and immediate, so it is the only way to make the CQE the *cause*.
+ *
+ * **What discriminates the two paths, with no timing assumption.** The reason.
+ * The deadline records `TIMED_OUT`; this branch records `ABORTED`. The op
+ * deadline is 30 s, far longer than the test can take, so `ABORTED` is only
+ * reachable through the CQE.
+ *
+ * Built on `createTransport()` rather than a raw `MultipeerIbgdaTransport`:
+ * the wrapper materialises and connects peers, and an earlier revision of this
+ * test that constructed the transport directly hung in setup before the kernel
+ * ever ran.
+ */
+TEST_P(MultipeerIbTransportTestFixture, BadRkeyCompletionErrorUnwinds) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "requires exactly 2 ranks, got " << numRanks;
+  }
+  if (backend() != IbTestBackend::Ibgda) {
+    GTEST_SKIP() << "completion-error handling under test is IBGDA-specific";
+  }
+
+  const std::size_t nbytes = 64 * 1024;
+  const int numBlocks = 1;
+  const int blockSize = 32;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  constexpr std::chrono::milliseconds kDeadline{30000};
+  constexpr std::chrono::milliseconds kMaxElapsed{5000};
+
+  // Local outcome, reduced across ranks after the try so the skip decision is
+  // uniform. See the MPI_Allreduce below.
+  int localSetupOk = 0;
+  std::string skipReason;
+  try {
+    auto transport = createTransport();
+    DeviceBuffer dataBuffer(nbytes);
+    auto localDataBuf = transport->registerBuffer(dataBuffer.get(), nbytes);
+    auto remoteDataBufs = transport->exchangeBuffer(localDataBuf);
+    const int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
+    auto peerTransport = transport->getP2pTransportDevice(peerRank);
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    if (globalRank == 0) {
+      // Flip the high bits rather than zeroing: zero is a plausible "unset"
+      // value that a future host-side guard might reject before the WQE is
+      // posted, which would silently stop this test exercising the NIC.
+      auto badRemoteBuf = remoteDataBufs[peerIndex];
+      // Every populated device key, not just [0]. QP lanes index this array by
+      // their own `nic_id`, so on a 2-NIC part (GB200/GB300) poisoning only
+      // slot 0 leaves NIC 1 perfectly valid and any put that lands on such a
+      // lane completes normally -- the test would pass while exercising
+      // nothing. `size` is the populated count; indexing past it traps.
+      ASSERT_GT(badRemoteBuf.rkey_per_device.size, 0);
+      for (int nic = 0; nic < badRemoteBuf.rkey_per_device.size; ++nic) {
+        badRemoteBuf.rkey_per_device[nic].value ^= 0xDEAD0000U;
+      }
+
+      comms::fault_tolerance::Abort abort(/*enabled=*/true);
+      // The budget belongs on the *device* handle. `startTimeout()` arms a
+      // host-side deadline only; the device resolves its own from
+      // `opTimeoutMs_`, and a bare `Abort` has none, leaving `deadlineCycles_`
+      // at 0 -- "no deadline". An earlier revision hung for exactly that.
+      auto deviceAbort = abort.getDeviceHandle();
+      deviceAbort.setOpTimeoutMs(kDeadline.count());
+
+      const auto start = std::chrono::steady_clock::now();
+      test::testPutAndFlushWithAbort(
+          peerTransport,
+          localDataBuf,
+          badRemoteBuf,
+          nbytes,
+          deviceAbort,
+          numBlocks,
+          blockSize);
+      // Deliberately not CUDACHECK_TEST: a trap surfaces here, and reporting it
+      // is the point rather than aborting the process on it.
+      const cudaError_t syncStatus = cudaDeviceSynchronize();
+      const auto elapsed =
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::steady_clock::now() - start);
+
+      EXPECT_EQ(cudaSuccess, syncStatus)
+          << "the completion error must unwind, not trap: "
+          << cudaGetErrorString(syncStatus);
+      EXPECT_LT(elapsed.count(), kMaxElapsed.count())
+          << "an error CQE is reported immediately; this long suggests the wait "
+             "ended on something other than the completion error";
+      EXPECT_EQ(
+          comms::fault_tolerance::AbortReason::NETWORK_ERROR, abort.reason())
+          << "expected the completion error to latch NETWORK_ERROR; TIMED_OUT "
+             "would mean the deadline won and the CQE branch was never reached";
+    }
+
+    localSetupOk = 1;
+  } catch (const std::exception& e) {
+    skipReason = e.what();
+  }
+  // Agreed across ranks BEFORE anyone skips. Only rank 0 runs the injection and
+  // the CUDA sync, so a rank-local launch failure used to send it through
+  // GTEST_SKIP() without ever entering the barrier below, leaving its peer
+  // blocked until the harness timeout. Reaching the barrier unconditionally and
+  // reducing the verdict makes both ranks skip or continue together.
+  int allSetupOk = 0;
+  MPI_CHECK(MPI_Allreduce(
+      &localSetupOk, &allSetupOk, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD));
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  if (allSetupOk == 0) {
+    GTEST_SKIP() << "IB transport not available on some rank: " << skipReason;
+  }
+}
+
+/*
+ * A registered send whose completions never land, drained by the production
+ * loop shape -- the case the synthetic progress-slot test in D116982768 cannot
+ * reach.
+ *
+ * `abandon_progress_state()` terminalises `IbChannelProgress`; the registered
+ * completion drain reads the per-lane completion masks instead and has no
+ * equivalent short-circuit. Its abort path persists the lanes it did NOT drain,
+ * so before the fix every later call re-reported `Aborted` forever, and
+ * `ReduceScatterDirectIbV2.cu`'s `while (... != Drained)` spun for the life of
+ * the kernel.
+ *
+ * A bad rkey is what makes the completions genuinely never land: the NIC
+ * answers `REM_ACCESS_ERR`, `is_local_completion_ready()` stays false and
+ * latches `ABORTED`. A pre-abort would be vacuous (nothing ever posts) and
+ * racing a healthy CQE would be flaky, so this is the only deterministic
+ * construction.
+ *
+ * The drain loop is capped so a regression fails loudly here instead of hanging
+ * until the harness timeout; `drainIterations` is the real assertion.
+ */
+TEST_P(MultipeerIbTransportTestFixture, RegisteredSendDrainTerminatesOnAbort) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "requires exactly 2 ranks, got " << numRanks;
+  }
+  if (backend() != IbTestBackend::Ibgda) {
+    GTEST_SKIP() << "registered-source send is IBGDA-specific";
+  }
+
+  constexpr std::size_t nbytes = 64 * 1024;
+  constexpr int pipelineDepth = 2;
+  constexpr int numBlocks = 1;
+  constexpr int blockSize = 128;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  // Long enough that it cannot be what ends the drain -- the CQE must be.
+  constexpr std::chrono::milliseconds kDeadline{30000};
+  constexpr std::chrono::milliseconds kMaxElapsed{15000};
+  // Generous: the fix needs 2 (Aborted, then Drained). Anything near the cap
+  // means the drain is not terminal.
+  constexpr uint64_t kDrainIterationCap = 10000;
+
+  // Local outcome, reduced across ranks after the try so the skip decision is
+  // uniform. See the MPI_Allreduce below.
+  int localSetupOk = 0;
+  std::string skipReason;
+  try {
+    // Explicit channel config rather than the fixture's createTransport():
+    // the registered path reads the channel layout, and a transport built
+    // without channels traps with "numChannels must be > 0".
+    MultipeerIbTransportConfig config{
+        .cudaDevice = localRank,
+        .perChannelSize = nbytes / numBlocks,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
+    };
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    TestIbTransport transport(
+        backend(), globalRank, numRanks, std::move(bootstrap), config);
+
+    DeviceBuffer dataBuffer(nbytes);
+    auto localDataBuf = transport.registerBuffer(dataBuffer.get(), nbytes);
+    auto remoteDataBufs = transport.exchangeBuffer(localDataBuf);
+
+    // Both ranks, before the barrier: materializing a peer is COLLECTIVE
+    // (connectPeers -> doMaterializePeer -> exchangeRawWithPeer), so calling it
+    // on rank 0 alone blocks that rank in MPI_Recv waiting for a partner that
+    // never arrives.
+    auto* peerTransport = transport.getIbgdaTransportDevice(peerRank);
+    ASSERT_NE(peerTransport, nullptr);
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    if (globalRank == 0) {
+      const int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
+      // Same poisoning as BadRkeyCompletionErrorUnwinds: flip the high bits of
+      // an exchanged peer buffer's rkey. Those keys are known-valid, unlike the
+      // channel layout's staging keys.
+      auto poisonedRemote = remoteDataBufs[peerIndex];
+      ASSERT_GT(poisonedRemote.rkey_per_device.size, 0);
+      for (int nic = 0; nic < poisonedRemote.rkey_per_device.size; ++nic) {
+        poisonedRemote.rkey_per_device[nic].value ^= 0xDEAD0000U;
+      }
+
+      DeviceBuffer observationBuf(sizeof(test::RegisteredSendObservation));
+      CUDACHECK_TEST(cudaMemset(
+          observationBuf.get(), 0, sizeof(test::RegisteredSendObservation)));
+
+      comms::fault_tolerance::Abort abort(/*enabled=*/true);
+      auto deviceAbort = abort.getDeviceHandle();
+      deviceAbort.setOpTimeoutMs(kDeadline.count());
+
+      const auto start = std::chrono::steady_clock::now();
+      test::testRegisteredSendDrainWithAbort(
+          peerTransport,
+          localDataBuf,
+          poisonedRemote,
+          nbytes,
+          /*maxSignalBytes=*/0,
+          static_cast<test::RegisteredSendObservation*>(observationBuf.get()),
+          kDrainIterationCap,
+          deviceAbort,
+          numBlocks,
+          blockSize);
+      const cudaError_t syncStatus = cudaDeviceSynchronize();
+      const auto elapsed =
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::steady_clock::now() - start);
+
+      test::RegisteredSendObservation observation{};
+      CUDACHECK_TEST(cudaMemcpy(
+          &observation,
+          observationBuf.get(),
+          sizeof(observation),
+          cudaMemcpyDeviceToHost));
+
+      EXPECT_EQ(cudaSuccess, syncStatus)
+          << "the aborted drain must unwind, not trap: "
+          << cudaGetErrorString(syncStatus);
+      EXPECT_LT(elapsed.count(), kMaxElapsed.count())
+          << "drain took " << elapsed.count()
+          << " ms; an error CQE is immediate, so this suggests it spun";
+      EXPECT_GE(observation.abortedCount, 1u)
+          << "no Aborted was ever observed, so the completion error never "
+             "reached the drain and this test proved nothing";
+      EXPECT_LT(observation.drainIterations, kDrainIterationCap)
+          << "the drain never returned Drained -- it is not terminal on abort";
+      EXPECT_EQ(
+          comms::fault_tolerance::AbortReason::NETWORK_ERROR, abort.reason())
+          << "expected the completion error to latch NETWORK_ERROR; TIMED_OUT "
+             "would mean the 30 s deadline won and the CQE branch was never "
+             "reached";
+    }
+
+    localSetupOk = 1;
+  } catch (const std::exception& e) {
+    skipReason = e.what();
+  }
+  // Agreed across ranks BEFORE anyone skips. Only rank 0 runs the injection and
+  // the CUDA sync, so a rank-local launch failure used to send it through
+  // GTEST_SKIP() without ever entering the barrier below, leaving its peer
+  // blocked until the harness timeout. Reaching the barrier unconditionally and
+  // reducing the verdict makes both ranks skip or continue together.
+  int allSetupOk = 0;
+  MPI_CHECK(MPI_Allreduce(
+      &localSetupOk, &allSetupOk, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD));
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  if (allSetupOk == 0) {
+    GTEST_SKIP() << "IB transport not available on some rank: " << skipReason;
+  }
+}
 
 TEST_P(MultipeerIbTransportTestFixture, PutSignalGroupBasic) {
   if (numRanks != 2) {

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -1367,4 +1367,157 @@ void testMultiQpPutAndSignal(
   }
 }
 
+// =============================================================================
+// Kernel: put + flush against a caller-supplied abort handle
+//
+// No signal is posted -- the point is to reach the completion drain, and a
+// signal would only add a second WQE that fails the same way.
+// =============================================================================
+
+__global__ void putAndFlushWithAbortKernel(
+    P2pIbTransportDevice transport,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    std::size_t nbytes,
+    comms::fault_tolerance::AbortDevice abort) {
+  auto group = make_block_group();
+  if (group.is_global_leader()) {
+    abort.start();
+    transport.put(
+        localBuf, remoteBuf, nbytes, /*signalId=*/-1, /*signalVal=*/0);
+    transport.flush(abort);
+  }
+}
+
+// =============================================================================
+// Kernel: registered send with a poisoned rkey, then the production drain loop
+//
+// The rkey lives in the transport's own channel layout rather than in a
+// caller-supplied buffer, because progress_registered_send_once() derives its
+// RDMA destination from `acquire_channel()` -- so unlike putAndFlushWithAbort,
+// the corruption has to happen on the device object itself. Flipping the high
+// bits (rather than zeroing) keeps the value implausible as an "unset" default
+// that some future host-side guard might reject before the WQE is posted.
+// =============================================================================
+
+__global__ void registeredSendDrainAbortKernel(
+    P2pIbTransportDevice transport,
+    IbgdaLocalBuffer source,
+    IbgdaRemoteBuffer poisonedRemote,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    RegisteredSendObservation* observation,
+    uint64_t drainIterationCap,
+    comms::fault_tolerance::AbortDevice abort) {
+  auto group = make_block_group();
+  abort.start();
+
+  // Drive the QPs into error state first, using the same caller-supplied
+  // bad-rkey buffer BadRkeyCompletionErrorUnwinds uses. Deliberately no
+  // flush(): the error CQEs must still be unreaped when the drain runs, which
+  // is what gives the drain a genuine never-completing lane to abort on.
+  //
+  // One put per QP lane because `put()` round-robins over them and each lane is
+  // its own QP -- leaving any lane unpoisoned would let the registered send
+  // pick a healthy one and complete. Derived from the transport rather than
+  // assumed: the lane count is a runtime property of the channel, so a
+  // hardcoded guess silently under-poisons on any part that has more.
+  const uint32_t poisonPuts = transport.ibgda->send_completion_lane_count();
+  if (group.is_global_leader()) {
+    for (uint32_t i = 0; i < poisonPuts; ++i) {
+      transport.put(
+          source, poisonedRemote, nbytes, /*signalId=*/-1, /*signalVal=*/0);
+    }
+  }
+  group.sync();
+
+  transport.init_registered_send_progress(group, nbytes, maxSignalBytes);
+
+  IbgdaRegisteredSendProgressStatus status;
+  do {
+    status = transport.progress_registered_send_once(
+        group, source, nbytes, maxSignalBytes, abort);
+    if (group.is_leader() && observation != nullptr) {
+      observation->record(status);
+    }
+  } while (status != IbgdaRegisteredSendProgressStatus::Posted &&
+           status != IbgdaRegisteredSendProgressStatus::Drained &&
+           status != IbgdaRegisteredSendProgressStatus::Aborted);
+
+  // Deliberately the exact shape of ReduceScatterDirectIbV2.cu's drain: exits
+  // on `Drained` only. Before the terminality fix this never leaves, because
+  // the aborted drain re-reports `Aborted` on every call.
+  uint64_t iterations = 0;
+  while (status != IbgdaRegisteredSendProgressStatus::Drained &&
+         iterations < drainIterationCap) {
+    status = transport.progress_registered_send_drain_once(group, abort);
+    if (group.is_leader() && observation != nullptr) {
+      observation->record(status);
+    }
+    ++iterations;
+  }
+  if (group.is_leader() && observation != nullptr) {
+    observation->drainIterations = iterations;
+  }
+}
+
+void testRegisteredSendDrainWithAbort(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& source,
+    const IbgdaRemoteBuffer& poisonedRemote,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    RegisteredSendObservation* observation,
+    uint64_t drainIterationCap,
+    comms::fault_tolerance::AbortDevice abort,
+    int numBlocks,
+    int blockSize) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)source;
+  (void)poisonedRemote;
+  (void)nbytes;
+  (void)maxSignalBytes;
+  (void)observation;
+  (void)drainIterationCap;
+  (void)abort;
+  (void)numBlocks;
+  (void)blockSize;
+  throw std::runtime_error("registered-source send is NVIDIA-only");
+#else
+  P2pIbTransportDevice unifiedTransport(transport);
+  registeredSendDrainAbortKernel<<<numBlocks, blockSize>>>(
+      unifiedTransport,
+      source,
+      poisonedRemote,
+      nbytes,
+      maxSignalBytes,
+      observation,
+      drainIterationCap,
+      abort);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+#endif
+}
+
+void testPutAndFlushWithAbort(
+    P2pIbTransportDevice transport,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t nbytes,
+    comms::fault_tolerance::AbortDevice abort,
+    int numBlocks,
+    int blockSize) {
+  putAndFlushWithAbortKernel<<<numBlocks, blockSize>>>(
+      transport, localBuf, remoteBuf, nbytes, abort);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
 } // namespace comms::prims::test

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -739,6 +739,40 @@ void testWarpProxySendRecv(
 #endif
 }
 
+void launchWarpProxyStalledSend(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    uint32_t queueDepth,
+    comms::fault_tolerance::AbortDevice abort) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)buffer;
+  (void)nbytes;
+  (void)maxSignalBytes;
+  (void)queueDepth;
+  (void)abort;
+  throw std::runtime_error("warp proxy is NVIDIA-only");
+#else
+  warpProxySendRecvKernel<<<1, WarpProxyTest::kBlockThreads>>>(
+      transport,
+      buffer,
+      nbytes,
+      maxSignalBytes,
+      /*send=*/true,
+      queueDepth,
+      /*queueFullCount=*/nullptr,
+      abort);
+  const cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+  // Deliberately no synchronize: the caller aborts while this is parked.
+#endif
+}
+
 void testProgressSendRecv(
     P2pIbgdaTransportDevice* transport,
     void* buffer,

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -128,6 +128,10 @@ struct RegisteredSendObservation {
   uint64_t progressedCount{0};
   uint64_t postedCount{0};
   uint64_t drainedCount{0};
+  uint64_t abortedCount{0};
+  /// Iterations the drain loop actually took. Only written by the
+  /// drain-abort test; zero elsewhere.
+  uint64_t drainIterations{0};
 
   template <typename Status>
   IBGDA_HOST_DEVICE void record(Status status) {
@@ -143,6 +147,9 @@ struct RegisteredSendObservation {
         break;
       case Status::Drained:
         ++drainedCount;
+        break;
+      case Status::Aborted:
+        ++abortedCount;
         break;
     }
   }
@@ -435,6 +442,56 @@ void testMultiQpPutAndSignal(
     std::size_t totalBytes,
     int signalId,
     uint64_t signalVal,
+    int numBlocks,
+    int blockSize);
+
+/**
+ * Test kernel: put + flush against a caller-supplied abort handle.
+ *
+ * The fault injector for the completion-error path: give it a `remoteBuf` whose
+ * rkey the peer rejects and the NIC produces an error CQE, which `flush()`
+ * observes inside `wait_local_on_qp`. Unlike a dead peer -- where the op simply
+ * never completes until IB retry exhaustion, roughly a minute out -- a remote
+ * access error is terminal and reported immediately.
+ *
+ * `abort` is by value: `AbortDevice` is a handle over shared state, so the copy
+ * the kernel mutates and the host's `Abort` observe the same latch.
+ */
+/**
+ * Test kernel: a real registered send whose completions never land, followed by
+ * the production-shaped drain loop.
+ *
+ * `poisonedRemote` is an exchanged peer buffer with its rkey corrupted. The
+ * kernel puts to it several times -- deliberately without flushing -- to drive
+ * the channel's QP lanes into error state, so the registered send that follows
+ * has completions the NIC will never report successfully. The drain then loops
+ * `while (status != Drained)` exactly as `ReduceScatterDirectIbV2.cu` does.
+ *
+ * The channel layout's own staging rkeys are NOT usable for this: they are not
+ * populated at the point the kernel runs, and indexing them traps.
+ *
+ * `drainIterationCap` bounds that loop so a regression reports a failure
+ * instead of hanging until the harness timeout; `observation->drainIterations`
+ * records what it actually took, which is the assertion that matters.
+ */
+void testRegisteredSendDrainWithAbort(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& source,
+    const IbgdaRemoteBuffer& poisonedRemote,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    RegisteredSendObservation* observation,
+    uint64_t drainIterationCap,
+    comms::fault_tolerance::AbortDevice abort,
+    int numBlocks,
+    int blockSize);
+
+void testPutAndFlushWithAbort(
+    P2pIbTransportDevice transport,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t nbytes,
+    comms::fault_tolerance::AbortDevice abort,
     int numBlocks,
     int blockSize);
 

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "comms/common/fault_tolerance/AbortDevice.cuh"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 
 namespace comms::prims {
@@ -214,6 +215,24 @@ void testWarpProxySendRecv(
     bool send,
     uint32_t queueDepth,
     uint64_t* queueFullCount);
+
+/**
+ * Test kernel: warp-proxy send against a peer that never runs its own proxy.
+ *
+ * Launches asynchronously and does NOT synchronize -- the caller is expected to
+ * abort the supplied handle while the kernel is parked, then synchronize. The
+ * abort is caller-owned rather than `testAbortDevice()` on purpose: that helper
+ * is a `TRAP`-mode watchdog, so it can only end a stuck proxy by taking the
+ * CUDA context down, which cannot distinguish "the service loop honoured the
+ * abort" from "the watchdog fired".
+ */
+void launchWarpProxyStalledSend(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    std::size_t maxSignalBytes,
+    uint32_t queueDepth,
+    comms::fault_tolerance::AbortDevice abort);
 
 /**
  * Test kernel: Resumable pipelined send or recv progress loop.

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -777,11 +777,12 @@ template <typename>
 __device__ __forceinline__ void
 P2pIbTransportDevice::progress_recv_release_once(
     ThreadGroup& group,
+    const AbortDevice& timeout,
     const detail::RecvChunkAcquisition& view) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->progress_recv_release_once(group, view);
+    ibrc->progress_recv_release_once(group, timeout, view);
   } else {
-    ibgda->progress_recv_release_once(group, view);
+    ibgda->progress_recv_release_once(group, timeout, view);
   }
 }
 

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -101,6 +101,7 @@ template <typename Transport, typename Proto>
 __device__ __forceinline__ void progress_recv_release_once(
     Transport& transport,
     ThreadGroup& group,
+    const AbortDevice& timeout,
     const RecvChunkAcquisition& view);
 
 template <typename Transport>
@@ -428,6 +429,7 @@ struct P2pIbTransportDevice {
   template <typename = void>
   __device__ __forceinline__ void progress_recv_release_once(
       ThreadGroup& group,
+      const AbortDevice& timeout,
       const detail::RecvChunkAcquisition& view);
 
   template <

--- a/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
@@ -216,7 +216,7 @@ __device__ __forceinline__ void assert_progress_slot_idle(
     const char* opName);
 
 template <typename P, typename Transport>
-__device__ __forceinline__ void prepare_send_slot(
+[[nodiscard]] __device__ __forceinline__ bool prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
     uint32_t slotId,
@@ -711,8 +711,22 @@ __device__ __forceinline__ SendSignal prepareForwardBuf(
         static_cast<uint8_t>(kPipesTraceQpLaneMask),
         fwdSignalVal);
   }
-  prepare_send_slot<protocol::Simple>(
-      fwdTransport, group, fwdSlot, fwdPipelineCycle, timeout);
+  if (prepare_send_slot<protocol::Simple>(
+          fwdTransport, group, fwdSlot, fwdPipelineCycle, timeout)) {
+    // Slot not retired: a lane's completion was never observed, so the NIC may
+    // still be reading this staging. Staging over it is the memory hazard the
+    // retirement guard exists to prevent, so stop before CopyOp::forward.
+    //
+    // An empty signal is the "nothing to piggyback" value -- the same one the
+    // host-compile arm below returns. On this Simple overload the success path
+    // always returns a real `fwdRemoteChannel.dataReady`, so an empty `buf` is
+    // an unambiguous "this chunk was abandoned" marker for the caller; on LL it
+    // is the normal case, which is why the caller tests it only for Simple.
+    //
+    // `prepare_send_slot()` broadcasts its verdict, so this return is
+    // group-uniform and barrier-safe.
+    return SendSignal{};
+  }
   if (group.is_leader()) {
     trace_allreduce_event(
         sendTraceContext,
@@ -1120,8 +1134,14 @@ __device__ __forceinline__ void send_impl(
           (dataOff + chunkSize <= nbytes) ? chunkSize : (nbytes - dataOff);
 
       // (1) Wait for NIC to finish with this slot's local sendStaging.
-      prepare_send_slot<Proto>(
-          transport, group, ringSlot, pipelineCycle, timeout);
+      if (prepare_send_slot<Proto>(
+              transport, group, ringSlot, pipelineCycle, timeout)) {
+        // Unretired slot -- see prepare_send_slot. Breaking rather than
+        // continuing keeps this loop from staging over a buffer the NIC may
+        // still be reading, and from publishing chunks for an operation that
+        // has already given up.
+        break;
+      }
 
       // (2) Cooperative compress: src -> local sendStaging via CopyOp. The
       //     return value is the compressed byte count the leader uses to size
@@ -1239,12 +1259,17 @@ __device__ __forceinline__ void send_impl(
             static_cast<uint8_t>(kPipesTraceQpLaneMask),
             bytesThis);
       }
-      if constexpr (std::is_void_v<IbOps>) {
-        prepare_send_slot<Proto>(
-            transport, group, slot, pipelineCycle, timeout);
-      } else {
-        ibOps->prepare_send_slot(
-            transport, group, slot, pipelineCycle, timeout);
+      const bool slotUnretired = [&] {
+        if constexpr (std::is_void_v<IbOps>) {
+          return prepare_send_slot<Proto>(
+              transport, group, slot, pipelineCycle, timeout);
+        } else {
+          return ibOps->prepare_send_slot(
+              transport, group, slot, pipelineCycle, timeout);
+        }
+      }();
+      if (slotUnretired) {
+        break;
       }
       if (group.is_leader()) {
         trace_allreduce_event(
@@ -2098,11 +2123,23 @@ __device__ __forceinline__ void forward_impl(
           recvTraceContext,
           sendTraceContext,
           args...);
-      // The DATA_READY wait inside prepareForwardBuf may have given up, so this
-      // chunk was never written. Forward is the worst of the three paths to get
-      // wrong on abort: continuing would ACK the predecessor for a chunk we
-      // never consumed *and* hand the successor data that never arrived,
-      // releasing two correctly-blocked peers at once.
+      // The DATA_READY wait inside prepareForwardBuf may have given up, or the
+      // fwd slot may not have retired, so this chunk was never written. Forward
+      // is the worst of the three paths to get wrong on abort: continuing would
+      // ACK the predecessor for a chunk we never consumed *and* hand the
+      // successor data that never arrived, releasing two correctly-blocked
+      // peers at once.
+      //
+      // The empty-signal test is not redundant with `groupAborted()`. That read
+      // is amortized behind `nextPollCycles_`, so it can still answer false on
+      // the iteration where slot preparation gave up; the signal is derived
+      // from the broadcast verdict itself and cannot be stale. Simple only --
+      // LL returns an empty signal on its success path.
+      if constexpr (std::is_same_v<Proto, protocol::Simple>) {
+        if (sig.buf.ptr == nullptr) {
+          break;
+        }
+      }
       if (groupAborted(group, timeout)) {
         break;
       }
@@ -2203,12 +2240,16 @@ __device__ __forceinline__ void forward_impl(
     } else {
       const uint64_t recvToken =
           ibOps->wait_recv(transport, group, recvProtocolBytesThis, timeout);
-      ibOps->prepare_send_slot(
-          fwdTransport,
-          group,
-          static_cast<uint32_t>(fwdSlot),
-          fwdPipelineCycle,
-          timeout);
+      if (ibOps->prepare_send_slot(
+              fwdTransport,
+              group,
+              static_cast<uint32_t>(fwdSlot),
+              fwdPipelineCycle,
+              timeout)) {
+        // Unretired forward slot -- stop before CopyOp::forward stages into a
+        // buffer the NIC may still be reading.
+        break;
+      }
       const std::size_t validBytes =
           valid_payload_bytes(dataOff, payloadBytes, nbytes);
       if (validBytes > 0) {
@@ -2533,36 +2574,67 @@ __device__ __forceinline__ void assert_progress_slot_idle(
 #endif
 }
 
+/*
+ * Returns true when the slot could NOT be retired, so the caller must stop
+ * before staging or putting anything.
+ *
+ * `wait_local_completion()` is `void` and stays that way (FT principle 3): on
+ * abort or an expired deadline it exits its spin through `FT_ABORT_BREAK`,
+ * leaving that lane's completion unobserved. Clearing the whole mask and
+ * advancing the generation regardless -- which is what this used to do -- tells
+ * a later `try_prepare_send_slot()` that those completions landed when they did
+ * not, dropping the one guard that stops the next operation overwriting
+ * send-staging while the NIC is still reading out of it.
+ *
+ * The drain path already states this invariant in
+ * `P2pIbTransportProgressImpl.cuh` ("The masks are deliberately left ALONE
+ * rather than cleared"); the blocking path did not honour it. So each lane is
+ * re-checked after its wait and only *observed* completions are cleared, and
+ * the generation advances only once the mask actually reaches zero.
+ *
+ * The verdict leaves through the `group.sync()` that already terminated this
+ * function, now a broadcast, so making it group-uniform costs no extra barrier.
+ */
 template <typename P, typename Transport>
-__device__ __forceinline__ void prepare_send_slot(
+[[nodiscard]] __device__ __forceinline__ bool prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
     uint32_t slotId,
     uint64_t generation,
     const Timeout& timeout) {
+  uint32_t unretired = 0;
   if (group.is_leader()) {
     auto& slot = transport.template local_channel_slot<P>(group.group_id)
                      .sendCompletionSlots[slotId];
     if (slot.generation != generation) {
-      const uint64_t pending = slot.laneMask;
+      uint64_t pending = slot.laneMask;
       const uint32_t numLanes = transport.send_completion_lane_count();
       for (uint32_t laneId = 0; laneId < numLanes; ++laneId) {
-        if ((pending & (1ULL << laneId)) == 0) {
+        const uint64_t laneBit = 1ULL << laneId;
+        if ((pending & laneBit) == 0) {
           continue;
         }
-        transport.wait_local_completion(
-            group.group_id,
-            IbLocalCompletionTicket{
-                .completionId = laneId,
-                .value = slot.values[laneId],
-            },
-            timeout);
+        const IbLocalCompletionTicket ticket{
+            .completionId = laneId,
+            .value = slot.values[laneId],
+        };
+        transport.wait_local_completion(group.group_id, ticket, timeout);
+        // Confirm rather than assume: the wait above cannot report that it gave
+        // up, and a lane earlier in this loop may already have latched the
+        // abort, so later lanes can fall straight through it.
+        if (transport.is_local_completion_ready(group.group_id, ticket)) {
+          pending &= ~laneBit;
+        }
       }
-      slot.laneMask = 0;
-      slot.generation = generation;
+      slot.laneMask = pending;
+      if (pending == 0) {
+        slot.generation = generation;
+      } else {
+        unretired = 1U;
+      }
     }
   }
-  group.sync();
+  return group.broadcast<uint32_t>(unretired) != 0U;
 }
 
 template <typename P, typename Transport>
@@ -2588,13 +2660,13 @@ __device__ __forceinline__ void record_send_completion(
 }
 
 template <typename Transport>
-__device__ __forceinline__ void prepare_send_slot(
+[[nodiscard]] __device__ __forceinline__ bool prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
     uint32_t slotId,
     uint64_t generation,
     const Timeout& timeout) {
-  prepare_send_slot<protocol::Simple>(
+  return prepare_send_slot<protocol::Simple>(
       transport, group, slotId, generation, timeout);
 }
 

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -72,6 +72,36 @@ __device__ __forceinline__ void abandon_progress_state(
     IbChannelProgress& slot,
     IbChannelProgress& state);
 
+/*
+ * Where the abort is consulted on the ready path, and why it is not a
+ * standalone entry guard.
+ *
+ * Every abort check in this file used to hang off a wait, and each consults the
+ * abort only on its *not-ready* branch. So a call that found everything ready
+ * reached the put, the fused DATA_READY, or the SLOT_FREE credit having never
+ * looked at the abort -- and publishing any of those after an abort is what
+ * principle 4 forbids: a false signal releases a peer that is correctly blocked
+ * and stops it ever reaching its own deadline, so the fault reads to that peer
+ * as success.
+ *
+ * The obvious fix -- one guard at the top of each progress call -- adds a
+ * group-wide broadcast to every *healthy* attempt, and Tree scheduling and
+ * batched send/recv drive these in tight loops. Instead the verdict rides out
+ * through synchronization that already exists:
+ *
+ *   - `try_prepare_send_slot()` and both `progress_recv_ready()` overloads
+ *     already broadcast a readiness verdict; the leader now decides the abort
+ *     inside that same block and returns `kProgressAborted` through it.
+ *   - The pre-put `group.sync()` becomes a broadcast carrying the verdict,
+ *     which covers a call resuming at WaitSlotFree -- that path skips slot
+ *     preparation, and skips the SLOT_FREE wait entirely for a chunk inside the
+ *     pipeline depth.
+ *
+ * Net added barriers on the healthy path: zero, except LL's ready path, which
+ * had no existing broadcast to fold into and now pays the one the not-ready
+ * path already paid.
+ */
+
 template <typename Proto = protocol::Simple>
 __device__ __forceinline__ ProgressGeometry make_progress_geometry(
     const IbChannelLayout& channelLayout,
@@ -565,14 +595,30 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
       }
     }
 
+    // Last gate before the put and its fused DATA_READY.
+    //
+    // A call that *resumes* at WaitSlotFree skipped `try_prepare_send_slot`,
+    // and the SLOT_FREE wait above is itself skipped for any chunk inside the
+    // pipeline depth -- so on that path nothing has consulted the abort yet.
+    // This replaces the `group.sync()` that already stood here rather than
+    // adding a barrier: a broadcast is the same single synchronization, and it
+    // carries the verdict out with it.
+    uint32_t sendAborted = 0;
     if (group.is_leader()) {
       trace_allreduce_event(
           traceContext,
           PipesTraceEventType::kAllReduceSendSyncBegin,
           static_cast<uint8_t>(kPipesTraceQpLaneMask),
           chunk.wireBytes);
+      sendAborted =
+          FT_ABORT_CHECK(timeout, "send publish on an aborted communicator")
+          ? 1U
+          : 0U;
     }
-    group.sync();
+    if (group.broadcast<uint32_t>(sendAborted) != 0U) {
+      abandon_progress_state(group, progressSlot, state);
+      return IbgdaSendRecvProgressStatus::Aborted;
+    }
     if (group.is_leader()) {
       __threadfence_system();
       trace_allreduce_event(
@@ -770,7 +816,21 @@ progress_registered_send_once(
         (isFinalChunk ? protocol::Simple::wire_bytes(state.activeTailPadding)
                       : 0);
 
-    group.sync();
+    // Same gate as the plain send path, for the same reason: a resumed call
+    // entering at WaitSlotFree consulted nothing, and this replaces the
+    // `group.sync()` that already stood here rather than adding a barrier.
+    uint32_t sendAborted = 0;
+    if (group.is_leader()) {
+      sendAborted =
+          FT_ABORT_CHECK(
+              timeout, "registered send publish on an aborted communicator")
+          ? 1U
+          : 0U;
+    }
+    if (group.broadcast<uint32_t>(sendAborted) != 0U) {
+      abandon_progress_state(group, progressSlot, state);
+      return IbgdaRegisteredSendProgressStatus::Aborted;
+    }
     if (group.is_leader()) {
       __threadfence_system();
       ThreadGroup solo{
@@ -1101,42 +1161,51 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
   if (group.is_leader()) {
     unsigned long long current = 0;
     unsigned long long expected = 0;
-    ready = poll_recv_data_ready(
-                transport,
-                localChannel,
-                localDataReady,
-                waitCredit,
-                current,
-                expected)
-        ? 1U
-        : 0U;
-    if (!ready) {
-      if (fine_trace_enabled(traceContext) && traceState != nullptr &&
-          !traceState->dataReadyWaitOpen) {
+    // Asked before readiness, so the already-landed path is covered too. This
+    // function already broadcasts, so the check is free of extra barriers; a
+    // separate entry guard would add one to every healthy poll. Without it a
+    // chunk whose data had arrived went on to consume it and credit SLOT_FREE
+    // without ever consulting the abort.
+    if (FT_ABORT_CHECK(timeout, "recv progress on an aborted communicator")) {
+      ready = kProgressAborted;
+    } else {
+      ready = poll_recv_data_ready(
+                  transport,
+                  localChannel,
+                  localDataReady,
+                  waitCredit,
+                  current,
+                  expected)
+          ? 1U
+          : 0U;
+      if (!ready) {
+        if (fine_trace_enabled(traceContext) && traceState != nullptr &&
+            !traceState->dataReadyWaitOpen) {
+          trace_allreduce_event(
+              traceContext,
+              PipesTraceEventType::kAllReduceDataReadyWaitBegin,
+              qpLane,
+              waitCredit);
+          traceState->dataReadyWaitOpen = true;
+        }
+        if (FT_ABORT_CHECK(
+                timeout,
+                "progress_recv_once waiting for DATA_READY expected>=%llu, "
+                "current=%llu",
+                expected,
+                current)) {
+          ready = kProgressAborted;
+        }
+      } else if (
+          fine_trace_enabled(traceContext) && traceState != nullptr &&
+          traceState->dataReadyWaitOpen) {
         trace_allreduce_event(
             traceContext,
-            PipesTraceEventType::kAllReduceDataReadyWaitBegin,
+            PipesTraceEventType::kAllReduceDataReadyWaitEnd,
             qpLane,
             waitCredit);
-        traceState->dataReadyWaitOpen = true;
+        traceState->dataReadyWaitOpen = false;
       }
-      if (FT_ABORT_CHECK(
-              timeout,
-              "progress_recv_once waiting for DATA_READY expected>=%llu, "
-              "current=%llu",
-              expected,
-              current)) {
-        ready = kProgressAborted;
-      }
-    } else if (
-        fine_trace_enabled(traceContext) && traceState != nullptr &&
-        traceState->dataReadyWaitOpen) {
-      trace_allreduce_event(
-          traceContext,
-          PipesTraceEventType::kAllReduceDataReadyWaitEnd,
-          qpLane,
-          waitCredit);
-      traceState->dataReadyWaitOpen = false;
     }
   }
   // Broadcast makes the answer group-uniform, which is what lets abort ride out
@@ -1250,27 +1319,24 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
   // Packet geometry lives in LLImpl, which owns the format; this seam only
   // decides what to do with the verdict -- report not-ready on false, rather
   // than spin.
-  if (LLImpl<P>::all_flags_set(
-          group,
-          staging,
-          P::max_payload(chunk.wireBytes),
-          static_cast<typename P::FlagType>(chunk.flagVal))) {
-    if (group.is_leader()) {
-      // LL carries no DATA_READY, but its put still advanced the sender's
-      // IbQpState::cursor -- select_put_lane_ordinal() increments that cursor
-      // on every put regardless of protocol, and it is channel-scoped, not
-      // slot-scoped. recvDataReadyLaneCursor mirrors it, so the mirror has to
-      // advance here too: consuming an LL chunk without it leaves the two one
-      // chunk apart per LL transfer, and Simple's next receive on this channel
-      // then waits on a lane the sender never wrote. Matches the unconditional
-      // bump in poll_recv_data_ready() (a single lane makes it a no-op).
-      ++localChannel.recvDataReadyLaneCursor;
-    }
-    return kProgressReady;
-  }
+  // `all_flags_set` is group-collective, so every thread evaluates it; the
+  // verdict below is then decided once by the leader and broadcast.
+  const bool flagsSet = LLImpl<P>::all_flags_set(
+      group,
+      staging,
+      P::max_payload(chunk.wireBytes),
+      static_cast<typename P::FlagType>(chunk.flagVal));
   // Only the leader checks, so the answer has to be broadcast before it leaves:
   // a per-thread verdict here would split the group at the caller's next
   // collective step.
+  //
+  // The abort is asked *before* readiness, and the ready path now leaves
+  // through the same single broadcast as the not-ready path rather than
+  // returning early. Previously a chunk whose flags were already set returned
+  // `kProgressReady` without ever consulting the abort, and the caller went on
+  // to consume the packet and credit SLOT_FREE. One broadcast on every path is
+  // the floor here -- unlike Simple, LL's ready path had no existing barrier to
+  // fold into.
   uint32_t status = kProgressNotReady;
   if (group.is_leader()) {
     if (FT_ABORT_CHECK(
@@ -1280,6 +1346,17 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
             static_cast<unsigned long long>(chunk.flagVal),
             static_cast<unsigned long long>(chunk.wireBytes))) {
       status = kProgressAborted;
+    } else if (flagsSet) {
+      // LL carries no DATA_READY, but its put still advanced the sender's
+      // IbQpState::cursor -- select_put_lane_ordinal() increments that cursor
+      // on every put regardless of protocol, and it is channel-scoped, not
+      // slot-scoped. recvDataReadyLaneCursor mirrors it, so the mirror has to
+      // advance here too: consuming an LL chunk without it leaves the two one
+      // chunk apart per LL transfer, and Simple's next receive on this channel
+      // then waits on a lane the sender never wrote. Matches the unconditional
+      // bump in poll_recv_data_ready() (a single lane makes it a no-op).
+      ++localChannel.recvDataReadyLaneCursor;
+      status = kProgressReady;
     }
   }
   return group.broadcast<uint32_t>(status);
@@ -1679,9 +1756,29 @@ template <typename Transport, typename Proto>
 __device__ __forceinline__ void progress_recv_release_once(
     Transport& transport,
     ThreadGroup& group,
+    const AbortDevice& timeout,
     const RecvChunkAcquisition& view) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   if (view.staging == nullptr) {
+    return;
+  }
+  // SLOT_FREE is a peer-visible credit: it tells the sender this range has been
+  // consumed and may be overwritten. After an abort the consumption either did
+  // not happen or is not trustworthy, so crediting it releases a peer that is
+  // correctly blocked -- principle 4. This function had no abort parameter at
+  // all and signalled unconditionally, which is why the split-receive path
+  // stayed uncontained while the fused one was fixed.
+  //
+  // Leader-decides-and-broadcasts, because a subset skipping the signal while
+  // the rest enter `transport.signal()` would split the group.
+  uint32_t aborted = 0;
+  if (group.is_leader()) {
+    aborted =
+        FT_ABORT_CHECK(timeout, "recv slot release on an aborted communicator")
+        ? 1U
+        : 0U;
+  }
+  if (group.broadcast<uint32_t>(aborted) != 0U) {
     return;
   }
   auto& channelLayout = transport.channel_layout();
@@ -1692,6 +1789,7 @@ __device__ __forceinline__ void progress_recv_release_once(
 #else
   (void)transport;
   (void)group;
+  (void)timeout;
   (void)view;
 #endif
 }
@@ -2094,37 +2192,52 @@ __device__ __forceinline__ uint32_t try_prepare_send_slot(
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t ready = kProgressReady;
   if (group.is_leader()) {
-    auto& slot = transport.template local_channel_slot<P>(group.group_id)
-                     .sendCompletionSlots[slotId];
-    if (slot.generation != generation) {
-      uint64_t pending = slot.laneMask;
-      const uint32_t numLanes = transport.send_completion_lane_count();
-      for (uint32_t laneId = 0; laneId < numLanes; ++laneId) {
-        const uint64_t laneBit = 1ULL << laneId;
-        if ((pending & laneBit) == 0) {
-          continue;
+    // Consulted on the ready path too, not just when the slot is busy.
+    //
+    // This function already broadcasts its verdict, so folding the abort into
+    // it costs no extra barrier -- which is the whole point: a standalone entry
+    // guard would add a group-wide broadcast to every healthy progress attempt,
+    // and Tree scheduling and batched send/recv call this in tight loops.
+    //
+    // Checking only inside the not-ready branch below is what left the hole: a
+    // call that finds the slot already free never looked at the abort and went
+    // on to stage the payload and issue the put with its fused DATA_READY.
+    if (FT_ABORT_CHECK(
+            timeout, "send slot preparation on an aborted communicator")) {
+      ready = kProgressAborted;
+    } else {
+      auto& slot = transport.template local_channel_slot<P>(group.group_id)
+                       .sendCompletionSlots[slotId];
+      if (slot.generation != generation) {
+        uint64_t pending = slot.laneMask;
+        const uint32_t numLanes = transport.send_completion_lane_count();
+        for (uint32_t laneId = 0; laneId < numLanes; ++laneId) {
+          const uint64_t laneBit = 1ULL << laneId;
+          if ((pending & laneBit) == 0) {
+            continue;
+          }
+          const IbLocalCompletionTicket ticket{
+              .completionId = laneId,
+              .value = slot.values[laneId],
+          };
+          if (transport.is_local_completion_ready(group.group_id, ticket)) {
+            pending &= ~laneBit;
+          }
         }
-        const IbLocalCompletionTicket ticket{
-            .completionId = laneId,
-            .value = slot.values[laneId],
-        };
-        if (transport.is_local_completion_ready(group.group_id, ticket)) {
-          pending &= ~laneBit;
-        }
-      }
-      slot.laneMask = pending;
-      if (pending == 0) {
-        slot.generation = generation;
-      } else {
-        ready = kProgressNotReady;
-        if (FT_ABORT_CHECK(
-                timeout,
-                "send slot local completion timed out slot=%u generation=%llu "
-                "pending=0x%llx",
-                slotId,
-                static_cast<unsigned long long>(generation),
-                static_cast<unsigned long long>(pending))) {
-          ready = kProgressAborted;
+        slot.laneMask = pending;
+        if (pending == 0) {
+          slot.generation = generation;
+        } else {
+          ready = kProgressNotReady;
+          if (FT_ABORT_CHECK(
+                  timeout,
+                  "send slot local completion timed out slot=%u generation=%llu "
+                  "pending=0x%llx",
+                  slotId,
+                  static_cast<unsigned long long>(generation),
+                  static_cast<unsigned long long>(pending))) {
+            ready = kProgressAborted;
+          }
         }
       }
     }

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -936,7 +936,8 @@ progress_registered_send_drain_once(
             .completionId = laneId,
             .value = slot.values[laneId],
         };
-        if (transport.is_local_completion_ready(group.group_id, ticket)) {
+        if (transport.is_local_completion_ready(
+                group.group_id, ticket, timeout)) {
           pending &= ~laneBit;
           madeProgress = true;
           continue;
@@ -2220,7 +2221,8 @@ __device__ __forceinline__ uint32_t try_prepare_send_slot(
               .completionId = laneId,
               .value = slot.values[laneId],
           };
-          if (transport.is_local_completion_ready(group.group_id, ticket)) {
+          if (transport.is_local_completion_ready(
+                  group.group_id, ticket, timeout)) {
             pending &= ~laneBit;
           }
         }

--- a/comms/prims/transport/ibgda/IbgdaWarpProxy.cuh
+++ b/comms/prims/transport/ibgda/IbgdaWarpProxy.cuh
@@ -144,7 +144,6 @@ class IbgdaWarpProxy {
       workers_.sync();
     }
 
-    // Posts staged sends and publishes receive credits.
     // Drains staged sends and issues outstanding receive credits -- unless the
     // operation aborts, in which case it returns with commands still queued and
     // their credits deliberately unissued. See the abort-completion note on the
@@ -227,14 +226,18 @@ class IbgdaWarpProxy {
           args...);
     }
 
-    __device__ __forceinline__ void prepare_send_slot(
+    // Returns true when the slot could not be retired -- see
+    // detail::prepare_send_slot. The caller must not stage or put on a slot the
+    // NIC may still be reading.
+    [[nodiscard]] __device__ __forceinline__ bool prepare_send_slot(
         P2pIbgdaTransportDevice& transport,
         ThreadGroup& workers,
         uint32_t slot,
         uint64_t generation,
         const Timeout& timeout) {
       IbgdaWarpProxy::wait_prior_send_posted(storage_, workers, slot, timeout);
-      detail::prepare_send_slot(transport, workers, slot, generation, timeout);
+      return detail::prepare_send_slot(
+          transport, workers, slot, generation, timeout);
     }
 
     __device__ __forceinline__ void submit_send(

--- a/comms/prims/transport/ibgda/IbgdaWarpProxy.cuh
+++ b/comms/prims/transport/ibgda/IbgdaWarpProxy.cuh
@@ -37,12 +37,23 @@ namespace comms::prims {
  * warp owns remote readiness polling, WQE posting, ticket publication, and
  * receive credits. A run exclusively owns every (transport, channel) passed
  * through Ops until run() returns; transport objects must have shared or global
- * lifetime. Ops calls may return after work is queued. run() returns after
- * staged sends are posted and receive credits are issued. workerFn must use
+ * lifetime. Ops calls may return after work is queued. workerFn must use
  * Ops::group() for synchronization and issue Ops calls collectively from that
  * single producer group; block-wide barriers and concurrent subgroup issuers
  * are unsupported. Fused forwarding releases each upstream receive credit
  * before its dependent downstream send becomes eligible for posting.
+ *
+ * Completion has two shapes, and they differ in what they promise:
+ *
+ * - **Normal completion**: run() returns after staged sends are posted and
+ *   receive credits are issued, so the queues are drained.
+ * - **Abort completion**: run() returns with `send.posted < send.tail` and/or
+ *   `recv.credited < recv.tail`. Pending commands are deliberately abandoned
+ *   and their credits never issued -- publishing them would signal a peer for
+ *   work this rank gave up on, which is what releases a correctly blocked peer
+ *   and stops it reaching its own deadline. Queue drain is therefore NOT a
+ *   postcondition of run(); termination is. Recovery is `reconfigure()`, as
+ *   everywhere else in the abort contract.
  */
 template <
     uint32_t WorkerThreads,
@@ -134,6 +145,11 @@ class IbgdaWarpProxy {
     }
 
     // Posts staged sends and publishes receive credits.
+    // Drains staged sends and issues outstanding receive credits -- unless the
+    // operation aborts, in which case it returns with commands still queued and
+    // their credits deliberately unissued. See the abort-completion note on the
+    // class comment: "drained" is not a postcondition once an abort is latched,
+    // termination is.
     __device__ __forceinline__ void drain() {
       IbgdaWarpProxy::drain_queues(storage_, workers_, timeout_);
     }
@@ -233,8 +249,14 @@ class IbgdaWarpProxy {
         uint64_t generation,
         uint64_t requiredRecvCredit,
         const Timeout& timeout) {
-      IbgdaWarpProxy::template wait_queue_space<true>(
-          storage_, workers, timeout);
+      // The wait reports its own verdict through the barrier it already had,
+      // so declining to enqueue costs no extra synchronization. Enqueuing here
+      // would hand the service warp a command it turns into a peer-visible put
+      // with a fused DATA_READY.
+      if (IbgdaWarpProxy::template wait_queue_space<true>(
+              storage_, workers, timeout)) {
+        return;
+      }
       IbgdaWarpProxy::enqueue_send(
           storage_,
           workers,
@@ -257,8 +279,13 @@ class IbgdaWarpProxy {
         ThreadGroup& workers,
         std::size_t protocolBytes,
         const Timeout& timeout) {
-      IbgdaWarpProxy::template wait_queue_space<false>(
-          storage_, workers, timeout);
+      // Same shape as `submit_send()`. `kInvalidSequence` is what makes
+      // `publish_recv()` free: it can decline on a register compare instead of
+      // taking another barrier to re-ask.
+      if (IbgdaWarpProxy::template wait_queue_space<false>(
+              storage_, workers, timeout)) {
+        return kInvalidSequence;
+      }
       const uint64_t sequence = IbgdaWarpProxy::enqueue_recv(
           storage_,
           workers,
@@ -267,7 +294,10 @@ class IbgdaWarpProxy {
               .protocolBytes = protocolBytes,
               .channel = static_cast<uint32_t>(workers.group_id),
           });
-      IbgdaWarpProxy::wait_recv_ready(storage_, workers, sequence, timeout);
+      if (IbgdaWarpProxy::wait_recv_ready(
+              storage_, workers, sequence, timeout)) {
+        return kInvalidSequence;
+      }
       return sequence;
     }
 
@@ -278,6 +308,16 @@ class IbgdaWarpProxy {
         uint64_t sequence) {
       (void)transport;
       (void)protocolBytes;
+      // Advancing `recv.copied` is what lets the service warp emit SLOT_FREE
+      // for this chunk, so it must not happen for a receive that never landed.
+      //
+      // The sentinel carries that decision from `wait_recv()`, which already
+      // made it group-uniformly through its own barrier. Re-asking here would
+      // cost another block-wide barrier per chunk to learn something already
+      // known, so this is a register compare.
+      if (sequence == kInvalidSequence) {
+        return;
+      }
       IbgdaWarpProxy::publish_recv_copied(storage_, workers, sequence);
     }
 
@@ -490,10 +530,11 @@ class IbgdaWarpProxy {
   }
 
   template <bool IsSend>
-  __device__ __forceinline__ static void wait_queue_space(
+  __device__ __forceinline__ static bool wait_queue_space(
       SharedState& storage,
       ThreadGroup& workers,
       const Timeout& timeout) {
+    uint32_t aborted = 0;
     if (workers.is_leader()) {
       uint64_t& tailValue = IsSend ? storage.send.tail : storage.recv.tail;
       uint64_t& headValue =
@@ -508,17 +549,20 @@ class IbgdaWarpProxy {
         queueFullCount.fetch_add(1, cuda::memory_order_relaxed);
       }
       while (currentTail - currentHead >= storage.queueDepth) {
-        FT_ABORT_BREAK(
-            timeout,
-            "IbgdaWarpProxy %s queue full channel=%u head=%llu tail=%llu",
-            IsSend ? "send" : "recv",
-            workers.group_id,
-            static_cast<unsigned long long>(currentHead),
-            static_cast<unsigned long long>(currentTail));
+        if (FT_ABORT_CHECK(
+                timeout,
+                "IbgdaWarpProxy %s queue full channel=%u head=%llu tail=%llu",
+                IsSend ? "send" : "recv",
+                workers.group_id,
+                static_cast<unsigned long long>(currentHead),
+                static_cast<unsigned long long>(currentTail))) {
+          aborted = 1U;
+          break;
+        }
         currentHead = head.load(cuda::memory_order_acquire);
       }
     }
-    workers.sync();
+    return workers.broadcast<uint32_t>(aborted) != 0U;
   }
 
   __device__ __forceinline__ static void wait_prior_send_posted(
@@ -575,26 +619,32 @@ class IbgdaWarpProxy {
     return workers.broadcast(sequence);
   }
 
-  __device__ __forceinline__ static void wait_recv_ready(
+  // Same shape as `wait_queue_space`: the verdict leaves through the barrier
+  // this already had, and the abort is read only while actually stalled.
+  __device__ __forceinline__ static bool wait_recv_ready(
       SharedState& storage,
       ThreadGroup& workers,
       uint64_t sequence,
       const Timeout& timeout) {
+    uint32_t aborted = 0;
     if (workers.is_leader()) {
       BlockAtomicU64 ready(storage.recv.ready);
       uint64_t current = ready.load(cuda::memory_order_acquire);
       while (current <= sequence) {
-        FT_ABORT_BREAK(
-            timeout,
-            "IbgdaWarpProxy waiting for DATA_READY channel=%u ready=%llu "
-            "required=%llu",
-            workers.group_id,
-            static_cast<unsigned long long>(current),
-            static_cast<unsigned long long>(sequence + 1));
+        if (FT_ABORT_CHECK(
+                timeout,
+                "IbgdaWarpProxy waiting for DATA_READY channel=%u ready=%llu "
+                "required=%llu",
+                workers.group_id,
+                static_cast<unsigned long long>(current),
+                static_cast<unsigned long long>(sequence + 1))) {
+          aborted = 1U;
+          break;
+        }
         current = ready.load(cuda::memory_order_acquire);
       }
     }
-    workers.sync();
+    return workers.broadcast<uint32_t>(aborted) != 0U;
   }
 
   __device__ __forceinline__ static void publish_recv_copied(
@@ -744,25 +794,75 @@ class IbgdaWarpProxy {
       const Timeout& timeout) {
     BlockAtomicU32 producerDone(storage.producerDone);
     while (true) {
-      if (service.is_leader()) {
-        post_recv_credits(storage, fullBlock);
-        publish_recv_readiness(storage, timeout);
-        post_send_once(storage, fullBlock, timeout);
-      }
-
       uint32_t stop = 0;
-      if (service.is_leader() &&
-          producerDone.load(cuda::memory_order_acquire) != 0) {
-        BlockAtomicU64 sendTail(storage.send.tail);
-        BlockAtomicU64 sendPosted(storage.send.posted);
-        BlockAtomicU64 recvTail(storage.recv.tail);
-        BlockAtomicU64 recvCredited(storage.recv.credited);
-        stop = sendPosted.load(cuda::memory_order_acquire) ==
-                    sendTail.load(cuda::memory_order_acquire) &&
-                recvCredited.load(cuda::memory_order_acquire) ==
-                    recvTail.load(cuda::memory_order_acquire)
-            ? 1U
-            : 0U;
+      if (service.is_leader()) {
+        // An abort has to end this loop on its own. Its only other exit is a
+        // fully drained queue, and an abort is precisely what makes that
+        // unreachable: a worker that gave up mid-flight leaves posted < tail
+        // (or credited < tail) forever, so the drain condition below never
+        // becomes true and the service warp spins until the launch is killed.
+        //
+        // Exiting here does not strand the workers. Their credit and slot waits
+        // are FT_ABORT_BREAK-guarded, so the same abort releases both sides --
+        // which is the property that matters, since worker and service warp
+        // only coordinate through these release/acquire counters and each is
+        // otherwise waiting for the other to move them.
+        //
+        // Folded into the existing `stop` broadcast rather than given its own,
+        // so the check is warp-uniform at no extra barrier. Leader-only keeps
+        // it to one poll per iteration instead of one per lane.
+        //
+        // The check runs BEFORE the iteration's peer-visible work, and again
+        // between each abortable step, rather than once at the bottom. Both are
+        // needed, and for different reasons:
+        //
+        //   - `post_recv_credits()` emits `signal(slotFree)` and has no abort
+        //     check of its own; `post_send_once()` issues a `put` with a fused
+        //     `DATA_READY`. With the check below them, the iteration on which
+        //     the abort first becomes visible has already sent one more round.
+        //   - Hoisting alone does not close it: `publish_recv_readiness()` is
+        //     itself abortable, so an abort first observed *inside* it would
+        //     still be followed by `post_send_once()` in the same iteration.
+        //
+        // That is FT principle 4 -- never signal a peer for work you abandoned.
+        // A false credit releases a peer that is correctly blocked and stops it
+        // ever reaching its own deadline, so one rank's abort silently
+        // suppresses fault detection on the rest.
+        //
+        // The between-step checks are plain `isAborted()` reads rather than new
+        // return values: once an abortable step gives up it has already latched
+        // the reason in shared state, so a subsequent read sees it. Cheap, and
+        // it keeps the change to control flow instead of threading a status
+        // through `publish_recv_readiness()`.
+        bool aborted = FT_ABORT_CHECK(
+            timeout, "IbgdaWarpProxy::run_service abandoning drain");
+        // Each step runs only if nothing has aborted yet, and re-reads the flag
+        // afterwards because the step itself may have given up inside.
+        const auto step = [&](auto&& emit) {
+          if (aborted) {
+            return;
+          }
+          emit();
+          aborted = timeout.isAborted();
+        };
+        step([&] { post_recv_credits(storage, fullBlock); });
+        step([&] { publish_recv_readiness(storage, timeout); });
+        step([&] { post_send_once(storage, fullBlock, timeout); });
+
+        if (aborted) {
+          stop = 1U;
+        } else if (producerDone.load(cuda::memory_order_acquire) != 0) {
+          BlockAtomicU64 sendTail(storage.send.tail);
+          BlockAtomicU64 sendPosted(storage.send.posted);
+          BlockAtomicU64 recvTail(storage.recv.tail);
+          BlockAtomicU64 recvCredited(storage.recv.credited);
+          stop = sendPosted.load(cuda::memory_order_acquire) ==
+                      sendTail.load(cuda::memory_order_acquire) &&
+                  recvCredited.load(cuda::memory_order_acquire) ==
+                      recvTail.load(cuda::memory_order_acquire)
+              ? 1U
+              : 0U;
+        }
       }
       stop = service.broadcast(stop);
       if (stop != 0) {

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -684,7 +684,8 @@ class P2pIbgdaTransportDevice {
 
   __device__ __forceinline__ bool is_local_completion_ready(
       uint32_t channelId,
-      const IbLocalCompletionTicket& ticket) {
+      const IbLocalCompletionTicket& ticket,
+      const Timeout& timeout = Timeout()) {
     IbgdaLane lane =
         lane_from_ordinal(channelId, IbDirection::Send, ticket.completionId);
     const int status = doca_gpu_dev_verbs_poll_one_cq_at<
@@ -702,7 +703,33 @@ class P2pIbgdaTransportDevice {
         ticket.completionId,
         static_cast<unsigned long long>(ticket.value),
         status);
-    PIPES_DEVICE_TRAP();
+    // An error completion is a *fault* -- a peer whose QP went to error state,
+    // a bad rkey, an unreachable remote -- not a programming error. Trapping
+    // takes down the CUDA context for the entire process, which is precisely
+    // the outcome fault tolerance exists to prevent, so under FT this latches
+    // the abort instead and lets the caller's own check unwind. The legacy trap
+    // is kept for the FT-disabled path, where nothing else would notice.
+    //
+    // Mirrors `P2pIbrcTransportDevice::check_status`, which is the reference
+    // implementation for this pattern.
+    if (!timeout.isEnabled()) {
+      PIPES_DEVICE_TRAP();
+      return false;
+    }
+    // NETWORK_ERROR, not ABORTED. The condition here is a peer whose QP went to
+    // error state, a bad rkey, an unreachable remote -- exactly what
+    // FAULT_TOLERANCE.md defines NETWORK_ERROR as ("a transport or peer-network
+    // failure"), while ABORTED is reserved for an explicit user or transport
+    // abort. Since the reason is first-writer-wins and drives host telemetry,
+    // using ABORTED here permanently misfiled every completion fault as a user
+    // abort. It also sharpens `BadRkeyCompletionErrorUnwinds`, which asserts
+    // the reason to tell the CQE path from the deadline path.
+    (void)timeout.setAbort(
+        comms::fault_tolerance::AbortReason::NETWORK_ERROR,
+        "IBGDA local completion error CQE");
+    // Deliberately "not ready": the caller polls this inside a loop that
+    // already consults the abort, so reporting not-ready routes it through the
+    // same unwind path an expiry would take instead of inventing a second one.
     return false;
   }
 
@@ -1090,6 +1117,39 @@ class P2pIbgdaTransportDevice {
               timeout,
               "wait_local_on_qp timed out (ticket=%llu)",
               static_cast<unsigned long long>(ticket));
+        } else if (status != 0) {
+          // Previously this fell straight out of the loop: the `while` only
+          // continues on EBUSY, so an error status returned from a `void`
+          // function and the caller was left believing the put had landed. A
+          // silent success on a hardware error is worse than a trap, because
+          // nothing downstream can tell that anything went wrong.
+          //
+          // No `!isEnabled()` trap arm here, unlike `is_local_completion_ready`
+          // below: this whole branch is inside the `else` of `isEnabled()`, so
+          // the handle is enabled by construction. With FT off the function
+          // takes the blocking `doca_gpu_dev_verbs_wait` above and never
+          // inspects a status at all, so there is no disabled-path error to
+          // preserve.
+          // Gated on the CAS result so the diagnostic is one-shot. An error CQE
+          // is sticky and this function is re-entered by its caller's spin
+          // loop, so printing first meant one printf plus one system-scope CAS
+          // attempt per iteration until some other poll observed the abort --
+          // a large log burst and repeated mapped-host traffic for a single
+          // fault. `setAbort()` already reports whether it won the transition,
+          // which is exactly the first-writer property the log wants.
+          //
+          // The message stays a printf rather than a `context` string because
+          // it carries the ticket and status; `context` is a plain `const
+          // char*` and cannot format them.
+          if (timeout.setAbort(
+                  comms::fault_tolerance::AbortReason::NETWORK_ERROR)) {
+            printf(
+                "P2pIbgdaTransportDevice: wait_local_on_qp completion failed "
+                "(ticket=%llu status=%d)\n",
+                static_cast<unsigned long long>(ticket),
+                status);
+          }
+          break;
         }
       } while (status == EBUSY);
     }

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -2325,10 +2325,11 @@ class P2pIbgdaTransportDevice {
   template <typename = void>
   __device__ __forceinline__ void progress_recv_release_once(
       ThreadGroup& group,
+      const AbortDevice& timeout,
       const detail::RecvChunkAcquisition& view) {
     detail::
         progress_recv_release_once<P2pIbgdaTransportDevice, protocol::Simple>(
-            *this, group, view);
+            *this, group, timeout, view);
   }
 
   /**

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -702,10 +702,11 @@ class P2pIbrcTransportDevice {
   template <typename = void>
   __device__ __forceinline__ void progress_recv_release_once(
       ThreadGroup& group,
+      const AbortDevice& timeout,
       const detail::RecvChunkAcquisition& view) {
     detail::
         progress_recv_release_once<P2pIbrcTransportDevice, protocol::Simple>(
-            *this, group, view);
+            *this, group, timeout, view);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -405,9 +405,15 @@ class P2pIbrcTransportDevice {
     group.sync();
   }
 
+  // The `timeout` parameter exists for signature parity with the IBGDA
+  // transport: the progress path is templated on the transport type and passes
+  // it to whichever one it has. IBRC does not need it -- `check_status()` below
+  // already latches the abort on the communicator-scoped `abort_` member -- so
+  // it is accepted and ignored rather than threaded through.
   __device__ __forceinline__ bool is_local_completion_ready(
       uint32_t channelId,
-      const IbLocalCompletionTicket& ticket) const {
+      const IbLocalCompletionTicket& ticket,
+      const Timeout& /*timeout*/ = Timeout()) const {
     const auto& queue = cmdQueues[queue_for_lane(
         channelId, IbDirection::Send, ticket.completionId)];
     check_status(queue);


### PR DESCRIPTION
Summary:
A completion error on an IBGDA send is a *fault* -- a peer whose QP went to
error state, a bad rkey, an unreachable remote -- not a programming error. Two
call sites treated it as neither, in opposite and both-wrong ways.

`is_local_completion_ready()` trapped:

```cpp
if (status == 0) return true;
if (status == EBUSY) return false;
printf("... local completion failed ... status=%d\n", ...);
PIPES_DEVICE_TRAP();
```

`PIPES_DEVICE_TRAP()` takes down the CUDA context for the entire process, which
is exactly the outcome fault tolerance exists to prevent. It fired regardless of
whether fault tolerance was enabled.

`wait_local_on_qp()` did the opposite -- it silently reported success:

```cpp
do {
  status = poll_one_cq_at(...);
  if (status == EBUSY) { FT_ABORT_BREAK(timeout, ...); }
} while (status == EBUSY);
```

The loop only continues on `EBUSY`, so any error status fell straight out and
the function returned `void`. The caller was left believing the put had landed.
A silent success on a hardware error is worse than a trap, because nothing
downstream can tell that anything went wrong.

Both now follow `P2pIbrcTransportDevice::check_status`, which already had this
right: keep the legacy trap only when fault tolerance is disabled (nothing else
would notice there), and otherwise latch the abort and let the caller's existing
check unwind. `is_local_completion_ready()` gains an optional `Timeout` so it
has a handle to latch on; the two progress-path callers already had one in
scope and now pass it. It deliberately reports "not ready" rather than "ready"
on error, so the caller unwinds through the same path an expiry would take
rather than through a second one.

Found by auditing every `PIPES_DEVICE_TRAP()` / `__trap()` site in
`comms/prims` and `comms/mccl` and asking of each whether its condition can be
caused by something outside this process. Of roughly 150 sites these two were
the only fault-triggered traps left unhandled; everything else is a geometry,
bounds or misuse assertion that a peer cannot provoke, and there are no
remaining `TIMEOUT_TRAP_IF_EXPIRED*` uses outside tests. That negative result is
worth as much as the fix: this class is now closed, not merely reduced.

Scope note: a *dead peer* does not reach this path on any practical timescale.
Measured on 8x H100 with a 30 s deadline, every survivor ran the deadline out
and aborted on its own timer without a single error CQE being polled, because IB
retry exhaustion (`timeout` x `retry_cnt`) can run to about a minute. The
deadline, not the completion queue, is what makes rank death survivable. This
path is reached by fail-fast errors instead -- an invalid rkey, a QP already in
error state -- which is why the coverage for it is a targeted prims-level
injector rather than a collective-level scenario.

Reviewed By: arttianezhu

Differential Revision: D116743951


