### PR TITLE
comms/uniflow/controller: write down that Conn is single-sender

### DIFF
--- a/comms/uniflow/Connection.h
+++ b/comms/uniflow/Connection.h
@@ -23,7 +23,7 @@ class Connection {
 
   ~Connection();
 
-  /// Graceful shutdown: stop reader, shut down transport, close ctrl.
+  /// Graceful shutdown: shut down transport, then close ctrl.
   void shutdown();
 
   Status sendCtrlMsg(std::span<const uint8_t> payload);

--- a/comms/uniflow/controller/Controller.h
+++ b/comms/uniflow/controller/Controller.h
@@ -10,6 +10,19 @@
 
 namespace uniflow::controller {
 
+/// A framed, bidirectional connection to one peer.
+///
+/// Not safe for concurrent use: at most one send() and one recv() may be in
+/// flight at a time, and callers must serialize their own access. Overlapping
+/// sends do not merely scramble bytes -- each send() writes its own length
+/// prefix, so two senders interleave frames and the peer reassembles a payload
+/// from both.
+///
+/// Enforcement is uneven, so do not rely on a diagnostic. TcpConn<AsyncIO>
+/// rejects an overlapping call with ErrCode::ResourceExhausted, but
+/// TcpConn<SyncIO> -- what accept() and connect() return, and therefore what
+/// every control connection is -- has no such check and corrupts the stream
+/// silently.
 class Conn {
  public:
   virtual ~Conn() = default;
@@ -31,7 +44,8 @@ class Conn {
       std::span<uint8_t> buf) = 0;
 
   /// Interrupt any blocked recv(). After close(), recv() must return an error.
-  /// Used by Connection to stop its reader thread during shutdown.
+  /// Called by Connection::shutdown() to release whatever thread is parked in
+  /// recv(); that thread belongs to the caller, not to Connection.
   virtual void close() {}
 };
 


### PR DESCRIPTION
Summary:
Conn documents buffer ownership and lifetime but says nothing about
concurrency, and the answer is not inferable from the header: there is no
mutex in TcpConn, and Connection -- the only production holder of a control
conn -- has none either (Connection.cpp and Connection.h contain zero
mutex/lock_guard/unique_lock).

The contract is already decided, just unevenly enforced. TcpConn<AsyncIO>
rejects an overlapping send with ErrCode::ResourceExhausted
(TcpController.cpp:706), covered by ConcurrentSendReturnsResourceExhausted and
ConcurrentRecvReturnsResourceExhausted. But every conn handed out by accept()
or connect() is a TcpConn<SyncIO> -- all four factory paths call
TcpConn<SyncIO>::create and there are no TcpConn<AsyncIO>::create calls -- so
the one guard in the tree sits on the policy the control path never
instantiates. A caller reading this header cannot tell that.

Worth stating now because D117132590 made the failure mode quieter rather
than louder. A frame used to leave as two ::send() calls, prefix then
payload, so two senders interleaved at frame granularity and corruption
showed up almost immediately. It is now a single ::sendmsg(), so a frame that
fits in the socket buffer is effectively atomic against a concurrent sender
while a frame large enough to block is not. Size-dependent and rare is
harder to diagnose than immediate. To be clear about blame: the missing
serialization is not new, and no diff in this stack touches Connection at
all -- sendCtrlMsg and shutdown() are unchanged since D-era commits from
April. This stack changed the symptom, not the defect.

Also drops two comments that assert an ownership discipline that no longer
exists, and which the new contract would otherwise contradict a few lines
away. Connection.h said shutdown() stops a reader, and Conn::close() said it
was used to stop Connection's reader thread. Connection has no thread: its
only members are ctrl_ and transport_. The reader moved up into Python, so
close() now unblocks a thread owned by the caller, which is what the comment
says instead.

Documents the contract only; it does not add serialization. The data plane
already serializes correctly -- TcpTransport funnels every send through one
senderLoop() draining outQueue_ under outMu_, described at TcpTransport.h:522
as "serialized by construction". The control plane has no equivalent, and
whether to give Connection::sendCtrlMsg a mutex is a separate change at a
separate layer.

___

Differential Revision: D117425940


