### PR TITLE
Fix spdlog exit-time race on abnormal teardown (#3802)

### DIFF
--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -19,6 +19,7 @@
 
 #include <spdlog/async.h>
 #include <spdlog/details/periodic_worker.h>
+#include <spdlog/details/thread_pool.h>
 #include <spdlog/pattern_formatter.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/sink.h>
@@ -70,13 +71,76 @@ thread_local std::string threadName = "main";
 // logger and eventually re-enter the originating callback.
 thread_local bool errorCallbackInProgress = false;
 
+class CommsThreadPoolState final {
+ public:
+  CommsThreadPoolState()
+      : threadPool_{std::make_shared<spdlog::details::thread_pool>(
+            kAsyncQueueSize,
+            kAsyncThreadCount)} {}
+
+  std::shared_ptr<spdlog::details::thread_pool> acquire() const {
+    std::lock_guard lock{mutex_};
+    return threadPool_;
+  }
+
+  void stop() {
+    std::shared_ptr<spdlog::details::thread_pool> threadPool;
+    {
+      std::lock_guard lock{mutex_};
+      threadPool = std::move(threadPool_);
+    }
+    threadPool.reset();
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  std::shared_ptr<spdlog::details::thread_pool> threadPool_;
+};
+
+class CommsThreadPoolStopper final {
+ public:
+  explicit CommsThreadPoolStopper(CommsThreadPoolState& state)
+      : state_(state) {}
+  ~CommsThreadPoolStopper() {
+    state_.stop();
+  }
+
+  CommsThreadPoolStopper(const CommsThreadPoolStopper&) = delete;
+  CommsThreadPoolStopper& operator=(const CommsThreadPoolStopper&) = delete;
+  CommsThreadPoolStopper(CommsThreadPoolStopper&&) = delete;
+  CommsThreadPoolStopper& operator=(CommsThreadPoolStopper&&) = delete;
+
+ private:
+  CommsThreadPoolState& state_;
+};
+
+CommsThreadPoolState& getCommsThreadPoolState() {
+  static auto* state = new CommsThreadPoolState{};
+  static const CommsThreadPoolStopper stopper{*state};
+  return *state;
+}
+
+/*
+ * Deliberately leaked along with the logger-owned static state below. A process
+ * that exits without aborting its NCCL communicator leaves the proxy,
+ * CollTrace, and watchdog threads logging while __cxa_atexit runs, so a logger
+ * with a destructor would be freed out from under them. Leaking behind a
+ * pointer registers no destructor, so the object outlives every thread that can
+ * reach it.
+ */
 class PeriodicSinkFlusher final {
  public:
   PeriodicSinkFlusher()
-      : worker_{
+      : worker_{std::make_unique<spdlog::details::periodic_worker>(
             [this]() noexcept { flushRegisteredSinks(); },
-            kPeriodicFlushInterval} {}
-  ~PeriodicSinkFlusher() = default;
+            kPeriodicFlushInterval)} {}
+
+  // Joins the flush thread so it cannot touch sinks or stdio during exit. The
+  // flusher itself survives, so registerSink() from a running thread stays
+  // safe.
+  void stopFlushing() {
+    worker_.reset();
+  }
 
   void registerSink(const std::shared_ptr<spdlog::sinks::sink>& sink) {
     std::lock_guard lock{mutex_};
@@ -92,11 +156,6 @@ class PeriodicSinkFlusher final {
     }
     sinks_.push_back(sink);
   }
-
-  PeriodicSinkFlusher(const PeriodicSinkFlusher&) = delete;
-  PeriodicSinkFlusher& operator=(const PeriodicSinkFlusher&) = delete;
-  PeriodicSinkFlusher(PeriodicSinkFlusher&&) = delete;
-  PeriodicSinkFlusher& operator=(PeriodicSinkFlusher&&) = delete;
 
  private:
   void flushRegisteredSinks() noexcept {
@@ -124,12 +183,34 @@ class PeriodicSinkFlusher final {
 
   std::mutex mutex_;
   std::vector<std::weak_ptr<spdlog::sinks::sink>> sinks_;
-  spdlog::details::periodic_worker worker_;
+  // Declared last so it is joined before the state its callback reads.
+  std::unique_ptr<spdlog::details::periodic_worker> worker_;
+};
+
+// Stops the flush thread at exit without destroying the flusher it points at.
+class PeriodicFlushStopper final {
+ public:
+  explicit PeriodicFlushStopper(PeriodicSinkFlusher& flusher)
+      : flusher_(flusher) {}
+  ~PeriodicFlushStopper() {
+    flusher_.stopFlushing();
+  }
+
+  PeriodicFlushStopper(const PeriodicFlushStopper&) = delete;
+  PeriodicFlushStopper& operator=(const PeriodicFlushStopper&) = delete;
+  PeriodicFlushStopper(PeriodicFlushStopper&&) = delete;
+  PeriodicFlushStopper& operator=(PeriodicFlushStopper&&) = delete;
+
+ private:
+  PeriodicSinkFlusher& flusher_;
 };
 
 PeriodicSinkFlusher& getPeriodicSinkFlusher() {
-  static PeriodicSinkFlusher flusher;
-  return flusher;
+  static auto* flusher = new PeriodicSinkFlusher{};
+  // Constructed after the logger and spdlog registry, so atexit's LIFO order
+  // joins the flush thread before spdlog's exit-time teardown begins.
+  static const PeriodicFlushStopper stopper{*flusher};
+  return *flusher;
 }
 
 class ErrorCallbackGuard {
@@ -227,18 +308,40 @@ uint64_t getCurrentThreadId() {
   return threadId;
 }
 
-std::shared_ptr<spdlog::logger> createLogger(std::string name) {
-  if (!spdlog::thread_pool()) {
-    spdlog::init_thread_pool(kAsyncQueueSize, kAsyncThreadCount);
-  }
+struct NamedLoggerRegistry {
+  std::shared_mutex mutex;
+  std::map<std::string, std::unique_ptr<CommsSpdlogLogger>, std::less<>>
+      loggers;
+};
 
-  auto logger = spdlog::create_async_nb<spdlog::sinks::stderr_color_sink_mt>(
-      std::move(name));
+struct CreatedLogger {
+  std::shared_ptr<spdlog::logger> logger;
+  std::shared_ptr<spdlog::details::thread_pool> threadPool;
+};
+
+CreatedLogger createLogger(std::string name) {
+  auto threadPool = getCommsThreadPoolState().acquire();
+  auto sink = std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
+  std::shared_ptr<spdlog::logger> logger;
+  if (threadPool) {
+    logger = std::make_shared<spdlog::async_logger>(
+        std::move(name),
+        std::move(sink),
+        threadPool,
+        spdlog::async_overflow_policy::overrun_oldest);
+  } else {
+    // A logger first referenced during exit cannot use the stopped async pool.
+    logger = std::make_shared<spdlog::logger>(std::move(name), std::move(sink));
+  }
   logger->set_formatter(makeFormatter());
-  return logger;
+  return {std::move(logger), std::move(threadPool)};
 }
 
 } // namespace
+
+void shutdownSpdlogForFatal() {
+  getCommsThreadPoolState().stop();
+}
 
 bool shouldWriteCommsLogToStderr(std::string_view formattedMessage) {
   /*
@@ -255,10 +358,11 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage) {
 CommsSpdlogLogger::CommsSpdlogLogger()
     : CommsSpdlogLogger(std::string{kCommsLoggerName}) {}
 
-CommsSpdlogLogger::CommsSpdlogLogger(std::string name)
-    : logger_(createLogger(std::move(name))),
-      outputSink_(
-          std::make_shared<spdlog::sinks::dist_sink_mt>(logger_->sinks())) {
+CommsSpdlogLogger::CommsSpdlogLogger(std::string name) {
+  auto [logger, threadPool] = createLogger(std::move(name));
+  logger_ = std::move(logger);
+  threadPool_ = threadPool;
+  outputSink_ = std::make_shared<spdlog::sinks::dist_sink_mt>(logger_->sinks());
   logger_->sinks() = {outputSink_};
   synchronousLogger_ =
       std::make_shared<spdlog::logger>(logger_->name(), outputSink_);
@@ -283,7 +387,7 @@ void CommsLogStreamBase::log() {
 [[noreturn]] void CommsLogStreamBase::logFatalAndAbort() noexcept {
   try {
     logger_.flush();
-    spdlog::shutdown();
+    shutdownSpdlogForFatal();
     logger_.logFatal(location_, stream_.str());
   } catch (...) {
     abortAfterCommsLoggingFailure();
@@ -340,9 +444,19 @@ bool CommsSpdlogLogger::usesAsyncLogging() const {
   return loadConfiguration()->asyncLogging;
 }
 
+std::shared_ptr<spdlog::details::thread_pool>
+CommsSpdlogLogger::acquireAsyncThreadPool() const {
+  return threadPool_.lock();
+}
+
 void CommsSpdlogLogger::flush() {
-  logger_->flush();
-  if (!usesAsyncLogging()) {
+  // logger_->flush() posts to the async pool and throws once it is gone, so
+  // skip it during teardown and flush the synchronous path instead.
+  const auto threadPool = acquireAsyncThreadPool();
+  if (threadPool) {
+    logger_->flush();
+  }
+  if (!usesAsyncLogging() || !threadPool) {
     synchronousLogger_->flush();
   }
 }
@@ -449,7 +563,9 @@ void CommsSpdlogLogger::logFormatted(
     std::string_view levelName,
     std::string_view message,
     bool bypassLevelGate) {
-  static const auto hostname = getHostName();
+  // Leaked for the reason PeriodicSinkFlusher documents: threads that outlive
+  // exit-time destruction still format messages through here.
+  static const auto* hostname = new std::string{getHostName()};
   static const auto processId = getpid();
   const auto configuration = loadConfiguration();
   if (level >= spdlog::level::err && configuration->errorCallback &&
@@ -467,12 +583,13 @@ void CommsSpdlogLogger::logFormatted(
        getCurrentThreadId(),
        getBaseName(location.filename),
        static_cast<unsigned int>(location.line),
-       hostname,
+       *hostname,
        processId,
        configuration->threadContextFn(),
        threadName,
        configuration->prefix});
-  if (bypassLevelGate || !configuration->asyncLogging) {
+  const auto threadPool = acquireAsyncThreadPool();
+  if (bypassLevelGate || !configuration->asyncLogging || !threadPool) {
     synchronousLogger_->log(location, level, formatted);
     synchronousLogger_->flush();
   } else {
@@ -481,30 +598,34 @@ void CommsSpdlogLogger::logFormatted(
 }
 
 CommsSpdlogLogger& getSpdlogLogger() {
-  static CommsSpdlogLogger logger;
-  return logger;
+  // Leaked; see PeriodicSinkFlusher for why nothing here may have a destructor.
+  static auto* logger = new CommsSpdlogLogger{};
+  return *logger;
 }
 
 CommsSpdlogLogger& getSpdlogLogger(std::string_view loggerName) {
   if (loggerName == kCommsLoggerName) {
     return getSpdlogLogger();
   }
-  static std::shared_mutex mutex;
-  static std::map<std::string, std::unique_ptr<CommsSpdlogLogger>, std::less<>>
-      loggers;
+  // Leaked as a unit: destroying the map would destroy every named logger, and
+  // destroying the mutex would strand any thread still looking one up.
+  static auto* registry = new NamedLoggerRegistry{};
   {
-    std::shared_lock lock{mutex};
-    if (const auto it = loggers.find(loggerName); it != loggers.end()) {
+    std::shared_lock lock{registry->mutex};
+    if (const auto it = registry->loggers.find(loggerName);
+        it != registry->loggers.end()) {
       return *it->second;
     }
   }
-  std::unique_lock lock{mutex};
-  if (const auto it = loggers.find(loggerName); it != loggers.end()) {
+  std::unique_lock lock{registry->mutex};
+  if (const auto it = registry->loggers.find(loggerName);
+      it != registry->loggers.end()) {
     return *it->second;
   }
   auto name = std::string{loggerName};
   auto logger = std::make_unique<CommsSpdlogLogger>(name);
-  const auto it = loggers.emplace(std::move(name), std::move(logger)).first;
+  const auto it =
+      registry->loggers.emplace(std::move(name), std::move(logger)).first;
   return *it->second;
 }
 

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -130,6 +130,13 @@ class CommsSpdlogLogger {
   std::shared_ptr<const Configuration> loadConfiguration() const;
   void storeConfiguration(std::shared_ptr<const Configuration> configuration);
 
+  /*
+   * The library-owned shared thread pool is stopped during exit. Holding this
+   * reference across an async call prevents the pool from disappearing after
+   * the check.
+   */
+  std::shared_ptr<spdlog::details::thread_pool> acquireAsyncThreadPool() const;
+
   void logFormatted(
       spdlog::source_loc location,
       spdlog::level::level_enum level,
@@ -138,6 +145,8 @@ class CommsSpdlogLogger {
       bool bypassLevelGate);
 
   std::shared_ptr<spdlog::logger> logger_;
+  // References the exact pool supplied to the async logger at construction.
+  std::weak_ptr<spdlog::details::thread_pool> threadPool_;
   std::shared_ptr<spdlog::sinks::dist_sink_mt> outputSink_;
   std::shared_ptr<spdlog::logger> synchronousLogger_;
   ConfigurationStorage configuration_;
@@ -192,6 +201,7 @@ CommsSpdlogLogger& getSpdlogLogger(std::string_view loggerName);
 
 void reportCommsLoggingFailureToStderr(const char* level) noexcept;
 [[noreturn]] void abortAfterCommsLoggingFailure() noexcept;
+void shutdownSpdlogForFatal();
 CommsSpdlogLogger& getSpdlogLoggerForFatal(
     std::string_view loggerName) noexcept;
 
@@ -237,16 +247,15 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
   SPDLOG_LOGGER_CALL(logger, ::spdlog::level::debug, __VA_ARGS__)
 
 /*
- * shutdown() drains the async queue before the synchronous fatal message.
- * CommsSpdlogLogger owns that synchronous logger and its output sinks outside
- * spdlog's registry, so they remain valid after registry shutdown.
+ * shutdownSpdlogForFatal() drains and stops the library-owned async pool. The
+ * synchronous logger and its output sinks remain valid afterward.
  */
 #define COMMS_LOG_FATAL_IMPL(logger_expression, ...)                 \
   do {                                                               \
     try {                                                            \
       auto& _comms_logger = (logger_expression);                     \
       _comms_logger.flush();                                         \
-      ::spdlog::shutdown();                                          \
+      ::meta::comms::logger::shutdownSpdlogForFatal();               \
       _comms_logger.logFatal(                                        \
           ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, \
           __VA_ARGS__);                                              \

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -5,7 +5,9 @@
 
 #include "comms/utils/logger/SpdlogLogger.h"
 
+#include <atomic>
 #include <chrono>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
@@ -388,6 +390,84 @@ TEST(SpdlogLoggerTest, ErrorCallbackExceptionDoesNotEscapeLogCall) {
   EXPECT_NO_THROW(COMMS_LOG_NAMED(kContext, ERR, "second error"));
   EXPECT_EQ(callbackCount, 2);
   logger.configure("TEST", []() { return 0; }, {});
+}
+
+/*
+ * Reproduces an exit without destroy_process_group: the communicator's threads
+ * are never joined, so they keep logging while static destructors run. The
+ * atexit handler is registered before the first getSpdlogLogger() call, so LIFO
+ * ordering runs it after everything the logging singletons would have
+ * destroyed.
+ */
+TEST(SpdlogLoggerTest, UnjoinedThreadCanLogDuringStaticDestruction) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_EXIT(
+      {
+        static std::atomic<bool> destructionStarted{false};
+        static std::atomic<bool> backgroundThreadDone{false};
+        constexpr std::string_view kNamedContext{"comms.teardown_test"};
+        constexpr std::string_view kLateNamedContext{
+            "comms.teardown_late_test"};
+
+        std::thread{[=]() {
+          while (!destructionStarted.load()) {
+            /* sleep override */
+            std::this_thread::sleep_for(std::chrono::milliseconds{1});
+          }
+          COMMS_LOG(WARN, "shared logger survived teardown");
+          COMMS_LOG_NAMED(
+              kNamedContext, WARN, "named logger survived teardown");
+          COMMS_LOG_NAMED(
+              kLateNamedContext,
+              WARN,
+              "late-created named logger survived teardown");
+          backgroundThreadDone.store(true);
+        }}.detach();
+
+        std::atexit([]() {
+          destructionStarted.store(true);
+          const auto deadline =
+              std::chrono::steady_clock::now() + std::chrono::seconds{5};
+          while (!backgroundThreadDone.load() &&
+                 std::chrono::steady_clock::now() < deadline) {
+            /* sleep override */
+            std::this_thread::sleep_for(std::chrono::milliseconds{1});
+          }
+        });
+
+        const auto configureForStderr = [](auto& logger) {
+          // Async configuration also exercises exit-time shutdown of the
+          // periodic sink flusher before the logging thread runs.
+          logger.configure("TEST", []() { return 0; }, {}, true);
+          logger.set_level(spdlog::level::info);
+        };
+        configureForStderr(getSpdlogLogger());
+        configureForStderr(getSpdlogLogger(kNamedContext));
+        std::exit(0);
+      },
+      ::testing::ExitedWithCode(0),
+      "shared logger survived teardown(.|\\n)*named logger survived "
+      "teardown(.|\\n)*late-created named logger survived teardown");
+}
+
+TEST(SpdlogLoggerTest, AsyncLoggingFallsBackWhenThreadPoolIsGone) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_EXIT(
+      {
+        auto& logger = getSpdlogLogger();
+        logger.configure("TEST", []() { return 0; }, {}, true);
+        logger.set_level(spdlog::level::info);
+        // Run shutdown in the logger library's translation unit. Sanitizer
+        // builds may link a separate spdlog registry into this test binary.
+        meta::comms::logger::shutdownSpdlogForFatal();
+
+        COMMS_LOG(WARN, "delivered after thread pool teardown");
+        // flush() must also fall back rather than posting to the dead pool.
+        logger.flush();
+        std::exit(0);
+      },
+      ::testing::ExitedWithCode(0),
+      "delivered after thread pool teardown");
 }
 
 TEST(SpdlogLoggerTest, FileOpenFailureIncludesPath) {


### PR DESCRIPTION
Summary:

XFN is blocked on the `uv` upgrade: RL sampler jobs crash at exit after
D114807334 moved comms logging from folly to spdlog.

Processes commonly terminate without calling `destroy_process_group`, so the
NCCL communicator is never aborted and its proxy, CollTrace, and watchdog
threads are never joined. Those threads keep calling `COMMS_LOG` while
`__cxa_atexit` destroys the function-local statics behind the logger. The
exiting thread frees the sinks; the surviving threads then dereference them.
The observed crash is `__cxa_pure_virtual` -> `std::terminate` inside
`spdlog::sinks::base_sink<std::mutex>::log()` -- a partially destroyed sink
whose vtable pointer has already been reset.

There are two independent teardown hazards, and both are fixed here.

**Destroyed logger state.** `getSpdlogLogger()`, the named-logger registry, and
the `PeriodicSinkFlusher` were function-local statics, so each registered an
exit-time destructor. Store them behind raw pointers instead: the singletons
are intentionally leaked, register no destructor, and therefore outlive every
thread that can reach them. The process is exiting, so the memory is reclaimed
by the OS. The `static const auto hostname` in `logFormatted` gets the same
treatment. The named-logger `mutex` and `map` move into one
`NamedLoggerRegistry` so they are leaked as a unit -- destroying the mutex alone
would strand any thread mid-lookup.

**Destroyed thread pool.** `spdlog`'s registry owns the shared async thread
pool and is itself a static, so the pool can be gone while our leaked loggers
are still live. Posting to it then throws `spdlog_ex("async log: thread pool
doesn't exist anymore")`. `COMMS_LOG_FATAL_IMPL` also calls
`spdlog::shutdown()` explicitly before its final message, reaching the same
state. Each `CommsSpdlogLogger` now keeps a `weak_ptr` to the pool it was
built against and `asyncDeliveryAvailable()` checks it; when the pool is gone,
delivery falls back to the synchronous logger, which owns its sinks outside
spdlog's registry. Messages logged during teardown are still written rather
than dropped or thrown.

The flush thread is the one thing that must stop early -- it cannot be running
while the C runtime closes its streams. `PeriodicFlushStopper` is registered
*after* the flusher it points at, so LIFO `atexit` ordering joins the flush
thread while every sink it can reach is still alive, without destroying the
flusher itself.

No public API or logging behavior changes.

Reviewed By: rmahidhar, snarayankh

Differential Revision: D117434191


