### PR TITLE
Fix spdlog exit-time race on abnormal teardown (#3806)

### DIFF
--- a/comms/utils/logger/LoggingFormat.cc
+++ b/comms/utils/logger/LoggingFormat.cc
@@ -57,7 +57,12 @@ struct LastErrorInfo {
   std::vector<std::string> lastErrorNativeStack;
 };
 
-static folly::Synchronized<LastErrorInfo> lastCommsError{};
+folly::Synchronized<LastErrorInfo>& getLastCommsErrorStorage() {
+  // Error callbacks remain reachable from logger threads during static
+  // destruction, so this storage must not register an exit-time destructor.
+  static auto* storage = new folly::Synchronized<LastErrorInfo>{};
+  return *storage;
+}
 } // Anonymous namespace
 
 namespace meta::comms::logger {
@@ -266,7 +271,7 @@ std::string NcclLogFormatter::formatMessage(
     // the call site's logErrorToScuba(), which runs after this formatter,
     // re-sets it when present, and a bare XLOG(ERR) correctly falls back to the
     // legacy per-frame chain.
-    auto lockedError = lastCommsError.wlock();
+    auto lockedError = getLastCommsErrorStorage().wlock();
     lockedError->lastErrorMessage = message.getMessage();
     lockedError->lastErrorNativeStack.clear();
   }
@@ -307,7 +312,7 @@ void logErrorToScuba(
 }
 
 void setLastError(const std::string& message, std::vector<std::string> stack) {
-  auto w = lastCommsError.wlock();
+  auto w = getLastCommsErrorStorage().wlock();
   w->lastErrorMessage = message;
   w->lastErrorNativeStack = std::move(stack);
 }
@@ -330,7 +335,7 @@ void logCommErrorToScuba(commResult_t code, const std::string& message) {
 std::string getLastCommsError() {
   std::ostringstream ss;
   {
-    auto lastCommsErrorRLocked = lastCommsError.rlock();
+    auto lastCommsErrorRLocked = getLastCommsErrorStorage().rlock();
     ss << lastCommsErrorRLocked->lastErrorMessage << "\nNCCL Stack trace:";
     // Prefer the native captured stack; fall back to the legacy per-frame
     // chain (still populated by v2_27/v2_29) when no native stack is present.
@@ -351,7 +356,8 @@ std::string getLastCommsError() {
 // LoggingFormat.h) -- v2_30/ctran use captureNativeErrorStack() +
 // setLastError().
 void appendErrorToStack(std::string error) {
-  lastCommsError.wlock()->lastErrorStack.push_back(std::move(error));
+  getLastCommsErrorStorage().wlock()->lastErrorStack.push_back(
+      std::move(error));
 }
 
 NcclLogFormatter::NcclLogFormatter(

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -4,7 +4,9 @@
 
 #include <sys/syscall.h>
 #include <unistd.h>
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdio>
 #include <cstring>
@@ -19,6 +21,7 @@
 
 #include <spdlog/async.h>
 #include <spdlog/details/periodic_worker.h>
+#include <spdlog/details/thread_pool.h>
 #include <spdlog/pattern_formatter.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/sink.h>
@@ -70,13 +73,118 @@ thread_local std::string threadName = "main";
 // logger and eventually re-enter the originating callback.
 thread_local bool errorCallbackInProgress = false;
 
+class CommsThreadPoolState final {
+ public:
+  class Lease final {
+   public:
+    Lease() = default;
+    Lease(
+        std::shared_lock<std::shared_mutex> lock,
+        std::shared_ptr<spdlog::details::thread_pool> threadPool)
+        : lock_(std::move(lock)), threadPool_(std::move(threadPool)) {}
+
+    explicit operator bool() const {
+      return threadPool_ != nullptr;
+    }
+
+    const std::shared_ptr<spdlog::details::thread_pool>& threadPool() const {
+      return threadPool_;
+    }
+
+   private:
+    // Destroy the strong reference before releasing the shared shutdown lock.
+    std::shared_lock<std::shared_mutex> lock_;
+    std::shared_ptr<spdlog::details::thread_pool> threadPool_;
+  };
+
+  CommsThreadPoolState()
+      : threadPool_{std::make_shared<spdlog::details::thread_pool>(
+            kAsyncQueueSize,
+            kAsyncThreadCount)} {}
+
+  Lease acquire() const {
+    if (stopping_.load(std::memory_order_acquire)) {
+      return {};
+    }
+    std::shared_lock lock{leaseMutex_};
+    if (stopping_.load(std::memory_order_acquire)) {
+      return {};
+    }
+    return {std::move(lock), threadPool_};
+  }
+
+  void stop() {
+    {
+      std::lock_guard lock{lifecycleMutex_};
+      stopping_.store(true, std::memory_order_release);
+    }
+    lifecycleCv_.notify_all();
+
+    // The exclusive lock rejects new leases and waits for existing calls to
+    // release theirs before destroying, draining, and joining the pool.
+    std::unique_lock lock{leaseMutex_};
+    auto threadPool = std::move(threadPool_);
+    threadPool.reset();
+  }
+
+  void waitForShutdownToStart() const {
+    std::unique_lock lock{lifecycleMutex_};
+    lifecycleCv_.wait(
+        lock, [this]() { return stopping_.load(std::memory_order_acquire); });
+  }
+
+ private:
+  std::atomic<bool> stopping_{false};
+  mutable std::mutex lifecycleMutex_;
+  mutable std::condition_variable lifecycleCv_;
+  mutable std::shared_mutex leaseMutex_;
+  std::shared_ptr<spdlog::details::thread_pool> threadPool_;
+};
+
+class CommsThreadPoolStopper final {
+ public:
+  explicit CommsThreadPoolStopper(CommsThreadPoolState& state)
+      : state_(state) {}
+  ~CommsThreadPoolStopper() {
+    state_.stop();
+  }
+
+  CommsThreadPoolStopper(const CommsThreadPoolStopper&) = delete;
+  CommsThreadPoolStopper& operator=(const CommsThreadPoolStopper&) = delete;
+  CommsThreadPoolStopper(CommsThreadPoolStopper&&) = delete;
+  CommsThreadPoolStopper& operator=(CommsThreadPoolStopper&&) = delete;
+
+ private:
+  CommsThreadPoolState& state_;
+};
+
+CommsThreadPoolState& getCommsThreadPoolState() {
+  static auto* state = new CommsThreadPoolState{};
+  static const CommsThreadPoolStopper stopper{*state};
+  return *state;
+}
+
+/*
+ * Deliberately leaked along with the logger-owned static state below. A process
+ * that exits without aborting its NCCL communicator leaves the proxy,
+ * CollTrace, and watchdog threads logging while __cxa_atexit runs, so a logger
+ * with a destructor would be freed out from under them. Leaking behind a
+ * pointer registers no destructor, so the object outlives every thread that can
+ * reach it.
+ */
 class PeriodicSinkFlusher final {
  public:
   PeriodicSinkFlusher()
-      : worker_{
+      : worker_{std::make_unique<spdlog::details::periodic_worker>(
             [this]() noexcept { flushRegisteredSinks(); },
-            kPeriodicFlushInterval} {}
-  ~PeriodicSinkFlusher() = default;
+            kPeriodicFlushInterval)} {}
+
+  // Joins the flush thread so it cannot touch sinks or stdio during exit. The
+  // flusher itself survives, so registerSink() from a running thread stays
+  // safe.
+  void stopFlushing() {
+    worker_.reset();
+  }
 
   void registerSink(const std::shared_ptr<spdlog::sinks::sink>& sink) {
     std::lock_guard lock{mutex_};
@@ -92,11 +200,6 @@ class PeriodicSinkFlusher final {
     }
     sinks_.push_back(sink);
   }
-
-  PeriodicSinkFlusher(const PeriodicSinkFlusher&) = delete;
-  PeriodicSinkFlusher& operator=(const PeriodicSinkFlusher&) = delete;
-  PeriodicSinkFlusher(PeriodicSinkFlusher&&) = delete;
-  PeriodicSinkFlusher& operator=(PeriodicSinkFlusher&&) = delete;
 
  private:
   void flushRegisteredSinks() noexcept {
@@ -124,12 +227,34 @@ class PeriodicSinkFlusher final {
 
   std::mutex mutex_;
   std::vector<std::weak_ptr<spdlog::sinks::sink>> sinks_;
-  spdlog::details::periodic_worker worker_;
+  // Declared last so it is joined before the state its callback reads.
+  std::unique_ptr<spdlog::details::periodic_worker> worker_;
+};
+
+// Stops the flush thread at exit without destroying the flusher it points at.
+class PeriodicFlushStopper final {
+ public:
+  explicit PeriodicFlushStopper(PeriodicSinkFlusher& flusher)
+      : flusher_(flusher) {}
+  ~PeriodicFlushStopper() {
+    flusher_.stopFlushing();
+  }
+
+  PeriodicFlushStopper(const PeriodicFlushStopper&) = delete;
+  PeriodicFlushStopper& operator=(const PeriodicFlushStopper&) = delete;
+  PeriodicFlushStopper(PeriodicFlushStopper&&) = delete;
+  PeriodicFlushStopper& operator=(PeriodicFlushStopper&&) = delete;
+
+ private:
+  PeriodicSinkFlusher& flusher_;
 };
 
 PeriodicSinkFlusher& getPeriodicSinkFlusher() {
-  static PeriodicSinkFlusher flusher;
-  return flusher;
+  static auto* flusher = new PeriodicSinkFlusher{};
+  // Constructed after the logger and spdlog registry, so atexit's LIFO order
+  // joins the flush thread before spdlog's exit-time teardown begins.
+  static const PeriodicFlushStopper stopper{*flusher};
+  return *flusher;
 }
 
 class ErrorCallbackGuard {
@@ -227,18 +352,56 @@ uint64_t getCurrentThreadId() {
   return threadId;
 }
 
-std::shared_ptr<spdlog::logger> createLogger(std::string name) {
-  if (!spdlog::thread_pool()) {
-    spdlog::init_thread_pool(kAsyncQueueSize, kAsyncThreadCount);
-  }
+struct NamedLoggerRegistry {
+  std::shared_mutex mutex;
+  std::map<std::string, std::unique_ptr<CommsSpdlogLogger>, std::less<>>
+      loggers;
+};
 
-  auto logger = spdlog::create_async_nb<spdlog::sinks::stderr_color_sink_mt>(
-      std::move(name));
+std::shared_ptr<spdlog::logger> createLogger(std::string name) {
+  auto threadPoolLease = getCommsThreadPoolState().acquire();
+  auto sink = std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
+  std::shared_ptr<spdlog::logger> logger;
+  if (threadPoolLease) {
+    logger = std::make_shared<spdlog::async_logger>(
+        std::move(name),
+        std::move(sink),
+        threadPoolLease.threadPool(),
+        spdlog::async_overflow_policy::overrun_oldest);
+  } else {
+    // A logger first referenced during exit cannot use the stopped async pool.
+    logger = std::make_shared<spdlog::logger>(std::move(name), std::move(sink));
+  }
   logger->set_formatter(makeFormatter());
   return logger;
 }
 
 } // namespace
+
+void shutdownSpdlogForFatal() {
+  getCommsThreadPoolState().stop();
+}
+
+namespace testing {
+
+bool holdAsyncThreadPoolLeaseForTesting(const std::function<void()>& callback) {
+  auto lease = getCommsThreadPoolState().acquire();
+  if (!lease) {
+    return false;
+  }
+  callback();
+  return true;
+}
+
+void waitForAsyncThreadPoolShutdownForTesting() {
+  getCommsThreadPoolState().waitForShutdownToStart();
+}
+
+bool asyncThreadPoolLeaseAvailableForTesting() {
+  return static_cast<bool>(getCommsThreadPoolState().acquire());
+}
+
+} // namespace testing
 
 bool shouldWriteCommsLogToStderr(std::string_view formattedMessage) {
   /*
@@ -256,9 +419,8 @@ CommsSpdlogLogger::CommsSpdlogLogger()
     : CommsSpdlogLogger(std::string{kCommsLoggerName}) {}
 
 CommsSpdlogLogger::CommsSpdlogLogger(std::string name)
-    : logger_(createLogger(std::move(name))),
-      outputSink_(
-          std::make_shared<spdlog::sinks::dist_sink_mt>(logger_->sinks())) {
+    : logger_(createLogger(std::move(name))) {
+  outputSink_ = std::make_shared<spdlog::sinks::dist_sink_mt>(logger_->sinks());
   logger_->sinks() = {outputSink_};
   synchronousLogger_ =
       std::make_shared<spdlog::logger>(logger_->name(), outputSink_);
@@ -283,7 +445,7 @@ void CommsLogStreamBase::log() {
 [[noreturn]] void CommsLogStreamBase::logFatalAndAbort() noexcept {
   try {
     logger_.flush();
-    spdlog::shutdown();
+    shutdownSpdlogForFatal();
     logger_.logFatal(location_, stream_.str());
   } catch (...) {
     abortAfterCommsLoggingFailure();
@@ -341,8 +503,13 @@ bool CommsSpdlogLogger::usesAsyncLogging() const {
 }
 
 void CommsSpdlogLogger::flush() {
-  logger_->flush();
-  if (!usesAsyncLogging()) {
+  // Once the async pool is gone, spdlog reports the failed post through its
+  // error handler and drops the flush, so use the synchronous path instead.
+  const auto threadPoolLease = getCommsThreadPoolState().acquire();
+  if (threadPoolLease) {
+    logger_->flush();
+  }
+  if (!usesAsyncLogging() || !threadPoolLease) {
     synchronousLogger_->flush();
   }
 }
@@ -449,7 +616,9 @@ void CommsSpdlogLogger::logFormatted(
     std::string_view levelName,
     std::string_view message,
     bool bypassLevelGate) {
-  static const auto hostname = getHostName();
+  // Leaked for the reason PeriodicSinkFlusher documents: threads that outlive
+  // exit-time destruction still format messages through here.
+  static const auto* hostname = new std::string{getHostName()};
   static const auto processId = getpid();
   const auto configuration = loadConfiguration();
   if (level >= spdlog::level::err && configuration->errorCallback &&
@@ -467,12 +636,13 @@ void CommsSpdlogLogger::logFormatted(
        getCurrentThreadId(),
        getBaseName(location.filename),
        static_cast<unsigned int>(location.line),
-       hostname,
+       *hostname,
        processId,
        configuration->threadContextFn(),
        threadName,
        configuration->prefix});
-  if (bypassLevelGate || !configuration->asyncLogging) {
+  const auto threadPoolLease = getCommsThreadPoolState().acquire();
+  if (bypassLevelGate || !configuration->asyncLogging || !threadPoolLease) {
     synchronousLogger_->log(location, level, formatted);
     synchronousLogger_->flush();
   } else {
@@ -481,30 +651,34 @@ void CommsSpdlogLogger::logFormatted(
 }
 
 CommsSpdlogLogger& getSpdlogLogger() {
-  static CommsSpdlogLogger logger;
-  return logger;
+  // Leaked; see PeriodicSinkFlusher for why nothing here may have a destructor.
+  static auto* logger = new CommsSpdlogLogger{};
+  return *logger;
 }
 
 CommsSpdlogLogger& getSpdlogLogger(std::string_view loggerName) {
   if (loggerName == kCommsLoggerName) {
     return getSpdlogLogger();
   }
-  static std::shared_mutex mutex;
-  static std::map<std::string, std::unique_ptr<CommsSpdlogLogger>, std::less<>>
-      loggers;
+  // Leaked as a unit: destroying the map would destroy every named logger, and
+  // destroying the mutex would strand any thread still looking one up.
+  static auto* registry = new NamedLoggerRegistry{};
   {
-    std::shared_lock lock{mutex};
-    if (const auto it = loggers.find(loggerName); it != loggers.end()) {
+    std::shared_lock lock{registry->mutex};
+    if (const auto it = registry->loggers.find(loggerName);
+        it != registry->loggers.end()) {
       return *it->second;
     }
   }
-  std::unique_lock lock{mutex};
-  if (const auto it = loggers.find(loggerName); it != loggers.end()) {
+  std::unique_lock lock{registry->mutex};
+  if (const auto it = registry->loggers.find(loggerName);
+      it != registry->loggers.end()) {
     return *it->second;
   }
   auto name = std::string{loggerName};
   auto logger = std::make_unique<CommsSpdlogLogger>(name);
-  const auto it = loggers.emplace(std::move(name), std::move(logger)).first;
+  const auto it =
+      registry->loggers.emplace(std::move(name), std::move(logger)).first;
   return *it->second;
 }
 

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -192,6 +192,7 @@ CommsSpdlogLogger& getSpdlogLogger(std::string_view loggerName);
 
 void reportCommsLoggingFailureToStderr(const char* level) noexcept;
 [[noreturn]] void abortAfterCommsLoggingFailure() noexcept;
+void shutdownSpdlogForFatal();
 CommsSpdlogLogger& getSpdlogLoggerForFatal(
     std::string_view loggerName) noexcept;
 
@@ -237,16 +238,16 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
   SPDLOG_LOGGER_CALL(logger, ::spdlog::level::debug, __VA_ARGS__)
 
 /*
- * shutdown() drains the async queue before the synchronous fatal message.
- * CommsSpdlogLogger owns that synchronous logger and its output sinks outside
- * spdlog's registry, so they remain valid after registry shutdown.
+ * shutdownSpdlogForFatal() releases the library-owned async pool. It drains
+ * once any in-flight log calls release their pool references; the synchronous
+ * logger and its output sinks remain valid throughout.
  */
 #define COMMS_LOG_FATAL_IMPL(logger_expression, ...)                 \
   do {                                                               \
     try {                                                            \
       auto& _comms_logger = (logger_expression);                     \
       _comms_logger.flush();                                         \
-      ::spdlog::shutdown();                                          \
+      ::meta::comms::logger::shutdownSpdlogForFatal();               \
       _comms_logger.logFatal(                                        \
           ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, \
           __VA_ARGS__);                                              \

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -5,7 +5,10 @@
 
 #include "comms/utils/logger/SpdlogLogger.h"
 
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
@@ -20,6 +23,12 @@
 #include "comms/utils/logger/CudaLog.h"
 
 using meta::comms::logger::getSpdlogLogger;
+
+namespace meta::comms::logger::testing {
+bool holdAsyncThreadPoolLeaseForTesting(const std::function<void()>& callback);
+void waitForAsyncThreadPoolShutdownForTesting();
+bool asyncThreadPoolLeaseAvailableForTesting();
+} // namespace meta::comms::logger::testing
 
 class ScopedTestFile {
  public:
@@ -388,6 +397,152 @@ TEST(SpdlogLoggerTest, ErrorCallbackExceptionDoesNotEscapeLogCall) {
   EXPECT_NO_THROW(COMMS_LOG_NAMED(kContext, ERR, "second error"));
   EXPECT_EQ(callbackCount, 2);
   logger.configure("TEST", []() { return 0; }, {});
+}
+
+/*
+ * Reproduces an exit without destroy_process_group: the communicator's threads
+ * are never joined, so they keep logging while static destructors run. The
+ * atexit handler is registered before the first getSpdlogLogger() call, so LIFO
+ * ordering runs it after everything the logging singletons would have
+ * destroyed.
+ */
+TEST(SpdlogLoggerTest, UnjoinedThreadCanLogDuringStaticDestruction) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_EXIT(
+      {
+        static std::atomic<bool> destructionStarted{false};
+        static std::atomic<bool> backgroundThreadDone{false};
+        constexpr std::string_view kNamedContext{"comms.teardown_test"};
+        constexpr std::string_view kLateNamedContext{
+            "comms.teardown_late_test"};
+
+        std::thread{[=]() {
+          while (!destructionStarted.load()) {
+            /* sleep override */
+            std::this_thread::sleep_for(std::chrono::milliseconds{1});
+          }
+          COMMS_LOG(WARN, "shared logger survived teardown");
+          COMMS_LOG_NAMED(
+              kNamedContext, WARN, "named logger survived teardown");
+          COMMS_LOG_NAMED(
+              kLateNamedContext,
+              WARN,
+              "late-created named logger survived teardown");
+          backgroundThreadDone.store(true);
+        }}.detach();
+
+        std::atexit([]() {
+          destructionStarted.store(true);
+          const auto deadline =
+              std::chrono::steady_clock::now() + std::chrono::seconds{5};
+          while (!backgroundThreadDone.load() &&
+                 std::chrono::steady_clock::now() < deadline) {
+            /* sleep override */
+            std::this_thread::sleep_for(std::chrono::milliseconds{1});
+          }
+        });
+
+        const auto configureForStderr = [](auto& logger) {
+          // Async configuration also exercises exit-time shutdown of the
+          // periodic sink flusher before the logging thread runs.
+          logger.configure("TEST", []() { return 0; }, {}, true);
+          logger.set_level(spdlog::level::info);
+        };
+        configureForStderr(getSpdlogLogger());
+        configureForStderr(getSpdlogLogger(kNamedContext));
+        std::exit(0);
+      },
+      ::testing::ExitedWithCode(0),
+      "shared logger survived teardown(.|\\n)*named logger survived "
+      "teardown(.|\\n)*late-created named logger survived teardown");
+}
+
+TEST(SpdlogLoggerTest, AsyncLoggingFallsBackWhenThreadPoolIsGone) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_EXIT(
+      {
+        auto& logger = getSpdlogLogger();
+        logger.configure("TEST", []() { return 0; }, {}, true);
+        logger.set_level(spdlog::level::info);
+        // Run shutdown in the logger library's translation unit. Sanitizer
+        // builds may link a separate spdlog registry into this test binary.
+        meta::comms::logger::shutdownSpdlogForFatal();
+
+        COMMS_LOG(WARN, "delivered after thread pool teardown");
+        // flush() must also fall back rather than posting to the dead pool.
+        logger.flush();
+        std::exit(0);
+      },
+      ::testing::ExitedWithCode(0),
+      "delivered after thread pool teardown");
+}
+
+TEST(SpdlogLoggerTest, ShutdownWaitsForActiveLeaseAndRejectsNewLeases) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_EXIT(
+      {
+        auto& logger = getSpdlogLogger();
+        logger.configure("TEST", []() { return 0; }, {}, true);
+        logger.set_level(spdlog::level::info);
+
+        std::mutex mutex;
+        std::condition_variable cv;
+        bool leaseHeld = false;
+        bool releaseLease = false;
+        std::atomic<bool> shutdownDone{false};
+
+        std::thread leaseHolder{[&]() {
+          const auto acquired =
+              meta::comms::logger::testing::holdAsyncThreadPoolLeaseForTesting(
+                  [&]() {
+                    std::unique_lock lock{mutex};
+                    leaseHeld = true;
+                    cv.notify_all();
+                    cv.wait(lock, [&]() { return releaseLease; });
+                  });
+          if (!acquired) {
+            std::_Exit(2);
+          }
+        }};
+
+        {
+          std::unique_lock lock{mutex};
+          if (!cv.wait_for(
+                  lock, std::chrono::seconds{5}, [&]() { return leaseHeld; })) {
+            std::_Exit(3);
+          }
+        }
+
+        std::thread shutdown{[&]() {
+          meta::comms::logger::shutdownSpdlogForFatal();
+          shutdownDone.store(true);
+        }};
+        meta::comms::logger::testing::
+            waitForAsyncThreadPoolShutdownForTesting();
+
+        if (shutdownDone.load()) {
+          std::_Exit(4);
+        }
+        if (meta::comms::logger::testing::
+                asyncThreadPoolLeaseAvailableForTesting()) {
+          std::_Exit(5);
+        }
+        COMMS_LOG(WARN, "synchronous log while shutdown waits for lease");
+
+        {
+          std::lock_guard lock{mutex};
+          releaseLease = true;
+        }
+        cv.notify_all();
+        leaseHolder.join();
+        shutdown.join();
+        if (!shutdownDone.load()) {
+          std::_Exit(6);
+        }
+        std::exit(0);
+      },
+      ::testing::ExitedWithCode(0),
+      "synchronous log while shutdown waits for lease");
 }
 
 TEST(SpdlogLoggerTest, FileOpenFailureIncludesPath) {


### PR DESCRIPTION
Summary:


XFN is blocked on the `uv` upgrade because RL sampler jobs crash at exit. D114807334 introduced the spdlog facade but did not redirect production logging; D116694639 is the strongest source-level regression point, exposed by D117312200's package bump, with D115583840 and D116380706 as earlier contributors.

Processes commonly terminate without calling `destroy_process_group`, leaving NCCL proxy, CollTrace, and watchdog threads running. Those threads continue calling `COMMS_LOG` while `__cxa_atexit` destroys logger state. The observed crash is `__cxa_pure_virtual` -> `std::terminate` inside `spdlog::sinks::base_sink<std::mutex>::log()`, consistent with a thread using a partially destroyed `dist_sink_mt`.

The fix closes the teardown lifetime hazards:

- `CommsSpdlogLogger`, the named-logger registry, the periodic flusher, the formatted-message hostname, and `lastCommsError` now use process-lifetime storage so surviving logger threads cannot access destroyed objects or synchronization primitives.
- Comms owns its async thread pool directly and constructs `spdlog::async_logger` without the global spdlog registry. This avoids duplicate-registry behavior and permits first-time named-logger construction during teardown.
- Async `log()` and `flush()` hold a strong pool reference across each operation, closing the availability-check TOCTOU. Once the pool is stopped, existing and newly created loggers deliver synchronously through the same sinks.
- Fatal shutdown stops the library-owned pool instead of invoking a caller translation unit's copy of `spdlog::shutdown()`. The fatal record itself remains synchronous.
- `PeriodicFlushStopper` joins the periodic worker before later exit-time teardown can invalidate sinks or stdio.

The intentionally retained allocations are bounded process-wide state and are reclaimed by the OS at process exit. There is no user-facing API or steady-state logging behavior change.

Reviewed By: rmahidhar, snarayankh

Differential Revision: D117434191


