### PR TITLE
Add Collective::AllToAll and its operation-trace constructor

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3458,9 +3458,9 @@ cvars:
    description : |-
      MCCL-native collective algorithm override. Use "none" or leave unset to
      preserve the collective's existing selection. Prefer qualified selectors
-     such as allreduce:tree or allreduce:ring; unqualified tree, ring, and
-     direct are accepted as AllReduce aliases for compatibility with the
-     initial AllReduce-only rollout.
+     such as allreduce:tree, allreduce:ring or alltoall:direct; unqualified
+     tree, ring, and direct are accepted as AllReduce aliases for compatibility
+     with the initial AllReduce-only rollout.
 
  - name        : MCCL_ALLREDUCE_IB_SIGNAL_BYTES
    type        : uint64_t


### PR DESCRIPTION
Summary:
Groundwork for an MCCL-hosted AllToAll built on the prims batched send/recv
executor landed in D116438928. Nothing selects it yet; this diff only makes the
selector expressible and the trace guard able to describe the operation.

`collectives::Collective` had no `AllToAll` member, so `MCCL_ALGO=alltoall:direct`
could not be parsed at all. Adds the enumerator, its `toString`/`fromString`
tokens (`alltoall`, `all_to_all`, `all-to-all`), and the `IAllToAll` /
`AllToAllAlgorithm` contract aliases that a concrete algorithm derives from.

`McclOperationTraceGuard` declared constructors for `AllReduceOpts`,
`ReduceScatterOpts` and `AllGatherOpts` only, so a dispatch site holding an
`AllToAllOpts` would not compile. Adds the matching constructor, scaling the
hash size by `nRanks` because `AllToAllOpts::numElements` is the per-peer chunk
-- the same convention AllGather and ReduceScatter already use.

That constructor computes its byte count through a new `checkedTraceBytes()`
helper rather than inline. A trace guard is constructed *before* the collective
validates its options, so it cannot assume either input is sane: an unsupported
datatype makes `commTypeSize()` return negative, and a large count overflows the
`int64_t` product, which is undefined behavior rather than merely a wrong
number. The helper saturates and reports 0 for a datatype the collective will
reject a few lines later.

`Gather` and `Scatter` are deliberately not added here. They land alongside
their first use so this diff carries no unused enumerators.

Differential Revision: D117463138


