### PR TITLE
Fix thread-name TLS teardown UAF (#3808)

### DIFF
--- a/comms/utils/logger/CommsLogFormatter.cc
+++ b/comms/utils/logger/CommsLogFormatter.cc
@@ -3,11 +3,39 @@
 #include "comms/utils/logger/CommsLogFormatter.h"
 
 #include <algorithm>
+#include <type_traits>
 
 #include <fmt/chrono.h>
 #include <fmt/format.h>
 
 namespace meta::comms::logger {
+namespace {
+
+/*
+ * Logging may continue after non-trivial TLS destructors have run. Constant
+ * initialization avoids dynamic initialization, while trivial destruction
+ * avoids registering a TLS destructor. Store the length to avoid scanning the
+ * buffer for every log line.
+ */
+struct LogThreadName {
+  char data[kMaxLogThreadNameLength + 1];
+  size_t size;
+};
+static_assert(std::is_trivially_destructible_v<LogThreadName>);
+
+thread_local LogThreadName logThreadName{"main", sizeof("main") - 1};
+
+} // namespace
+
+void setLogThreadName(std::string_view name) {
+  const auto size = name.copy(logThreadName.data, kMaxLogThreadNameLength);
+  logThreadName.data[size] = '\0';
+  logThreadName.size = size;
+}
+
+std::string_view getLogThreadName() {
+  return std::string_view{logThreadName.data, logThreadName.size};
+}
 
 std::string formatCommsLogMessage(
     std::string_view levelName,

--- a/comms/utils/logger/CommsLogFormatter.h
+++ b/comms/utils/logger/CommsLogFormatter.h
@@ -3,11 +3,27 @@
 #pragma once
 
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <string_view>
 
 namespace meta::comms::logger {
+
+/* Maximum number of bytes stored for a thread name. */
+inline constexpr size_t kMaxLogThreadNameLength = 63;
+
+/*
+ * Sets the current thread's name for comms log records. Longer names are
+ * truncated to kMaxLogThreadNameLength.
+ */
+void setLogThreadName(std::string_view name);
+
+/*
+ * Returns the current thread's log name, which defaults to "main". The returned
+ * view remains valid until the name changes or the thread exits.
+ */
+std::string_view getLogThreadName();
 
 struct CommsLogMetadata {
   std::chrono::system_clock::time_point timestamp;

--- a/comms/utils/logger/LoggingFormat.cc
+++ b/comms/utils/logger/LoggingFormat.cc
@@ -40,9 +40,18 @@ std::string getHostName(const char delim) {
 struct ProcMetaData {
   std::string hostname;
   int pid{};
-} procMetaData;
-folly::once_flag procMetaDataInitFlag;
-static thread_local std::string myThreadName = "main";
+  folly::once_flag initFlag;
+};
+
+ProcMetaData& getProcMetaData() {
+  /*
+   * Retain process metadata for the process lifetime because formatting may run
+   * during static destruction. Keeping the initialization guard here also
+   * prevents its destruction from racing with initialization.
+   */
+  static auto* metaData = new ProcMetaData{};
+  return *metaData;
+}
 
 struct LastErrorInfo {
   std::string lastErrorMessage;
@@ -194,11 +203,11 @@ std::string parseDebugFile(const char* ncclDebugFileEnv) {
             dfn,
             PATH_MAX + 1 - (dfn - debugFn),
             "%s",
-            procMetaData.hostname.c_str());
+            getProcMetaData().hostname.c_str());
         break;
       case 'p': // %p = pid
         dfn += snprintf(
-            dfn, PATH_MAX + 1 - (dfn - debugFn), "%d", procMetaData.pid);
+            dfn, PATH_MAX + 1 - (dfn - debugFn), "%d", getProcMetaData().pid);
         break;
       default: // Echo everything we don't understand
         *dfn++ = '%';
@@ -243,18 +252,16 @@ LogLevel getLoggerDebugLevel(std::string_view level) {
 }
 
 void initProcMetaData() {
-  folly::call_once(procMetaDataInitFlag, []() {
-    procMetaData.hostname = getHostName('.');
-    procMetaData.pid = getpid();
+  auto& metaData = getProcMetaData();
+  folly::call_once(metaData.initFlag, [&metaData]() {
+    metaData.hostname = getHostName('.');
+    metaData.pid = getpid();
   });
 }
 
 void initThreadMetaData(std::string_view threadName) {
   static thread_local folly::once_flag threadNameFlag;
-  folly::call_once(threadNameFlag, [&]() {
-    myThreadName = threadName;
-    setSpdlogThreadName(threadName);
-  });
+  folly::call_once(threadNameFlag, [&]() { setSpdlogThreadName(threadName); });
 }
 
 std::string NcclLogFormatter::formatMessage(
@@ -289,10 +296,10 @@ std::string NcclLogFormatter::formatMessage(
        .threadId = message.getThreadID(),
        .filename = std::string_view{basename.data(), basename.size()},
        .lineNumber = message.getLineNumber(),
-       .hostname = procMetaData.hostname,
-       .processId = procMetaData.pid,
+       .hostname = getProcMetaData().hostname,
+       .processId = getProcMetaData().pid,
        .threadContext = cudaDev,
-       .threadName = myThreadName,
+       .threadName = getLogThreadName(),
        .prefix = prefix_});
 }
 

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -68,7 +68,6 @@ constexpr size_t kAsyncThreadCount = 1;
  * recent lines only in the stdio buffer.
  */
 constexpr auto kPeriodicFlushInterval = std::chrono::seconds{1};
-thread_local std::string threadName = "main";
 // Guard the full callback chain so it cannot recurse through another context
 // logger and eventually re-enter the originating callback.
 thread_local bool errorCallbackInProgress = false;
@@ -639,7 +638,7 @@ void CommsSpdlogLogger::logFormatted(
        *hostname,
        processId,
        configuration->threadContextFn(),
-       threadName,
+       getLogThreadName(),
        configuration->prefix});
   const auto threadPoolLease = getCommsThreadPoolState().acquire();
   if (bypassLevelGate || !configuration->asyncLogging || !threadPoolLease) {
@@ -746,7 +745,7 @@ void configureCommsAndNamedSpdlogLoggers(
 }
 
 void setSpdlogThreadName(std::string_view name) {
-  threadName = name;
+  setLogThreadName(name);
 }
 
 } // namespace meta::comms::logger

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -20,6 +20,7 @@
 
 #include <gtest/gtest.h>
 
+#include "comms/utils/logger/CommsLogFormatter.h"
 #include "comms/utils/logger/CudaLog.h"
 
 using meta::comms::logger::getSpdlogLogger;
@@ -455,6 +456,44 @@ TEST(SpdlogLoggerTest, UnjoinedThreadCanLogDuringStaticDestruction) {
       ::testing::ExitedWithCode(0),
       "shared logger survived teardown(.|\\n)*named logger survived "
       "teardown(.|\\n)*late-created named logger survived teardown");
+}
+
+/*
+ * Exercises logging from an atexit handler after non-trivial TLS teardown. A
+ * maximum-length name prevents small-string optimization from hiding a
+ * lifetime error and verifies that the name remains intact.
+ */
+TEST(SpdlogLoggerTest, ExitingThreadCanLogFromAtexitAfterTlsTeardown) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_EXIT(
+      {
+        const std::string longThreadName(
+            meta::comms::logger::kMaxLogThreadNameLength, 'n');
+        meta::comms::logger::setSpdlogThreadName(longThreadName);
+
+        auto& logger = getSpdlogLogger();
+        logger.configure("TEST", []() { return 0; }, {}, true);
+        logger.set_level(spdlog::level::info);
+
+        std::atexit([]() {
+          COMMS_LOG(WARN, "logged from atexit on the exiting thread");
+        });
+        std::exit(0);
+      },
+      ::testing::ExitedWithCode(0),
+      "\\[n{63}\\].*logged from atexit on the exiting thread");
+}
+
+TEST(SpdlogLoggerTest, ThreadNameIsTruncatedToStorageCapacity) {
+  const std::string overlongName(
+      meta::comms::logger::kMaxLogThreadNameLength + 17, 'z');
+  meta::comms::logger::setSpdlogThreadName(overlongName);
+  EXPECT_EQ(
+      meta::comms::logger::getLogThreadName(),
+      std::string(meta::comms::logger::kMaxLogThreadNameLength, 'z'));
+
+  meta::comms::logger::setSpdlogThreadName("main");
+  EXPECT_EQ(meta::comms::logger::getLogThreadName(), "main");
 }
 
 TEST(SpdlogLoggerTest, AsyncLoggingFallsBackWhenThreadPoolIsGone) {


### PR DESCRIPTION
Summary:

Follow-up to D117434191, which made the comms logger singletons indestructible
so unjoined NCCL threads can keep logging while `__cxa_atexit` runs. That
covered the logger and its sinks, but `logFormatted()` still formatted every
message with a namespace-scope `thread_local std::string threadName`.

A thread destroys its own TLS *before* static and `atexit` destructors run.
Confirmed on this toolchain with a minimal probe:

```
main returning
DESTROY thread_local
ATEXIT handler
DESTROY static
```

Code in that phase still logs. `CtranIbSingleton::~CtranIbSingleton()` calls
`destroy()`, which emits `CTRAN_LOG(WARN, "CTRAN-IB: communicator {} are still
alive when CtranIbSingleton is destroyed.")` once per live communicator --
exactly the abnormal-teardown scenario D117434191 targets. Formatting that
warning reads `threadName` after its destructor has run, which is a
use-after-free as soon as the name outgrows the small-string buffer.

Move the thread name into `CommsLogFormatter` behind a trivially destructible
fixed buffer. Constant initialization means no dynamic initializer and no
`__cxa_thread_atexit` registration, so nothing is ever torn down and the
storage stays valid for the whole lifetime of the thread. Names longer than
`kMaxLogThreadNameLength` (63) are truncated; real thread names are far
shorter.

Both formatters now share that storage, so the Folly path's equivalent
`static thread_local std::string myThreadName` is deleted along with it and
`initThreadMetaData()` no longer keeps two copies in sync.

No public API or logging behavior changes: `setSpdlogThreadName()` keeps its
signature and delegates to the shared storage.

The copy uses `std::string_view::copy` rather than `memcpy`: it is bounded by
construction, has no null-source edge case, and keeps this `oss_cpp_library`
free of a `secure_lib` dependency that the OSS wheel build cannot satisfy.

**Reviewer follow-ups**

`static_assert(std::is_trivially_destructible_v<LogThreadName>)` makes the
load-bearing property checked rather than documented, and the comment now
separates the two independent invariants it had conflated: trivial
destructibility is what suppresses the `__cxa_thread_atexit` registration;
constant initialization is what removes the dynamic initializer.

`procMetaData` (`LoggingFormat.cc`) gets the same leak treatment. It is a
namespace-scope `std::string hostname` with a static destructor, read by
`NcclLogFormatter::formatMessage` on every line it formats, and `CLOGF` is
still `XLOGF` -- so it is the last destructible static on the Folly formatter
path. Its `folly::once_flag` is leaked with it so the guard cannot be destroyed
out from under a thread that is mid-initialization.

One correction to the review thread for the record: the `CtranIbSingleton`
teardown warning that motivates this stack does **not** read `procMetaData`.
`CTRAN_LOG(WARN, ...)` expands through `CtranLogger.h:29` to
`getSpdlogLogger("comms.ctran")`, i.e. the spdlog path, whose `hostname` was
already leaked by D117434191. `procMetaData` is reachable only via
`CLOGF`/`XLOGF`, so this is a latent hazard rather than a live one -- worth
closing because hostnames exceed the small-string buffer and cross-TU
destruction order is unspecified, but no demonstrated teardown caller exists
today.

Reviewed By: rmahidhar

Differential Revision: D117468895
