### PR TITLE
Give every build path a real CUDA architecture list

### DIFF
--- a/comms/ctran/CMakeLists.txt
+++ b/comms/ctran/CMakeLists.txt
@@ -15,13 +15,6 @@ if (NOT DEFINED ENABLE_TCPDM OR NOT ENABLE_TCPDM)
     list(FILTER CTRAN_SOURCES EXCLUDE REGEX ".*/ctran/backends/tcpdevmem/.*")
 endif()
 
-list(FILTER CMAKE_CUDA_FLAGS EXCLUDE REGEX ".*arch=compute_50,code=sm_50")
-list(FILTER CMAKE_CUDA_FLAGS EXCLUDE REGEX ".*arch=compute_60,code=sm_60")
-list(FILTER CMAKE_CUDA_FLAGS EXCLUDE REGEX ".*arch=compute_70,code=sm_70")
-list(FILTER CMAKE_CUDA_FLAGS EXCLUDE REGEX ".*arch=compute_75,code=sm_75")
-
-message(status "CMAKE_CUDA_FLAGS: ${CMAKE_CUDA_FLAGS}")
-
 # genctran.py generates source files (*.cu) for template instantiations across
 # different algorithms, data types, and operations.
 execute_process(


### PR DESCRIPTION
Summary:
`build_mccl.sh` already converts `TORCH_CUDA_ARCH_LIST` into
`-DCMAKE_CUDA_ARCHITECTURES`, but only for wheel builds. The iterative and
feedstock paths leave it unset, CMake falls back to its own default of `75`,
and every ctran/mccl TU compiles -- and device-links -- for `sm_75` on top of
the requested arch. Visible in CI as:

    -- prims CUDA_ARCHITECTURES: OFF (from CMAKE_CUDA_ARCHITECTURES=75)
    "--generate-code=arch=compute_75,code=[compute_75,sm_75]" ... -gencode=arch=compute_90a,code=sm_90a

This drops the wheel-only gate. The inner guard is kept, so a caller-supplied
`-DCMAKE_CUDA_ARCHITECTURES` still wins.

**Measured, not assumed.** Two CI runs of the same source, differing only in
this setting, both reaching `[708/712]` and stopping at the same pre-existing
link error (T286255802):

    arch=75 (today)   1h16m55s   min free 15.62 GiB   peak scratch 4.38 GiB
    arch=90a          43m35s     min free 16.34 GiB   peak scratch 3.66 GiB
                      -43%       +736 MiB             -16%

The case for landing this is **build time**, not disk. 43% is large and
unambiguous. The scratch improvement is real but both arms finished with 15+
GiB free on a 26 GiB tmpfs, so this run does not demonstrate it prevents the
ENOSPC failures -- those occurred on smaller workers not reproduced here.

Two honest caveats:

- The measurement moves two things at once. `comms/prims/CMakeLists.txt`
  filters only 5x-8x, so 90a survives and prims goes from
  `CUDA_ARCHITECTURES: OFF` to `90a`. The experiment therefore ADDS prims
  codegen while removing ctran/mccl's sm_75, which biases against the change:
  the 43% is a lower bound, not an inflated figure.
- n=1 per arm.

Also deletes the dead architecture filters in `comms/ctran/CMakeLists.txt`.
All four (`compute_50/60/70/75`) were inert for three independent reasons:
`CMAKE_CUDA_FLAGS` is a string not a list, so `list(FILTER)` could only drop
the whole element; the regexes do not match CMake's actual
`arch=compute_NN,code=[compute_NN,sm_NN]` emission; and the architecture comes
from the `CUDA_ARCHITECTURES` target property rather than the flags string. The
trailing `message(status ...)` used a lowercase mode string, so it never
printed as a status line and existed only to show the deleted filters' result.

**Blast radius.** `conda/feedstock/mccl/build.sh:20` invokes `build_mccl.sh`
with no wheel flag, so this changes feedstock behavior for the first time.

Differential Revision: D117526986


