### PR TITLE
Stop UniFlow's logger outliving its own pointer (#3811)

### DIFF
--- a/comms/uniflow/logging/Logger.cpp
+++ b/comms/uniflow/logging/Logger.cpp
@@ -2,6 +2,8 @@
 
 #include "comms/uniflow/logging/Logger.h"
 
+#include <memory>
+
 #include <spdlog/async.h>
 #include <spdlog/cfg/env.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
@@ -37,10 +39,44 @@ std::shared_ptr<spdlog::logger> createLogger() {
 }
 } // namespace
 
-// Thread-safe lazy initialization via C++11 "magic static".
+/*
+ * Thread-safe lazy initialization via C++11 "magic static", deliberately
+ * leaked. A process that exits without joining its worker threads leaves them
+ * logging while __cxa_atexit runs; a static shared_ptr would destroy the
+ * logger and its sink out from under them and hand every later caller a
+ * dangling pointer. Leaking behind a pointer registers no destructor, so the
+ * logger outlives every thread that can reach it. Same reasoning as
+ * comms/utils/logger/SpdlogLogger.cc.
+ *
+ * spdlog's registry still stops the shared thread pool at exit, so async
+ * delivery stops working at that point. Messages are then dropped rather than
+ * written through a destroyed sink: async_logger sees an expired weak_ptr to
+ * the pool and raises, which spdlog catches and routes to the logger's error
+ * handler -- by default a stderr line rate-limited to one per second, so the
+ * drop is reported but the record itself is lost.
+ */
 spdlog::logger* getLogger() {
-  static auto logger = createLogger();
-  return logger.get();
+  static auto* logger = new std::shared_ptr<spdlog::logger>{createLogger()};
+  return logger->get();
 }
+
+namespace testing {
+
+/*
+ * Reach spdlog's global registry from this library's own translation unit. A
+ * test cannot call spdlog::shutdown() or spdlog::thread_pool() for itself:
+ * spdlog is linked statically, so the test binary can hold its own copy of the
+ * registry's function-local static and would tear down or inspect a registry
+ * this logger never used -- passing without exercising anything.
+ */
+void shutdownRegistryForTesting() {
+  ::spdlog::shutdown();
+}
+
+bool globalThreadPoolAliveForTesting() {
+  return ::spdlog::thread_pool() != nullptr;
+}
+
+} // namespace testing
 
 } // namespace uniflow::logging

--- a/comms/uniflow/logging/tests/CMakeLists.txt
+++ b/comms/uniflow/logging/tests/CMakeLists.txt
@@ -8,3 +8,12 @@ target_link_libraries(LoggerTest
 target_compile_features(LoggerTest PUBLIC cxx_std_20)
 target_include_directories(LoggerTest PUBLIC ${ROOT})
 add_test(NAME LoggerTest COMMAND LoggerTest)
+
+# Separate binary: this one shuts spdlog's global registry down, which no other
+# test in the same process could survive logging after.
+add_executable(LoggerShutdownTest LoggerShutdownTest.cpp)
+target_link_libraries(LoggerShutdownTest
+    uniflow_logging spdlog::spdlog GTest::gtest_main)
+target_compile_features(LoggerShutdownTest PUBLIC cxx_std_20)
+target_include_directories(LoggerShutdownTest PUBLIC ${ROOT})
+add_test(NAME LoggerShutdownTest COMMAND LoggerShutdownTest)

--- a/comms/uniflow/logging/tests/LoggerShutdownTest.cpp
+++ b/comms/uniflow/logging/tests/LoggerShutdownTest.cpp
@@ -1,0 +1,93 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/logging/Logger.h"
+
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace uniflow::logging::testing {
+// Defined in Logger.cpp so they run against that translation unit's copy of
+// spdlog's statically-linked registry. Declared here rather than in Logger.h to
+// keep test-only entry points out of the public OSS header.
+void shutdownRegistryForTesting();
+bool globalThreadPoolAliveForTesting();
+} // namespace uniflow::logging::testing
+
+namespace {
+
+// The error handler can fire from the async worker thread while it drains.
+class ErrorLog {
+ public:
+  void record(const std::string& message) {
+    const std::lock_guard lock{mutex_};
+    messages_.push_back(message);
+  }
+
+  std::vector<std::string> messages() const {
+    const std::lock_guard lock{mutex_};
+    return messages_;
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  std::vector<std::string> messages_;
+};
+
+/*
+ * Shutting the registry down is process-global and irreversible, so this test
+ * gets its own binary: any later test that logged would hit the drop path below
+ * instead of the behavior it meant to check.
+ *
+ * Scope: this does NOT cover the deliberate leak in getLogger(). A leaked
+ * pointer and a plain function-local static both keep the logger alive for the
+ * whole process, and differ only in whether __cxa_atexit registers a
+ * destructor -- observable at exit, after this binary has already reported its
+ * results. What is covered is the contract that makes the leak worth having:
+ * reaching the logger once the pool is gone drops the message and reports it,
+ * instead of writing through a destroyed sink.
+ */
+TEST(LoggerShutdownTest, DropsAndReportsOnceThreadPoolIsGone) {
+  // Early return rather than ASSERT_NE: the null-safety analyzer does not read
+  // the gtest macro as a non-null proof for the dereferences below.
+  auto* const logger = uniflow::logging::getLogger();
+  if (logger == nullptr) {
+    ADD_FAILURE() << "getLogger() returned null";
+    return;
+  }
+  ASSERT_TRUE(uniflow::logging::testing::globalThreadPoolAliveForTesting());
+
+  ErrorLog errors;
+  logger->set_error_handler(
+      [&errors](const std::string& message) { errors.record(message); });
+
+  // SPDLOG_LOGGER_INFO on the checked pointer rather than UNIFLOW_LOG_INFO,
+  // which expands to another getLogger() call. Same compile-time gating, and it
+  // pins delivery to the instance whose lifetime this test is about.
+  SPDLOG_LOGGER_INFO(logger, "delivered while the pool is alive");
+  EXPECT_TRUE(errors.messages().empty());
+
+  uniflow::logging::testing::shutdownRegistryForTesting();
+  ASSERT_FALSE(uniflow::logging::testing::globalThreadPoolAliveForTesting());
+
+  // Registry shutdown drops its own reference to the logger; the logger itself
+  // outlives it, so callers still racing at exit get a live object.
+  EXPECT_EQ(uniflow::logging::getLogger(), logger);
+
+  SPDLOG_LOGGER_INFO(logger, "dropped once the pool is gone");
+  auto observed = errors.messages();
+  ASSERT_EQ(observed.size(), 1U);
+  EXPECT_NE(
+      observed[0].find("thread pool doesn't exist anymore"), std::string::npos);
+
+  // flush_() takes the same expired-weak_ptr branch as sink_it_().
+  logger->flush();
+  observed = errors.messages();
+  ASSERT_EQ(observed.size(), 2U);
+  EXPECT_NE(
+      observed[1].find("thread pool doesn't exist anymore"), std::string::npos);
+}
+
+} // namespace

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -378,11 +378,51 @@ std::shared_ptr<spdlog::logger> createLogger(std::string name) {
 
 } // namespace
 
+/*
+ * Stops the library-owned pool and nothing else. In particular it must not
+ * reach spdlog's global registry.
+ *
+ * spdlog::shutdown() would drain the registry pool that comms/uniflow/logging
+ * still rides, which is worth something -- but it gets there through
+ * registry::instance(), a function-local static. COMMS_LOG_FATAL can fire
+ * during static destruction, and once that singleton is gone the call is
+ * undefined behavior on the one path that must stay predictable. A narrow
+ * window, but the cost of losing it is an abort that misbehaves instead of
+ * aborting.
+ *
+ * Keeping the registry off this path is also the invariant comms already
+ * bought: comms loggers were moved off the registry onto their own pool and
+ * their own name map precisely so teardown answers to this translation unit.
+ * The price is that uniflow's queued messages do not survive the std::abort()
+ * below; the fix for that belongs on uniflow's side, as a synchronous fallback
+ * like the one this library has, not as a registry call from here.
+ */
 void shutdownSpdlogForFatal() {
   getCommsThreadPoolState().stop();
 }
 
 namespace testing {
+
+void addSinkForTesting(
+    CommsSpdlogLogger& logger,
+    std::shared_ptr<spdlog::sinks::sink> sink) {
+  logger.addSinkForTesting(std::move(sink));
+}
+
+/*
+ * Both of these touch spdlog's global registry from the logger library's own
+ * translation unit. A test cannot use spdlog::thread_pool() directly for this:
+ * the registry is header-only and under @mode/dev-asan the test binary holds a
+ * separate copy, so it would report on a registry shutdownSpdlogForFatal()
+ * never touches.
+ */
+void initGlobalThreadPoolForTesting() {
+  ::spdlog::init_thread_pool(kAsyncQueueSize, kAsyncThreadCount);
+}
+
+bool globalThreadPoolAliveForTesting() {
+  return ::spdlog::thread_pool() != nullptr;
+}
 
 bool holdAsyncThreadPoolLeaseForTesting(const std::function<void()>& callback) {
   auto lease = getCommsThreadPoolState().acquire();
@@ -505,11 +545,14 @@ bool CommsSpdlogLogger::usesAsyncLogging() const {
 void CommsSpdlogLogger::flush() {
   // Once the async pool is gone, spdlog reports the failed post through its
   // error handler and drops the flush, so use the synchronous path instead.
-  const auto threadPoolLease = getCommsThreadPoolState().acquire();
-  if (threadPoolLease) {
+  // The lease is released before that fallback for the reason logFormatted()
+  // documents: synchronous delivery must not hold a pool lease.
+  bool asyncFlushed = false;
+  if (const auto threadPoolLease = getCommsThreadPoolState().acquire()) {
     logger_->flush();
+    asyncFlushed = true;
   }
-  if (!usesAsyncLogging() || !threadPoolLease) {
+  if (!usesAsyncLogging() || !asyncFlushed) {
     synchronousLogger_->flush();
   }
 }
@@ -610,6 +653,12 @@ void CommsSpdlogLogger::configureOutput(std::string_view logFilePath) {
   outputSink_->set_sinks(std::move(sinks));
 }
 
+void CommsSpdlogLogger::addSinkForTesting(
+    std::shared_ptr<spdlog::sinks::sink> sink) {
+  sink->set_formatter(makeFormatter());
+  outputSink_->add_sink(std::move(sink));
+}
+
 void CommsSpdlogLogger::logFormatted(
     spdlog::source_loc location,
     spdlog::level::level_enum level,
@@ -641,13 +690,22 @@ void CommsSpdlogLogger::logFormatted(
        configuration->threadContextFn(),
        getLogThreadName(),
        configuration->prefix});
-  const auto threadPoolLease = getCommsThreadPoolState().acquire();
-  if (bypassLevelGate || !configuration->asyncLogging || !threadPoolLease) {
-    synchronousLogger_->log(location, level, formatted);
-    synchronousLogger_->flush();
-  } else {
-    logger_->log(location, level, formatted);
+  /*
+   * The lease only has to keep the pool alive across the async post, so it is
+   * scoped to that branch. acquire() takes a shared lock on leaseMutex_ that
+   * stop() -- called by shutdownSpdlogForFatal() and the exit-time stopper --
+   * takes exclusively, so holding the lease across synchronous delivery would
+   * make shutdown wait for the lease behind the sink write. Synchronous
+   * delivery no longer holds a pool lease, so that edge is gone.
+   */
+  if (!bypassLevelGate && configuration->asyncLogging) {
+    if (const auto threadPoolLease = getCommsThreadPoolState().acquire()) {
+      logger_->log(location, level, formatted);
+      return;
+    }
   }
+  synchronousLogger_->log(location, level, formatted);
+  synchronousLogger_->flush();
 }
 
 CommsSpdlogLogger& getSpdlogLogger() {

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -108,6 +108,11 @@ class CommsSpdlogLogger {
       bool asyncLogging = true);
   void configureOutput(std::string_view logFilePath);
 
+  // Test-only: appends to the dist sink so a test can observe delivery from
+  // inside the sink call, which is the only point where the lease scoping in
+  // logFormatted() is visible.
+  void addSinkForTesting(std::shared_ptr<spdlog::sinks::sink> sink);
+
  private:
   struct Configuration {
     std::string prefix{"COMMS"};
@@ -240,8 +245,11 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
   SPDLOG_LOGGER_CALL(logger, ::spdlog::level::trace, __VA_ARGS__)
 
 /*
- * shutdownSpdlogForFatal() releases the library-owned async pool. It drains
- * once any in-flight log calls release their pool references; the synchronous
+ * shutdownSpdlogForFatal() stops the library-owned async pool and nothing
+ * else. That pool drains once every in-flight async post releases its lease;
+ * synchronous delivery holds no lease. spdlog's global registry pool is left
+ * running on purpose: draining it means registry::instance(), which may
+ * already be gone when a FATAL fires during static destruction. The synchronous
  * logger and its output sinks remain valid throughout.
  */
 #define COMMS_LOG_FATAL_IMPL(logger_expression, ...)                 \

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -13,6 +13,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -22,6 +23,8 @@
 #include <vector>
 
 #include <gtest/gtest.h>
+#include <spdlog/async.h>
+#include <spdlog/sinks/sink.h>
 
 #include "comms/utils/logger/CommsLogFormatter.h"
 #include "comms/utils/logger/CudaLog.h"
@@ -32,7 +35,31 @@ namespace meta::comms::logger::testing {
 bool holdAsyncThreadPoolLeaseForTesting(const std::function<void()>& callback);
 void waitForAsyncThreadPoolShutdownForTesting();
 bool asyncThreadPoolLeaseAvailableForTesting();
+void addSinkForTesting(
+    CommsSpdlogLogger& logger,
+    std::shared_ptr<spdlog::sinks::sink> sink);
+void initGlobalThreadPoolForTesting();
+bool globalThreadPoolAliveForTesting();
 } // namespace meta::comms::logger::testing
+
+// Runs a callback from inside sink delivery, which is the only point at which
+// the thread-pool lease scoping in logFormatted() is observable.
+class CallbackSink final : public spdlog::sinks::sink {
+ public:
+  explicit CallbackSink(std::function<void()> onLog)
+      : onLog_{std::move(onLog)} {}
+
+  void log(const spdlog::details::log_msg& /* message */) override {
+    onLog_();
+  }
+  void flush() override {}
+  void set_pattern(const std::string& /* pattern */) override {}
+  void set_formatter(
+      std::unique_ptr<spdlog::formatter> /* formatter */) override {}
+
+ private:
+  std::function<void()> onLog_;
+};
 
 /*
  * Each instance owns a private directory. Concurrent copies of this binary --
@@ -615,6 +642,86 @@ TEST(SpdlogLoggerTest, ThreadNameIsTruncatedToStorageCapacity) {
 
   meta::comms::logger::setSpdlogThreadName("main");
   EXPECT_EQ(meta::comms::logger::getLogThreadName(), "main");
+}
+
+/*
+ * The thread-pool lease exists to keep the async pool alive across a post.
+ * acquire() takes a shared lock on leaseMutex_ that stop() takes exclusively,
+ * so holding the lease across synchronous delivery too would make
+ * shutdownSpdlogForFatal() -- and the exit-time stopper -- wait for the lease
+ * behind the sink write. Synchronous delivery no longer holds a pool lease.
+ * Deliver synchronously, run shutdown from another thread while still inside
+ * the sink, and require it to finish.
+ */
+TEST(SpdlogLoggerTest, ShutdownIsNotBlockedBySynchronousDelivery) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_EXIT(
+      {
+        auto& logger = getSpdlogLogger();
+        logger.configure(
+            "TEST", []() { return 0; }, {}, /*asyncLogging=*/false);
+        logger.set_level(spdlog::level::info);
+
+        std::atomic<bool> shutdownDone{false};
+        meta::comms::logger::testing::addSinkForTesting(
+            logger, std::make_shared<CallbackSink>([&]() {
+              std::thread shutdown{[&]() {
+                meta::comms::logger::shutdownSpdlogForFatal();
+                shutdownDone.store(true);
+              }};
+              const auto deadline =
+                  std::chrono::steady_clock::now() + std::chrono::seconds{10};
+              while (!shutdownDone.load() &&
+                     std::chrono::steady_clock::now() < deadline) {
+                /* sleep override */
+                std::this_thread::sleep_for(std::chrono::milliseconds{1});
+              }
+              if (!shutdownDone.load()) {
+                // Joining a blocked shutdown would hang rather than report.
+                shutdown.detach();
+                std::_Exit(2);
+              }
+              shutdown.join();
+            }));
+
+        COMMS_LOG(WARN, "synchronous delivery must not block shutdown");
+        std::exit(0);
+      },
+      ::testing::ExitedWithCode(0),
+      "synchronous delivery must not block shutdown");
+}
+
+/*
+ * The fatal path must not reach spdlog's global registry. spdlog::shutdown()
+ * gets there via registry::instance(), a function-local static, so a
+ * COMMS_LOG_FATAL raised during static destruction could touch it after it has
+ * been destroyed. Leaving the registry pool running is the observable proof
+ * that this path answers only to the library-owned pool.
+ *
+ * The registry is probed through the library's own translation unit on
+ * purpose. Calling spdlog::thread_pool() from here instead fails under
+ * @mode/dev-asan, where the test binary holds a separate copy of the
+ * header-only registry -- the same duplication that made an earlier teardown
+ * test in this file vacuous.
+ */
+TEST(SpdlogLoggerTest, FatalShutdownLeavesGlobalRegistryPoolAlone) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_EXIT(
+      {
+        namespace logger_testing = meta::comms::logger::testing;
+        logger_testing::initGlobalThreadPoolForTesting();
+        if (!logger_testing::globalThreadPoolAliveForTesting()) {
+          std::_Exit(2);
+        }
+        meta::comms::logger::shutdownSpdlogForFatal();
+        if (!logger_testing::globalThreadPoolAliveForTesting()) {
+          std::_Exit(3);
+        }
+        COMMS_LOG(WARN, "global registry pool untouched");
+        std::exit(0);
+      },
+      ::testing::ExitedWithCode(0),
+      "global registry pool untouched");
 }
 
 TEST(SpdlogLoggerTest, AsyncLoggingFallsBackWhenThreadPoolIsGone) {


### PR DESCRIPTION
Summary:

`uniflow::logging::getLogger()` returned `logger.get()` from a static
`shared_ptr`. A process that exits without joining its worker threads leaves
them logging while `__cxa_atexit` runs, so that static destroys the logger and
its sink out from under them and hands every later caller a dangling pointer --
the same use-after-destruction already fixed on the comms side. Leaked behind a
pointer, matching that fix: no destructor is registered, so the logger outlives
every thread that can reach it.

spdlog's registry still stops the shared thread pool at exit, so async delivery
stops working at that point. Messages are then dropped rather than written
through a destroyed sink: `async_logger` sees an expired `weak_ptr` to the pool
and raises, which spdlog catches and routes to the logger's error handler --
by default a stderr line rate-limited to one per second. The record is lost,
but the loss is reported rather than silent.

`LoggerShutdownTest` covers that contract: after the registry is shut down the
logger is still the same live object, and both a log call and a `flush()` reach
the error handler instead of a destroyed sink.

UniFlow has no synchronous fallback, so nothing carries those teardown-time
messages through. That gap is unchanged here and wants a fallback of the kind
the comms logger has.

No public API or steady-state logging behavior change.

Reviewed By: Scusemua

Differential Revision: D117519565


