### PR TITLE
[XCCL] Remove input output tensor size equality condition for all_to_all

### DIFF
--- a/comms/torchcomms/xccl/TorchCommXCCL.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCL.cpp
@@ -1728,11 +1728,6 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::all_to_all(
 
   // Validate all tensors
   for (int i = 0; i < comm_size_; ++i) {
-    if (input_tensor_list[i].numel() != output_tensor_list[i].numel())
-        [[unlikely]] {
-      throw std::runtime_error(
-          "Input and output tensor sizes must match for all_to_all");
-    }
     ensureTensorContiguous(input_tensor_list[i]);
     ensureTensorContiguous(output_tensor_list[i]);
   }


### PR DESCRIPTION
Recent changes in torchtitan test cases caused failures for MOE models using TorchComms backend. When get_spmd_backend() == "spmd_types", it goes through the _AllToAllUneven code path. Current implementation of TorchComms for all_to_all have conditions that does not allow uneven per-rank sizes in the list API.

This PR addresses the functional regression and also removes this extra checks to align with NCCL implementation.