### PR TITLE
Pipeline the single-group 2-active reduce-scatter so cross links run duplex (2.9x -> 3.7x)

### DIFF
--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
@@ -496,6 +496,178 @@ static ncclResult_t shardedRelayAllGather2Active(
 }
 
 /**
+ * Software-pipelined single-group 2-active sharded relay all-gather.
+ *
+ * Same logical collective and the same helper roles as
+ * shardedRelayAllGather2Active, but for nGroups == 1 -- where the active ranks
+ * and the helpers are disjoint sets -- the relay is tiled and pipelined so both
+ * directions of every cross link stay busy. See relayA2PipelineTiles() for why
+ * the two-group schedule cannot do that and what it costs.
+ *
+ * With T tiles and unit u = align(sendCount / ((H+1)*T + 1)):
+ *   sendBuff [0, H*T*u)   offload region; helper h owns [h*T*u, (h+1)*T*u),
+ *                         its tile t at h*T*u + t*u
+ *   sendBuff [H*T*u, sc)  direct region as T+1 chunks of u, the last absorbing
+ *                         the /((H+1)*T + 1) remainder and the alignment loss
+ *
+ * Group k, for k in [0, T]:
+ *   active   scatter tile k (k < T) to every helper, receive the partner's
+ *            tile k-1 (k > 0) from every helper straight into the gather slot,
+ *            and exchange direct chunk k over the active<->active link.
+ *   helper h receive tile k of each active's chunk into ping-pong buffer k%2,
+ *            forward buffer (k-1)%2 to the OTHER active.
+ *
+ * Every rank therefore posts exactly one send and one recv per link per group,
+ * which is also the best case for p2p channel assignment. The helper's staging
+ * is two units per active rather than the whole chunk, so a forwarded tile is
+ * still cache-resident when it is read back.
+ *
+ * Both in-place and out-of-place are supported: the gather slot never overlaps
+ * the send source.
+ */
+static ncclResult_t shardedRelayAllGather2ActivePipelined(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* sendCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nTiles,
+    size_t elementSize) {
+  const ShardedRelayRankConfig& cfg = configs[0];
+  const size_t sc = sendCounts[0];
+  const int H = numHelpers;
+  const int T = nTiles;
+  const size_t u =
+      ((sc / (static_cast<size_t>(H + 1) * T + 1)) / CHUNK_ALIGN_ELEMENTS) *
+      CHUNK_ALIGN_ELEMENTS;
+  if (u == 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t tileStride = static_cast<size_t>(T) * u;
+  const size_t directBase = static_cast<size_t>(H) * tileStride;
+  const size_t lastDirect = sc - directBase - tileStride;
+
+  // Diagonal: recvBuff[m*sc] = sendBuff, a no-op when in-place.
+  size_t gatherSlot = 0;
+  if (myActiveGroup == 0) {
+    const size_t diagSlot = static_cast<size_t>(cfg.myActiveIndex) * sc;
+    gatherSlot = static_cast<size_t>(1 - cfg.myActiveIndex) * sc;
+    char* diag = static_cast<char*>(recvBuffs[0]) + diagSlot * elementSize;
+    if (static_cast<const void*>(sendBuffs[0]) !=
+        static_cast<const void*>(diag)) {
+      cudaMemcpyAsync(
+          diag,
+          sendBuffs[0],
+          sc * elementSize,
+          cudaMemcpyDeviceToDevice,
+          stream);
+    }
+  }
+
+  // Helper staging: two ping-pong units per active source. Tiny by design, so a
+  // tile is forwarded out of cache rather than re-read from HBM.
+  char* hbuff = nullptr;
+  if (!cfg.isActiveRank) {
+    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+        kHelperScratchKeyBase,
+        static_cast<size_t>(cfg.nActiveRanks) * 2 * u * elementSize,
+        stream));
+    if (hbuff == nullptr) {
+      return ncclInternalError;
+    }
+  }
+
+  for (int k = 0; k <= T; k++) {
+    NCCLCHECK(ncclGroupStart());
+    if (cfg.isActiveRank) {
+      const char* sendbuff = static_cast<const char*>(sendBuffs[0]);
+      char* recvbuff = static_cast<char*>(recvBuffs[0]);
+      const int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      const size_t directOffset = directBase + static_cast<size_t>(k) * u;
+      const size_t directSize = (k < T) ? u : lastDirect;
+
+      if (k < T) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclSend(
+              sendbuff +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclSend(
+          sendbuff + directOffset * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+      if (k > 0) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclRecv(
+              recvbuff +
+                  (gatherSlot + static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k - 1) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclRecv(
+          recvbuff + (gatherSlot + directOffset) * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else {
+      if (k < T) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclRecv(
+              hbuff +
+                  (static_cast<size_t>(a) * 2 + static_cast<size_t>(k % 2)) *
+                      u * elementSize,
+              u,
+              datatype,
+              cfg.activeRanks[a],
+              comm,
+              stream));
+        }
+      }
+      if (k > 0) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclSend(
+              hbuff +
+                  (static_cast<size_t>(a) * 2 +
+                   static_cast<size_t>((k - 1) % 2)) *
+                      u * elementSize,
+              u,
+              datatype,
+              cfg.activeRanks[1 - a],
+              comm,
+              stream));
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+  }
+
+  return ncclSuccess;
+}
+
+/**
  * All-gather for > 2 active ranks (two-group scatter/forward relay).
  *
  * Every active SOURCE must deliver its sc elements to the A-1 other active
@@ -891,18 +1063,40 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
   if (rcclx::relay::selectAllGatherRoute(
           nActiveRanksPerGroup, numHelpers, nGroups, sendCounts, elementSize) ==
       rcclx::relay::AllGatherRoute::A2Relay) {
-    r = shardedRelayAllGather2Active(
-        sendBuffs2,
-        recvBuffs2,
-        sendCounts,
-        datatype,
-        comm,
-        stream,
-        configs,
-        myActiveGroup,
+    // A single-group call has the helpers to itself, so the scatter and the
+    // forward run on opposite directions of each cross link and can be
+    // software-pipelined into one duplex stream; relayA2PipelineTiles() returns
+    // 1 whenever that does not apply.
+    const int nTiles = rcclx::relay::relayA2PipelineTiles(
+        nActiveRanksPerGroup,
         numHelpers,
         nGroups,
+        rcclx::relay::relayMaxCount(sendCounts, nGroups),
         elementSize);
+    r = (nTiles > 1) ? shardedRelayAllGather2ActivePipelined(
+                           sendBuffs2,
+                           recvBuffs2,
+                           sendCounts,
+                           datatype,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           numHelpers,
+                           nTiles,
+                           elementSize)
+                     : shardedRelayAllGather2Active(
+                           sendBuffs2,
+                           recvBuffs2,
+                           sendCounts,
+                           datatype,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           numHelpers,
+                           nGroups,
+                           elementSize);
   } else {
     // A>2, or small A==2: flat scatter->forward relay (dual of reduce-scatter)
     // with a size-adaptive pure-direct small-size mode.

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
@@ -541,6 +541,173 @@ static ncclResult_t shardedRelayAllToAll2Active(
 }
 
 /**
+ * Software-pipelined single-group 2-active sharded relay all-to-all.
+ *
+ * Same logical collective and the same helper roles as
+ * shardedRelayAllToAll2Active, but for nGroups == 1 -- where the active ranks
+ * and the helpers are disjoint sets -- the relay is tiled and pipelined so both
+ * directions of every cross link stay busy. See relayA2PipelineTiles() for why
+ * the two-group schedule cannot do that and what it costs.
+ *
+ * With T tiles and unit u = align(segmentCount / ((H+1)*T + 1)), the exchange
+ * segment splits as:
+ *   [0, H*T*u)   offload region; helper h owns [h*T*u, (h+1)*T*u), its tile t
+ * at h*T*u + t*u [H*T*u, sc)  direct region as T+1 chunks of u, the last
+ * absorbing the
+ *                /((H+1)*T + 1) remainder and the alignment loss
+ *
+ * Group k, for k in [0, T]: the active rank scatters tile k (k < T) to every
+ * helper, receives the partner's tile k-1 (k > 0) from every helper straight
+ * into its receive segment, and exchanges direct chunk k over the
+ * active<->active link; helper h receives tile k of each active's chunk into
+ * ping-pong buffer k%2 and forwards buffer (k-1)%2 to the OTHER active rank.
+ *
+ * Every rank posts exactly one send and one recv per link per group. The
+ * helper's staging is two units per active rather than the whole chunk, so a
+ * forwarded tile is still cache-resident when it is read back.
+ *
+ * OUT-OF-PLACE ONLY, like every other all-to-all route.
+ */
+static ncclResult_t shardedRelayAllToAll2ActivePipelined(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* segmentCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nTiles,
+    size_t elementSize) {
+  const ShardedRelayRankConfig& cfg = configs[0];
+  const size_t sc = segmentCounts[0];
+  const int H = numHelpers;
+  const int T = nTiles;
+  const size_t u =
+      ((sc / (static_cast<size_t>(H + 1) * T + 1)) / CHUNK_ALIGN_ELEMENTS) *
+      CHUNK_ALIGN_ELEMENTS;
+  if (u == 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t tileStride = static_cast<size_t>(T) * u;
+  const size_t directBase = static_cast<size_t>(H) * tileStride;
+  const size_t lastDirect = sc - directBase - tileStride;
+
+  // Diagonal: recvSeg[m] = sendSeg[m].
+  size_t exchangeSegOffset = 0;
+  if (myActiveGroup == 0) {
+    const size_t diagOffset = static_cast<size_t>(cfg.myActiveIndex) * sc;
+    exchangeSegOffset = static_cast<size_t>(1 - cfg.myActiveIndex) * sc;
+    cudaMemcpyAsync(
+        static_cast<char*>(recvBuffs[0]) + diagOffset * elementSize,
+        static_cast<const char*>(sendBuffs[0]) + diagOffset * elementSize,
+        sc * elementSize,
+        cudaMemcpyDeviceToDevice,
+        stream);
+  }
+
+  // Helper staging: two ping-pong units per active source.
+  char* hbuff = nullptr;
+  if (!cfg.isActiveRank) {
+    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+        kHelperScratchKeyBase,
+        static_cast<size_t>(cfg.nActiveRanks) * 2 * u * elementSize,
+        stream));
+    if (hbuff == nullptr) {
+      return ncclInternalError;
+    }
+  }
+
+  for (int k = 0; k <= T; k++) {
+    NCCLCHECK(ncclGroupStart());
+    if (cfg.isActiveRank) {
+      const char* sendSeg = static_cast<const char*>(sendBuffs[0]) +
+          exchangeSegOffset * elementSize;
+      char* recvSeg =
+          static_cast<char*>(recvBuffs[0]) + exchangeSegOffset * elementSize;
+      const int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      const size_t directOffset = directBase + static_cast<size_t>(k) * u;
+      const size_t directSize = (k < T) ? u : lastDirect;
+
+      if (k < T) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclSend(
+              sendSeg +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclSend(
+          sendSeg + directOffset * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+      if (k > 0) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclRecv(
+              recvSeg +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k - 1) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclRecv(
+          recvSeg + directOffset * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else {
+      if (k < T) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclRecv(
+              hbuff +
+                  (static_cast<size_t>(a) * 2 + static_cast<size_t>(k % 2)) *
+                      u * elementSize,
+              u,
+              datatype,
+              cfg.activeRanks[a],
+              comm,
+              stream));
+        }
+      }
+      if (k > 0) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclSend(
+              hbuff +
+                  (static_cast<size_t>(a) * 2 +
+                   static_cast<size_t>((k - 1) % 2)) *
+                      u * elementSize,
+              u,
+              datatype,
+              cfg.activeRanks[1 - a],
+              comm,
+              stream));
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+  }
+
+  return ncclSuccess;
+}
+
+/**
  * A=4 no-pack XOR/Latin relay path.
  *
  * Each off-diagonal segment stays in place and is split into contiguous
@@ -915,18 +1082,40 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
   const rcclx::relay::AllToAllRoute route = rcclx::relay::selectAllToAllRoute(
       nActiveRanksPerGroup, numHelpers, nGroups, segmentCounts, elementSize);
   if (route == rcclx::relay::AllToAllRoute::A2Relay) {
-    r = shardedRelayAllToAll2Active(
-        sendBuffs2,
-        recvBuffs2,
-        segmentCounts,
-        datatype,
-        comm,
-        stream,
-        configs,
-        myActiveGroup,
+    // A single-group call has the helpers to itself, so the scatter and the
+    // forward run on opposite directions of each cross link and can be
+    // software-pipelined into one duplex stream; relayA2PipelineTiles() returns
+    // 1 whenever that does not apply.
+    const int nTiles = rcclx::relay::relayA2PipelineTiles(
+        nActiveRanksPerGroup,
         numHelpers,
         nGroups,
+        rcclx::relay::relayMaxCount(segmentCounts, nGroups),
         elementSize);
+    r = (nTiles > 1) ? shardedRelayAllToAll2ActivePipelined(
+                           sendBuffs2,
+                           recvBuffs2,
+                           segmentCounts,
+                           datatype,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           numHelpers,
+                           nTiles,
+                           elementSize)
+                     : shardedRelayAllToAll2Active(
+                           sendBuffs2,
+                           recvBuffs2,
+                           segmentCounts,
+                           datatype,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           numHelpers,
+                           nGroups,
+                           elementSize);
   } else if (route == rcclx::relay::AllToAllRoute::A4XorRelay) {
     r = shardedRelayAllToAllA4XorRelay(
         sendBuffs2,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
@@ -565,9 +565,8 @@ static ncclResult_t shardedRelayAllToAllA4XorRelay(
   A4RelayTask tasks[SHARDED_RELAY_MAX_GROUPS][A4_RELAY_TASKS];
 
   for (int g = 0; g < nGroups; g++) {
-    const size_t third = segmentCounts[g] / 3;
-    directACounts[g] = third;
     relayCounts[g] = rcclx::relay::allToAllA4RelayCount(segmentCounts[g]);
+    directACounts[g] = relayCounts[g];
     directBCounts[g] = segmentCounts[g] - directACounts[g] - relayCounts[g];
     if (!buildA4RelayTasks(configs[g], tasks[g])) {
       return ncclInvalidArgument;
@@ -810,7 +809,8 @@ static ncclResult_t shardedRelayAllToAllFlat(
  *
  * nActiveRanksPerGroup must be a power of two (2 or 4). A==2 selects its direct
  * or dedicated 6-helper relay schedule by size. A==4 uses the deterministic
- * XOR/Latin helper schedule in its retained window and exact direct otherwise.
+ * XOR/Latin helper schedule from its lower size bound up, and exact direct
+ * below it.
  */
 HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
     const void* const* sendBuffs,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.h
@@ -29,10 +29,10 @@
  * nActiveRanksPerGroup must be a power of two (2 or 4). A==2 selects between
  * the exact direct exchange at small sizes and the original 2-active
  * passthrough relay with 6 dedicated helpers. A==4 with 4
- * helpers uses the no-pack XOR/Latin relay when the common maximum per-active-
- * rank input size, A * max(segmentCounts) * elementSize, is in [63 MiB,
- * 256 MiB) and every group count is positive. Other A==4 calls use the exact
- * pure-direct all-to-all. OUT-OF-PLACE ONLY in all cases.
+ * helpers uses the no-pack XOR/Latin relay once the common maximum per-active-
+ * rank input size, A * max(segmentCounts) * elementSize, reaches 27 MiB (fused)
+ * or 9 MiB (independent) and every group count is positive. Smaller A==4 calls
+ * use the exact pure-direct all-to-all. OUT-OF-PLACE ONLY in all cases.
  *
  * Unlike allreduce/reduce-scatter, all-to-all performs NO reduction — it is
  * pure data movement — so no reduction kernels are used and there is no

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -988,6 +988,223 @@ static ncclResult_t shardedRelayAllReduce2Active(
 }
 
 /**
+ * Software-pipelined single-group 2-active sharded relay allreduce.
+ *
+ * Same logical collective and the same reduce-at-helper as
+ * shardedRelayAllReduce2Active, but for nGroups == 1 -- where the active ranks
+ * and the helpers are disjoint sets -- the relay is tiled and pipelined so both
+ * directions of every cross link stay busy. See relayA2PipelineTiles() for why
+ * the two-group schedule cannot do that and what it costs.
+ *
+ * With T tiles and unit u = align(count / ((H+1)*T + 1)):
+ *   [0, H*T*u)     relay region; helper h owns [h*T*u, (h+1)*T*u), its tile t
+ * at h*T*u + t*u [H*T*u, count) direct region as T+1 chunks of u, the last
+ * absorbing the
+ *                  /((H+1)*T + 1) remainder and the alignment loss
+ *
+ * Group k, for k in [0, T]: the active rank scatters tile k (k < T) to every
+ * helper, receives helper h's REDUCED tile k-1 (k > 0) straight into its final
+ * place in recvBuff, and exchanges direct chunk k over the active<->active
+ * link. Helper h receives tile k into ping-pong buffer k%2 and forwards the
+ * already reduced buffer (k-1)%2 to both active ranks.
+ *
+ * The helper's reduce of tile k is issued between group k, which receives it,
+ * and group k+1, which sends it -- so it is one launch per tile over u elements
+ * instead of one over the whole chunk. Both active ranks send the same logical
+ * tile index, so their sum is already the final allreduced value and the return
+ * hop stays one chunk per active rank.
+ *
+ * Both in-place and out-of-place are supported. The relay region cannot alias
+ * dangerously even in place: group k reads tile k from sendBuff while writing
+ * tile k-1 into recvBuff, which are different offsets.
+ */
+static ncclResult_t shardedRelayAllReduce2ActivePipelined(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* counts,
+    ncclDataType_t datatype,
+    int reductionDivisor,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nTiles,
+    size_t elementSize) {
+  const ShardedRelayRankConfig& cfg = configs[0];
+  const size_t count = counts[0];
+  const int H = numHelpers;
+  const int T = nTiles;
+  const size_t u =
+      ((count / (static_cast<size_t>(H + 1) * T + 1)) / CHUNK_ALIGN_ELEMENTS) *
+      CHUNK_ALIGN_ELEMENTS;
+  if (u == 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t tileStride = static_cast<size_t>(T) * u;
+  const size_t directBase = static_cast<size_t>(H) * tileStride;
+  const size_t directTotal = count - directBase;
+  const size_t lastDirect = directTotal - tileStride;
+
+  // In-place must stage the received direct chunks so the local contribution is
+  // still readable when the fused reduce runs; out-of-place lands them straight
+  // in recvBuff and reduces against sendBuff.
+  void* directScratch = nullptr;
+  const bool isInPlace = (myActiveGroup == 0) && (sendBuffs[0] == recvBuffs[0]);
+  if (myActiveGroup == 0 && isInPlace) {
+    directScratch = ScratchBufferCache::getInstance().get(
+        0, directTotal * elementSize, stream);
+    if (directScratch == nullptr) {
+      return ncclInternalError;
+    }
+  }
+  auto directDst = [&](size_t offsetWithinDirect) -> char* {
+    if (isInPlace) {
+      return static_cast<char*>(directScratch) +
+          offsetWithinDirect * elementSize;
+    }
+    return static_cast<char*>(recvBuffs[0]) +
+        (directBase + offsetWithinDirect) * elementSize;
+  };
+
+  // Helper staging: two ping-pong slot pairs, one pair per pipeline stage in
+  // flight. Small enough that a tile is reduced and forwarded out of cache.
+  char* hbuff = nullptr;
+  if (!cfg.isActiveRank) {
+    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+        kHelperScratchKeyBase,
+        static_cast<size_t>(cfg.nActiveRanks) * 2 * u * elementSize,
+        stream));
+    if (hbuff == nullptr) {
+      return ncclInternalError;
+    }
+  }
+  // Slot for active source a of the buffer that stage k uses.
+  auto helperSlot = [&](int a, int k) -> char* {
+    return hbuff +
+        (static_cast<size_t>(a) * 2 + static_cast<size_t>(k % 2)) * u *
+        elementSize;
+  };
+
+  for (int k = 0; k <= T; k++) {
+    NCCLCHECK(ncclGroupStart());
+    if (cfg.isActiveRank) {
+      const char* sendbuff = static_cast<const char*>(sendBuffs[0]);
+      char* recvbuff = static_cast<char*>(recvBuffs[0]);
+      const int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      const size_t directOffset = static_cast<size_t>(k) * u;
+      const size_t directSize = (k < T) ? u : lastDirect;
+
+      if (k < T) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclSend(
+              sendbuff +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclSend(
+          sendbuff + (directBase + directOffset) * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+      if (k > 0) {
+        // Already reduced by the helper, so this is its final value.
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclRecv(
+              recvbuff +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k - 1) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclRecv(
+          directDst(directOffset),
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else {
+      if (k < T) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclRecv(
+              helperSlot(a, k), u, datatype, cfg.activeRanks[a], comm, stream));
+        }
+      }
+      if (k > 0) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclSend(
+              helperSlot(0, k - 1),
+              u,
+              datatype,
+              cfg.activeRanks[a],
+              comm,
+              stream));
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+
+    // Reduce the tile this group received, before the next group forwards it.
+    if (!cfg.isActiveRank && k < T) {
+      DISPATCH_FUSED_REDUCE(
+          datatype,
+          helperSlot(0, k),
+          helperSlot(0, k),
+          helperSlot(1, k),
+          u,
+          reductionDivisor,
+          stream);
+    }
+  }
+
+  // Fold both received direct chunks in one fused pass; they are adjacent in
+  // recvBuff and in the scratch.
+  if (myActiveGroup == 0 && directTotal > 0) {
+    char* dst = static_cast<char*>(recvBuffs[0]) + directBase * elementSize;
+    if (isInPlace) {
+      if (reductionDivisor > 1) {
+        DISPATCH_INCREMENTAL_ADD_AND_SCALE(
+            datatype,
+            dst,
+            directScratch,
+            directTotal,
+            reductionDivisor,
+            stream);
+      } else {
+        DISPATCH_INCREMENTAL_ADD(
+            datatype, dst, directScratch, directTotal, stream);
+      }
+    } else {
+      DISPATCH_FUSED_REDUCE(
+          datatype,
+          dst,
+          static_cast<const char*>(sendBuffs[0]) + directBase * elementSize,
+          dst,
+          directTotal,
+          reductionDivisor,
+          stream);
+    }
+  }
+
+  return ncclSuccess;
+}
+
+/**
  * AllReduce for > 2 active ranks (flat helper-reduce-AND-broadcast). Combines
  * the two patterns that individually beat NCCL at 4-active: the
  * reduce-AT-helper of the flat reduce-scatter and the broadcast-AT-helper of
@@ -1384,19 +1601,47 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
 
   ncclResult_t r;
   if (nActiveRanksPerGroup == 2) {
-    r = shardedRelayAllReduce2Active(
-        sendBuffs2,
-        recvBuffs2,
-        counts,
-        datatype,
-        reductionDivisor,
-        comm,
-        stream,
-        configs,
-        myActiveGroup,
-        numHelpers,
-        nGroups,
-        elementSize);
+    // A single-group relay call has the helpers to itself, so the scatter and
+    // the reduced forward run on opposite directions of each cross link and can
+    // be software-pipelined into one duplex stream. relayA2PipelineTiles()
+    // returns 1 whenever that does not apply, and the small-message pure-direct
+    // route (owned by shardedRelayAllReduce2Active) never pipelines.
+    const int nTiles =
+        (rcclx::relay::selectAllReduceRoute(2, nGroups, counts, elementSize) ==
+         rcclx::relay::AllReduceRoute::A2Relay)
+        ? rcclx::relay::relayA2PipelineTiles(
+              2,
+              numHelpers,
+              nGroups,
+              rcclx::relay::relayMaxCount(counts, nGroups),
+              elementSize)
+        : 1;
+    r = (nTiles > 1) ? shardedRelayAllReduce2ActivePipelined(
+                           sendBuffs2,
+                           recvBuffs2,
+                           counts,
+                           datatype,
+                           reductionDivisor,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           numHelpers,
+                           nTiles,
+                           elementSize)
+                     : shardedRelayAllReduce2Active(
+                           sendBuffs2,
+                           recvBuffs2,
+                           counts,
+                           datatype,
+                           reductionDivisor,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           numHelpers,
+                           nGroups,
+                           elementSize);
   } else {
     // A>2: flat helper-reduce-and-broadcast (direct RS+AG over intra woven with
     // offload reduce+broadcast through the helpers).

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -1022,6 +1022,199 @@ static ncclResult_t shardedRelayReduceScatter2Active(
 }
 
 /**
+ * Software-pipelined single-group 2-active sharded relay reduce-scatter.
+ *
+ * Same logical collective and the same passthrough helpers as
+ * shardedRelayReduceScatter2Active, but for nGroups == 1 -- where the active
+ * ranks and the helpers are disjoint sets -- the relay is tiled and pipelined
+ * so both directions of every cross link stay busy. See relayA2PipelineTiles()
+ * for why the two-group schedule cannot do that and what it costs.
+ *
+ * Helpers stay pure passthrough here, unlike allreduce: slot 0 is a0's
+ * contribution to a1's output and slot 1 is a1's contribution to a0's output --
+ * different outputs, so there is nothing to sum at the helper. The active rank
+ * reduces once at the end, and foreignScratch still mirrors the output layout
+ * so that stays a single fused launch no matter how many tiles the relay used.
+ *
+ * With T tiles and unit u = align(recvCount / ((H+1)*T + 1)), the block shipped
+ * to the other active rank splits as:
+ *   [0, H*T*u)         relay region; helper h owns [h*T*u, (h+1)*T*u), its tile
+ *                      t at h*T*u + t*u
+ *   [H*T*u, recvCount) direct region as T+1 chunks of u, the last absorbing the
+ *                      /((H+1)*T + 1) remainder and the alignment loss
+ *
+ * Group k, for k in [0, T]: the active rank scatters tile k (k < T) to every
+ * helper, receives tile k-1 (k > 0) of the partner's contribution from every
+ * helper into the matching offset of foreignScratch, and exchanges direct chunk
+ * k over the active<->active link; helper h receives tile k of each active's
+ * chunk into ping-pong buffer k%2 and forwards buffer (k-1)%2 to the active
+ * rank that owns it.
+ */
+static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* recvCounts,
+    ncclDataType_t datatype,
+    int reductionDivisor,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nTiles,
+    size_t elementSize) {
+  const ShardedRelayRankConfig& cfg = configs[0];
+  const size_t recvcount = recvCounts[0];
+  const int H = numHelpers;
+  const int T = nTiles;
+  const size_t u = ((recvcount / (static_cast<size_t>(H + 1) * T + 1)) /
+                    CHUNK_ALIGN_ELEMENTS) *
+      CHUNK_ALIGN_ELEMENTS;
+  if (u == 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t tileStride = static_cast<size_t>(T) * u;
+  const size_t directBase = static_cast<size_t>(H) * tileStride;
+  const size_t lastDirect = recvcount - directBase - tileStride;
+
+  // Scratch mirroring the output block, so the whole reduction is one launch.
+  void* foreignScratch = nullptr;
+  size_t ownBlockOffset = 0;
+  size_t sendBlockOffset = 0;
+  bool isInPlace = false;
+  if (myActiveGroup == 0) {
+    ownBlockOffset = static_cast<size_t>(cfg.myActiveIndex) * recvcount;
+    sendBlockOffset = static_cast<size_t>(1 - cfg.myActiveIndex) * recvcount;
+    const char* ownBlock =
+        static_cast<const char*>(sendBuffs[0]) + ownBlockOffset * elementSize;
+    isInPlace =
+        (static_cast<const void*>(recvBuffs[0]) ==
+         static_cast<const void*>(ownBlock));
+    foreignScratch = ScratchBufferCache::getInstance().get(
+        SHARDED_RELAY_MAX_GROUPS, recvcount * elementSize, stream);
+    if (foreignScratch == nullptr) {
+      return ncclInternalError;
+    }
+  }
+
+  // Helper staging: two ping-pong units per active source.
+  char* hbuff = nullptr;
+  if (!cfg.isActiveRank) {
+    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+        kHelperScratchKeyBase,
+        static_cast<size_t>(cfg.nActiveRanks) * 2 * u * elementSize,
+        stream));
+    if (hbuff == nullptr) {
+      return ncclInternalError;
+    }
+  }
+  auto helperSlot = [&](int a, int k) -> char* {
+    return hbuff +
+        (static_cast<size_t>(a) * 2 + static_cast<size_t>(k % 2)) * u *
+        elementSize;
+  };
+
+  for (int k = 0; k <= T; k++) {
+    NCCLCHECK(ncclGroupStart());
+    if (cfg.isActiveRank) {
+      const char* sendBlock = static_cast<const char*>(sendBuffs[0]) +
+          sendBlockOffset * elementSize;
+      char* scratch = static_cast<char*>(foreignScratch);
+      const int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      const size_t directOffset = directBase + static_cast<size_t>(k) * u;
+      const size_t directSize = (k < T) ? u : lastDirect;
+
+      if (k < T) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclSend(
+              sendBlock +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclSend(
+          sendBlock + directOffset * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+      if (k > 0) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclRecv(
+              scratch +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k - 1) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclRecv(
+          scratch + directOffset * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else {
+      if (k < T) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclRecv(
+              helperSlot(a, k), u, datatype, cfg.activeRanks[a], comm, stream));
+        }
+      }
+      if (k > 0) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclSend(
+              helperSlot(a, k - 1),
+              u,
+              datatype,
+              cfg.activeRanks[1 - a],
+              comm,
+              stream));
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+  }
+
+  // One fused pass over the whole output block.
+  if (myActiveGroup == 0) {
+    void* out = recvBuffs[0];
+    if (isInPlace) {
+      if (reductionDivisor > 1) {
+        DISPATCH_INCREMENTAL_ADD_AND_SCALE(
+            datatype, out, foreignScratch, recvcount, reductionDivisor, stream);
+      } else {
+        DISPATCH_INCREMENTAL_ADD(
+            datatype, out, foreignScratch, recvcount, stream);
+      }
+    } else {
+      DISPATCH_FUSED_REDUCE(
+          datatype,
+          out,
+          static_cast<const char*>(sendBuffs[0]) + ownBlockOffset * elementSize,
+          foreignScratch,
+          recvcount,
+          reductionDivisor,
+          stream);
+    }
+  }
+
+  return ncclSuccess;
+}
+
+/**
  * Reduce-scatter for > 2 active ranks (two-group flat relay with
  * reduce-at-helper).
  *
@@ -1513,6 +1706,36 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
     for (int g = 0; g < nGroups; g++) {
       sendBuffs2[g] = sendBuffs[g];
       recvBuffs2[g] = recvBuffs[g];
+    }
+    // A single-group relay call has the helpers to itself, so the scatter and
+    // the forward run on opposite directions of each cross link and can be
+    // software-pipelined into one duplex stream. relayA2PipelineTiles() returns
+    // 1 whenever that does not apply, and the small-message pure-direct route
+    // (owned by shardedRelayReduceScatter2Active) never pipelines.
+    const int nTiles = (rcclx::relay::selectReduceScatterRoute(
+                            2, numHelpers, nGroups, recvCounts, elementSize) ==
+                        rcclx::relay::ReduceScatterRoute::A2Relay)
+        ? rcclx::relay::relayA2PipelineTiles(
+              2,
+              numHelpers,
+              nGroups,
+              rcclx::relay::relayMaxCount(recvCounts, nGroups),
+              elementSize)
+        : 1;
+    if (nTiles > 1) {
+      return shardedRelayReduceScatter2ActivePipelined(
+          sendBuffs2,
+          recvBuffs2,
+          recvCounts,
+          datatype,
+          reductionDivisor,
+          comm,
+          stream,
+          configs,
+          myActiveGroup,
+          numHelpers,
+          nTiles,
+          elementSize);
     }
     return shardedRelayReduceScatter2Active(
         sendBuffs2,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_route.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_route.h
@@ -115,8 +115,10 @@ inline size_t relayMaxCount(const size_t* counts, int nGroups) {
  *
  * A==2 crossover: the fused relay overtakes the direct exchange at ~9 MB and an
  * independent call at ~27 MB (independent has no cross-group contention, so
- * direct holds on longer); cross over below each. A==4 uses the XOR relay only
- * inside [63 MiB, 256 MiB).
+ * direct holds on longer); cross over below each. A==4 relays from 27 MB fused
+ * / 9 MB independent up, with no upper bound: the 256 MiB ceiling this used to
+ * carry was covering an alignment bug in the relay geometry, not a real
+ * crossover.
  */
 inline AllToAllRoute selectAllToAllRoute(
     int nActiveRanksPerGroup,
@@ -139,17 +141,23 @@ inline AllToAllRoute selectAllToAllRoute(
   for (int g = 0; g < nGroups; g++) {
     allSegmentCountsPositive &= segmentCounts[g] > 0;
   }
-  constexpr size_t kXorRelayMinBytes = static_cast<size_t>(63) << 20;
-  constexpr size_t kXorRelayMaxBytes = static_cast<size_t>(256) << 20;
+  constexpr size_t kXorRelayMinBytes = static_cast<size_t>(9) << 20;
+  const size_t xorRelayMinBytes = (nGroups > 1)
+      ? (static_cast<size_t>(27) << 20) // fused: >= 27 MB
+      : kXorRelayMinBytes; // independent: >= 9 MB
   const bool useXorRelay = nActiveRanksPerGroup == 4 && numHelpers == 4 &&
-      allSegmentCountsPositive && maxBytes >= kXorRelayMinBytes &&
-      maxBytes < kXorRelayMaxBytes;
+      allSegmentCountsPositive && maxBytes >= xorRelayMinBytes;
   return useXorRelay ? AllToAllRoute::A4XorRelay : AllToAllRoute::PureDirect;
 }
 
-// Per-source relay chunk of the A==4 XOR all-to-all. The direct-B region
-// absorbs both the /3 remainder and the alignment loss, so
-// 3 * relayCount <= segmentCount always holds.
+// Per-source relay chunk of the A==4 XOR all-to-all, and equally the size of
+// its leading direct region: the schedule's two serialized phases each carry
+// one such chunk per link, so the three regions are directA = relay = this
+// count with directB absorbing the /3 remainder and the alignment loss. Every
+// region boundary is therefore 128-element aligned; a plain segmentCount/3
+// directA is misaligned for every power-of-two segment (2^n is never divisible
+// by 3), which pushed the relay region onto an unaligned offset and cost more
+// than the relay saved.
 inline size_t allToAllA4RelayCount(size_t segmentCount) {
   return (segmentCount / 3 / kRelayChunkAlignElements) *
       kRelayChunkAlignElements;

--- a/comms/rcclx/develop/meta/relay/sharded_relay_route.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_route.h
@@ -284,4 +284,80 @@ inline size_t allReduceOffloadPermille(AllReduceRoute route) {
   return route == AllReduceRoute::FlatOffload ? 500 : 0;
 }
 
+// Largest software-pipeline depth the single-group relays will use.
+//
+// Capped at 4 for stability rather than for throughput. Every group boundary is
+// a cross-rank sync point, so a deeper pipeline gives co-resident independent
+// jobs more opportunities to skew against each other: at depth 8 the 4-job
+// parallel sweep becomes erratic and non-reproducible (0.74x-1.46x outliers
+// scattered through the size axis, different sizes each run), while depth 4 is
+// as stable as the unpipelined schedule. Depth 4 also happens to be what the
+// cost model below picks at every size measured on the single-group sweep, so
+// the cap costs nothing there.
+inline constexpr int kRelayMaxPipelineTiles = 4;
+
+// What one extra ncclGroup boundary costs, expressed as the per-link bytes that
+// take the same time: a grouped-P2P launch plus work-FIFO upload plus fence is
+// ~25 us, which at the measured ~50 GB/s per XGMI link is ~768 KiB. Deepening
+// the pipeline trades per-link bytes for boundaries, so this is what decides
+// where that trade stops paying.
+inline constexpr size_t kRelayPipelineBoundaryBytes = 768u << 10;
+
+/**
+ * Software-pipeline depth for the single-group 2-active relay.
+ *
+ * With nGroups == 1 the active ranks and the helpers are DISJOINT sets, so a
+ * cross link carries the scatter (active -> helper) in one direction and the
+ * forward (helper -> active) in the other. Running those as two serialized
+ * ncclGroups therefore leaves every cross link HALF-DUPLEX for the whole call:
+ * the forward direction is idle for all of group 1 and the scatter direction
+ * for all of group 2.
+ *
+ * Tiling the relay into T tiles and issuing tile t's forward in the SAME group
+ * as tile t+1's scatter fills both directions. Per link and direction each of
+ * the T+1 groups then carries one unit u, against a count of
+ * ((H+1)*T + 1)*u -- so the cost is (T+1)/((H+1)*T + 1) of the count:
+ * count/4 at T = 1 (identical to the two-group schedule) falling towards
+ * count/7 as T grows on an 8-GPU node, i.e. a 4x ceiling becomes 7x. count/7 is
+ * also the hard floor, since an active rank must move its whole buffer out
+ * across its 7 links exactly once.
+ *
+ * A FUSED call gains nothing here, which is why this is gated on nGroups == 1:
+ * there every rank is active for one group and a helper for the others, so its
+ * scatter and its forward are egress on the SAME link direction. They add
+ * rather than overlap, and the extra group boundaries are pure cost.
+ *
+ * The depth is whichever power of two minimizes
+ * (T + 1) * (perStageBytes + kRelayPipelineBoundaryBytes), which is the two
+ * competing terms stated directly rather than a size threshold per depth.
+ */
+inline int relayA2PipelineTiles(
+    int nActiveRanksPerGroup,
+    int numHelpers,
+    int nGroups,
+    size_t maxCount,
+    size_t elementSize) {
+  if (nGroups != 1 || nActiveRanksPerGroup != 2 || numHelpers < 1) {
+    return 1;
+  }
+  const size_t bytes = maxCount * elementSize;
+  const size_t perTileStages = static_cast<size_t>(numHelpers) + 1;
+  int bestTiles = 1;
+  size_t bestCost = 0;
+  for (int tiles = 1; tiles <= kRelayMaxPipelineTiles; tiles *= 2) {
+    const size_t units = perTileStages * static_cast<size_t>(tiles) + 1;
+    // A stage still has to be a whole aligned chunk.
+    if (maxCount / units < kRelayChunkAlignElements) {
+      break;
+    }
+    const size_t cost = static_cast<size_t>(tiles + 1) *
+        (bytes / units + kRelayPipelineBoundaryBytes);
+    if (bestCost == 0 || cost < bestCost) {
+      bestCost = cost;
+      bestTiles = tiles;
+    }
+  }
+  return bestTiles;
+}
+
 } // namespace rcclx::relay

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
@@ -787,6 +787,73 @@ TEST_F(ShardedRelayMultiGroupAllGatherTest, Correctness_SingleGroup_64MB) {
 }
 
 /**
+ * Test: Single group, IN-PLACE, at a size the software pipeline covers.
+ *
+ * nGroups == 1 puts the relay on the pipelined schedule (the active ranks and
+ * the helpers are disjoint there, so the scatter and the forward run on
+ * opposite directions of each cross link and are interleaved). 64 MB clears the
+ * pipeline floor, so this pins the pipelined path's in-place handling -- the
+ * diagonal is already in the send slot and must not be re-copied, while the
+ * gather slot is written tile by tile across the pipeline stages.
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllGatherTest,
+    Correctness_SingleGroup_InPlace_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 1;
+  const int nActiveRanksPerGroup = 2;
+  const size_t sendBytes = 64ULL * 1024 * 1024;
+  const size_t sendCount = sendBytes / sizeof(int32_t);
+
+  const int activeRanks[] = {0, 1};
+  const int* allActiveRanks[] = {activeRanks};
+
+  const bool isActive = (this->globalRank == 0 || this->globalRank == 1);
+  const int myActiveIndex = this->globalRank;
+
+  int32_t* buff = nullptr;
+  const size_t buffBytes =
+      static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+  HIPCHECK_TEST(hipMalloc(&buff, buffBytes));
+
+  barrierSyncOn(buff);
+
+  HIPCHECK_TEST(hipMemset(buff, 0, buffBytes));
+  // In-place: this rank's contribution already sits in its own output slot.
+  int32_t* mySlot = buff + static_cast<size_t>(myActiveIndex) * sendCount;
+  if (isActive) {
+    fillDeviceRegion(mySlot, sendCount, rankFillValue(myActiveIndex));
+  }
+
+  const void* sendPtrs[1] = {isActive ? mySlot : buff};
+  void* recvPtrs[1] = {buff};
+  size_t sendCounts[] = {sendCount};
+
+  const ncclResult_t result = callAllGatherCompat(
+      sendPtrs,
+      recvPtrs,
+      sendCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  if (isActive) {
+    verifyAllGatherOutput(buff, sendCount, 0);
+  }
+
+  HIPCHECK_TEST(hipFree(buff));
+}
+
+/**
  * Test: Correctness with minimum passthrough helper buffers (OUT-OF-PLACE)
  */
 TEST_F(

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
@@ -512,7 +512,7 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
         initActiveSendBuffer(
             sendBuffs[g], segmentCount, myActiveIndex, nActiveRanksPerGroup);
         if (checkRegionBoundaries) {
-          const size_t directA = segmentCount / 3;
+          const size_t directA = relayCount;
           const size_t regionOffsets[5] = {
               directA - 1,
               directA,
@@ -561,7 +561,7 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
     HIPCHECK_TEST(hipStreamSynchronize(this->stream));
 
     if (checkRegionBoundaries) {
-      const size_t directA = segmentCount / 3;
+      const size_t directA = relayCount;
       const size_t regionOffsets[5] = {
           directA - 1,
           directA,
@@ -654,7 +654,7 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
       initActiveSendBuffer(
           sendBuff, segmentCount, myActiveIndex, nActiveRanksPerGroup);
       if (checkRegionBoundaries) {
-        const size_t directA = segmentCount / 3;
+        const size_t directA = relayCount;
         const size_t regionOffsets[5] = {
             directA - 1,
             directA,
@@ -703,7 +703,7 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
 
     if (isActive) {
       if (checkRegionBoundaries) {
-        const size_t directA = segmentCount / 3;
+        const size_t directA = relayCount;
         const size_t regionOffsets[5] = {
             directA - 1,
             directA,
@@ -1508,12 +1508,12 @@ TEST_F(ShardedRelayMultiGroupAllToAllTest, Z_BusBW_4Groups_OutOfPlace_1GB) {
  */
 TEST_F(
     ShardedRelayMultiGroupAllToAllTest,
-    Correctness_4Active_RoutedLowerBoundary_63MiB) {
+    Correctness_4Active_RoutedLowerBoundary_27MiB) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 27ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t));
   runA4CorrectnessCase(segmentCount, true);
 }
@@ -1525,7 +1525,7 @@ TEST_F(
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 27ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t)) - 1;
   runA4CorrectnessCase(segmentCount, false);
 }
@@ -1537,21 +1537,26 @@ TEST_F(
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 27ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t)) + 1;
   runA4CorrectnessCase(segmentCount, true, true);
 }
 
+// 256 MiB is a power of two, so segmentCount is not divisible by 3 and the
+// relay's leading direct region has to be aligned down rather than taken as an
+// exact third. Routed here (this size used to be the top of the window), with
+// the region boundaries checked so a misaligned split is caught.
 TEST_F(
     ShardedRelayMultiGroupAllToAllTest,
-    Correctness_4Active_DirectUpperBoundary_256MiB) {
+    Correctness_4Active_RoutedPowerOfTwo_256MiB) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
   constexpr size_t perActiveBytes = 256ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t));
-  runA4CorrectnessCase(segmentCount, false);
+  static_assert(segmentCount % 3 != 0, "256 MiB must not divide into thirds");
+  runA4CorrectnessCase(segmentCount, true, true);
 }
 
 // Single-group (nGroups=1) A=4 all-to-all: ranks {0,1,2,3} active, {4,5,6,7}
@@ -1559,12 +1564,12 @@ TEST_F(
 // tests cover, across the routed and direct regimes.
 TEST_F(
     ShardedRelayMultiGroupAllToAllTest,
-    Correctness_4Active_SingleGroup_Routed_63MiB) {
+    Correctness_4Active_SingleGroup_Routed_9MiB) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 9ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t));
   runA4SingleGroupCorrectnessCase(segmentCount, true);
 }
@@ -1576,7 +1581,7 @@ TEST_F(
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 9ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t)) - 1;
   runA4SingleGroupCorrectnessCase(segmentCount, false);
 }
@@ -1588,7 +1593,7 @@ TEST_F(
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 9ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t)) + 1;
   runA4SingleGroupCorrectnessCase(segmentCount, true, true);
 }


### PR DESCRIPTION
Summary:
Last of the four 2-active relays to get the duplex pipelining introduced for the
all-gather. With nGroups == 1 the active ranks and the helpers are DISJOINT sets,
so a cross link carries only the scatter in one direction and only the forward in
the other, and the two-group schedule leaves every cross link HALF-DUPLEX for the
whole call. Tiling the relay and issuing tile t's forward in the same group as
tile t+1's scatter fills both directions, taking the per-link cost from
2*recvCount/(H+2) = recvCount/4 towards recvCount/7 -- the floor, since an active
rank must move its foreign block out across its 7 links exactly once.

Unlike allreduce, helpers stay pure PASSTHROUGH here and are not asked to reduce:
slot 0 is a0's contribution to a1's output and slot 1 is a1's contribution to
a0's output, which are different outputs with nothing in common to sum. The active
rank reduces once at the end, and because foreignScratch still mirrors the output
block layout that stays a single fused launch regardless of how many tiles the
relay used.

Depth selection, the boundary cost model, the depth-4 stability cap and the
nGroups == 1 gate are the shared relayA2PipelineTiles() from the all-gather
change. The small-message pure-direct route stays inside
shardedRelayReduceScatter2Active and never pipelines. Helper staging drops from
the whole chunk to two ping-pong units per active source.

Reduce-scatter gains a little less than the other three (1.30x on relay latency
at 1 GB versus 1.35x for all-gather) for two structural reasons worth recording:
its relayed quantity is recvCount, i.e. half the message, so a given message
lands at a shallower depth; and the closing full-buffer reduce is serial work the
pipeline does not shrink.

Perf -- single-group 2-active reduce-scatter (MI350X, 8 GPUs, bf16, best-of-100,
speedup = 2-rank NCCL reduce-scatter with the other 6 ranks idle / relay),
same-day before and after:

```
  Msg Size    before     after    relay ms
  13.5 MB      1.06x     1.09x    0.183 -> 0.176  (depth 1, unchanged)
    27 MB      2.38x     2.43x    0.149 -> 0.145  (depth 1, unchanged)
  31.5 MB      2.45x     2.55x    0.166 -> 0.157
    36 MB      2.59x     2.61x    0.178 -> 0.174
    63 MB      2.86x     3.16x    0.266 -> 0.245
  67.5 MB      2.90x     3.23x    0.285 -> 0.255
    72 MB      2.91x     3.21x    0.297 -> 0.272
   135 MB      3.21x     3.63x    0.497 -> 0.440
   144 MB      3.20x     3.64x    0.524 -> 0.460
   256 MB      3.00x     3.58x    0.915 -> 0.767
   512 MB      2.95x     3.68x    1.777 -> 1.414
     1 GB      2.88x     3.74x    3.499 -> 2.694
```

Everything below 27 MB is on the pure-direct route for an independent call and is
untouched. Fused (4 groups) re-measured to confirm no change: 2.40x / 2.77x /
3.15x / 2.91x at 27 MB / 63 MB / 135 MB / 1 GB.

Parallel (4 co-resident jobs) is neutral to better, against the checked-in
baseline:

```
  Msg Size    before     after
    27 MB      1.77x     2.00x
    36 MB      1.86x     2.06x
    63 MB      2.19x     2.46x
  67.5 MB      2.36x     2.58x
   135 MB      2.65x     2.58x
   144 MB      2.58x     2.66x
   256 MB      2.54x     2.50x
   512 MB      2.45x     2.54x
```

A measurement note that cost me a false regression: the FIRST sweep after a
rebuild reads 10-13% slow at 27-72 MB (cold scratch allocation and kernel
warm-up), which showed up as reduce-scatter losing at 36 MB. Two warm repeats put
it back at 0.173/0.173 ms against a 0.178 ms baseline. All numbers above are
warm.

The 4-active flat reduce-scatter and the pure-direct route are untouched.

Differential Revision: D117629687


