### PR TITLE
Pipeline the single-group 4-active all-gather relay (1.36x -> 1.66x) (#3819)

### DIFF
--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
@@ -496,6 +496,178 @@ static ncclResult_t shardedRelayAllGather2Active(
 }
 
 /**
+ * Software-pipelined single-group 2-active sharded relay all-gather.
+ *
+ * Same logical collective and the same helper roles as
+ * shardedRelayAllGather2Active, but for nGroups == 1 -- where the active ranks
+ * and the helpers are disjoint sets -- the relay is tiled and pipelined so both
+ * directions of every cross link stay busy. See relayA2PipelineTiles() for why
+ * the two-group schedule cannot do that and what it costs.
+ *
+ * With T tiles and unit u = align(sendCount / ((H+1)*T + 1)):
+ *   sendBuff [0, H*T*u)   offload region; helper h owns [h*T*u, (h+1)*T*u),
+ *                         its tile t at h*T*u + t*u
+ *   sendBuff [H*T*u, sc)  direct region as T+1 chunks of u, the last absorbing
+ *                         the /((H+1)*T + 1) remainder and the alignment loss
+ *
+ * Group k, for k in [0, T]:
+ *   active   scatter tile k (k < T) to every helper, receive the partner's
+ *            tile k-1 (k > 0) from every helper straight into the gather slot,
+ *            and exchange direct chunk k over the active<->active link.
+ *   helper h receive tile k of each active's chunk into ping-pong buffer k%2,
+ *            forward buffer (k-1)%2 to the OTHER active.
+ *
+ * Every rank therefore posts exactly one send and one recv per link per group,
+ * which is also the best case for p2p channel assignment. The helper's staging
+ * is two units per active rather than the whole chunk, so a forwarded tile is
+ * still cache-resident when it is read back.
+ *
+ * Both in-place and out-of-place are supported: the gather slot never overlaps
+ * the send source.
+ */
+static ncclResult_t shardedRelayAllGather2ActivePipelined(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* sendCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nTiles,
+    size_t elementSize) {
+  const ShardedRelayRankConfig& cfg = configs[0];
+  const size_t sc = sendCounts[0];
+  const int H = numHelpers;
+  const int T = nTiles;
+  const size_t u =
+      ((sc / (static_cast<size_t>(H + 1) * T + 1)) / CHUNK_ALIGN_ELEMENTS) *
+      CHUNK_ALIGN_ELEMENTS;
+  if (u == 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t tileStride = static_cast<size_t>(T) * u;
+  const size_t directBase = static_cast<size_t>(H) * tileStride;
+  const size_t lastDirect = sc - directBase - tileStride;
+
+  // Diagonal: recvBuff[m*sc] = sendBuff, a no-op when in-place.
+  size_t gatherSlot = 0;
+  if (myActiveGroup == 0) {
+    const size_t diagSlot = static_cast<size_t>(cfg.myActiveIndex) * sc;
+    gatherSlot = static_cast<size_t>(1 - cfg.myActiveIndex) * sc;
+    char* diag = static_cast<char*>(recvBuffs[0]) + diagSlot * elementSize;
+    if (static_cast<const void*>(sendBuffs[0]) !=
+        static_cast<const void*>(diag)) {
+      cudaMemcpyAsync(
+          diag,
+          sendBuffs[0],
+          sc * elementSize,
+          cudaMemcpyDeviceToDevice,
+          stream);
+    }
+  }
+
+  // Helper staging: two ping-pong units per active source. Tiny by design, so a
+  // tile is forwarded out of cache rather than re-read from HBM.
+  char* hbuff = nullptr;
+  if (!cfg.isActiveRank) {
+    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+        kHelperScratchKeyBase,
+        static_cast<size_t>(cfg.nActiveRanks) * 2 * u * elementSize,
+        stream));
+    if (hbuff == nullptr) {
+      return ncclInternalError;
+    }
+  }
+
+  for (int k = 0; k <= T; k++) {
+    NCCLCHECK(ncclGroupStart());
+    if (cfg.isActiveRank) {
+      const char* sendbuff = static_cast<const char*>(sendBuffs[0]);
+      char* recvbuff = static_cast<char*>(recvBuffs[0]);
+      const int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      const size_t directOffset = directBase + static_cast<size_t>(k) * u;
+      const size_t directSize = (k < T) ? u : lastDirect;
+
+      if (k < T) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclSend(
+              sendbuff +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclSend(
+          sendbuff + directOffset * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+      if (k > 0) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclRecv(
+              recvbuff +
+                  (gatherSlot + static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k - 1) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclRecv(
+          recvbuff + (gatherSlot + directOffset) * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else {
+      if (k < T) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclRecv(
+              hbuff +
+                  (static_cast<size_t>(a) * 2 + static_cast<size_t>(k % 2)) *
+                      u * elementSize,
+              u,
+              datatype,
+              cfg.activeRanks[a],
+              comm,
+              stream));
+        }
+      }
+      if (k > 0) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclSend(
+              hbuff +
+                  (static_cast<size_t>(a) * 2 +
+                   static_cast<size_t>((k - 1) % 2)) *
+                      u * elementSize,
+              u,
+              datatype,
+              cfg.activeRanks[1 - a],
+              comm,
+              stream));
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+  }
+
+  return ncclSuccess;
+}
+
+/**
  * All-gather for > 2 active ranks (two-group scatter/forward relay).
  *
  * Every active SOURCE must deliver its sc elements to the A-1 other active
@@ -891,18 +1063,40 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
   if (rcclx::relay::selectAllGatherRoute(
           nActiveRanksPerGroup, numHelpers, nGroups, sendCounts, elementSize) ==
       rcclx::relay::AllGatherRoute::A2Relay) {
-    r = shardedRelayAllGather2Active(
-        sendBuffs2,
-        recvBuffs2,
-        sendCounts,
-        datatype,
-        comm,
-        stream,
-        configs,
-        myActiveGroup,
+    // A single-group call has the helpers to itself, so the scatter and the
+    // forward run on opposite directions of each cross link and can be
+    // software-pipelined into one duplex stream; relayA2PipelineTiles() returns
+    // 1 whenever that does not apply.
+    const int nTiles = rcclx::relay::relayA2PipelineTiles(
+        nActiveRanksPerGroup,
         numHelpers,
         nGroups,
+        rcclx::relay::relayMaxCount(sendCounts, nGroups),
         elementSize);
+    r = (nTiles > 1) ? shardedRelayAllGather2ActivePipelined(
+                           sendBuffs2,
+                           recvBuffs2,
+                           sendCounts,
+                           datatype,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           numHelpers,
+                           nTiles,
+                           elementSize)
+                     : shardedRelayAllGather2Active(
+                           sendBuffs2,
+                           recvBuffs2,
+                           sendCounts,
+                           datatype,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           numHelpers,
+                           nGroups,
+                           elementSize);
   } else {
     // A>2, or small A==2: flat scatter->forward relay (dual of reduce-scatter)
     // with a size-adaptive pure-direct small-size mode.

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
@@ -501,7 +501,7 @@ static ncclResult_t shardedRelayAllGather2Active(
  * Same logical collective and the same helper roles as
  * shardedRelayAllGather2Active, but for nGroups == 1 -- where the active ranks
  * and the helpers are disjoint sets -- the relay is tiled and pipelined so both
- * directions of every cross link stay busy. See relayA2PipelineTiles() for why
+ * directions of every cross link stay busy. See relayPipelineTiles() for why
  * the two-group schedule cannot do that and what it costs.
  *
  * With T tiles and unit u = align(sendCount / ((H+1)*T + 1)):
@@ -1065,12 +1065,11 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
       rcclx::relay::AllGatherRoute::A2Relay) {
     // A single-group call has the helpers to itself, so the scatter and the
     // forward run on opposite directions of each cross link and can be
-    // software-pipelined into one duplex stream; relayA2PipelineTiles() returns
+    // software-pipelined into one duplex stream; relayPipelineTiles() returns
     // 1 whenever that does not apply.
-    const int nTiles = rcclx::relay::relayA2PipelineTiles(
-        nActiveRanksPerGroup,
-        numHelpers,
+    const int nTiles = rcclx::relay::relayPipelineTiles(
         nGroups,
+        rcclx::relay::relayShapeA2(numHelpers),
         rcclx::relay::relayMaxCount(sendCounts, nGroups),
         elementSize);
     r = (nTiles > 1) ? shardedRelayAllGather2ActivePipelined(

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
@@ -958,6 +958,213 @@ static ncclResult_t shardedRelayAllGatherFlat(
 }
 
 /**
+ * Software-pipelined single-group A>2 flat all-gather.
+ *
+ * Same scatter/forward relay as shardedRelayAllGatherFlat, but for nGroups == 1
+ * -- where the active ranks and the helpers are disjoint -- the offload is
+ * tiled so the scatter and the forward share a group and each cross link runs
+ * duplex. See relayPipelineTiles().
+ *
+ * This schedule is ASYMMETRIC, unlike the 2-active one: a helper fans each
+ * source's slice out to the A-1 other destinations, so a cross link carries one
+ * unit UP and A-1 units DOWN. Merging is therefore bounded by the down
+ * direction and the up direction stays underused, which is why the payoff is
+ * smaller here. With v = align(sc / ((H + A - 1)*T + 1)) each group carries
+ * (A-1)*v on the busiest link and the direct region is split to match, so the
+ * cost is ((A-1)*T + 1)*v: at A = H = 4 that is sc/2 at T = 1 (identical to the
+ * two-group schedule) falling towards 3*sc/7. That floor is also the hard one
+ * -- an active rank has to take in A-1 = 3 whole buffers across its 7 links.
+ *
+ * The divisor is derived from A and H rather than fixed at the A = H = 4 value
+ * of 7 because the layout below consumes H*T + 1 + (T-1)*(A-1) units before the
+ * final direct chunk; any other geometry that reaches this path (A = 4 with
+ * H = 5..8 on a 9-to-12-rank comm, or A = 8 with H = 8 on a 16-rank one) would
+ * otherwise push directOffset(T) past sc and underflow directSize(T).
+ *
+ * Buffer layout of sendBuff [0, sc):
+ *   [0, H*T*v)   offload region; helper h owns [h*T*v, (h+1)*T*v), tile t at
+ *                h*T*v + t*v
+ *   [H*T*v, sc)  direct region, one chunk per group sized to that group's cross
+ *                load: v for group 0 (which has no forward to receive yet) and
+ *                (A-1)*v for the rest, the last absorbing the remainder
+ *
+ * Both in-place and out-of-place are supported; the gather slots never overlap
+ * the send source.
+ */
+static ncclResult_t shardedRelayAllGatherFlatPipelined(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* sendCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nActiveRanksPerGroup,
+    int nTiles,
+    size_t elementSize) {
+  const ShardedRelayRankConfig& cfg = configs[0];
+  const size_t sc = sendCounts[0];
+  const int A = nActiveRanksPerGroup;
+  const int H = numHelpers;
+  const int T = nTiles;
+  const size_t v = ((sc /
+                     (static_cast<size_t>(
+                          rcclx::relay::relayShapeFanout(A, H).totalPerTile) *
+                          T +
+                      1)) /
+                    CHUNK_ALIGN_ELEMENTS) *
+      CHUNK_ALIGN_ELEMENTS;
+  if (v == 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t tileStride = static_cast<size_t>(T) * v;
+  const size_t directBase = static_cast<size_t>(H) * tileStride;
+  // Group 0 carries one unit of direct traffic, every later group carries A-1.
+  const size_t heavy = static_cast<size_t>(A - 1) * v;
+  auto directOffset = [&](int k) -> size_t {
+    return directBase + (k == 0 ? 0 : v + static_cast<size_t>(k - 1) * heavy);
+  };
+  auto directSize = [&](int k) -> size_t {
+    if (k == 0) {
+      return v;
+    }
+    return (k < T) ? heavy : (sc - directOffset(T));
+  };
+
+  // Diagonal: recvBuff[m*sc] = sendBuff, a no-op when in-place.
+  if (myActiveGroup == 0) {
+    char* diag = static_cast<char*>(recvBuffs[0]) +
+        static_cast<size_t>(cfg.myActiveIndex) * sc * elementSize;
+    if (static_cast<const void*>(sendBuffs[0]) !=
+        static_cast<const void*>(diag)) {
+      cudaMemcpyAsync(
+          diag,
+          sendBuffs[0],
+          sc * elementSize,
+          cudaMemcpyDeviceToDevice,
+          stream);
+    }
+  }
+
+  // Helper staging: two ping-pong tiles per active source.
+  char* hbuff = nullptr;
+  if (!cfg.isActiveRank) {
+    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+        kHelperScratchKeyBase,
+        static_cast<size_t>(A) * 2 * v * elementSize,
+        stream));
+    if (hbuff == nullptr) {
+      return ncclInternalError;
+    }
+  }
+  auto helperSlot = [&](int s, int k) -> char* {
+    return hbuff +
+        (static_cast<size_t>(s) * 2 + static_cast<size_t>(k % 2)) * v *
+        elementSize;
+  };
+
+  for (int k = 0; k <= T; k++) {
+    NCCLCHECK(ncclGroupStart());
+    if (cfg.isActiveRank) {
+      const char* sendbuff = static_cast<const char*>(sendBuffs[0]);
+      char* recvbuff = static_cast<char*>(recvBuffs[0]);
+      const int m = cfg.myActiveIndex;
+      const size_t dOff = directOffset(k);
+      const size_t dSz = directSize(k);
+
+      for (int d = 0; d < A; d++) {
+        if (d == m) {
+          continue;
+        }
+        NCCLCHECK(ncclSend(
+            sendbuff + dOff * elementSize,
+            dSz,
+            datatype,
+            cfg.activeRanks[d],
+            comm,
+            stream));
+      }
+      if (k < T) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclSend(
+              sendbuff +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k) * v) *
+                      elementSize,
+              v,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      for (int s = 0; s < A; s++) {
+        if (s == m) {
+          continue;
+        }
+        NCCLCHECK(ncclRecv(
+            recvbuff + (static_cast<size_t>(s) * sc + dOff) * elementSize,
+            dSz,
+            datatype,
+            cfg.activeRanks[s],
+            comm,
+            stream));
+      }
+      if (k > 0) {
+        // Helper h delivers tile k-1 of every other source's offload chunk.
+        for (int h = 0; h < H; h++) {
+          for (int s = 0; s < A; s++) {
+            if (s == m) {
+              continue;
+            }
+            NCCLCHECK(ncclRecv(
+                recvbuff +
+                    (static_cast<size_t>(s) * sc +
+                     static_cast<size_t>(h) * tileStride +
+                     static_cast<size_t>(k - 1) * v) *
+                        elementSize,
+                v,
+                datatype,
+                cfg.helperRanks[h],
+                comm,
+                stream));
+          }
+        }
+      }
+    } else {
+      if (k < T) {
+        for (int s = 0; s < A; s++) {
+          NCCLCHECK(ncclRecv(
+              helperSlot(s, k), v, datatype, cfg.activeRanks[s], comm, stream));
+        }
+      }
+      if (k > 0) {
+        // Per-peer send order matches each destination's receive order above.
+        for (int s = 0; s < A; s++) {
+          for (int d = 0; d < A; d++) {
+            if (d == s) {
+              continue;
+            }
+            NCCLCHECK(ncclSend(
+                helperSlot(s, k - 1),
+                v,
+                datatype,
+                cfg.activeRanks[d],
+                comm,
+                stream));
+          }
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+  }
+
+  return ncclSuccess;
+}
+
+/**
  * Fused Multi-Group Sharded Relay All-Gather.
  *
  * Executes multiple sharded relay all-gathers in one fused call, phase-synced
@@ -1060,9 +1267,9 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
   // shard exchange with minimal latency. The size -> route mapping lives in
   // selectAllGatherRoute() so the tests assert the same definition this
   // dispatch uses.
-  if (rcclx::relay::selectAllGatherRoute(
-          nActiveRanksPerGroup, numHelpers, nGroups, sendCounts, elementSize) ==
-      rcclx::relay::AllGatherRoute::A2Relay) {
+  const rcclx::relay::AllGatherRoute route = rcclx::relay::selectAllGatherRoute(
+      nActiveRanksPerGroup, numHelpers, nGroups, sendCounts, elementSize);
+  if (route == rcclx::relay::AllGatherRoute::A2Relay) {
     // A single-group call has the helpers to itself, so the scatter and the
     // forward run on opposite directions of each cross link and can be
     // software-pipelined into one duplex stream; relayPipelineTiles() returns
@@ -1098,20 +1305,46 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
                            elementSize);
   } else {
     // A>2, or small A==2: flat scatter->forward relay (dual of reduce-scatter)
-    // with a size-adaptive pure-direct small-size mode.
-    r = shardedRelayAllGatherFlat(
-        sendBuffs2,
-        recvBuffs2,
-        sendCounts,
-        datatype,
-        comm,
-        stream,
-        configs,
-        myActiveGroup,
-        numHelpers,
-        nActiveRanksPerGroup,
-        nGroups,
-        elementSize);
+    // with a size-adaptive pure-direct small-size mode. A single-group call
+    // with the offload enabled can additionally be software-pipelined so the
+    // scatter and the forward share each cross link's two directions.
+    const bool offload = route == rcclx::relay::AllGatherRoute::FlatOffload;
+    const int nTiles = offload
+        ? rcclx::relay::relayPipelineTiles(
+              nGroups,
+              rcclx::relay::relayShapeFanout(nActiveRanksPerGroup, numHelpers),
+              rcclx::relay::relayMaxCount(sendCounts, nGroups),
+              elementSize)
+        : 1;
+    if (nTiles > 1) {
+      r = shardedRelayAllGatherFlatPipelined(
+          sendBuffs2,
+          recvBuffs2,
+          sendCounts,
+          datatype,
+          comm,
+          stream,
+          configs,
+          myActiveGroup,
+          numHelpers,
+          nActiveRanksPerGroup,
+          nTiles,
+          elementSize);
+    } else {
+      r = shardedRelayAllGatherFlat(
+          sendBuffs2,
+          recvBuffs2,
+          sendCounts,
+          datatype,
+          comm,
+          stream,
+          configs,
+          myActiveGroup,
+          numHelpers,
+          nActiveRanksPerGroup,
+          nGroups,
+          elementSize);
+    }
   }
 
   return r;

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
@@ -541,6 +541,173 @@ static ncclResult_t shardedRelayAllToAll2Active(
 }
 
 /**
+ * Software-pipelined single-group 2-active sharded relay all-to-all.
+ *
+ * Same logical collective and the same helper roles as
+ * shardedRelayAllToAll2Active, but for nGroups == 1 -- where the active ranks
+ * and the helpers are disjoint sets -- the relay is tiled and pipelined so both
+ * directions of every cross link stay busy. See relayA2PipelineTiles() for why
+ * the two-group schedule cannot do that and what it costs.
+ *
+ * With T tiles and unit u = align(segmentCount / ((H+1)*T + 1)), the exchange
+ * segment splits as:
+ *   [0, H*T*u)   offload region; helper h owns [h*T*u, (h+1)*T*u), its tile t
+ * at h*T*u + t*u [H*T*u, sc)  direct region as T+1 chunks of u, the last
+ * absorbing the
+ *                /((H+1)*T + 1) remainder and the alignment loss
+ *
+ * Group k, for k in [0, T]: the active rank scatters tile k (k < T) to every
+ * helper, receives the partner's tile k-1 (k > 0) from every helper straight
+ * into its receive segment, and exchanges direct chunk k over the
+ * active<->active link; helper h receives tile k of each active's chunk into
+ * ping-pong buffer k%2 and forwards buffer (k-1)%2 to the OTHER active rank.
+ *
+ * Every rank posts exactly one send and one recv per link per group. The
+ * helper's staging is two units per active rather than the whole chunk, so a
+ * forwarded tile is still cache-resident when it is read back.
+ *
+ * OUT-OF-PLACE ONLY, like every other all-to-all route.
+ */
+static ncclResult_t shardedRelayAllToAll2ActivePipelined(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* segmentCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nTiles,
+    size_t elementSize) {
+  const ShardedRelayRankConfig& cfg = configs[0];
+  const size_t sc = segmentCounts[0];
+  const int H = numHelpers;
+  const int T = nTiles;
+  const size_t u =
+      ((sc / (static_cast<size_t>(H + 1) * T + 1)) / CHUNK_ALIGN_ELEMENTS) *
+      CHUNK_ALIGN_ELEMENTS;
+  if (u == 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t tileStride = static_cast<size_t>(T) * u;
+  const size_t directBase = static_cast<size_t>(H) * tileStride;
+  const size_t lastDirect = sc - directBase - tileStride;
+
+  // Diagonal: recvSeg[m] = sendSeg[m].
+  size_t exchangeSegOffset = 0;
+  if (myActiveGroup == 0) {
+    const size_t diagOffset = static_cast<size_t>(cfg.myActiveIndex) * sc;
+    exchangeSegOffset = static_cast<size_t>(1 - cfg.myActiveIndex) * sc;
+    cudaMemcpyAsync(
+        static_cast<char*>(recvBuffs[0]) + diagOffset * elementSize,
+        static_cast<const char*>(sendBuffs[0]) + diagOffset * elementSize,
+        sc * elementSize,
+        cudaMemcpyDeviceToDevice,
+        stream);
+  }
+
+  // Helper staging: two ping-pong units per active source.
+  char* hbuff = nullptr;
+  if (!cfg.isActiveRank) {
+    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+        kHelperScratchKeyBase,
+        static_cast<size_t>(cfg.nActiveRanks) * 2 * u * elementSize,
+        stream));
+    if (hbuff == nullptr) {
+      return ncclInternalError;
+    }
+  }
+
+  for (int k = 0; k <= T; k++) {
+    NCCLCHECK(ncclGroupStart());
+    if (cfg.isActiveRank) {
+      const char* sendSeg = static_cast<const char*>(sendBuffs[0]) +
+          exchangeSegOffset * elementSize;
+      char* recvSeg =
+          static_cast<char*>(recvBuffs[0]) + exchangeSegOffset * elementSize;
+      const int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      const size_t directOffset = directBase + static_cast<size_t>(k) * u;
+      const size_t directSize = (k < T) ? u : lastDirect;
+
+      if (k < T) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclSend(
+              sendSeg +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclSend(
+          sendSeg + directOffset * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+      if (k > 0) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclRecv(
+              recvSeg +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k - 1) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclRecv(
+          recvSeg + directOffset * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else {
+      if (k < T) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclRecv(
+              hbuff +
+                  (static_cast<size_t>(a) * 2 + static_cast<size_t>(k % 2)) *
+                      u * elementSize,
+              u,
+              datatype,
+              cfg.activeRanks[a],
+              comm,
+              stream));
+        }
+      }
+      if (k > 0) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclSend(
+              hbuff +
+                  (static_cast<size_t>(a) * 2 +
+                   static_cast<size_t>((k - 1) % 2)) *
+                      u * elementSize,
+              u,
+              datatype,
+              cfg.activeRanks[1 - a],
+              comm,
+              stream));
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+  }
+
+  return ncclSuccess;
+}
+
+/**
  * A=4 no-pack XOR/Latin relay path.
  *
  * Each off-diagonal segment stays in place and is split into contiguous
@@ -915,18 +1082,40 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
   const rcclx::relay::AllToAllRoute route = rcclx::relay::selectAllToAllRoute(
       nActiveRanksPerGroup, numHelpers, nGroups, segmentCounts, elementSize);
   if (route == rcclx::relay::AllToAllRoute::A2Relay) {
-    r = shardedRelayAllToAll2Active(
-        sendBuffs2,
-        recvBuffs2,
-        segmentCounts,
-        datatype,
-        comm,
-        stream,
-        configs,
-        myActiveGroup,
+    // A single-group call has the helpers to itself, so the scatter and the
+    // forward run on opposite directions of each cross link and can be
+    // software-pipelined into one duplex stream; relayA2PipelineTiles() returns
+    // 1 whenever that does not apply.
+    const int nTiles = rcclx::relay::relayA2PipelineTiles(
+        nActiveRanksPerGroup,
         numHelpers,
         nGroups,
+        rcclx::relay::relayMaxCount(segmentCounts, nGroups),
         elementSize);
+    r = (nTiles > 1) ? shardedRelayAllToAll2ActivePipelined(
+                           sendBuffs2,
+                           recvBuffs2,
+                           segmentCounts,
+                           datatype,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           numHelpers,
+                           nTiles,
+                           elementSize)
+                     : shardedRelayAllToAll2Active(
+                           sendBuffs2,
+                           recvBuffs2,
+                           segmentCounts,
+                           datatype,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           numHelpers,
+                           nGroups,
+                           elementSize);
   } else if (route == rcclx::relay::AllToAllRoute::A4XorRelay) {
     r = shardedRelayAllToAllA4XorRelay(
         sendBuffs2,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
@@ -546,7 +546,7 @@ static ncclResult_t shardedRelayAllToAll2Active(
  * Same logical collective and the same helper roles as
  * shardedRelayAllToAll2Active, but for nGroups == 1 -- where the active ranks
  * and the helpers are disjoint sets -- the relay is tiled and pipelined so both
- * directions of every cross link stay busy. See relayA2PipelineTiles() for why
+ * directions of every cross link stay busy. See relayPipelineTiles() for why
  * the two-group schedule cannot do that and what it costs.
  *
  * With T tiles and unit u = align(segmentCount / ((H+1)*T + 1)), the exchange
@@ -894,6 +894,163 @@ static ncclResult_t shardedRelayAllToAllA4XorRelay(
   return ncclSuccess;
 }
 
+/**
+ * Software-pipelined single-group A=4 XOR/Latin relay all-to-all.
+ *
+ * Same helper assignment as shardedRelayAllToAllA4XorRelay -- each (source,
+ * dest) pair's relay region takes two hops through the one helper that the
+ * Latin permutation gives it -- but for nGroups == 1, where the active ranks
+ * and the helpers are disjoint, the relay is tiled so the scatter and the
+ * forward share a group and each cross link runs duplex. See
+ * relayPipelineTiles().
+ *
+ * The unpipelined schedule pays one relay unit on the cross links plus one
+ * direct unit on the intra links in each of two groups, hence 2*sc/3. Merging
+ * makes each of the T+1 groups carry one relay unit UP and one DOWN on every
+ * cross link, matched by one direct unit on the intra links, so with u =
+ * align(sc/(2*T + 1)) the cost is (T+1)*u: 2*sc/3 at T = 1 falling towards
+ * sc/2.
+ *
+ * Segment layout for dest j:
+ *   [0, T*u)      relay region, tile t at t*u, two hops via helper h(j)
+ *   [T*u, sc)     direct region as T+1 chunks of u, the last absorbing the
+ *                 /(2*T + 1) remainder and the alignment loss
+ *
+ * Each helper owns 3 tasks with three DISTINCT sources and three DISTINCT
+ * destinations, so per group every rank posts exactly one send and one recv per
+ * link per direction -- 3 relay plus 3 direct each way for an active rank, 3
+ * each way for a helper.
+ *
+ * OUT-OF-PLACE ONLY, like every other all-to-all route.
+ */
+static ncclResult_t shardedRelayAllToAllA4XorRelayPipelined(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* segmentCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int nTiles,
+    size_t elementSize) {
+  const ShardedRelayRankConfig& cfg = configs[0];
+  const size_t sc = segmentCounts[0];
+  const int T = nTiles;
+  const size_t u =
+      ((sc / (static_cast<size_t>(2) * T + 1)) / CHUNK_ALIGN_ELEMENTS) *
+      CHUNK_ALIGN_ELEMENTS;
+  if (u == 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t relayTotal = static_cast<size_t>(T) * u;
+  const size_t lastDirect = sc - relayTotal - relayTotal;
+
+  A4RelayTask tasks[A4_RELAY_TASKS];
+  if (!buildA4RelayTasks(cfg, tasks)) {
+    return ncclInvalidArgument;
+  }
+
+  // Diagonal stays a local copy.
+  if (myActiveGroup == 0) {
+    const size_t diagOffset = static_cast<size_t>(cfg.myActiveIndex) * sc;
+    cudaMemcpyAsync(
+        static_cast<char*>(recvBuffs[0]) + diagOffset * elementSize,
+        static_cast<const char*>(sendBuffs[0]) + diagOffset * elementSize,
+        sc * elementSize,
+        cudaMemcpyDeviceToDevice,
+        stream);
+  }
+
+  // Helper staging: two ping-pong units per task.
+  char* hbuff = nullptr;
+  if (!cfg.isActiveRank) {
+    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+        kHelperScratchKeyBase,
+        static_cast<size_t>(A4_RELAY_TASKS_PER_HELPER) * 2 * u * elementSize,
+        stream));
+    if (hbuff == nullptr) {
+      return ncclInternalError;
+    }
+  }
+
+  for (int k = 0; k <= T; k++) {
+    NCCLCHECK(ncclGroupStart());
+    const int m = cfg.myActiveIndex;
+    const size_t directOffset = relayTotal + static_cast<size_t>(k) * u;
+    const size_t directSize = (k < T) ? u : lastDirect;
+
+    for (const A4RelayTask& task : tasks) {
+      if (cfg.isActiveRank) {
+        if (task.sourceIndex == m) {
+          const char* sendSegment = static_cast<const char*>(sendBuffs[0]) +
+              static_cast<size_t>(task.destIndex) * sc * elementSize;
+          if (k < T) {
+            NCCLCHECK(ncclSend(
+                sendSegment + static_cast<size_t>(k) * u * elementSize,
+                u,
+                datatype,
+                cfg.helperRanks[task.helperIndex],
+                comm,
+                stream));
+          }
+          NCCLCHECK(ncclSend(
+              sendSegment + directOffset * elementSize,
+              directSize,
+              datatype,
+              cfg.activeRanks[task.destIndex],
+              comm,
+              stream));
+        }
+        if (task.destIndex == m) {
+          char* recvSegment = static_cast<char*>(recvBuffs[0]) +
+              static_cast<size_t>(task.sourceIndex) * sc * elementSize;
+          if (k > 0) {
+            NCCLCHECK(ncclRecv(
+                recvSegment + static_cast<size_t>(k - 1) * u * elementSize,
+                u,
+                datatype,
+                cfg.helperRanks[task.helperIndex],
+                comm,
+                stream));
+          }
+          NCCLCHECK(ncclRecv(
+              recvSegment + directOffset * elementSize,
+              directSize,
+              datatype,
+              cfg.activeRanks[task.sourceIndex],
+              comm,
+              stream));
+        }
+      } else if (task.helperIndex == cfg.myHelperIndex) {
+        char* slotBase =
+            hbuff + static_cast<size_t>(task.helperSlot) * 2 * u * elementSize;
+        if (k < T) {
+          NCCLCHECK(ncclRecv(
+              slotBase + static_cast<size_t>(k % 2) * u * elementSize,
+              u,
+              datatype,
+              cfg.activeRanks[task.sourceIndex],
+              comm,
+              stream));
+        }
+        if (k > 0) {
+          NCCLCHECK(ncclSend(
+              slotBase + static_cast<size_t>((k - 1) % 2) * u * elementSize,
+              u,
+              datatype,
+              cfg.activeRanks[task.destIndex],
+              comm,
+              stream));
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+  }
+
+  return ncclSuccess;
+}
+
 static ncclResult_t shardedRelayAllToAllFlat(
     const void* const* sendBuffs,
     void* const* recvBuffs,
@@ -1084,12 +1241,11 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
   if (route == rcclx::relay::AllToAllRoute::A2Relay) {
     // A single-group call has the helpers to itself, so the scatter and the
     // forward run on opposite directions of each cross link and can be
-    // software-pipelined into one duplex stream; relayA2PipelineTiles() returns
+    // software-pipelined into one duplex stream; relayPipelineTiles() returns
     // 1 whenever that does not apply.
-    const int nTiles = rcclx::relay::relayA2PipelineTiles(
-        nActiveRanksPerGroup,
-        numHelpers,
+    const int nTiles = rcclx::relay::relayPipelineTiles(
         nGroups,
+        rcclx::relay::relayShapeA2(numHelpers),
         rcclx::relay::relayMaxCount(segmentCounts, nGroups),
         elementSize);
     r = (nTiles > 1) ? shardedRelayAllToAll2ActivePipelined(
@@ -1117,17 +1273,36 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
                            nGroups,
                            elementSize);
   } else if (route == rcclx::relay::AllToAllRoute::A4XorRelay) {
-    r = shardedRelayAllToAllA4XorRelay(
-        sendBuffs2,
-        recvBuffs2,
-        segmentCounts,
-        datatype,
-        comm,
-        stream,
-        configs,
-        myActiveGroup,
+    // A single-group call has the helpers to itself, so the relay's two hops
+    // run on opposite directions of each cross link and can be
+    // software-pipelined into one duplex stream.
+    const int nTiles = rcclx::relay::relayPipelineTiles(
         nGroups,
+        rcclx::relay::kRelayShapeA4AllToAll,
+        rcclx::relay::relayMaxCount(segmentCounts, nGroups),
         elementSize);
+    r = (nTiles > 1) ? shardedRelayAllToAllA4XorRelayPipelined(
+                           sendBuffs2,
+                           recvBuffs2,
+                           segmentCounts,
+                           datatype,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           nTiles,
+                           elementSize)
+                     : shardedRelayAllToAllA4XorRelay(
+                           sendBuffs2,
+                           recvBuffs2,
+                           segmentCounts,
+                           datatype,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           nGroups,
+                           elementSize);
   } else {
     // A==4 outside the routed window, or small A==2: exact direct all-to-all.
     r = shardedRelayAllToAllFlat(

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
@@ -565,9 +565,8 @@ static ncclResult_t shardedRelayAllToAllA4XorRelay(
   A4RelayTask tasks[SHARDED_RELAY_MAX_GROUPS][A4_RELAY_TASKS];
 
   for (int g = 0; g < nGroups; g++) {
-    const size_t third = segmentCounts[g] / 3;
-    directACounts[g] = third;
     relayCounts[g] = rcclx::relay::allToAllA4RelayCount(segmentCounts[g]);
+    directACounts[g] = relayCounts[g];
     directBCounts[g] = segmentCounts[g] - directACounts[g] - relayCounts[g];
     if (!buildA4RelayTasks(configs[g], tasks[g])) {
       return ncclInvalidArgument;
@@ -810,7 +809,8 @@ static ncclResult_t shardedRelayAllToAllFlat(
  *
  * nActiveRanksPerGroup must be a power of two (2 or 4). A==2 selects its direct
  * or dedicated 6-helper relay schedule by size. A==4 uses the deterministic
- * XOR/Latin helper schedule in its retained window and exact direct otherwise.
+ * XOR/Latin helper schedule from its lower size bound up, and exact direct
+ * below it.
  */
 HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
     const void* const* sendBuffs,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.h
@@ -29,10 +29,10 @@
  * nActiveRanksPerGroup must be a power of two (2 or 4). A==2 selects between
  * the exact direct exchange at small sizes and the original 2-active
  * passthrough relay with 6 dedicated helpers. A==4 with 4
- * helpers uses the no-pack XOR/Latin relay when the common maximum per-active-
- * rank input size, A * max(segmentCounts) * elementSize, is in [63 MiB,
- * 256 MiB) and every group count is positive. Other A==4 calls use the exact
- * pure-direct all-to-all. OUT-OF-PLACE ONLY in all cases.
+ * helpers uses the no-pack XOR/Latin relay once the common maximum per-active-
+ * rank input size, A * max(segmentCounts) * elementSize, reaches 27 MiB (fused)
+ * or 9 MiB (independent) and every group count is positive. Smaller A==4 calls
+ * use the exact pure-direct all-to-all. OUT-OF-PLACE ONLY in all cases.
  *
  * Unlike allreduce/reduce-scatter, all-to-all performs NO reduction — it is
  * pure data movement — so no reduction kernels are used and there is no

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -988,6 +988,223 @@ static ncclResult_t shardedRelayAllReduce2Active(
 }
 
 /**
+ * Software-pipelined single-group 2-active sharded relay allreduce.
+ *
+ * Same logical collective and the same reduce-at-helper as
+ * shardedRelayAllReduce2Active, but for nGroups == 1 -- where the active ranks
+ * and the helpers are disjoint sets -- the relay is tiled and pipelined so both
+ * directions of every cross link stay busy. See relayA2PipelineTiles() for why
+ * the two-group schedule cannot do that and what it costs.
+ *
+ * With T tiles and unit u = align(count / ((H+1)*T + 1)):
+ *   [0, H*T*u)     relay region; helper h owns [h*T*u, (h+1)*T*u), its tile t
+ * at h*T*u + t*u [H*T*u, count) direct region as T+1 chunks of u, the last
+ * absorbing the
+ *                  /((H+1)*T + 1) remainder and the alignment loss
+ *
+ * Group k, for k in [0, T]: the active rank scatters tile k (k < T) to every
+ * helper, receives helper h's REDUCED tile k-1 (k > 0) straight into its final
+ * place in recvBuff, and exchanges direct chunk k over the active<->active
+ * link. Helper h receives tile k into ping-pong buffer k%2 and forwards the
+ * already reduced buffer (k-1)%2 to both active ranks.
+ *
+ * The helper's reduce of tile k is issued between group k, which receives it,
+ * and group k+1, which sends it -- so it is one launch per tile over u elements
+ * instead of one over the whole chunk. Both active ranks send the same logical
+ * tile index, so their sum is already the final allreduced value and the return
+ * hop stays one chunk per active rank.
+ *
+ * Both in-place and out-of-place are supported. The relay region cannot alias
+ * dangerously even in place: group k reads tile k from sendBuff while writing
+ * tile k-1 into recvBuff, which are different offsets.
+ */
+static ncclResult_t shardedRelayAllReduce2ActivePipelined(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* counts,
+    ncclDataType_t datatype,
+    int reductionDivisor,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nTiles,
+    size_t elementSize) {
+  const ShardedRelayRankConfig& cfg = configs[0];
+  const size_t count = counts[0];
+  const int H = numHelpers;
+  const int T = nTiles;
+  const size_t u =
+      ((count / (static_cast<size_t>(H + 1) * T + 1)) / CHUNK_ALIGN_ELEMENTS) *
+      CHUNK_ALIGN_ELEMENTS;
+  if (u == 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t tileStride = static_cast<size_t>(T) * u;
+  const size_t directBase = static_cast<size_t>(H) * tileStride;
+  const size_t directTotal = count - directBase;
+  const size_t lastDirect = directTotal - tileStride;
+
+  // In-place must stage the received direct chunks so the local contribution is
+  // still readable when the fused reduce runs; out-of-place lands them straight
+  // in recvBuff and reduces against sendBuff.
+  void* directScratch = nullptr;
+  const bool isInPlace = (myActiveGroup == 0) && (sendBuffs[0] == recvBuffs[0]);
+  if (myActiveGroup == 0 && isInPlace) {
+    directScratch = ScratchBufferCache::getInstance().get(
+        0, directTotal * elementSize, stream);
+    if (directScratch == nullptr) {
+      return ncclInternalError;
+    }
+  }
+  auto directDst = [&](size_t offsetWithinDirect) -> char* {
+    if (isInPlace) {
+      return static_cast<char*>(directScratch) +
+          offsetWithinDirect * elementSize;
+    }
+    return static_cast<char*>(recvBuffs[0]) +
+        (directBase + offsetWithinDirect) * elementSize;
+  };
+
+  // Helper staging: two ping-pong slot pairs, one pair per pipeline stage in
+  // flight. Small enough that a tile is reduced and forwarded out of cache.
+  char* hbuff = nullptr;
+  if (!cfg.isActiveRank) {
+    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+        kHelperScratchKeyBase,
+        static_cast<size_t>(cfg.nActiveRanks) * 2 * u * elementSize,
+        stream));
+    if (hbuff == nullptr) {
+      return ncclInternalError;
+    }
+  }
+  // Slot for active source a of the buffer that stage k uses.
+  auto helperSlot = [&](int a, int k) -> char* {
+    return hbuff +
+        (static_cast<size_t>(a) * 2 + static_cast<size_t>(k % 2)) * u *
+        elementSize;
+  };
+
+  for (int k = 0; k <= T; k++) {
+    NCCLCHECK(ncclGroupStart());
+    if (cfg.isActiveRank) {
+      const char* sendbuff = static_cast<const char*>(sendBuffs[0]);
+      char* recvbuff = static_cast<char*>(recvBuffs[0]);
+      const int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      const size_t directOffset = static_cast<size_t>(k) * u;
+      const size_t directSize = (k < T) ? u : lastDirect;
+
+      if (k < T) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclSend(
+              sendbuff +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclSend(
+          sendbuff + (directBase + directOffset) * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+      if (k > 0) {
+        // Already reduced by the helper, so this is its final value.
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclRecv(
+              recvbuff +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k - 1) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclRecv(
+          directDst(directOffset),
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else {
+      if (k < T) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclRecv(
+              helperSlot(a, k), u, datatype, cfg.activeRanks[a], comm, stream));
+        }
+      }
+      if (k > 0) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclSend(
+              helperSlot(0, k - 1),
+              u,
+              datatype,
+              cfg.activeRanks[a],
+              comm,
+              stream));
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+
+    // Reduce the tile this group received, before the next group forwards it.
+    if (!cfg.isActiveRank && k < T) {
+      DISPATCH_FUSED_REDUCE(
+          datatype,
+          helperSlot(0, k),
+          helperSlot(0, k),
+          helperSlot(1, k),
+          u,
+          reductionDivisor,
+          stream);
+    }
+  }
+
+  // Fold both received direct chunks in one fused pass; they are adjacent in
+  // recvBuff and in the scratch.
+  if (myActiveGroup == 0 && directTotal > 0) {
+    char* dst = static_cast<char*>(recvBuffs[0]) + directBase * elementSize;
+    if (isInPlace) {
+      if (reductionDivisor > 1) {
+        DISPATCH_INCREMENTAL_ADD_AND_SCALE(
+            datatype,
+            dst,
+            directScratch,
+            directTotal,
+            reductionDivisor,
+            stream);
+      } else {
+        DISPATCH_INCREMENTAL_ADD(
+            datatype, dst, directScratch, directTotal, stream);
+      }
+    } else {
+      DISPATCH_FUSED_REDUCE(
+          datatype,
+          dst,
+          static_cast<const char*>(sendBuffs[0]) + directBase * elementSize,
+          dst,
+          directTotal,
+          reductionDivisor,
+          stream);
+    }
+  }
+
+  return ncclSuccess;
+}
+
+/**
  * AllReduce for > 2 active ranks (flat helper-reduce-AND-broadcast). Combines
  * the two patterns that individually beat NCCL at 4-active: the
  * reduce-AT-helper of the flat reduce-scatter and the broadcast-AT-helper of
@@ -1384,19 +1601,47 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
 
   ncclResult_t r;
   if (nActiveRanksPerGroup == 2) {
-    r = shardedRelayAllReduce2Active(
-        sendBuffs2,
-        recvBuffs2,
-        counts,
-        datatype,
-        reductionDivisor,
-        comm,
-        stream,
-        configs,
-        myActiveGroup,
-        numHelpers,
-        nGroups,
-        elementSize);
+    // A single-group relay call has the helpers to itself, so the scatter and
+    // the reduced forward run on opposite directions of each cross link and can
+    // be software-pipelined into one duplex stream. relayA2PipelineTiles()
+    // returns 1 whenever that does not apply, and the small-message pure-direct
+    // route (owned by shardedRelayAllReduce2Active) never pipelines.
+    const int nTiles =
+        (rcclx::relay::selectAllReduceRoute(2, nGroups, counts, elementSize) ==
+         rcclx::relay::AllReduceRoute::A2Relay)
+        ? rcclx::relay::relayA2PipelineTiles(
+              2,
+              numHelpers,
+              nGroups,
+              rcclx::relay::relayMaxCount(counts, nGroups),
+              elementSize)
+        : 1;
+    r = (nTiles > 1) ? shardedRelayAllReduce2ActivePipelined(
+                           sendBuffs2,
+                           recvBuffs2,
+                           counts,
+                           datatype,
+                           reductionDivisor,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           numHelpers,
+                           nTiles,
+                           elementSize)
+                     : shardedRelayAllReduce2Active(
+                           sendBuffs2,
+                           recvBuffs2,
+                           counts,
+                           datatype,
+                           reductionDivisor,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           numHelpers,
+                           nGroups,
+                           elementSize);
   } else {
     // A>2: flat helper-reduce-and-broadcast (direct RS+AG over intra woven with
     // offload reduce+broadcast through the helpers).

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -993,7 +993,7 @@ static ncclResult_t shardedRelayAllReduce2Active(
  * Same logical collective and the same reduce-at-helper as
  * shardedRelayAllReduce2Active, but for nGroups == 1 -- where the active ranks
  * and the helpers are disjoint sets -- the relay is tiled and pipelined so both
- * directions of every cross link stay busy. See relayA2PipelineTiles() for why
+ * directions of every cross link stay busy. See relayPipelineTiles() for why
  * the two-group schedule cannot do that and what it costs.
  *
  * With T tiles and unit u = align(count / ((H+1)*T + 1)):
@@ -1603,16 +1603,15 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
   if (nActiveRanksPerGroup == 2) {
     // A single-group relay call has the helpers to itself, so the scatter and
     // the reduced forward run on opposite directions of each cross link and can
-    // be software-pipelined into one duplex stream. relayA2PipelineTiles()
+    // be software-pipelined into one duplex stream. relayPipelineTiles()
     // returns 1 whenever that does not apply, and the small-message pure-direct
     // route (owned by shardedRelayAllReduce2Active) never pipelines.
     const int nTiles =
         (rcclx::relay::selectAllReduceRoute(2, nGroups, counts, elementSize) ==
          rcclx::relay::AllReduceRoute::A2Relay)
-        ? rcclx::relay::relayA2PipelineTiles(
-              2,
-              numHelpers,
+        ? rcclx::relay::relayPipelineTiles(
               nGroups,
+              rcclx::relay::relayShapeA2(numHelpers),
               rcclx::relay::relayMaxCount(counts, nGroups),
               elementSize)
         : 1;

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -1027,7 +1027,7 @@ static ncclResult_t shardedRelayReduceScatter2Active(
  * Same logical collective and the same passthrough helpers as
  * shardedRelayReduceScatter2Active, but for nGroups == 1 -- where the active
  * ranks and the helpers are disjoint sets -- the relay is tiled and pipelined
- * so both directions of every cross link stay busy. See relayA2PipelineTiles()
+ * so both directions of every cross link stay busy. See relayPipelineTiles()
  * for why the two-group schedule cannot do that and what it costs.
  *
  * Helpers stay pure passthrough here, unlike allreduce: slot 0 is a0's
@@ -1709,16 +1709,15 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
     }
     // A single-group relay call has the helpers to itself, so the scatter and
     // the forward run on opposite directions of each cross link and can be
-    // software-pipelined into one duplex stream. relayA2PipelineTiles() returns
+    // software-pipelined into one duplex stream. relayPipelineTiles() returns
     // 1 whenever that does not apply, and the small-message pure-direct route
     // (owned by shardedRelayReduceScatter2Active) never pipelines.
     const int nTiles = (rcclx::relay::selectReduceScatterRoute(
                             2, numHelpers, nGroups, recvCounts, elementSize) ==
                         rcclx::relay::ReduceScatterRoute::A2Relay)
-        ? rcclx::relay::relayA2PipelineTiles(
-              2,
-              numHelpers,
+        ? rcclx::relay::relayPipelineTiles(
               nGroups,
+              rcclx::relay::relayShapeA2(numHelpers),
               rcclx::relay::relayMaxCount(recvCounts, nGroups),
               elementSize)
         : 1;

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -1022,6 +1022,199 @@ static ncclResult_t shardedRelayReduceScatter2Active(
 }
 
 /**
+ * Software-pipelined single-group 2-active sharded relay reduce-scatter.
+ *
+ * Same logical collective and the same passthrough helpers as
+ * shardedRelayReduceScatter2Active, but for nGroups == 1 -- where the active
+ * ranks and the helpers are disjoint sets -- the relay is tiled and pipelined
+ * so both directions of every cross link stay busy. See relayA2PipelineTiles()
+ * for why the two-group schedule cannot do that and what it costs.
+ *
+ * Helpers stay pure passthrough here, unlike allreduce: slot 0 is a0's
+ * contribution to a1's output and slot 1 is a1's contribution to a0's output --
+ * different outputs, so there is nothing to sum at the helper. The active rank
+ * reduces once at the end, and foreignScratch still mirrors the output layout
+ * so that stays a single fused launch no matter how many tiles the relay used.
+ *
+ * With T tiles and unit u = align(recvCount / ((H+1)*T + 1)), the block shipped
+ * to the other active rank splits as:
+ *   [0, H*T*u)         relay region; helper h owns [h*T*u, (h+1)*T*u), its tile
+ *                      t at h*T*u + t*u
+ *   [H*T*u, recvCount) direct region as T+1 chunks of u, the last absorbing the
+ *                      /((H+1)*T + 1) remainder and the alignment loss
+ *
+ * Group k, for k in [0, T]: the active rank scatters tile k (k < T) to every
+ * helper, receives tile k-1 (k > 0) of the partner's contribution from every
+ * helper into the matching offset of foreignScratch, and exchanges direct chunk
+ * k over the active<->active link; helper h receives tile k of each active's
+ * chunk into ping-pong buffer k%2 and forwards buffer (k-1)%2 to the active
+ * rank that owns it.
+ */
+static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* recvCounts,
+    ncclDataType_t datatype,
+    int reductionDivisor,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nTiles,
+    size_t elementSize) {
+  const ShardedRelayRankConfig& cfg = configs[0];
+  const size_t recvcount = recvCounts[0];
+  const int H = numHelpers;
+  const int T = nTiles;
+  const size_t u = ((recvcount / (static_cast<size_t>(H + 1) * T + 1)) /
+                    CHUNK_ALIGN_ELEMENTS) *
+      CHUNK_ALIGN_ELEMENTS;
+  if (u == 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t tileStride = static_cast<size_t>(T) * u;
+  const size_t directBase = static_cast<size_t>(H) * tileStride;
+  const size_t lastDirect = recvcount - directBase - tileStride;
+
+  // Scratch mirroring the output block, so the whole reduction is one launch.
+  void* foreignScratch = nullptr;
+  size_t ownBlockOffset = 0;
+  size_t sendBlockOffset = 0;
+  bool isInPlace = false;
+  if (myActiveGroup == 0) {
+    ownBlockOffset = static_cast<size_t>(cfg.myActiveIndex) * recvcount;
+    sendBlockOffset = static_cast<size_t>(1 - cfg.myActiveIndex) * recvcount;
+    const char* ownBlock =
+        static_cast<const char*>(sendBuffs[0]) + ownBlockOffset * elementSize;
+    isInPlace =
+        (static_cast<const void*>(recvBuffs[0]) ==
+         static_cast<const void*>(ownBlock));
+    foreignScratch = ScratchBufferCache::getInstance().get(
+        SHARDED_RELAY_MAX_GROUPS, recvcount * elementSize, stream);
+    if (foreignScratch == nullptr) {
+      return ncclInternalError;
+    }
+  }
+
+  // Helper staging: two ping-pong units per active source.
+  char* hbuff = nullptr;
+  if (!cfg.isActiveRank) {
+    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+        kHelperScratchKeyBase,
+        static_cast<size_t>(cfg.nActiveRanks) * 2 * u * elementSize,
+        stream));
+    if (hbuff == nullptr) {
+      return ncclInternalError;
+    }
+  }
+  auto helperSlot = [&](int a, int k) -> char* {
+    return hbuff +
+        (static_cast<size_t>(a) * 2 + static_cast<size_t>(k % 2)) * u *
+        elementSize;
+  };
+
+  for (int k = 0; k <= T; k++) {
+    NCCLCHECK(ncclGroupStart());
+    if (cfg.isActiveRank) {
+      const char* sendBlock = static_cast<const char*>(sendBuffs[0]) +
+          sendBlockOffset * elementSize;
+      char* scratch = static_cast<char*>(foreignScratch);
+      const int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      const size_t directOffset = directBase + static_cast<size_t>(k) * u;
+      const size_t directSize = (k < T) ? u : lastDirect;
+
+      if (k < T) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclSend(
+              sendBlock +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclSend(
+          sendBlock + directOffset * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+      if (k > 0) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclRecv(
+              scratch +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k - 1) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclRecv(
+          scratch + directOffset * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else {
+      if (k < T) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclRecv(
+              helperSlot(a, k), u, datatype, cfg.activeRanks[a], comm, stream));
+        }
+      }
+      if (k > 0) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclSend(
+              helperSlot(a, k - 1),
+              u,
+              datatype,
+              cfg.activeRanks[1 - a],
+              comm,
+              stream));
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+  }
+
+  // One fused pass over the whole output block.
+  if (myActiveGroup == 0) {
+    void* out = recvBuffs[0];
+    if (isInPlace) {
+      if (reductionDivisor > 1) {
+        DISPATCH_INCREMENTAL_ADD_AND_SCALE(
+            datatype, out, foreignScratch, recvcount, reductionDivisor, stream);
+      } else {
+        DISPATCH_INCREMENTAL_ADD(
+            datatype, out, foreignScratch, recvcount, stream);
+      }
+    } else {
+      DISPATCH_FUSED_REDUCE(
+          datatype,
+          out,
+          static_cast<const char*>(sendBuffs[0]) + ownBlockOffset * elementSize,
+          foreignScratch,
+          recvcount,
+          reductionDivisor,
+          stream);
+    }
+  }
+
+  return ncclSuccess;
+}
+
+/**
  * Reduce-scatter for > 2 active ranks (two-group flat relay with
  * reduce-at-helper).
  *
@@ -1513,6 +1706,36 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
     for (int g = 0; g < nGroups; g++) {
       sendBuffs2[g] = sendBuffs[g];
       recvBuffs2[g] = recvBuffs[g];
+    }
+    // A single-group relay call has the helpers to itself, so the scatter and
+    // the forward run on opposite directions of each cross link and can be
+    // software-pipelined into one duplex stream. relayA2PipelineTiles() returns
+    // 1 whenever that does not apply, and the small-message pure-direct route
+    // (owned by shardedRelayReduceScatter2Active) never pipelines.
+    const int nTiles = (rcclx::relay::selectReduceScatterRoute(
+                            2, numHelpers, nGroups, recvCounts, elementSize) ==
+                        rcclx::relay::ReduceScatterRoute::A2Relay)
+        ? rcclx::relay::relayA2PipelineTiles(
+              2,
+              numHelpers,
+              nGroups,
+              rcclx::relay::relayMaxCount(recvCounts, nGroups),
+              elementSize)
+        : 1;
+    if (nTiles > 1) {
+      return shardedRelayReduceScatter2ActivePipelined(
+          sendBuffs2,
+          recvBuffs2,
+          recvCounts,
+          datatype,
+          reductionDivisor,
+          comm,
+          stream,
+          configs,
+          myActiveGroup,
+          numHelpers,
+          nTiles,
+          elementSize);
     }
     return shardedRelayReduceScatter2Active(
         sendBuffs2,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_route.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_route.h
@@ -115,8 +115,10 @@ inline size_t relayMaxCount(const size_t* counts, int nGroups) {
  *
  * A==2 crossover: the fused relay overtakes the direct exchange at ~9 MB and an
  * independent call at ~27 MB (independent has no cross-group contention, so
- * direct holds on longer); cross over below each. A==4 uses the XOR relay only
- * inside [63 MiB, 256 MiB).
+ * direct holds on longer); cross over below each. A==4 relays from 27 MB fused
+ * / 9 MB independent up, with no upper bound: the 256 MiB ceiling this used to
+ * carry was covering an alignment bug in the relay geometry, not a real
+ * crossover.
  */
 inline AllToAllRoute selectAllToAllRoute(
     int nActiveRanksPerGroup,
@@ -139,17 +141,23 @@ inline AllToAllRoute selectAllToAllRoute(
   for (int g = 0; g < nGroups; g++) {
     allSegmentCountsPositive &= segmentCounts[g] > 0;
   }
-  constexpr size_t kXorRelayMinBytes = static_cast<size_t>(63) << 20;
-  constexpr size_t kXorRelayMaxBytes = static_cast<size_t>(256) << 20;
+  constexpr size_t kXorRelayMinBytes = static_cast<size_t>(9) << 20;
+  const size_t xorRelayMinBytes = (nGroups > 1)
+      ? (static_cast<size_t>(27) << 20) // fused: >= 27 MB
+      : kXorRelayMinBytes; // independent: >= 9 MB
   const bool useXorRelay = nActiveRanksPerGroup == 4 && numHelpers == 4 &&
-      allSegmentCountsPositive && maxBytes >= kXorRelayMinBytes &&
-      maxBytes < kXorRelayMaxBytes;
+      allSegmentCountsPositive && maxBytes >= xorRelayMinBytes;
   return useXorRelay ? AllToAllRoute::A4XorRelay : AllToAllRoute::PureDirect;
 }
 
-// Per-source relay chunk of the A==4 XOR all-to-all. The direct-B region
-// absorbs both the /3 remainder and the alignment loss, so
-// 3 * relayCount <= segmentCount always holds.
+// Per-source relay chunk of the A==4 XOR all-to-all, and equally the size of
+// its leading direct region: the schedule's two serialized phases each carry
+// one such chunk per link, so the three regions are directA = relay = this
+// count with directB absorbing the /3 remainder and the alignment loss. Every
+// region boundary is therefore 128-element aligned; a plain segmentCount/3
+// directA is misaligned for every power-of-two segment (2^n is never divisible
+// by 3), which pushed the relay region onto an unaligned offset and cost more
+// than the relay saved.
 inline size_t allToAllA4RelayCount(size_t segmentCount) {
   return (segmentCount / 3 / kRelayChunkAlignElements) *
       kRelayChunkAlignElements;

--- a/comms/rcclx/develop/meta/relay/sharded_relay_route.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_route.h
@@ -304,7 +304,41 @@ inline constexpr int kRelayMaxPipelineTiles = 4;
 inline constexpr size_t kRelayPipelineBoundaryBytes = 768u << 10;
 
 /**
- * Software-pipeline depth for the single-group 2-active relay.
+ * Geometry a single-group relay's software pipeline has, in units of the
+ * smallest chunk the schedule moves.
+ *
+ * A relay schedule is described by two linear functions of the depth T:
+ *   totalUnits(T)  how many units the relayed count divides into, so one unit
+ * is count / totalUnits(T) linkUnits(T)   how many units the busiest link
+ * direction ends up carrying, which is what the call actually costs Both are
+ * affine in T, so each is a (perTile, fixed) pair. The depth-1 case always
+ * reproduces the existing two-group schedule, which is the check that a shape
+ * is written correctly.
+ *
+ * The four shipped shapes, on an 8-GPU node (H helpers):
+ *
+ *   2-active, all four collectives   link {1, 1}   total {H+1, 1}
+ *     One unit per link per group. count/4 at T = 1 -> count/7 as T grows.
+ *
+ *   4-active all-to-all              link {1, 1}   total {2, 1}
+ *     One unit up and one down per cross link per group, matched by one direct
+ *     unit on the intra links. 2*count/3 at T = 1 -> count/2.
+ *
+ */
+struct RelayPipelineShape {
+  int linkPerTile;
+  int linkFixed;
+  int totalPerTile;
+  int totalFixed;
+};
+
+inline constexpr RelayPipelineShape relayShapeA2(int numHelpers) {
+  return {1, 1, numHelpers + 1, 1};
+}
+inline constexpr RelayPipelineShape kRelayShapeA4AllToAll = {1, 1, 2, 1};
+
+/**
+ * Software-pipeline depth for a single-group relay.
  *
  * With nGroups == 1 the active ranks and the helpers are DISJOINT sets, so a
  * cross link carries the scatter (active -> helper) in one direction and the
@@ -314,13 +348,11 @@ inline constexpr size_t kRelayPipelineBoundaryBytes = 768u << 10;
  * for all of group 2.
  *
  * Tiling the relay into T tiles and issuing tile t's forward in the SAME group
- * as tile t+1's scatter fills both directions. Per link and direction each of
- * the T+1 groups then carries one unit u, against a count of
- * ((H+1)*T + 1)*u -- so the cost is (T+1)/((H+1)*T + 1) of the count:
- * count/4 at T = 1 (identical to the two-group schedule) falling towards
- * count/7 as T grows on an 8-GPU node, i.e. a 4x ceiling becomes 7x. count/7 is
- * also the hard floor, since an active rank must move its whole buffer out
- * across its 7 links exactly once.
+ * as tile t+1's scatter fills both directions. What that is worth depends on
+ * the schedule's shape (see RelayPipelineShape); at 2 active ranks it takes the
+ * per-link cost from count/4 towards count/7, which is also the hard floor
+ * since an active rank must move its buffer out across its 7 links exactly
+ * once.
  *
  * A FUSED call gains nothing here, which is why this is gated on nGroups == 1:
  * there every rank is active for one group and a helper for the others, so its
@@ -328,30 +360,34 @@ inline constexpr size_t kRelayPipelineBoundaryBytes = 768u << 10;
  * rather than overlap, and the extra group boundaries are pure cost.
  *
  * The depth is whichever power of two minimizes
- * (T + 1) * (perStageBytes + kRelayPipelineBoundaryBytes), which is the two
- * competing terms stated directly rather than a size threshold per depth.
+ * linkUnits(T) * unitBytes + (T + 1) * kRelayPipelineBoundaryBytes, which is
+ * the two competing terms stated directly rather than a size threshold per
+ * depth.
  */
-inline int relayA2PipelineTiles(
-    int nActiveRanksPerGroup,
-    int numHelpers,
+inline int relayPipelineTiles(
     int nGroups,
+    RelayPipelineShape shape,
     size_t maxCount,
     size_t elementSize) {
-  if (nGroups != 1 || nActiveRanksPerGroup != 2 || numHelpers < 1) {
+  if (nGroups != 1 || shape.totalPerTile < 1) {
     return 1;
   }
   const size_t bytes = maxCount * elementSize;
-  const size_t perTileStages = static_cast<size_t>(numHelpers) + 1;
   int bestTiles = 1;
   size_t bestCost = 0;
   for (int tiles = 1; tiles <= kRelayMaxPipelineTiles; tiles *= 2) {
-    const size_t units = perTileStages * static_cast<size_t>(tiles) + 1;
-    // A stage still has to be a whole aligned chunk.
-    if (maxCount / units < kRelayChunkAlignElements) {
+    const size_t totalUnits =
+        static_cast<size_t>(shape.totalPerTile) * static_cast<size_t>(tiles) +
+        static_cast<size_t>(shape.totalFixed);
+    // A unit still has to be a whole aligned chunk.
+    if (maxCount / totalUnits < kRelayChunkAlignElements) {
       break;
     }
-    const size_t cost = static_cast<size_t>(tiles + 1) *
-        (bytes / units + kRelayPipelineBoundaryBytes);
+    const size_t linkUnits =
+        static_cast<size_t>(shape.linkPerTile) * static_cast<size_t>(tiles) +
+        static_cast<size_t>(shape.linkFixed);
+    const size_t cost = linkUnits * (bytes / totalUnits) +
+        static_cast<size_t>(tiles + 1) * kRelayPipelineBoundaryBytes;
     if (bestCost == 0 || cost < bestCost) {
       bestCost = cost;
       bestTiles = tiles;

--- a/comms/rcclx/develop/meta/relay/sharded_relay_route.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_route.h
@@ -284,4 +284,80 @@ inline size_t allReduceOffloadPermille(AllReduceRoute route) {
   return route == AllReduceRoute::FlatOffload ? 500 : 0;
 }
 
+// Largest software-pipeline depth the single-group relays will use.
+//
+// Capped at 4 for stability rather than for throughput. Every group boundary is
+// a cross-rank sync point, so a deeper pipeline gives co-resident independent
+// jobs more opportunities to skew against each other: at depth 8 the 4-job
+// parallel sweep becomes erratic and non-reproducible (0.74x-1.46x outliers
+// scattered through the size axis, different sizes each run), while depth 4 is
+// as stable as the unpipelined schedule. Depth 4 also happens to be what the
+// cost model below picks at every size measured on the single-group sweep, so
+// the cap costs nothing there.
+inline constexpr int kRelayMaxPipelineTiles = 4;
+
+// What one extra ncclGroup boundary costs, expressed as the per-link bytes that
+// take the same time: a grouped-P2P launch plus work-FIFO upload plus fence is
+// ~25 us, which at the measured ~50 GB/s per XGMI link is ~768 KiB. Deepening
+// the pipeline trades per-link bytes for boundaries, so this is what decides
+// where that trade stops paying.
+inline constexpr size_t kRelayPipelineBoundaryBytes = 768u << 10;
+
+/**
+ * Software-pipeline depth for the single-group 2-active relay.
+ *
+ * With nGroups == 1 the active ranks and the helpers are DISJOINT sets, so a
+ * cross link carries the scatter (active -> helper) in one direction and the
+ * forward (helper -> active) in the other. Running those as two serialized
+ * ncclGroups therefore leaves every cross link HALF-DUPLEX for the whole call:
+ * the forward direction is idle for all of group 1 and the scatter direction
+ * for all of group 2.
+ *
+ * Tiling the relay into T tiles and issuing tile t's forward in the SAME group
+ * as tile t+1's scatter fills both directions. Per link and direction each of
+ * the T+1 groups then carries one unit u, against a count of
+ * ((H+1)*T + 1)*u -- so the cost is (T+1)/((H+1)*T + 1) of the count:
+ * count/4 at T = 1 (identical to the two-group schedule) falling towards
+ * count/7 as T grows on an 8-GPU node, i.e. a 4x ceiling becomes 7x. count/7 is
+ * also the hard floor, since an active rank must move its whole buffer out
+ * across its 7 links exactly once.
+ *
+ * A FUSED call gains nothing here, which is why this is gated on nGroups == 1:
+ * there every rank is active for one group and a helper for the others, so its
+ * scatter and its forward are egress on the SAME link direction. They add
+ * rather than overlap, and the extra group boundaries are pure cost.
+ *
+ * The depth is whichever power of two minimizes
+ * (T + 1) * (perStageBytes + kRelayPipelineBoundaryBytes), which is the two
+ * competing terms stated directly rather than a size threshold per depth.
+ */
+inline int relayA2PipelineTiles(
+    int nActiveRanksPerGroup,
+    int numHelpers,
+    int nGroups,
+    size_t maxCount,
+    size_t elementSize) {
+  if (nGroups != 1 || nActiveRanksPerGroup != 2 || numHelpers < 1) {
+    return 1;
+  }
+  const size_t bytes = maxCount * elementSize;
+  const size_t perTileStages = static_cast<size_t>(numHelpers) + 1;
+  int bestTiles = 1;
+  size_t bestCost = 0;
+  for (int tiles = 1; tiles <= kRelayMaxPipelineTiles; tiles *= 2) {
+    const size_t units = perTileStages * static_cast<size_t>(tiles) + 1;
+    // A stage still has to be a whole aligned chunk.
+    if (maxCount / units < kRelayChunkAlignElements) {
+      break;
+    }
+    const size_t cost = static_cast<size_t>(tiles + 1) *
+        (bytes / units + kRelayPipelineBoundaryBytes);
+    if (bestCost == 0 || cost < bestCost) {
+      bestCost = cost;
+      bestTiles = tiles;
+    }
+  }
+  return bestTiles;
+}
+
 } // namespace rcclx::relay

--- a/comms/rcclx/develop/meta/relay/sharded_relay_route.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_route.h
@@ -304,26 +304,34 @@ inline constexpr int kRelayMaxPipelineTiles = 4;
 inline constexpr size_t kRelayPipelineBoundaryBytes = 768u << 10;
 
 /**
- * Geometry a single-group relay's software pipeline has, in units of the
+ * Geometry of a single-group relay's software pipeline, in units of the
  * smallest chunk the schedule moves.
  *
- * A relay schedule is described by two linear functions of the depth T:
- *   totalUnits(T)  how many units the relayed count divides into, so one unit
- * is count / totalUnits(T) linkUnits(T)   how many units the busiest link
- * direction ends up carrying, which is what the call actually costs Both are
- * affine in T, so each is a (perTile, fixed) pair. The depth-1 case always
- * reproduces the existing two-group schedule, which is the check that a shape
- * is written correctly.
+ * A schedule is described by two affine functions of the depth T, each a
+ * (perTile, fixed) pair:
  *
- * The four shipped shapes, on an 8-GPU node (H helpers):
+ * - totalUnits(T): how many units the relayed count divides into. One unit is
+ *   count / totalUnits(T).
+ * - linkUnits(T): how many units the busiest link direction carries, which is
+ *   what the call actually costs.
  *
- *   2-active, all four collectives   link {1, 1}   total {H+1, 1}
- *     One unit per link per group. count/4 at T = 1 -> count/7 as T grows.
+ * Depth 1 always reproduces the existing two-group schedule, which is the check
+ * that a shape is written correctly.
  *
- *   4-active all-to-all              link {1, 1}   total {2, 1}
- *     One unit up and one down per cross link per group, matched by one direct
- *     unit on the intra links. 2*count/3 at T = 1 -> count/2.
+ * The shipped shapes, for A active ranks and H helpers:
  *
+ * - 2-active, all four collectives. link {1, 1}, total {H+1, 1}. One unit per
+ *   link per group; count/4 at T = 1 falling towards count/7 at H = 6.
+ * - 4-active all-to-all. link {1, 1}, total {2, 1}. One unit up and one down
+ * per cross link per group, matched by one direct unit on the intra links;
+ *   2*count/3 at T = 1 falling towards count/2.
+ * - A>2 all-gather fanout. link {A-1, 1}, total {H+A-1, 1}. Asymmetric: the
+ *   helper fans each source's slice out to the A-1 other destinations, so one
+ *   direction of the cross link carries A-1 units for every 1 the other
+ *   carries and merging is bounded by the heavy direction. At A = H = 4 that
+ *   is link {3, 1} / total {7, 1}: count/2 at T = 1 falling towards
+ *   3*count/7, which is also the hard floor since an active rank must take in
+ *   A-1 whole buffers across its 7 links.
  */
 struct RelayPipelineShape {
   int linkPerTile;
@@ -336,6 +344,17 @@ inline constexpr RelayPipelineShape relayShapeA2(int numHelpers) {
   return {1, 1, numHelpers + 1, 1};
 }
 inline constexpr RelayPipelineShape kRelayShapeA4AllToAll = {1, 1, 2, 1};
+
+// The all-gather fanout schedule's layout consumes H*T + 1 + (T-1)*(A-1) units
+// before its final direct chunk, so totalUnits must be at least that for
+// directSize(T) = count - directOffset(T) not to underflow. Deriving both
+// members from A and H keeps the shape and the kernel's own layout in step for
+// every geometry buildShardedRelayRankConfig() accepts, not just A = H = 4.
+inline constexpr RelayPipelineShape relayShapeFanout(
+    int nActiveRanks,
+    int numHelpers) {
+  return {nActiveRanks - 1, 1, numHelpers + nActiveRanks - 1, 1};
+}
 
 /**
  * Software-pipeline depth for a single-group relay.

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
@@ -1405,6 +1405,145 @@ TEST_F(ShardedRelayMultiGroupAllGatherTest, Z_BusBW_4Groups_InPlace_1GB) {
 }
 
 /**
+ * Test: single group (nGroups == 1) at 4 active ranks, both placements.
+ *
+ * nGroups == 1 makes the active ranks {0,1,2,3} and the helpers {4,5,6,7}
+ * disjoint, which is what puts the flat relay on its software-pipelined
+ * schedule: the offload scatter and the helper fan-out share a group so each
+ * cross link runs duplex. 64 MB is above the offload threshold and deep enough
+ * for the cost model to tile, so this is the only coverage of that path -- the
+ * other 4-active cases all run 2 groups, where the relay stays unpipelined.
+ */
+class ShardedRelayAllGatherSingleGroupA4Test
+    : public ShardedRelayMultiGroupAllGatherTest {
+ protected:
+  void runSingleGroupA4Case(bool inPlace) {
+    const int nGroups = 1;
+    const int nActiveRanksPerGroup = 4;
+    const size_t sendBytes = 64ULL * 1024 * 1024;
+    const size_t sendCount = sendBytes / sizeof(int32_t);
+    const size_t outBytes =
+        static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+
+    const int activeRanks[] = {0, 1, 2, 3};
+    const int* allActiveRanks[] = {activeRanks};
+    const bool isActive = this->globalRank < nActiveRanksPerGroup;
+    const int myActiveIndex = this->globalRank;
+
+    // Helpers hand in a placeholder; the kernel stages into its own scratch.
+    int32_t* recvBuff = nullptr;
+    int32_t* sendBuff = nullptr;
+    HIPCHECK_TEST(hipMalloc(&recvBuff, outBytes));
+    if (isActive && !inPlace) {
+      HIPCHECK_TEST(hipMalloc(&sendBuff, sendBytes));
+    }
+
+    barrierSyncOn(recvBuff);
+
+    HIPCHECK_TEST(hipMemset(recvBuff, 0, outBytes));
+    // Only the active ranks have a slot in recvBuff; forming the pointer on a
+    // helper (globalRank 4..7) would run past the A=4 slots allocated.
+    int32_t* mySlot = isActive
+        ? recvBuff + static_cast<size_t>(myActiveIndex) * sendCount
+        : nullptr;
+    if (isActive) {
+      // In-place: the contribution already sits in this rank's output slot.
+      fillDeviceRegion(
+          inPlace ? mySlot : sendBuff, sendCount, rankFillValue(myActiveIndex));
+    }
+
+    const void* sendPtrs[1] = {
+        isActive ? (inPlace ? mySlot : sendBuff) : recvBuff};
+    void* recvPtrs[1] = {recvBuff};
+    size_t sendCounts[1] = {sendCount};
+
+    const ncclResult_t result = callAllGatherCompat(
+        sendPtrs,
+        recvPtrs,
+        sendCounts,
+        ncclInt32,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+    if (isActive) {
+      verifyAllGatherOutput(recvBuff, sendCount, 0, nActiveRanksPerGroup);
+    }
+
+    HIPCHECK_TEST(hipFree(recvBuff));
+    if (sendBuff != nullptr) {
+      HIPCHECK_TEST(hipFree(sendBuff));
+    }
+  }
+};
+
+TEST_F(ShardedRelayAllGatherSingleGroupA4Test, Correctness_OutOfPlace_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runSingleGroupA4Case(/*inPlace=*/false);
+}
+
+TEST_F(ShardedRelayAllGatherSingleGroupA4Test, Correctness_InPlace_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runSingleGroupA4Case(/*inPlace=*/true);
+}
+
+/**
+ * Test: the pipelined fanout layout fits inside the count at EVERY geometry
+ * buildShardedRelayRankConfig() accepts, not just the A = H = 4 one the 8-rank
+ * cases above exercise.
+ *
+ * The GPU cases here are pinned to 8 ranks, so a single-group A = 4 call always
+ * has exactly 4 helpers and the A + H combinations that a 9-to-16-rank comm
+ * would produce (A = 4 with H = 5..8, or A = 8 with H = 8) are unreachable from
+ * this harness. What those geometries can break is arithmetic, not scheduling:
+ * shardedRelayAllGatherFlatPipelined() lays out H*T + 1 + (T-1)*(A-1) units
+ * before its final direct chunk, and if totalUnits(T) is smaller than that then
+ * directSize(T) = sc - directOffset(T) underflows as size_t and a wild count
+ * reaches ncclSend/ncclRecv. So assert the invariant against the shape directly
+ * over the whole accepted (A, H) space, which needs no ranks at all.
+ */
+TEST(ShardedRelayAllGatherFanoutShape, LayoutFitsAtEveryAcceptedGeometry) {
+  // Mirrors SHARDED_RELAY_MAX_ACTIVE / SHARDED_RELAY_MAX_HELPERS.
+  constexpr int kMaxActive = 8;
+  constexpr int kMaxHelpers = 8;
+
+  for (int a = 2; a <= kMaxActive; a *= 2) {
+    for (int h = 1; h <= kMaxHelpers; h++) {
+      const rcclx::relay::RelayPipelineShape shape =
+          rcclx::relay::relayShapeFanout(a, h);
+      for (int t = 1; t <= 8; t *= 2) {
+        const int totalUnits = shape.totalPerTile * t + shape.totalFixed;
+        // Units the layout consumes before the final direct chunk, which must
+        // itself be at least one heavy chunk of A-1 units.
+        const int consumed = h * t + 1 + (t - 1) * (a - 1);
+        EXPECT_LE(consumed + (a - 1), totalUnits)
+            << "fanout layout overruns the count at A=" << a << " H=" << h
+            << " T=" << t << ": consumes " << consumed << " units plus a final "
+            << (a - 1) << "-unit chunk out of " << totalUnits;
+      }
+    }
+  }
+
+  // Depth 1 must reproduce the two-group schedule, and the shipped 8-GPU
+  // geometry must still resolve to the constants the perf numbers were measured
+  // at, so the parameterization is a generalization and not a change.
+  const rcclx::relay::RelayPipelineShape shipped =
+      rcclx::relay::relayShapeFanout(4, 4);
+  EXPECT_EQ(shipped.linkPerTile, 3);
+  EXPECT_EQ(shipped.linkFixed, 1);
+  EXPECT_EQ(shipped.totalPerTile, 7);
+  EXPECT_EQ(shipped.totalFixed, 1);
+}
+
+/**
  * 4-ACTIVE tests (2 groups of 4 active ranks each).
  *   Group 0: active {0,1,2,3}, helpers {4,5,6,7}
  *   Group 1: active {4,5,6,7}, helpers {0,1,2,3}

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
@@ -787,6 +787,73 @@ TEST_F(ShardedRelayMultiGroupAllGatherTest, Correctness_SingleGroup_64MB) {
 }
 
 /**
+ * Test: Single group, IN-PLACE, at a size the software pipeline covers.
+ *
+ * nGroups == 1 puts the relay on the pipelined schedule (the active ranks and
+ * the helpers are disjoint there, so the scatter and the forward run on
+ * opposite directions of each cross link and are interleaved). 64 MB clears the
+ * pipeline floor, so this pins the pipelined path's in-place handling -- the
+ * diagonal is already in the send slot and must not be re-copied, while the
+ * gather slot is written tile by tile across the pipeline stages.
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllGatherTest,
+    Correctness_SingleGroup_InPlace_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 1;
+  const int nActiveRanksPerGroup = 2;
+  const size_t sendBytes = 64ULL * 1024 * 1024;
+  const size_t sendCount = sendBytes / sizeof(int32_t);
+
+  const int activeRanks[] = {0, 1};
+  const int* allActiveRanks[] = {activeRanks};
+
+  const bool isActive = (this->globalRank == 0 || this->globalRank == 1);
+  const int myActiveIndex = this->globalRank;
+
+  int32_t* buff = nullptr;
+  const size_t buffBytes =
+      static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+  HIPCHECK_TEST(hipMalloc(&buff, buffBytes));
+
+  barrierSyncOn(buff);
+
+  HIPCHECK_TEST(hipMemset(buff, 0, buffBytes));
+  // In-place: this rank's contribution already sits in its own output slot.
+  int32_t* mySlot = buff + static_cast<size_t>(myActiveIndex) * sendCount;
+  if (isActive) {
+    fillDeviceRegion(mySlot, sendCount, rankFillValue(myActiveIndex));
+  }
+
+  const void* sendPtrs[1] = {isActive ? mySlot : buff};
+  void* recvPtrs[1] = {buff};
+  size_t sendCounts[] = {sendCount};
+
+  const ncclResult_t result = callAllGatherCompat(
+      sendPtrs,
+      recvPtrs,
+      sendCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  if (isActive) {
+    verifyAllGatherOutput(buff, sendCount, 0);
+  }
+
+  HIPCHECK_TEST(hipFree(buff));
+}
+
+/**
  * Test: Correctness with minimum passthrough helper buffers (OUT-OF-PLACE)
  */
 TEST_F(

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
@@ -1599,6 +1599,29 @@ TEST_F(
 }
 
 /**
+ * A=4 single group at a size the software pipeline covers.
+ *
+ * The 9 MiB single-group cases above are just above the routing threshold,
+ * which the depth cost model resolves to depth 1 -- so they exercise the
+ * unpipelined XOR schedule. 64 MiB per active rank is the first swept size deep
+ * enough to tile, so this is the coverage for the pipelined schedule, where
+ * each cross link carries the relay's two hops at once in opposite directions.
+ * Verified over whole segments rather than at region boundaries, since the
+ * pipelined layout splits the segment differently.
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_4Active_SingleGroup_Pipelined_64MiB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  constexpr size_t perActiveBytes = 64ULL * 1024 * 1024;
+  constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t));
+  runA4SingleGroupCorrectnessCase(segmentCount, true);
+}
+
+/**
  * Tiny-segment regression for the exact direct fallback below the retained
  * A=4 XOR/Latin routing window.
  */

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
@@ -512,7 +512,7 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
         initActiveSendBuffer(
             sendBuffs[g], segmentCount, myActiveIndex, nActiveRanksPerGroup);
         if (checkRegionBoundaries) {
-          const size_t directA = segmentCount / 3;
+          const size_t directA = relayCount;
           const size_t regionOffsets[5] = {
               directA - 1,
               directA,
@@ -561,7 +561,7 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
     HIPCHECK_TEST(hipStreamSynchronize(this->stream));
 
     if (checkRegionBoundaries) {
-      const size_t directA = segmentCount / 3;
+      const size_t directA = relayCount;
       const size_t regionOffsets[5] = {
           directA - 1,
           directA,
@@ -654,7 +654,7 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
       initActiveSendBuffer(
           sendBuff, segmentCount, myActiveIndex, nActiveRanksPerGroup);
       if (checkRegionBoundaries) {
-        const size_t directA = segmentCount / 3;
+        const size_t directA = relayCount;
         const size_t regionOffsets[5] = {
             directA - 1,
             directA,
@@ -703,7 +703,7 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
 
     if (isActive) {
       if (checkRegionBoundaries) {
-        const size_t directA = segmentCount / 3;
+        const size_t directA = relayCount;
         const size_t regionOffsets[5] = {
             directA - 1,
             directA,
@@ -1508,12 +1508,12 @@ TEST_F(ShardedRelayMultiGroupAllToAllTest, Z_BusBW_4Groups_OutOfPlace_1GB) {
  */
 TEST_F(
     ShardedRelayMultiGroupAllToAllTest,
-    Correctness_4Active_RoutedLowerBoundary_63MiB) {
+    Correctness_4Active_RoutedLowerBoundary_27MiB) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 27ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t));
   runA4CorrectnessCase(segmentCount, true);
 }
@@ -1525,7 +1525,7 @@ TEST_F(
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 27ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t)) - 1;
   runA4CorrectnessCase(segmentCount, false);
 }
@@ -1537,21 +1537,26 @@ TEST_F(
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 27ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t)) + 1;
   runA4CorrectnessCase(segmentCount, true, true);
 }
 
+// 256 MiB is a power of two, so segmentCount is not divisible by 3 and the
+// relay's leading direct region has to be aligned down rather than taken as an
+// exact third. Routed here (this size used to be the top of the window), with
+// the region boundaries checked so a misaligned split is caught.
 TEST_F(
     ShardedRelayMultiGroupAllToAllTest,
-    Correctness_4Active_DirectUpperBoundary_256MiB) {
+    Correctness_4Active_RoutedPowerOfTwo_256MiB) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
   constexpr size_t perActiveBytes = 256ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t));
-  runA4CorrectnessCase(segmentCount, false);
+  static_assert(segmentCount % 3 != 0, "256 MiB must not divide into thirds");
+  runA4CorrectnessCase(segmentCount, true, true);
 }
 
 // Single-group (nGroups=1) A=4 all-to-all: ranks {0,1,2,3} active, {4,5,6,7}
@@ -1559,12 +1564,12 @@ TEST_F(
 // tests cover, across the routed and direct regimes.
 TEST_F(
     ShardedRelayMultiGroupAllToAllTest,
-    Correctness_4Active_SingleGroup_Routed_63MiB) {
+    Correctness_4Active_SingleGroup_Routed_9MiB) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 9ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t));
   runA4SingleGroupCorrectnessCase(segmentCount, true);
 }
@@ -1576,7 +1581,7 @@ TEST_F(
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 9ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t)) - 1;
   runA4SingleGroupCorrectnessCase(segmentCount, false);
 }
@@ -1588,7 +1593,7 @@ TEST_F(
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 9ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t)) + 1;
   runA4SingleGroupCorrectnessCase(segmentCount, true, true);
 }


### PR DESCRIPTION
Summary:

Applies the duplex pipelining to the 4-active flat all-gather. With nGroups == 1
the active ranks and the helpers are disjoint, so the offload scatter
(active -> helper) and the helper fan-out (helper -> active) sit on OPPOSITE
directions of the same cross link and the two-group form leaves each of them half
idle. Tiling the offload so tile t's fan-out shares a group with tile t+1's
scatter fills both directions.

This schedule is ASYMMETRIC, unlike the 2-active one: a helper fans each source's
slice out to the A-1 = 3 other destinations, so a cross link carries one unit UP
for every three DOWN. Merging is bounded by the down direction and the up
direction stays underused, so the model only allows 1.12x here versus 1.75x at
2 active. With v = align(sc / (7*T + 1)) each group carries 3v on the busiest link
and the direct region is split to match -- v for group 0, which has no fan-out to
receive yet, and 3v for the rest -- giving (3*T + 1)*v: sc/2 at T = 1 (identical
to the two-group schedule) falling towards 3*sc/7. That floor is the hard one,
since an active rank must take in A-1 whole buffers across its 7 links.

The measured gain is well ABOVE the link model: 1.22x at 1 GB and 1.28x at
512 MB against the model's 1.12x. The extra comes from helper staging, which
drops from A*cs (512 MB at a 1 GB message) to two ping-pong tiles per source
(~148 MB at depth 4) and so stops spilling out of cache on the fan-out re-reads.
That also removes most of the large-size decay this path had: speedup used to
fall 1.64x -> 1.55x -> 1.42x -> 1.36x from 135 MB to 1 GB and is now
1.77x -> 1.82x -> 1.81x -> 1.66x.

Adds the all-gather shape to RelayPipelineShape; depth selection, the boundary
cost model, the depth cap and the nGroups == 1 gate are the shared
relayPipelineTiles(). Fused calls keep the original schedule bit-for-bit.

Perf -- single-group 4-active all-gather (MI350X, 8 GPUs, bf16, best-of-100,
speedup = 4-rank NCCL all-gather with the other 4 ranks idle / relay), same-day
before and after:

```
  Msg Size    before     after    relay ms
     9 MB      1.34x     1.35x    0.172 -> 0.171  (depth 1, unchanged)
  13.5 MB      1.41x     1.45x    0.222 -> 0.223  (depth 1, unchanged)
    27 MB      1.58x     1.57x    0.377 -> 0.378
  31.5 MB      1.64x     1.61x    0.428 -> 0.423
    36 MB      1.60x     1.62x    0.480 -> 0.477
    63 MB      1.64x     1.70x    0.792 -> 0.771
  67.5 MB      1.64x     1.72x    0.854 -> 0.817
    72 MB      1.65x     1.72x    0.907 -> 0.868
   135 MB      1.64x     1.77x    1.664 -> 1.542
   144 MB      1.64x     1.77x    1.770 -> 1.641
   256 MB      1.55x     1.82x    3.306 -> 2.808
   512 MB      1.42x     1.81x    7.114 -> 5.563
     1 GB      1.36x     1.65x   14.709 -> 12.105
```

Fused (2 groups) is unchanged by construction and re-measured to confirm, matching
the checked-in `perf_data/bench_sharded_relay_fused_sweep_results.txt` exactly:
1.28x / 1.31x / 1.32x / 1.31x at 63 MB / 135 MB / 256 MB / 1 GB.

Parallel (2 co-resident jobs) improves too, comparing minima over 4 repetitions
per depth (see the note below on why single runs are not usable here):

```
  Msg Size   depth 1   pipelined
   135 MB     1.849       1.585
   144 MB     1.992       1.667
   256 MB     3.650       2.880
   512 MB     7.131       6.505
     1 GB    15.234      14.606
```

**Note on parallel-sweep variance.** A single parallel run initially looked like
this change destabilized the co-resident case (isolated 0.67x-0.80x points). It
does not. That sweep has a run-scoped, bimodal ~20-30% spread on relay times which
is present at depth 1 with EQUAL OR LARGER magnitude (max/min over 4 runs at
144 MB: 1.78 at depth 1 versus 1.24 at depth 4), is identical across co-resident
jobs to within 3%, and does not appear in the NCCL baseline. It is not DVFS (fclk
stays pinned at 1500 MHz, sclk moves ~6%) and is not the torch allocator
(expandable_segments does not change it). Pinning NCCL_MIN/MAX_P2P_NCHANNELS makes
it deterministic to +/-1% but costs 1.75x at 32 channels and 20x at 8, which
localizes it to p2p channel resourcing inside RCCL rather than anything the relay
schedule controls. The practical consequence is that parallel comparisons need
repetitions and must compare minima; all parallel numbers here do.

Differential Revision: D117629690


