### PR TITLE
Add a production-shape relay control plane test (2 and 4 active) (#3839)

### DIFF
--- a/comms/rcclx/develop/meta/relay/relay_control.cc
+++ b/comms/rcclx/develop/meta/relay/relay_control.cc
@@ -1,0 +1,1223 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "meta/relay/relay_control.h"
+
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "bootstrap.h"
+#include "comm.h"
+#include "debug.h"
+#include "param.h"
+
+namespace rcclx::relay {
+
+namespace {
+
+/**
+ * Segment header. Fixed 64 bytes; every field is read by peers, so this is a
+ * wire format and its layout is pinned by the static_assert below.
+ */
+struct Header {
+  uint32_t magic;
+  uint32_t version;
+  uint32_t nRanks;
+  uint32_t nActive; // diagnostic only; 0 when not known at init
+  uint64_t commHash;
+  uint32_t abortReason;
+  uint32_t abortRank;
+  uint32_t ringDepth;
+  uint32_t maxCalls;
+  uint32_t creatorPid;
+  uint32_t hwmCalls;
+  // Stamped last by the creator, with release ordering, so an attacher that
+  // sees 1 also sees a fully written header. Without it a rank that wins the
+  // race to shm_open an existing-but-unstamped segment reads zeroes and reports
+  // a bogus magic mismatch instead of simply waiting.
+  uint32_t ready;
+  // Which rank owns publishing. There is ONE ring per communicator, so two
+  // ranks publishing the same epoch would race the seqlock and drive it
+  // backwards -- even though their plans are byte-identical, because both know
+  // the same token count. Claimed on first publish and enforced thereafter, so
+  // the misuse surfaces as an error instead of as corruption.
+  uint32_t publisherRank;
+  // Start time of creatorPid, so a RECYCLED pid can be told from the process
+  // that recorded it. Without this a stale segment whose pid has been reused by
+  // an unrelated process looks live forever, and create() then refuses to build
+  // a segment for that commHash until someone removes the shm object by hand.
+  // 0 means "could not be determined", in which case the pid alone decides.
+  uint64_t creatorStartTime;
+};
+static_assert(
+    sizeof(Header) == 64,
+    "Header is a wire format; its size is part of the segment layout");
+
+constexpr size_t kSlotAlign = 64;
+
+// The per-slot prologue: the seqlock word plus the fixed plan record. Counts
+// follow it, `maxCalls` of them, which is why the slot stride is a runtime
+// value rather than a type's size.
+constexpr size_t kSlotPrologue = sizeof(uint64_t) + sizeof(RelayPlanInfo);
+
+size_t alignUp(size_t v, size_t a) {
+  return (v + a - 1) & ~(a - 1);
+}
+
+size_t slotStride(uint32_t maxCalls) {
+  return alignUp(
+      kSlotPrologue + static_cast<size_t>(maxCalls) * sizeof(uint64_t),
+      kSlotAlign);
+}
+
+size_t consumedBytes(uint32_t nRanks) {
+  return alignUp(static_cast<size_t>(nRanks) * sizeof(uint64_t), kSlotAlign);
+}
+
+int64_t nowNs() {
+  struct timespec ts{};
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<int64_t>(ts.tv_sec) * 1000000000LL +
+      static_cast<int64_t>(ts.tv_nsec);
+}
+
+inline void cpuRelax() {
+#if defined(__x86_64__) || defined(__i386__)
+  __builtin_ia32_pause();
+#elif defined(__aarch64__)
+  __asm__ __volatile__("yield" ::: "memory");
+#else
+  __atomic_thread_fence(__ATOMIC_SEQ_CST);
+#endif
+}
+
+// Enough pauses to cover a publisher that is a few hundred nanoseconds ahead of
+// us, and no more. In steady state the publisher runs a whole forward ahead, so
+// the plan is already there on the first load and none of this budget is spent;
+// it exists for cold start and for the first forward after a shape change.
+constexpr int kSpinBudget = 256;
+constexpr int64_t kBackoffStartNs = 10 * 1000; // 10 us
+constexpr int64_t kBackoffMaxNs = 1000 * 1000; // 1 ms
+
+// publisherRank's "nobody has claimed it" value. Not 0, because 0 is a real
+// rank and in practice the likely publisher.
+constexpr uint32_t kNoPublisher = 0xFFFFFFFFu;
+
+// abortRank before any abort has been attributed. Distinct from a real rank so
+// a reader cannot mistake "not yet recorded" for rank 0.
+constexpr uint32_t kRelayAbortRankUnknown = 0xFFFFFFFFu;
+
+/**
+ * Per-rank consumer progress, encoded in one word so it can be published with a
+ * single release store.
+ *
+ *   0      rank has never entered consume(): NOT a consumer of this segment,
+ *          and must never be waited on -- the active ranks attach too, and
+ *          waiting on them would deadlock immediately.
+ *   1      rank is consuming but has not completed an epoch yet.
+ *   k + 2  rank has completed every epoch through k.
+ *
+ * Registration happens on ENTRY to consume(), not on completion. Completion
+ * would leave a consumer that has started but not yet finished epoch 0
+ * unprotected, letting the publisher run a full ring ahead and overwrite the
+ * slot that consumer is about to read -- which is a realistic race, because a
+ * helper does work between consumes.
+ */
+constexpr uint64_t kConsumerUnregistered = 0;
+constexpr uint64_t kConsumerRegistered = 1;
+
+uint64_t consumedEncode(uint64_t epoch) {
+  return epoch + 2;
+}
+
+// What a consumer must have reached before the slot for `epoch` may be reused.
+// The slot was last written by epoch - ringDepth, so that is what must be done.
+uint64_t consumedNeededFor(uint64_t epoch, uint32_t ringDepth) {
+  return (epoch - ringDepth) + 2;
+}
+
+/**
+ * Spin briefly, then sleep with exponential backoff, then give up.
+ *
+ * The give-up is the point. The store this replaces had a wait() timeout, which
+ * is the property that kept a helper loop from wedging silently; removing the
+ * store removes that, so it has to be put back here.
+ */
+class BoundedWait {
+ public:
+  explicit BoundedWait(int64_t timeoutNs)
+      : start_(nowNs()), deadline_(start_ + (timeoutNs > 0 ? timeoutNs : 0)) {}
+
+  // False once the budget is exhausted.
+  bool step() {
+    if (spins_ < kSpinBudget) {
+      ++spins_;
+      cpuRelax();
+      return true;
+    }
+    const int64_t now = nowNs();
+    if (now >= deadline_) {
+      return false;
+    }
+    int64_t sleepNs = std::min(backoffNs_, deadline_ - now);
+    struct timespec ts{
+        static_cast<time_t>(sleepNs / 1000000000LL),
+        static_cast<long>(sleepNs % 1000000000LL)};
+    nanosleep(&ts, nullptr);
+    backoffNs_ = std::min(backoffNs_ * 2, kBackoffMaxNs);
+    return true;
+  }
+
+  int64_t elapsedNs() const {
+    return nowNs() - start_;
+  }
+
+ private:
+  int64_t start_;
+  int64_t deadline_;
+  int64_t backoffNs_{kBackoffStartNs};
+  int spins_{0};
+};
+
+// Start time of a process in clock ticks since boot, from field 22 of
+// /proc/<pid>/stat. 0 if it cannot be read.
+//
+// Parsed from the LAST ')' rather than by splitting on spaces: field 2 is the
+// executable name in parentheses and may itself contain spaces and parens, so
+// counting fields from the front misreads for any such process.
+uint64_t processStartTime(pid_t pid) {
+  char path[64];
+  snprintf(path, sizeof(path), "/proc/%d/stat", static_cast<int>(pid));
+  FILE* f = fopen(path, "re");
+  if (f == nullptr) {
+    return 0;
+  }
+  char buf[1024];
+  const size_t got = fread(buf, 1, sizeof(buf) - 1, f);
+  fclose(f);
+  if (got == 0) {
+    return 0;
+  }
+  buf[got] = '\0';
+  const char* close = strrchr(buf, ')');
+  if (close == nullptr) {
+    return 0;
+  }
+  // Fields 3.. follow the ')'. starttime is field 22, so it is the 20th value
+  // after it.
+  const char* p = close + 1;
+  for (int field = 3; field < 22; field++) {
+    while (*p == ' ') {
+      p++;
+    }
+    while (*p != '\0' && *p != ' ') {
+      p++;
+    }
+    if (*p == '\0') {
+      return 0;
+    }
+  }
+  while (*p == ' ') {
+    p++;
+  }
+  return strtoull(p, nullptr, 10);
+}
+
+// seq is 2*epoch+1 while a slot is in flux and 2*epoch+2 once it is stable, so
+// which epoch a seq value refers to depends on its parity. Getting that wrong
+// misreports the epoch in exactly the desync diagnostics this is here to make
+// legible.
+uint64_t epochFromSeq(uint64_t seq) {
+  if (seq < 2) {
+    return 0;
+  }
+  return (seq % 2 == 0) ? ((seq - 2) / 2) : ((seq - 1) / 2);
+}
+
+// True if a process with this pid exists AND is the same process that recorded
+// startTime. Used to decide whether a segment left behind by an earlier run is
+// garbage or belongs to something still running -- the difference between
+// safely reclaiming it and destroying a live job's state.
+//
+// The start time is what makes this unambiguous. pids are recycled, so
+// kill(pid, 0) alone reports an unrelated process as the live creator.
+bool creatorAlive(uint32_t pid, uint64_t startTime) {
+  if (pid == 0) {
+    return false;
+  }
+  if (kill(static_cast<pid_t>(pid), 0) != 0 && errno != EPERM) {
+    return false;
+  }
+  if (startTime == 0) {
+    return true; // creator could not record one; fall back to pid alone
+  }
+  const uint64_t current = processStartTime(static_cast<pid_t>(pid));
+  // Unreadable (permissions, or it exited between the two checks): treat the
+  // pid as authoritative rather than reclaim a segment that may be live.
+  return current == 0 || current == startTime;
+}
+
+} // namespace
+
+// Defined in sharded_relay_oneshot.cc. Reused rather than redefined so a relay
+// user sets one variable, not two, and so the control segment and the one-shot
+// region cannot end up half-enabled with respect to each other.
+NCCL_PARAM_DECLARE(ShardedRelayModeEnable);
+
+// Calls per published plan. Not a compile-time constant because calls per
+// forward is chunk count in the workload this targets -- deployment config, not
+// a bounded property -- and about two orders of magnitude larger once attention
+// all-to-all is covered. Raising this costs slot bytes, nothing else.
+NCCL_PARAM(RelayControlMaxCalls, "RELAY_CONTROL_MAX_CALLS", 128);
+
+// How many forwards the publisher may run ahead. Not load-bearing: the active
+// rank self-limits, because its own stream is serialized behind the collectives
+// it just enqueued, so it cannot get far ahead regardless.
+NCCL_PARAM(RelayControlRingDepth, "RELAY_CONTROL_RING_DEPTH", 4);
+
+uint32_t relayControlConfiguredMaxCalls() {
+  const int64_t v = ncclParamRelayControlMaxCalls();
+  if (v < 1) {
+    return 1;
+  }
+  if (v > 65536) {
+    return 65536;
+  }
+  return static_cast<uint32_t>(v);
+}
+
+uint32_t relayControlConfiguredRingDepth() {
+  const int64_t v = ncclParamRelayControlRingDepth();
+  // Two is the smallest depth that is a ring at all. Above 1024 the slot array
+  // is larger than any plausible run-ahead and almost certainly a typo.
+  if (v < 2) {
+    return 2;
+  }
+  if (v > 1024) {
+    return 1024;
+  }
+  return static_cast<uint32_t>(v);
+}
+
+size_t RelayControlBlock::segmentBytes(
+    uint32_t nRanks,
+    uint32_t ringDepth,
+    uint32_t maxCalls) {
+  return sizeof(Header) + consumedBytes(nRanks) +
+      static_cast<size_t>(ringDepth) * slotStride(maxCalls);
+}
+
+std::string RelayControlBlock::nameFor(uint64_t commHash) {
+  char buf[64];
+  snprintf(
+      buf,
+      sizeof(buf),
+      "/rcclx_relay_ctl_%016llx",
+      static_cast<unsigned long long>(commHash));
+  return std::string(buf);
+}
+
+RelayControlBlock::~RelayControlBlock() {
+  detach();
+}
+
+uint8_t* RelayControlBlock::slotAt(uint64_t epoch) const {
+  const size_t stride = slotStride(cfg_.maxCalls);
+  const size_t index = static_cast<size_t>(epoch % cfg_.ringDepth);
+  return base_ + sizeof(Header) + consumedBytes(cfg_.nRanks) + index * stride;
+}
+
+uint64_t* RelayControlBlock::slotSeq(uint64_t epoch) const {
+  return reinterpret_cast<uint64_t*>(slotAt(epoch));
+}
+
+RelayPlanInfo* RelayControlBlock::slotInfo(uint64_t epoch) const {
+  return reinterpret_cast<RelayPlanInfo*>(slotAt(epoch) + sizeof(uint64_t));
+}
+
+uint64_t* RelayControlBlock::slotCounts(uint64_t epoch) const {
+  return reinterpret_cast<uint64_t*>(slotAt(epoch) + kSlotPrologue);
+}
+
+uint64_t* RelayControlBlock::consumedArray() const {
+  return reinterpret_cast<uint64_t*>(base_ + sizeof(Header));
+}
+
+bool RelayControlBlock::create(const RelayControlConfig& cfg) {
+  if (cfg.nRanks == 0 || cfg.ringDepth < 2 || cfg.maxCalls == 0 ||
+      cfg.rank >= cfg.nRanks) {
+    WARN(
+        "Relay control: refusing to create a segment with nRanks=%u rank=%u ringDepth=%u maxCalls=%u",
+        cfg.nRanks,
+        cfg.rank,
+        cfg.ringDepth,
+        cfg.maxCalls);
+    return false;
+  }
+  detach();
+  cfg_ = cfg;
+  name_ = nameFor(cfg.commHash);
+  bytes_ = segmentBytes(cfg.nRanks, cfg.ringDepth, cfg.maxCalls);
+
+  int fd = shm_open(name_.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+  if (fd < 0 && errno == EEXIST) {
+    // Someone got here first. Either a crashed earlier run left this behind, in
+    // which case reclaiming it is right, or a live process owns it, in which
+    // case taking it would corrupt that job -- so the creator decides, and we
+    // never steal from a live one.
+    //
+    // An UNSTAMPED header is the trap here. A creator that has just won
+    // O_CREAT|O_EXCL but has not yet reached ftruncate/memset/magic presents
+    // exactly what an abandoned segment presents: a short read, or a zero
+    // magic. Calling that stale would unlink the segment out from under a live
+    // creator that still holds a mapping to it. So an unstamped header is
+    // retried for a bounded spell, and only declared abandoned if it never gets
+    // stamped.
+    bool reclaim = false;
+    BoundedWait probeWait(200LL * 1000LL * 1000LL);
+    for (;;) {
+      int probe = shm_open(name_.c_str(), O_RDONLY, 0600);
+      if (probe < 0) {
+        reclaim = true; // vanished under us; nothing to protect
+        break;
+      }
+      Header probeHdr{};
+      const ssize_t got = read(probe, &probeHdr, sizeof(probeHdr));
+      close(probe);
+      const bool stamped = got == static_cast<ssize_t>(sizeof(probeHdr)) &&
+          probeHdr.magic == kRelayControlMagic && probeHdr.ready == 1u;
+      if (stamped) {
+        reclaim = !creatorAlive(probeHdr.creatorPid, probeHdr.creatorStartTime);
+        break;
+      }
+      if (!probeWait.step()) {
+        reclaim = true; // never stamped within the budget: genuinely abandoned
+        break;
+      }
+    }
+    if (!reclaim) {
+      WARN(
+          "Relay control: %s already exists and its creator is still running; not creating a segment for this communicator",
+          name_.c_str());
+      return false;
+    }
+    INFO(
+        NCCL_INIT, "Relay control: reclaiming stale segment %s", name_.c_str());
+    shm_unlink(name_.c_str());
+    fd = shm_open(name_.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+  }
+  if (fd < 0) {
+    WARN(
+        "Relay control: shm_open(%s) for create failed: %s",
+        name_.c_str(),
+        strerror(errno));
+    return false;
+  }
+
+  if (ftruncate(fd, static_cast<off_t>(bytes_)) != 0) {
+    WARN(
+        "Relay control: ftruncate(%s, %zu) failed: %s",
+        name_.c_str(),
+        bytes_,
+        strerror(errno));
+    close(fd);
+    shm_unlink(name_.c_str());
+    return false;
+  }
+
+  void* map = mmap(nullptr, bytes_, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  close(fd);
+  if (map == MAP_FAILED) {
+    WARN(
+        "Relay control: mmap(%s, %zu) failed: %s",
+        name_.c_str(),
+        bytes_,
+        strerror(errno));
+    shm_unlink(name_.c_str());
+    return false;
+  }
+  base_ = static_cast<uint8_t*>(map);
+  owner_ = true;
+
+  // Zero first: it is what makes every slot's seq 0, i.e. "nothing published
+  // yet", and every consumed entry 0, i.e. "no rank has registered as a
+  // consumer".
+  std::memset(base_, 0, bytes_);
+
+  Header* h = reinterpret_cast<Header*>(base_);
+  h->version = kRelayControlVersion;
+  h->nRanks = cfg.nRanks;
+  h->nActive = cfg.nActive;
+  h->commHash = cfg.commHash;
+  h->ringDepth = cfg.ringDepth;
+  h->maxCalls = cfg.maxCalls;
+  h->creatorPid = static_cast<uint32_t>(getpid());
+  h->creatorStartTime = processStartTime(getpid());
+  h->publisherRank = kNoPublisher;
+  // No abort has been attributed yet. A sentinel rather than 0 so a reader that
+  // catches the window between the abort reason landing and its rank being
+  // stored reports "unattributed" instead of blaming rank 0.
+  h->abortRank = kRelayAbortRankUnknown;
+  // Magic before ready, both with release ordering, so nothing can observe
+  // ready=1 over a header that is not yet valid.
+  __atomic_store_n(&h->magic, kRelayControlMagic, __ATOMIC_RELEASE);
+  __atomic_store_n(&h->ready, 1u, __ATOMIC_RELEASE);
+  return true;
+}
+
+bool RelayControlBlock::attach(const RelayControlConfig& cfg) {
+  detach();
+  if (cfg.nRanks == 0 || cfg.rank >= cfg.nRanks) {
+    // consume() indexes consumedArray()[cfg_.rank], which is only nRanks long,
+    // so an out-of-range rank would write past it into the first slot's seqlock
+    // and plan area and corrupt the ring for every peer. Rejected here (and in
+    // create()) so it cannot reach that point at all.
+    WARN(
+        "Relay control: refusing to attach with rank=%u of nRanks=%u",
+        cfg.rank,
+        cfg.nRanks);
+    return false;
+  }
+  cfg_ = cfg;
+  name_ = nameFor(cfg.commHash);
+  const size_t want = segmentBytes(cfg.nRanks, cfg.ringDepth, cfg.maxCalls);
+
+  int fd = shm_open(name_.c_str(), O_RDWR, 0600);
+  if (fd < 0) {
+    WARN(
+        "Relay control: shm_open(%s) for attach failed: %s",
+        name_.c_str(),
+        strerror(errno));
+    return false;
+  }
+  struct stat st{};
+  if (fstat(fd, &st) != 0) {
+    WARN("Relay control: fstat(%s) failed: %s", name_.c_str(), strerror(errno));
+    close(fd);
+    return false;
+  }
+  const size_t actual = static_cast<size_t>(st.st_size);
+  if (actual < sizeof(Header)) {
+    WARN(
+        "Relay control: %s is %zu bytes, too small to hold a header",
+        name_.c_str(),
+        actual);
+    close(fd);
+    return false;
+  }
+  // Map what is actually there rather than what we expected, so a geometry
+  // mismatch can be reported from the header with both values instead of
+  // showing up as an unexplained size error.
+  void* map = mmap(nullptr, actual, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  close(fd);
+  if (map == MAP_FAILED) {
+    WARN(
+        "Relay control: mmap(%s, %zu) failed: %s",
+        name_.c_str(),
+        actual,
+        strerror(errno));
+    return false;
+  }
+  base_ = static_cast<uint8_t*>(map);
+  bytes_ = actual;
+  owner_ = false;
+
+  Header* h = reinterpret_cast<Header*>(base_);
+
+  // The creator may have won the shm_open race but not yet stamped the header.
+  // Bounded, and short: the caller has already been through a bootstrap
+  // all-gather with the creator, so this is a formality rather than a real
+  // wait.
+  BoundedWait ready(1000LL * 1000LL * 1000LL);
+  while (__atomic_load_n(&h->ready, __ATOMIC_ACQUIRE) != 1u) {
+    if (!ready.step()) {
+      WARN(
+          "Relay control: %s was never marked ready by its creator",
+          name_.c_str());
+      detach();
+      return false;
+    }
+  }
+
+  const uint32_t magic = __atomic_load_n(&h->magic, __ATOMIC_ACQUIRE);
+  if (magic != kRelayControlMagic) {
+    WARN(
+        "Relay control: %s has magic %08x, expected %08x",
+        name_.c_str(),
+        magic,
+        kRelayControlMagic);
+    detach();
+    return false;
+  }
+  if (h->version != kRelayControlVersion) {
+    WARN(
+        "Relay control: %s has version %u but this build speaks version %u; the ranks of this job are not running the same librccl",
+        name_.c_str(),
+        h->version,
+        kRelayControlVersion);
+    detach();
+    return false;
+  }
+  if (h->commHash != cfg.commHash) {
+    WARN(
+        "Relay control: %s belongs to commHash %llx, not %llx",
+        name_.c_str(),
+        static_cast<unsigned long long>(h->commHash),
+        static_cast<unsigned long long>(cfg.commHash));
+    detach();
+    return false;
+  }
+  // Geometry comes from environment parameters, so a disagreement here means
+  // the ranks of this job were launched with different settings. Failing at
+  // init is the entire point of recording it: the alternative is reading a
+  // differently-shaped slot at runtime.
+  if (h->nRanks != cfg.nRanks || h->ringDepth != cfg.ringDepth ||
+      h->maxCalls != cfg.maxCalls || actual != want) {
+    WARN(
+        "Relay control: %s geometry is nRanks=%u ringDepth=%u maxCalls=%u (%zu bytes) but this rank expects nRanks=%u ringDepth=%u maxCalls=%u (%zu bytes); check that NCCL_RELAY_CONTROL_MAX_CALLS and NCCL_RELAY_CONTROL_RING_DEPTH are set identically on every rank",
+        name_.c_str(),
+        h->nRanks,
+        h->ringDepth,
+        h->maxCalls,
+        actual,
+        cfg.nRanks,
+        cfg.ringDepth,
+        cfg.maxCalls,
+        want);
+    detach();
+    return false;
+  }
+  if (!creatorAlive(h->creatorPid, h->creatorStartTime)) {
+    WARN(
+        "Relay control: %s was created by pid %u, which is gone",
+        name_.c_str(),
+        h->creatorPid);
+    detach();
+    return false;
+  }
+  return true;
+}
+
+void RelayControlBlock::detach() {
+  if (base_ != nullptr) {
+    munmap(base_, bytes_);
+    base_ = nullptr;
+  }
+  if (owner_ && !name_.empty()) {
+    shm_unlink(name_.c_str());
+  }
+  owner_ = false;
+  bytes_ = 0;
+  name_.clear();
+}
+
+uint32_t RelayControlBlock::ringDepth() const {
+  return cfg_.ringDepth;
+}
+
+uint32_t RelayControlBlock::maxCalls() const {
+  return cfg_.maxCalls;
+}
+
+uint32_t RelayControlBlock::abortReason() const {
+  if (!valid()) {
+    return kRelayAbortNone;
+  }
+  return __atomic_load_n(
+      &reinterpret_cast<Header*>(base_)->abortReason, __ATOMIC_ACQUIRE);
+}
+
+uint32_t RelayControlBlock::abortRank() const {
+  if (!valid()) {
+    return 0;
+  }
+  return __atomic_load_n(
+      &reinterpret_cast<Header*>(base_)->abortRank, __ATOMIC_ACQUIRE);
+}
+
+uint32_t RelayControlBlock::highWaterCalls() const {
+  if (!valid()) {
+    return 0;
+  }
+  return __atomic_load_n(
+      &reinterpret_cast<Header*>(base_)->hwmCalls, __ATOMIC_RELAXED);
+}
+
+uint64_t RelayControlBlock::consumerProgress(uint32_t rank) const {
+  if (!valid() || rank >= cfg_.nRanks) {
+    return 0;
+  }
+  return __atomic_load_n(&consumedArray()[rank], __ATOMIC_ACQUIRE);
+}
+
+void RelayControlBlock::setAbort(uint32_t reason) {
+  if (!valid() || reason == kRelayAbortNone) {
+    return;
+  }
+  Header* h = reinterpret_cast<Header*>(base_);
+  // First abort wins, and ONLY the winner attributes itself. Storing the rank
+  // before the exchange would overwrite the first abort's rank every time a
+  // later one lost the race, so the segment would report the first reason
+  // attributed to an unrelated rank that failed long afterwards.
+  uint32_t expected = kRelayAbortNone;
+  if (__atomic_compare_exchange_n(
+          &h->abortReason,
+          &expected,
+          reason,
+          false,
+          __ATOMIC_RELEASE,
+          __ATOMIC_RELAXED)) {
+    __atomic_store_n(&h->abortRank, cfg_.rank, __ATOMIC_RELEASE);
+  }
+}
+
+bool RelayControlBlock::waitForSlotDrain(uint64_t epoch, int64_t timeoutNs) {
+  // The slot this epoch lands on was last used by epoch - ringDepth. Before
+  // that many forwards have happened there is nothing to drain.
+  if (epoch < cfg_.ringDepth) {
+    return true;
+  }
+  const uint64_t need = consumedNeededFor(epoch, cfg_.ringDepth);
+  const uint64_t* consumed = consumedArray();
+  BoundedWait wait(timeoutNs);
+  for (;;) {
+    uint32_t lagging = UINT32_MAX;
+    for (uint32_t r = 0; r < cfg_.nRanks; r++) {
+      if (r == cfg_.rank) {
+        continue; // the publisher does not consume its own plans
+      }
+      const uint64_t v = __atomic_load_n(&consumed[r], __ATOMIC_ACQUIRE);
+      if (v == kConsumerUnregistered) {
+        continue;
+      }
+      if (v < need) {
+        lagging = r;
+        break;
+      }
+    }
+    if (lagging == UINT32_MAX) {
+      return true;
+    }
+    const uint32_t ab = abortReason();
+    if (ab != kRelayAbortNone) {
+      WARN(
+          "Relay control: rank %u cannot publish epoch %llu because rank %u aborted (reason %u)",
+          cfg_.rank,
+          static_cast<unsigned long long>(epoch),
+          abortRank(),
+          ab);
+      return false;
+    }
+    if (!wait.step()) {
+      const uint64_t v = __atomic_load_n(&consumed[lagging], __ATOMIC_ACQUIRE);
+      WARN(
+          "Relay control: rank %u timed out after %lld ms publishing epoch %llu; rank %u has %s and the ring is %u deep",
+          cfg_.rank,
+          static_cast<long long>(wait.elapsedNs() / 1000000LL),
+          static_cast<unsigned long long>(epoch),
+          lagging,
+          v == kConsumerRegistered ? "not completed any epoch yet"
+                                   : "fallen more than a ring behind",
+          cfg_.ringDepth);
+      setAbort(kRelayAbortTimeout);
+      return false;
+    }
+  }
+}
+
+ncclResult_t RelayControlBlock::publish(
+    uint64_t epoch,
+    const RelayPlanInfo& info,
+    const size_t* counts,
+    int64_t timeoutNs) {
+  if (!valid()) {
+    return ncclInvalidArgument;
+  }
+  if (info.flags != 0) {
+    WARN("Relay control: plan flags must be 0, got %u", info.flags);
+    return ncclInvalidArgument;
+  }
+  if (info.opCode >= kRelayOpCount) {
+    WARN("Relay control: plan opCode %u is out of range", info.opCode);
+    return ncclInvalidArgument;
+  }
+  if (info.nCalls > cfg_.maxCalls) {
+    WARN(
+        "Relay control: plan for epoch %llu names %u calls but this segment holds %u; raise NCCL_RELAY_CONTROL_MAX_CALLS on every rank",
+        static_cast<unsigned long long>(epoch),
+        info.nCalls,
+        cfg_.maxCalls);
+    return ncclInvalidArgument;
+  }
+  if (info.nCalls > 0 && counts == nullptr) {
+    WARN("Relay control: plan names %u calls but counts is null", info.nCalls);
+    return ncclInvalidArgument;
+  }
+
+  // Unconditional, unlike the check inside waitForSlotDrain's wait loop, which
+  // is never reached when the slot is already drained (epoch < ringDepth, or
+  // every consumer current). Without this a publisher keeps filling slots on a
+  // poisoned segment that no consumer will ever read again; consume() checks
+  // the flag on every iteration, so this is what makes the poison symmetric.
+  const uint32_t aborted = abortReason();
+  if (aborted != kRelayAbortNone) {
+    WARN(
+        "Relay control: rank %u not publishing epoch %llu because rank %u aborted (reason %u)",
+        cfg_.rank,
+        static_cast<unsigned long long>(epoch),
+        abortRank(),
+        aborted);
+    return ncclInternalError;
+  }
+
+  // One ring, so one publisher. Claim it on the first publish and hold every
+  // later publish to it: two ranks writing the same slot would drive the
+  // seqlock backwards, and because their plans are byte-identical the damage
+  // would be invisible in the data and show up only as a spurious desync.
+  Header* hdr = reinterpret_cast<Header*>(base_);
+  uint32_t owner = kNoPublisher;
+  if (!__atomic_compare_exchange_n(
+          &hdr->publisherRank,
+          &owner,
+          cfg_.rank,
+          false,
+          __ATOMIC_RELEASE,
+          __ATOMIC_ACQUIRE) &&
+      owner != cfg_.rank) {
+    WARN(
+        "Relay control: rank %u tried to publish epoch %llu but rank %u already owns publishing on this communicator; exactly one rank may publish",
+        cfg_.rank,
+        static_cast<unsigned long long>(epoch),
+        owner);
+    return ncclInvalidArgument;
+  }
+
+  if (!waitForSlotDrain(epoch, timeoutNs)) {
+    return ncclInternalError;
+  }
+
+  uint64_t* seq = slotSeq(epoch);
+
+  // Epochs must advance. The slot's own seqlock word is the record of that: a
+  // slot last written by epoch - ringDepth holds 2*(epoch-ringDepth)+2, which
+  // is below 2*epoch+2, so anything at or above that means this epoch -- or a
+  // later one landing on the same slot -- has already been published.
+  //
+  // Two things go wrong without the check. Re-publishing an epoch drives the
+  // seqlock BACKWARDS from 2e+2 to 2e+1, which a concurrent reader observes as
+  // a tear on a slot nobody is actually tearing. And a caller that restarts its
+  // epoch counter at 0 walks back over slots holding plans no consumer has
+  // taken: waitForSlotDrain returns immediately for any epoch < ringDepth, so
+  // the overwrite is silent. The class already enforces a single publisher for
+  // this reason; this closes the other half of that invariant.
+  const uint64_t published = __atomic_load_n(seq, __ATOMIC_ACQUIRE);
+  if (published >= 2 * epoch + 2) {
+    WARN(
+        "Relay control: rank %u tried to publish epoch %llu but its slot already holds epoch %llu; epochs must advance",
+        cfg_.rank,
+        static_cast<unsigned long long>(epoch),
+        static_cast<unsigned long long>(epochFromSeq(published)));
+    return ncclInvalidArgument;
+  }
+
+  // Seqlock write. The odd store marks the slot in flux; the release FENCE
+  // after it is what stops the body stores below from becoming visible before
+  // it, which is what makes a reader's re-read of seq able to detect a tear.
+  __atomic_store_n(seq, 2 * epoch + 1, __ATOMIC_RELAXED);
+  __atomic_thread_fence(__ATOMIC_RELEASE);
+
+  *slotInfo(epoch) = info;
+  uint64_t* dst = slotCounts(epoch);
+  for (uint32_t i = 0; i < info.nCalls; i++) {
+    dst[i] = static_cast<uint64_t>(counts[i]);
+  }
+
+  // Release: everything above is visible to anyone who observes this value.
+  __atomic_store_n(seq, 2 * epoch + 2, __ATOMIC_RELEASE);
+
+  uint32_t hwm = __atomic_load_n(&hdr->hwmCalls, __ATOMIC_RELAXED);
+  while (info.nCalls > hwm) {
+    if (__atomic_compare_exchange_n(
+            &hdr->hwmCalls,
+            &hwm,
+            info.nCalls,
+            false,
+            __ATOMIC_RELAXED,
+            __ATOMIC_RELAXED)) {
+      break;
+    }
+  }
+  return ncclSuccess;
+}
+
+ncclResult_t RelayControlBlock::publishShutdown(
+    uint64_t epoch,
+    int64_t timeoutNs) {
+  RelayPlanInfo info{};
+  info.nCalls = 0;
+  info.opCode = kRelayOpShutdown;
+  return publish(epoch, info, nullptr, timeoutNs);
+}
+
+ncclResult_t RelayControlBlock::consume(
+    uint64_t epoch,
+    RelayPlanInfo* info,
+    size_t* counts,
+    uint32_t countsCapacity,
+    int64_t timeoutNs) {
+  if (!valid() || info == nullptr) {
+    return ncclInvalidArgument;
+  }
+  if (countsCapacity > 0 && counts == nullptr) {
+    return ncclInvalidArgument;
+  }
+  const uint64_t want = 2 * epoch + 2;
+  const uint64_t* seq = slotSeq(epoch);
+  BoundedWait wait(timeoutNs);
+
+  // Register before waiting, so a publisher cannot run a full ring ahead while
+  // we are still working on our first epoch. Only ever moves 0 -> 1; a consumer
+  // that has real progress recorded must not be rewound.
+  uint64_t* myProgress = &consumedArray()[cfg_.rank];
+  uint64_t unregistered = kConsumerUnregistered;
+  __atomic_compare_exchange_n(
+      myProgress,
+      &unregistered,
+      kConsumerRegistered,
+      false,
+      __ATOMIC_RELEASE,
+      __ATOMIC_RELAXED);
+
+  for (;;) {
+    const uint32_t ab = abortReason();
+    if (ab != kRelayAbortNone) {
+      WARN(
+          "Relay control: rank %u stopping at epoch %llu because rank %u aborted (reason %u)",
+          cfg_.rank,
+          static_cast<unsigned long long>(epoch),
+          abortRank(),
+          ab);
+      return ncclInternalError;
+    }
+
+    const uint64_t s1 = __atomic_load_n(seq, __ATOMIC_ACQUIRE);
+    // Both retry paths below fall through to wait.step() rather than looping
+    // straight back. Spinning without it would burn a core indefinitely and,
+    // far worse, silently drop the bounded-wait guarantee this class exists to
+    // keep: a corrupted or geometry-mismatched slot whose seq happens to match
+    // `want` never resolves, so the loop would never time out either.
+    bool torn = false;
+    RelayPlanInfo local{};
+    if (s1 == want) {
+      local = *slotInfo(epoch);
+      // A published plan can never exceed the segment's capacity, so a value
+      // that does means we read a slot mid-write. Retry rather than trust it.
+      if (local.nCalls > cfg_.maxCalls) {
+        torn = true;
+      }
+    }
+    if (s1 == want && !torn) {
+      const uint64_t* src = slotCounts(epoch);
+      const uint32_t copy = std::min(local.nCalls, countsCapacity);
+      for (uint32_t i = 0; i < copy; i++) {
+        counts[i] = static_cast<size_t>(src[i]);
+      }
+      // Acquire fence, then a relaxed re-read: the fence keeps the body reads
+      // above from being reordered after this load, which is what makes the
+      // comparison meaningful.
+      __atomic_thread_fence(__ATOMIC_ACQUIRE);
+      if (__atomic_load_n(seq, __ATOMIC_RELAXED) != s1) {
+        torn = true;
+      }
+    }
+    if (s1 == want && !torn) {
+      *info = local;
+      if (local.nCalls > countsCapacity) {
+        WARN(
+            "Relay control: plan for epoch %llu names %u calls but the caller's buffer holds %u",
+            static_cast<unsigned long long>(epoch),
+            local.nCalls,
+            countsCapacity);
+        // Deliberately NOT marked consumed: the plan was not taken, so the
+        // publisher must keep treating this slot as occupied.
+        return ncclInvalidArgument;
+      }
+      // Releases the slot ringDepth forwards from now.
+      __atomic_store_n(myProgress, consumedEncode(epoch), __ATOMIC_RELEASE);
+      return ncclSuccess;
+    }
+
+    if (!torn && s1 > want) {
+      // The slot has moved a full ring past us. No amount of waiting brings
+      // that epoch back, so this is a desync, not slowness.
+      WARN(
+          "Relay control: rank %u wanted epoch %llu but its slot has already advanced to epoch %llu; the ranks of this communicator are out of step",
+          cfg_.rank,
+          static_cast<unsigned long long>(epoch),
+          static_cast<unsigned long long>(epochFromSeq(s1)));
+      return ncclInternalError;
+    }
+
+    if (!wait.step()) {
+      WARN(
+          "Relay control: rank %u timed out after %lld ms waiting for epoch %llu (slot last held epoch %llu)",
+          cfg_.rank,
+          static_cast<long long>(wait.elapsedNs() / 1000000LL),
+          static_cast<unsigned long long>(epoch),
+          static_cast<unsigned long long>(epochFromSeq(s1)));
+      setAbort(kRelayAbortTimeout);
+      return ncclInternalError;
+    }
+  }
+}
+
+namespace {
+
+struct CommEntry {
+  // Guards THIS entry's setup. Per-comm rather than process-global because
+  // setupForComm() runs two bootstrap all-gathers: holding one global lock
+  // across a collective deadlocks as soon as two communicators are initialized
+  // concurrently and their peer processes reach the collectives in opposite
+  // order -- each process would sit in one comm's all-gather holding the lock
+  // the peer it is waiting for needs to enter the other. entryMutex() therefore
+  // guards only the map.
+  std::mutex mu;
+  // Sticky: a retry would have to be collectively agreed, and a rank retrying
+  // alone would enter a bootstrap all-gather the others are not in.
+  bool tried{false};
+  // The map is keyed on the comm POINTER, which the allocator recycles.
+  // commHash distinguishes a recycled address from the comm that used to live
+  // there, so a missed release cannot be mistaken for a live segment.
+  uint64_t commHash{0};
+  // shared_ptr, not unique_ptr, so publish/consume can hold the segment mapped
+  // for the duration of a call without holding entryMutex() across it.
+  std::shared_ptr<RelayControlBlock> block;
+};
+
+std::mutex& entryMutex() {
+  static std::mutex m;
+  return m;
+}
+
+std::map<const void*, CommEntry>& entries() {
+  static std::map<const void*, CommEntry> e;
+  return e;
+}
+
+/**
+ * Create-or-attach for one communicator.
+ *
+ * ALWAYS runs both bootstrap all-gathers, even after a local failure, because
+ * they are collective: an early return on one rank desynchronizes the bootstrap
+ * for every other rank.
+ */
+std::shared_ptr<RelayControlBlock> setupForComm(ncclComm_t comm) {
+  RelayControlConfig cfg;
+  cfg.nRanks = static_cast<uint32_t>(comm->nRanks);
+  cfg.rank = static_cast<uint32_t>(comm->rank);
+  cfg.nActive = 0; // not known at init; diagnostic only
+  cfg.commHash = comm->commHash;
+  cfg.ringDepth = relayControlConfiguredRingDepth();
+  cfg.maxCalls = relayControlConfiguredMaxCalls();
+
+  auto block = std::make_shared<RelayControlBlock>();
+  bool ok = true;
+  if (comm->rank == 0) {
+    ok = block->create(cfg);
+  }
+
+  // Barrier plus creator status in one exchange: nobody may attach before the
+  // segment exists, and if the creator failed there is nothing to attach to.
+  std::vector<uint8_t> created(comm->nRanks, 0);
+  created[comm->rank] = ok ? 1 : 0;
+  if (bootstrapAllGather(comm->bootstrap, created.data(), sizeof(uint8_t)) !=
+      ncclSuccess) {
+    ok = false;
+  } else if (created[0] == 0) {
+    ok = false;
+  }
+
+  if (ok && comm->rank != 0) {
+    ok = block->attach(cfg);
+  }
+
+  // Unanimity. A segment only some ranks have is worse than none: the ranks
+  // that have it wait for peers that never publish or consume, which hangs
+  // instead of degrading. Same rule, same reason, as the one-shot IPC region.
+  std::vector<uint8_t> votes(comm->nRanks, 0);
+  votes[comm->rank] = ok ? 1 : 0;
+  if (bootstrapAllGather(comm->bootstrap, votes.data(), sizeof(uint8_t)) !=
+      ncclSuccess) {
+    ok = false;
+  } else {
+    for (int r = 0; r < comm->nRanks; r++) {
+      if (votes[r] == 0) {
+        ok = false;
+        break;
+      }
+    }
+  }
+
+  if (!ok) {
+    block->detach();
+    return nullptr;
+  }
+  INFO(
+      NCCL_INIT,
+      "Relay control: rank %d attached %s (%u ranks, ring %u, %u calls/plan, %zu bytes)",
+      comm->rank,
+      RelayControlBlock::nameFor(cfg.commHash).c_str(),
+      cfg.nRanks,
+      cfg.ringDepth,
+      cfg.maxCalls,
+      RelayControlBlock::segmentBytes(cfg.nRanks, cfg.ringDepth, cfg.maxCalls));
+  return block;
+}
+
+// Caller must hold entryMutex(). Returns a REFERENCE-COUNTED handle so the
+// caller can drop the lock and still be sure the segment stays mapped for the
+// duration of its call, even if a concurrent release erases the entry.
+std::shared_ptr<RelayControlBlock> lookupLocked(ncclComm_t comm) {
+  if (comm == nullptr) {
+    return nullptr;
+  }
+  auto it = entries().find(static_cast<const void*>(comm));
+  if (it == entries().end() || it->second.commHash != comm->commHash) {
+    return nullptr;
+  }
+  const std::shared_ptr<RelayControlBlock>& b = it->second.block;
+  return (b != nullptr && b->valid()) ? b : nullptr;
+}
+
+} // namespace
+
+void relayControlInit(ncclComm_t comm) {
+  if (comm == nullptr || ncclParamShardedRelayModeEnable() != 1) {
+    return;
+  }
+  if (comm->nRanks < 2) {
+    return;
+  }
+  // entryMutex() covers only the map -- the staleness check and the lookup. It
+  // is deliberately NOT held across setupForComm(), which runs two bootstrap
+  // all-gathers; see CommEntry::mu.
+  CommEntry* ep = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(entryMutex());
+    auto it = entries().find(static_cast<const void*>(comm));
+    if (it != entries().end() && it->second.tried &&
+        it->second.commHash != comm->commHash) {
+      // A stale entry can only exist if this comm's release was missed and the
+      // allocator handed its address to a new comm. Every rank of the new comm
+      // sees the same mismatch, because commHash is agreed across it. The whole
+      // node goes, mutex included -- safe because the comm it belonged to is
+      // gone, so nobody can be holding that mutex.
+      entries().erase(it);
+    }
+    ep = &entries()[static_cast<const void*>(comm)];
+  }
+  // std::map is node based, so the reference stays valid once the map lock is
+  // dropped; only erasing this key invalidates it, and that happens here or in
+  // relayControlRelease(), both only for a comm that is done with.
+  CommEntry& e = *ep;
+
+  std::lock_guard<std::mutex> lock(e.mu);
+  if (e.tried) {
+    return;
+  }
+  e.tried = true;
+  e.commHash = comm->commHash;
+  e.block = setupForComm(comm);
+}
+
+void relayControlRelease(ncclComm_t comm) {
+  if (comm == nullptr) {
+    return;
+  }
+  // Erasing the node destroys CommEntry::mu, so this must not run concurrently
+  // with an init/publish/consume for the same comm -- it is called from comm
+  // teardown, after the last collective on that comm. Any publish or consume
+  // still in flight holds its own shared_ptr, so the segment outlives the
+  // erase.
+  std::lock_guard<std::mutex> lock(entryMutex());
+  auto it = entries().find(static_cast<const void*>(comm));
+  if (it == entries().end()) {
+    return;
+  }
+  if (it->second.block != nullptr && it->second.block->valid()) {
+    // The one number worth reporting: it turns the capacity parameter from a
+    // guess into an observation.
+    INFO(
+        NCCL_INIT,
+        "Relay control: rank %d releasing segment, high-water mark %u calls per plan (capacity %u)",
+        comm->rank,
+        it->second.block->highWaterCalls(),
+        it->second.block->maxCalls());
+  }
+  entries().erase(it);
+}
+
+bool relayControlReady(ncclComm_t comm) {
+  std::lock_guard<std::mutex> lock(entryMutex());
+  return lookupLocked(comm) != nullptr;
+}
+
+// entryMutex() is taken only to resolve the comm to a segment, never held
+// across publish() or consume(). Both can block for the whole timeoutNs, and
+// the mutex is process-wide: holding it there stalls relayControlInit,
+// relayControlRelease, relayControlReady and every other communicator's publish
+// and consume for that entire budget. The shared_ptr is what the lock used to
+// be providing -- it keeps the segment mapped for the duration of the call even
+// if a concurrent commFree() erases the entry.
+static std::shared_ptr<RelayControlBlock> resolve(ncclComm_t comm) {
+  std::lock_guard<std::mutex> lock(entryMutex());
+  return lookupLocked(comm);
+}
+
+ncclResult_t relayControlPublish(
+    ncclComm_t comm,
+    uint64_t epoch,
+    const RelayPlanInfo& info,
+    const size_t* counts,
+    int64_t timeoutNs) {
+  const std::shared_ptr<RelayControlBlock> b = resolve(comm);
+  if (b == nullptr) {
+    return ncclInvalidArgument;
+  }
+  return b->publish(epoch, info, counts, timeoutNs);
+}
+
+ncclResult_t relayControlConsume(
+    ncclComm_t comm,
+    uint64_t epoch,
+    RelayPlanInfo* info,
+    size_t* counts,
+    uint32_t countsCapacity,
+    int64_t timeoutNs) {
+  const std::shared_ptr<RelayControlBlock> b = resolve(comm);
+  if (b == nullptr) {
+    return ncclInvalidArgument;
+  }
+  return b->consume(epoch, info, counts, countsCapacity, timeoutNs);
+}
+
+} // namespace rcclx::relay

--- a/comms/rcclx/develop/meta/relay/relay_control.h
+++ b/comms/rcclx/develop/meta/relay/relay_control.h
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include "nccl.h"
+
+/**
+ * Host-side control plane for the sharded-relay collectives.
+ *
+ * WHY THIS EXISTS
+ *
+ * A relay collective is symmetric over the whole communicator: it happens only
+ * when every rank's host thread independently enqueues it. Route selection
+ * needs no agreement -- it is a pure function of size, evaluated per rank (see
+ * sharded_relay_route.h) -- so nothing here negotiates a route.
+ *
+ * The problem is that a communicator is a DATA PLANE, NOT A SCHEDULER. In the
+ * deployment this targets, the helper ranks are separate processes that do not
+ * run the model: no batch, no forward pass, no scheduler. Nothing in ncclComm
+ * can make such a process post a call. Per call a helper needs exactly two
+ * dynamic things:
+ *
+ *   - `counts`, derived from the caller's token count, and
+ *   - "does this call happen at all?", which depends on contiguity, alignment,
+ *     compile state, capture state and phase -- all knowable ONLY on the ranks
+ *     running the model.
+ *
+ * Everything else is static configuration, and a helper's buffers are a
+ * one-element placeholder the kernel never reads.
+ *
+ * The integration that motivated this carried that payload over a TCP key/value
+ * store, once per call, at ~0.9 ms -- against a collective that takes ~1 ms and
+ * an internal relay/direct crossover at 1 MiB. The transport was ~1000x too
+ * slow for the thing it was gating.
+ *
+ * WHAT MAKES A CHEAP FIX POSSIBLE
+ *
+ * The active/helper RENDEZVOUS is already handled on-device: the ncclSend and
+ * ncclRecv pairs inside a relay schedule block until peers arrive. A helper
+ * that enqueues early waits on the GPU; one that enqueues late makes the active
+ * rank wait on the GPU. So this control plane needs CORRECT PROGRAM ORDER AND
+ * ARGUMENTS, not low-latency wake-up.
+ *
+ * Hence: publish ONE plan per forward, let the helper run ahead and enqueue
+ * every call the plan names, and let RCCL's P2P do the per-call rendezvous. The
+ * active rank's host thread then does no control work per call at all.
+ *
+ * DESIGN
+ *
+ * One POSIX shm segment per (node, communicator), created at comm init and
+ * named from commHash. Inside it, a ring of plan slots each guarded by a
+ * seqlock (even = stable, odd = write in progress) plus a small header holding
+ * the geometry, an abort flag and per-rank consumption progress.
+ *
+ * Deliberately absent:
+ *
+ *   - No route field. Route is a pure function of size, so every rank derives
+ *     the same answer from the published counts with zero communication. A
+ *     route field would be a second place for that mapping to drift.
+ *   - No token count. The DECISION (counts) is published, never the INPUT (T),
+ *     so the eligibility predicate has exactly one home: the active side. A
+ *     helper that re-derived eligibility would be a second implementation of
+ * it.
+ *   - No device-visible flags. Producer and consumer are both host threads;
+ *     nothing reads a plan from a kernel.
+ *
+ * COLLECTIVE, AND WHY THAT MATTERS
+ *
+ * Setup does a bootstrap all-gather, so every rank of the communicator must
+ * take part, and the segment is enabled only if EVERY rank reports success --
+ * the same unanimity rule, for the same reason, as the one-shot IPC region (see
+ * sharded_relay_oneshot.h): a segment only some ranks have is worse than none,
+ * because the ranks that have it wait for peers that took the other path, which
+ * hangs rather than degrades.
+ *
+ * THE INVARIANT
+ *
+ * The control plane's decision point is strictly BEFORE ncclShardedRelay* is
+ * called. After that point only RCCL's own abort machinery applies: a rank
+ * already blocked inside a collective cannot be rescued by a flag in shared
+ * memory. That is what makes the bounded wait below load-bearing rather than
+ * decorative, and it is why publish() must be ordered before a forward's first
+ * relay enqueue.
+ */
+namespace rcclx::relay {
+
+// 'RLYC'. Stamped first and checked on attach, so a segment left behind by an
+// unrelated program cannot be mistaken for ours.
+constexpr uint32_t kRelayControlMagic = 0x524C5943u;
+
+// Bump on ANY change to the header or slot layout. Checked on attach, which is
+// what turns a mixed-build deployment into a loud failure at init instead of
+// silent corruption at runtime.
+constexpr uint32_t kRelayControlVersion = 1u;
+
+// What a plan describes. Shutdown is expressed as an opcode rather than a
+// separate entry point so a graceful stop needs no extra API.
+enum RelayControlOp : uint32_t {
+  kRelayOpShutdown = 0,
+  kRelayOpAllReduce = 1,
+  kRelayOpReduceScatter = 2,
+  kRelayOpAllGather = 3,
+  kRelayOpAllToAll = 4,
+  kRelayOpCount = 5,
+};
+
+enum RelayControlAbort : uint32_t {
+  kRelayAbortNone = 0,
+  // Set by consume() itself when its budget runs out. Without this, one stuck
+  // rank means every other rank independently burns its own full timeout and
+  // the operator sees N confusing failures instead of one attributed cause.
+  kRelayAbortTimeout = 1,
+  // Set explicitly by a caller that is failing for its own reasons.
+  kRelayAbortCaller = 2,
+};
+
+/**
+ * The fixed-size part of a published plan.
+ *
+ * Mirrors the exported ncclRelayPlanInfo field for field. Counts travel
+ * separately rather than inline, which is what lets the record stay a fixed 32
+ * bytes -- ABI-stable, with reserved space to grow into -- while the per-plan
+ * call capacity remains a RUNTIME parameter. Calls per forward is chunk count
+ * in the workload this targets, and roughly two orders of magnitude larger once
+ * attention all-to-all is covered, so a compile-time ceiling would have been
+ * wrong in the direction of travel.
+ */
+struct RelayPlanInfo {
+  uint32_t nCalls{0}; // 0 with opCode kRelayOpShutdown means shutdown
+  uint32_t opCode{0};
+  uint32_t dtype{0}; // ncclDataType_t
+  uint32_t redOp{0}; // ncclRedOp_t
+  uint32_t flags{0}; // reserved, must be 0
+  uint32_t reserved[3]{0u, 0u, 0u};
+};
+static_assert(
+    sizeof(RelayPlanInfo) == 32,
+    "RelayPlanInfo is a wire format; its size is part of the segment layout");
+
+/**
+ * Everything the segment's geometry and identity is derived from.
+ *
+ * All explicit, with no communicator anywhere, so the protocol can be tested
+ * without a comm, a GPU or a bootstrap network -- which is the only way to get
+ * a torn-read test that actually runs many writers and readers.
+ */
+struct RelayControlConfig {
+  uint32_t nRanks{0};
+  uint32_t nActive{0};
+  uint32_t rank{0};
+  uint64_t commHash{0};
+  uint32_t ringDepth{0};
+  uint32_t maxCalls{0};
+};
+
+/**
+ * A ring of plan slots in POSIX shared memory.
+ *
+ * Not thread-safe: a comm's entry is serialized by the caller, matching NCCL's
+ * own one-thread-per-comm contract.
+ */
+class RelayControlBlock {
+ public:
+  RelayControlBlock() = default;
+  ~RelayControlBlock();
+
+  // Mapping ownership is not copyable, and there is no reason to move one.
+  RelayControlBlock(const RelayControlBlock&) = delete;
+  RelayControlBlock& operator=(const RelayControlBlock&) = delete;
+
+  /**
+   * Create the segment, zero it, and stamp the header. Exactly one rank per
+   * (node, communicator) may call this.
+   *
+   * Uses O_CREAT|O_EXCL so a collision is detected rather than silently shared.
+   * A segment left behind by a crashed run is reclaimed only when its recorded
+   * creator pid is gone -- see the implementation, which will not steal one
+   * from a live process.
+   */
+  bool create(const RelayControlConfig& cfg);
+
+  /**
+   * Open a segment someone else created and prove it is the one we expect.
+   *
+   * Validates magic, version, commHash, geometry and creator liveness. The
+   * geometry check is why ringDepth and maxCalls are recorded in the header at
+   * all: they come from environment parameters, and a rank whose environment
+   * disagrees must fail HERE, at init, rather than read a differently-shaped
+   * slot at runtime.
+   */
+  bool attach(const RelayControlConfig& cfg);
+
+  // Unmap, and unlink if we created it. Safe to call on an unopened block.
+  void detach();
+
+  bool valid() const {
+    return base_ != nullptr;
+  }
+
+  /**
+   * Publish one forward's plan.
+   *
+   * EXACTLY ONE RANK per communicator may publish. There is one ring, so two
+   * publishers would race the seqlock and drive it backwards; because both know
+   * the same token count their plans are byte-identical, so the damage would be
+   * invisible in the data and surface only as a spurious desync elsewhere. The
+   * first caller claims publishing and any other rank is rejected.
+   *
+   * Blocks while the slot this epoch lands on still holds a plan that a
+   * registered consumer has not taken yet; dropping a plan would desynchronize
+   * the communicator, so waiting is the only correct choice. Bounded, and
+   * bounded waits report which rank was lagging.
+   *
+   * Returns ncclInvalidArgument if nCalls exceeds the segment's capacity, with
+   * a log line naming the parameter to raise.
+   */
+  ncclResult_t publish(
+      uint64_t epoch,
+      const RelayPlanInfo& info,
+      const size_t* counts,
+      int64_t timeoutNs);
+
+  /**
+   * Take one forward's plan.
+   *
+   * A consumer REGISTERS itself here, on entry, and only from then on will a
+   * publisher wait for it. That is a contract, not an oversight: a rank's role
+   * is not knowable to the segment -- the active ranks attach too and never
+   * consume, so waiting on everyone who attached would deadlock at once.
+   *
+   * The consequence is that a consumer must reach its first consume() before
+   * the publisher completes `ringDepth` forwards. In practice that is free:
+   * comm init is a bootstrap barrier both sides leave together, and the
+   * publisher would have to finish ringDepth entire forwards, GPU work
+   * included, before the helper executes one instruction of its loop. If it is
+   * ever violated the late consumer gets the bounded desync error below rather
+   * than silent corruption.
+   *
+   * `countsCapacity` is what stops a publisher from overrunning the caller's
+   * buffer; on a too-small buffer `info` is still filled in so the caller can
+   * see the size it needed.
+   *
+   * Returns ncclInternalError on timeout (having set the abort flag) or if a
+   * peer aborted, and on a detected desync -- the slot having already advanced
+   * a full ring past the requested epoch, which no amount of waiting can undo.
+   */
+  ncclResult_t consume(
+      uint64_t epoch,
+      RelayPlanInfo* info,
+      size_t* counts,
+      uint32_t countsCapacity,
+      int64_t timeoutNs);
+
+  // Publish a shutdown plan, so a helper loop exits promptly instead of
+  // waiting out its timeout.
+  ncclResult_t publishShutdown(uint64_t epoch, int64_t timeoutNs);
+
+  void setAbort(uint32_t reason);
+  uint32_t abortReason() const;
+  uint32_t abortRank() const;
+
+  // Largest nCalls ever published here. Logged at teardown so the capacity
+  // parameter can be set from observation rather than from a guess.
+  uint32_t highWaterCalls() const;
+
+  uint32_t ringDepth() const;
+  uint32_t maxCalls() const;
+
+  /**
+   * Raw consumer-progress word for a rank: 0 if it has never entered consume(),
+   * 1 if it is consuming but has completed nothing, else completed-epoch + 2.
+   * Exposed so tests can assert that a rejected plan was NOT marked consumed.
+   */
+  uint64_t consumerProgress(uint32_t rank) const;
+
+  // Byte size of a segment with this geometry. Exposed for tests that fabricate
+  // or corrupt a segment on purpose.
+  static size_t
+  segmentBytes(uint32_t nRanks, uint32_t ringDepth, uint32_t maxCalls);
+
+  // The shm object name for a communicator, e.g. "/rcclx_relay_ctl_<hex>".
+  static std::string nameFor(uint64_t commHash);
+
+ private:
+  uint8_t* slotAt(uint64_t epoch) const;
+  uint64_t* slotSeq(uint64_t epoch) const;
+  RelayPlanInfo* slotInfo(uint64_t epoch) const;
+  uint64_t* slotCounts(uint64_t epoch) const;
+  uint64_t* consumedArray() const;
+  bool waitForSlotDrain(uint64_t epoch, int64_t timeoutNs);
+
+  uint8_t* base_{nullptr};
+  size_t bytes_{0};
+  bool owner_{false};
+  std::string name_;
+  RelayControlConfig cfg_{};
+};
+
+/**
+ * Build this communicator's control segment during ncclCommInitRank.
+ *
+ * Only acts when NCCL_SHARDED_RELAY_MODE_ENABLE=1 -- the same switch that
+ * pre-creates the one-shot IPC region, so a relay user sets one variable rather
+ * than two. Setup is COLLECTIVE (see the file comment), so init is the one
+ * place it is free: every rank is already there, and no later call -- including
+ * the first call of a graph capture, which could not run a bootstrap all-gather
+ * anyway -- has to pay for it or refuse it.
+ *
+ * Failure is not an error. Every caller is expected to have a fallback, so a
+ * comm that cannot build a segment simply behaves as if the variable were
+ * unset.
+ */
+void relayControlInit(ncclComm_t comm);
+
+/**
+ * Drop this communicator's segment. Called from RCCL's commFree(), the only
+ * point at which the relay learns a comm is going away. Purely local -- an
+ * munmap and, for the creator, an unlink -- so it honours commFree()'s
+ * no-sync-among-ranks contract. A no-op for a comm that never had one.
+ */
+void relayControlRelease(ncclComm_t comm);
+
+// True if this comm has a usable segment, without creating one.
+bool relayControlReady(ncclComm_t comm);
+
+ncclResult_t relayControlPublish(
+    ncclComm_t comm,
+    uint64_t epoch,
+    const RelayPlanInfo& info,
+    const size_t* counts,
+    int64_t timeoutNs);
+
+ncclResult_t relayControlConsume(
+    ncclComm_t comm,
+    uint64_t epoch,
+    RelayPlanInfo* info,
+    size_t* counts,
+    uint32_t countsCapacity,
+    int64_t timeoutNs);
+
+// Configured geometry, after environment overrides. Callers size their consume
+// buffer from the capacity; tests use both to build a matching segment.
+uint32_t relayControlConfiguredMaxCalls();
+uint32_t relayControlConfiguredRingDepth();
+
+} // namespace rcclx::relay

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
@@ -1074,17 +1074,37 @@ static ncclResult_t shardedRelayAllGatherFlatPipelined(
       const size_t dOff = directOffset(k);
       const size_t dSz = directSize(k);
 
+      // Direct exchange, issued as v-sized pieces rather than one (A-1)*v op,
+      // so that every operation in the group is the same size and all seven
+      // links get a comparable channel budget. See
+      // kRelayUniformDirectOpMinBytes for why this is size-gated here but
+      // unconditional in the reduce-scatter mirror.
+      const size_t dPiece = v;
+      const int dN =
+          (sc * elementSize >= rcclx::relay::kRelayUniformDirectOpMinBytes &&
+           dSz >= dPiece)
+          ? static_cast<int>(dSz / dPiece)
+          : 1;
+      auto dPieceOff = [&](int i) -> size_t {
+        return dOff + static_cast<size_t>(i) * dPiece;
+      };
+      auto dPieceSz = [&](int i) -> size_t {
+        return (i < dN - 1) ? dPiece
+                            : (dSz - static_cast<size_t>(dN - 1) * dPiece);
+      };
       for (int d = 0; d < A; d++) {
         if (d == m) {
           continue;
         }
-        NCCLCHECK(ncclSend(
-            sendbuff + dOff * elementSize,
-            dSz,
-            datatype,
-            cfg.activeRanks[d],
-            comm,
-            stream));
+        for (int i = 0; i < dN; i++) {
+          NCCLCHECK(ncclSend(
+              sendbuff + dPieceOff(i) * elementSize,
+              dPieceSz(i),
+              datatype,
+              cfg.activeRanks[d],
+              comm,
+              stream));
+        }
       }
       if (k < T) {
         for (int h = 0; h < H; h++) {
@@ -1104,13 +1124,16 @@ static ncclResult_t shardedRelayAllGatherFlatPipelined(
         if (s == m) {
           continue;
         }
-        NCCLCHECK(ncclRecv(
-            recvbuff + (static_cast<size_t>(s) * sc + dOff) * elementSize,
-            dSz,
-            datatype,
-            cfg.activeRanks[s],
-            comm,
-            stream));
+        for (int i = 0; i < dN; i++) {
+          NCCLCHECK(ncclRecv(
+              recvbuff +
+                  (static_cast<size_t>(s) * sc + dPieceOff(i)) * elementSize,
+              dPieceSz(i),
+              datatype,
+              cfg.activeRanks[s],
+              comm,
+              stream));
+        }
       }
       if (k > 0) {
         // Helper h delivers tile k-1 of every other source's offload chunk.

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
@@ -8,6 +8,7 @@
 
 #include "sharded_relay_all_gather.h"
 #include "comm.h"
+#include "sharded_relay_graph_scratch.h"
 #include "sharded_relay_route.h"
 
 #include <cstdint>
@@ -44,6 +45,25 @@ class ScratchBufferCache {
   void* get(int key, size_t requiredBytes, cudaStream_t stream) {
     if (requiredBytes == 0) {
       return nullptr;
+    }
+
+    // A capturing stream must not use this cache. hipMallocAsync would record
+    // an allocation node whose address is only valid while the graph runs, and
+    // a later growth would hipFreeAsync a pointer this graph has already baked
+    // in. Captures get a graph-scoped buffer instead; see
+    // sharded_relay_graph_scratch.h.
+    //
+    // Ahead of the lock on purpose: this is a HIP runtime call, and there is no
+    // reason to hold a process-wide mutex across it while relay collectives run
+    // concurrently on other streams. Measured either way it is in the noise, so
+    // this is hygiene rather than a fix for anything.
+    struct ncclCudaGraph graph;
+    if (ncclCudaGetCapturingGraph(&graph, stream) != ncclSuccess) {
+      return nullptr;
+    }
+    if (ncclCudaGraphValid(graph)) {
+      return rcclx::relay::graphScratchGet(
+          this, key, requiredBytes, stream, graph);
     }
     int device;
     cudaGetDevice(&device);

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
@@ -767,7 +767,26 @@ static ncclResult_t shardedRelayAllGatherFlat(
   }
 
   // Diagonal: recvBuff[m*sc] = sendBuff.
-  if (myActiveGroup >= 0 && sendCounts[myActiveGroup] > 0 && !isInPlace) {
+  //
+  // With the offload disabled the whole shard goes out in one group, so the
+  // diagonal can ride along in it as a P2P pair whose peer is the issuing rank:
+  // that is serviced as a local copy inside the same kernel, costing no
+  // transfer and, unlike this cudaMemcpyAsync, no second launch. With the
+  // offload enabled the direct region is only d1 of the sc elements, so the
+  // diagonal does not correspond to any single operation in the group and has
+  // to stay a separate copy.
+  //
+  // Restricted to nGroups == 1. Folding it in the FUSED case made
+  // Correctness_4Groups_A2_FusedRoutingThresholds fail intermittently (once in
+  // four runs) with mismatched slots. There, all eight ranks issue a self pair
+  // alongside a real one in the same group, rather than just the two active
+  // ranks; whether that is an RCCL self-P2P ordering issue or something else
+  // was not chased, because every sub-1x cell this targets is single-group and
+  // the fused route has its own tuned reference. Do not lift this gate without
+  // running the fused suite repeatedly -- a single green run is not evidence.
+  const bool foldDiagonalIntoGroup = !useOffload && !isInPlace && nGroups == 1;
+  if (myActiveGroup >= 0 && sendCounts[myActiveGroup] > 0 && !isInPlace &&
+      !foldDiagonalIntoGroup) {
     cudaMemcpyAsync(
         static_cast<char*>(recvBuffs[myActiveGroup]) +
             myDiagOffset * elementSize,
@@ -815,13 +834,13 @@ static ncclResult_t shardedRelayAllGatherFlat(
 
       if (d1 > 0) {
         for (int d = 0; d < A; d++) {
-          if (d == m)
+          if (d == m && !foldDiagonalIntoGroup)
             continue;
           NCCLCHECK(ncclSend(
               sendbuff, d1, datatype, cfg.activeRanks[d], comm, stream));
         }
         for (int s = 0; s < A; s++) {
-          if (s == m)
+          if (s == m && !foldDiagonalIntoGroup)
             continue;
           NCCLCHECK(ncclRecv(
               recvbuff + static_cast<size_t>(s) * sc * elementSize,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
@@ -496,6 +496,178 @@ static ncclResult_t shardedRelayAllGather2Active(
 }
 
 /**
+ * Software-pipelined single-group 2-active sharded relay all-gather.
+ *
+ * Same logical collective and the same helper roles as
+ * shardedRelayAllGather2Active, but for nGroups == 1 -- where the active ranks
+ * and the helpers are disjoint sets -- the relay is tiled and pipelined so both
+ * directions of every cross link stay busy. See relayA2PipelineTiles() for why
+ * the two-group schedule cannot do that and what it costs.
+ *
+ * With T tiles and unit u = align(sendCount / ((H+1)*T + 1)):
+ *   sendBuff [0, H*T*u)   offload region; helper h owns [h*T*u, (h+1)*T*u),
+ *                         its tile t at h*T*u + t*u
+ *   sendBuff [H*T*u, sc)  direct region as T+1 chunks of u, the last absorbing
+ *                         the /((H+1)*T + 1) remainder and the alignment loss
+ *
+ * Group k, for k in [0, T]:
+ *   active   scatter tile k (k < T) to every helper, receive the partner's
+ *            tile k-1 (k > 0) from every helper straight into the gather slot,
+ *            and exchange direct chunk k over the active<->active link.
+ *   helper h receive tile k of each active's chunk into ping-pong buffer k%2,
+ *            forward buffer (k-1)%2 to the OTHER active.
+ *
+ * Every rank therefore posts exactly one send and one recv per link per group,
+ * which is also the best case for p2p channel assignment. The helper's staging
+ * is two units per active rather than the whole chunk, so a forwarded tile is
+ * still cache-resident when it is read back.
+ *
+ * Both in-place and out-of-place are supported: the gather slot never overlaps
+ * the send source.
+ */
+static ncclResult_t shardedRelayAllGather2ActivePipelined(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* sendCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nTiles,
+    size_t elementSize) {
+  const ShardedRelayRankConfig& cfg = configs[0];
+  const size_t sc = sendCounts[0];
+  const int H = numHelpers;
+  const int T = nTiles;
+  const size_t u =
+      ((sc / (static_cast<size_t>(H + 1) * T + 1)) / CHUNK_ALIGN_ELEMENTS) *
+      CHUNK_ALIGN_ELEMENTS;
+  if (u == 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t tileStride = static_cast<size_t>(T) * u;
+  const size_t directBase = static_cast<size_t>(H) * tileStride;
+  const size_t lastDirect = sc - directBase - tileStride;
+
+  // Diagonal: recvBuff[m*sc] = sendBuff, a no-op when in-place.
+  size_t gatherSlot = 0;
+  if (myActiveGroup == 0) {
+    const size_t diagSlot = static_cast<size_t>(cfg.myActiveIndex) * sc;
+    gatherSlot = static_cast<size_t>(1 - cfg.myActiveIndex) * sc;
+    char* diag = static_cast<char*>(recvBuffs[0]) + diagSlot * elementSize;
+    if (static_cast<const void*>(sendBuffs[0]) !=
+        static_cast<const void*>(diag)) {
+      cudaMemcpyAsync(
+          diag,
+          sendBuffs[0],
+          sc * elementSize,
+          cudaMemcpyDeviceToDevice,
+          stream);
+    }
+  }
+
+  // Helper staging: two ping-pong units per active source. Tiny by design, so a
+  // tile is forwarded out of cache rather than re-read from HBM.
+  char* hbuff = nullptr;
+  if (!cfg.isActiveRank) {
+    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+        kHelperScratchKeyBase,
+        static_cast<size_t>(cfg.nActiveRanks) * 2 * u * elementSize,
+        stream));
+    if (hbuff == nullptr) {
+      return ncclInternalError;
+    }
+  }
+
+  for (int k = 0; k <= T; k++) {
+    NCCLCHECK(ncclGroupStart());
+    if (cfg.isActiveRank) {
+      const char* sendbuff = static_cast<const char*>(sendBuffs[0]);
+      char* recvbuff = static_cast<char*>(recvBuffs[0]);
+      const int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      const size_t directOffset = directBase + static_cast<size_t>(k) * u;
+      const size_t directSize = (k < T) ? u : lastDirect;
+
+      if (k < T) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclSend(
+              sendbuff +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclSend(
+          sendbuff + directOffset * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+      if (k > 0) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclRecv(
+              recvbuff +
+                  (gatherSlot + static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k - 1) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclRecv(
+          recvbuff + (gatherSlot + directOffset) * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else {
+      if (k < T) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclRecv(
+              hbuff +
+                  (static_cast<size_t>(a) * 2 + static_cast<size_t>(k % 2)) *
+                      u * elementSize,
+              u,
+              datatype,
+              cfg.activeRanks[a],
+              comm,
+              stream));
+        }
+      }
+      if (k > 0) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclSend(
+              hbuff +
+                  (static_cast<size_t>(a) * 2 +
+                   static_cast<size_t>((k - 1) % 2)) *
+                      u * elementSize,
+              u,
+              datatype,
+              cfg.activeRanks[1 - a],
+              comm,
+              stream));
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+  }
+
+  return ncclSuccess;
+}
+
+/**
  * All-gather for > 2 active ranks (two-group scatter/forward relay).
  *
  * Every active SOURCE must deliver its sc elements to the A-1 other active
@@ -891,18 +1063,40 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
   if (rcclx::relay::selectAllGatherRoute(
           nActiveRanksPerGroup, numHelpers, nGroups, sendCounts, elementSize) ==
       rcclx::relay::AllGatherRoute::A2Relay) {
-    r = shardedRelayAllGather2Active(
-        sendBuffs2,
-        recvBuffs2,
-        sendCounts,
-        datatype,
-        comm,
-        stream,
-        configs,
-        myActiveGroup,
+    // A single-group call has the helpers to itself, so the scatter and the
+    // forward run on opposite directions of each cross link and can be
+    // software-pipelined into one duplex stream; relayA2PipelineTiles() returns
+    // 1 whenever that does not apply.
+    const int nTiles = rcclx::relay::relayA2PipelineTiles(
+        nActiveRanksPerGroup,
         numHelpers,
         nGroups,
+        rcclx::relay::relayMaxCount(sendCounts, nGroups),
         elementSize);
+    r = (nTiles > 1) ? shardedRelayAllGather2ActivePipelined(
+                           sendBuffs2,
+                           recvBuffs2,
+                           sendCounts,
+                           datatype,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           numHelpers,
+                           nTiles,
+                           elementSize)
+                     : shardedRelayAllGather2Active(
+                           sendBuffs2,
+                           recvBuffs2,
+                           sendCounts,
+                           datatype,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           numHelpers,
+                           nGroups,
+                           elementSize);
   } else {
     // A>2, or small A==2: flat scatter->forward relay (dual of reduce-scatter)
     // with a size-adaptive pure-direct small-size mode.

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
@@ -501,7 +501,7 @@ static ncclResult_t shardedRelayAllGather2Active(
  * Same logical collective and the same helper roles as
  * shardedRelayAllGather2Active, but for nGroups == 1 -- where the active ranks
  * and the helpers are disjoint sets -- the relay is tiled and pipelined so both
- * directions of every cross link stay busy. See relayA2PipelineTiles() for why
+ * directions of every cross link stay busy. See relayPipelineTiles() for why
  * the two-group schedule cannot do that and what it costs.
  *
  * With T tiles and unit u = align(sendCount / ((H+1)*T + 1)):
@@ -1065,12 +1065,11 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
       rcclx::relay::AllGatherRoute::A2Relay) {
     // A single-group call has the helpers to itself, so the scatter and the
     // forward run on opposite directions of each cross link and can be
-    // software-pipelined into one duplex stream; relayA2PipelineTiles() returns
+    // software-pipelined into one duplex stream; relayPipelineTiles() returns
     // 1 whenever that does not apply.
-    const int nTiles = rcclx::relay::relayA2PipelineTiles(
-        nActiveRanksPerGroup,
-        numHelpers,
+    const int nTiles = rcclx::relay::relayPipelineTiles(
         nGroups,
+        rcclx::relay::relayShapeA2(numHelpers),
         rcclx::relay::relayMaxCount(sendCounts, nGroups),
         elementSize);
     r = (nTiles > 1) ? shardedRelayAllGather2ActivePipelined(

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
@@ -958,6 +958,213 @@ static ncclResult_t shardedRelayAllGatherFlat(
 }
 
 /**
+ * Software-pipelined single-group A>2 flat all-gather.
+ *
+ * Same scatter/forward relay as shardedRelayAllGatherFlat, but for nGroups == 1
+ * -- where the active ranks and the helpers are disjoint -- the offload is
+ * tiled so the scatter and the forward share a group and each cross link runs
+ * duplex. See relayPipelineTiles().
+ *
+ * This schedule is ASYMMETRIC, unlike the 2-active one: a helper fans each
+ * source's slice out to the A-1 other destinations, so a cross link carries one
+ * unit UP and A-1 units DOWN. Merging is therefore bounded by the down
+ * direction and the up direction stays underused, which is why the payoff is
+ * smaller here. With v = align(sc / ((H + A - 1)*T + 1)) each group carries
+ * (A-1)*v on the busiest link and the direct region is split to match, so the
+ * cost is ((A-1)*T + 1)*v: at A = H = 4 that is sc/2 at T = 1 (identical to the
+ * two-group schedule) falling towards 3*sc/7. That floor is also the hard one
+ * -- an active rank has to take in A-1 = 3 whole buffers across its 7 links.
+ *
+ * The divisor is derived from A and H rather than fixed at the A = H = 4 value
+ * of 7 because the layout below consumes H*T + 1 + (T-1)*(A-1) units before the
+ * final direct chunk; any other geometry that reaches this path (A = 4 with
+ * H = 5..8 on a 9-to-12-rank comm, or A = 8 with H = 8 on a 16-rank one) would
+ * otherwise push directOffset(T) past sc and underflow directSize(T).
+ *
+ * Buffer layout of sendBuff [0, sc):
+ *   [0, H*T*v)   offload region; helper h owns [h*T*v, (h+1)*T*v), tile t at
+ *                h*T*v + t*v
+ *   [H*T*v, sc)  direct region, one chunk per group sized to that group's cross
+ *                load: v for group 0 (which has no forward to receive yet) and
+ *                (A-1)*v for the rest, the last absorbing the remainder
+ *
+ * Both in-place and out-of-place are supported; the gather slots never overlap
+ * the send source.
+ */
+static ncclResult_t shardedRelayAllGatherFlatPipelined(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* sendCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nActiveRanksPerGroup,
+    int nTiles,
+    size_t elementSize) {
+  const ShardedRelayRankConfig& cfg = configs[0];
+  const size_t sc = sendCounts[0];
+  const int A = nActiveRanksPerGroup;
+  const int H = numHelpers;
+  const int T = nTiles;
+  const size_t v = ((sc /
+                     (static_cast<size_t>(
+                          rcclx::relay::relayShapeFanout(A, H).totalPerTile) *
+                          T +
+                      1)) /
+                    CHUNK_ALIGN_ELEMENTS) *
+      CHUNK_ALIGN_ELEMENTS;
+  if (v == 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t tileStride = static_cast<size_t>(T) * v;
+  const size_t directBase = static_cast<size_t>(H) * tileStride;
+  // Group 0 carries one unit of direct traffic, every later group carries A-1.
+  const size_t heavy = static_cast<size_t>(A - 1) * v;
+  auto directOffset = [&](int k) -> size_t {
+    return directBase + (k == 0 ? 0 : v + static_cast<size_t>(k - 1) * heavy);
+  };
+  auto directSize = [&](int k) -> size_t {
+    if (k == 0) {
+      return v;
+    }
+    return (k < T) ? heavy : (sc - directOffset(T));
+  };
+
+  // Diagonal: recvBuff[m*sc] = sendBuff, a no-op when in-place.
+  if (myActiveGroup == 0) {
+    char* diag = static_cast<char*>(recvBuffs[0]) +
+        static_cast<size_t>(cfg.myActiveIndex) * sc * elementSize;
+    if (static_cast<const void*>(sendBuffs[0]) !=
+        static_cast<const void*>(diag)) {
+      cudaMemcpyAsync(
+          diag,
+          sendBuffs[0],
+          sc * elementSize,
+          cudaMemcpyDeviceToDevice,
+          stream);
+    }
+  }
+
+  // Helper staging: two ping-pong tiles per active source.
+  char* hbuff = nullptr;
+  if (!cfg.isActiveRank) {
+    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+        kHelperScratchKeyBase,
+        static_cast<size_t>(A) * 2 * v * elementSize,
+        stream));
+    if (hbuff == nullptr) {
+      return ncclInternalError;
+    }
+  }
+  auto helperSlot = [&](int s, int k) -> char* {
+    return hbuff +
+        (static_cast<size_t>(s) * 2 + static_cast<size_t>(k % 2)) * v *
+        elementSize;
+  };
+
+  for (int k = 0; k <= T; k++) {
+    NCCLCHECK(ncclGroupStart());
+    if (cfg.isActiveRank) {
+      const char* sendbuff = static_cast<const char*>(sendBuffs[0]);
+      char* recvbuff = static_cast<char*>(recvBuffs[0]);
+      const int m = cfg.myActiveIndex;
+      const size_t dOff = directOffset(k);
+      const size_t dSz = directSize(k);
+
+      for (int d = 0; d < A; d++) {
+        if (d == m) {
+          continue;
+        }
+        NCCLCHECK(ncclSend(
+            sendbuff + dOff * elementSize,
+            dSz,
+            datatype,
+            cfg.activeRanks[d],
+            comm,
+            stream));
+      }
+      if (k < T) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclSend(
+              sendbuff +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k) * v) *
+                      elementSize,
+              v,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      for (int s = 0; s < A; s++) {
+        if (s == m) {
+          continue;
+        }
+        NCCLCHECK(ncclRecv(
+            recvbuff + (static_cast<size_t>(s) * sc + dOff) * elementSize,
+            dSz,
+            datatype,
+            cfg.activeRanks[s],
+            comm,
+            stream));
+      }
+      if (k > 0) {
+        // Helper h delivers tile k-1 of every other source's offload chunk.
+        for (int h = 0; h < H; h++) {
+          for (int s = 0; s < A; s++) {
+            if (s == m) {
+              continue;
+            }
+            NCCLCHECK(ncclRecv(
+                recvbuff +
+                    (static_cast<size_t>(s) * sc +
+                     static_cast<size_t>(h) * tileStride +
+                     static_cast<size_t>(k - 1) * v) *
+                        elementSize,
+                v,
+                datatype,
+                cfg.helperRanks[h],
+                comm,
+                stream));
+          }
+        }
+      }
+    } else {
+      if (k < T) {
+        for (int s = 0; s < A; s++) {
+          NCCLCHECK(ncclRecv(
+              helperSlot(s, k), v, datatype, cfg.activeRanks[s], comm, stream));
+        }
+      }
+      if (k > 0) {
+        // Per-peer send order matches each destination's receive order above.
+        for (int s = 0; s < A; s++) {
+          for (int d = 0; d < A; d++) {
+            if (d == s) {
+              continue;
+            }
+            NCCLCHECK(ncclSend(
+                helperSlot(s, k - 1),
+                v,
+                datatype,
+                cfg.activeRanks[d],
+                comm,
+                stream));
+          }
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+  }
+
+  return ncclSuccess;
+}
+
+/**
  * Fused Multi-Group Sharded Relay All-Gather.
  *
  * Executes multiple sharded relay all-gathers in one fused call, phase-synced
@@ -1060,9 +1267,9 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
   // shard exchange with minimal latency. The size -> route mapping lives in
   // selectAllGatherRoute() so the tests assert the same definition this
   // dispatch uses.
-  if (rcclx::relay::selectAllGatherRoute(
-          nActiveRanksPerGroup, numHelpers, nGroups, sendCounts, elementSize) ==
-      rcclx::relay::AllGatherRoute::A2Relay) {
+  const rcclx::relay::AllGatherRoute route = rcclx::relay::selectAllGatherRoute(
+      nActiveRanksPerGroup, numHelpers, nGroups, sendCounts, elementSize);
+  if (route == rcclx::relay::AllGatherRoute::A2Relay) {
     // A single-group call has the helpers to itself, so the scatter and the
     // forward run on opposite directions of each cross link and can be
     // software-pipelined into one duplex stream; relayPipelineTiles() returns
@@ -1098,20 +1305,46 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
                            elementSize);
   } else {
     // A>2, or small A==2: flat scatter->forward relay (dual of reduce-scatter)
-    // with a size-adaptive pure-direct small-size mode.
-    r = shardedRelayAllGatherFlat(
-        sendBuffs2,
-        recvBuffs2,
-        sendCounts,
-        datatype,
-        comm,
-        stream,
-        configs,
-        myActiveGroup,
-        numHelpers,
-        nActiveRanksPerGroup,
-        nGroups,
-        elementSize);
+    // with a size-adaptive pure-direct small-size mode. A single-group call
+    // with the offload enabled can additionally be software-pipelined so the
+    // scatter and the forward share each cross link's two directions.
+    const bool offload = route == rcclx::relay::AllGatherRoute::FlatOffload;
+    const int nTiles = offload
+        ? rcclx::relay::relayPipelineTiles(
+              nGroups,
+              rcclx::relay::relayShapeFanout(nActiveRanksPerGroup, numHelpers),
+              rcclx::relay::relayMaxCount(sendCounts, nGroups),
+              elementSize)
+        : 1;
+    if (nTiles > 1) {
+      r = shardedRelayAllGatherFlatPipelined(
+          sendBuffs2,
+          recvBuffs2,
+          sendCounts,
+          datatype,
+          comm,
+          stream,
+          configs,
+          myActiveGroup,
+          numHelpers,
+          nActiveRanksPerGroup,
+          nTiles,
+          elementSize);
+    } else {
+      r = shardedRelayAllGatherFlat(
+          sendBuffs2,
+          recvBuffs2,
+          sendCounts,
+          datatype,
+          comm,
+          stream,
+          configs,
+          myActiveGroup,
+          numHelpers,
+          nActiveRanksPerGroup,
+          nGroups,
+          elementSize);
+    }
   }
 
   return r;

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
@@ -541,6 +541,173 @@ static ncclResult_t shardedRelayAllToAll2Active(
 }
 
 /**
+ * Software-pipelined single-group 2-active sharded relay all-to-all.
+ *
+ * Same logical collective and the same helper roles as
+ * shardedRelayAllToAll2Active, but for nGroups == 1 -- where the active ranks
+ * and the helpers are disjoint sets -- the relay is tiled and pipelined so both
+ * directions of every cross link stay busy. See relayA2PipelineTiles() for why
+ * the two-group schedule cannot do that and what it costs.
+ *
+ * With T tiles and unit u = align(segmentCount / ((H+1)*T + 1)), the exchange
+ * segment splits as:
+ *   [0, H*T*u)   offload region; helper h owns [h*T*u, (h+1)*T*u), its tile t
+ * at h*T*u + t*u [H*T*u, sc)  direct region as T+1 chunks of u, the last
+ * absorbing the
+ *                /((H+1)*T + 1) remainder and the alignment loss
+ *
+ * Group k, for k in [0, T]: the active rank scatters tile k (k < T) to every
+ * helper, receives the partner's tile k-1 (k > 0) from every helper straight
+ * into its receive segment, and exchanges direct chunk k over the
+ * active<->active link; helper h receives tile k of each active's chunk into
+ * ping-pong buffer k%2 and forwards buffer (k-1)%2 to the OTHER active rank.
+ *
+ * Every rank posts exactly one send and one recv per link per group. The
+ * helper's staging is two units per active rather than the whole chunk, so a
+ * forwarded tile is still cache-resident when it is read back.
+ *
+ * OUT-OF-PLACE ONLY, like every other all-to-all route.
+ */
+static ncclResult_t shardedRelayAllToAll2ActivePipelined(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* segmentCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nTiles,
+    size_t elementSize) {
+  const ShardedRelayRankConfig& cfg = configs[0];
+  const size_t sc = segmentCounts[0];
+  const int H = numHelpers;
+  const int T = nTiles;
+  const size_t u =
+      ((sc / (static_cast<size_t>(H + 1) * T + 1)) / CHUNK_ALIGN_ELEMENTS) *
+      CHUNK_ALIGN_ELEMENTS;
+  if (u == 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t tileStride = static_cast<size_t>(T) * u;
+  const size_t directBase = static_cast<size_t>(H) * tileStride;
+  const size_t lastDirect = sc - directBase - tileStride;
+
+  // Diagonal: recvSeg[m] = sendSeg[m].
+  size_t exchangeSegOffset = 0;
+  if (myActiveGroup == 0) {
+    const size_t diagOffset = static_cast<size_t>(cfg.myActiveIndex) * sc;
+    exchangeSegOffset = static_cast<size_t>(1 - cfg.myActiveIndex) * sc;
+    cudaMemcpyAsync(
+        static_cast<char*>(recvBuffs[0]) + diagOffset * elementSize,
+        static_cast<const char*>(sendBuffs[0]) + diagOffset * elementSize,
+        sc * elementSize,
+        cudaMemcpyDeviceToDevice,
+        stream);
+  }
+
+  // Helper staging: two ping-pong units per active source.
+  char* hbuff = nullptr;
+  if (!cfg.isActiveRank) {
+    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+        kHelperScratchKeyBase,
+        static_cast<size_t>(cfg.nActiveRanks) * 2 * u * elementSize,
+        stream));
+    if (hbuff == nullptr) {
+      return ncclInternalError;
+    }
+  }
+
+  for (int k = 0; k <= T; k++) {
+    NCCLCHECK(ncclGroupStart());
+    if (cfg.isActiveRank) {
+      const char* sendSeg = static_cast<const char*>(sendBuffs[0]) +
+          exchangeSegOffset * elementSize;
+      char* recvSeg =
+          static_cast<char*>(recvBuffs[0]) + exchangeSegOffset * elementSize;
+      const int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      const size_t directOffset = directBase + static_cast<size_t>(k) * u;
+      const size_t directSize = (k < T) ? u : lastDirect;
+
+      if (k < T) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclSend(
+              sendSeg +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclSend(
+          sendSeg + directOffset * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+      if (k > 0) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclRecv(
+              recvSeg +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k - 1) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclRecv(
+          recvSeg + directOffset * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else {
+      if (k < T) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclRecv(
+              hbuff +
+                  (static_cast<size_t>(a) * 2 + static_cast<size_t>(k % 2)) *
+                      u * elementSize,
+              u,
+              datatype,
+              cfg.activeRanks[a],
+              comm,
+              stream));
+        }
+      }
+      if (k > 0) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclSend(
+              hbuff +
+                  (static_cast<size_t>(a) * 2 +
+                   static_cast<size_t>((k - 1) % 2)) *
+                      u * elementSize,
+              u,
+              datatype,
+              cfg.activeRanks[1 - a],
+              comm,
+              stream));
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+  }
+
+  return ncclSuccess;
+}
+
+/**
  * A=4 no-pack XOR/Latin relay path.
  *
  * Each off-diagonal segment stays in place and is split into contiguous
@@ -915,18 +1082,40 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
   const rcclx::relay::AllToAllRoute route = rcclx::relay::selectAllToAllRoute(
       nActiveRanksPerGroup, numHelpers, nGroups, segmentCounts, elementSize);
   if (route == rcclx::relay::AllToAllRoute::A2Relay) {
-    r = shardedRelayAllToAll2Active(
-        sendBuffs2,
-        recvBuffs2,
-        segmentCounts,
-        datatype,
-        comm,
-        stream,
-        configs,
-        myActiveGroup,
+    // A single-group call has the helpers to itself, so the scatter and the
+    // forward run on opposite directions of each cross link and can be
+    // software-pipelined into one duplex stream; relayA2PipelineTiles() returns
+    // 1 whenever that does not apply.
+    const int nTiles = rcclx::relay::relayA2PipelineTiles(
+        nActiveRanksPerGroup,
         numHelpers,
         nGroups,
+        rcclx::relay::relayMaxCount(segmentCounts, nGroups),
         elementSize);
+    r = (nTiles > 1) ? shardedRelayAllToAll2ActivePipelined(
+                           sendBuffs2,
+                           recvBuffs2,
+                           segmentCounts,
+                           datatype,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           numHelpers,
+                           nTiles,
+                           elementSize)
+                     : shardedRelayAllToAll2Active(
+                           sendBuffs2,
+                           recvBuffs2,
+                           segmentCounts,
+                           datatype,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           numHelpers,
+                           nGroups,
+                           elementSize);
   } else if (route == rcclx::relay::AllToAllRoute::A4XorRelay) {
     r = shardedRelayAllToAllA4XorRelay(
         sendBuffs2,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
@@ -8,6 +8,7 @@
 
 #include "sharded_relay_all_to_all.h"
 #include "comm.h"
+#include "sharded_relay_graph_scratch.h"
 #include "sharded_relay_route.h"
 
 #include <cstdint>
@@ -43,6 +44,25 @@ class ScratchBufferCache {
   void* get(int key, size_t requiredBytes, cudaStream_t stream) {
     if (requiredBytes == 0) {
       return nullptr;
+    }
+
+    // A capturing stream must not use this cache. hipMallocAsync would record
+    // an allocation node whose address is only valid while the graph runs, and
+    // a later growth would hipFreeAsync a pointer this graph has already baked
+    // in. Captures get a graph-scoped buffer instead; see
+    // sharded_relay_graph_scratch.h.
+    //
+    // Ahead of the lock on purpose: this is a HIP runtime call, and there is no
+    // reason to hold a process-wide mutex across it while relay collectives run
+    // concurrently on other streams. Measured either way it is in the noise, so
+    // this is hygiene rather than a fix for anything.
+    struct ncclCudaGraph graph;
+    if (ncclCudaGetCapturingGraph(&graph, stream) != ncclSuccess) {
+      return nullptr;
+    }
+    if (ncclCudaGraphValid(graph)) {
+      return rcclx::relay::graphScratchGet(
+          this, key, requiredBytes, stream, graph);
     }
     int device;
     cudaGetDevice(&device);

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
@@ -1067,8 +1067,22 @@ static ncclResult_t shardedRelayAllToAllFlat(
   const int A = nActiveRanksPerGroup;
   (void)numHelpers; // pure-direct: no helper relay for A>2 all-to-all.
 
-  // Diagonal copy recvSeg[m] = sendSeg[m] (active group only, out-of-place).
-  if (myActiveGroup >= 0 && segmentCounts[myActiveGroup] > 0) {
+  // The diagonal (recvSeg[m] = sendSeg[m]) rides along in the comm group below
+  // as a P2P pair whose peer is the issuing rank: that is serviced as a local
+  // copy inside the same kernel, so it costs no transfer and, unlike a separate
+  // cudaMemcpyAsync, no second launch -- worth ~5 us, which at these sizes is
+  // 10% of the whole call.
+  //
+  // Restricted to nGroups == 1. The same fold in the all-gather's fused case
+  // made a fused routing-threshold test fail intermittently (once in four
+  // runs); there all eight ranks issue a self pair alongside a real one in the
+  // same group rather than just the active ones. Every sub-1x cell this targets
+  // is single-group, so the fused route keeps the separate copy. Do not lift
+  // this gate without running the fused suites repeatedly.
+  const bool foldDiagonalIntoGroup = (nGroups == 1);
+
+  if (!foldDiagonalIntoGroup && myActiveGroup >= 0 &&
+      segmentCounts[myActiveGroup] > 0) {
     const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
     size_t sc = segmentCounts[myActiveGroup];
     size_t diagOffset = static_cast<size_t>(cfg.myActiveIndex) * sc;
@@ -1097,7 +1111,7 @@ static ncclResult_t shardedRelayAllToAllFlat(
     char* recvbuff = static_cast<char*>(recvBuffs[g]);
     int m = cfg.myActiveIndex;
     for (int j = 0; j < A; j++) {
-      if (j == m)
+      if (j == m && !foldDiagonalIntoGroup)
         continue;
       NCCLCHECK(ncclSend(
           sendbuff + static_cast<size_t>(j) * sc * elementSize,
@@ -1108,7 +1122,7 @@ static ncclResult_t shardedRelayAllToAllFlat(
           stream));
     }
     for (int s = 0; s < A; s++) {
-      if (s == m)
+      if (s == m && !foldDiagonalIntoGroup)
         continue;
       NCCLCHECK(ncclRecv(
           recvbuff + static_cast<size_t>(s) * sc * elementSize,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
@@ -546,7 +546,7 @@ static ncclResult_t shardedRelayAllToAll2Active(
  * Same logical collective and the same helper roles as
  * shardedRelayAllToAll2Active, but for nGroups == 1 -- where the active ranks
  * and the helpers are disjoint sets -- the relay is tiled and pipelined so both
- * directions of every cross link stay busy. See relayA2PipelineTiles() for why
+ * directions of every cross link stay busy. See relayPipelineTiles() for why
  * the two-group schedule cannot do that and what it costs.
  *
  * With T tiles and unit u = align(segmentCount / ((H+1)*T + 1)), the exchange
@@ -894,6 +894,163 @@ static ncclResult_t shardedRelayAllToAllA4XorRelay(
   return ncclSuccess;
 }
 
+/**
+ * Software-pipelined single-group A=4 XOR/Latin relay all-to-all.
+ *
+ * Same helper assignment as shardedRelayAllToAllA4XorRelay -- each (source,
+ * dest) pair's relay region takes two hops through the one helper that the
+ * Latin permutation gives it -- but for nGroups == 1, where the active ranks
+ * and the helpers are disjoint, the relay is tiled so the scatter and the
+ * forward share a group and each cross link runs duplex. See
+ * relayPipelineTiles().
+ *
+ * The unpipelined schedule pays one relay unit on the cross links plus one
+ * direct unit on the intra links in each of two groups, hence 2*sc/3. Merging
+ * makes each of the T+1 groups carry one relay unit UP and one DOWN on every
+ * cross link, matched by one direct unit on the intra links, so with u =
+ * align(sc/(2*T + 1)) the cost is (T+1)*u: 2*sc/3 at T = 1 falling towards
+ * sc/2.
+ *
+ * Segment layout for dest j:
+ *   [0, T*u)      relay region, tile t at t*u, two hops via helper h(j)
+ *   [T*u, sc)     direct region as T+1 chunks of u, the last absorbing the
+ *                 /(2*T + 1) remainder and the alignment loss
+ *
+ * Each helper owns 3 tasks with three DISTINCT sources and three DISTINCT
+ * destinations, so per group every rank posts exactly one send and one recv per
+ * link per direction -- 3 relay plus 3 direct each way for an active rank, 3
+ * each way for a helper.
+ *
+ * OUT-OF-PLACE ONLY, like every other all-to-all route.
+ */
+static ncclResult_t shardedRelayAllToAllA4XorRelayPipelined(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* segmentCounts,
+    ncclDataType_t datatype,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int nTiles,
+    size_t elementSize) {
+  const ShardedRelayRankConfig& cfg = configs[0];
+  const size_t sc = segmentCounts[0];
+  const int T = nTiles;
+  const size_t u =
+      ((sc / (static_cast<size_t>(2) * T + 1)) / CHUNK_ALIGN_ELEMENTS) *
+      CHUNK_ALIGN_ELEMENTS;
+  if (u == 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t relayTotal = static_cast<size_t>(T) * u;
+  const size_t lastDirect = sc - relayTotal - relayTotal;
+
+  A4RelayTask tasks[A4_RELAY_TASKS];
+  if (!buildA4RelayTasks(cfg, tasks)) {
+    return ncclInvalidArgument;
+  }
+
+  // Diagonal stays a local copy.
+  if (myActiveGroup == 0) {
+    const size_t diagOffset = static_cast<size_t>(cfg.myActiveIndex) * sc;
+    cudaMemcpyAsync(
+        static_cast<char*>(recvBuffs[0]) + diagOffset * elementSize,
+        static_cast<const char*>(sendBuffs[0]) + diagOffset * elementSize,
+        sc * elementSize,
+        cudaMemcpyDeviceToDevice,
+        stream);
+  }
+
+  // Helper staging: two ping-pong units per task.
+  char* hbuff = nullptr;
+  if (!cfg.isActiveRank) {
+    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+        kHelperScratchKeyBase,
+        static_cast<size_t>(A4_RELAY_TASKS_PER_HELPER) * 2 * u * elementSize,
+        stream));
+    if (hbuff == nullptr) {
+      return ncclInternalError;
+    }
+  }
+
+  for (int k = 0; k <= T; k++) {
+    NCCLCHECK(ncclGroupStart());
+    const int m = cfg.myActiveIndex;
+    const size_t directOffset = relayTotal + static_cast<size_t>(k) * u;
+    const size_t directSize = (k < T) ? u : lastDirect;
+
+    for (const A4RelayTask& task : tasks) {
+      if (cfg.isActiveRank) {
+        if (task.sourceIndex == m) {
+          const char* sendSegment = static_cast<const char*>(sendBuffs[0]) +
+              static_cast<size_t>(task.destIndex) * sc * elementSize;
+          if (k < T) {
+            NCCLCHECK(ncclSend(
+                sendSegment + static_cast<size_t>(k) * u * elementSize,
+                u,
+                datatype,
+                cfg.helperRanks[task.helperIndex],
+                comm,
+                stream));
+          }
+          NCCLCHECK(ncclSend(
+              sendSegment + directOffset * elementSize,
+              directSize,
+              datatype,
+              cfg.activeRanks[task.destIndex],
+              comm,
+              stream));
+        }
+        if (task.destIndex == m) {
+          char* recvSegment = static_cast<char*>(recvBuffs[0]) +
+              static_cast<size_t>(task.sourceIndex) * sc * elementSize;
+          if (k > 0) {
+            NCCLCHECK(ncclRecv(
+                recvSegment + static_cast<size_t>(k - 1) * u * elementSize,
+                u,
+                datatype,
+                cfg.helperRanks[task.helperIndex],
+                comm,
+                stream));
+          }
+          NCCLCHECK(ncclRecv(
+              recvSegment + directOffset * elementSize,
+              directSize,
+              datatype,
+              cfg.activeRanks[task.sourceIndex],
+              comm,
+              stream));
+        }
+      } else if (task.helperIndex == cfg.myHelperIndex) {
+        char* slotBase =
+            hbuff + static_cast<size_t>(task.helperSlot) * 2 * u * elementSize;
+        if (k < T) {
+          NCCLCHECK(ncclRecv(
+              slotBase + static_cast<size_t>(k % 2) * u * elementSize,
+              u,
+              datatype,
+              cfg.activeRanks[task.sourceIndex],
+              comm,
+              stream));
+        }
+        if (k > 0) {
+          NCCLCHECK(ncclSend(
+              slotBase + static_cast<size_t>((k - 1) % 2) * u * elementSize,
+              u,
+              datatype,
+              cfg.activeRanks[task.destIndex],
+              comm,
+              stream));
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+  }
+
+  return ncclSuccess;
+}
+
 static ncclResult_t shardedRelayAllToAllFlat(
     const void* const* sendBuffs,
     void* const* recvBuffs,
@@ -1084,12 +1241,11 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
   if (route == rcclx::relay::AllToAllRoute::A2Relay) {
     // A single-group call has the helpers to itself, so the scatter and the
     // forward run on opposite directions of each cross link and can be
-    // software-pipelined into one duplex stream; relayA2PipelineTiles() returns
+    // software-pipelined into one duplex stream; relayPipelineTiles() returns
     // 1 whenever that does not apply.
-    const int nTiles = rcclx::relay::relayA2PipelineTiles(
-        nActiveRanksPerGroup,
-        numHelpers,
+    const int nTiles = rcclx::relay::relayPipelineTiles(
         nGroups,
+        rcclx::relay::relayShapeA2(numHelpers),
         rcclx::relay::relayMaxCount(segmentCounts, nGroups),
         elementSize);
     r = (nTiles > 1) ? shardedRelayAllToAll2ActivePipelined(
@@ -1117,17 +1273,36 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
                            nGroups,
                            elementSize);
   } else if (route == rcclx::relay::AllToAllRoute::A4XorRelay) {
-    r = shardedRelayAllToAllA4XorRelay(
-        sendBuffs2,
-        recvBuffs2,
-        segmentCounts,
-        datatype,
-        comm,
-        stream,
-        configs,
-        myActiveGroup,
+    // A single-group call has the helpers to itself, so the relay's two hops
+    // run on opposite directions of each cross link and can be
+    // software-pipelined into one duplex stream.
+    const int nTiles = rcclx::relay::relayPipelineTiles(
         nGroups,
+        rcclx::relay::kRelayShapeA4AllToAll,
+        rcclx::relay::relayMaxCount(segmentCounts, nGroups),
         elementSize);
+    r = (nTiles > 1) ? shardedRelayAllToAllA4XorRelayPipelined(
+                           sendBuffs2,
+                           recvBuffs2,
+                           segmentCounts,
+                           datatype,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           nTiles,
+                           elementSize)
+                     : shardedRelayAllToAllA4XorRelay(
+                           sendBuffs2,
+                           recvBuffs2,
+                           segmentCounts,
+                           datatype,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           nGroups,
+                           elementSize);
   } else {
     // A==4 outside the routed window, or small A==2: exact direct all-to-all.
     r = shardedRelayAllToAllFlat(

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
@@ -565,9 +565,8 @@ static ncclResult_t shardedRelayAllToAllA4XorRelay(
   A4RelayTask tasks[SHARDED_RELAY_MAX_GROUPS][A4_RELAY_TASKS];
 
   for (int g = 0; g < nGroups; g++) {
-    const size_t third = segmentCounts[g] / 3;
-    directACounts[g] = third;
     relayCounts[g] = rcclx::relay::allToAllA4RelayCount(segmentCounts[g]);
+    directACounts[g] = relayCounts[g];
     directBCounts[g] = segmentCounts[g] - directACounts[g] - relayCounts[g];
     if (!buildA4RelayTasks(configs[g], tasks[g])) {
       return ncclInvalidArgument;
@@ -810,7 +809,8 @@ static ncclResult_t shardedRelayAllToAllFlat(
  *
  * nActiveRanksPerGroup must be a power of two (2 or 4). A==2 selects its direct
  * or dedicated 6-helper relay schedule by size. A==4 uses the deterministic
- * XOR/Latin helper schedule in its retained window and exact direct otherwise.
+ * XOR/Latin helper schedule from its lower size bound up, and exact direct
+ * below it.
  */
 HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
     const void* const* sendBuffs,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.h
@@ -29,10 +29,10 @@
  * nActiveRanksPerGroup must be a power of two (2 or 4). A==2 selects between
  * the exact direct exchange at small sizes and the original 2-active
  * passthrough relay with 6 dedicated helpers. A==4 with 4
- * helpers uses the no-pack XOR/Latin relay when the common maximum per-active-
- * rank input size, A * max(segmentCounts) * elementSize, is in [63 MiB,
- * 256 MiB) and every group count is positive. Other A==4 calls use the exact
- * pure-direct all-to-all. OUT-OF-PLACE ONLY in all cases.
+ * helpers uses the no-pack XOR/Latin relay once the common maximum per-active-
+ * rank input size, A * max(segmentCounts) * elementSize, reaches 27 MiB (fused)
+ * or 9 MiB (independent) and every group count is positive. Smaller A==4 calls
+ * use the exact pure-direct all-to-all. OUT-OF-PLACE ONLY in all cases.
  *
  * Unlike allreduce/reduce-scatter, all-to-all performs NO reduction — it is
  * pure data movement — so no reduction kernels are used and there is no

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -410,6 +410,102 @@ class ScratchBufferCache {
     }                                                                       \
   } while (0)
 
+#define LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                          \
+    TYPE, dst, seed, contribs, numContribs, count, divisor, stream) \
+  launchSeededMultiReduceKernel<TYPE>(                              \
+      dst, seed, contribs, numContribs, count, divisor, stream)
+
+#define DISPATCH_SEEDED_MULTI_REDUCE(                                          \
+    datatype, dst, seed, contribs, numContribs, count, divisor, stream)        \
+  do {                                                                         \
+    switch (datatype) {                                                        \
+      case ncclInt8:                                                           \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            int8_t, dst, seed, contribs, numContribs, count, divisor, stream); \
+        break;                                                                 \
+      case ncclUint8:                                                          \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            uint8_t,                                                           \
+            dst,                                                               \
+            seed,                                                              \
+            contribs,                                                          \
+            numContribs,                                                       \
+            count,                                                             \
+            divisor,                                                           \
+            stream);                                                           \
+        break;                                                                 \
+      case ncclInt32:                                                          \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            int32_t,                                                           \
+            dst,                                                               \
+            seed,                                                              \
+            contribs,                                                          \
+            numContribs,                                                       \
+            count,                                                             \
+            divisor,                                                           \
+            stream);                                                           \
+        break;                                                                 \
+      case ncclUint32:                                                         \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            uint32_t,                                                          \
+            dst,                                                               \
+            seed,                                                              \
+            contribs,                                                          \
+            numContribs,                                                       \
+            count,                                                             \
+            divisor,                                                           \
+            stream);                                                           \
+        break;                                                                 \
+      case ncclInt64:                                                          \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            int64_t,                                                           \
+            dst,                                                               \
+            seed,                                                              \
+            contribs,                                                          \
+            numContribs,                                                       \
+            count,                                                             \
+            divisor,                                                           \
+            stream);                                                           \
+        break;                                                                 \
+      case ncclUint64:                                                         \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            uint64_t,                                                          \
+            dst,                                                               \
+            seed,                                                              \
+            contribs,                                                          \
+            numContribs,                                                       \
+            count,                                                             \
+            divisor,                                                           \
+            stream);                                                           \
+        break;                                                                 \
+      case ncclFloat16:                                                        \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            __half, dst, seed, contribs, numContribs, count, divisor, stream); \
+        break;                                                                 \
+      case ncclFloat:                                                          \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            float, dst, seed, contribs, numContribs, count, divisor, stream);  \
+        break;                                                                 \
+      case ncclDouble:                                                         \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            double, dst, seed, contribs, numContribs, count, divisor, stream); \
+        break;                                                                 \
+      case ncclBfloat16:                                                       \
+        LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                                     \
+            __nv_bfloat16,                                                     \
+            dst,                                                               \
+            seed,                                                              \
+            contribs,                                                          \
+            numContribs,                                                       \
+            count,                                                             \
+            divisor,                                                           \
+            stream);                                                           \
+        break;                                                                 \
+      default:                                                                 \
+        break;                                                                 \
+    }                                                                          \
+  } while (0)
+
 #define LAUNCH_MULTI_REDUCE_KERNEL(                           \
     TYPE, dst, contribs, numContribs, count, divisor, stream) \
   launchMultiReduceKernel<TYPE>(                              \
@@ -1267,6 +1363,90 @@ static ncclResult_t shardedRelayAllReduceFlat(
     if (counts[g] != 0 && (counts[g] % static_cast<size_t>(A)) != 0) {
       return ncclInvalidArgument;
     }
+  }
+
+  // ==========================================================================
+  // SINGLE-GROUP SMALL-MESSAGE FULL-EXCHANGE FAST PATH (A > 2)
+  // ==========================================================================
+  // Below the crossover this schedule's cost is entirely launch latency, and
+  // the reduce-scatter + all-gather form it would otherwise run is the most
+  // expensive shape in the relay set at FOUR launches on the critical path: the
+  // sendbuff -> recvbuff staging copy, the reduce-scatter group, the shard
+  // reduce, and the all-gather group. A plain full exchange needs TWO -- one
+  // group in which every active rank ships its whole buffer to the other A-1,
+  // then one fused reduce over all A contributions. It moves (A-1)*count per
+  // link instead of 2*(A-1)*count/A, but below the crossover the bytes are not
+  // what is being paid for. This is the same trade the A==2 path already makes
+  // (see shardedRelayAllReduce2Active), generalized to A > 2.
+  //
+  // No separate size gate: the route selector already bounds the pure-direct
+  // regime, so "offload disabled" IS "below the crossover". Restricted to
+  // nGroups == 1 because a fused call has every rank active in one group and a
+  // helper in the others, so its links carry several groups' traffic at once
+  // and the bytes this trades away are not free there.
+  if (kOffPermille == 0 && nGroups == 1) {
+    const size_t count = counts[0];
+    void* xScratch = nullptr;
+    if (myActiveGroup >= 0 && count > 0) {
+      xScratch = ScratchBufferCache::getInstance().get(
+          SHARDED_RELAY_MAX_GROUPS,
+          static_cast<size_t>(A - 1) * count * elementSize,
+          stream);
+      if (xScratch == nullptr) {
+        return ncclInternalError;
+      }
+    }
+
+    if (count > 0) {
+      NCCLCHECK(ncclGroupStart());
+      const ShardedRelayRankConfig& cfg = configs[0];
+      if (cfg.isActiveRank) {
+        const int m = cfg.myActiveIndex;
+        for (int k = 0; k < A; k++) {
+          if (k == m) {
+            continue;
+          }
+          NCCLCHECK(ncclSend(
+              sendBuffs[0], count, datatype, cfg.activeRanks[k], comm, stream));
+        }
+        for (int s = 0; s < A; s++) {
+          if (s == m) {
+            continue;
+          }
+          const int p = (s < m) ? s : s - 1;
+          NCCLCHECK(ncclRecv(
+              static_cast<char*>(xScratch) +
+                  static_cast<size_t>(p) * count * elementSize,
+              count,
+              datatype,
+              cfg.activeRanks[s],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclGroupEnd());
+    }
+
+    if (myActiveGroup >= 0 && count > 0) {
+      void* out = recvBuffs[0];
+      if (out == sendBuffs[0]) {
+        // In-place: recvbuff already holds this rank's contribution, so it is
+        // both the seed and the destination.
+        DISPATCH_MULTI_REDUCE(
+            datatype, out, xScratch, A - 1, count, reductionDivisor, stream);
+      } else {
+        DISPATCH_SEEDED_MULTI_REDUCE(
+            datatype,
+            out,
+            sendBuffs[0],
+            xScratch,
+            A - 1,
+            count,
+            reductionDivisor,
+            stream);
+      }
+    }
+    return ncclSuccess;
   }
 
   // Per-group geometry: pO (offload) aligned to H*CHUNK_ALIGN; pD = count - pO

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -775,7 +775,7 @@ static constexpr int kHelperScratchKeyBase = SHARDED_RELAY_MAX_GROUPS + 1;
     srcStride,                                        \
     ownOffset,                                        \
     slotBytes,                                        \
-    epoch,                                            \
+    seq,                                              \
     divisor,                                          \
     stream)                                           \
   do {                                                \
@@ -794,7 +794,7 @@ static constexpr int kHelperScratchKeyBase = SHARDED_RELAY_MAX_GROUPS + 1;
             srcStride,                                \
             ownOffset,                                \
             slotBytes,                                \
-            epoch,                                    \
+            seq,                                      \
             divisor,                                  \
             stream);                                  \
         break;                                        \
@@ -811,7 +811,7 @@ static constexpr int kHelperScratchKeyBase = SHARDED_RELAY_MAX_GROUPS + 1;
             srcStride,                                \
             ownOffset,                                \
             slotBytes,                                \
-            epoch,                                    \
+            seq,                                      \
             divisor,                                  \
             stream);                                  \
         break;                                        \
@@ -828,7 +828,7 @@ static constexpr int kHelperScratchKeyBase = SHARDED_RELAY_MAX_GROUPS + 1;
             srcStride,                                \
             ownOffset,                                \
             slotBytes,                                \
-            epoch,                                    \
+            seq,                                      \
             divisor,                                  \
             stream);                                  \
         break;                                        \
@@ -845,7 +845,7 @@ static constexpr int kHelperScratchKeyBase = SHARDED_RELAY_MAX_GROUPS + 1;
             srcStride,                                \
             ownOffset,                                \
             slotBytes,                                \
-            epoch,                                    \
+            seq,                                      \
             divisor,                                  \
             stream);                                  \
         break;                                        \
@@ -862,7 +862,7 @@ static constexpr int kHelperScratchKeyBase = SHARDED_RELAY_MAX_GROUPS + 1;
             srcStride,                                \
             ownOffset,                                \
             slotBytes,                                \
-            epoch,                                    \
+            seq,                                      \
             divisor,                                  \
             stream);                                  \
         break;                                        \
@@ -879,7 +879,7 @@ static constexpr int kHelperScratchKeyBase = SHARDED_RELAY_MAX_GROUPS + 1;
             srcStride,                                \
             ownOffset,                                \
             slotBytes,                                \
-            epoch,                                    \
+            seq,                                      \
             divisor,                                  \
             stream);                                  \
         break;                                        \
@@ -896,7 +896,7 @@ static constexpr int kHelperScratchKeyBase = SHARDED_RELAY_MAX_GROUPS + 1;
             srcStride,                                \
             ownOffset,                                \
             slotBytes,                                \
-            epoch,                                    \
+            seq,                                      \
             divisor,                                  \
             stream);                                  \
         break;                                        \
@@ -913,7 +913,7 @@ static constexpr int kHelperScratchKeyBase = SHARDED_RELAY_MAX_GROUPS + 1;
             srcStride,                                \
             ownOffset,                                \
             slotBytes,                                \
-            epoch,                                    \
+            seq,                                      \
             divisor,                                  \
             stream);                                  \
         break;                                        \
@@ -964,13 +964,14 @@ static bool tryOneShotAllReduce(
   if (maxCount * elementSize > rcclx::relay::kRelayOneShotMaxBytes) {
     return false;
   }
-  // The epoch advances per host launch, so a replayed graph would reuse a stale
-  // value and the handshake would pass before the data arrived.
+  // Creating the region is not capturable: it does a bootstrap all-gather and a
+  // synchronous hipMemset. Using one that already exists is fine, so under
+  // capture take the path only if the region is already up.
   struct ncclCudaGraph graph;
   if (ncclCudaGetCapturingGraph(&graph, stream) != ncclSuccess) {
     return false;
   }
-  if (ncclCudaGraphValid(graph)) {
+  if (ncclCudaGraphValid(graph) && !rcclx::relay::oneShotReady(comm)) {
     return false;
   }
 
@@ -1005,7 +1006,7 @@ static bool tryOneShotAllReduce(
       /*srcStride=*/0,
       /*ownOffset=*/0,
       osl.slotBytes,
-      osl.epoch,
+      osl.seq,
       reductionDivisor,
       stream);
   // An unsupported datatype must not silently produce nothing. Falling back is

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -9,6 +9,7 @@
 #include "sharded_relay_allreduce.h"
 #include "comm.h"
 #include "sharded_relay_allreduce_kernels.h"
+#include "sharded_relay_oneshot.h"
 #include "sharded_relay_route.h"
 
 #include <hip/hip_bfloat16.h>
@@ -740,6 +741,260 @@ static bool buildShardedRelayRankConfig(
 // groups where they are a helper.
 static constexpr int kHelperScratchKeyBase = SHARDED_RELAY_MAX_GROUPS + 1;
 
+#define DISPATCH_ONESHOT_PUSH_REDUCE(                 \
+    datatype,                                         \
+    handled,                                          \
+    out,                                              \
+    sendBuff,                                         \
+    table,                                            \
+    ranks,                                            \
+    nActive,                                          \
+    myRank,                                           \
+    mySlot,                                           \
+    rc,                                               \
+    srcStride,                                        \
+    ownOffset,                                        \
+    slotBytes,                                        \
+    epoch,                                            \
+    divisor,                                          \
+    stream)                                           \
+  do {                                                \
+    (handled) = true;                                 \
+    switch (datatype) {                               \
+      case ncclInt32:                                 \
+        launchOneShotPushReduceKernel<int32_t>(       \
+            out,                                      \
+            sendBuff,                                 \
+            table,                                    \
+            ranks,                                    \
+            nActive,                                  \
+            myRank,                                   \
+            mySlot,                                   \
+            rc,                                       \
+            srcStride,                                \
+            ownOffset,                                \
+            slotBytes,                                \
+            epoch,                                    \
+            divisor,                                  \
+            stream);                                  \
+        break;                                        \
+      case ncclUint32:                                \
+        launchOneShotPushReduceKernel<uint32_t>(      \
+            out,                                      \
+            sendBuff,                                 \
+            table,                                    \
+            ranks,                                    \
+            nActive,                                  \
+            myRank,                                   \
+            mySlot,                                   \
+            rc,                                       \
+            srcStride,                                \
+            ownOffset,                                \
+            slotBytes,                                \
+            epoch,                                    \
+            divisor,                                  \
+            stream);                                  \
+        break;                                        \
+      case ncclInt64:                                 \
+        launchOneShotPushReduceKernel<int64_t>(       \
+            out,                                      \
+            sendBuff,                                 \
+            table,                                    \
+            ranks,                                    \
+            nActive,                                  \
+            myRank,                                   \
+            mySlot,                                   \
+            rc,                                       \
+            srcStride,                                \
+            ownOffset,                                \
+            slotBytes,                                \
+            epoch,                                    \
+            divisor,                                  \
+            stream);                                  \
+        break;                                        \
+      case ncclUint64:                                \
+        launchOneShotPushReduceKernel<uint64_t>(      \
+            out,                                      \
+            sendBuff,                                 \
+            table,                                    \
+            ranks,                                    \
+            nActive,                                  \
+            myRank,                                   \
+            mySlot,                                   \
+            rc,                                       \
+            srcStride,                                \
+            ownOffset,                                \
+            slotBytes,                                \
+            epoch,                                    \
+            divisor,                                  \
+            stream);                                  \
+        break;                                        \
+      case ncclFloat16:                               \
+        launchOneShotPushReduceKernel<__half>(        \
+            out,                                      \
+            sendBuff,                                 \
+            table,                                    \
+            ranks,                                    \
+            nActive,                                  \
+            myRank,                                   \
+            mySlot,                                   \
+            rc,                                       \
+            srcStride,                                \
+            ownOffset,                                \
+            slotBytes,                                \
+            epoch,                                    \
+            divisor,                                  \
+            stream);                                  \
+        break;                                        \
+      case ncclFloat:                                 \
+        launchOneShotPushReduceKernel<float>(         \
+            out,                                      \
+            sendBuff,                                 \
+            table,                                    \
+            ranks,                                    \
+            nActive,                                  \
+            myRank,                                   \
+            mySlot,                                   \
+            rc,                                       \
+            srcStride,                                \
+            ownOffset,                                \
+            slotBytes,                                \
+            epoch,                                    \
+            divisor,                                  \
+            stream);                                  \
+        break;                                        \
+      case ncclDouble:                                \
+        launchOneShotPushReduceKernel<double>(        \
+            out,                                      \
+            sendBuff,                                 \
+            table,                                    \
+            ranks,                                    \
+            nActive,                                  \
+            myRank,                                   \
+            mySlot,                                   \
+            rc,                                       \
+            srcStride,                                \
+            ownOffset,                                \
+            slotBytes,                                \
+            epoch,                                    \
+            divisor,                                  \
+            stream);                                  \
+        break;                                        \
+      case ncclBfloat16:                              \
+        launchOneShotPushReduceKernel<__nv_bfloat16>( \
+            out,                                      \
+            sendBuff,                                 \
+            table,                                    \
+            ranks,                                    \
+            nActive,                                  \
+            myRank,                                   \
+            mySlot,                                   \
+            rc,                                       \
+            srcStride,                                \
+            ownOffset,                                \
+            slotBytes,                                \
+            epoch,                                    \
+            divisor,                                  \
+            stream);                                  \
+        break;                                        \
+      default:                                        \
+        (handled) = false;                            \
+        break;                                        \
+    }                                                 \
+  } while (0)
+
+// Try the one-shot IPC kernel for a single-group A-active allreduce, and report
+// whether it ran.
+//
+// The pure-direct allreduce schedules -- the A==2 full exchange and the A>2 one
+// added alongside it -- are both TWO launches: one group, then one reduce. That
+// is one more than NCCL, and it is the same shape the reduce-scatter had before
+// the one-shot path replaced it. The fix transfers directly: allreduce is the
+// srcStride == 0 case of the same push-reduce kernel, because every peer is
+// owed the whole buffer rather than a per-peer block, and every rank keeps the
+// whole result rather than a shard.
+//
+// Bytes moved are unchanged -- (A-1)*count pushed per rank, exactly what the
+// group form sent -- so this trades a launch for nothing.
+//
+// Every predicate is derived from sizes and the communicator only, so all ranks
+// reach the same decision: a rank that ran the one-shot kernel while a peer
+// took the ncclSend path would spin forever rather than merely run slower.
+// oneShotAcquire() is COLLECTIVE on first use, so it is called before any
+// branch on myActiveGroup and it agrees its own success across ranks.
+static bool tryOneShotAllReduce(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* counts,
+    ncclDataType_t datatype,
+    int reductionDivisor,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int nActiveRanksPerGroup,
+    int nGroups,
+    size_t elementSize) {
+  const size_t maxCount = rcclx::relay::relayMaxCount(counts, nGroups);
+  if (nGroups != 1 || maxCount == 0) {
+    return false;
+  }
+  // Each of the A staging slots holds a whole contribution here, not a shard,
+  // so the gate is the per-rank count directly.
+  if (maxCount * elementSize > rcclx::relay::kRelayOneShotMaxBytes) {
+    return false;
+  }
+  // The epoch advances per host launch, so a replayed graph would reuse a stale
+  // value and the handshake would pass before the data arrived.
+  struct ncclCudaGraph graph;
+  if (ncclCudaGetCapturingGraph(&graph, stream) != ncclSuccess) {
+    return false;
+  }
+  if (ncclCudaGraphValid(graph)) {
+    return false;
+  }
+
+  rcclx::relay::OneShotLaunch osl{};
+  if (!rcclx::relay::oneShotAcquire(comm, &osl)) {
+    return false;
+  }
+
+  // Helpers have nothing to do, but they DID have to reach the acquire above,
+  // which is the whole reason it sits before this branch.
+  if (myActiveGroup < 0 || counts[myActiveGroup] == 0) {
+    return true;
+  }
+
+  const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
+  rcclx::relay::OneShotRanks ranks{};
+  for (int a = 0; a < nActiveRanksPerGroup; a++) {
+    ranks.r[a] = cfg.activeRanks[a];
+  }
+  bool handled = false;
+  DISPATCH_ONESHOT_PUSH_REDUCE(
+      datatype,
+      handled,
+      recvBuffs[myActiveGroup],
+      sendBuffs[myActiveGroup],
+      osl.table,
+      ranks,
+      nActiveRanksPerGroup,
+      comm->rank,
+      cfg.myActiveIndex,
+      counts[myActiveGroup],
+      /*srcStride=*/0,
+      /*ownOffset=*/0,
+      osl.slotBytes,
+      osl.epoch,
+      reductionDivisor,
+      stream);
+  // An unsupported datatype must not silently produce nothing. Falling back is
+  // safe only because the dtype is identical on every rank, so either all of
+  // them fall back or none do -- and in pure-direct mode the helpers post
+  // nothing anyway, so a helper that already returned true is equivalent.
+  return handled;
+}
+
 static ncclResult_t shardedRelayAllReduce2Active(
     const void* const* sendBuffs,
     void* const* recvBuffs,
@@ -767,6 +1022,24 @@ static ncclResult_t shardedRelayAllReduce2Active(
   // about A==2.
   if (rcclx::relay::selectAllReduceRoute(2, nGroups, counts, elementSize) ==
       rcclx::relay::AllReduceRoute::PureDirect) {
+    // One kernel instead of the group-plus-reduce pair below. See
+    // tryOneShotAllReduce().
+    if (tryOneShotAllReduce(
+            sendBuffs,
+            recvBuffs,
+            counts,
+            datatype,
+            reductionDivisor,
+            comm,
+            stream,
+            configs,
+            myActiveGroup,
+            2,
+            nGroups,
+            elementSize)) {
+      return ncclSuccess;
+    }
+
     void* pdScratch = nullptr;
     if (myActiveGroup >= 0 && counts[myActiveGroup] > 0) {
       pdScratch = ScratchBufferCache::getInstance().get(
@@ -1385,6 +1658,24 @@ static ncclResult_t shardedRelayAllReduceFlat(
   // helper in the others, so its links carry several groups' traffic at once
   // and the bytes this trades away are not free there.
   if (kOffPermille == 0 && nGroups == 1) {
+    // One kernel instead of the group-plus-reduce pair below. See
+    // tryOneShotAllReduce().
+    if (tryOneShotAllReduce(
+            sendBuffs,
+            recvBuffs,
+            counts,
+            datatype,
+            reductionDivisor,
+            comm,
+            stream,
+            configs,
+            myActiveGroup,
+            A,
+            nGroups,
+            elementSize)) {
+      return ncclSuccess;
+    }
+
     const size_t count = counts[0];
     void* xScratch = nullptr;
     if (myActiveGroup >= 0 && count > 0) {

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -1577,6 +1577,18 @@ static ncclResult_t shardedRelayAllReduceFlatPipelined(
     return ncclInvalidArgument;
   }
   const size_t oTile = 2 * y;
+  // The offload moves oTile = 2*y per link per group while the direct exchange
+  // moves y, and RCCL budgets channels per operation -- so a cross link
+  // carrying its bytes as one op gets half the channels of an intra link
+  // carrying the same bytes as two. Splitting the offload into y-sized pieces
+  // makes every operation in the group the same size. Gated on size for the
+  // same reason as the all-gather mirror: measured 1.98x -> 2.05x at 1 GB
+  // and 1.88x -> 1.97x at 512 MB, but ~1% worse at 135-144 MB where the extra
+  // ops do not amortize.
+  const int oN =
+      (count * elementSize >= rcclx::relay::kRelayUniformDirectOpMinBytes) ? 2
+                                                                           : 1;
+  const size_t oPiece = oTile / static_cast<size_t>(oN);
   const size_t oChunk = static_cast<size_t>(T) * oTile;
   const size_t pO = static_cast<size_t>(H) * oChunk;
   const size_t pD = count - pO;
@@ -1671,17 +1683,26 @@ static ncclResult_t shardedRelayAllReduceFlatPipelined(
         }
       }
       if (k < T) {
+        // Offload scatter, split into y-sized pieces so every operation in the
+        // group is the same size as the direct tiles. oTile is exactly 2*y, so
+        // the split is exact. See kRelayUniformDirectOpMinBytes for why this
+        // matters: RCCL budgets channels per operation, so a link carrying its
+        // bytes as one large op gets half the channels of a link carrying the
+        // same bytes as two.
         for (int h = 0; h < H; h++) {
-          NCCLCHECK(ncclSend(
-              recvbuff +
-                  (pD + static_cast<size_t>(h) * oChunk +
-                   static_cast<size_t>(k) * oTile) *
-                      elementSize,
-              oTile,
-              datatype,
-              cfg.helperRanks[h],
-              comm,
-              stream));
+          for (int i = 0; i < oN; i++) {
+            NCCLCHECK(ncclSend(
+                recvbuff +
+                    (pD + static_cast<size_t>(h) * oChunk +
+                     static_cast<size_t>(k) * oTile +
+                     static_cast<size_t>(i) * oPiece) *
+                        elementSize,
+                oPiece,
+                datatype,
+                cfg.helperRanks[h],
+                comm,
+                stream));
+          }
         }
       }
 
@@ -1715,41 +1736,51 @@ static ncclResult_t shardedRelayAllReduceFlatPipelined(
               comm,
               stream));
         }
-        // Already reduced by the helper, so this is the final value.
+        // Already reduced by the helper, so this is the final value. Split to
+        // match the scatter above.
         for (int h = 0; h < H; h++) {
-          NCCLCHECK(ncclRecv(
-              recvbuff +
-                  (pD + static_cast<size_t>(h) * oChunk +
-                   static_cast<size_t>(k - 1) * oTile) *
-                      elementSize,
-              oTile,
-              datatype,
-              cfg.helperRanks[h],
-              comm,
-              stream));
+          for (int i = 0; i < oN; i++) {
+            NCCLCHECK(ncclRecv(
+                recvbuff +
+                    (pD + static_cast<size_t>(h) * oChunk +
+                     static_cast<size_t>(k - 1) * oTile +
+                     static_cast<size_t>(i) * oPiece) *
+                        elementSize,
+                oPiece,
+                datatype,
+                cfg.helperRanks[h],
+                comm,
+                stream));
+          }
         }
       }
     } else {
       if (k < T) {
         for (int a = 0; a < A; a++) {
-          NCCLCHECK(ncclRecv(
-              helperSlot(a, k),
-              oTile,
-              datatype,
-              cfg.activeRanks[a],
-              comm,
-              stream));
+          for (int i = 0; i < oN; i++) {
+            NCCLCHECK(ncclRecv(
+                helperSlot(a, k) +
+                    static_cast<size_t>(i) * oPiece * elementSize,
+                oPiece,
+                datatype,
+                cfg.activeRanks[a],
+                comm,
+                stream));
+          }
         }
       }
       if (k > 0) {
         for (int a = 0; a < A; a++) {
-          NCCLCHECK(ncclSend(
-              helperSlot(0, k - 1),
-              oTile,
-              datatype,
-              cfg.activeRanks[a],
-              comm,
-              stream));
+          for (int i = 0; i < oN; i++) {
+            NCCLCHECK(ncclSend(
+                helperSlot(0, k - 1) +
+                    static_cast<size_t>(i) * oPiece * elementSize,
+                oPiece,
+                datatype,
+                cfg.activeRanks[a],
+                comm,
+                stream));
+          }
         }
       }
     }

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -9,6 +9,7 @@
 #include "sharded_relay_allreduce.h"
 #include "comm.h"
 #include "sharded_relay_allreduce_kernels.h"
+#include "sharded_relay_graph_scratch.h"
 #include "sharded_relay_oneshot.h"
 #include "sharded_relay_route.h"
 
@@ -72,6 +73,25 @@ class ScratchBufferCache {
   void* get(int key, size_t requiredBytes, cudaStream_t stream) {
     if (requiredBytes == 0) {
       return nullptr;
+    }
+
+    // A capturing stream must not use this cache. hipMallocAsync would record
+    // an allocation node whose address is only valid while the graph runs, and
+    // a later growth would hipFreeAsync a pointer this graph has already baked
+    // in. Captures get a graph-scoped buffer instead; see
+    // sharded_relay_graph_scratch.h.
+    //
+    // Ahead of the lock on purpose: this is a HIP runtime call, and there is no
+    // reason to hold a process-wide mutex across it while relay collectives run
+    // concurrently on other streams. Measured either way it is in the noise, so
+    // this is hygiene rather than a fix for anything.
+    struct ncclCudaGraph graph;
+    if (ncclCudaGetCapturingGraph(&graph, stream) != ncclSuccess) {
+      return nullptr;
+    }
+    if (ncclCudaGraphValid(graph)) {
+      return rcclx::relay::graphScratchGet(
+          this, key, requiredBytes, stream, graph);
     }
 
     int device;

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -1505,6 +1505,288 @@ static ncclResult_t shardedRelayAllReduceFlat(
 }
 
 /**
+ * Software-pipelined single-group A>2 flat allreduce.
+ *
+ * Same two regions as shardedRelayAllReduceFlat -- a direct reduce-scatter plus
+ * all-gather over the intra links, and an offload region the helpers reduce and
+ * broadcast -- but for nGroups == 1, where the active ranks and the helpers are
+ * disjoint, both are tiled and pipelined. See relayAllReducePipelineTiles()
+ * for why this schedule needs its own depth selector and why it only pays from
+ * depth 4 up.
+ *
+ * Two dependencies are pipelined here, not one:
+ *   offload   scatter tile k in group k; the helper sums the A chunks; the
+ *             reduced tile is broadcast back in group k+1. Because the helper
+ *             takes one chunk per active rank and returns one per active rank,
+ *             the cross link carries the same in each direction -- this is the
+ *             4-active shape that is NOT throttled by a heavy direction.
+ *   direct    reduce-scatter tile k in group k, the owner reduces its shard's
+ *             tile k, and the all-gather of that tile goes out in group k+1.
+ *
+ * With y = align(count / ((A + 2H)*T)): the offload region is H*2*T*y (tile
+ * 2y), the direct region is the rest with per-owner shard dShard = pD/A (tile
+ * y, the last absorbing the remainder), and each of the T+1 groups carries 2y
+ * on the busiest link, so the cost is 2*(T+1)*y -- at A = H = 4, count/4 for
+ * the two-group schedule falling to 5*count/24 at depth 4 and 3*count/16 at
+ * depth 8.
+ *
+ * The divisor is A + 2H rather than a fixed 12 because the layout consumes
+ * 2*H*T units for the offload region and A*T for the direct region's shards. A
+ * = 4 with H = 5..8 (a 9-to-12-rank comm) and A = 8 with H = 8 (a 16-rank one)
+ * also reach this path, and a fixed 12 would make pO exceed count so pD = count
+ * - pO underflows, handing a wild dShard to the reduce kernels and to ncclSend.
+ *
+ * dScratch is laid out TILE-major, not shard-major as in the flat path: the
+ * owner's per-tile reduce has to fold the A-1 peer contributions for one tile
+ * while the next group is already in flight, and the fused multi-input reduce
+ * requires those to be contiguous with stride tileSz.
+ *
+ * Both in-place and out-of-place are supported; out-of-place seeds recvBuff
+ * from sendBuff once and then operates in place, as the flat path does.
+ */
+static ncclResult_t shardedRelayAllReduceFlatPipelined(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* counts,
+    ncclDataType_t datatype,
+    int reductionDivisor,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nActiveRanksPerGroup,
+    int nTiles,
+    size_t elementSize) {
+  const ShardedRelayRankConfig& cfg = configs[0];
+  const size_t count = counts[0];
+  const int A = nActiveRanksPerGroup;
+  const int H = numHelpers;
+  const int T = nTiles;
+  if ((count % static_cast<size_t>(A)) != 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t y =
+      ((count /
+        (static_cast<size_t>(
+             rcclx::relay::relayAllReducePipelineUnitsPerTile(A, H)) *
+         T)) /
+       CHUNK_ALIGN_ELEMENTS) *
+      CHUNK_ALIGN_ELEMENTS;
+  if (y == 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t oTile = 2 * y;
+  const size_t oChunk = static_cast<size_t>(T) * oTile;
+  const size_t pO = static_cast<size_t>(H) * oChunk;
+  const size_t pD = count - pO;
+  const size_t dShard = pD / static_cast<size_t>(A);
+  auto tileOffset = [&](int t) -> size_t { return static_cast<size_t>(t) * y; };
+  auto tileSize = [&](int t) -> size_t {
+    return (t < T - 1) ? y : (dShard - tileOffset(T - 1));
+  };
+  // Peer p's contribution to tile t, tile-major so one tile's A-1 inputs are
+  // contiguous with stride tileSize(t).
+  auto dSlot = [&](int t, int p) -> size_t {
+    return static_cast<size_t>(A - 1) * tileOffset(t) +
+        static_cast<size_t>(p) * tileSize(t);
+  };
+
+  void* dScratch = nullptr;
+  if (myActiveGroup == 0) {
+    if (sendBuffs[0] != recvBuffs[0]) {
+      cudaMemcpyAsync(
+          recvBuffs[0],
+          sendBuffs[0],
+          count * elementSize,
+          cudaMemcpyDeviceToDevice,
+          stream);
+    }
+    dScratch = ScratchBufferCache::getInstance().get(
+        SHARDED_RELAY_MAX_GROUPS,
+        static_cast<size_t>(A - 1) * dShard * elementSize,
+        stream);
+    if (dScratch == nullptr) {
+      return ncclInternalError;
+    }
+  }
+
+  // Helper staging: A chunks per ping-pong buffer, buffer-major so the A inputs
+  // of one stage are contiguous with stride oTile for the fused reduce.
+  char* hbuff = nullptr;
+  if (!cfg.isActiveRank) {
+    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+        kHelperScratchKeyBase,
+        2 * static_cast<size_t>(A) * oTile * elementSize,
+        stream));
+    if (hbuff == nullptr) {
+      return ncclInternalError;
+    }
+  }
+  auto helperSlot = [&](int a, int k) -> char* {
+    return hbuff +
+        ((static_cast<size_t>(k % 2) * A + static_cast<size_t>(a)) * oTile) *
+        elementSize;
+  };
+
+  for (int k = 0; k <= T; k++) {
+    NCCLCHECK(ncclGroupStart());
+    if (cfg.isActiveRank) {
+      char* recvbuff = static_cast<char*>(recvBuffs[0]);
+      const int m = cfg.myActiveIndex;
+
+      // Sends: reduce-scatter tile k, then all-gather tile k-1. The receive
+      // loops below use the same order, which is what keeps each peer's matched
+      // pair in step.
+      if (k < T) {
+        for (int j = 0; j < A; j++) {
+          if (j == m) {
+            continue;
+          }
+          NCCLCHECK(ncclSend(
+              recvbuff +
+                  (static_cast<size_t>(j) * dShard + tileOffset(k)) *
+                      elementSize,
+              tileSize(k),
+              datatype,
+              cfg.activeRanks[j],
+              comm,
+              stream));
+        }
+      }
+      if (k > 0) {
+        for (int j = 0; j < A; j++) {
+          if (j == m) {
+            continue;
+          }
+          NCCLCHECK(ncclSend(
+              recvbuff +
+                  (static_cast<size_t>(m) * dShard + tileOffset(k - 1)) *
+                      elementSize,
+              tileSize(k - 1),
+              datatype,
+              cfg.activeRanks[j],
+              comm,
+              stream));
+        }
+      }
+      if (k < T) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclSend(
+              recvbuff +
+                  (pD + static_cast<size_t>(h) * oChunk +
+                   static_cast<size_t>(k) * oTile) *
+                      elementSize,
+              oTile,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+
+      if (k < T) {
+        for (int s = 0; s < A; s++) {
+          if (s == m) {
+            continue;
+          }
+          const int p = (s < m) ? s : s - 1;
+          NCCLCHECK(ncclRecv(
+              static_cast<char*>(dScratch) + dSlot(k, p) * elementSize,
+              tileSize(k),
+              datatype,
+              cfg.activeRanks[s],
+              comm,
+              stream));
+        }
+      }
+      if (k > 0) {
+        for (int j = 0; j < A; j++) {
+          if (j == m) {
+            continue;
+          }
+          NCCLCHECK(ncclRecv(
+              recvbuff +
+                  (static_cast<size_t>(j) * dShard + tileOffset(k - 1)) *
+                      elementSize,
+              tileSize(k - 1),
+              datatype,
+              cfg.activeRanks[j],
+              comm,
+              stream));
+        }
+        // Already reduced by the helper, so this is the final value.
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclRecv(
+              recvbuff +
+                  (pD + static_cast<size_t>(h) * oChunk +
+                   static_cast<size_t>(k - 1) * oTile) *
+                      elementSize,
+              oTile,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+    } else {
+      if (k < T) {
+        for (int a = 0; a < A; a++) {
+          NCCLCHECK(ncclRecv(
+              helperSlot(a, k),
+              oTile,
+              datatype,
+              cfg.activeRanks[a],
+              comm,
+              stream));
+        }
+      }
+      if (k > 0) {
+        for (int a = 0; a < A; a++) {
+          NCCLCHECK(ncclSend(
+              helperSlot(0, k - 1),
+              oTile,
+              datatype,
+              cfg.activeRanks[a],
+              comm,
+              stream));
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+
+    if (k < T) {
+      if (cfg.isActiveRank) {
+        // Fold this tile of my own shard, before the next group gathers it.
+        char* dst = static_cast<char*>(recvBuffs[0]) +
+            (static_cast<size_t>(cfg.myActiveIndex) * dShard + tileOffset(k)) *
+                elementSize;
+        DISPATCH_MULTI_REDUCE(
+            datatype,
+            dst,
+            static_cast<char*>(dScratch) + dSlot(k, 0) * elementSize,
+            A - 1,
+            tileSize(k),
+            reductionDivisor,
+            stream);
+      } else {
+        // Sum all A chunks into slot 0, which the next group broadcasts.
+        DISPATCH_MULTI_REDUCE(
+            datatype,
+            helperSlot(0, k),
+            helperSlot(1, k),
+            A - 1,
+            oTile,
+            reductionDivisor,
+            stream);
+      }
+    }
+  }
+
+  return ncclSuccess;
+}
+
+/**
  * Fused Multi-Group Sharded Relay AllReduce.
  *
  * Executes multiple sharded relay allreduces in one fused call, phase-synced
@@ -1643,7 +1925,31 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
                            elementSize);
   } else {
     // A>2: flat helper-reduce-and-broadcast (direct RS+AG over intra woven with
-    // offload reduce+broadcast through the helpers).
+    // offload reduce+broadcast through the helpers). A single-group call can
+    // pipeline both dependencies so each cross link runs duplex; the selector
+    // returns 1 below the crossover, where the two-group schedule is better.
+    const int nTiles = rcclx::relay::relayAllReducePipelineTiles(
+        nGroups,
+        nActiveRanksPerGroup,
+        numHelpers,
+        rcclx::relay::relayMaxCount(counts, nGroups),
+        elementSize);
+    if (nTiles > 1) {
+      return shardedRelayAllReduceFlatPipelined(
+          sendBuffs2,
+          recvBuffs2,
+          counts,
+          datatype,
+          reductionDivisor,
+          comm,
+          stream,
+          configs,
+          myActiveGroup,
+          numHelpers,
+          nActiveRanksPerGroup,
+          nTiles,
+          elementSize);
+    }
     r = shardedRelayAllReduceFlat(
         sendBuffs2,
         recvBuffs2,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -988,6 +988,223 @@ static ncclResult_t shardedRelayAllReduce2Active(
 }
 
 /**
+ * Software-pipelined single-group 2-active sharded relay allreduce.
+ *
+ * Same logical collective and the same reduce-at-helper as
+ * shardedRelayAllReduce2Active, but for nGroups == 1 -- where the active ranks
+ * and the helpers are disjoint sets -- the relay is tiled and pipelined so both
+ * directions of every cross link stay busy. See relayA2PipelineTiles() for why
+ * the two-group schedule cannot do that and what it costs.
+ *
+ * With T tiles and unit u = align(count / ((H+1)*T + 1)):
+ *   [0, H*T*u)     relay region; helper h owns [h*T*u, (h+1)*T*u), its tile t
+ * at h*T*u + t*u [H*T*u, count) direct region as T+1 chunks of u, the last
+ * absorbing the
+ *                  /((H+1)*T + 1) remainder and the alignment loss
+ *
+ * Group k, for k in [0, T]: the active rank scatters tile k (k < T) to every
+ * helper, receives helper h's REDUCED tile k-1 (k > 0) straight into its final
+ * place in recvBuff, and exchanges direct chunk k over the active<->active
+ * link. Helper h receives tile k into ping-pong buffer k%2 and forwards the
+ * already reduced buffer (k-1)%2 to both active ranks.
+ *
+ * The helper's reduce of tile k is issued between group k, which receives it,
+ * and group k+1, which sends it -- so it is one launch per tile over u elements
+ * instead of one over the whole chunk. Both active ranks send the same logical
+ * tile index, so their sum is already the final allreduced value and the return
+ * hop stays one chunk per active rank.
+ *
+ * Both in-place and out-of-place are supported. The relay region cannot alias
+ * dangerously even in place: group k reads tile k from sendBuff while writing
+ * tile k-1 into recvBuff, which are different offsets.
+ */
+static ncclResult_t shardedRelayAllReduce2ActivePipelined(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* counts,
+    ncclDataType_t datatype,
+    int reductionDivisor,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nTiles,
+    size_t elementSize) {
+  const ShardedRelayRankConfig& cfg = configs[0];
+  const size_t count = counts[0];
+  const int H = numHelpers;
+  const int T = nTiles;
+  const size_t u =
+      ((count / (static_cast<size_t>(H + 1) * T + 1)) / CHUNK_ALIGN_ELEMENTS) *
+      CHUNK_ALIGN_ELEMENTS;
+  if (u == 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t tileStride = static_cast<size_t>(T) * u;
+  const size_t directBase = static_cast<size_t>(H) * tileStride;
+  const size_t directTotal = count - directBase;
+  const size_t lastDirect = directTotal - tileStride;
+
+  // In-place must stage the received direct chunks so the local contribution is
+  // still readable when the fused reduce runs; out-of-place lands them straight
+  // in recvBuff and reduces against sendBuff.
+  void* directScratch = nullptr;
+  const bool isInPlace = (myActiveGroup == 0) && (sendBuffs[0] == recvBuffs[0]);
+  if (myActiveGroup == 0 && isInPlace) {
+    directScratch = ScratchBufferCache::getInstance().get(
+        0, directTotal * elementSize, stream);
+    if (directScratch == nullptr) {
+      return ncclInternalError;
+    }
+  }
+  auto directDst = [&](size_t offsetWithinDirect) -> char* {
+    if (isInPlace) {
+      return static_cast<char*>(directScratch) +
+          offsetWithinDirect * elementSize;
+    }
+    return static_cast<char*>(recvBuffs[0]) +
+        (directBase + offsetWithinDirect) * elementSize;
+  };
+
+  // Helper staging: two ping-pong slot pairs, one pair per pipeline stage in
+  // flight. Small enough that a tile is reduced and forwarded out of cache.
+  char* hbuff = nullptr;
+  if (!cfg.isActiveRank) {
+    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+        kHelperScratchKeyBase,
+        static_cast<size_t>(cfg.nActiveRanks) * 2 * u * elementSize,
+        stream));
+    if (hbuff == nullptr) {
+      return ncclInternalError;
+    }
+  }
+  // Slot for active source a of the buffer that stage k uses.
+  auto helperSlot = [&](int a, int k) -> char* {
+    return hbuff +
+        (static_cast<size_t>(a) * 2 + static_cast<size_t>(k % 2)) * u *
+        elementSize;
+  };
+
+  for (int k = 0; k <= T; k++) {
+    NCCLCHECK(ncclGroupStart());
+    if (cfg.isActiveRank) {
+      const char* sendbuff = static_cast<const char*>(sendBuffs[0]);
+      char* recvbuff = static_cast<char*>(recvBuffs[0]);
+      const int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      const size_t directOffset = static_cast<size_t>(k) * u;
+      const size_t directSize = (k < T) ? u : lastDirect;
+
+      if (k < T) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclSend(
+              sendbuff +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclSend(
+          sendbuff + (directBase + directOffset) * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+      if (k > 0) {
+        // Already reduced by the helper, so this is its final value.
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclRecv(
+              recvbuff +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k - 1) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclRecv(
+          directDst(directOffset),
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else {
+      if (k < T) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclRecv(
+              helperSlot(a, k), u, datatype, cfg.activeRanks[a], comm, stream));
+        }
+      }
+      if (k > 0) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclSend(
+              helperSlot(0, k - 1),
+              u,
+              datatype,
+              cfg.activeRanks[a],
+              comm,
+              stream));
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+
+    // Reduce the tile this group received, before the next group forwards it.
+    if (!cfg.isActiveRank && k < T) {
+      DISPATCH_FUSED_REDUCE(
+          datatype,
+          helperSlot(0, k),
+          helperSlot(0, k),
+          helperSlot(1, k),
+          u,
+          reductionDivisor,
+          stream);
+    }
+  }
+
+  // Fold both received direct chunks in one fused pass; they are adjacent in
+  // recvBuff and in the scratch.
+  if (myActiveGroup == 0 && directTotal > 0) {
+    char* dst = static_cast<char*>(recvBuffs[0]) + directBase * elementSize;
+    if (isInPlace) {
+      if (reductionDivisor > 1) {
+        DISPATCH_INCREMENTAL_ADD_AND_SCALE(
+            datatype,
+            dst,
+            directScratch,
+            directTotal,
+            reductionDivisor,
+            stream);
+      } else {
+        DISPATCH_INCREMENTAL_ADD(
+            datatype, dst, directScratch, directTotal, stream);
+      }
+    } else {
+      DISPATCH_FUSED_REDUCE(
+          datatype,
+          dst,
+          static_cast<const char*>(sendBuffs[0]) + directBase * elementSize,
+          dst,
+          directTotal,
+          reductionDivisor,
+          stream);
+    }
+  }
+
+  return ncclSuccess;
+}
+
+/**
  * AllReduce for > 2 active ranks (flat helper-reduce-AND-broadcast). Combines
  * the two patterns that individually beat NCCL at 4-active: the
  * reduce-AT-helper of the flat reduce-scatter and the broadcast-AT-helper of
@@ -1384,19 +1601,47 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
 
   ncclResult_t r;
   if (nActiveRanksPerGroup == 2) {
-    r = shardedRelayAllReduce2Active(
-        sendBuffs2,
-        recvBuffs2,
-        counts,
-        datatype,
-        reductionDivisor,
-        comm,
-        stream,
-        configs,
-        myActiveGroup,
-        numHelpers,
-        nGroups,
-        elementSize);
+    // A single-group relay call has the helpers to itself, so the scatter and
+    // the reduced forward run on opposite directions of each cross link and can
+    // be software-pipelined into one duplex stream. relayA2PipelineTiles()
+    // returns 1 whenever that does not apply, and the small-message pure-direct
+    // route (owned by shardedRelayAllReduce2Active) never pipelines.
+    const int nTiles =
+        (rcclx::relay::selectAllReduceRoute(2, nGroups, counts, elementSize) ==
+         rcclx::relay::AllReduceRoute::A2Relay)
+        ? rcclx::relay::relayA2PipelineTiles(
+              2,
+              numHelpers,
+              nGroups,
+              rcclx::relay::relayMaxCount(counts, nGroups),
+              elementSize)
+        : 1;
+    r = (nTiles > 1) ? shardedRelayAllReduce2ActivePipelined(
+                           sendBuffs2,
+                           recvBuffs2,
+                           counts,
+                           datatype,
+                           reductionDivisor,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           numHelpers,
+                           nTiles,
+                           elementSize)
+                     : shardedRelayAllReduce2Active(
+                           sendBuffs2,
+                           recvBuffs2,
+                           counts,
+                           datatype,
+                           reductionDivisor,
+                           comm,
+                           stream,
+                           configs,
+                           myActiveGroup,
+                           numHelpers,
+                           nGroups,
+                           elementSize);
   } else {
     // A>2: flat helper-reduce-and-broadcast (direct RS+AG over intra woven with
     // offload reduce+broadcast through the helpers).

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -993,7 +993,7 @@ static ncclResult_t shardedRelayAllReduce2Active(
  * Same logical collective and the same reduce-at-helper as
  * shardedRelayAllReduce2Active, but for nGroups == 1 -- where the active ranks
  * and the helpers are disjoint sets -- the relay is tiled and pipelined so both
- * directions of every cross link stay busy. See relayA2PipelineTiles() for why
+ * directions of every cross link stay busy. See relayPipelineTiles() for why
  * the two-group schedule cannot do that and what it costs.
  *
  * With T tiles and unit u = align(count / ((H+1)*T + 1)):
@@ -1603,16 +1603,15 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
   if (nActiveRanksPerGroup == 2) {
     // A single-group relay call has the helpers to itself, so the scatter and
     // the reduced forward run on opposite directions of each cross link and can
-    // be software-pipelined into one duplex stream. relayA2PipelineTiles()
+    // be software-pipelined into one duplex stream. relayPipelineTiles()
     // returns 1 whenever that does not apply, and the small-message pure-direct
     // route (owned by shardedRelayAllReduce2Active) never pipelines.
     const int nTiles =
         (rcclx::relay::selectAllReduceRoute(2, nGroups, counts, elementSize) ==
          rcclx::relay::AllReduceRoute::A2Relay)
-        ? rcclx::relay::relayA2PipelineTiles(
-              2,
-              numHelpers,
+        ? rcclx::relay::relayPipelineTiles(
               nGroups,
+              rcclx::relay::relayShapeA2(numHelpers),
               rcclx::relay::relayMaxCount(counts, nGroups),
               elementSize)
         : 1;

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.cu
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.cu
@@ -280,19 +280,19 @@ __device__ __forceinline__ bool oneShotEpochReached(
 }
 
 template <typename T>
-__global__ void oneShotReduceScatter2Kernel(
+__global__ void oneShotReduceScatterKernel(
     T* __restrict__ out,
     const T* __restrict__ sendBuff,
     rcclx::relay::OneShotPeerTable table,
+    rcclx::relay::OneShotRanks ranks,
+    int nActive,
     int myRank,
-    int peerRank,
     int mySlot,
-    int peerSlot,
     size_t rc,
     size_t slotBytes,
     uint32_t epoch,
     int divisor) {
-  // 16 bytes is the widest access, and moving the push as 16-byte stores rather
+  // 16 bytes is the widest access, and moving the push as 16-byte units rather
   // than element-wise is what makes this competitive: measured, the kernel is
   // copy-throughput bound, not handshake bound (1 block is 6x slower than 64 at
   // 576 KB, while the extra 63 flag round trips cost nothing).
@@ -301,16 +301,19 @@ __global__ void oneShotReduceScatter2Kernel(
     T e[kEvec];
   };
 
-  T* dst = reinterpret_cast<T*>(
-      table.staging[peerRank] + static_cast<size_t>(mySlot) * slotBytes);
-  const T* src = sendBuff + static_cast<size_t>(peerSlot) * rc;
-  const T* staged = reinterpret_cast<const T*>(
-      table.staging[myRank] + static_cast<size_t>(peerSlot) * slotBytes);
+  // My own staging slots: slot s receives source s's contribution to my block.
+  const T* staged[rcclx::relay::kOneShotMaxRanks];
+  for (int s = 0; s < nActive; s++) {
+    staged[s] = reinterpret_cast<const T*>(
+        table.staging[myRank] + static_cast<size_t>(s) * slotBytes);
+  }
   const T* own = sendBuff + static_cast<size_t>(mySlot) * rc;
 
   // Staging slots are hipMalloc'd and slot-aligned, so they are always 16-byte
-  // aligned; the caller's buffers are not guaranteed to be, so check rather
-  // than assume. A misaligned call still works, just element-wise.
+  // aligned; the caller's buffers are not guaranteed to be, and a per-source
+  // offset of rc elements is only aligned when rc*sizeof(T) is a multiple
+  // of 16. Check rather than assume -- a misaligned call still works, just
+  // element-wise.
   //
   // This is a LOCAL property: the two ranks own independent allocations, so one
   // can be aligned while the other is not. It therefore must NOT feed the block
@@ -319,10 +322,10 @@ __global__ void oneShotReduceScatter2Kernel(
   // block b goes on to reduce -- it would read staging that the peer pushed
   // from some other block, whose flag it never waited on. vecOk selects only
   // HOW a block moves its own fixed range, never WHICH range it gets.
-  const uintptr_t bits = reinterpret_cast<uintptr_t>(dst) |
-      reinterpret_cast<uintptr_t>(src) | reinterpret_cast<uintptr_t>(staged) |
-      reinterpret_cast<uintptr_t>(own) | reinterpret_cast<uintptr_t>(out);
-  const bool vecOk = (bits & 15u) == 0;
+  const uintptr_t bits = reinterpret_cast<uintptr_t>(sendBuff) |
+      reinterpret_cast<uintptr_t>(out) |
+      reinterpret_cast<uintptr_t>(table.staging[myRank]);
+  const bool vecOk = ((bits & 15u) == 0) && ((rc * sizeof(T)) % 16u == 0);
 
   // Per-block element range, derived only from rc, kEvec and gridDim -- all
   // rank-agreed (gridDim comes from rc, kOneShotThreads and kOneShotMaxBlocks)
@@ -342,68 +345,98 @@ __global__ void oneShotReduceScatter2Kernel(
   // begin sends the whole range through the element-wise loops instead.
   const size_t vecEnd = vecOk ? (ve * kEvec) : begin;
 
-  // Step 1: push my foreign block into the peer's staging slot.
-  if (vecOk && vecEnd > begin) {
-    const Vec* s4 = reinterpret_cast<const Vec*>(src + begin);
-    Vec* d4 = reinterpret_cast<Vec*>(dst + begin);
-    const size_t nv = (vecEnd - begin) / kEvec;
-    for (size_t v = threadIdx.x; v < nv; v += blockDim.x) {
-      d4[v] = s4[v];
+  // Step 1: push each peer's block into that peer's staging slot mySlot.
+  for (int j = 0; j < nActive; j++) {
+    if (j == mySlot) {
+      continue;
+    }
+    T* dst = reinterpret_cast<T*>(
+        table.staging[ranks.r[j]] + static_cast<size_t>(mySlot) * slotBytes);
+    const T* src = sendBuff + static_cast<size_t>(j) * rc;
+    if (vecOk && vecEnd > begin) {
+      const Vec* s4 = reinterpret_cast<const Vec*>(src + begin);
+      Vec* d4 = reinterpret_cast<Vec*>(dst + begin);
+      const size_t nv = (vecEnd - begin) / kEvec;
+      for (size_t v = threadIdx.x; v < nv; v += blockDim.x) {
+        d4[v] = s4[v];
+      }
+    }
+    for (size_t i = vecEnd + threadIdx.x; i < end; i += blockDim.x) {
+      dst[i] = src[i];
     }
   }
-  for (size_t i = vecEnd + threadIdx.x; i < end; i += blockDim.x) {
-    dst[i] = src[i];
-  }
 
-  // Step 2: publish the stores, then raise the peer's flag for this block. The
-  // release store must not be reordered before the data, hence the system-scope
-  // fence; the peer pairs it with an acquire load.
+  // Step 2: publish the stores, then raise every peer's flag for this block.
+  // The release store must not be reordered before the data, hence the
+  // system-scope fence; the reader pairs it with an acquire load.
   __syncthreads();
   if (threadIdx.x == 0) {
     __threadfence_system();
-    __atomic_store_n(
-        &table.flags[peerRank]
-                    [mySlot * rcclx::relay::kOneShotMaxBlocks + blockIdx.x],
-        epoch,
-        __ATOMIC_RELEASE);
+    for (int j = 0; j < nActive; j++) {
+      if (j == mySlot) {
+        continue;
+      }
+      __atomic_store_n(
+          &table.flags[ranks.r[j]]
+                      [mySlot * rcclx::relay::kOneShotMaxBlocks + blockIdx.x],
+          epoch,
+          __ATOMIC_RELEASE);
+    }
   }
 
-  // Step 3: wait for the peer's matching block. Flags are never cleared: the
-  // epoch only advances, so a value left by an earlier call always compares as
-  // not-yet-arrived for this one.
+  // Step 3: wait for every source's matching block. Flags are never cleared:
+  // the epoch only advances, so a value left by an earlier call always compares
+  // as not-yet-arrived for this one.
   if (threadIdx.x == 0) {
-    uint32_t* mine =
-        &table.flags[myRank]
-                    [peerSlot * rcclx::relay::kOneShotMaxBlocks + blockIdx.x];
-    while (
-        !oneShotEpochReached(__atomic_load_n(mine, __ATOMIC_ACQUIRE), epoch)) {
+    for (int s = 0; s < nActive; s++) {
+      if (s == mySlot) {
+        continue;
+      }
+      uint32_t* mine =
+          &table
+               .flags[myRank][s * rcclx::relay::kOneShotMaxBlocks + blockIdx.x];
+      while (!oneShotEpochReached(
+          __atomic_load_n(mine, __ATOMIC_ACQUIRE), epoch)) {
+      }
     }
   }
   __syncthreads();
 
-  // Step 4: reduce my own contribution with what the peer staged. In-place is
-  // safe: out aliases own at the same element index.
+  // Step 4: reduce my own contribution with what every source staged. In-place
+  // is safe: out aliases own at the same element index.
   if (vecOk && vecEnd > begin) {
     const Vec* o4 = reinterpret_cast<const Vec*>(own + begin);
-    const Vec* g4 = reinterpret_cast<const Vec*>(staged + begin);
     Vec* r4 = reinterpret_cast<Vec*>(out + begin);
     const size_t nv = (vecEnd - begin) / kEvec;
     for (size_t v = threadIdx.x; v < nv; v += blockDim.x) {
       Vec a = o4[v];
-      const Vec b = g4[v];
-#pragma unroll
-      for (int k = 0; k < kEvec; k++) {
-        T acc = a.e[k] + b.e[k];
-        if (divisor > 1) {
-          acc = acc / static_cast<T>(divisor);
+      for (int s = 0; s < nActive; s++) {
+        if (s == mySlot) {
+          continue;
         }
-        a.e[k] = acc;
+        const Vec b = reinterpret_cast<const Vec*>(staged[s] + begin)[v];
+#pragma unroll
+        for (int k = 0; k < kEvec; k++) {
+          a.e[k] = a.e[k] + b.e[k];
+        }
+      }
+      if (divisor > 1) {
+#pragma unroll
+        for (int k = 0; k < kEvec; k++) {
+          a.e[k] = a.e[k] / static_cast<T>(divisor);
+        }
       }
       r4[v] = a;
     }
   }
   for (size_t i = vecEnd + threadIdx.x; i < end; i += blockDim.x) {
-    T acc = own[i] + staged[i];
+    T acc = own[i];
+    for (int s = 0; s < nActive; s++) {
+      if (s == mySlot) {
+        continue;
+      }
+      acc = acc + staged[s][i];
+    }
     if (divisor > 1) {
       acc = acc / static_cast<T>(divisor);
     }
@@ -412,14 +445,14 @@ __global__ void oneShotReduceScatter2Kernel(
 }
 
 template <typename T>
-void launchOneShotReduceScatter2Kernel(
+void launchOneShotReduceScatterKernel(
     void* out,
     const void* sendBuff,
     const rcclx::relay::OneShotPeerTable& table,
+    const rcclx::relay::OneShotRanks& ranks,
+    int nActive,
     int myRank,
-    int peerRank,
     int mySlot,
-    int peerSlot,
     size_t rc,
     size_t slotBytes,
     uint32_t epoch,
@@ -433,14 +466,14 @@ void launchOneShotReduceScatter2Kernel(
   if (gridSize > rcclx::relay::kOneShotMaxBlocks) {
     gridSize = rcclx::relay::kOneShotMaxBlocks;
   }
-  oneShotReduceScatter2Kernel<T><<<gridSize, blockSize, 0, stream>>>(
+  oneShotReduceScatterKernel<T><<<gridSize, blockSize, 0, stream>>>(
       static_cast<T*>(out),
       static_cast<const T*>(sendBuff),
       table,
+      ranks,
+      nActive,
       myRank,
-      peerRank,
       mySlot,
-      peerSlot,
       rc,
       slotBytes,
       epoch,
@@ -480,14 +513,14 @@ void launchOneShotReduceScatter2Kernel(
       size_t count,                                                        \
       int divisor,                                                         \
       cudaStream_t stream);                                                \
-  template void launchOneShotReduceScatter2Kernel<T>(                      \
+  template void launchOneShotReduceScatterKernel<T>(                       \
       void* out,                                                           \
       const void* sendBuff,                                                \
       const rcclx::relay::OneShotPeerTable& table,                         \
+      const rcclx::relay::OneShotRanks& ranks,                             \
+      int nActive,                                                         \
       int myRank,                                                          \
-      int peerRank,                                                        \
       int mySlot,                                                          \
-      int peerSlot,                                                        \
       size_t rc,                                                           \
       size_t slotBytes,                                                    \
       uint32_t epoch,                                                      \

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.cu
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.cu
@@ -280,7 +280,7 @@ __device__ __forceinline__ bool oneShotEpochReached(
 }
 
 template <typename T>
-__global__ void oneShotReduceScatterKernel(
+__global__ void oneShotPushReduceKernel(
     T* __restrict__ out,
     const T* __restrict__ sendBuff,
     rcclx::relay::OneShotPeerTable table,
@@ -289,6 +289,8 @@ __global__ void oneShotReduceScatterKernel(
     int myRank,
     int mySlot,
     size_t rc,
+    size_t srcStride,
+    size_t ownOffset,
     size_t slotBytes,
     uint32_t epoch,
     int divisor) {
@@ -307,7 +309,7 @@ __global__ void oneShotReduceScatterKernel(
     staged[s] = reinterpret_cast<const T*>(
         table.staging[myRank] + static_cast<size_t>(s) * slotBytes);
   }
-  const T* own = sendBuff + static_cast<size_t>(mySlot) * rc;
+  const T* own = sendBuff + ownOffset;
 
   // Staging slots are hipMalloc'd and slot-aligned, so they are always 16-byte
   // aligned; the caller's buffers are not guaranteed to be, and a per-source
@@ -325,7 +327,9 @@ __global__ void oneShotReduceScatterKernel(
   const uintptr_t bits = reinterpret_cast<uintptr_t>(sendBuff) |
       reinterpret_cast<uintptr_t>(out) |
       reinterpret_cast<uintptr_t>(table.staging[myRank]);
-  const bool vecOk = ((bits & 15u) == 0) && ((rc * sizeof(T)) % 16u == 0);
+  const bool vecOk = ((bits & 15u) == 0) &&
+      ((srcStride * sizeof(T)) % 16u == 0) &&
+      ((ownOffset * sizeof(T)) % 16u == 0) && ((rc * sizeof(T)) % 16u == 0);
 
   // Per-block element range, derived only from rc, kEvec and gridDim -- all
   // rank-agreed (gridDim comes from rc, kOneShotThreads and kOneShotMaxBlocks)
@@ -352,7 +356,7 @@ __global__ void oneShotReduceScatterKernel(
     }
     T* dst = reinterpret_cast<T*>(
         table.staging[ranks.r[j]] + static_cast<size_t>(mySlot) * slotBytes);
-    const T* src = sendBuff + static_cast<size_t>(j) * rc;
+    const T* src = sendBuff + static_cast<size_t>(j) * srcStride;
     if (vecOk && vecEnd > begin) {
       const Vec* s4 = reinterpret_cast<const Vec*>(src + begin);
       Vec* d4 = reinterpret_cast<Vec*>(dst + begin);
@@ -445,7 +449,7 @@ __global__ void oneShotReduceScatterKernel(
 }
 
 template <typename T>
-void launchOneShotReduceScatterKernel(
+void launchOneShotPushReduceKernel(
     void* out,
     const void* sendBuff,
     const rcclx::relay::OneShotPeerTable& table,
@@ -454,6 +458,8 @@ void launchOneShotReduceScatterKernel(
     int myRank,
     int mySlot,
     size_t rc,
+    size_t srcStride,
+    size_t ownOffset,
     size_t slotBytes,
     uint32_t epoch,
     int divisor,
@@ -466,7 +472,7 @@ void launchOneShotReduceScatterKernel(
   if (gridSize > rcclx::relay::kOneShotMaxBlocks) {
     gridSize = rcclx::relay::kOneShotMaxBlocks;
   }
-  oneShotReduceScatterKernel<T><<<gridSize, blockSize, 0, stream>>>(
+  oneShotPushReduceKernel<T><<<gridSize, blockSize, 0, stream>>>(
       static_cast<T*>(out),
       static_cast<const T*>(sendBuff),
       table,
@@ -475,6 +481,8 @@ void launchOneShotReduceScatterKernel(
       myRank,
       mySlot,
       rc,
+      srcStride,
+      ownOffset,
       slotBytes,
       epoch,
       divisor);
@@ -513,7 +521,7 @@ void launchOneShotReduceScatterKernel(
       size_t count,                                                        \
       int divisor,                                                         \
       cudaStream_t stream);                                                \
-  template void launchOneShotReduceScatterKernel<T>(                       \
+  template void launchOneShotPushReduceKernel<T>(                          \
       void* out,                                                           \
       const void* sendBuff,                                                \
       const rcclx::relay::OneShotPeerTable& table,                         \
@@ -522,6 +530,8 @@ void launchOneShotReduceScatterKernel(
       int myRank,                                                          \
       int mySlot,                                                          \
       size_t rc,                                                           \
+      size_t srcStride,                                                    \
+      size_t ownOffset,                                                    \
       size_t slotBytes,                                                    \
       uint32_t epoch,                                                      \
       int divisor,                                                         \

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.cu
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.cu
@@ -259,6 +259,194 @@ void launchSeededMultiReduceKernel(
 // (which only sees `extern template` declarations via the header) would
 // fail to link the launchers — leaving the underlying `__global__`
 // kernels' host stubs unresolved at runtime.
+
+/*
+ * ONE-SHOT 2-RANK REDUCE-SCATTER
+ *
+ * A single kernel that both moves the data and reduces it, so it replaces an
+ * ncclGroup plus a reduce launch. See sharded_relay_oneshot.h for why the group
+ * itself, not the reduce, is what has to go.
+ *
+ * Ordering: the data stores must be visible to the peer BEFORE it observes the
+ * flag, so thread 0 issues __threadfence_system() and then a release store; the
+ * reader spins with an acquire load. The epoch comparison is wraparound-safe,
+ * and flags are never reset -- the epoch only advances, so a stale flag from a
+ * previous call always compares as not-yet-arrived for the current one.
+ */
+__device__ __forceinline__ bool oneShotEpochReached(
+    uint32_t got,
+    uint32_t want) {
+  return (got - want) <= (uint32_t(-1) >> 1);
+}
+
+template <typename T>
+__global__ void oneShotReduceScatter2Kernel(
+    T* __restrict__ out,
+    const T* __restrict__ sendBuff,
+    rcclx::relay::OneShotPeerTable table,
+    int myRank,
+    int peerRank,
+    int mySlot,
+    int peerSlot,
+    size_t rc,
+    size_t slotBytes,
+    uint32_t epoch,
+    int divisor) {
+  // 16 bytes is the widest access, and moving the push as 16-byte stores rather
+  // than element-wise is what makes this competitive: measured, the kernel is
+  // copy-throughput bound, not handshake bound (1 block is 6x slower than 64 at
+  // 576 KB, while the extra 63 flag round trips cost nothing).
+  constexpr int kEvec = static_cast<int>(16 / sizeof(T));
+  struct alignas(16) Vec {
+    T e[kEvec];
+  };
+
+  T* dst = reinterpret_cast<T*>(
+      table.staging[peerRank] + static_cast<size_t>(mySlot) * slotBytes);
+  const T* src = sendBuff + static_cast<size_t>(peerSlot) * rc;
+  const T* staged = reinterpret_cast<const T*>(
+      table.staging[myRank] + static_cast<size_t>(peerSlot) * slotBytes);
+  const T* own = sendBuff + static_cast<size_t>(mySlot) * rc;
+
+  // Staging slots are hipMalloc'd and slot-aligned, so they are always 16-byte
+  // aligned; the caller's buffers are not guaranteed to be, so check rather
+  // than assume. A misaligned call still works, just element-wise.
+  //
+  // This is a LOCAL property: the two ranks own independent allocations, so one
+  // can be aligned while the other is not. It therefore must NOT feed the block
+  // partition below. Blocks handshake pairwise on a single block index, so if
+  // the ranks partitioned differently, block b's flag would not cover the range
+  // block b goes on to reduce -- it would read staging that the peer pushed
+  // from some other block, whose flag it never waited on. vecOk selects only
+  // HOW a block moves its own fixed range, never WHICH range it gets.
+  const uintptr_t bits = reinterpret_cast<uintptr_t>(dst) |
+      reinterpret_cast<uintptr_t>(src) | reinterpret_cast<uintptr_t>(staged) |
+      reinterpret_cast<uintptr_t>(own) | reinterpret_cast<uintptr_t>(out);
+  const bool vecOk = (bits & 15u) == 0;
+
+  // Per-block element range, derived only from rc, kEvec and gridDim -- all
+  // rank-agreed (gridDim comes from rc, kOneShotThreads and kOneShotMaxBlocks)
+  // -- so both ranks assign the same [begin, end) to the same block index
+  // whatever their buffer alignment. Ranges are whole 16-byte vectors so that
+  // begin stays 16-byte aligned for a rank that can vectorize.
+  const size_t nvec = rc / kEvec;
+  const size_t vchunk = (nvec + gridDim.x - 1) / gridDim.x;
+  size_t vb = vchunk * blockIdx.x;
+  vb = (vb < nvec) ? vb : nvec;
+  size_t ve = vb + vchunk;
+  ve = (ve < nvec) ? ve : nvec;
+  const size_t begin = vb * kEvec;
+  // The last block also takes the ragged tail rc % kEvec.
+  const size_t end = (blockIdx.x == gridDim.x - 1) ? rc : (ve * kEvec);
+  // End of the 16-byte bulk this block moves vectorized; collapsing it to
+  // begin sends the whole range through the element-wise loops instead.
+  const size_t vecEnd = vecOk ? (ve * kEvec) : begin;
+
+  // Step 1: push my foreign block into the peer's staging slot.
+  if (vecOk && vecEnd > begin) {
+    const Vec* s4 = reinterpret_cast<const Vec*>(src + begin);
+    Vec* d4 = reinterpret_cast<Vec*>(dst + begin);
+    const size_t nv = (vecEnd - begin) / kEvec;
+    for (size_t v = threadIdx.x; v < nv; v += blockDim.x) {
+      d4[v] = s4[v];
+    }
+  }
+  for (size_t i = vecEnd + threadIdx.x; i < end; i += blockDim.x) {
+    dst[i] = src[i];
+  }
+
+  // Step 2: publish the stores, then raise the peer's flag for this block. The
+  // release store must not be reordered before the data, hence the system-scope
+  // fence; the peer pairs it with an acquire load.
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    __threadfence_system();
+    __atomic_store_n(
+        &table.flags[peerRank]
+                    [mySlot * rcclx::relay::kOneShotMaxBlocks + blockIdx.x],
+        epoch,
+        __ATOMIC_RELEASE);
+  }
+
+  // Step 3: wait for the peer's matching block. Flags are never cleared: the
+  // epoch only advances, so a value left by an earlier call always compares as
+  // not-yet-arrived for this one.
+  if (threadIdx.x == 0) {
+    uint32_t* mine =
+        &table.flags[myRank]
+                    [peerSlot * rcclx::relay::kOneShotMaxBlocks + blockIdx.x];
+    while (
+        !oneShotEpochReached(__atomic_load_n(mine, __ATOMIC_ACQUIRE), epoch)) {
+    }
+  }
+  __syncthreads();
+
+  // Step 4: reduce my own contribution with what the peer staged. In-place is
+  // safe: out aliases own at the same element index.
+  if (vecOk && vecEnd > begin) {
+    const Vec* o4 = reinterpret_cast<const Vec*>(own + begin);
+    const Vec* g4 = reinterpret_cast<const Vec*>(staged + begin);
+    Vec* r4 = reinterpret_cast<Vec*>(out + begin);
+    const size_t nv = (vecEnd - begin) / kEvec;
+    for (size_t v = threadIdx.x; v < nv; v += blockDim.x) {
+      Vec a = o4[v];
+      const Vec b = g4[v];
+#pragma unroll
+      for (int k = 0; k < kEvec; k++) {
+        T acc = a.e[k] + b.e[k];
+        if (divisor > 1) {
+          acc = acc / static_cast<T>(divisor);
+        }
+        a.e[k] = acc;
+      }
+      r4[v] = a;
+    }
+  }
+  for (size_t i = vecEnd + threadIdx.x; i < end; i += blockDim.x) {
+    T acc = own[i] + staged[i];
+    if (divisor > 1) {
+      acc = acc / static_cast<T>(divisor);
+    }
+    out[i] = acc;
+  }
+}
+
+template <typename T>
+void launchOneShotReduceScatter2Kernel(
+    void* out,
+    const void* sendBuff,
+    const rcclx::relay::OneShotPeerTable& table,
+    int myRank,
+    int peerRank,
+    int mySlot,
+    int peerSlot,
+    size_t rc,
+    size_t slotBytes,
+    uint32_t epoch,
+    int divisor,
+    cudaStream_t stream) {
+  const int blockSize = rcclx::relay::kOneShotThreads;
+  int gridSize = static_cast<int>((rc + blockSize - 1) / blockSize);
+  if (gridSize < 1) {
+    gridSize = 1;
+  }
+  if (gridSize > rcclx::relay::kOneShotMaxBlocks) {
+    gridSize = rcclx::relay::kOneShotMaxBlocks;
+  }
+  oneShotReduceScatter2Kernel<T><<<gridSize, blockSize, 0, stream>>>(
+      static_cast<T*>(out),
+      static_cast<const T*>(sendBuff),
+      table,
+      myRank,
+      peerRank,
+      mySlot,
+      peerSlot,
+      rc,
+      slotBytes,
+      epoch,
+      divisor);
+}
+
 #define RCCLX_INSTANTIATE_RELAY_KERNELS(T)                                 \
   template void launchIncrementalAddKernel<T>(                             \
       void* output, const void* input, size_t count, cudaStream_t stream); \
@@ -290,6 +478,19 @@ void launchSeededMultiReduceKernel(
       const void* contribs,                                                \
       int numContribs,                                                     \
       size_t count,                                                        \
+      int divisor,                                                         \
+      cudaStream_t stream);                                                \
+  template void launchOneShotReduceScatter2Kernel<T>(                      \
+      void* out,                                                           \
+      const void* sendBuff,                                                \
+      const rcclx::relay::OneShotPeerTable& table,                         \
+      int myRank,                                                          \
+      int peerRank,                                                        \
+      int mySlot,                                                          \
+      int peerSlot,                                                        \
+      size_t rc,                                                           \
+      size_t slotBytes,                                                    \
+      uint32_t epoch,                                                      \
       int divisor,                                                         \
       cudaStream_t stream);
 

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.cu
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.cu
@@ -271,7 +271,9 @@ void launchSeededMultiReduceKernel(
  * flag, so thread 0 issues __threadfence_system() and then a release store; the
  * reader spins with an acquire load. The epoch comparison is wraparound-safe,
  * and flags are never reset -- the epoch only advances, so a stale flag from a
- * previous call always compares as not-yet-arrived for the current one.
+ * previous call always compares as not-yet-arrived for the current one. The
+ * epoch itself comes from a per-block device counter; see the comment at the
+ * point it is bumped for why it cannot be a kernel argument.
  */
 __device__ __forceinline__ bool oneShotEpochReached(
     uint32_t got,
@@ -292,7 +294,7 @@ __global__ void oneShotPushReduceKernel(
     size_t srcStride,
     size_t ownOffset,
     size_t slotBytes,
-    uint32_t epoch,
+    uint32_t* seq,
     int divisor) {
   // 16 bytes is the widest access, and moving the push as 16-byte units rather
   // than element-wise is what makes this competitive: measured, the kernel is
@@ -368,6 +370,29 @@ __global__ void oneShotPushReduceKernel(
     for (size_t i = vecEnd + threadIdx.x; i < end; i += blockDim.x) {
       dst[i] = src[i];
     }
+  }
+
+  // The epoch is derived here rather than passed in. As a by-value kernel
+  // argument it was baked when a graph was captured, so every replay reused the
+  // capture-time value: on replay N every peer flag already holds it, the
+  // step-3 spin falls straight through, and step 4 reduces whatever the staging
+  // happened to hold. Reading and bumping a device counter makes a replay
+  // advance it exactly like a fresh launch.
+  //
+  // Per BLOCK, not one counter for the grid. Grid size follows the message
+  // size, so a later smaller call runs fewer blocks; a single shared counter
+  // would let the blocks that did run race ahead of the ones that did not, and
+  // the peer comparison is per (source, block). RCCL's own symmetric kernels
+  // keep their counter per block for the same reason.
+  //
+  // Only thread 0 flags and waits, so only thread 0 needs the value and no
+  // broadcast is required. Unsynchronised between concurrent one-shot calls on
+  // one comm, exactly as the host counter it replaces was -- those already
+  // share this comm's flag array.
+  uint32_t epoch = 0;
+  if (threadIdx.x == 0) {
+    epoch = seq[blockIdx.x] + 1u;
+    seq[blockIdx.x] = epoch;
   }
 
   // Step 2: publish the stores, then raise every peer's flag for this block.
@@ -461,7 +486,7 @@ void launchOneShotPushReduceKernel(
     size_t srcStride,
     size_t ownOffset,
     size_t slotBytes,
-    uint32_t epoch,
+    uint32_t* seq,
     int divisor,
     cudaStream_t stream) {
   const int blockSize = rcclx::relay::kOneShotThreads;
@@ -484,7 +509,7 @@ void launchOneShotPushReduceKernel(
       srcStride,
       ownOffset,
       slotBytes,
-      epoch,
+      seq,
       divisor);
 }
 
@@ -533,7 +558,7 @@ void launchOneShotPushReduceKernel(
       size_t srcStride,                                                    \
       size_t ownOffset,                                                    \
       size_t slotBytes,                                                    \
-      uint32_t epoch,                                                      \
+      uint32_t* seq,                                                       \
       int divisor,                                                         \
       cudaStream_t stream);
 

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.h
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "meta/relay/sharded_relay_oneshot.h"
 #include "nccl.h"
 
 /*
@@ -68,6 +69,39 @@ void launchMultiReduceKernel(
     int divisor,
     cudaStream_t stream);
 
+/**
+ * One-shot 2-rank reduce-scatter: transfer AND reduction in a single launch.
+ *
+ * sendBuff holds 2*rc elements. Rank m must produce
+ *   out[i] = (sendBuff[m*rc + i] + peerSendBuff[m*rc + i]) / divisor
+ *
+ * Step 1  store my foreign block into the PEER's staging slot mySlot.
+ * Step 2  fence, then raise the peer's flag for this block.
+ * Step 3  spin until the peer raised MY flag for this block.
+ * Step 4  out = own block + what the peer staged.
+ *
+ * Blocks handshake pairwise, so no global barrier and no co-residency
+ * requirement: every block writes and flags before it waits.
+ *
+ * `inPlace` means out aliases sendBuff + mySlot*rc; the reduce reads that as
+ * its own contribution and writes it back, which is safe because it is the same
+ * element index.
+ */
+template <typename T>
+void launchOneShotReduceScatter2Kernel(
+    void* out,
+    const void* sendBuff,
+    const rcclx::relay::OneShotPeerTable& table,
+    int myRank,
+    int peerRank,
+    int mySlot,
+    int peerSlot,
+    size_t rc,
+    size_t slotBytes,
+    uint32_t epoch,
+    int divisor,
+    cudaStream_t stream);
+
 template <typename T>
 void launchSeededMultiReduceKernel(
     void* dst,
@@ -111,6 +145,19 @@ void launchSeededMultiReduceKernel(
       const void* contribs,                                                \
       int numContribs,                                                     \
       size_t count,                                                        \
+      int divisor,                                                         \
+      cudaStream_t stream);                                                \
+  extern template void launchOneShotReduceScatter2Kernel<T>(               \
+      void* out,                                                           \
+      const void* sendBuff,                                                \
+      const rcclx::relay::OneShotPeerTable& table,                         \
+      int myRank,                                                          \
+      int peerRank,                                                        \
+      int mySlot,                                                          \
+      int peerSlot,                                                        \
+      size_t rc,                                                           \
+      size_t slotBytes,                                                    \
+      uint32_t epoch,                                                      \
       int divisor,                                                         \
       cudaStream_t stream);
 

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.h
@@ -88,7 +88,7 @@ void launchMultiReduceKernel(
  * and writes the same element index.
  */
 template <typename T>
-void launchOneShotReduceScatterKernel(
+void launchOneShotPushReduceKernel(
     void* out,
     const void* sendBuff,
     const rcclx::relay::OneShotPeerTable& table,
@@ -97,6 +97,8 @@ void launchOneShotReduceScatterKernel(
     int myRank,
     int mySlot,
     size_t rc,
+    size_t srcStride,
+    size_t ownOffset,
     size_t slotBytes,
     uint32_t epoch,
     int divisor,
@@ -147,7 +149,7 @@ void launchSeededMultiReduceKernel(
       size_t count,                                                        \
       int divisor,                                                         \
       cudaStream_t stream);                                                \
-  extern template void launchOneShotReduceScatterKernel<T>(                \
+  extern template void launchOneShotPushReduceKernel<T>(                   \
       void* out,                                                           \
       const void* sendBuff,                                                \
       const rcclx::relay::OneShotPeerTable& table,                         \
@@ -156,6 +158,8 @@ void launchSeededMultiReduceKernel(
       int myRank,                                                          \
       int mySlot,                                                          \
       size_t rc,                                                           \
+      size_t srcStride,                                                    \
+      size_t ownOffset,                                                    \
       size_t slotBytes,                                                    \
       uint32_t epoch,                                                      \
       int divisor,                                                         \

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.h
@@ -70,32 +70,32 @@ void launchMultiReduceKernel(
     cudaStream_t stream);
 
 /**
- * One-shot 2-rank reduce-scatter: transfer AND reduction in a single launch.
+ * One-shot reduce-scatter over A active ranks: transfer AND reduction in a
+ * single launch, replacing an ncclGroup plus a reduce kernel.
  *
- * sendBuff holds 2*rc elements. Rank m must produce
- *   out[i] = (sendBuff[m*rc + i] + peerSendBuff[m*rc + i]) / divisor
+ * sendBuff holds A*rc elements. The rank whose active index is mySlot produces
+ *   out[i] = (sum over sources s of sendBuff_s[mySlot*rc + i]) / divisor
  *
- * Step 1  store my foreign block into the PEER's staging slot mySlot.
- * Step 2  fence, then raise the peer's flag for this block.
- * Step 3  spin until the peer raised MY flag for this block.
- * Step 4  out = own block + what the peer staged.
+ * Step 1  store each peer's block into that peer's staging slot mySlot.
+ * Step 2  fence, then raise every peer's flag for this block.
+ * Step 3  spin until every source raised MY flag for this block.
+ * Step 4  out = own block + every staged block.
  *
- * Blocks handshake pairwise, so no global barrier and no co-residency
+ * Blocks handshake pairwise, so there is no global barrier and no co-residency
  * requirement: every block writes and flags before it waits.
  *
- * `inPlace` means out aliases sendBuff + mySlot*rc; the reduce reads that as
- * its own contribution and writes it back, which is safe because it is the same
- * element index.
+ * In-place (out aliasing sendBuff + mySlot*rc) is supported: the reduce reads
+ * and writes the same element index.
  */
 template <typename T>
-void launchOneShotReduceScatter2Kernel(
+void launchOneShotReduceScatterKernel(
     void* out,
     const void* sendBuff,
     const rcclx::relay::OneShotPeerTable& table,
+    const rcclx::relay::OneShotRanks& ranks,
+    int nActive,
     int myRank,
-    int peerRank,
     int mySlot,
-    int peerSlot,
     size_t rc,
     size_t slotBytes,
     uint32_t epoch,
@@ -147,14 +147,14 @@ void launchSeededMultiReduceKernel(
       size_t count,                                                        \
       int divisor,                                                         \
       cudaStream_t stream);                                                \
-  extern template void launchOneShotReduceScatter2Kernel<T>(               \
+  extern template void launchOneShotReduceScatterKernel<T>(                \
       void* out,                                                           \
       const void* sendBuff,                                                \
       const rcclx::relay::OneShotPeerTable& table,                         \
+      const rcclx::relay::OneShotRanks& ranks,                             \
+      int nActive,                                                         \
       int myRank,                                                          \
-      int peerRank,                                                        \
       int mySlot,                                                          \
-      int peerSlot,                                                        \
       size_t rc,                                                           \
       size_t slotBytes,                                                    \
       uint32_t epoch,                                                      \

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.h
@@ -100,7 +100,7 @@ void launchOneShotPushReduceKernel(
     size_t srcStride,
     size_t ownOffset,
     size_t slotBytes,
-    uint32_t epoch,
+    uint32_t* seq,
     int divisor,
     cudaStream_t stream);
 
@@ -161,7 +161,7 @@ void launchSeededMultiReduceKernel(
       size_t srcStride,                                                    \
       size_t ownOffset,                                                    \
       size_t slotBytes,                                                    \
-      uint32_t epoch,                                                      \
+      uint32_t* seq,                                                       \
       int divisor,                                                         \
       cudaStream_t stream);
 

--- a/comms/rcclx/develop/meta/relay/sharded_relay_graph_scratch.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_graph_scratch.cc
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "sharded_relay_graph_scratch.h"
+
+#include <algorithm>
+#include <map>
+#include <mutex>
+#include <tuple>
+#include <vector>
+
+namespace rcclx {
+namespace relay {
+
+namespace {
+
+// (cacheTag, device, stream, key, graphId) -> current buffer. The graph id is
+// part of the key so a captured buffer is never shared with, or freed by,
+// anything outside its own graph.
+using ScratchKey =
+    std::tuple<const void*, int, const void*, int, unsigned long long>;
+
+struct ScratchEntry {
+  void* buffer{nullptr};
+  size_t size{0};
+};
+
+// Per-graph bookkeeping. destructorRegistered is a CLAIM rather than a record
+// of success: it is set under tableMutex() by whichever call will go on to call
+// ncclCudaGraphAddDestructor outside the lock, so two threads capturing into
+// the same graph cannot both register, and is cleared again if that call fails.
+struct GraphAllocs {
+  bool destructorRegistered{false};
+  // Every allocation ever handed to this graph, so a grown-over predecessor is
+  // still reclaimable. It cannot be freed at growth time: the graph has already
+  // captured nodes that reference it.
+  std::vector<void*> buffers;
+};
+
+// Function-local statics rather than file-scope objects: this is linked into a
+// library whose teardown order relative to other translation units is not
+// something we want to depend on.
+std::mutex& tableMutex() {
+  static std::mutex m;
+  return m;
+}
+
+std::map<ScratchKey, ScratchEntry>& table() {
+  static std::map<ScratchKey, ScratchEntry> t;
+  return t;
+}
+
+// Every allocation ever handed to a graph, keyed by graph id.
+std::map<unsigned long long, GraphAllocs>& graphAllocs() {
+  static std::map<unsigned long long, GraphAllocs> m;
+  return m;
+}
+
+// Graph ids whose destructor has fired, behind their own mutex. The destructor
+// callback touches nothing else and makes no HIP call: it can run on a
+// HIP-internal thread, and RCCL's own graph destructor (persistentDestructor in
+// enqueue.cc) is equally careful to only enqueue there and reclaim later.
+std::mutex& deadMutex() {
+  static std::mutex m;
+  return m;
+}
+
+std::vector<unsigned long long>& deadGraphs() {
+  static std::vector<unsigned long long> v;
+  return v;
+}
+
+void graphDiedCallback(void* arg) {
+  auto* graphId = static_cast<unsigned long long*>(arg);
+  {
+    std::lock_guard<std::mutex> lock(deadMutex());
+    deadGraphs().push_back(*graphId);
+  }
+  delete graphId;
+}
+
+// Free the buffers of every graph whose destructor has fired. Deliberately
+// called from graphScratchGet, on a user thread, rather than from the
+// destructor callback itself, which can run on a HIP-internal thread and must
+// make no HIP call.
+//
+// The consequence is that the dead list is only drained by a LATER capture. If
+// capture-path usage stops for good, the last dead graphs' buffers are held
+// until process exit. That is accepted rather than fixed: the alternative is
+// freeing from the callback, which is exactly what is not safe there. The
+// residue is bounded by the buffers of the graphs destroyed after the final
+// graphScratchGet call, and every one of them was already held for that graph's
+// whole lifetime, so this costs no more than keeping the last generation of
+// graphs alive slightly longer.
+void reclaimDeadGraphs() {
+  std::vector<unsigned long long> dead;
+  {
+    std::lock_guard<std::mutex> lock(deadMutex());
+    if (deadGraphs().empty()) {
+      return;
+    }
+    dead.swap(deadGraphs());
+  }
+
+  std::vector<void*> stale;
+  {
+    std::lock_guard<std::mutex> lock(tableMutex());
+    for (unsigned long long id : dead) {
+      auto allocIt = graphAllocs().find(id);
+      if (allocIt != graphAllocs().end()) {
+        stale.insert(
+            stale.end(),
+            allocIt->second.buffers.begin(),
+            allocIt->second.buffers.end());
+        graphAllocs().erase(allocIt);
+      }
+    }
+    for (auto it = table().begin(); it != table().end();) {
+      const unsigned long long id = std::get<4>(it->first);
+      it = (std::find(dead.begin(), dead.end(), id) != dead.end())
+          ? table().erase(it)
+          : std::next(it);
+    }
+  }
+
+  // Outside the lock: hipFree can block, and nothing here needs the table.
+  for (void* buffer : stale) {
+    (void)cudaFree(buffer);
+  }
+}
+
+// Matches the rounding the per-collective caches apply, so a graph does not end
+// up with a differently sized buffer than the uncaptured path would have used.
+size_t roundedAllocSize(size_t requiredBytes) {
+  constexpr size_t kGranularity = 64ull * 1024 * 1024;
+  if (requiredBytes < 1024 * 1024) {
+    return requiredBytes;
+  }
+  return ((requiredBytes + kGranularity - 1) / kGranularity) * kGranularity;
+}
+
+} // namespace
+
+void* graphScratchGet(
+    const void* cacheTag,
+    int key,
+    size_t requiredBytes,
+    cudaStream_t stream,
+    struct ncclCudaGraph graph) {
+  if (requiredBytes == 0) {
+    return nullptr;
+  }
+
+  reclaimDeadGraphs();
+
+  int device = 0;
+  if (cudaGetDevice(&device) != cudaSuccess) {
+    return nullptr;
+  }
+
+  const ScratchKey mapKey{
+      cacheTag, device, static_cast<const void*>(stream), key, graph.graphId};
+
+  {
+    std::lock_guard<std::mutex> lock(tableMutex());
+    auto it = table().find(mapKey);
+    if (it != table().end() && it->second.size >= requiredBytes) {
+      return it->second.buffer;
+    }
+  }
+
+  // Allocate outside the capture. Relaxed capture mode is what makes a blocking
+  // allocation legal on a thread with a capture in progress; enqueue.cc does
+  // the same exchange before allocating a graph's persistent work buffer.
+  cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
+  if (cudaThreadExchangeStreamCaptureMode(&mode) != cudaSuccess) {
+    return nullptr;
+  }
+  void* buffer = nullptr;
+  const size_t allocSize = roundedAllocSize(requiredBytes);
+  const cudaError_t err = cudaMalloc(&buffer, allocSize);
+  (void)cudaThreadExchangeStreamCaptureMode(&mode);
+  if (err != cudaSuccess) {
+    return nullptr;
+  }
+
+  // tableMutex() is process-wide and shared by every collective's cache, so no
+  // HIP call is made while holding it: doing so serializes concurrent captures
+  // on unrelated streams. The lock is taken twice instead -- once to CLAIM the
+  // destructor registration for this graph, once to publish the buffer -- with
+  // ncclCudaGraphAddDestructor and the error-path cudaFree in between, outside
+  // it. reclaimDeadGraphs() frees outside the lock for the same reason.
+  bool mustRegister = false;
+  {
+    std::lock_guard<std::mutex> lock(tableMutex());
+    GraphAllocs& allocs = graphAllocs()[graph.graphId];
+    if (!allocs.destructorRegistered) {
+      allocs.destructorRegistered = true;
+      mustRegister = true;
+    }
+  }
+
+  if (mustRegister) {
+    // One destructor per graph is enough, and the callback needs an id that
+    // outlives this frame.
+    auto* tag = new unsigned long long(graph.graphId);
+    if (ncclCudaGraphAddDestructor(graph, graphDiedCallback, tag) !=
+        ncclSuccess) {
+      delete tag;
+      {
+        std::lock_guard<std::mutex> lock(tableMutex());
+        // Release the claim. Nothing has been published for this buffer yet, so
+        // dropping an entry that holds no buffers leaves no trace; if another
+        // call has since published one, leave its buffers alone and only let
+        // the registration be retried.
+        auto it = graphAllocs().find(graph.graphId);
+        if (it != graphAllocs().end()) {
+          if (it->second.buffers.empty()) {
+            graphAllocs().erase(it);
+          } else {
+            it->second.destructorRegistered = false;
+          }
+        }
+      }
+      (void)cudaFree(buffer);
+      return nullptr;
+    }
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(tableMutex());
+    graphAllocs()[graph.graphId].buffers.push_back(buffer);
+    ScratchEntry& entry = table()[mapKey];
+    entry.buffer = buffer;
+    entry.size = allocSize;
+  }
+  return buffer;
+}
+
+} // namespace relay
+} // namespace rcclx

--- a/comms/rcclx/develop/meta/relay/sharded_relay_graph_scratch.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_graph_scratch.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+#include "comm.h"
+
+namespace rcclx {
+namespace relay {
+
+/**
+ * Scratch allocation for a relay collective that is being captured into a HIP
+ * graph.
+ *
+ * Each collective keeps its own ScratchBufferCache, and all four allocate with
+ * hipMallocAsync on the caller's stream. That is correct right up until the
+ * stream is capturing, and then it breaks three separate ways:
+ *
+ *   1. hipMallocAsync inside a capture records a graph allocation node. Its
+ *      address is only valid while that graph is executing, but the cache goes
+ *      on handing the same pointer to later uncaptured calls.
+ *   2. A cache growth inside a capture records the hipFreeAsync of the previous
+ *      pointer as a free node, so the buffer is freed on every replay and the
+ *      second replay is a double free.
+ *   3. A cache growth AFTER a capture hipFreeAsyncs a pointer the graph has
+ *      already baked into its nodes, returning it to the pool while the graph
+ * is still live and replayable.
+ *
+ * This hands a capture a buffer that is allocated OUTSIDE the capture, so no
+ * allocation node is recorded; is private to that graph, so no growth on
+ * another stream or graph can free it underneath; and is reclaimed once the
+ * graph is destroyed.
+ *
+ * Only the graph path lives here. Uncaptured calls stay on each collective's
+ * own cache, unchanged -- this is a correctness fix, and there is no reason to
+ * also perturb the path that carries all of the measured performance.
+ *
+ * `cacheTag` distinguishes the calling cache so the four per-collective caches
+ * do not share entries; pass the cache instance address. `key` is that cache's
+ * own buffer key. Returns nullptr on failure, which the caller must treat the
+ * same way it treats an allocation failure today.
+ */
+void* graphScratchGet(
+    const void* cacheTag,
+    int key,
+    size_t requiredBytes,
+    cudaStream_t stream,
+    struct ncclCudaGraph graph);
+
+} // namespace relay
+} // namespace rcclx

--- a/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.cc
@@ -16,6 +16,7 @@
 
 #include "bootstrap.h"
 #include "comm.h"
+#include "debug.h"
 #include "meta/relay/sharded_relay_route.h"
 
 namespace rcclx::relay {
@@ -24,8 +25,8 @@ namespace {
 
 // Per-peer slot capacity. The largest per-peer contribution any relay
 // collective stages is bounded by the per-active-rank input size, so the gate
-// doubles as the slot size: nRanks * kRelayOneShotMaxBytes per rank in total,
-// which at 8 ranks and a 1 MiB gate is 8 MiB.
+// doubles as the slot size: nRanks * kRelayOneShotMaxBytes in total, which at 8
+// ranks and a 1 MiB gate is 8 MiB.
 constexpr size_t kSlotBytes = kRelayOneShotMaxBytes;
 
 // Uncached (HSA fine-grained) device memory, matching how RCCL allocates its
@@ -41,6 +42,18 @@ constexpr unsigned int kRegionAllocFlags = hipDeviceMallocUncached;
 constexpr unsigned int kRegionAllocFlags = hipDeviceMallocFinegrained;
 #endif
 
+// Identity tag stamped at the end of every region. It answers the one question
+// an IPC mapping cannot otherwise answer: is the memory this handle opened
+// really the peer's CURRENT region, or a previous incarnation at an address the
+// allocator recycled? Any rank can compute any other rank's expected value from
+// the agreed commHash, so checking costs no extra communication.
+constexpr size_t kSentinelBytes = sizeof(uint64_t);
+
+uint64_t sentinelFor(uint64_t commHash, int rank) {
+  return (commHash ^ 0x9E3779B97F4A7C15ull) * 0x100000001B3ull +
+      static_cast<uint64_t>(rank) + 1ull;
+}
+
 struct Region {
   // Guards this region's construction and its epoch counter.
   //
@@ -49,12 +62,9 @@ struct Region {
   // deadlocks as soon as two communicators are set up concurrently and their
   // peer processes reach the collectives in opposite order: each process would
   // hold its own lock inside one comm's all-gather while the peer it is waiting
-  // for is blocked on that same lock, unable to enter it. regionsMutex()
+  // for is blocked on that same lock, unable to enter it. regionMutex()
   // therefore guards only the map.
   std::mutex mu;
-  // The communicator this region belongs to. Kept so a POINTER that has been
-  // recycled by the allocator can be told apart from the comm it used to be.
-  const void* commPtr{nullptr};
   bool tried{false};
   bool valid{false};
   void* base{nullptr}; // local allocation, exported
@@ -62,30 +72,43 @@ struct Region {
   size_t slotBytes{0};
   int nRanks{0};
   uint32_t epoch{0};
-  // Peer pointers we opened and must close.
   void* openedPeers[kOneShotMaxRanks]{};
+  // Identity of the communicator this region belongs to. The map is keyed on
+  // the comm POINTER, which the allocator recycles; commHash distinguishes a
+  // recycled address from the comm that used to live there, so a missed release
+  // cannot be mistaken for a live region.
+  uint64_t commHash{0};
 };
 
-std::mutex& regionsMutex() {
+std::mutex& regionMutex() {
   static std::mutex m;
   return m;
 }
 
-// Keyed on comm->commHash, NOT on the ncclComm_t pointer.
-//
-// Keying on the pointer deadlocks. A destroyed communicator leaves its entry
-// behind (there is no relay-visible hook on comm teardown), and the allocator
-// may hand the same address to the NEXT communicator -- on some ranks but not
-// others, since each rank is its own process with its own heap. A rank that
-// finds the stale entry skips creation, a rank that does not enters
-// bootstrapAllGather, and the participation mismatch hangs the bootstrap.
-// Observed exactly that way: a suite stuck 20 minutes in bootstrapAllGather
-// under oneShotAcquire.
-//
-// commHash is identical across the ranks of one communicator and different for
-// a different communicator, so it is consistent where the pointer is not.
-std::map<uint64_t, Region>& regions() {
-  static std::map<uint64_t, Region> r;
+/**
+ * One region per COMMUNICATOR, lazily created on that comm's first eligible
+ * call and released from its teardown (see oneShotRelease, wired into RCCL's
+ * commFree).
+ *
+ * Per-comm rather than per-process, and independent: each region owns its own
+ * staging, its own flags and its own epoch, so nothing about one communicator's
+ * one-shot traffic can reach another's. Two consequences that matter:
+ *
+ *  - The create decision is made from THIS comm's state alone, which starts
+ *    uniformly absent on every rank of it. So all of a comm's ranks always
+ * agree on whether to enter createRegion's collective bootstrap. An earlier
+ *    process-global design decided it from whichever comm arrived first, which
+ * let some ranks decline while others entered the bootstrap -- a hang.
+ *  - Flags are per region, so concurrent collectives on DIFFERENT comms cannot
+ *    alias each other's handshake.
+ *
+ * Lifetime is exactly the comm's, which is what removes the two failure modes
+ * of the earlier attempts: nothing is leaked (release frees the allocation) and
+ * nothing is evicted while live (so the epoch never rewinds under a peer that
+ * is still waiting on it).
+ */
+std::map<const void*, Region>& regions() {
+  static std::map<const void*, Region> r;
   return r;
 }
 
@@ -97,6 +120,11 @@ void destroyRegion(Region& reg) {
     }
   }
   if (reg.base != nullptr) {
+    // Safe to free: NCCL requires comms to be used collectively, so every rank
+    // has finished its collectives on this comm before any rank destroys it,
+    // and no peer can still be reading this region. A peer that nonetheless
+    // opened a mapping against a recycled address is caught by the sentinel
+    // check in createRegion.
     hipFree(reg.base);
     reg.base = nullptr;
   }
@@ -113,23 +141,38 @@ bool createRegion(ncclComm_t comm, Region& reg) {
   const int rank = comm->rank;
   reg.nRanks = nRanks;
   reg.slotBytes = kSlotBytes;
+  reg.commHash = comm->commHash;
 
   const size_t stagingBytes = static_cast<size_t>(nRanks) * kSlotBytes;
   const size_t flagBytes =
       static_cast<size_t>(nRanks) * kOneShotMaxBlocks * sizeof(uint32_t);
+
+  const size_t sentinelOffset = stagingBytes + flagBytes;
+  const size_t totalBytes = sentinelOffset + kSentinelBytes;
 
   bool ok = true;
 
   // IPC requires a non-mempool allocation: mempool-backed (hipMallocAsync)
   // memory cannot be exported, which is why this does not use
   // ScratchBufferCache.
-  if (hipExtMallocWithFlags(
-          &reg.base, stagingBytes + flagBytes, kRegionAllocFlags) !=
+  if (hipExtMallocWithFlags(&reg.base, totalBytes, kRegionAllocFlags) !=
       hipSuccess) {
     reg.base = nullptr;
     ok = false;
   }
-  if (ok && hipMemset(reg.base, 0, stagingBytes + flagBytes) != hipSuccess) {
+  if (ok && hipMemset(reg.base, 0, totalBytes) != hipSuccess) {
+    ok = false;
+  }
+
+  // Stamp our identity before the handle is published, so any peer that opens
+  // this handle can prove the memory it got is this region.
+  const uint64_t mySentinel = sentinelFor(comm->commHash, rank);
+  if (ok &&
+      hipMemcpy(
+          static_cast<char*>(reg.base) + sentinelOffset,
+          &mySentinel,
+          kSentinelBytes,
+          hipMemcpyHostToDevice) != hipSuccess) {
     ok = false;
   }
 
@@ -165,6 +208,30 @@ bool createRegion(ncclComm_t comm, Region& reg) {
         break;
       }
       reg.openedPeers[r] = peerBase;
+      // Prove this mapping is peer r's current region. Without this a wrong
+      // mapping is silent: our stores land in memory the peer no longer reads,
+      // the peer never sees its epoch, and it spins in the kernel until the job
+      // is killed. Rejecting here feeds the collective vote below, which turns
+      // it into an agreed fallback to ncclSend/ncclRecv.
+      uint64_t peerSentinel = 0;
+      if (hipMemcpy(
+              &peerSentinel,
+              static_cast<char*>(peerBase) + sentinelOffset,
+              kSentinelBytes,
+              hipMemcpyDeviceToHost) != hipSuccess) {
+        ok = false;
+        break;
+      }
+      const uint64_t wantSentinel = sentinelFor(comm->commHash, r);
+      if (peerSentinel != wantSentinel) {
+        WARN(
+            "Sharded relay one-shot: mapping for peer %d is not its current region (sentinel %llx, expected %llx); disabling the one-shot region for this communicator",
+            r,
+            static_cast<unsigned long long>(peerSentinel),
+            static_cast<unsigned long long>(wantSentinel));
+        ok = false;
+        break;
+      }
       reg.table.staging[r] = static_cast<char*>(peerBase);
       reg.table.flags[r] = reinterpret_cast<uint32_t*>(
           static_cast<char*>(peerBase) + stagingBytes);
@@ -206,49 +273,56 @@ bool oneShotAcquire(ncclComm_t comm, OneShotLaunch* out) {
     return false;
   }
 
-  // regionsMutex() covers only the map -- the stale-pointer sweep and the
-  // lookup. It is deliberately NOT held across createRegion(), which runs two
-  // bootstrap all-gathers: one global lock spanning a collective deadlocks as
-  // soon as two communicators are set up concurrently and their peer processes
-  // reach the collectives in opposite order.
+  // regionMutex() covers only the map -- the staleness check and the lookup. It
+  // is deliberately NOT held across createRegion(), which runs two bootstrap
+  // all-gathers: one global lock spanning a collective deadlocks as soon as two
+  // communicators are set up concurrently and their peer processes reach the
+  // collectives in opposite order -- each process would hold its own lock
+  // inside one comm's all-gather while the peer it is waiting for is blocked on
+  // it.
   Region* regp = nullptr;
   {
-    std::lock_guard<std::mutex> mapLock(regionsMutex());
+    std::lock_guard<std::mutex> mapLock(regionMutex());
 
-    // Drop any region left by a previous communicator that occupied this
-    // address. Its IPC mappings refer to memory that went away with it. That
-    // comm is gone, so nothing can be holding the region's mu.
-    for (auto it = regions().begin(); it != regions().end();) {
-      if (it->second.commPtr == static_cast<const void*>(comm) &&
-          it->first != comm->commHash) {
-        destroyRegion(it->second);
-        it = regions().erase(it);
-      } else {
-        ++it;
-      }
+    // A stale entry can only exist if this comm's release was missed and the
+    // allocator handed its address to a new comm. Drop the whole node rather
+    // than hand back mappings into memory that went away with the old comm;
+    // every rank of the new comm sees the same mismatch, because commHash is
+    // agreed across it. Erasing here, under the map lock, is also what keeps
+    // Region assignable-free: the node's mutex goes away with it, and the comm
+    // it belonged to is gone so nobody can be holding that mutex.
+    auto it = regions().find(static_cast<const void*>(comm));
+    if (it != regions().end() && it->second.tried &&
+        it->second.commHash != comm->commHash) {
+      destroyRegion(it->second);
+      regions().erase(it);
     }
 
-    regp = &regions()[comm->commHash];
+    regp = &regions()[static_cast<const void*>(comm)];
   }
   // std::map is node based, so the reference stays valid once the map lock is
-  // dropped; only erasing this key invalidates it, and that happens at comm
-  // destroy or in the sweep above, both after the last acquire for that comm.
+  // dropped; only erasing this key invalidates it, and that happens either in
+  // the sweep above or in oneShotRelease(), both only for a comm that is done.
   Region& reg = *regp;
 
   std::lock_guard<std::mutex> lock(reg.mu);
+
+  // Attempted once per comm. `tried` is sticky: a retry would have to be
+  // collectively agreed, and a rank retrying alone would enter a bootstrap
+  // all-gather the others are not in.
   if (!reg.tried) {
     reg.tried = true;
-    reg.commPtr = static_cast<const void*>(comm);
     createRegion(comm, reg);
   }
   if (!reg.valid) {
     return false;
   }
 
-  // The epoch must be unique per launch and must advance identically on every
-  // rank, which it does because every rank takes exactly one epoch per
-  // collective call. Bumping it under this comm's lock keeps two streams on one
-  // communicator from taking the same value.
+  // Unique per launch, and advances identically on every rank because every
+  // rank takes exactly one epoch per collective call on this comm. It never
+  // rewinds: the region is only ever destroyed with the comm. Bumping it under
+  // this comm's lock keeps two streams on one communicator from taking the same
+  // value.
   reg.epoch += 1;
 
   out->table = reg.table;
@@ -265,8 +339,8 @@ void oneShotRelease(ncclComm_t comm) {
   // Erasing the node destroys Region::mu, so this must not run concurrently
   // with an oneShotAcquire() for the same comm -- it is called from comm
   // teardown, after the last collective on that comm has been issued.
-  std::lock_guard<std::mutex> lock(regionsMutex());
-  auto it = regions().find(comm->commHash);
+  std::lock_guard<std::mutex> lock(regionMutex());
+  auto it = regions().find(static_cast<const void*>(comm));
   if (it == regions().end()) {
     return;
   }

--- a/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.cc
@@ -18,6 +18,7 @@
 #include "comm.h"
 #include "debug.h"
 #include "meta/relay/sharded_relay_route.h"
+#include "param.h"
 
 namespace rcclx::relay {
 
@@ -272,6 +273,20 @@ bool createRegion(ncclComm_t comm, Region& reg) {
 }
 
 } // namespace
+
+// Opt-in eager creation. Off by default, which keeps the lazy first-use path
+// that every existing deployment measures.
+NCCL_PARAM(ShardedRelayModeEnable, "SHARDED_RELAY_MODE_ENABLE", 0);
+
+void oneShotInit(ncclComm_t comm) {
+  if (comm == nullptr || ncclParamShardedRelayModeEnable() != 1) {
+    return;
+  }
+  // Discard the launch: this is only here to force creation. The region itself
+  // is kept on the comm, so the next real caller finds it ready.
+  OneShotLaunch unused{};
+  (void)oneShotAcquire(comm, &unused);
+}
 
 bool oneShotReady(ncclComm_t comm) {
   if (comm == nullptr) {

--- a/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.cc
@@ -52,6 +52,9 @@ struct Region {
   // for is blocked on that same lock, unable to enter it. regionsMutex()
   // therefore guards only the map.
   std::mutex mu;
+  // The communicator this region belongs to. Kept so a POINTER that has been
+  // recycled by the allocator can be told apart from the comm it used to be.
+  const void* commPtr{nullptr};
   bool tried{false};
   bool valid{false};
   void* base{nullptr}; // local allocation, exported
@@ -68,8 +71,21 @@ std::mutex& regionsMutex() {
   return m;
 }
 
-std::map<const void*, Region>& regions() {
-  static std::map<const void*, Region> r;
+// Keyed on comm->commHash, NOT on the ncclComm_t pointer.
+//
+// Keying on the pointer deadlocks. A destroyed communicator leaves its entry
+// behind (there is no relay-visible hook on comm teardown), and the allocator
+// may hand the same address to the NEXT communicator -- on some ranks but not
+// others, since each rank is its own process with its own heap. A rank that
+// finds the stale entry skips creation, a rank that does not enters
+// bootstrapAllGather, and the participation mismatch hangs the bootstrap.
+// Observed exactly that way: a suite stuck 20 minutes in bootstrapAllGather
+// under oneShotAcquire.
+//
+// commHash is identical across the ranks of one communicator and different for
+// a different communicator, so it is consistent where the pointer is not.
+std::map<uint64_t, Region>& regions() {
+  static std::map<uint64_t, Region> r;
   return r;
 }
 
@@ -190,20 +206,39 @@ bool oneShotAcquire(ncclComm_t comm, OneShotLaunch* out) {
     return false;
   }
 
-  // regionsMutex() covers only the map lookup, never the collectives inside
-  // createRegion(). std::map is node based, so the reference stays valid once
-  // the map lock is dropped; only erasing this key invalidates it, and that
-  // happens at comm destroy, i.e. after the last acquire for this comm.
+  // regionsMutex() covers only the map -- the stale-pointer sweep and the
+  // lookup. It is deliberately NOT held across createRegion(), which runs two
+  // bootstrap all-gathers: one global lock spanning a collective deadlocks as
+  // soon as two communicators are set up concurrently and their peer processes
+  // reach the collectives in opposite order.
   Region* regp = nullptr;
   {
     std::lock_guard<std::mutex> mapLock(regionsMutex());
-    regp = &regions()[static_cast<const void*>(comm)];
+
+    // Drop any region left by a previous communicator that occupied this
+    // address. Its IPC mappings refer to memory that went away with it. That
+    // comm is gone, so nothing can be holding the region's mu.
+    for (auto it = regions().begin(); it != regions().end();) {
+      if (it->second.commPtr == static_cast<const void*>(comm) &&
+          it->first != comm->commHash) {
+        destroyRegion(it->second);
+        it = regions().erase(it);
+      } else {
+        ++it;
+      }
+    }
+
+    regp = &regions()[comm->commHash];
   }
+  // std::map is node based, so the reference stays valid once the map lock is
+  // dropped; only erasing this key invalidates it, and that happens at comm
+  // destroy or in the sweep above, both after the last acquire for that comm.
   Region& reg = *regp;
 
   std::lock_guard<std::mutex> lock(reg.mu);
   if (!reg.tried) {
     reg.tried = true;
+    reg.commPtr = static_cast<const void*>(comm);
     createRegion(comm, reg);
   }
   if (!reg.valid) {
@@ -231,7 +266,7 @@ void oneShotRelease(ncclComm_t comm) {
   // with an oneShotAcquire() for the same comm -- it is called from comm
   // teardown, after the last collective on that comm has been issued.
   std::lock_guard<std::mutex> lock(regionsMutex());
-  auto it = regions().find(static_cast<const void*>(comm));
+  auto it = regions().find(comm->commHash);
   if (it == regions().end()) {
     return;
   }

--- a/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.cc
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "meta/relay/sharded_relay_oneshot.h"
+
+#include <hip/hip_runtime.h>
+#include <cstring>
+#include <map>
+#include <mutex>
+#include <vector>
+
+#include "bootstrap.h"
+#include "comm.h"
+#include "meta/relay/sharded_relay_route.h"
+
+namespace rcclx::relay {
+
+namespace {
+
+// Per-peer slot capacity. The largest per-peer contribution any relay
+// collective stages is bounded by the per-active-rank input size, so the gate
+// doubles as the slot size: nRanks * kRelayOneShotMaxBytes per rank in total,
+// which at 8 ranks and a 1 MiB gate is 8 MiB.
+constexpr size_t kSlotBytes = kRelayOneShotMaxBytes;
+
+// Uncached (HSA fine-grained) device memory, matching how RCCL allocates its
+// own IPC-exported buffers in transport/p2p.cc. Not a tuning choice: the flags
+// in this region are polled across processes from inside a kernel, and cached
+// device memory does not reliably expose a peer's writes to that poll on
+// gfx94x/gfx95x -- gfx9_threadfence.h's cheap fence is only correct for
+// uncached buffers. Our build defines -DHIP_UNCACHED_MEMORY for exactly this
+// reason ("needed for MI300 which will hang w/o", see rccl_build_config.bzl).
+#if defined(HIP_UNCACHED_MEMORY)
+constexpr unsigned int kRegionAllocFlags = hipDeviceMallocUncached;
+#else
+constexpr unsigned int kRegionAllocFlags = hipDeviceMallocFinegrained;
+#endif
+
+struct Region {
+  // Guards this region's construction and its epoch counter.
+  //
+  // Per-comm rather than process-global because createRegion() runs two
+  // bootstrap all-gathers. Holding one global lock across a collective
+  // deadlocks as soon as two communicators are set up concurrently and their
+  // peer processes reach the collectives in opposite order: each process would
+  // hold its own lock inside one comm's all-gather while the peer it is waiting
+  // for is blocked on that same lock, unable to enter it. regionsMutex()
+  // therefore guards only the map.
+  std::mutex mu;
+  bool tried{false};
+  bool valid{false};
+  void* base{nullptr}; // local allocation, exported
+  OneShotPeerTable table{};
+  size_t slotBytes{0};
+  int nRanks{0};
+  uint32_t epoch{0};
+  // Peer pointers we opened and must close.
+  void* openedPeers[kOneShotMaxRanks]{};
+};
+
+std::mutex& regionsMutex() {
+  static std::mutex m;
+  return m;
+}
+
+std::map<const void*, Region>& regions() {
+  static std::map<const void*, Region> r;
+  return r;
+}
+
+void destroyRegion(Region& reg) {
+  for (int i = 0; i < kOneShotMaxRanks; i++) {
+    if (reg.openedPeers[i] != nullptr) {
+      hipIpcCloseMemHandle(reg.openedPeers[i]);
+      reg.openedPeers[i] = nullptr;
+    }
+  }
+  if (reg.base != nullptr) {
+    hipFree(reg.base);
+    reg.base = nullptr;
+  }
+  reg.valid = false;
+}
+
+/**
+ * Build the region. Returns false on any local failure, but ALWAYS runs the two
+ * bootstrap all-gathers so every rank stays in lockstep -- an early return on
+ * one rank would desynchronize the bootstrap for the others.
+ */
+bool createRegion(ncclComm_t comm, Region& reg) {
+  const int nRanks = comm->nRanks;
+  const int rank = comm->rank;
+  reg.nRanks = nRanks;
+  reg.slotBytes = kSlotBytes;
+
+  const size_t stagingBytes = static_cast<size_t>(nRanks) * kSlotBytes;
+  const size_t flagBytes =
+      static_cast<size_t>(nRanks) * kOneShotMaxBlocks * sizeof(uint32_t);
+
+  bool ok = true;
+
+  // IPC requires a non-mempool allocation: mempool-backed (hipMallocAsync)
+  // memory cannot be exported, which is why this does not use
+  // ScratchBufferCache.
+  if (hipExtMallocWithFlags(
+          &reg.base, stagingBytes + flagBytes, kRegionAllocFlags) !=
+      hipSuccess) {
+    reg.base = nullptr;
+    ok = false;
+  }
+  if (ok && hipMemset(reg.base, 0, stagingBytes + flagBytes) != hipSuccess) {
+    ok = false;
+  }
+
+  hipIpcMemHandle_t myHandle{};
+  std::memset(&myHandle, 0, sizeof(myHandle));
+  if (ok && hipIpcGetMemHandle(&myHandle, reg.base) != hipSuccess) {
+    ok = false;
+  }
+
+  // Exchange handles even if we failed locally: the all-gather is collective.
+  std::vector<hipIpcMemHandle_t> handles(nRanks);
+  std::memset(handles.data(), 0, handles.size() * sizeof(hipIpcMemHandle_t));
+  handles[rank] = myHandle;
+  if (bootstrapAllGather(
+          comm->bootstrap, handles.data(), sizeof(hipIpcMemHandle_t)) !=
+      ncclSuccess) {
+    ok = false;
+  }
+
+  if (ok) {
+    for (int r = 0; r < nRanks; r++) {
+      if (r == rank) {
+        reg.table.staging[r] = static_cast<char*>(reg.base);
+        reg.table.flags[r] = reinterpret_cast<uint32_t*>(
+            static_cast<char*>(reg.base) + stagingBytes);
+        continue;
+      }
+      void* peerBase = nullptr;
+      if (hipIpcOpenMemHandle(
+              &peerBase, handles[r], hipIpcMemLazyEnablePeerAccess) !=
+          hipSuccess) {
+        ok = false;
+        break;
+      }
+      reg.openedPeers[r] = peerBase;
+      reg.table.staging[r] = static_cast<char*>(peerBase);
+      reg.table.flags[r] = reinterpret_cast<uint32_t*>(
+          static_cast<char*>(peerBase) + stagingBytes);
+    }
+  }
+
+  // Agree on the outcome. A region that only some ranks have is worse than no
+  // region: the ranks that have it would spin for peers that took the
+  // ncclSend/ncclRecv path, which hangs instead of degrading.
+  std::vector<uint8_t> votes(nRanks, 0);
+  votes[rank] = ok ? 1 : 0;
+  if (bootstrapAllGather(comm->bootstrap, votes.data(), sizeof(uint8_t)) !=
+      ncclSuccess) {
+    ok = false;
+  } else {
+    for (int r = 0; r < nRanks; r++) {
+      if (votes[r] == 0) {
+        ok = false;
+        break;
+      }
+    }
+  }
+
+  if (!ok) {
+    destroyRegion(reg);
+    return false;
+  }
+  reg.valid = true;
+  return true;
+}
+
+} // namespace
+
+bool oneShotAcquire(ncclComm_t comm, OneShotLaunch* out) {
+  if (comm == nullptr || out == nullptr) {
+    return false;
+  }
+  if (comm->nRanks > kOneShotMaxRanks || comm->nRanks < 2) {
+    return false;
+  }
+
+  // regionsMutex() covers only the map lookup, never the collectives inside
+  // createRegion(). std::map is node based, so the reference stays valid once
+  // the map lock is dropped; only erasing this key invalidates it, and that
+  // happens at comm destroy, i.e. after the last acquire for this comm.
+  Region* regp = nullptr;
+  {
+    std::lock_guard<std::mutex> mapLock(regionsMutex());
+    regp = &regions()[static_cast<const void*>(comm)];
+  }
+  Region& reg = *regp;
+
+  std::lock_guard<std::mutex> lock(reg.mu);
+  if (!reg.tried) {
+    reg.tried = true;
+    createRegion(comm, reg);
+  }
+  if (!reg.valid) {
+    return false;
+  }
+
+  // The epoch must be unique per launch and must advance identically on every
+  // rank, which it does because every rank takes exactly one epoch per
+  // collective call. Bumping it under this comm's lock keeps two streams on one
+  // communicator from taking the same value.
+  reg.epoch += 1;
+
+  out->table = reg.table;
+  out->slotBytes = reg.slotBytes;
+  out->nRanks = reg.nRanks;
+  out->epoch = reg.epoch;
+  return true;
+}
+
+void oneShotRelease(ncclComm_t comm) {
+  if (comm == nullptr) {
+    return;
+  }
+  // Erasing the node destroys Region::mu, so this must not run concurrently
+  // with an oneShotAcquire() for the same comm -- it is called from comm
+  // teardown, after the last collective on that comm has been issued.
+  std::lock_guard<std::mutex> lock(regionsMutex());
+  auto it = regions().find(static_cast<const void*>(comm));
+  if (it == regions().end()) {
+    return;
+  }
+  destroyRegion(it->second);
+  regions().erase(it);
+}
+
+} // namespace rcclx::relay

--- a/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.cc
@@ -71,7 +71,7 @@ struct Region {
   OneShotPeerTable table{};
   size_t slotBytes{0};
   int nRanks{0};
-  uint32_t epoch{0};
+  uint32_t* seq{nullptr}; // device, kOneShotMaxBlocks entries
   void* openedPeers[kOneShotMaxRanks]{};
   // Identity of the communicator this region belongs to. The map is keyed on
   // the comm POINTER, which the allocator recycles; commHash distinguishes a
@@ -91,7 +91,7 @@ std::mutex& regionMutex() {
  * commFree).
  *
  * Per-comm rather than per-process, and independent: each region owns its own
- * staging, its own flags and its own epoch, so nothing about one communicator's
+ * staging, its own flags and its own counters, so nothing about one comm's
  * one-shot traffic can reach another's. Two consequences that matter:
  *
  *  - The create decision is made from THIS comm's state alone, which starts
@@ -146,8 +146,13 @@ bool createRegion(ncclComm_t comm, Region& reg) {
   const size_t stagingBytes = static_cast<size_t>(nRanks) * kSlotBytes;
   const size_t flagBytes =
       static_cast<size_t>(nRanks) * kOneShotMaxBlocks * sizeof(uint32_t);
+  // Trails the flags in the same allocation so the memset below zeroes it too,
+  // which is what makes the first epoch 1 and every never-written flag compare
+  // as not-yet-arrived.
+  const size_t seqBytes =
+      static_cast<size_t>(kOneShotMaxBlocks) * sizeof(uint32_t);
 
-  const size_t sentinelOffset = stagingBytes + flagBytes;
+  const size_t sentinelOffset = stagingBytes + flagBytes + seqBytes;
   const size_t totalBytes = sentinelOffset + kSentinelBytes;
 
   bool ok = true;
@@ -193,6 +198,9 @@ bool createRegion(ncclComm_t comm, Region& reg) {
   }
 
   if (ok) {
+    // Local only: a rank's own counter, never read through a peer mapping.
+    reg.seq = reinterpret_cast<uint32_t*>(
+        static_cast<char*>(reg.base) + stagingBytes + flagBytes);
     for (int r = 0; r < nRanks; r++) {
       if (r == rank) {
         reg.table.staging[r] = static_cast<char*>(reg.base);
@@ -265,6 +273,18 @@ bool createRegion(ncclComm_t comm, Region& reg) {
 
 } // namespace
 
+bool oneShotReady(ncclComm_t comm) {
+  if (comm == nullptr) {
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(regionMutex());
+  auto it = regions().find(static_cast<const void*>(comm));
+  // find rather than operator[]: this must not create a Region entry, or a
+  // capturing caller would leave behind a tried=false shell keyed to this comm.
+  return it != regions().end() && it->second.valid &&
+      it->second.commHash == comm->commHash;
+}
+
 bool oneShotAcquire(ncclComm_t comm, OneShotLaunch* out) {
   if (comm == nullptr || out == nullptr) {
     return false;
@@ -318,17 +338,10 @@ bool oneShotAcquire(ncclComm_t comm, OneShotLaunch* out) {
     return false;
   }
 
-  // Unique per launch, and advances identically on every rank because every
-  // rank takes exactly one epoch per collective call on this comm. It never
-  // rewinds: the region is only ever destroyed with the comm. Bumping it under
-  // this comm's lock keeps two streams on one communicator from taking the same
-  // value.
-  reg.epoch += 1;
-
   out->table = reg.table;
   out->slotBytes = reg.slotBytes;
   out->nRanks = reg.nRanks;
-  out->epoch = reg.epoch;
+  out->seq = reg.seq;
   return true;
 }
 

--- a/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.h
@@ -101,13 +101,19 @@ struct OneShotRanks {
   int r[kOneShotMaxRanks];
 };
 
-// Everything one launch needs. Returned by value so the epoch is unique to the
-// call that took it.
+// Everything one launch needs.
 struct OneShotLaunch {
   OneShotPeerTable table;
   size_t slotBytes;
   int nRanks;
-  uint32_t epoch;
+  // Per-block handshake counter, device memory, one array per rank. The kernel
+  // bumps seq[blockIdx.x] itself and uses the result as the epoch for that
+  // block. It is NOT a host-side counter passed by value: as a kernel argument
+  // it got baked into a captured graph, and every replay then reused the same
+  // epoch, which every peer flag already satisfied. All ranks stay in step
+  // because all of them run the same one-shot calls in the same order, which is
+  // what the size-only gating in the callers guarantees.
+  uint32_t* seq;
 };
 
 /**
@@ -121,6 +127,21 @@ struct OneShotLaunch {
  * COLLECTIVE on first call for a given communicator. See the file comment.
  */
 bool oneShotAcquire(ncclComm_t comm, OneShotLaunch* out);
+
+/**
+ * True if this communicator's region already exists, without creating one.
+ *
+ * For callers under graph capture. Creation is not capturable -- it does a
+ * bootstrap all-gather and a synchronous hipMemset -- but a region that already
+ * exists is perfectly usable from a captured kernel, so a caller can consult
+ * this and fall back rather than refusing every captured call outright.
+ *
+ * Purely local and collective-safe to call: whether a region exists is agreed
+ * across the communicator, since it is only ever established by an all-gather
+ * that every rank takes part in. So every rank gets the same answer and either
+ * all of them fall back or none do.
+ */
+bool oneShotReady(ncclComm_t comm);
 
 /**
  * Free a communicator's region. Called from RCCL's commFree(), which is the

--- a/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.h
@@ -93,6 +93,13 @@ struct OneShotPeerTable {
   uint32_t* flags[kOneShotMaxRanks];
 };
 
+// The communicator ranks of a group's active set, indexed by active index.
+// Passed to the kernel by value so it can resolve "active index j" to a peer
+// table slot.
+struct OneShotRanks {
+  int r[kOneShotMaxRanks];
+};
+
 // Everything one launch needs. Returned by value so the epoch is unique to the
 // call that took it.
 struct OneShotLaunch {

--- a/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.h
@@ -55,8 +55,9 @@
  * rank PUSHES its contribution into peers' pre-registered staging. That also
  * means the per-call cost is zero: nothing is registered or mapped per call.
  *
- * Setup cost, measured for 8 ranks: hipIpcGetMemHandle 0.012 ms +
- * bootstrapAllGather 1.7 ms + 7x hipIpcOpenMemHandle 0.65 ms, so ~1.7 ms once.
+ * Setup cost, measured for 8 ranks: hipIpcGetMemHandle 0.008 ms +
+ * bootstrapAllGather 1.5 ms + 7x hipIpcOpenMemHandle 0.36 ms, so ~1.9 ms once
+ * per PROCESS -- not per communicator, and not per call.
  *
  * COLLECTIVE, AND WHY THAT MATTERS
  *
@@ -122,8 +123,11 @@ struct OneShotLaunch {
 bool oneShotAcquire(ncclComm_t comm, OneShotLaunch* out);
 
 /**
- * Drop a communicator's region. Safe to call for a communicator that never had
- * one. Intended for communicator teardown.
+ * Free a communicator's region. Called from RCCL's commFree(), which is the
+ * only point at which the relay learns a comm is going away; without it the
+ * region outlives the comm and its peer mappings accumulate. Purely local -- an
+ * hipIpcCloseMemHandle per peer plus one hipFree -- so it honours commFree()'s
+ * no-sync-among-ranks contract. A no-op for a comm that never took the path.
  */
 void oneShotRelease(ncclComm_t comm);
 

--- a/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "nccl.h"
+
+/**
+ * Peer-addressable staging for the relay's one-shot small-message kernels.
+ *
+ * WHY THIS EXISTS
+ *
+ * Below ~576 KB a relay call contains no bandwidth term at all -- the measured
+ * time is flat across 4 KB..576 KB -- so the only unit of cost is a launch.
+ * Every collective got to >1x by removing launches, except reduce-scatter,
+ * which cannot: its output is an arithmetic function of what arrives, and
+ * RCCL's grouped-P2P kernel copies but does not reduce, so it needs two
+ * launches where NCCL needs one. Deleting the trailing reduce outright still
+ * measured 0.90-1.04x, because ONE ncclGroup of P2P ops costs ~0.038 ms while
+ * NCCL's entire fused reduce_scatter costs ~0.035 ms. The ncclGroup itself is
+ * the floor.
+ *
+ * The way past it is a single kernel that moves the data AND reduces it, with
+ * no group machinery. RCCL ships exactly that (ncclSymRun_ReduceScatter_LL) but
+ * it is unreachable on this platform: comm->symmetricSupport requires
+ * ncclCuMemEnable(), and ncclIsCuMemSupported() returns 0 unconditionally on
+ * AMD, so the symmetric window registration that would supply peer pointers can
+ * never be enabled. Hence this: the same idea built on plain hipIpc*.
+ *
+ * DESIGN
+ *
+ * One region per communicator, created lazily on the first eligible call and
+ * kept for the communicator's life. Each rank allocates
+ *
+ *     [nRanks slots of slotBytes][nRanks * kOneShotMaxBlocks flags]
+ *
+ * with hipExtMallocWithFlags, uncached (HSA fine-grained) because the flags are
+ * polled across processes from inside a kernel -- and NOT the relay's
+ * ScratchBufferCache, whose cudaMallocAsync (mempool-backed) allocations cannot
+ * be IPC-exported --
+ * exports one handle, and opens every peer's. A rank then reaches peer p's slot
+ * s as `table.staging[p] + s * slotBytes`.
+ *
+ * Callers never register their own buffers. Measured on this build,
+ * ncclCommRegister returns success with a NULL handle in 0.001 ms, i.e. it is a
+ * no-op, so reading a peer's sendbuff directly is not available. Instead each
+ * rank PUSHES its contribution into peers' pre-registered staging. That also
+ * means the per-call cost is zero: nothing is registered or mapped per call.
+ *
+ * Setup cost, measured for 8 ranks: hipIpcGetMemHandle 0.012 ms +
+ * bootstrapAllGather 1.7 ms + 7x hipIpcOpenMemHandle 0.65 ms, so ~1.7 ms once.
+ *
+ * COLLECTIVE, AND WHY THAT MATTERS
+ *
+ * oneShotAcquire() performs a bootstrap all-gather, so EVERY rank of the
+ * communicator must call it on the same call -- including ranks that are
+ * helpers for this collective and will not launch anything. Callers must
+ * therefore gate it on a predicate derived only from sizes (which are
+ * collective-consistent), never on whether the calling rank happens to be
+ * active.
+ *
+ * Success is agreed across ranks before the region is used: each rank
+ * all-gathers its own ok flag and the region is enabled only if every rank
+ * succeeded. Without that, a partial failure would leave some ranks running a
+ * one-shot kernel that spins for a peer that took the ncclSend path, which
+ * hangs rather than degrades.
+ */
+namespace rcclx::relay {
+
+// An 8-GPU node. Sized for the topology the relay targets rather than made
+// dynamic, because the peer table is passed to a kernel by value.
+constexpr int kOneShotMaxRanks = 8;
+
+// Blocks handshake pairwise (block b waits only on the peer's block b), so
+// there is no global barrier and no co-residency requirement: every block
+// writes and flags BEFORE it waits, so a block that is not yet resident cannot
+// hold another back.
+constexpr int kOneShotMaxBlocks = 64;
+constexpr int kOneShotThreads = 256;
+
+// Where every rank's staging and flags live in THIS rank's address space. The
+// self entry points at the local allocation; peers are IPC-mapped.
+struct OneShotPeerTable {
+  char* staging[kOneShotMaxRanks];
+  uint32_t* flags[kOneShotMaxRanks];
+};
+
+// Everything one launch needs. Returned by value so the epoch is unique to the
+// call that took it.
+struct OneShotLaunch {
+  OneShotPeerTable table;
+  size_t slotBytes;
+  int nRanks;
+  uint32_t epoch;
+};
+
+/**
+ * Hand out the communicator's one-shot region, creating it on first use.
+ *
+ * Returns false if the region is unavailable -- allocation failed, hipIpc*
+ * failed, the communicator is larger than kOneShotMaxRanks, or any rank failed.
+ * A false return is identical on every rank, so callers can fall back to the
+ * ncclSend/ncclRecv path without risking a mixed-schedule hang.
+ *
+ * COLLECTIVE on first call for a given communicator. See the file comment.
+ */
+bool oneShotAcquire(ncclComm_t comm, OneShotLaunch* out);
+
+/**
+ * Drop a communicator's region. Safe to call for a communicator that never had
+ * one. Intended for communicator teardown.
+ */
+void oneShotRelease(ncclComm_t comm);
+
+} // namespace rcclx::relay

--- a/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_oneshot.h
@@ -129,6 +129,24 @@ struct OneShotLaunch {
 bool oneShotAcquire(ncclComm_t comm, OneShotLaunch* out);
 
 /**
+ * Build this communicator's region now, during ncclCommInitRank.
+ *
+ * Only acts when NCCL_SHARDED_RELAY_MODE_ENABLE=1. Creation is COLLECTIVE (see
+ * the file comment), so init is the one place it can be done for free: every
+ * rank is already there, and doing it here means no later call -- including the
+ * first call of a graph capture -- has to pay for it or refuse it.
+ *
+ * Like every NCCL parameter this assumes the variable is set identically on
+ * every rank of the communicator. Setting it on some ranks only would leave
+ * those ranks in a bootstrap all-gather the others never join.
+ *
+ * Failure is not an error: the region is optional and every caller already has
+ * a fallback, so a comm that cannot build one simply behaves as if the variable
+ * were unset.
+ */
+void oneShotInit(ncclComm_t comm);
+
+/**
  * True if this communicator's region already exists, without creating one.
  *
  * For callers under graph capture. Creation is not capturable -- it does a

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -9,6 +9,7 @@
 #include "sharded_relay_reduce_scatter.h"
 #include "comm.h"
 #include "sharded_relay_allreduce_kernels.h"
+#include "sharded_relay_oneshot.h"
 #include "sharded_relay_route.h"
 
 #include <hip/hip_bfloat16.h>
@@ -622,6 +623,155 @@ bool buildShardedRelayRankConfig(
     }                                                                      \
   } while (0)
 
+// Dtype dispatch for the one-shot 2-rank reduce-scatter. Deliberately narrower
+// than the other macros: only the types the small-message paths actually see
+// are worth an instantiation, and an unsupported type must fall through to the
+// ncclSend/ncclRecv schedule rather than silently do nothing, so the caller
+// checks the bool this sets.
+#define DISPATCH_ONESHOT_REDUCE_SCATTER2(                 \
+    datatype,                                             \
+    handled,                                              \
+    out,                                                  \
+    sendBuff,                                             \
+    table,                                                \
+    myRank,                                               \
+    peerRank,                                             \
+    mySlot,                                               \
+    peerSlot,                                             \
+    rc,                                                   \
+    slotBytes,                                            \
+    epoch,                                                \
+    divisor,                                              \
+    stream)                                               \
+  do {                                                    \
+    (handled) = true;                                     \
+    switch (datatype) {                                   \
+      case ncclInt32:                                     \
+        launchOneShotReduceScatter2Kernel<int32_t>(       \
+            out,                                          \
+            sendBuff,                                     \
+            table,                                        \
+            myRank,                                       \
+            peerRank,                                     \
+            mySlot,                                       \
+            peerSlot,                                     \
+            rc,                                           \
+            slotBytes,                                    \
+            epoch,                                        \
+            divisor,                                      \
+            stream);                                      \
+        break;                                            \
+      case ncclUint32:                                    \
+        launchOneShotReduceScatter2Kernel<uint32_t>(      \
+            out,                                          \
+            sendBuff,                                     \
+            table,                                        \
+            myRank,                                       \
+            peerRank,                                     \
+            mySlot,                                       \
+            peerSlot,                                     \
+            rc,                                           \
+            slotBytes,                                    \
+            epoch,                                        \
+            divisor,                                      \
+            stream);                                      \
+        break;                                            \
+      case ncclInt64:                                     \
+        launchOneShotReduceScatter2Kernel<int64_t>(       \
+            out,                                          \
+            sendBuff,                                     \
+            table,                                        \
+            myRank,                                       \
+            peerRank,                                     \
+            mySlot,                                       \
+            peerSlot,                                     \
+            rc,                                           \
+            slotBytes,                                    \
+            epoch,                                        \
+            divisor,                                      \
+            stream);                                      \
+        break;                                            \
+      case ncclUint64:                                    \
+        launchOneShotReduceScatter2Kernel<uint64_t>(      \
+            out,                                          \
+            sendBuff,                                     \
+            table,                                        \
+            myRank,                                       \
+            peerRank,                                     \
+            mySlot,                                       \
+            peerSlot,                                     \
+            rc,                                           \
+            slotBytes,                                    \
+            epoch,                                        \
+            divisor,                                      \
+            stream);                                      \
+        break;                                            \
+      case ncclFloat16:                                   \
+        launchOneShotReduceScatter2Kernel<__half>(        \
+            out,                                          \
+            sendBuff,                                     \
+            table,                                        \
+            myRank,                                       \
+            peerRank,                                     \
+            mySlot,                                       \
+            peerSlot,                                     \
+            rc,                                           \
+            slotBytes,                                    \
+            epoch,                                        \
+            divisor,                                      \
+            stream);                                      \
+        break;                                            \
+      case ncclFloat:                                     \
+        launchOneShotReduceScatter2Kernel<float>(         \
+            out,                                          \
+            sendBuff,                                     \
+            table,                                        \
+            myRank,                                       \
+            peerRank,                                     \
+            mySlot,                                       \
+            peerSlot,                                     \
+            rc,                                           \
+            slotBytes,                                    \
+            epoch,                                        \
+            divisor,                                      \
+            stream);                                      \
+        break;                                            \
+      case ncclDouble:                                    \
+        launchOneShotReduceScatter2Kernel<double>(        \
+            out,                                          \
+            sendBuff,                                     \
+            table,                                        \
+            myRank,                                       \
+            peerRank,                                     \
+            mySlot,                                       \
+            peerSlot,                                     \
+            rc,                                           \
+            slotBytes,                                    \
+            epoch,                                        \
+            divisor,                                      \
+            stream);                                      \
+        break;                                            \
+      case ncclBfloat16:                                  \
+        launchOneShotReduceScatter2Kernel<__nv_bfloat16>( \
+            out,                                          \
+            sendBuff,                                     \
+            table,                                        \
+            myRank,                                       \
+            peerRank,                                     \
+            mySlot,                                       \
+            peerSlot,                                     \
+            rc,                                           \
+            slotBytes,                                    \
+            epoch,                                        \
+            divisor,                                      \
+            stream);                                      \
+        break;                                            \
+      default:                                            \
+        (handled) = false;                                \
+        break;                                            \
+    }                                                     \
+  } while (0)
+
 #define LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                          \
     TYPE, dst, seed, contribs, numContribs, count, divisor, stream) \
   launchSeededMultiReduceKernel<TYPE>(                              \
@@ -804,6 +954,68 @@ static ncclResult_t shardedRelayReduceScatter2Active(
   if (rcclx::relay::selectReduceScatterRoute(
           2, numHelpers, nGroups, recvCounts, elementSize) ==
       rcclx::relay::ReduceScatterRoute::PureDirect) {
+    // ======================================================================
+    // ONE-SHOT IPC FAST PATH
+    // ======================================================================
+    // The schedule below is already minimal for ncclSend/ncclRecv -- one group
+    // plus one fused reduce -- and that is still one launch more than NCCL,
+    // which fuses transfer and reduction into a single kernel. Measured, the
+    // group ALONE costs more than NCCL's whole collective, so no amount of
+    // trimming here reaches 1x. The one-shot kernel removes the group entirely:
+    // it pushes into the peer's pre-registered staging, handshakes on a flag,
+    // and reduces in registers, all in one launch.
+    //
+    // Every predicate below is derived only from sizes and the communicator, so
+    // all ranks reach the same decision. That matters more than usual here: if
+    // one rank ran the one-shot kernel while its peer took the ncclSend path,
+    // the first would spin forever instead of merely running slower.
+    // oneShotAcquire() is COLLECTIVE on first use, which is why it is called
+    // here -- before any branch on myActiveGroup -- and why it agrees its own
+    // success across ranks.
+    const size_t osMaxCount = rcclx::relay::relayMaxCount(recvCounts, nGroups);
+    bool useOneShot = (nGroups == 1) && (osMaxCount > 0) &&
+        (2 * osMaxCount * elementSize <= rcclx::relay::kRelayOneShotMaxBytes);
+    if (useOneShot) {
+      // The epoch advances per host launch, so a replayed graph would reuse a
+      // stale value and the handshake would pass before the data arrived.
+      struct ncclCudaGraph graph;
+      NCCLCHECK(ncclCudaGetCapturingGraph(&graph, stream));
+      useOneShot = !ncclCudaGraphValid(graph);
+    }
+    rcclx::relay::OneShotLaunch osl{};
+    if (useOneShot) {
+      useOneShot = rcclx::relay::oneShotAcquire(comm, &osl);
+    }
+    if (useOneShot && myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0) {
+      const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
+      const size_t rc = recvCounts[myActiveGroup];
+      const int m = cfg.myActiveIndex;
+      const int other = 1 - m;
+      bool handled = false;
+      DISPATCH_ONESHOT_REDUCE_SCATTER2(
+          datatype,
+          handled,
+          recvBuffs[myActiveGroup],
+          sendBuffs[myActiveGroup],
+          osl.table,
+          comm->rank,
+          cfg.activeRanks[other],
+          m,
+          other,
+          rc,
+          osl.slotBytes,
+          osl.epoch,
+          reductionDivisor,
+          stream);
+      // An unsupported datatype must not silently produce nothing. Falling back
+      // is safe only because the dtype is the same on every rank, so either all
+      // of them fall back or none do.
+      useOneShot = handled;
+    }
+    if (useOneShot) {
+      return ncclSuccess;
+    }
+
     void* pdScratch = nullptr;
     size_t pdRecvcount = 0;
     size_t pdOwnOff = 0;

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -1604,6 +1604,299 @@ static ncclResult_t shardedRelayReduceScatterFlat(
 }
 
 /**
+ * Software-pipelined single-group A>2 flat reduce-scatter.
+ *
+ * Same reduce-at-helper relay as shardedRelayReduceScatterFlat, but for
+ * nGroups == 1 -- where the active ranks and the helpers are disjoint -- the
+ * offload is tiled so the scatter and the reduced return share a group and each
+ * cross link runs duplex. See relayPipelineTiles().
+ *
+ * This is the mirror of the pipelined all-gather and equally ASYMMETRIC: a
+ * source scatters the slice of ALL A-1 of its foreign blocks, so a cross link
+ * carries A-1 units UP for every 1 the reduced return brings DOWN. Merging is
+ * bounded by the up direction. With w = align(recvCount / ((H + A - 1)*T + 1))
+ * each of the first T groups carries (A-1)*w on the busiest link and the last
+ * carries w, giving ((A-1)*T + 1)*w: at A = H = 4 that is recvCount/2 at T = 1
+ * (identical to the two-group schedule) falling towards 3*recvCount/7.
+ *
+ * The divisor is derived from A and H rather than fixed at the A = H = 4 value
+ * of 7 because the layout below needs H*T + (A-1)*T + 1 units to fit: any other
+ * geometry that reaches this path (A = 4 with H = 5..8 on a 9-to-12-rank comm,
+ * or A = 8 with H = 8 on a 16-rank one) would otherwise push offloadTotal past
+ * rc and underflow directSz, so an enormous count would reach
+ * ncclSend/ncclRecv. relayShapeFanout() is shared with the all-gather because
+ * the two schedules have the same unit accounting.
+ *
+ * Block layout [0, recvCount):
+ *   [0, directSz)          direct region, one chunk per group sized to that
+ *                          group's cross load: (A-1)*w for the first T groups
+ * and the remainder (>= w) for the last [directSz, recvCount)  offload region;
+ * helper h owns T tiles of w
+ *
+ * Unlike allreduce, the helper's reduce here is per tile because it gates the
+ * return hop: after the group that receives tile k it sums that tile's A-1
+ * contributions per owner, and the next group ships one reduced tile per owner.
+ * The OWNER's reduce stays a single fused pass over the whole block at the end
+ * -- reduce-scatter has no gather phase to wait on it -- so dScratch keeps the
+ * flat path's shard-major layout and the closing reduction is unchanged.
+ */
+static ncclResult_t shardedRelayReduceScatterFlatPipelined(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* recvCounts,
+    ncclDataType_t datatype,
+    int reductionDivisor,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nActiveRanksPerGroup,
+    int nTiles,
+    size_t elementSize) {
+  const ShardedRelayRankConfig& cfg = configs[0];
+  const size_t rc = recvCounts[0];
+  const int A = nActiveRanksPerGroup;
+  const int H = numHelpers;
+  const int T = nTiles;
+  const size_t w = ((rc /
+                     (static_cast<size_t>(
+                          rcclx::relay::relayShapeFanout(A, H).totalPerTile) *
+                          T +
+                      1)) /
+                    CHUNK_ALIGN_ELEMENTS) *
+      CHUNK_ALIGN_ELEMENTS;
+  if (w == 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t tileStride = static_cast<size_t>(T) * w;
+  const size_t offloadTotal = static_cast<size_t>(H) * tileStride;
+  const size_t directSz = rc - offloadTotal;
+  const size_t heavy = static_cast<size_t>(A - 1) * w;
+  auto directOffset = [&](int k) -> size_t {
+    return static_cast<size_t>(k) * heavy;
+  };
+  auto directSize = [&](int k) -> size_t {
+    return (k < T) ? heavy : (directSz - directOffset(T));
+  };
+
+  // Active-rank scratch, both mirroring the flat path so the closing reduction
+  // is identical: dScratch holds the A-1 peer contributions to my direct
+  // region, one contiguous directSz block each; oScratch mirrors my output's
+  // offload region.
+  void* dScratch = nullptr;
+  void* oScratch = nullptr;
+  bool isInPlace = false;
+  if (myActiveGroup == 0) {
+    const char* ownBlock = static_cast<const char*>(sendBuffs[0]) +
+        static_cast<size_t>(cfg.myActiveIndex) * rc * elementSize;
+    isInPlace =
+        (static_cast<const void*>(recvBuffs[0]) ==
+         static_cast<const void*>(ownBlock));
+    dScratch = ScratchBufferCache::getInstance().get(
+        SHARDED_RELAY_MAX_GROUPS,
+        static_cast<size_t>(A - 1) * directSz * elementSize,
+        stream);
+    oScratch = ScratchBufferCache::getInstance().get(
+        0, offloadTotal * elementSize, stream);
+    if (dScratch == nullptr || oScratch == nullptr) {
+      return ncclInternalError;
+    }
+  }
+
+  // Helper staging: one slot per (owner, contributing source) per ping-pong
+  // buffer. Laid out buffer-major so that for a fixed buffer and owner the A-1
+  // contributions are contiguous with stride w, which is what the fused
+  // multi-input reduce below requires.
+  char* hbuff = nullptr;
+  const size_t slotsPerBuf = static_cast<size_t>(A) * (A - 1);
+  if (!cfg.isActiveRank) {
+    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+        kHelperScratchKeyBase, 2 * slotsPerBuf * w * elementSize, stream));
+    if (hbuff == nullptr) {
+      return ncclInternalError;
+    }
+  }
+  auto helperSlot = [&](int owner, int t, int k) -> char* {
+    return hbuff +
+        ((static_cast<size_t>(k % 2) * slotsPerBuf +
+          static_cast<size_t>(owner) * (A - 1) + static_cast<size_t>(t)) *
+         w) *
+        elementSize;
+  };
+
+  for (int k = 0; k <= T; k++) {
+    NCCLCHECK(ncclGroupStart());
+    if (cfg.isActiveRank) {
+      const char* sendbuff = static_cast<const char*>(sendBuffs[0]);
+      const int m = cfg.myActiveIndex;
+      const size_t dOff = directOffset(k);
+      const size_t dSz = directSize(k);
+
+      // Direct reduce-scatter: my chunk of block j goes to its owner j.
+      for (int j = 0; j < A; j++) {
+        if (j == m) {
+          continue;
+        }
+        NCCLCHECK(ncclSend(
+            sendbuff + (static_cast<size_t>(j) * rc + dOff) * elementSize,
+            dSz,
+            datatype,
+            cfg.activeRanks[j],
+            comm,
+            stream));
+      }
+      if (k < T) {
+        // Offload scatter: helper h gets tile k of each of my foreign blocks.
+        for (int h = 0; h < H; h++) {
+          for (int j = 0; j < A; j++) {
+            if (j == m) {
+              continue;
+            }
+            NCCLCHECK(ncclSend(
+                sendbuff +
+                    (static_cast<size_t>(j) * rc + directSz +
+                     static_cast<size_t>(h) * tileStride +
+                     static_cast<size_t>(k) * w) *
+                        elementSize,
+                w,
+                datatype,
+                cfg.helperRanks[h],
+                comm,
+                stream));
+          }
+        }
+      }
+      for (int s = 0; s < A; s++) {
+        if (s == m) {
+          continue;
+        }
+        const int p = (s < m) ? s : s - 1;
+        NCCLCHECK(ncclRecv(
+            static_cast<char*>(dScratch) +
+                (static_cast<size_t>(p) * directSz + dOff) * elementSize,
+            dSz,
+            datatype,
+            cfg.activeRanks[s],
+            comm,
+            stream));
+      }
+      if (k > 0) {
+        // One already-reduced tile per helper, landing where my output wants
+        // it.
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclRecv(
+              static_cast<char*>(oScratch) +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k - 1) * w) *
+                      elementSize,
+              w,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+    } else {
+      if (k < T) {
+        // Collect owner j's tile k from every contributing source s != j. The
+        // per-peer order matches each source's send order above.
+        for (int s = 0; s < A; s++) {
+          for (int j = 0; j < A; j++) {
+            if (j == s) {
+              continue;
+            }
+            const int t = (s < j) ? s : s - 1;
+            NCCLCHECK(ncclRecv(
+                helperSlot(j, t, k),
+                w,
+                datatype,
+                cfg.activeRanks[s],
+                comm,
+                stream));
+          }
+        }
+      }
+      if (k > 0) {
+        for (int j = 0; j < A; j++) {
+          NCCLCHECK(ncclSend(
+              helperSlot(j, 0, k - 1),
+              w,
+              datatype,
+              cfg.activeRanks[j],
+              comm,
+              stream));
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+
+    // Sum this tile's A-1 contributions per owner, before the next group ships
+    // them. No divisor here: the owner applies it once at the end.
+    if (!cfg.isActiveRank && k < T) {
+      for (int j = 0; j < A; j++) {
+        char* dst = helperSlot(j, 0, k);
+        DISPATCH_MULTI_REDUCE(
+            datatype, dst, dst + w * elementSize, A - 2, w, 1, stream);
+      }
+    }
+  }
+
+  // Owner reduce, identical to the flat path: one fused pass over the direct
+  // region and one over the offload region.
+  if (myActiveGroup == 0) {
+    char* out = static_cast<char*>(recvBuffs[0]);
+    const char* ownBlock = static_cast<const char*>(sendBuffs[0]) +
+        static_cast<size_t>(cfg.myActiveIndex) * rc * elementSize;
+
+    if (A == 4 && !isInPlace) {
+      DISPATCH_SEEDED_MULTI_REDUCE(
+          datatype,
+          out,
+          ownBlock,
+          dScratch,
+          A - 1,
+          directSz,
+          reductionDivisor,
+          stream);
+    } else {
+      if (!isInPlace) {
+        cudaMemcpyAsync(
+            out,
+            ownBlock,
+            directSz * elementSize,
+            cudaMemcpyDeviceToDevice,
+            stream);
+      }
+      DISPATCH_MULTI_REDUCE(
+          datatype, out, dScratch, A - 1, directSz, reductionDivisor, stream);
+    }
+
+    char* oOut = out + directSz * elementSize;
+    if (isInPlace) {
+      if (reductionDivisor > 1) {
+        DISPATCH_INCREMENTAL_ADD_AND_SCALE(
+            datatype, oOut, oScratch, offloadTotal, reductionDivisor, stream);
+      } else {
+        DISPATCH_INCREMENTAL_ADD(
+            datatype, oOut, oScratch, offloadTotal, stream);
+      }
+    } else {
+      DISPATCH_FUSED_REDUCE(
+          datatype,
+          oOut,
+          ownBlock + directSz * elementSize,
+          oScratch,
+          offloadTotal,
+          reductionDivisor,
+          stream);
+    }
+  }
+
+  return ncclSuccess;
+}
+
+/**
  * Fused Multi-Group Sharded Relay Reduce-Scatter.
  *
  * Executes multiple sharded relay reduce-scatters in one fused call,
@@ -1751,7 +2044,36 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
         elementSize);
   }
   // A>2: two-group flat relay with reduce-at-helper woven with a direct
-  // all-to-all reduce-scatter over the intra links.
+  // all-to-all reduce-scatter over the intra links. A single-group call with
+  // the offload enabled can additionally be software-pipelined so the scatter
+  // and the reduced return share each cross link's two directions.
+  const bool offload =
+      rcclx::relay::selectReduceScatterRoute(
+          nActiveRanksPerGroup, numHelpers, nGroups, recvCounts, elementSize) ==
+      rcclx::relay::ReduceScatterRoute::FlatOffload;
+  const int nTiles = offload
+      ? rcclx::relay::relayPipelineTiles(
+            nGroups,
+            rcclx::relay::relayShapeFanout(nActiveRanksPerGroup, numHelpers),
+            rcclx::relay::relayMaxCount(recvCounts, nGroups),
+            elementSize)
+      : 1;
+  if (nTiles > 1) {
+    return shardedRelayReduceScatterFlatPipelined(
+        sendBuffs,
+        recvBuffs,
+        recvCounts,
+        datatype,
+        reductionDivisor,
+        comm,
+        stream,
+        configs,
+        myActiveGroup,
+        numHelpers,
+        nActiveRanksPerGroup,
+        nTiles,
+        elementSize);
+  }
   return shardedRelayReduceScatterFlat(
       sendBuffs,
       recvBuffs,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -9,6 +9,7 @@
 #include "sharded_relay_reduce_scatter.h"
 #include "comm.h"
 #include "sharded_relay_allreduce_kernels.h"
+#include "sharded_relay_graph_scratch.h"
 #include "sharded_relay_oneshot.h"
 #include "sharded_relay_route.h"
 
@@ -51,6 +52,25 @@ class ScratchBufferCache {
   void* get(int key, size_t requiredBytes, cudaStream_t stream) {
     if (requiredBytes == 0) {
       return nullptr;
+    }
+
+    // A capturing stream must not use this cache. hipMallocAsync would record
+    // an allocation node whose address is only valid while the graph runs, and
+    // a later growth would hipFreeAsync a pointer this graph has already baked
+    // in. Captures get a graph-scoped buffer instead; see
+    // sharded_relay_graph_scratch.h.
+    //
+    // Ahead of the lock on purpose: this is a HIP runtime call, and there is no
+    // reason to hold a process-wide mutex across it while relay collectives run
+    // concurrently on other streams. Measured either way it is in the noise, so
+    // this is hygiene rather than a fix for anything.
+    struct ncclCudaGraph graph;
+    if (ncclCudaGetCapturingGraph(&graph, stream) != ncclSuccess) {
+      return nullptr;
+    }
+    if (ncclCudaGraphValid(graph)) {
+      return rcclx::relay::graphScratchGet(
+          this, key, requiredBytes, stream, graph);
     }
 
     int device;

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -15,9 +15,11 @@
 
 #include <hip/hip_bfloat16.h>
 #include <hip/hip_fp16.h>
+#include <algorithm>
 #include <map>
 #include <mutex>
 #include <tuple>
+#include <vector>
 
 // GPU memory access alignment in elements for chunk size rounding.
 // Distinct from the CPU CACHE_LINE_SIZE (64 bytes) defined in comm.h
@@ -159,9 +161,10 @@ class ScratchBufferCache {
  * closing join creates a side -> caller dependency, so group k+1 never waits on
  * the reduce of stage k.
  *
- * One stream and one event pool per (device, caller stream), for the same
- * reason ScratchBufferCache keys on the stream: two relay collectives can run
- * concurrently on one device on different streams.
+ * One stream and one event pool per (device, caller stream, graph id), for the
+ * same reason ScratchBufferCache keys on the stream: two relay collectives can
+ * run concurrently on one device on different streams. The graph id is part of
+ * the key because a stream can only belong to one capture at a time.
  */
 class ReduceOverlapCache {
  public:
@@ -184,20 +187,78 @@ class ReduceOverlapCache {
 
   // Returns nullptr if the resources could not be created, in which case the
   // caller must fall back to one reduce on its own stream.
-  const Handle* get(cudaStream_t callerStream) {
+  //
+  // A capture gets its own stream and event pool, keyed on the graph id. The
+  // handshake here (record on the caller's stream, wait on the side stream,
+  // rejoin at the end) is exactly the fork/join shape capture understands, so
+  // the side stream is pulled into the graph by the event dependency and its
+  // reduces become a parallel branch. What is NOT safe is sharing one side
+  // stream between a capture and anything else, since a stream can only belong
+  // to one capture at a time -- hence one per graph.
+  const Handle* get(cudaStream_t callerStream, struct ncclCudaGraph graph) {
     int device;
     if (cudaGetDevice(&device) != cudaSuccess) {
       return nullptr;
     }
 
-    std::lock_guard<std::mutex> lock(mutex_);
-    auto& entry = handles_[std::make_pair(
-        device, static_cast<const void*>(callerStream))];
-    if (!entry.tried) {
-      entry.tried = true;
-      entry.valid = create(&entry.handle);
+    // Drains outside mutex_, so a blocking stream/event destroy cannot stall
+    // every other relay collective waiting for this cache.
+    reclaimDead();
+
+    const Key key{
+        device, static_cast<const void*>(callerStream), graph.graphId};
+
+    Handle orphaned{};
+    bool haveOrphan = false;
+    const Handle* result = nullptr;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      Entry& entry = handles_[key];
+      if (!entry.tried) {
+        entry.tried = true;
+        {
+          // create() is stream/event creation, which is exactly the kind of
+          // potentially-unsafe runtime call that invalidates an in-progress
+          // capture under the default thread-local mode. get() is now called
+          // WHILE the caller's stream is capturing, so the exchange is
+          // required; sharded_relay_graph_scratch.cc does the same around its
+          // allocation.
+          RelaxedCaptureMode relaxed;
+          entry.valid = create(&entry.handle);
+        }
+        if (ncclCudaGraphValid(graph)) {
+          // The stream and events only carry capture topology; the graph holds
+          // its own copy of the resulting nodes and does not touch either at
+          // replay. So they are dead weight the moment the graph is gone, and
+          // tying them to it keeps a process that captures repeatedly from
+          // accumulating a stream and 10 events per graph forever.
+          //
+          // Registered even when create() FAILED: the destructor is what erases
+          // this entry, so without it a failed attempt would leave a node per
+          // graph id behind for the life of the process. destroy() on an
+          // all-null handle is a no-op, so reclaim handles both cases.
+          auto* tag = new unsigned long long(graph.graphId);
+          if (ncclCudaGraphAddDestructor(graph, graphDiedCallback, tag) !=
+              ncclSuccess) {
+            delete tag;
+            // Nothing will ever reclaim this entry now, so do not leave it (or
+            // its stream and 10 events) behind. Destroyed after the lock drops.
+            orphaned = entry.handle;
+            haveOrphan = true;
+            handles_.erase(key);
+          }
+        }
+      }
+      if (!haveOrphan) {
+        result = entry.valid ? &entry.handle : nullptr;
+      }
     }
-    return entry.valid ? &entry.handle : nullptr;
+
+    if (haveOrphan) {
+      RelaxedCaptureMode relaxed;
+      destroy(&orphaned);
+    }
+    return result;
   }
 
   ReduceOverlapCache(const ReduceOverlapCache&) = delete;
@@ -206,6 +267,30 @@ class ReduceOverlapCache {
  private:
   ReduceOverlapCache() = default;
   ~ReduceOverlapCache() = default;
+
+  using Key = std::tuple<int, const void*, unsigned long long>;
+
+  // Puts the calling thread in relaxed capture mode for its lifetime. Under the
+  // default mode, a potentially-unsafe runtime call made on a thread with a
+  // capture in progress invalidates that capture; relaxed mode is what makes
+  // stream/event creation and destruction legal here.
+  class RelaxedCaptureMode {
+   public:
+    RelaxedCaptureMode() {
+      ok_ = cudaThreadExchangeStreamCaptureMode(&mode_) == cudaSuccess;
+    }
+    ~RelaxedCaptureMode() {
+      if (ok_) {
+        (void)cudaThreadExchangeStreamCaptureMode(&mode_);
+      }
+    }
+    RelaxedCaptureMode(const RelaxedCaptureMode&) = delete;
+    RelaxedCaptureMode& operator=(const RelaxedCaptureMode&) = delete;
+
+   private:
+    cudaStreamCaptureMode mode_{cudaStreamCaptureModeRelaxed};
+    bool ok_{true};
+  };
 
   // cudaStreamNonBlocking so the side stream does not implicitly synchronize
   // with the legacy default stream; all ordering here is explicit via events.
@@ -255,9 +340,73 @@ class ReduceOverlapCache {
     bool valid = false;
   };
 
+  // Runs when a graph is destroyed, possibly on a HIP-internal thread, so it
+  // records the id and nothing more -- destroying a stream or an event from
+  // here would be a HIP call in an unspecified context. reclaimDeadLocked does
+  // the work on the next get(), on a user thread.
+  static void graphDiedCallback(void* arg) {
+    auto* graphId = static_cast<unsigned long long*>(arg);
+    {
+      std::lock_guard<std::mutex> lock(deadMutex());
+      deadGraphs().push_back(*graphId);
+    }
+    delete graphId;
+  }
+
+  static std::mutex& deadMutex() {
+    static std::mutex m;
+    return m;
+  }
+
+  static std::vector<unsigned long long>& deadGraphs() {
+    static std::vector<unsigned long long> v;
+    return v;
+  }
+
+  // Erases the entries of every graph whose destructor has fired, then destroys
+  // their streams and events OUTSIDE mutex_. Stream and event destruction can
+  // block on in-flight work, and this runs at the start of every get(), so
+  // doing it under the lock would serialize every other relay collective on the
+  // device. sharded_relay_graph_scratch.cc's reclaimDeadGraphs() frees outside
+  // its table lock for the same reason.
+  void reclaimDead() {
+    std::vector<unsigned long long> dead;
+    {
+      std::lock_guard<std::mutex> lock(deadMutex());
+      if (deadGraphs().empty()) {
+        return;
+      }
+      dead.swap(deadGraphs());
+    }
+
+    std::vector<Handle> stale;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      for (auto it = handles_.begin(); it != handles_.end();) {
+        const unsigned long long id = std::get<2>(it->first);
+        if (std::find(dead.begin(), dead.end(), id) != dead.end()) {
+          stale.push_back(it->second.handle);
+          it = handles_.erase(it);
+        } else {
+          ++it;
+        }
+      }
+    }
+
+    if (stale.empty()) {
+      return;
+    }
+    RelaxedCaptureMode relaxed;
+    for (Handle& h : stale) {
+      destroy(&h);
+    }
+  }
+
   std::mutex mutex_;
-  // (device, caller stream) -> side stream and its event pool.
-  std::map<std::pair<int, const void*>, Entry> handles_;
+  // (device, caller stream, graph id) -> side stream and its event pool. The
+  // graph id is ULLONG_MAX for uncaptured calls, so they all share one entry
+  // per stream exactly as before.
+  std::map<Key, Entry> handles_;
 };
 
 // Maximum number of helper ranks supported per group.
@@ -1578,14 +1727,19 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
   };
 
   // Per-region reduces run on a side stream so they overlap the transfers that
-  // follow. Four things force the single trailing pass on the caller's stream
+  // follow. Three things force the single trailing pass on the caller's stream
   // instead: a depth deeper than the event pool (a depth-T pipeline runs T+1
   // groups and each needs its own event, so this bounds the overlap to the pool
   // rather than letting a raised kRelayMaxPipelineTiles index past it); a
   // message too small for the overlap to pay for its event traffic (see
-  // kRelayOverlapReduceMinBytes); graph capture, because RCCL requires every
-  // stream in a group to be captured by the same graph and the side stream is
-  // uncaptured; and any failure to create the side stream or its events.
+  // kRelayOverlapReduceMinBytes); and any failure to create the side stream or
+  // its events.
+  //
+  // Graph capture used to be a fourth. It is not, because the record/wait pair
+  // below is the fork/join shape capture is defined for: the side stream joins
+  // the capture through the event dependency, its reduces are captured as a
+  // parallel branch, and the allDone wait rejoins the origin before the capture
+  // ends. Only the resources have to be per graph, which the cache key handles.
   const bool ownerReduces = (myActiveGroup == 0);
   const ReduceOverlapCache::Handle* ovl = nullptr;
   if (ownerReduces && T + 1 <= ReduceOverlapCache::kStageEvents &&
@@ -1593,88 +1747,121 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
           rcclx::relay::kRelayOverlapReduceMinBytes) {
     struct ncclCudaGraph graph;
     NCCLCHECK(ncclCudaGetCapturingGraph(&graph, stream));
-    if (!ncclCudaGraphValid(graph)) {
-      ovl = ReduceOverlapCache::getInstance().get(stream);
-    }
+    ovl = ReduceOverlapCache::getInstance().get(stream, graph);
   }
 
-  for (int k = 0; k <= T; k++) {
-    NCCLCHECK(ncclGroupStart());
-    if (cfg.isActiveRank) {
-      const char* sendBlock = static_cast<const char*>(sendBuffs[0]) +
-          sendBlockOffset * elementSize;
-      char* scratch = static_cast<char*>(foreignScratch);
-      const int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
-      const size_t dOff = directOffset(k);
-      const size_t dSz = directSize(k);
+  // Once the side stream has been attached to the caller's stream, EVERY exit
+  // from here has to rejoin it, error paths included. A capture that ends with
+  // a forked-but-unjoined branch fails at cudaStreamEndCapture -- so an error
+  // mid-pipeline would cost the whole graph rather than just this call -- and
+  // leaves the cached side stream in a capturing state, poisoning it for every
+  // later call that keys onto the same handle. The pipeline therefore runs in a
+  // lambda whose result is held until after the join below.
+  bool forked = false;
+  const ncclResult_t pipelineResult = [&]() -> ncclResult_t {
+    for (int k = 0; k <= T; k++) {
+      NCCLCHECK(ncclGroupStart());
+      if (cfg.isActiveRank) {
+        const char* sendBlock = static_cast<const char*>(sendBuffs[0]) +
+            sendBlockOffset * elementSize;
+        char* scratch = static_cast<char*>(foreignScratch);
+        const int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+        const size_t dOff = directOffset(k);
+        const size_t dSz = directSize(k);
 
-      if (k < T) {
-        for (int h = 0; h < H; h++) {
-          NCCLCHECK(ncclSend(
-              sendBlock + relayOffset(h, k) * elementSize,
-              u,
-              datatype,
-              cfg.helperRanks[h],
-              comm,
-              stream));
+        if (k < T) {
+          for (int h = 0; h < H; h++) {
+            NCCLCHECK(ncclSend(
+                sendBlock + relayOffset(h, k) * elementSize,
+                u,
+                datatype,
+                cfg.helperRanks[h],
+                comm,
+                stream));
+          }
+        }
+        NCCLCHECK(ncclSend(
+            sendBlock + dOff * elementSize,
+            dSz,
+            datatype,
+            partner,
+            comm,
+            stream));
+        if (k > 0) {
+          for (int h = 0; h < H; h++) {
+            NCCLCHECK(ncclRecv(
+                scratch + relayOffset(h, k - 1) * elementSize,
+                u,
+                datatype,
+                cfg.helperRanks[h],
+                comm,
+                stream));
+          }
+        }
+        NCCLCHECK(ncclRecv(
+            scratch + dOff * elementSize,
+            dSz,
+            datatype,
+            partner,
+            comm,
+            stream));
+      } else {
+        if (k < T) {
+          for (int a = 0; a < cfg.nActiveRanks; a++) {
+            NCCLCHECK(ncclRecv(
+                helperSlot(a, k),
+                u,
+                datatype,
+                cfg.activeRanks[a],
+                comm,
+                stream));
+          }
+        }
+        if (k > 0) {
+          for (int a = 0; a < cfg.nActiveRanks; a++) {
+            NCCLCHECK(ncclSend(
+                helperSlot(a, k - 1),
+                u,
+                datatype,
+                cfg.activeRanks[1 - a],
+                comm,
+                stream));
+          }
         }
       }
-      NCCLCHECK(ncclSend(
-          sendBlock + dOff * elementSize,
-          dSz,
-          datatype,
-          partner,
-          comm,
-          stream));
-      if (k > 0) {
-        for (int h = 0; h < H; h++) {
-          NCCLCHECK(ncclRecv(
-              scratch + relayOffset(h, k - 1) * elementSize,
-              u,
-              datatype,
-              cfg.helperRanks[h],
-              comm,
-              stream));
-        }
-      }
-      NCCLCHECK(ncclRecv(
-          scratch + dOff * elementSize, dSz, datatype, partner, comm, stream));
-    } else {
-      if (k < T) {
-        for (int a = 0; a < cfg.nActiveRanks; a++) {
-          NCCLCHECK(ncclRecv(
-              helperSlot(a, k), u, datatype, cfg.activeRanks[a], comm, stream));
-        }
-      }
-      if (k > 0) {
-        for (int a = 0; a < cfg.nActiveRanks; a++) {
-          NCCLCHECK(ncclSend(
-              helperSlot(a, k - 1),
-              u,
-              datatype,
-              cfg.activeRanks[1 - a],
-              comm,
-              stream));
-        }
+      NCCLCHECK(ncclGroupEnd());
+
+      // Region k has landed in full. Reduce it now, on the side stream, so it
+      // overlaps groups k+1..T instead of waiting behind them.
+      if (ovl != nullptr) {
+        CUDACHECK(cudaEventRecord(ovl->stageDone[k], stream));
+        CUDACHECK(cudaStreamWaitEvent(ovl->stream, ovl->stageDone[k], 0));
+        // The wait is what attaches the side stream, so the join is owed from
+        // here on -- not from the record, which on its own leaves it detached.
+        forked = true;
+        reduceSpan(regionOffset(k), regionSize(k), ovl->stream);
       }
     }
-    NCCLCHECK(ncclGroupEnd());
+    return ncclSuccess;
+  }();
 
-    // Region k has landed in full. Reduce it now, on the side stream, so it
-    // overlaps groups k+1..T instead of waiting behind them.
-    if (ovl != nullptr) {
-      CUDACHECK(cudaEventRecord(ovl->stageDone[k], stream));
-      CUDACHECK(cudaStreamWaitEvent(ovl->stream, ovl->stageDone[k], 0));
-      reduceSpan(regionOffset(k), regionSize(k), ovl->stream);
-    }
-  }
-
-  if (ovl != nullptr) {
+  if (forked) {
     // The caller's stream must not observe the output before the last region's
-    // reduce has retired. This is the only side -> caller dependency.
-    CUDACHECK(cudaEventRecord(ovl->allDone, ovl->stream));
-    CUDACHECK(cudaStreamWaitEvent(stream, ovl->allDone, 0));
-  } else if (ownerReduces) {
+    // reduce has retired. This is the only side -> caller dependency, and it is
+    // issued even when the pipeline failed, to close the fork. Both calls are
+    // attempted before any error is reported, and the pipeline's own failure
+    // takes precedence, since that is the one that describes what went wrong.
+    const cudaError_t joinRecord = cudaEventRecord(ovl->allDone, ovl->stream);
+    const cudaError_t joinWait = cudaStreamWaitEvent(stream, ovl->allDone, 0);
+    if (pipelineResult != ncclSuccess) {
+      return pipelineResult;
+    }
+    CUDACHECK(joinRecord);
+    CUDACHECK(joinWait);
+  } else if (pipelineResult != ncclSuccess) {
+    return pipelineResult;
+  }
+  if (ovl == nullptr && ownerReduces) {
     // Fallback: one pass over the whole output block on the caller's stream.
     reduceSpan(0, recvcount, stream);
   }

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -628,148 +628,166 @@ bool buildShardedRelayRankConfig(
 // worth an instantiation, and an unsupported type must fall through to the
 // ncclSend/ncclRecv schedule rather than silently do nothing, so the caller
 // checks the bool this sets.
-#define DISPATCH_ONESHOT_REDUCE_SCATTER(                 \
-    datatype,                                            \
-    handled,                                             \
-    out,                                                 \
-    sendBuff,                                            \
-    table,                                               \
-    ranks,                                               \
-    nActive,                                             \
-    myRank,                                              \
-    mySlot,                                              \
-    rc,                                                  \
-    slotBytes,                                           \
-    epoch,                                               \
-    divisor,                                             \
-    stream)                                              \
-  do {                                                   \
-    (handled) = true;                                    \
-    switch (datatype) {                                  \
-      case ncclInt32:                                    \
-        launchOneShotReduceScatterKernel<int32_t>(       \
-            out,                                         \
-            sendBuff,                                    \
-            table,                                       \
-            ranks,                                       \
-            nActive,                                     \
-            myRank,                                      \
-            mySlot,                                      \
-            rc,                                          \
-            slotBytes,                                   \
-            epoch,                                       \
-            divisor,                                     \
-            stream);                                     \
-        break;                                           \
-      case ncclUint32:                                   \
-        launchOneShotReduceScatterKernel<uint32_t>(      \
-            out,                                         \
-            sendBuff,                                    \
-            table,                                       \
-            ranks,                                       \
-            nActive,                                     \
-            myRank,                                      \
-            mySlot,                                      \
-            rc,                                          \
-            slotBytes,                                   \
-            epoch,                                       \
-            divisor,                                     \
-            stream);                                     \
-        break;                                           \
-      case ncclInt64:                                    \
-        launchOneShotReduceScatterKernel<int64_t>(       \
-            out,                                         \
-            sendBuff,                                    \
-            table,                                       \
-            ranks,                                       \
-            nActive,                                     \
-            myRank,                                      \
-            mySlot,                                      \
-            rc,                                          \
-            slotBytes,                                   \
-            epoch,                                       \
-            divisor,                                     \
-            stream);                                     \
-        break;                                           \
-      case ncclUint64:                                   \
-        launchOneShotReduceScatterKernel<uint64_t>(      \
-            out,                                         \
-            sendBuff,                                    \
-            table,                                       \
-            ranks,                                       \
-            nActive,                                     \
-            myRank,                                      \
-            mySlot,                                      \
-            rc,                                          \
-            slotBytes,                                   \
-            epoch,                                       \
-            divisor,                                     \
-            stream);                                     \
-        break;                                           \
-      case ncclFloat16:                                  \
-        launchOneShotReduceScatterKernel<__half>(        \
-            out,                                         \
-            sendBuff,                                    \
-            table,                                       \
-            ranks,                                       \
-            nActive,                                     \
-            myRank,                                      \
-            mySlot,                                      \
-            rc,                                          \
-            slotBytes,                                   \
-            epoch,                                       \
-            divisor,                                     \
-            stream);                                     \
-        break;                                           \
-      case ncclFloat:                                    \
-        launchOneShotReduceScatterKernel<float>(         \
-            out,                                         \
-            sendBuff,                                    \
-            table,                                       \
-            ranks,                                       \
-            nActive,                                     \
-            myRank,                                      \
-            mySlot,                                      \
-            rc,                                          \
-            slotBytes,                                   \
-            epoch,                                       \
-            divisor,                                     \
-            stream);                                     \
-        break;                                           \
-      case ncclDouble:                                   \
-        launchOneShotReduceScatterKernel<double>(        \
-            out,                                         \
-            sendBuff,                                    \
-            table,                                       \
-            ranks,                                       \
-            nActive,                                     \
-            myRank,                                      \
-            mySlot,                                      \
-            rc,                                          \
-            slotBytes,                                   \
-            epoch,                                       \
-            divisor,                                     \
-            stream);                                     \
-        break;                                           \
-      case ncclBfloat16:                                 \
-        launchOneShotReduceScatterKernel<__nv_bfloat16>( \
-            out,                                         \
-            sendBuff,                                    \
-            table,                                       \
-            ranks,                                       \
-            nActive,                                     \
-            myRank,                                      \
-            mySlot,                                      \
-            rc,                                          \
-            slotBytes,                                   \
-            epoch,                                       \
-            divisor,                                     \
-            stream);                                     \
-        break;                                           \
-      default:                                           \
-        (handled) = false;                               \
-        break;                                           \
-    }                                                    \
+#define DISPATCH_ONESHOT_REDUCE_SCATTER(              \
+    datatype,                                         \
+    handled,                                          \
+    out,                                              \
+    sendBuff,                                         \
+    table,                                            \
+    ranks,                                            \
+    nActive,                                          \
+    myRank,                                           \
+    mySlot,                                           \
+    rc,                                               \
+    srcStride,                                        \
+    ownOffset,                                        \
+    slotBytes,                                        \
+    epoch,                                            \
+    divisor,                                          \
+    stream)                                           \
+  do {                                                \
+    (handled) = true;                                 \
+    switch (datatype) {                               \
+      case ncclInt32:                                 \
+        launchOneShotPushReduceKernel<int32_t>(       \
+            out,                                      \
+            sendBuff,                                 \
+            table,                                    \
+            ranks,                                    \
+            nActive,                                  \
+            myRank,                                   \
+            mySlot,                                   \
+            rc,                                       \
+            srcStride,                                \
+            ownOffset,                                \
+            slotBytes,                                \
+            epoch,                                    \
+            divisor,                                  \
+            stream);                                  \
+        break;                                        \
+      case ncclUint32:                                \
+        launchOneShotPushReduceKernel<uint32_t>(      \
+            out,                                      \
+            sendBuff,                                 \
+            table,                                    \
+            ranks,                                    \
+            nActive,                                  \
+            myRank,                                   \
+            mySlot,                                   \
+            rc,                                       \
+            srcStride,                                \
+            ownOffset,                                \
+            slotBytes,                                \
+            epoch,                                    \
+            divisor,                                  \
+            stream);                                  \
+        break;                                        \
+      case ncclInt64:                                 \
+        launchOneShotPushReduceKernel<int64_t>(       \
+            out,                                      \
+            sendBuff,                                 \
+            table,                                    \
+            ranks,                                    \
+            nActive,                                  \
+            myRank,                                   \
+            mySlot,                                   \
+            rc,                                       \
+            srcStride,                                \
+            ownOffset,                                \
+            slotBytes,                                \
+            epoch,                                    \
+            divisor,                                  \
+            stream);                                  \
+        break;                                        \
+      case ncclUint64:                                \
+        launchOneShotPushReduceKernel<uint64_t>(      \
+            out,                                      \
+            sendBuff,                                 \
+            table,                                    \
+            ranks,                                    \
+            nActive,                                  \
+            myRank,                                   \
+            mySlot,                                   \
+            rc,                                       \
+            srcStride,                                \
+            ownOffset,                                \
+            slotBytes,                                \
+            epoch,                                    \
+            divisor,                                  \
+            stream);                                  \
+        break;                                        \
+      case ncclFloat16:                               \
+        launchOneShotPushReduceKernel<__half>(        \
+            out,                                      \
+            sendBuff,                                 \
+            table,                                    \
+            ranks,                                    \
+            nActive,                                  \
+            myRank,                                   \
+            mySlot,                                   \
+            rc,                                       \
+            srcStride,                                \
+            ownOffset,                                \
+            slotBytes,                                \
+            epoch,                                    \
+            divisor,                                  \
+            stream);                                  \
+        break;                                        \
+      case ncclFloat:                                 \
+        launchOneShotPushReduceKernel<float>(         \
+            out,                                      \
+            sendBuff,                                 \
+            table,                                    \
+            ranks,                                    \
+            nActive,                                  \
+            myRank,                                   \
+            mySlot,                                   \
+            rc,                                       \
+            srcStride,                                \
+            ownOffset,                                \
+            slotBytes,                                \
+            epoch,                                    \
+            divisor,                                  \
+            stream);                                  \
+        break;                                        \
+      case ncclDouble:                                \
+        launchOneShotPushReduceKernel<double>(        \
+            out,                                      \
+            sendBuff,                                 \
+            table,                                    \
+            ranks,                                    \
+            nActive,                                  \
+            myRank,                                   \
+            mySlot,                                   \
+            rc,                                       \
+            srcStride,                                \
+            ownOffset,                                \
+            slotBytes,                                \
+            epoch,                                    \
+            divisor,                                  \
+            stream);                                  \
+        break;                                        \
+      case ncclBfloat16:                              \
+        launchOneShotPushReduceKernel<__nv_bfloat16>( \
+            out,                                      \
+            sendBuff,                                 \
+            table,                                    \
+            ranks,                                    \
+            nActive,                                  \
+            myRank,                                   \
+            mySlot,                                   \
+            rc,                                       \
+            srcStride,                                \
+            ownOffset,                                \
+            slotBytes,                                \
+            epoch,                                    \
+            divisor,                                  \
+            stream);                                  \
+        break;                                        \
+      default:                                        \
+        (handled) = false;                            \
+        break;                                        \
+    }                                                 \
   } while (0)
 
 // Try the one-shot IPC kernel for a single-group A-active reduce-scatter, and
@@ -841,6 +859,9 @@ static bool tryOneShotReduceScatter(
       comm->rank,
       cfg.myActiveIndex,
       recvCounts[myActiveGroup],
+      /*srcStride=*/recvCounts[myActiveGroup],
+      /*ownOffset=*/static_cast<size_t>(cfg.myActiveIndex) *
+          recvCounts[myActiveGroup],
       osl.slotBytes,
       osl.epoch,
       reductionDivisor,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -623,154 +623,234 @@ bool buildShardedRelayRankConfig(
     }                                                                      \
   } while (0)
 
-// Dtype dispatch for the one-shot 2-rank reduce-scatter. Deliberately narrower
-// than the other macros: only the types the small-message paths actually see
-// are worth an instantiation, and an unsupported type must fall through to the
+// Dtype dispatch for the one-shot reduce-scatter. Deliberately narrower than
+// the other macros: only the types the small-message paths actually see are
+// worth an instantiation, and an unsupported type must fall through to the
 // ncclSend/ncclRecv schedule rather than silently do nothing, so the caller
 // checks the bool this sets.
-#define DISPATCH_ONESHOT_REDUCE_SCATTER2(                 \
-    datatype,                                             \
-    handled,                                              \
-    out,                                                  \
-    sendBuff,                                             \
-    table,                                                \
-    myRank,                                               \
-    peerRank,                                             \
-    mySlot,                                               \
-    peerSlot,                                             \
-    rc,                                                   \
-    slotBytes,                                            \
-    epoch,                                                \
-    divisor,                                              \
-    stream)                                               \
-  do {                                                    \
-    (handled) = true;                                     \
-    switch (datatype) {                                   \
-      case ncclInt32:                                     \
-        launchOneShotReduceScatter2Kernel<int32_t>(       \
-            out,                                          \
-            sendBuff,                                     \
-            table,                                        \
-            myRank,                                       \
-            peerRank,                                     \
-            mySlot,                                       \
-            peerSlot,                                     \
-            rc,                                           \
-            slotBytes,                                    \
-            epoch,                                        \
-            divisor,                                      \
-            stream);                                      \
-        break;                                            \
-      case ncclUint32:                                    \
-        launchOneShotReduceScatter2Kernel<uint32_t>(      \
-            out,                                          \
-            sendBuff,                                     \
-            table,                                        \
-            myRank,                                       \
-            peerRank,                                     \
-            mySlot,                                       \
-            peerSlot,                                     \
-            rc,                                           \
-            slotBytes,                                    \
-            epoch,                                        \
-            divisor,                                      \
-            stream);                                      \
-        break;                                            \
-      case ncclInt64:                                     \
-        launchOneShotReduceScatter2Kernel<int64_t>(       \
-            out,                                          \
-            sendBuff,                                     \
-            table,                                        \
-            myRank,                                       \
-            peerRank,                                     \
-            mySlot,                                       \
-            peerSlot,                                     \
-            rc,                                           \
-            slotBytes,                                    \
-            epoch,                                        \
-            divisor,                                      \
-            stream);                                      \
-        break;                                            \
-      case ncclUint64:                                    \
-        launchOneShotReduceScatter2Kernel<uint64_t>(      \
-            out,                                          \
-            sendBuff,                                     \
-            table,                                        \
-            myRank,                                       \
-            peerRank,                                     \
-            mySlot,                                       \
-            peerSlot,                                     \
-            rc,                                           \
-            slotBytes,                                    \
-            epoch,                                        \
-            divisor,                                      \
-            stream);                                      \
-        break;                                            \
-      case ncclFloat16:                                   \
-        launchOneShotReduceScatter2Kernel<__half>(        \
-            out,                                          \
-            sendBuff,                                     \
-            table,                                        \
-            myRank,                                       \
-            peerRank,                                     \
-            mySlot,                                       \
-            peerSlot,                                     \
-            rc,                                           \
-            slotBytes,                                    \
-            epoch,                                        \
-            divisor,                                      \
-            stream);                                      \
-        break;                                            \
-      case ncclFloat:                                     \
-        launchOneShotReduceScatter2Kernel<float>(         \
-            out,                                          \
-            sendBuff,                                     \
-            table,                                        \
-            myRank,                                       \
-            peerRank,                                     \
-            mySlot,                                       \
-            peerSlot,                                     \
-            rc,                                           \
-            slotBytes,                                    \
-            epoch,                                        \
-            divisor,                                      \
-            stream);                                      \
-        break;                                            \
-      case ncclDouble:                                    \
-        launchOneShotReduceScatter2Kernel<double>(        \
-            out,                                          \
-            sendBuff,                                     \
-            table,                                        \
-            myRank,                                       \
-            peerRank,                                     \
-            mySlot,                                       \
-            peerSlot,                                     \
-            rc,                                           \
-            slotBytes,                                    \
-            epoch,                                        \
-            divisor,                                      \
-            stream);                                      \
-        break;                                            \
-      case ncclBfloat16:                                  \
-        launchOneShotReduceScatter2Kernel<__nv_bfloat16>( \
-            out,                                          \
-            sendBuff,                                     \
-            table,                                        \
-            myRank,                                       \
-            peerRank,                                     \
-            mySlot,                                       \
-            peerSlot,                                     \
-            rc,                                           \
-            slotBytes,                                    \
-            epoch,                                        \
-            divisor,                                      \
-            stream);                                      \
-        break;                                            \
-      default:                                            \
-        (handled) = false;                                \
-        break;                                            \
-    }                                                     \
+#define DISPATCH_ONESHOT_REDUCE_SCATTER(                 \
+    datatype,                                            \
+    handled,                                             \
+    out,                                                 \
+    sendBuff,                                            \
+    table,                                               \
+    ranks,                                               \
+    nActive,                                             \
+    myRank,                                              \
+    mySlot,                                              \
+    rc,                                                  \
+    slotBytes,                                           \
+    epoch,                                               \
+    divisor,                                             \
+    stream)                                              \
+  do {                                                   \
+    (handled) = true;                                    \
+    switch (datatype) {                                  \
+      case ncclInt32:                                    \
+        launchOneShotReduceScatterKernel<int32_t>(       \
+            out,                                         \
+            sendBuff,                                    \
+            table,                                       \
+            ranks,                                       \
+            nActive,                                     \
+            myRank,                                      \
+            mySlot,                                      \
+            rc,                                          \
+            slotBytes,                                   \
+            epoch,                                       \
+            divisor,                                     \
+            stream);                                     \
+        break;                                           \
+      case ncclUint32:                                   \
+        launchOneShotReduceScatterKernel<uint32_t>(      \
+            out,                                         \
+            sendBuff,                                    \
+            table,                                       \
+            ranks,                                       \
+            nActive,                                     \
+            myRank,                                      \
+            mySlot,                                      \
+            rc,                                          \
+            slotBytes,                                   \
+            epoch,                                       \
+            divisor,                                     \
+            stream);                                     \
+        break;                                           \
+      case ncclInt64:                                    \
+        launchOneShotReduceScatterKernel<int64_t>(       \
+            out,                                         \
+            sendBuff,                                    \
+            table,                                       \
+            ranks,                                       \
+            nActive,                                     \
+            myRank,                                      \
+            mySlot,                                      \
+            rc,                                          \
+            slotBytes,                                   \
+            epoch,                                       \
+            divisor,                                     \
+            stream);                                     \
+        break;                                           \
+      case ncclUint64:                                   \
+        launchOneShotReduceScatterKernel<uint64_t>(      \
+            out,                                         \
+            sendBuff,                                    \
+            table,                                       \
+            ranks,                                       \
+            nActive,                                     \
+            myRank,                                      \
+            mySlot,                                      \
+            rc,                                          \
+            slotBytes,                                   \
+            epoch,                                       \
+            divisor,                                     \
+            stream);                                     \
+        break;                                           \
+      case ncclFloat16:                                  \
+        launchOneShotReduceScatterKernel<__half>(        \
+            out,                                         \
+            sendBuff,                                    \
+            table,                                       \
+            ranks,                                       \
+            nActive,                                     \
+            myRank,                                      \
+            mySlot,                                      \
+            rc,                                          \
+            slotBytes,                                   \
+            epoch,                                       \
+            divisor,                                     \
+            stream);                                     \
+        break;                                           \
+      case ncclFloat:                                    \
+        launchOneShotReduceScatterKernel<float>(         \
+            out,                                         \
+            sendBuff,                                    \
+            table,                                       \
+            ranks,                                       \
+            nActive,                                     \
+            myRank,                                      \
+            mySlot,                                      \
+            rc,                                          \
+            slotBytes,                                   \
+            epoch,                                       \
+            divisor,                                     \
+            stream);                                     \
+        break;                                           \
+      case ncclDouble:                                   \
+        launchOneShotReduceScatterKernel<double>(        \
+            out,                                         \
+            sendBuff,                                    \
+            table,                                       \
+            ranks,                                       \
+            nActive,                                     \
+            myRank,                                      \
+            mySlot,                                      \
+            rc,                                          \
+            slotBytes,                                   \
+            epoch,                                       \
+            divisor,                                     \
+            stream);                                     \
+        break;                                           \
+      case ncclBfloat16:                                 \
+        launchOneShotReduceScatterKernel<__nv_bfloat16>( \
+            out,                                         \
+            sendBuff,                                    \
+            table,                                       \
+            ranks,                                       \
+            nActive,                                     \
+            myRank,                                      \
+            mySlot,                                      \
+            rc,                                          \
+            slotBytes,                                   \
+            epoch,                                       \
+            divisor,                                     \
+            stream);                                     \
+        break;                                           \
+      default:                                           \
+        (handled) = false;                               \
+        break;                                           \
+    }                                                    \
   } while (0)
+
+// Try the one-shot IPC kernel for a single-group A-active reduce-scatter, and
+// report whether it ran. Shared by the A==2 and A>2 dispatches because the
+// schedule is identical -- push, flag, spin, reduce -- and only A differs.
+//
+// Every predicate is derived from sizes and the communicator only, so all ranks
+// reach the same decision. That matters more than usual: a rank that ran the
+// one-shot kernel while a peer took the ncclSend path would spin forever rather
+// than merely run slower. oneShotAcquire() is COLLECTIVE on first use, so it is
+// called before any branch on myActiveGroup and it agrees its own success
+// across ranks.
+static bool tryOneShotReduceScatter(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* recvCounts,
+    ncclDataType_t datatype,
+    int reductionDivisor,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int nActiveRanksPerGroup,
+    int nGroups,
+    size_t elementSize) {
+  const size_t maxCount = rcclx::relay::relayMaxCount(recvCounts, nGroups);
+  if (nGroups != 1 || maxCount == 0) {
+    return false;
+  }
+  if (static_cast<size_t>(nActiveRanksPerGroup) * maxCount * elementSize >
+      rcclx::relay::kRelayOneShotMaxBytes) {
+    return false;
+  }
+  // The epoch advances per host launch, so a replayed graph would reuse a stale
+  // value and the handshake would pass before the data arrived.
+  struct ncclCudaGraph graph;
+  if (ncclCudaGetCapturingGraph(&graph, stream) != ncclSuccess) {
+    return false;
+  }
+  if (ncclCudaGraphValid(graph)) {
+    return false;
+  }
+
+  rcclx::relay::OneShotLaunch osl{};
+  if (!rcclx::relay::oneShotAcquire(comm, &osl)) {
+    return false;
+  }
+
+  // Helpers have nothing to do here, but they DID have to reach the acquire
+  // above, which is the whole reason it sits before this branch.
+  if (myActiveGroup < 0 || recvCounts[myActiveGroup] == 0) {
+    return true;
+  }
+
+  const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
+  rcclx::relay::OneShotRanks ranks{};
+  for (int a = 0; a < nActiveRanksPerGroup; a++) {
+    ranks.r[a] = cfg.activeRanks[a];
+  }
+  bool handled = false;
+  DISPATCH_ONESHOT_REDUCE_SCATTER(
+      datatype,
+      handled,
+      recvBuffs[myActiveGroup],
+      sendBuffs[myActiveGroup],
+      osl.table,
+      ranks,
+      nActiveRanksPerGroup,
+      comm->rank,
+      cfg.myActiveIndex,
+      recvCounts[myActiveGroup],
+      osl.slotBytes,
+      osl.epoch,
+      reductionDivisor,
+      stream);
+  // An unsupported datatype must not silently produce nothing. Falling back is
+  // safe only because the dtype is identical on every rank, so either all of
+  // them fall back or none do -- and in pure-direct mode the helpers post
+  // nothing anyway, so a helper that already returned true is equivalent.
+  return handled;
+}
 
 #define LAUNCH_SEEDED_MULTI_REDUCE_KERNEL(                          \
     TYPE, dst, seed, contribs, numContribs, count, divisor, stream) \
@@ -961,58 +1041,20 @@ static ncclResult_t shardedRelayReduceScatter2Active(
     // plus one fused reduce -- and that is still one launch more than NCCL,
     // which fuses transfer and reduction into a single kernel. Measured, the
     // group ALONE costs more than NCCL's whole collective, so no amount of
-    // trimming here reaches 1x. The one-shot kernel removes the group entirely:
-    // it pushes into the peer's pre-registered staging, handshakes on a flag,
-    // and reduces in registers, all in one launch.
-    //
-    // Every predicate below is derived only from sizes and the communicator, so
-    // all ranks reach the same decision. That matters more than usual here: if
-    // one rank ran the one-shot kernel while its peer took the ncclSend path,
-    // the first would spin forever instead of merely running slower.
-    // oneShotAcquire() is COLLECTIVE on first use, which is why it is called
-    // here -- before any branch on myActiveGroup -- and why it agrees its own
-    // success across ranks.
-    const size_t osMaxCount = rcclx::relay::relayMaxCount(recvCounts, nGroups);
-    bool useOneShot = (nGroups == 1) && (osMaxCount > 0) &&
-        (2 * osMaxCount * elementSize <= rcclx::relay::kRelayOneShotMaxBytes);
-    if (useOneShot) {
-      // The epoch advances per host launch, so a replayed graph would reuse a
-      // stale value and the handshake would pass before the data arrived.
-      struct ncclCudaGraph graph;
-      NCCLCHECK(ncclCudaGetCapturingGraph(&graph, stream));
-      useOneShot = !ncclCudaGraphValid(graph);
-    }
-    rcclx::relay::OneShotLaunch osl{};
-    if (useOneShot) {
-      useOneShot = rcclx::relay::oneShotAcquire(comm, &osl);
-    }
-    if (useOneShot && myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0) {
-      const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
-      const size_t rc = recvCounts[myActiveGroup];
-      const int m = cfg.myActiveIndex;
-      const int other = 1 - m;
-      bool handled = false;
-      DISPATCH_ONESHOT_REDUCE_SCATTER2(
-          datatype,
-          handled,
-          recvBuffs[myActiveGroup],
-          sendBuffs[myActiveGroup],
-          osl.table,
-          comm->rank,
-          cfg.activeRanks[other],
-          m,
-          other,
-          rc,
-          osl.slotBytes,
-          osl.epoch,
-          reductionDivisor,
-          stream);
-      // An unsupported datatype must not silently produce nothing. Falling back
-      // is safe only because the dtype is the same on every rank, so either all
-      // of them fall back or none do.
-      useOneShot = handled;
-    }
-    if (useOneShot) {
+    // trimming here reaches 1x. The one-shot kernel removes the group entirely.
+    if (tryOneShotReduceScatter(
+            sendBuffs,
+            recvBuffs,
+            recvCounts,
+            datatype,
+            reductionDivisor,
+            comm,
+            stream,
+            configs,
+            myActiveGroup,
+            2,
+            nGroups,
+            elementSize)) {
       return ncclSuccess;
     }
 
@@ -1665,6 +1707,27 @@ static ncclResult_t shardedRelayReduceScatterFlat(
   const bool useOffload = rcclx::relay::selectReduceScatterRoute(
                               A, H, nGroups, recvCounts, elementSize) ==
       rcclx::relay::ReduceScatterRoute::FlatOffload;
+
+  // Below the offload crossover this runs a pure-direct exchange plus a reduce:
+  // two launches against NCCL's one. Same story as the A==2 path, same fix --
+  // one kernel that pushes, handshakes, and reduces. Only attempted when the
+  // offload is disabled, i.e. in the regime the one-shot gate covers.
+  if (!useOffload &&
+      tryOneShotReduceScatter(
+          sendBuffs,
+          recvBuffs,
+          recvCounts,
+          datatype,
+          reductionDivisor,
+          comm,
+          stream,
+          configs,
+          myActiveGroup,
+          A,
+          nGroups,
+          elementSize)) {
+    return ncclSuccess;
+  }
 
   // Per-group geometry. cs = recvCount/(A+H) aligned down; the direct region
   // absorbs the remainder so directSz + H*cs == recvCount.

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -1027,7 +1027,7 @@ static ncclResult_t shardedRelayReduceScatter2Active(
  * Same logical collective and the same passthrough helpers as
  * shardedRelayReduceScatter2Active, but for nGroups == 1 -- where the active
  * ranks and the helpers are disjoint sets -- the relay is tiled and pipelined
- * so both directions of every cross link stay busy. See relayA2PipelineTiles()
+ * so both directions of every cross link stay busy. See relayPipelineTiles()
  * for why the two-group schedule cannot do that and what it costs.
  *
  * Helpers stay pure passthrough here, unlike allreduce: slot 0 is a0's
@@ -1709,16 +1709,15 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
     }
     // A single-group relay call has the helpers to itself, so the scatter and
     // the forward run on opposite directions of each cross link and can be
-    // software-pipelined into one duplex stream. relayA2PipelineTiles() returns
+    // software-pipelined into one duplex stream. relayPipelineTiles() returns
     // 1 whenever that does not apply, and the small-message pure-direct route
     // (owned by shardedRelayReduceScatter2Active) never pipelines.
     const int nTiles = (rcclx::relay::selectReduceScatterRoute(
                             2, numHelpers, nGroups, recvCounts, elementSize) ==
                         rcclx::relay::ReduceScatterRoute::A2Relay)
-        ? rcclx::relay::relayA2PipelineTiles(
-              2,
-              numHelpers,
+        ? rcclx::relay::relayPipelineTiles(
               nGroups,
+              rcclx::relay::relayShapeA2(numHelpers),
               rcclx::relay::relayMaxCount(recvCounts, nGroups),
               elementSize)
         : 1;

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -1905,18 +1905,45 @@ static ncclResult_t shardedRelayReduceScatterFlatPipelined(
       const size_t dOff = directOffset(k);
       const size_t dSz = directSize(k);
 
-      // Direct reduce-scatter: my chunk of block j goes to its owner j.
+      // Direct reduce-scatter: my chunk of block j goes to its owner j, issued
+      // as w-sized pieces rather than one (A-1)*w op.
+      //
+      // Both directions of every link carry the same 3w per group, but they
+      // were carrying it as DIFFERENT op counts: the cross links as three
+      // w-sized offload sends, the intra links as a single 3w direct send. RCCL
+      // budgets channels per operation, so the single-op link received a third
+      // of the channels and became the bottleneck while the cross links
+      // finished early. Splitting the direct region into w-sized pieces makes
+      // every op in the group the same size, so all seven links are provisioned
+      // alike.
+      //
+      // Measured at 1 GB, 4 active ranks: 4.239 -> 3.539 ms (1.30x -> 1.56x).
+      // Splitting further is worse (six pieces read 4.304 ms), so uniformity is
+      // the goal, not op count for its own sake. The 2-active shapes already
+      // ship a direct chunk of exactly u, which is why they never showed this.
+      const size_t dPiece = w;
+      const int dN = (dSz >= dPiece) ? static_cast<int>(dSz / dPiece) : 1;
+      auto dPieceOff = [&](int i) -> size_t {
+        return dOff + static_cast<size_t>(i) * dPiece;
+      };
+      auto dPieceSz = [&](int i) -> size_t {
+        return (i < dN - 1) ? dPiece
+                            : (dSz - static_cast<size_t>(dN - 1) * dPiece);
+      };
       for (int j = 0; j < A; j++) {
         if (j == m) {
           continue;
         }
-        NCCLCHECK(ncclSend(
-            sendbuff + (static_cast<size_t>(j) * rc + dOff) * elementSize,
-            dSz,
-            datatype,
-            cfg.activeRanks[j],
-            comm,
-            stream));
+        for (int i = 0; i < dN; i++) {
+          NCCLCHECK(ncclSend(
+              sendbuff +
+                  (static_cast<size_t>(j) * rc + dPieceOff(i)) * elementSize,
+              dPieceSz(i),
+              datatype,
+              cfg.activeRanks[j],
+              comm,
+              stream));
+        }
       }
       if (k < T) {
         // Offload scatter: helper h gets tile k of each of my foreign blocks.
@@ -1944,14 +1971,17 @@ static ncclResult_t shardedRelayReduceScatterFlatPipelined(
           continue;
         }
         const int p = (s < m) ? s : s - 1;
-        NCCLCHECK(ncclRecv(
-            static_cast<char*>(dScratch) +
-                (static_cast<size_t>(p) * directSz + dOff) * elementSize,
-            dSz,
-            datatype,
-            cfg.activeRanks[s],
-            comm,
-            stream));
+        for (int i = 0; i < dN; i++) {
+          NCCLCHECK(ncclRecv(
+              static_cast<char*>(dScratch) +
+                  (static_cast<size_t>(p) * directSz + dPieceOff(i)) *
+                      elementSize,
+              dPieceSz(i),
+              datatype,
+              cfg.activeRanks[s],
+              comm,
+              stream));
+        }
       }
       if (k > 0) {
         // One already-reduced tile per helper, landing where my output wants

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -125,6 +125,120 @@ class ScratchBufferCache {
   std::map<std::tuple<int, const void*, int>, BufferEntry> buffers_;
 };
 
+/**
+ * Side-Stream Cache Singleton
+ *
+ * The pipelined reduce-scatter's owner reduce is pure serialized tail: it runs
+ * only once the last transfer has landed, and at 1 GB with 2 active ranks it is
+ * 0.61 ms of a 2.64 ms call (measured by skipping it). Splitting it per
+ * pipeline stage on the caller's stream buys nothing, because stream order is
+ * total -- the T+1 smaller reduces just serialize in the same places. So the
+ * per-stage reduces go on a side stream, gated by an event recorded at each
+ * group boundary, and the caller's stream joins once at the end. Only that
+ * closing join creates a side -> caller dependency, so group k+1 never waits on
+ * the reduce of stage k.
+ *
+ * One stream and one event pool per (device, caller stream), for the same
+ * reason ScratchBufferCache keys on the stream: two relay collectives can run
+ * concurrently on one device on different streams.
+ */
+class ReduceOverlapCache {
+ public:
+  // One event per pipeline group: the depth is at most kRelayMaxPipelineTiles
+  // and a depth-T pipeline runs T+1 groups. Callers MUST check T+1 against this
+  // before indexing stageDone -- a deeper pipeline than the pool cannot be
+  // overlapped, and reading past the array is a segfault, not a slow path.
+  static constexpr int kStageEvents = rcclx::relay::kRelayMaxPipelineTiles + 1;
+
+  struct Handle {
+    cudaStream_t stream{};
+    cudaEvent_t stageDone[kStageEvents]{};
+    cudaEvent_t allDone{};
+  };
+
+  static ReduceOverlapCache& getInstance() {
+    static ReduceOverlapCache instance;
+    return instance;
+  }
+
+  // Returns nullptr if the resources could not be created, in which case the
+  // caller must fall back to one reduce on its own stream.
+  const Handle* get(cudaStream_t callerStream) {
+    int device;
+    if (cudaGetDevice(&device) != cudaSuccess) {
+      return nullptr;
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto& entry = handles_[std::make_pair(
+        device, static_cast<const void*>(callerStream))];
+    if (!entry.tried) {
+      entry.tried = true;
+      entry.valid = create(&entry.handle);
+    }
+    return entry.valid ? &entry.handle : nullptr;
+  }
+
+  ReduceOverlapCache(const ReduceOverlapCache&) = delete;
+  ReduceOverlapCache& operator=(const ReduceOverlapCache&) = delete;
+
+ private:
+  ReduceOverlapCache() = default;
+  ~ReduceOverlapCache() = default;
+
+  // cudaStreamNonBlocking so the side stream does not implicitly synchronize
+  // with the legacy default stream; all ordering here is explicit via events.
+  // Timing is disabled on the events because nothing queries their elapsed
+  // time, which keeps the record cheap.
+  static bool create(Handle* h) {
+    if (cudaStreamCreateWithFlags(&h->stream, cudaStreamNonBlocking) !=
+        cudaSuccess) {
+      h->stream = nullptr;
+      return false;
+    }
+    for (int i = 0; i < kStageEvents; i++) {
+      if (cudaEventCreateWithFlags(&h->stageDone[i], cudaEventDisableTiming) !=
+          cudaSuccess) {
+        destroy(h);
+        return false;
+      }
+    }
+    if (cudaEventCreateWithFlags(&h->allDone, cudaEventDisableTiming) !=
+        cudaSuccess) {
+      destroy(h);
+      return false;
+    }
+    return true;
+  }
+
+  static void destroy(Handle* h) {
+    for (int i = 0; i < kStageEvents; i++) {
+      if (h->stageDone[i] != nullptr) {
+        cudaEventDestroy(h->stageDone[i]);
+        h->stageDone[i] = nullptr;
+      }
+    }
+    if (h->allDone != nullptr) {
+      cudaEventDestroy(h->allDone);
+      h->allDone = nullptr;
+    }
+    if (h->stream != nullptr) {
+      cudaStreamDestroy(h->stream);
+      h->stream = nullptr;
+    }
+  }
+
+  struct Entry {
+    Handle handle;
+    bool tried = false;
+    bool valid = false;
+  };
+
+  std::mutex mutex_;
+  // (device, caller stream) -> side stream and its event pool.
+  std::map<std::pair<int, const void*>, Entry> handles_;
+};
+
 // Maximum number of helper ranks supported per group.
 constexpr int SHARDED_RELAY_MAX_HELPERS = 8;
 
@@ -1037,18 +1151,27 @@ static ncclResult_t shardedRelayReduceScatter2Active(
  * so that stays a single fused launch no matter how many tiles the relay used.
  *
  * With T tiles and unit u = align(recvCount / ((H+1)*T + 1)), the block shipped
- * to the other active rank splits as:
- *   [0, H*T*u)         relay region; helper h owns [h*T*u, (h+1)*T*u), its tile
- *                      t at h*T*u + t*u
- *   [H*T*u, recvCount) direct region as T+1 chunks of u, the last absorbing the
- *                      /((H+1)*T + 1) remainder and the alignment loss
+ * to the other active rank splits into T+1 STAGE-major regions, so that
+ * everything arriving in one group is contiguous:
+ *   region 0        direct chunk 0 alone, size u
+ *   region k >= 1   relay stage k-1's H pieces of u, then direct chunk k;
+ *                   size (H+1)*u, with region T absorbing the
+ *                   /((H+1)*T + 1) remainder and the alignment loss
  *
- * Group k, for k in [0, T]: the active rank scatters tile k (k < T) to every
- * helper, receives tile k-1 (k > 0) of the partner's contribution from every
- * helper into the matching offset of foreignScratch, and exchanges direct chunk
- * k over the active<->active link; helper h receives tile k of each active's
- * chunk into ping-pong buffer k%2 and forwards buffer (k-1)%2 to the active
- * rank that owns it.
+ * Region k is exactly the set of pieces that lands in group k, which is what
+ * lets a single launch reduce it. The unit count is unchanged at (H+1)*T + 1,
+ * so relayPipelineTiles() still describes the depth.
+ *
+ * Group k, for k in [0, T]: the active rank scatters relay stage k (k < T) to
+ * every helper, receives stage k-1 (k > 0) of the partner's contribution from
+ * every helper into the matching offset of foreignScratch, and exchanges direct
+ * chunk k over the active<->active link; helper h receives tile k of each
+ * active's chunk into ping-pong buffer k%2 and forwards buffer (k-1)%2 to the
+ * active rank that owns it.
+ *
+ * The owner's reduce is then issued per region on a side stream as each group
+ * completes, rather than as one pass over the whole block at the end -- that
+ * tail was 0.61 ms of a 2.64 ms call at 1 GB. See ReduceOverlapCache.
  */
 static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
     const void* const* sendBuffs,
@@ -1073,11 +1196,30 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
   if (u == 0) {
     return ncclInvalidArgument;
   }
-  const size_t tileStride = static_cast<size_t>(T) * u;
-  const size_t directBase = static_cast<size_t>(H) * tileStride;
-  const size_t lastDirect = recvcount - directBase - tileStride;
+  // STAGE-major geometry: region k holds precisely what group k receives.
+  const size_t stageSpan = static_cast<size_t>(H + 1) * u;
+  auto regionOffset = [&](int k) -> size_t {
+    return (k == 0) ? 0 : (u + static_cast<size_t>(k - 1) * stageSpan);
+  };
+  auto regionSize = [&](int k) -> size_t {
+    if (k == 0) {
+      return u;
+    }
+    return (k < T) ? stageSpan : (recvcount - regionOffset(T));
+  };
+  // Relay tile (h, t) is the h-th piece of region t+1; direct chunk k is the
+  // piece that follows region k's relay pieces.
+  auto relayOffset = [&](int h, int t) -> size_t {
+    return regionOffset(t + 1) + static_cast<size_t>(h) * u;
+  };
+  auto directOffset = [&](int k) -> size_t {
+    return (k == 0) ? 0 : (regionOffset(k) + static_cast<size_t>(H) * u);
+  };
+  auto directSize = [&](int k) -> size_t {
+    return (k < T) ? u : (recvcount - directOffset(T));
+  };
 
-  // Scratch mirroring the output block, so the whole reduction is one launch.
+  // Scratch mirroring the output block, so a region's reduce is one launch.
   void* foreignScratch = nullptr;
   size_t ownBlockOffset = 0;
   size_t sendBlockOffset = 0;
@@ -1114,6 +1256,52 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
         elementSize;
   };
 
+  // out[span] = (own[span] + scratch[span]) / divisor.
+  auto reduceSpan = [&](size_t off, size_t sz, cudaStream_t s) {
+    char* out = static_cast<char*>(recvBuffs[0]) + off * elementSize;
+    const char* scratch =
+        static_cast<const char*>(foreignScratch) + off * elementSize;
+    if (isInPlace) {
+      if (reductionDivisor > 1) {
+        DISPATCH_INCREMENTAL_ADD_AND_SCALE(
+            datatype, out, scratch, sz, reductionDivisor, s);
+      } else {
+        DISPATCH_INCREMENTAL_ADD(datatype, out, scratch, sz, s);
+      }
+    } else {
+      DISPATCH_FUSED_REDUCE(
+          datatype,
+          out,
+          static_cast<const char*>(sendBuffs[0]) +
+              (ownBlockOffset + off) * elementSize,
+          scratch,
+          sz,
+          reductionDivisor,
+          s);
+    }
+  };
+
+  // Per-region reduces run on a side stream so they overlap the transfers that
+  // follow. Four things force the single trailing pass on the caller's stream
+  // instead: a depth deeper than the event pool (a depth-T pipeline runs T+1
+  // groups and each needs its own event, so this bounds the overlap to the pool
+  // rather than letting a raised kRelayMaxPipelineTiles index past it); a
+  // message too small for the overlap to pay for its event traffic (see
+  // kRelayOverlapReduceMinBytes); graph capture, because RCCL requires every
+  // stream in a group to be captured by the same graph and the side stream is
+  // uncaptured; and any failure to create the side stream or its events.
+  const bool ownerReduces = (myActiveGroup == 0);
+  const ReduceOverlapCache::Handle* ovl = nullptr;
+  if (ownerReduces && T + 1 <= ReduceOverlapCache::kStageEvents &&
+      recvcount * static_cast<size_t>(cfg.nActiveRanks) * elementSize >=
+          rcclx::relay::kRelayOverlapReduceMinBytes) {
+    struct ncclCudaGraph graph;
+    NCCLCHECK(ncclCudaGetCapturingGraph(&graph, stream));
+    if (!ncclCudaGraphValid(graph)) {
+      ovl = ReduceOverlapCache::getInstance().get(stream);
+    }
+  }
+
   for (int k = 0; k <= T; k++) {
     NCCLCHECK(ncclGroupStart());
     if (cfg.isActiveRank) {
@@ -1121,16 +1309,13 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
           sendBlockOffset * elementSize;
       char* scratch = static_cast<char*>(foreignScratch);
       const int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
-      const size_t directOffset = directBase + static_cast<size_t>(k) * u;
-      const size_t directSize = (k < T) ? u : lastDirect;
+      const size_t dOff = directOffset(k);
+      const size_t dSz = directSize(k);
 
       if (k < T) {
         for (int h = 0; h < H; h++) {
           NCCLCHECK(ncclSend(
-              sendBlock +
-                  (static_cast<size_t>(h) * tileStride +
-                   static_cast<size_t>(k) * u) *
-                      elementSize,
+              sendBlock + relayOffset(h, k) * elementSize,
               u,
               datatype,
               cfg.helperRanks[h],
@@ -1139,8 +1324,8 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
         }
       }
       NCCLCHECK(ncclSend(
-          sendBlock + directOffset * elementSize,
-          directSize,
+          sendBlock + dOff * elementSize,
+          dSz,
           datatype,
           partner,
           comm,
@@ -1148,10 +1333,7 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
       if (k > 0) {
         for (int h = 0; h < H; h++) {
           NCCLCHECK(ncclRecv(
-              scratch +
-                  (static_cast<size_t>(h) * tileStride +
-                   static_cast<size_t>(k - 1) * u) *
-                      elementSize,
+              scratch + relayOffset(h, k - 1) * elementSize,
               u,
               datatype,
               cfg.helperRanks[h],
@@ -1160,12 +1342,7 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
         }
       }
       NCCLCHECK(ncclRecv(
-          scratch + directOffset * elementSize,
-          directSize,
-          datatype,
-          partner,
-          comm,
-          stream));
+          scratch + dOff * elementSize, dSz, datatype, partner, comm, stream));
     } else {
       if (k < T) {
         for (int a = 0; a < cfg.nActiveRanks; a++) {
@@ -1186,29 +1363,24 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
       }
     }
     NCCLCHECK(ncclGroupEnd());
+
+    // Region k has landed in full. Reduce it now, on the side stream, so it
+    // overlaps groups k+1..T instead of waiting behind them.
+    if (ovl != nullptr) {
+      CUDACHECK(cudaEventRecord(ovl->stageDone[k], stream));
+      CUDACHECK(cudaStreamWaitEvent(ovl->stream, ovl->stageDone[k], 0));
+      reduceSpan(regionOffset(k), regionSize(k), ovl->stream);
+    }
   }
 
-  // One fused pass over the whole output block.
-  if (myActiveGroup == 0) {
-    void* out = recvBuffs[0];
-    if (isInPlace) {
-      if (reductionDivisor > 1) {
-        DISPATCH_INCREMENTAL_ADD_AND_SCALE(
-            datatype, out, foreignScratch, recvcount, reductionDivisor, stream);
-      } else {
-        DISPATCH_INCREMENTAL_ADD(
-            datatype, out, foreignScratch, recvcount, stream);
-      }
-    } else {
-      DISPATCH_FUSED_REDUCE(
-          datatype,
-          out,
-          static_cast<const char*>(sendBuffs[0]) + ownBlockOffset * elementSize,
-          foreignScratch,
-          recvcount,
-          reductionDivisor,
-          stream);
-    }
+  if (ovl != nullptr) {
+    // The caller's stream must not observe the output before the last region's
+    // reduce has retired. This is the only side -> caller dependency.
+    CUDACHECK(cudaEventRecord(ovl->allDone, ovl->stream));
+    CUDACHECK(cudaStreamWaitEvent(stream, ovl->allDone, 0));
+  } else if (ownerReduces) {
+    // Fallback: one pass over the whole output block on the caller's stream.
+    reduceSpan(0, recvcount, stream);
   }
 
   return ncclSuccess;

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -662,7 +662,7 @@ bool buildShardedRelayRankConfig(
     srcStride,                                        \
     ownOffset,                                        \
     slotBytes,                                        \
-    epoch,                                            \
+    seq,                                              \
     divisor,                                          \
     stream)                                           \
   do {                                                \
@@ -681,7 +681,7 @@ bool buildShardedRelayRankConfig(
             srcStride,                                \
             ownOffset,                                \
             slotBytes,                                \
-            epoch,                                    \
+            seq,                                      \
             divisor,                                  \
             stream);                                  \
         break;                                        \
@@ -698,7 +698,7 @@ bool buildShardedRelayRankConfig(
             srcStride,                                \
             ownOffset,                                \
             slotBytes,                                \
-            epoch,                                    \
+            seq,                                      \
             divisor,                                  \
             stream);                                  \
         break;                                        \
@@ -715,7 +715,7 @@ bool buildShardedRelayRankConfig(
             srcStride,                                \
             ownOffset,                                \
             slotBytes,                                \
-            epoch,                                    \
+            seq,                                      \
             divisor,                                  \
             stream);                                  \
         break;                                        \
@@ -732,7 +732,7 @@ bool buildShardedRelayRankConfig(
             srcStride,                                \
             ownOffset,                                \
             slotBytes,                                \
-            epoch,                                    \
+            seq,                                      \
             divisor,                                  \
             stream);                                  \
         break;                                        \
@@ -749,7 +749,7 @@ bool buildShardedRelayRankConfig(
             srcStride,                                \
             ownOffset,                                \
             slotBytes,                                \
-            epoch,                                    \
+            seq,                                      \
             divisor,                                  \
             stream);                                  \
         break;                                        \
@@ -766,7 +766,7 @@ bool buildShardedRelayRankConfig(
             srcStride,                                \
             ownOffset,                                \
             slotBytes,                                \
-            epoch,                                    \
+            seq,                                      \
             divisor,                                  \
             stream);                                  \
         break;                                        \
@@ -783,7 +783,7 @@ bool buildShardedRelayRankConfig(
             srcStride,                                \
             ownOffset,                                \
             slotBytes,                                \
-            epoch,                                    \
+            seq,                                      \
             divisor,                                  \
             stream);                                  \
         break;                                        \
@@ -800,7 +800,7 @@ bool buildShardedRelayRankConfig(
             srcStride,                                \
             ownOffset,                                \
             slotBytes,                                \
-            epoch,                                    \
+            seq,                                      \
             divisor,                                  \
             stream);                                  \
         break;                                        \
@@ -841,13 +841,14 @@ static bool tryOneShotReduceScatter(
       rcclx::relay::kRelayOneShotMaxBytes) {
     return false;
   }
-  // The epoch advances per host launch, so a replayed graph would reuse a stale
-  // value and the handshake would pass before the data arrived.
+  // Creating the region is not capturable: it does a bootstrap all-gather and a
+  // synchronous hipMemset. Using one that already exists is fine, so under
+  // capture take the path only if the region is already up.
   struct ncclCudaGraph graph;
   if (ncclCudaGetCapturingGraph(&graph, stream) != ncclSuccess) {
     return false;
   }
-  if (ncclCudaGraphValid(graph)) {
+  if (ncclCudaGraphValid(graph) && !rcclx::relay::oneShotReady(comm)) {
     return false;
   }
 
@@ -883,7 +884,7 @@ static bool tryOneShotReduceScatter(
       /*ownOffset=*/static_cast<size_t>(cfg.myActiveIndex) *
           recvCounts[myActiveGroup],
       osl.slotBytes,
-      osl.epoch,
+      osl.seq,
       reductionDivisor,
       stream);
   // An unsupported datatype must not silently produce nothing. Falling back is

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -1022,6 +1022,199 @@ static ncclResult_t shardedRelayReduceScatter2Active(
 }
 
 /**
+ * Software-pipelined single-group 2-active sharded relay reduce-scatter.
+ *
+ * Same logical collective and the same passthrough helpers as
+ * shardedRelayReduceScatter2Active, but for nGroups == 1 -- where the active
+ * ranks and the helpers are disjoint sets -- the relay is tiled and pipelined
+ * so both directions of every cross link stay busy. See relayA2PipelineTiles()
+ * for why the two-group schedule cannot do that and what it costs.
+ *
+ * Helpers stay pure passthrough here, unlike allreduce: slot 0 is a0's
+ * contribution to a1's output and slot 1 is a1's contribution to a0's output --
+ * different outputs, so there is nothing to sum at the helper. The active rank
+ * reduces once at the end, and foreignScratch still mirrors the output layout
+ * so that stays a single fused launch no matter how many tiles the relay used.
+ *
+ * With T tiles and unit u = align(recvCount / ((H+1)*T + 1)), the block shipped
+ * to the other active rank splits as:
+ *   [0, H*T*u)         relay region; helper h owns [h*T*u, (h+1)*T*u), its tile
+ *                      t at h*T*u + t*u
+ *   [H*T*u, recvCount) direct region as T+1 chunks of u, the last absorbing the
+ *                      /((H+1)*T + 1) remainder and the alignment loss
+ *
+ * Group k, for k in [0, T]: the active rank scatters tile k (k < T) to every
+ * helper, receives tile k-1 (k > 0) of the partner's contribution from every
+ * helper into the matching offset of foreignScratch, and exchanges direct chunk
+ * k over the active<->active link; helper h receives tile k of each active's
+ * chunk into ping-pong buffer k%2 and forwards buffer (k-1)%2 to the active
+ * rank that owns it.
+ */
+static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
+    const void* const* sendBuffs,
+    void* const* recvBuffs,
+    const size_t* recvCounts,
+    ncclDataType_t datatype,
+    int reductionDivisor,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const ShardedRelayRankConfig* configs,
+    int myActiveGroup,
+    int numHelpers,
+    int nTiles,
+    size_t elementSize) {
+  const ShardedRelayRankConfig& cfg = configs[0];
+  const size_t recvcount = recvCounts[0];
+  const int H = numHelpers;
+  const int T = nTiles;
+  const size_t u = ((recvcount / (static_cast<size_t>(H + 1) * T + 1)) /
+                    CHUNK_ALIGN_ELEMENTS) *
+      CHUNK_ALIGN_ELEMENTS;
+  if (u == 0) {
+    return ncclInvalidArgument;
+  }
+  const size_t tileStride = static_cast<size_t>(T) * u;
+  const size_t directBase = static_cast<size_t>(H) * tileStride;
+  const size_t lastDirect = recvcount - directBase - tileStride;
+
+  // Scratch mirroring the output block, so the whole reduction is one launch.
+  void* foreignScratch = nullptr;
+  size_t ownBlockOffset = 0;
+  size_t sendBlockOffset = 0;
+  bool isInPlace = false;
+  if (myActiveGroup == 0) {
+    ownBlockOffset = static_cast<size_t>(cfg.myActiveIndex) * recvcount;
+    sendBlockOffset = static_cast<size_t>(1 - cfg.myActiveIndex) * recvcount;
+    const char* ownBlock =
+        static_cast<const char*>(sendBuffs[0]) + ownBlockOffset * elementSize;
+    isInPlace =
+        (static_cast<const void*>(recvBuffs[0]) ==
+         static_cast<const void*>(ownBlock));
+    foreignScratch = ScratchBufferCache::getInstance().get(
+        SHARDED_RELAY_MAX_GROUPS, recvcount * elementSize, stream);
+    if (foreignScratch == nullptr) {
+      return ncclInternalError;
+    }
+  }
+
+  // Helper staging: two ping-pong units per active source.
+  char* hbuff = nullptr;
+  if (!cfg.isActiveRank) {
+    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+        kHelperScratchKeyBase,
+        static_cast<size_t>(cfg.nActiveRanks) * 2 * u * elementSize,
+        stream));
+    if (hbuff == nullptr) {
+      return ncclInternalError;
+    }
+  }
+  auto helperSlot = [&](int a, int k) -> char* {
+    return hbuff +
+        (static_cast<size_t>(a) * 2 + static_cast<size_t>(k % 2)) * u *
+        elementSize;
+  };
+
+  for (int k = 0; k <= T; k++) {
+    NCCLCHECK(ncclGroupStart());
+    if (cfg.isActiveRank) {
+      const char* sendBlock = static_cast<const char*>(sendBuffs[0]) +
+          sendBlockOffset * elementSize;
+      char* scratch = static_cast<char*>(foreignScratch);
+      const int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
+      const size_t directOffset = directBase + static_cast<size_t>(k) * u;
+      const size_t directSize = (k < T) ? u : lastDirect;
+
+      if (k < T) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclSend(
+              sendBlock +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclSend(
+          sendBlock + directOffset * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+      if (k > 0) {
+        for (int h = 0; h < H; h++) {
+          NCCLCHECK(ncclRecv(
+              scratch +
+                  (static_cast<size_t>(h) * tileStride +
+                   static_cast<size_t>(k - 1) * u) *
+                      elementSize,
+              u,
+              datatype,
+              cfg.helperRanks[h],
+              comm,
+              stream));
+        }
+      }
+      NCCLCHECK(ncclRecv(
+          scratch + directOffset * elementSize,
+          directSize,
+          datatype,
+          partner,
+          comm,
+          stream));
+    } else {
+      if (k < T) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclRecv(
+              helperSlot(a, k), u, datatype, cfg.activeRanks[a], comm, stream));
+        }
+      }
+      if (k > 0) {
+        for (int a = 0; a < cfg.nActiveRanks; a++) {
+          NCCLCHECK(ncclSend(
+              helperSlot(a, k - 1),
+              u,
+              datatype,
+              cfg.activeRanks[1 - a],
+              comm,
+              stream));
+        }
+      }
+    }
+    NCCLCHECK(ncclGroupEnd());
+  }
+
+  // One fused pass over the whole output block.
+  if (myActiveGroup == 0) {
+    void* out = recvBuffs[0];
+    if (isInPlace) {
+      if (reductionDivisor > 1) {
+        DISPATCH_INCREMENTAL_ADD_AND_SCALE(
+            datatype, out, foreignScratch, recvcount, reductionDivisor, stream);
+      } else {
+        DISPATCH_INCREMENTAL_ADD(
+            datatype, out, foreignScratch, recvcount, stream);
+      }
+    } else {
+      DISPATCH_FUSED_REDUCE(
+          datatype,
+          out,
+          static_cast<const char*>(sendBuffs[0]) + ownBlockOffset * elementSize,
+          foreignScratch,
+          recvcount,
+          reductionDivisor,
+          stream);
+    }
+  }
+
+  return ncclSuccess;
+}
+
+/**
  * Reduce-scatter for > 2 active ranks (two-group flat relay with
  * reduce-at-helper).
  *
@@ -1513,6 +1706,36 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
     for (int g = 0; g < nGroups; g++) {
       sendBuffs2[g] = sendBuffs[g];
       recvBuffs2[g] = recvBuffs[g];
+    }
+    // A single-group relay call has the helpers to itself, so the scatter and
+    // the forward run on opposite directions of each cross link and can be
+    // software-pipelined into one duplex stream. relayA2PipelineTiles() returns
+    // 1 whenever that does not apply, and the small-message pure-direct route
+    // (owned by shardedRelayReduceScatter2Active) never pipelines.
+    const int nTiles = (rcclx::relay::selectReduceScatterRoute(
+                            2, numHelpers, nGroups, recvCounts, elementSize) ==
+                        rcclx::relay::ReduceScatterRoute::A2Relay)
+        ? rcclx::relay::relayA2PipelineTiles(
+              2,
+              numHelpers,
+              nGroups,
+              rcclx::relay::relayMaxCount(recvCounts, nGroups),
+              elementSize)
+        : 1;
+    if (nTiles > 1) {
+      return shardedRelayReduceScatter2ActivePipelined(
+          sendBuffs2,
+          recvBuffs2,
+          recvCounts,
+          datatype,
+          reductionDivisor,
+          comm,
+          stream,
+          configs,
+          myActiveGroup,
+          numHelpers,
+          nTiles,
+          elementSize);
     }
     return shardedRelayReduceScatter2Active(
         sendBuffs2,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_route.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_route.h
@@ -115,8 +115,10 @@ inline size_t relayMaxCount(const size_t* counts, int nGroups) {
  *
  * A==2 crossover: the fused relay overtakes the direct exchange at ~9 MB and an
  * independent call at ~27 MB (independent has no cross-group contention, so
- * direct holds on longer); cross over below each. A==4 uses the XOR relay only
- * inside [63 MiB, 256 MiB).
+ * direct holds on longer); cross over below each. A==4 relays from 27 MB fused
+ * / 9 MB independent up, with no upper bound: the 256 MiB ceiling this used to
+ * carry was covering an alignment bug in the relay geometry, not a real
+ * crossover.
  */
 inline AllToAllRoute selectAllToAllRoute(
     int nActiveRanksPerGroup,
@@ -139,17 +141,23 @@ inline AllToAllRoute selectAllToAllRoute(
   for (int g = 0; g < nGroups; g++) {
     allSegmentCountsPositive &= segmentCounts[g] > 0;
   }
-  constexpr size_t kXorRelayMinBytes = static_cast<size_t>(63) << 20;
-  constexpr size_t kXorRelayMaxBytes = static_cast<size_t>(256) << 20;
+  constexpr size_t kXorRelayMinBytes = static_cast<size_t>(9) << 20;
+  const size_t xorRelayMinBytes = (nGroups > 1)
+      ? (static_cast<size_t>(27) << 20) // fused: >= 27 MB
+      : kXorRelayMinBytes; // independent: >= 9 MB
   const bool useXorRelay = nActiveRanksPerGroup == 4 && numHelpers == 4 &&
-      allSegmentCountsPositive && maxBytes >= kXorRelayMinBytes &&
-      maxBytes < kXorRelayMaxBytes;
+      allSegmentCountsPositive && maxBytes >= xorRelayMinBytes;
   return useXorRelay ? AllToAllRoute::A4XorRelay : AllToAllRoute::PureDirect;
 }
 
-// Per-source relay chunk of the A==4 XOR all-to-all. The direct-B region
-// absorbs both the /3 remainder and the alignment loss, so
-// 3 * relayCount <= segmentCount always holds.
+// Per-source relay chunk of the A==4 XOR all-to-all, and equally the size of
+// its leading direct region: the schedule's two serialized phases each carry
+// one such chunk per link, so the three regions are directA = relay = this
+// count with directB absorbing the /3 remainder and the alignment loss. Every
+// region boundary is therefore 128-element aligned; a plain segmentCount/3
+// directA is misaligned for every power-of-two segment (2^n is never divisible
+// by 3), which pushed the relay region onto an unaligned offset and cost more
+// than the relay saved.
 inline size_t allToAllA4RelayCount(size_t segmentCount) {
   return (segmentCount / 3 / kRelayChunkAlignElements) *
       kRelayChunkAlignElements;

--- a/comms/rcclx/develop/meta/relay/sharded_relay_route.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_route.h
@@ -304,7 +304,41 @@ inline constexpr int kRelayMaxPipelineTiles = 4;
 inline constexpr size_t kRelayPipelineBoundaryBytes = 768u << 10;
 
 /**
- * Software-pipeline depth for the single-group 2-active relay.
+ * Geometry a single-group relay's software pipeline has, in units of the
+ * smallest chunk the schedule moves.
+ *
+ * A relay schedule is described by two linear functions of the depth T:
+ *   totalUnits(T)  how many units the relayed count divides into, so one unit
+ * is count / totalUnits(T) linkUnits(T)   how many units the busiest link
+ * direction ends up carrying, which is what the call actually costs Both are
+ * affine in T, so each is a (perTile, fixed) pair. The depth-1 case always
+ * reproduces the existing two-group schedule, which is the check that a shape
+ * is written correctly.
+ *
+ * The four shipped shapes, on an 8-GPU node (H helpers):
+ *
+ *   2-active, all four collectives   link {1, 1}   total {H+1, 1}
+ *     One unit per link per group. count/4 at T = 1 -> count/7 as T grows.
+ *
+ *   4-active all-to-all              link {1, 1}   total {2, 1}
+ *     One unit up and one down per cross link per group, matched by one direct
+ *     unit on the intra links. 2*count/3 at T = 1 -> count/2.
+ *
+ */
+struct RelayPipelineShape {
+  int linkPerTile;
+  int linkFixed;
+  int totalPerTile;
+  int totalFixed;
+};
+
+inline constexpr RelayPipelineShape relayShapeA2(int numHelpers) {
+  return {1, 1, numHelpers + 1, 1};
+}
+inline constexpr RelayPipelineShape kRelayShapeA4AllToAll = {1, 1, 2, 1};
+
+/**
+ * Software-pipeline depth for a single-group relay.
  *
  * With nGroups == 1 the active ranks and the helpers are DISJOINT sets, so a
  * cross link carries the scatter (active -> helper) in one direction and the
@@ -314,13 +348,11 @@ inline constexpr size_t kRelayPipelineBoundaryBytes = 768u << 10;
  * for all of group 2.
  *
  * Tiling the relay into T tiles and issuing tile t's forward in the SAME group
- * as tile t+1's scatter fills both directions. Per link and direction each of
- * the T+1 groups then carries one unit u, against a count of
- * ((H+1)*T + 1)*u -- so the cost is (T+1)/((H+1)*T + 1) of the count:
- * count/4 at T = 1 (identical to the two-group schedule) falling towards
- * count/7 as T grows on an 8-GPU node, i.e. a 4x ceiling becomes 7x. count/7 is
- * also the hard floor, since an active rank must move its whole buffer out
- * across its 7 links exactly once.
+ * as tile t+1's scatter fills both directions. What that is worth depends on
+ * the schedule's shape (see RelayPipelineShape); at 2 active ranks it takes the
+ * per-link cost from count/4 towards count/7, which is also the hard floor
+ * since an active rank must move its buffer out across its 7 links exactly
+ * once.
  *
  * A FUSED call gains nothing here, which is why this is gated on nGroups == 1:
  * there every rank is active for one group and a helper for the others, so its
@@ -328,30 +360,34 @@ inline constexpr size_t kRelayPipelineBoundaryBytes = 768u << 10;
  * rather than overlap, and the extra group boundaries are pure cost.
  *
  * The depth is whichever power of two minimizes
- * (T + 1) * (perStageBytes + kRelayPipelineBoundaryBytes), which is the two
- * competing terms stated directly rather than a size threshold per depth.
+ * linkUnits(T) * unitBytes + (T + 1) * kRelayPipelineBoundaryBytes, which is
+ * the two competing terms stated directly rather than a size threshold per
+ * depth.
  */
-inline int relayA2PipelineTiles(
-    int nActiveRanksPerGroup,
-    int numHelpers,
+inline int relayPipelineTiles(
     int nGroups,
+    RelayPipelineShape shape,
     size_t maxCount,
     size_t elementSize) {
-  if (nGroups != 1 || nActiveRanksPerGroup != 2 || numHelpers < 1) {
+  if (nGroups != 1 || shape.totalPerTile < 1) {
     return 1;
   }
   const size_t bytes = maxCount * elementSize;
-  const size_t perTileStages = static_cast<size_t>(numHelpers) + 1;
   int bestTiles = 1;
   size_t bestCost = 0;
   for (int tiles = 1; tiles <= kRelayMaxPipelineTiles; tiles *= 2) {
-    const size_t units = perTileStages * static_cast<size_t>(tiles) + 1;
-    // A stage still has to be a whole aligned chunk.
-    if (maxCount / units < kRelayChunkAlignElements) {
+    const size_t totalUnits =
+        static_cast<size_t>(shape.totalPerTile) * static_cast<size_t>(tiles) +
+        static_cast<size_t>(shape.totalFixed);
+    // A unit still has to be a whole aligned chunk.
+    if (maxCount / totalUnits < kRelayChunkAlignElements) {
       break;
     }
-    const size_t cost = static_cast<size_t>(tiles + 1) *
-        (bytes / units + kRelayPipelineBoundaryBytes);
+    const size_t linkUnits =
+        static_cast<size_t>(shape.linkPerTile) * static_cast<size_t>(tiles) +
+        static_cast<size_t>(shape.linkFixed);
+    const size_t cost = linkUnits * (bytes / totalUnits) +
+        static_cast<size_t>(tiles + 1) * kRelayPipelineBoundaryBytes;
     if (bestCost == 0 || cost < bestCost) {
       bestCost = cost;
       bestTiles = tiles;

--- a/comms/rcclx/develop/meta/relay/sharded_relay_route.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_route.h
@@ -284,4 +284,80 @@ inline size_t allReduceOffloadPermille(AllReduceRoute route) {
   return route == AllReduceRoute::FlatOffload ? 500 : 0;
 }
 
+// Largest software-pipeline depth the single-group relays will use.
+//
+// Capped at 4 for stability rather than for throughput. Every group boundary is
+// a cross-rank sync point, so a deeper pipeline gives co-resident independent
+// jobs more opportunities to skew against each other: at depth 8 the 4-job
+// parallel sweep becomes erratic and non-reproducible (0.74x-1.46x outliers
+// scattered through the size axis, different sizes each run), while depth 4 is
+// as stable as the unpipelined schedule. Depth 4 also happens to be what the
+// cost model below picks at every size measured on the single-group sweep, so
+// the cap costs nothing there.
+inline constexpr int kRelayMaxPipelineTiles = 4;
+
+// What one extra ncclGroup boundary costs, expressed as the per-link bytes that
+// take the same time: a grouped-P2P launch plus work-FIFO upload plus fence is
+// ~25 us, which at the measured ~50 GB/s per XGMI link is ~768 KiB. Deepening
+// the pipeline trades per-link bytes for boundaries, so this is what decides
+// where that trade stops paying.
+inline constexpr size_t kRelayPipelineBoundaryBytes = 768u << 10;
+
+/**
+ * Software-pipeline depth for the single-group 2-active relay.
+ *
+ * With nGroups == 1 the active ranks and the helpers are DISJOINT sets, so a
+ * cross link carries the scatter (active -> helper) in one direction and the
+ * forward (helper -> active) in the other. Running those as two serialized
+ * ncclGroups therefore leaves every cross link HALF-DUPLEX for the whole call:
+ * the forward direction is idle for all of group 1 and the scatter direction
+ * for all of group 2.
+ *
+ * Tiling the relay into T tiles and issuing tile t's forward in the SAME group
+ * as tile t+1's scatter fills both directions. Per link and direction each of
+ * the T+1 groups then carries one unit u, against a count of
+ * ((H+1)*T + 1)*u -- so the cost is (T+1)/((H+1)*T + 1) of the count:
+ * count/4 at T = 1 (identical to the two-group schedule) falling towards
+ * count/7 as T grows on an 8-GPU node, i.e. a 4x ceiling becomes 7x. count/7 is
+ * also the hard floor, since an active rank must move its whole buffer out
+ * across its 7 links exactly once.
+ *
+ * A FUSED call gains nothing here, which is why this is gated on nGroups == 1:
+ * there every rank is active for one group and a helper for the others, so its
+ * scatter and its forward are egress on the SAME link direction. They add
+ * rather than overlap, and the extra group boundaries are pure cost.
+ *
+ * The depth is whichever power of two minimizes
+ * (T + 1) * (perStageBytes + kRelayPipelineBoundaryBytes), which is the two
+ * competing terms stated directly rather than a size threshold per depth.
+ */
+inline int relayA2PipelineTiles(
+    int nActiveRanksPerGroup,
+    int numHelpers,
+    int nGroups,
+    size_t maxCount,
+    size_t elementSize) {
+  if (nGroups != 1 || nActiveRanksPerGroup != 2 || numHelpers < 1) {
+    return 1;
+  }
+  const size_t bytes = maxCount * elementSize;
+  const size_t perTileStages = static_cast<size_t>(numHelpers) + 1;
+  int bestTiles = 1;
+  size_t bestCost = 0;
+  for (int tiles = 1; tiles <= kRelayMaxPipelineTiles; tiles *= 2) {
+    const size_t units = perTileStages * static_cast<size_t>(tiles) + 1;
+    // A stage still has to be a whole aligned chunk.
+    if (maxCount / units < kRelayChunkAlignElements) {
+      break;
+    }
+    const size_t cost = static_cast<size_t>(tiles + 1) *
+        (bytes / units + kRelayPipelineBoundaryBytes);
+    if (bestCost == 0 || cost < bestCost) {
+      bestCost = cost;
+      bestTiles = tiles;
+    }
+  }
+  return bestTiles;
+}
+
 } // namespace rcclx::relay

--- a/comms/rcclx/develop/meta/relay/sharded_relay_route.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_route.h
@@ -113,12 +113,14 @@ inline size_t relayMaxCount(const size_t* counts, int nGroups) {
  * A * max(segmentCounts) * elementSize, which equals the bench's per-rank input
  * label.
  *
- * A==2 crossover: the fused relay overtakes the direct exchange at ~9 MB and an
- * independent call at ~27 MB (independent has no cross-group contention, so
- * direct holds on longer); cross over below each. A==4 relays from 27 MB fused
- * / 9 MB independent up, with no upper bound: the 256 MiB ceiling this used to
- * carry was covering an alignment bug in the relay geometry, not a real
- * crossover.
+ * A==2 crossover: measured on the single-group sweep AFTER the tiling and
+ * pipelining work, the relay overtakes the direct exchange at 4.5 MB (relay
+ * 0.077 ms vs direct 0.089 ms; at 2.25 MB it is 0.067 vs 0.066, a tie). The
+ * 27 MB this used to carry was measured before pipelining and left the whole
+ * 4.5-27 MB band on the direct route at ~1.07x when the relay was already
+ * worth 1.26x-2.25x there. A==4 relays from 27 MB fused / 10 MB independent
+ * up, with no upper bound: the 256 MiB ceiling this used to carry was covering
+ * an alignment bug in the relay geometry, not a real crossover.
  */
 inline AllToAllRoute selectAllToAllRoute(
     int nActiveRanksPerGroup,
@@ -132,7 +134,7 @@ inline AllToAllRoute selectAllToAllRoute(
   if (nActiveRanksPerGroup == 2) {
     const size_t pureDirectMaxBytes = (nGroups > 1)
         ? (static_cast<size_t>(2) << 20) // fused: < 2 MB
-        : (static_cast<size_t>(27) << 20); // independent: < 27 MB
+        : (static_cast<size_t>(3) << 20); // independent: < 3 MB
     return (maxBytes < pureDirectMaxBytes) ? AllToAllRoute::PureDirect
                                            : AllToAllRoute::A2Relay;
   }
@@ -141,10 +143,10 @@ inline AllToAllRoute selectAllToAllRoute(
   for (int g = 0; g < nGroups; g++) {
     allSegmentCountsPositive &= segmentCounts[g] > 0;
   }
-  constexpr size_t kXorRelayMinBytes = static_cast<size_t>(9) << 20;
+  constexpr size_t kXorRelayMinBytes = static_cast<size_t>(10) << 20;
   const size_t xorRelayMinBytes = (nGroups > 1)
       ? (static_cast<size_t>(27) << 20) // fused: >= 27 MB
-      : kXorRelayMinBytes; // independent: >= 9 MB
+      : kXorRelayMinBytes; // independent: >= 10 MB
   const bool useXorRelay = nActiveRanksPerGroup == 4 && numHelpers == 4 &&
       allSegmentCountsPositive && maxBytes >= xorRelayMinBytes;
   return useXorRelay ? AllToAllRoute::A4XorRelay : AllToAllRoute::PureDirect;
@@ -169,13 +171,13 @@ inline size_t allToAllA4RelayCount(size_t segmentCount) {
  * Size metric is max(sendCounts) * elementSize -- the per-rank input shard
  * label, with no active-rank factor.
  *
- * A==2 crossover: the fused 2-active relay overtakes the direct exchange at
- * ~4.5 MB and an independent call at ~13.5 MB; cross over below each. For A>2
- * the flat path turns a profit on the 2-hop offload from ~12 MB when fused and
- * ~8 MB when independent (an independent call has the cross links to itself).
- * A==2 never takes the offload: it only reaches the flat path in the
- * small-message regime where the relay was already ruled out, so offloading
- * would re-add the hop it was routed there to avoid.
+ * A==2 crossover: measured post-pipelining, the relay overtakes the direct
+ * exchange at 2.25 MB (relay 0.076 ms vs direct 0.090 ms; at 1.125 MB it is
+ * 0.068 vs 0.067, a tie). For A>2 the flat path turns a profit on the 2-hop
+ * offload from 4.5 MB when independent (0.120 vs 0.140). A==2 never takes the
+ * offload: it only reaches the flat path in the small-message regime where the
+ * relay was already ruled out, so offloading would re-add the hop it was routed
+ * there to avoid.
  */
 inline AllGatherRoute selectAllGatherRoute(
     int nActiveRanksPerGroup,
@@ -188,14 +190,14 @@ inline AllGatherRoute selectAllGatherRoute(
   if (nActiveRanksPerGroup == 2) {
     const size_t pureDirectMaxBytes = (nGroups > 1)
         ? (static_cast<size_t>(2) << 20) // fused: < 2 MB
-        : (static_cast<size_t>(9) << 20); // independent: < 9 MB
+        : (static_cast<size_t>(2) << 20); // independent: < 2 MB
     return (maxBytes < pureDirectMaxBytes) ? AllGatherRoute::PureDirect
                                            : AllGatherRoute::A2Relay;
   }
 
   const size_t offloadMinBytes = (nGroups > 1)
       ? (static_cast<size_t>(12) << 20) // fused: >= 12 MB
-      : (static_cast<size_t>(8) << 20); // independent: >= 8 MB
+      : (static_cast<size_t>(3) << 20); // independent: >= 3 MB
   const bool useOffload = (numHelpers > 0) && (nActiveRanksPerGroup > 2) &&
       (maxBytes >= offloadMinBytes);
   return useOffload ? AllGatherRoute::FlatOffload : AllGatherRoute::PureDirect;
@@ -208,10 +210,13 @@ inline AllGatherRoute selectAllGatherRoute(
  * label. The A==2 fast path measures 2 * recvCount * elementSize, which is the
  * same value because it is only reachable when A==2.
  *
- * A==2 crossover: the fused relay overtakes the direct exchange at ~9 MB and an
- * independent call at ~27 MB; cross over just below each. For A>2 the offload's
- * extra hop and second group boundary only pay for themselves past ~48 MB;
- * below that the single-group pure-direct reduce-scatter wins outright.
+ * A==2 crossover: measured post-pipelining, the relay overtakes the direct
+ * exchange at 4.5 MB (relay 0.074 ms vs direct 0.089 ms; at 2.25 MB it is 0.065
+ * vs 0.067, a tie). The 27 MB this used to carry predates pipelining. For A>2
+ * the offload's extra hop and second group boundary still only pay for
+ * themselves past ~48 MB -- its relay curve is the one shape pipelining did not
+ * move below 27 MB (0.202 ms vs 0.187 ms direct there) -- so that threshold is
+ * unchanged.
  */
 inline ReduceScatterRoute selectReduceScatterRoute(
     int nActiveRanksPerGroup,
@@ -225,7 +230,7 @@ inline ReduceScatterRoute selectReduceScatterRoute(
   if (nActiveRanksPerGroup == 2) {
     const size_t pureDirectMaxBytes = (nGroups > 1)
         ? (static_cast<size_t>(2) << 20) // fused: < 2 MB
-        : (static_cast<size_t>(27) << 20); // independent: < 27 MB
+        : (static_cast<size_t>(3) << 20); // independent: < 3 MB
     return (maxBytes < pureDirectMaxBytes) ? ReduceScatterRoute::PureDirect
                                            : ReduceScatterRoute::A2Relay;
   }
@@ -242,15 +247,14 @@ inline ReduceScatterRoute selectReduceScatterRoute(
  * Size metric is max(counts) * elementSize -- the bench per-rank input label,
  * with no active-rank factor.
  *
- * A==2 crossover: the relay wins big at large sizes (one group spread across
- * all helpers) so the crossover is low, and an independent call has no
- * cross-group contention on the direct link so pure-direct holds on longer
- * (2 MB fused, 6 MB independent). For A>2 the fused sweep phase-syncs every
- * group so the offload cross links stay clean and it pays off almost
- * immediately, while an independent call contends with whatever else is in
- * flight (2 MB fused, 9 MB independent); below the crossover the offload only
- * adds helper-hop latency, so the flat path runs a pure-direct
- * reduce-scatter + all-gather among the active ranks with helpers idle.
+ * A==2 crossover: measured post-pipelining, the relay overtakes the direct
+ * exchange at 2.25 MB (relay 0.080 ms vs direct 0.090 ms; at 1.125 MB it is
+ * 0.073 vs 0.066, still direct). For A>2 the offload wins from 1.125 MB
+ * (0.072 vs 0.076) -- the earliest crossover of any shape, because its
+ * pure-direct alternative is the only 3-launch schedule in the set (direct
+ * reduce-scatter, then a reduce, then a direct all-gather) and it measures
+ * 0.89-0.97x of NCCL at every size, so there is very little for the relay to
+ * beat. The 6 MB / 9 MB these used to carry predate pipelining.
  *
  * Unlike the other three selectors this one does not consult numHelpers: the
  * allreduce predicates it replaces never did.
@@ -265,14 +269,14 @@ inline AllReduceRoute selectAllReduceRoute(
   if (nActiveRanksPerGroup == 2) {
     const size_t pureDirectMaxBytes = (nGroups > 1)
         ? (static_cast<size_t>(2) << 20) // fused: < 2 MB
-        : (static_cast<size_t>(6) << 20); // independent: < 6 MB
+        : (static_cast<size_t>(2) << 20); // independent: < 2 MB
     return (maxBytes < pureDirectMaxBytes) ? AllReduceRoute::PureDirect
                                            : AllReduceRoute::A2Relay;
   }
 
   const size_t pureDirectMaxBytes = (nGroups > 1)
       ? (static_cast<size_t>(2) << 20) // fused: < 2 MB
-      : (static_cast<size_t>(9) << 20); // independent: < 9 MB
+      : (static_cast<size_t>(1) << 20); // independent: < 1 MB
   return (maxBytes < pureDirectMaxBytes) ? AllReduceRoute::PureDirect
                                          : AllReduceRoute::FlatOffload;
 }

--- a/comms/rcclx/develop/meta/relay/sharded_relay_route.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_route.h
@@ -330,6 +330,29 @@ inline constexpr size_t kRelayOverlapReduceMinBytes = static_cast<size_t>(256)
 inline constexpr size_t kRelayUniformDirectOpMinBytes = static_cast<size_t>(256)
     << 20;
 
+// Largest per-active-rank message the one-shot IPC path handles, and equally
+// the per-peer staging slot size it provisions.
+//
+// Below this the collective is pure launch cost, and a single kernel that
+// pushes into peers' pre-registered staging, handshakes on a flag, and reduces
+// in registers replaces a whole ncclGroup plus a reduce. Above it the push
+// costs two HBM trips NCCL's streaming kernel does not pay -- store into the
+// peer's staging, then read it back to reduce -- and that overtakes the launch
+// it saves.
+//
+// The feasibility probe measured the KERNEL crossover (2-rank reduce-scatter,
+// float, streamed) between 1 MiB and 2.25 MiB:
+//
+//   4 KB .. 1152 KB   1.46x - 1.71x faster than NCCL's fused kernel
+//   2304 KB           0.89x
+//   4608 KB           0.78x
+//   9216 KB           0.73x
+//
+// so 1 MiB is the last power of two entirely inside the winning region. Staging
+// is nRanks * this per rank, i.e. 8 MiB on an 8-GPU node, allocated once per
+// communicator.
+inline constexpr size_t kRelayOneShotMaxBytes = static_cast<size_t>(1) << 20;
+
 // Largest software-pipeline depth the single-group relays will use.
 //
 // 8 is where the measured optimum stops moving. Depth 16 is a wash at best

--- a/comms/rcclx/develop/meta/relay/sharded_relay_route.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_route.h
@@ -304,26 +304,34 @@ inline constexpr int kRelayMaxPipelineTiles = 4;
 inline constexpr size_t kRelayPipelineBoundaryBytes = 768u << 10;
 
 /**
- * Geometry a single-group relay's software pipeline has, in units of the
+ * Geometry of a single-group relay's software pipeline, in units of the
  * smallest chunk the schedule moves.
  *
- * A relay schedule is described by two linear functions of the depth T:
- *   totalUnits(T)  how many units the relayed count divides into, so one unit
- * is count / totalUnits(T) linkUnits(T)   how many units the busiest link
- * direction ends up carrying, which is what the call actually costs Both are
- * affine in T, so each is a (perTile, fixed) pair. The depth-1 case always
- * reproduces the existing two-group schedule, which is the check that a shape
- * is written correctly.
+ * A schedule is described by two affine functions of the depth T, each a
+ * (perTile, fixed) pair:
  *
- * The four shipped shapes, on an 8-GPU node (H helpers):
+ * - totalUnits(T): how many units the relayed count divides into. One unit is
+ *   count / totalUnits(T).
+ * - linkUnits(T): how many units the busiest link direction carries, which is
+ *   what the call actually costs.
  *
- *   2-active, all four collectives   link {1, 1}   total {H+1, 1}
- *     One unit per link per group. count/4 at T = 1 -> count/7 as T grows.
+ * Depth 1 always reproduces the existing two-group schedule, which is the check
+ * that a shape is written correctly.
  *
- *   4-active all-to-all              link {1, 1}   total {2, 1}
- *     One unit up and one down per cross link per group, matched by one direct
- *     unit on the intra links. 2*count/3 at T = 1 -> count/2.
+ * The shipped shapes, for A active ranks and H helpers:
  *
+ * - 2-active, all four collectives. link {1, 1}, total {H+1, 1}. One unit per
+ *   link per group; count/4 at T = 1 falling towards count/7 at H = 6.
+ * - 4-active all-to-all. link {1, 1}, total {2, 1}. One unit up and one down
+ * per cross link per group, matched by one direct unit on the intra links;
+ *   2*count/3 at T = 1 falling towards count/2.
+ * - A>2 all-gather fanout. link {A-1, 1}, total {H+A-1, 1}. Asymmetric: the
+ *   helper fans each source's slice out to the A-1 other destinations, so one
+ *   direction of the cross link carries A-1 units for every 1 the other
+ *   carries and merging is bounded by the heavy direction. At A = H = 4 that
+ *   is link {3, 1} / total {7, 1}: count/2 at T = 1 falling towards
+ *   3*count/7, which is also the hard floor since an active rank must take in
+ *   A-1 whole buffers across its 7 links.
  */
 struct RelayPipelineShape {
   int linkPerTile;
@@ -336,6 +344,17 @@ inline constexpr RelayPipelineShape relayShapeA2(int numHelpers) {
   return {1, 1, numHelpers + 1, 1};
 }
 inline constexpr RelayPipelineShape kRelayShapeA4AllToAll = {1, 1, 2, 1};
+
+// The all-gather fanout schedule's layout consumes H*T + 1 + (T-1)*(A-1) units
+// before its final direct chunk, so totalUnits must be at least that for
+// directSize(T) = count - directOffset(T) not to underflow. Deriving both
+// members from A and H keeps the shape and the kernel's own layout in step for
+// every geometry buildShardedRelayRankConfig() accepts, not just A = H = 4.
+inline constexpr RelayPipelineShape relayShapeFanout(
+    int nActiveRanks,
+    int numHelpers) {
+  return {nActiveRanks - 1, 1, numHelpers + nActiveRanks - 1, 1};
+}
 
 /**
  * Software-pipeline depth for a single-group relay.

--- a/comms/rcclx/develop/meta/relay/sharded_relay_route.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_route.h
@@ -286,15 +286,40 @@ inline size_t allReduceOffloadPermille(AllReduceRoute route) {
 
 // Largest software-pipeline depth the single-group relays will use.
 //
-// Capped at 4 for stability rather than for throughput. Every group boundary is
-// a cross-rank sync point, so a deeper pipeline gives co-resident independent
-// jobs more opportunities to skew against each other: at depth 8 the 4-job
-// parallel sweep becomes erratic and non-reproducible (0.74x-1.46x outliers
-// scattered through the size axis, different sizes each run), while depth 4 is
-// as stable as the unpipelined schedule. Depth 4 also happens to be what the
-// cost model below picks at every size measured on the single-group sweep, so
-// the cap costs nothing there.
-inline constexpr int kRelayMaxPipelineTiles = 4;
+// 8 is where the measured optimum stops moving. Depth 16 is a wash at best
+// (2-active allreduce at 1 GB: 4.252 ms at depth 8, 4.253 ms at 16) and a loss
+// where the per-stage op count is already high (4-active all-to-all at 512 MB:
+// 1.836 ms -> 1.993 ms), so there is nothing past 8 to take.
+//
+// This was briefly capped at 4, on the belief that depth 8 destabilized
+// co-resident jobs. That was a measurement error worth recording, because the
+// sweep it came from will mislead the same way again: the parallel sweep's
+// relay times vary run to run by ~20-30%, in two loose clusters, and a single
+// run against a single-run baseline reads that as a regression. It is not the
+// pipeline: the spread is present at depth 1 with EQUAL OR LARGER magnitude
+// (max/min over 4 runs at 144 MB: 1.78 at depth 1 versus 1.24 at depth 4), and
+// it is identical across co-resident jobs to within 3%, so it is not cross-job
+// skew either.
+//
+// Contributors identified, in descending order of how sure we are:
+//  - Co-tenant GPU work on a shared node. Confirmed: while another workload had
+//    the GPUs, a 4-active single-group all-gather at 256 MB read 8.3-10.6 ms
+//    for the NCCL baseline against 5.08 ms on an idle node, and per-rep spreads
+//    went from 1.00-1.12 to 1.25-1.45. Always check BENCH_SWEEP_PER_REP spreads
+//    before trusting a number.
+//  - p2p channel resourcing. Pinning NCCL_MIN/MAX_P2P_NCHANNELS makes the
+//  timing
+//    deterministic to +/-1% but costs 1.75x at 32 channels and 20x at 8, since
+//    the default resolves to 64 channels with 8 per peer and forcing it lower
+//    puts all 7 peers on shared channels. Suggestive, not conclusive.
+// Ruled out: clocks (fclk stays pinned at 1500 MHz, sclk moves ~6%, and neither
+// tracks the slow runs) and the host allocator (expandable_segments changes
+// nothing).
+//
+// The single-group sweep does NOT show this: on an idle node it repeats to
+// within 0.3-0.6%, which is why it is the sweep the size gating above is tuned
+// on. Parallel comparisons need repeated invocations and must compare minima.
+inline constexpr int kRelayMaxPipelineTiles = 8;
 
 // What one extra ncclGroup boundary costs, expressed as the per-link bytes that
 // take the same time: a grouped-P2P launch plus work-FIFO upload plus fence is

--- a/comms/rcclx/develop/meta/relay/sharded_relay_route.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_route.h
@@ -440,4 +440,84 @@ inline int relayPipelineTiles(
   return bestTiles;
 }
 
+/**
+ * Software-pipeline depth for the single-group A>2 allreduce.
+ *
+ * This one needs its own selector because, unlike every other relay, its
+ * depth-1 form is NOT the shipped two-group schedule, so it cannot be expressed
+ * as a RelayPipelineShape whose depth-1 case reproduces today's behaviour.
+ *
+ * The two-group allreduce splits the count into equal direct and offload halves
+ * and moves count/4 per link. The pipelined form runs T direct tiles (a
+ * reduce-scatter tile per group, its all-gather one group later) woven with T
+ * offload tiles, and moves 2*(T+1)*count/((A + 2H)*T) per link: at A = H = 4
+ * that is count/3 at T = 1 and exactly count/4 at T = 2 -- worse, then
+ * break-even with an extra boundary. It first pays at depth 4 (5*count/24) and
+ * again at 8 (3*count/16), so only those are offered, and only when they also
+ * cover their extra boundaries.
+ *
+ * The unit count is A + 2H rather than a fixed 12 because that is what the
+ * layout actually consumes: the offload region takes 2*H*T units and the direct
+ * region needs A*T for its per-owner shards to tile. At the shipped A = H = 4
+ * geometry that is 12, but A = 4 with H = 5..8 (a 9-to-12-rank comm) or A = 8
+ * with H = 8 (a 16-rank one) also reach this path, and a fixed 12 would push pO
+ * past count and underflow pD. The depth THRESHOLDS below are still calibrated
+ * against A = H = 4 measurements; other geometries get a correct layout from a
+ * cost model that has not been re-measured for them.
+ *
+ * Its offload is what makes it worth doing at all: the helper takes one chunk
+ * per active rank and returns one reduced chunk per active rank, so the cross
+ * link carries the same in each direction and merging is not throttled by a
+ * heavy side, unlike the all-gather and reduce-scatter shapes.
+ *
+ * A stage here is priced at TWICE kRelayPipelineBoundaryBytes because this is
+ * the only schedule that issues two reduce kernels per stage -- the owner
+ * folding its direct shard's tile and the helper summing its offload tile -- on
+ * top of the group boundary itself. Measured, that is what it takes: the depth
+ * curve wants the two-group schedule at or below 72 MB, depth 4 from 135 MB to
+ * 256 MB, and depth 8 from 512 MB, which pins the per-stage price to
+ * between 1.33 and 1.875 MiB. At the shared 768 KiB it crosses over near 54 MB
+ * instead and loses 7-8% at 63-72 MB.
+ */
+// Units the pipelined allreduce layout divides the count into per tile:
+// 2*H for the offload region (the helper takes one chunk per active rank and
+// returns one, so a tile is 2y) plus A for the direct region's per-owner
+// shards.
+inline constexpr int relayAllReducePipelineUnitsPerTile(
+    int nActiveRanks,
+    int numHelpers) {
+  return nActiveRanks + 2 * numHelpers;
+}
+
+inline int relayAllReducePipelineTiles(
+    int nGroups,
+    int nActiveRanks,
+    int numHelpers,
+    size_t maxCount,
+    size_t elementSize) {
+  if (nGroups != 1) {
+    return 1;
+  }
+  const size_t bytes = maxCount * elementSize;
+  // Depth 1 means "keep the two-group schedule", so that is what to beat.
+  constexpr size_t kStageBytes = 2 * kRelayPipelineBoundaryBytes;
+  size_t bestCost = bytes / 4 + 2 * kStageBytes;
+  int bestTiles = 1;
+  const size_t unitsPerTile = static_cast<size_t>(
+      relayAllReducePipelineUnitsPerTile(nActiveRanks, numHelpers));
+  for (int tiles = 4; tiles <= kRelayMaxPipelineTiles; tiles *= 2) {
+    const size_t units = unitsPerTile * static_cast<size_t>(tiles);
+    if (maxCount / units < kRelayChunkAlignElements) {
+      break;
+    }
+    const size_t cost = 2 * static_cast<size_t>(tiles + 1) * (bytes / units) +
+        static_cast<size_t>(tiles + 1) * kStageBytes;
+    if (cost < bestCost) {
+      bestCost = cost;
+      bestTiles = tiles;
+    }
+  }
+  return bestTiles;
+}
+
 } // namespace rcclx::relay

--- a/comms/rcclx/develop/meta/relay/sharded_relay_route.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_route.h
@@ -303,6 +303,29 @@ inline size_t allReduceOffloadPermille(AllReduceRoute route) {
 inline constexpr size_t kRelayOverlapReduceMinBytes = static_cast<size_t>(256)
     << 20;
 
+// Smallest message for which the pipelined A>2 all-gather issues its direct
+// exchange as v-sized pieces instead of one (A-1)*v operation.
+//
+// Both directions of every link carry the same 3v per group, but the cross
+// links carried it as three v-sized ops while the intra links carried it as a
+// single 3v op, and RCCL budgets channels per operation -- so the single-op
+// link got a third of the channels and gated the group. Making every op in a
+// group the same size provisions all seven links alike.
+//
+// The mirrored reduce-scatter shape takes this unconditionally because it wins
+// everywhere its offload route is active (1.30x -> 1.61x at 1 GB, 1.26x
+// -> 1.46x at 135 MB). All-gather has far less to gain, being already the
+// closest variant to the roofline, and the extra ops do not amortize at
+// moderate sizes:
+//
+//   135 MB  1.77x -> 1.73x     256 MB  1.81x -> 1.83x
+//   144 MB  1.76x -> 1.74x     512 MB  1.83x -> 1.88x
+//                                1 GB  1.83x -> 1.91x
+//
+// so it is gated to where it measurably pays.
+inline constexpr size_t kRelayUniformDirectOpMinBytes = static_cast<size_t>(256)
+    << 20;
+
 // Largest software-pipeline depth the single-group relays will use.
 //
 // 8 is where the measured optimum stops moving. Depth 16 is a wash at best

--- a/comms/rcclx/develop/meta/relay/sharded_relay_route.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_route.h
@@ -284,6 +284,25 @@ inline size_t allReduceOffloadPermille(AllReduceRoute route) {
   return route == AllReduceRoute::FlatOffload ? 500 : 0;
 }
 
+// Smallest message the single-group 2-active reduce-scatter overlaps its owner
+// reduce for, measured against the two bounds that bracket the change (the
+// unoverlapped schedule, and the same schedule with the reduce skipped
+// entirely). Fraction of that interval closed, per size:
+//
+//    63-72 MB   the overlap LOSES 6-8%
+//   135-144 MB  a wash (-0.5% to +1.1%)
+//   256 MB      47%
+//   512 MB      65%
+//     1 GB      80%   (3.82x -> 4.68x vs NCCL; the ceiling is T/(T+1) = 89%)
+//
+// Two effects push the crossover up: the T+1 event record/wait pairs are a
+// fixed cost, and the last region's reduce can never be hidden because no
+// transfer follows it -- at small sizes the depth is lower, so that unhidden
+// region is a larger share of the whole. 256 MiB is the smallest size measured
+// to win clearly; there is no sample between 144 MiB and it.
+inline constexpr size_t kRelayOverlapReduceMinBytes = static_cast<size_t>(256)
+    << 20;
+
 // Largest software-pipeline depth the single-group relays will use.
 //
 // 8 is where the measured optimum stops moving. Depth 16 is a wash at best

--- a/comms/rcclx/develop/meta/relay/tests/RelayControlTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/RelayControlTest.cu
@@ -1,0 +1,913 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/**
+ * Protocol tests for the sharded-relay host control plane.
+ *
+ * WHY FORKED PROCESSES AND NOT RANKS
+ *
+ * The interesting failures here are not "does a plan arrive" -- they are what
+ * happens when a segment is malformed, when its creator is dead, when a
+ * consumer falls more than a ring behind, and when a reader lands in the middle
+ * of a write. A rank layout cannot produce any of those on demand: every rank
+ * runs the same code with the same environment. Forked children can, because
+ * the parent chooses each child's geometry, its role, and when it dies.
+ *
+ * So this suite runs at ppn=1 and builds its own writer/reader processes. The
+ * communicator-bound layer -- relayControlInit/Release and the bootstrap
+ * unanimity vote -- is covered where a real 8-rank comm exists, in the
+ * production-shape control plane test.
+ */
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include "meta/relay/relay_control.h"
+#include "nccl.h"
+
+using namespace rcclx::relay;
+
+namespace {
+
+constexpr int64_t kMs = 1000LL * 1000LL;
+constexpr int64_t kGenerousTimeoutNs = 60LL * 1000LL * kMs; // 60 s
+constexpr int64_t kShortTimeoutNs = 150LL * kMs;
+
+// Every test gets its own segment name. Tests share a process and the harness
+// may run several binaries on one host, so a fixed name would make unrelated
+// runs collide and fail for reasons that have nothing to do with the protocol.
+uint64_t uniqueHash(uint32_t salt) {
+  return (static_cast<uint64_t>(getpid()) << 24) ^ (salt * 0x9E3779B9ull) ^
+      0xC0FFEEull;
+}
+
+RelayControlConfig makeConfig(
+    uint64_t hash,
+    uint32_t nRanks,
+    uint32_t rank,
+    uint32_t ringDepth,
+    uint32_t maxCalls) {
+  RelayControlConfig cfg;
+  cfg.nRanks = nRanks;
+  cfg.rank = rank;
+  cfg.nActive = 0;
+  cfg.commHash = hash;
+  cfg.ringDepth = ringDepth;
+  cfg.maxCalls = maxCalls;
+  return cfg;
+}
+
+// A deterministic, epoch-dependent plan. The point of varying nCalls, opCode
+// and every count with the epoch is that a torn or stale read cannot coincide
+// with a correct one: any mismatch localizes to a field and an epoch.
+uint32_t planCalls(uint64_t epoch, uint32_t maxCalls) {
+  return 1u + static_cast<uint32_t>(epoch % maxCalls);
+}
+
+uint32_t planOp(uint64_t epoch) {
+  return kRelayOpAllReduce +
+      static_cast<uint32_t>(epoch % (kRelayOpCount - kRelayOpAllReduce));
+}
+
+size_t planCount(uint64_t epoch, uint32_t i) {
+  return static_cast<size_t>(epoch * 1000003ull + i * 7ull + 1ull);
+}
+
+RelayPlanInfo makePlan(uint64_t epoch, uint32_t maxCalls) {
+  RelayPlanInfo info{};
+  info.nCalls = planCalls(epoch, maxCalls);
+  info.opCode = planOp(epoch);
+  info.dtype = static_cast<uint32_t>(ncclFloat32);
+  info.redOp = static_cast<uint32_t>(ncclSum);
+  return info;
+}
+
+void fillCounts(uint64_t epoch, uint32_t n, std::vector<size_t>& out) {
+  for (uint32_t i = 0; i < n; i++) {
+    out[i] = planCount(epoch, i);
+  }
+}
+
+// Child exit codes. Distinct per failure so a red test says which invariant
+// broke, in a context where gtest assertions cannot be reported upward.
+enum ChildStatus : int {
+  kChildOk = 0,
+  kChildAttachFailed = 10,
+  kChildConsumeFailed = 11,
+  kChildWrongCallCount = 12,
+  kChildWrongOpCode = 13,
+  kChildWrongCounts = 14,
+  kChildCreateFailed = 15,
+};
+
+void expectChildOk(pid_t pid) {
+  int status = 0;
+  ASSERT_EQ(waitpid(pid, &status, 0), pid);
+  ASSERT_TRUE(WIFEXITED(status))
+      << "child did not exit normally (signal "
+      << (WIFSIGNALED(status) ? WTERMSIG(status) : -1) << ")";
+  ASSERT_EQ(WEXITSTATUS(status), kChildOk)
+      << "child reported failure code " << WEXITSTATUS(status);
+}
+
+/**
+ * Wait until every listed rank has registered as a consumer.
+ *
+ * This is the precondition the real integration gets for free and these tests
+ * must establish for themselves. In production, comm init is a bootstrap
+ * all-gather that publisher and helpers leave together, and the publisher's
+ * first forward then costs milliseconds of Python and GPU work while the
+ * helper's very next action is its first consume() -- so the helper is always
+ * registered long before the ring could wrap.
+ *
+ * Here the "helpers" are freshly forked processes that need milliseconds to
+ * exist, racing a publisher whose publishes take 50 ns. Without this barrier
+ * the publisher laps the ring before the last child registers, and that child
+ * correctly reports a desync -- a real property, specified by
+ * ALateConsumerGetsADesyncErrorNotCorruption, but not the property these tests
+ * are about.
+ */
+void awaitConsumers(
+    const RelayControlBlock& block,
+    const std::vector<uint32_t>& ranks) {
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(30);
+  for (;;) {
+    size_t registered = 0;
+    for (const uint32_t r : ranks) {
+      if (block.consumerProgress(r) != 0) {
+        registered++;
+      }
+    }
+    if (registered == ranks.size()) {
+      return;
+    }
+    ASSERT_LT(std::chrono::steady_clock::now(), deadline)
+        << "only " << registered << " of " << ranks.size()
+        << " consumers ever registered";
+    usleep(200);
+  }
+}
+
+} // namespace
+
+TEST(RelayControlBlockTest, CreateAndAttachRoundTripsOnePlan) {
+  const uint64_t hash = uniqueHash(1);
+  const uint32_t maxCalls = 8;
+  auto cfg = makeConfig(hash, 2, 0, 4, maxCalls);
+
+  RelayControlBlock writer;
+  ASSERT_TRUE(writer.create(cfg));
+  EXPECT_EQ(writer.ringDepth(), 4u);
+  EXPECT_EQ(writer.maxCalls(), maxCalls);
+
+  RelayControlBlock reader;
+  ASSERT_TRUE(reader.attach(makeConfig(hash, 2, 1, 4, maxCalls)));
+
+  std::vector<size_t> counts(maxCalls);
+  RelayPlanInfo sent = makePlan(0, maxCalls);
+  fillCounts(0, sent.nCalls, counts);
+  ASSERT_EQ(
+      writer.publish(0, sent, counts.data(), kGenerousTimeoutNs), ncclSuccess);
+
+  RelayPlanInfo got{};
+  std::vector<size_t> gotCounts(maxCalls, 0);
+  ASSERT_EQ(
+      reader.consume(0, &got, gotCounts.data(), maxCalls, kGenerousTimeoutNs),
+      ncclSuccess);
+  EXPECT_EQ(got.nCalls, sent.nCalls);
+  EXPECT_EQ(got.opCode, sent.opCode);
+  EXPECT_EQ(got.dtype, sent.dtype);
+  EXPECT_EQ(got.redOp, sent.redOp);
+  for (uint32_t i = 0; i < sent.nCalls; i++) {
+    EXPECT_EQ(gotCounts[i], planCount(0, i)) << "count " << i;
+  }
+  EXPECT_EQ(writer.highWaterCalls(), sent.nCalls);
+}
+
+TEST(RelayControlBlockTest, SegmentBytesMatchesTheDocumentedLayout) {
+  // 64-byte header + one 64-byte-aligned consumed block + ringDepth slots of
+  // (8 seq + 32 info + 8 * maxCalls), each aligned to 64.
+  EXPECT_EQ(RelayControlBlock::segmentBytes(8, 4, 128), 64u + 64u + 4u * 1088u);
+  // Defaults stay comfortably inside a few pages.
+  EXPECT_LT(RelayControlBlock::segmentBytes(8, 4, 128), 8u * 1024u);
+}
+
+TEST(RelayControlBlockTest, RingWrapsWithoutLosingOrCorruptingPlans) {
+  const uint64_t hash = uniqueHash(2);
+  const uint32_t maxCalls = 4;
+  const uint32_t ringDepth = 2;
+  RelayControlBlock writer;
+  ASSERT_TRUE(writer.create(makeConfig(hash, 2, 0, ringDepth, maxCalls)));
+  RelayControlBlock reader;
+  ASSERT_TRUE(reader.attach(makeConfig(hash, 2, 1, ringDepth, maxCalls)));
+
+  std::vector<size_t> counts(maxCalls);
+  std::vector<size_t> got(maxCalls);
+  // Several times around the ring, so slot reuse is exercised rather than just
+  // the first pass through fresh slots.
+  for (uint64_t epoch = 0; epoch < 10; epoch++) {
+    RelayPlanInfo sent = makePlan(epoch, maxCalls);
+    fillCounts(epoch, sent.nCalls, counts);
+    ASSERT_EQ(
+        writer.publish(epoch, sent, counts.data(), kGenerousTimeoutNs),
+        ncclSuccess)
+        << "epoch " << epoch;
+    RelayPlanInfo info{};
+    ASSERT_EQ(
+        reader.consume(epoch, &info, got.data(), maxCalls, kGenerousTimeoutNs),
+        ncclSuccess)
+        << "epoch " << epoch;
+    ASSERT_EQ(info.nCalls, sent.nCalls) << "epoch " << epoch;
+    for (uint32_t i = 0; i < sent.nCalls; i++) {
+      ASSERT_EQ(got[i], planCount(epoch, i))
+          << "epoch " << epoch << " count " << i;
+    }
+  }
+}
+
+TEST(RelayControlBlockTest, ConcurrentReadersNeverObserveATornPlan) {
+  const uint32_t kReaders = 4;
+  const uint32_t nRanks = kReaders + 1;
+  const uint32_t maxCalls = 64;
+  const uint32_t ringDepth = 4;
+  const uint64_t kEpochs = 400;
+  const uint64_t hash = uniqueHash(3);
+
+  RelayControlBlock writer;
+  ASSERT_TRUE(writer.create(makeConfig(hash, nRanks, 0, ringDepth, maxCalls)));
+
+  std::vector<pid_t> readers;
+  for (uint32_t r = 1; r <= kReaders; r++) {
+    const pid_t pid = fork();
+    ASSERT_GE(pid, 0);
+    if (pid == 0) {
+      RelayControlBlock reader;
+      if (!reader.attach(makeConfig(hash, nRanks, r, ringDepth, maxCalls))) {
+        _exit(kChildAttachFailed);
+      }
+      std::vector<size_t> counts(maxCalls, 0);
+      for (uint64_t epoch = 0; epoch < kEpochs; epoch++) {
+        RelayPlanInfo info{};
+        if (reader.consume(
+                epoch, &info, counts.data(), maxCalls, kGenerousTimeoutNs) !=
+            ncclSuccess) {
+          _exit(kChildConsumeFailed);
+        }
+        if (info.nCalls != planCalls(epoch, maxCalls)) {
+          _exit(kChildWrongCallCount);
+        }
+        if (info.opCode != planOp(epoch)) {
+          _exit(kChildWrongOpCode);
+        }
+        for (uint32_t i = 0; i < info.nCalls; i++) {
+          if (counts[i] != planCount(epoch, i)) {
+            _exit(kChildWrongCounts);
+          }
+        }
+      }
+      _exit(kChildOk);
+    }
+    readers.push_back(pid);
+  }
+
+  // Every reader must be in its consume loop before the ring can wrap.
+  awaitConsumers(writer, {1, 2, 3, 4});
+
+  std::vector<size_t> counts(maxCalls);
+  for (uint64_t epoch = 0; epoch < kEpochs; epoch++) {
+    RelayPlanInfo info = makePlan(epoch, maxCalls);
+    fillCounts(epoch, info.nCalls, counts);
+    ASSERT_EQ(
+        writer.publish(epoch, info, counts.data(), kGenerousTimeoutNs),
+        ncclSuccess)
+        << "epoch " << epoch;
+  }
+
+  for (const pid_t pid : readers) {
+    expectChildOk(pid);
+  }
+  EXPECT_EQ(writer.highWaterCalls(), maxCalls);
+}
+
+TEST(
+    RelayControlBlockTest,
+    PublisherWaitsForALaggingConsumerRatherThanDropping) {
+  const uint32_t maxCalls = 4;
+  const uint32_t ringDepth = 2;
+  const uint64_t kEpochs = 12;
+  const uint64_t hash = uniqueHash(4);
+
+  RelayControlBlock writer;
+  ASSERT_TRUE(writer.create(makeConfig(hash, 2, 0, ringDepth, maxCalls)));
+
+  const pid_t pid = fork();
+  ASSERT_GE(pid, 0);
+  if (pid == 0) {
+    RelayControlBlock reader;
+    if (!reader.attach(makeConfig(hash, 2, 1, ringDepth, maxCalls))) {
+      _exit(kChildAttachFailed);
+    }
+    std::vector<size_t> counts(maxCalls, 0);
+    for (uint64_t epoch = 0; epoch < kEpochs; epoch++) {
+      RelayPlanInfo info{};
+      if (reader.consume(
+              epoch, &info, counts.data(), maxCalls, kGenerousTimeoutNs) !=
+          ncclSuccess) {
+        _exit(kChildConsumeFailed);
+      }
+      if (info.nCalls != planCalls(epoch, maxCalls)) {
+        _exit(kChildWrongCallCount);
+      }
+      for (uint32_t i = 0; i < info.nCalls; i++) {
+        if (counts[i] != planCount(epoch, i)) {
+          _exit(kChildWrongCounts);
+        }
+      }
+      // Lag AFTER registering, which is what a real helper doing work between
+      // consumes looks like. Sleeping before the first consume would instead
+      // violate the start-up contract tested separately below.
+      usleep(20 * 1000);
+    }
+    _exit(kChildOk);
+  }
+
+  awaitConsumers(writer, {1});
+
+  std::vector<size_t> counts(maxCalls);
+  for (uint64_t epoch = 0; epoch < kEpochs; epoch++) {
+    RelayPlanInfo info = makePlan(epoch, maxCalls);
+    fillCounts(epoch, info.nCalls, counts);
+    ASSERT_EQ(
+        writer.publish(epoch, info, counts.data(), kGenerousTimeoutNs),
+        ncclSuccess)
+        << "epoch " << epoch;
+  }
+  expectChildOk(pid);
+}
+
+/**
+ * The start-up contract, and what happens when it is broken.
+ *
+ * A rank's ROLE is not knowable to the segment: active ranks attach too, and
+ * they never consume, so the publisher cannot simply wait on everyone who
+ * attached. Consumers therefore register themselves on entry to consume(),
+ * which means a consumer that has not yet reached its first consume() is not
+ * protected, and the publisher is free to run a full ring ahead.
+ *
+ * In the real system that window does not exist in any practical sense: comm
+ * init is a bootstrap barrier that both sides leave together, the helper's next
+ * action is its first consume(), and the publisher would have to complete
+ * ringDepth ENTIRE forwards -- GPU work included -- before the helper executes
+ * one instruction of its loop.
+ *
+ * This test exists so that the behaviour when it IS broken is specified rather
+ * than discovered: the late consumer gets a bounded, attributed desync error,
+ * not corruption and not a hang.
+ */
+TEST(RelayControlBlockTest, ALateConsumerGetsADesyncErrorNotCorruption) {
+  const uint32_t maxCalls = 4;
+  const uint32_t ringDepth = 2;
+  const uint64_t hash = uniqueHash(21);
+
+  RelayControlBlock writer;
+  ASSERT_TRUE(writer.create(makeConfig(hash, 2, 0, ringDepth, maxCalls)));
+  RelayControlBlock reader;
+  ASSERT_TRUE(reader.attach(makeConfig(hash, 2, 1, ringDepth, maxCalls)));
+
+  // The consumer has attached but never entered consume(), so it is not
+  // registered and the publisher runs away.
+  std::vector<size_t> counts(maxCalls);
+  for (uint64_t epoch = 0; epoch < 6; epoch++) {
+    RelayPlanInfo info = makePlan(epoch, maxCalls);
+    fillCounts(epoch, info.nCalls, counts);
+    ASSERT_EQ(
+        writer.publish(epoch, info, counts.data(), kGenerousTimeoutNs),
+        ncclSuccess)
+        << "epoch " << epoch;
+  }
+
+  RelayPlanInfo got{};
+  std::vector<size_t> out(maxCalls, 0);
+  const auto start = std::chrono::steady_clock::now();
+  EXPECT_EQ(
+      reader.consume(0, &got, out.data(), maxCalls, kGenerousTimeoutNs),
+      ncclInternalError);
+  // Bounded and immediate: waiting cannot bring epoch 0 back.
+  EXPECT_LT(
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::steady_clock::now() - start)
+          .count(),
+      1000);
+}
+
+TEST(RelayControlBlockTest, PublisherTimesOutAndAttributesTheLaggingRank) {
+  const uint32_t maxCalls = 4;
+  const uint32_t ringDepth = 2;
+  const uint64_t hash = uniqueHash(5);
+
+  RelayControlBlock writer;
+  ASSERT_TRUE(writer.create(makeConfig(hash, 2, 0, ringDepth, maxCalls)));
+  RelayControlBlock reader;
+  ASSERT_TRUE(reader.attach(makeConfig(hash, 2, 1, ringDepth, maxCalls)));
+
+  std::vector<size_t> counts(maxCalls);
+  std::vector<size_t> got(maxCalls);
+  for (uint64_t epoch = 0; epoch < 2; epoch++) {
+    RelayPlanInfo info = makePlan(epoch, maxCalls);
+    fillCounts(epoch, info.nCalls, counts);
+    ASSERT_EQ(
+        writer.publish(epoch, info, counts.data(), kGenerousTimeoutNs),
+        ncclSuccess);
+  }
+  // The consumer takes epoch 0 and then stops, so the slot epoch 3 needs is
+  // still holding an unread epoch 1.
+  RelayPlanInfo info{};
+  ASSERT_EQ(
+      reader.consume(0, &info, got.data(), maxCalls, kGenerousTimeoutNs),
+      ncclSuccess);
+
+  // Epoch 2 reuses epoch 0's slot, which has been consumed.
+  RelayPlanInfo two = makePlan(2, maxCalls);
+  fillCounts(2, two.nCalls, counts);
+  ASSERT_EQ(
+      writer.publish(2, two, counts.data(), kGenerousTimeoutNs), ncclSuccess);
+
+  // Epoch 3 reuses epoch 1's slot, which has not been. This must block and then
+  // fail, never silently overwrite.
+  RelayPlanInfo three = makePlan(3, maxCalls);
+  fillCounts(3, three.nCalls, counts);
+  EXPECT_EQ(
+      writer.publish(3, three, counts.data(), kShortTimeoutNs),
+      ncclInternalError);
+  EXPECT_EQ(writer.abortReason(), static_cast<uint32_t>(kRelayAbortTimeout));
+  EXPECT_EQ(writer.abortRank(), 0u);
+}
+
+TEST(RelayControlBlockTest, ConsumeTimesOutAndPoisonsTheSegment) {
+  const uint64_t hash = uniqueHash(6);
+  RelayControlBlock writer;
+  ASSERT_TRUE(writer.create(makeConfig(hash, 2, 0, 4, 8)));
+  RelayControlBlock reader;
+  ASSERT_TRUE(reader.attach(makeConfig(hash, 2, 1, 4, 8)));
+
+  RelayPlanInfo info{};
+  std::vector<size_t> counts(8, 0);
+  const auto start = std::chrono::steady_clock::now();
+  EXPECT_EQ(
+      reader.consume(0, &info, counts.data(), 8, kShortTimeoutNs),
+      ncclInternalError);
+  const auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                             std::chrono::steady_clock::now() - start)
+                             .count();
+  // Bounded is the whole point: the store this replaces had a wait() timeout,
+  // and removing the store must not remove that property.
+  EXPECT_LT(elapsedMs, 5000);
+  EXPECT_EQ(reader.abortReason(), static_cast<uint32_t>(kRelayAbortTimeout));
+  EXPECT_EQ(reader.abortRank(), 1u);
+  // And the failure is visible to everyone else, so one stuck rank produces one
+  // attributed cause rather than N independent timeouts.
+  EXPECT_EQ(writer.abortReason(), static_cast<uint32_t>(kRelayAbortTimeout));
+  EXPECT_EQ(writer.abortRank(), 1u);
+}
+
+TEST(RelayControlBlockTest, PeerAbortStopsConsumersImmediately) {
+  const uint64_t hash = uniqueHash(7);
+  RelayControlBlock writer;
+  ASSERT_TRUE(writer.create(makeConfig(hash, 2, 0, 4, 8)));
+  RelayControlBlock reader;
+  ASSERT_TRUE(reader.attach(makeConfig(hash, 2, 1, 4, 8)));
+
+  writer.setAbort(kRelayAbortCaller);
+  EXPECT_EQ(reader.abortReason(), static_cast<uint32_t>(kRelayAbortCaller));
+  EXPECT_EQ(reader.abortRank(), 0u);
+
+  RelayPlanInfo info{};
+  std::vector<size_t> counts(8, 0);
+  const auto start = std::chrono::steady_clock::now();
+  EXPECT_EQ(
+      reader.consume(0, &info, counts.data(), 8, kGenerousTimeoutNs),
+      ncclInternalError);
+  // Returns on the abort, not on the 60 s budget.
+  EXPECT_LT(
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::steady_clock::now() - start)
+          .count(),
+      1000);
+}
+
+TEST(RelayControlBlockTest, RejectsAPlanLargerThanTheSegmentCapacity) {
+  const uint64_t hash = uniqueHash(8);
+  const uint32_t maxCalls = 4;
+  RelayControlBlock writer;
+  ASSERT_TRUE(writer.create(makeConfig(hash, 2, 0, 4, maxCalls)));
+
+  std::vector<size_t> counts(maxCalls + 1, 1);
+  RelayPlanInfo info{};
+  info.nCalls = maxCalls + 1;
+  info.opCode = kRelayOpAllReduce;
+  EXPECT_EQ(
+      writer.publish(0, info, counts.data(), kGenerousTimeoutNs),
+      ncclInvalidArgument);
+
+  // Exactly at capacity is fine: the rejection is > capacity, not >=.
+  info.nCalls = maxCalls;
+  EXPECT_EQ(
+      writer.publish(0, info, counts.data(), kGenerousTimeoutNs), ncclSuccess);
+}
+
+TEST(RelayControlBlockTest, ConsumeRejectsATooSmallBufferAndLeavesTheSlotHeld) {
+  const uint64_t hash = uniqueHash(9);
+  const uint32_t maxCalls = 8;
+  RelayControlBlock writer;
+  ASSERT_TRUE(writer.create(makeConfig(hash, 2, 0, 4, maxCalls)));
+  RelayControlBlock reader;
+  ASSERT_TRUE(reader.attach(makeConfig(hash, 2, 1, 4, maxCalls)));
+
+  std::vector<size_t> counts(maxCalls, 0);
+  RelayPlanInfo info{};
+  info.nCalls = 6;
+  info.opCode = kRelayOpAllGather;
+  fillCounts(0, info.nCalls, counts);
+  ASSERT_EQ(
+      writer.publish(0, info, counts.data(), kGenerousTimeoutNs), ncclSuccess);
+
+  RelayPlanInfo got{};
+  std::vector<size_t> small(2, 0);
+  EXPECT_EQ(
+      reader.consume(0, &got, small.data(), 2, kGenerousTimeoutNs),
+      ncclInvalidArgument);
+  // The caller is told the size it needed, so the error is actionable.
+  EXPECT_EQ(got.nCalls, 6u);
+  // And the plan was NOT taken, so the publisher must keep the slot reserved.
+  EXPECT_EQ(reader.consumerProgress(1), 1u /* registered, nothing completed */);
+
+  // A correctly sized buffer still gets the plan afterwards.
+  std::vector<size_t> big(maxCalls, 0);
+  EXPECT_EQ(
+      reader.consume(0, &got, big.data(), maxCalls, kGenerousTimeoutNs),
+      ncclSuccess);
+  EXPECT_EQ(got.nCalls, 6u);
+  for (uint32_t i = 0; i < 6; i++) {
+    EXPECT_EQ(big[i], planCount(0, i)) << "count " << i;
+  }
+}
+
+TEST(RelayControlBlockTest, DetectsDesyncWhenTheSlotHasAdvancedPastTheEpoch) {
+  const uint64_t hash = uniqueHash(10);
+  const uint32_t maxCalls = 4;
+  const uint32_t ringDepth = 2;
+  // nRanks=1: no consumer ever registers, so the publisher is free to run
+  // ahead, which is exactly the state a late consumer would find.
+  RelayControlBlock writer;
+  ASSERT_TRUE(writer.create(makeConfig(hash, 1, 0, ringDepth, maxCalls)));
+
+  std::vector<size_t> counts(maxCalls);
+  for (uint64_t epoch = 0; epoch <= 2; epoch++) {
+    RelayPlanInfo info = makePlan(epoch, maxCalls);
+    fillCounts(epoch, info.nCalls, counts);
+    ASSERT_EQ(
+        writer.publish(epoch, info, counts.data(), kGenerousTimeoutNs),
+        ncclSuccess);
+  }
+
+  // Epoch 0's slot now holds epoch 2. Waiting cannot bring epoch 0 back, so
+  // this must fail immediately rather than burn the timeout.
+  RelayPlanInfo got{};
+  std::vector<size_t> out(maxCalls, 0);
+  const auto start = std::chrono::steady_clock::now();
+  EXPECT_EQ(
+      writer.consume(0, &got, out.data(), maxCalls, kGenerousTimeoutNs),
+      ncclInternalError);
+  EXPECT_LT(
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::steady_clock::now() - start)
+          .count(),
+      1000);
+}
+
+TEST(RelayControlBlockTest, RejectsASecondPublisher) {
+  const uint64_t hash = uniqueHash(11);
+  const uint32_t maxCalls = 4;
+  RelayControlBlock first;
+  ASSERT_TRUE(first.create(makeConfig(hash, 4, 0, 4, maxCalls)));
+  RelayControlBlock second;
+  ASSERT_TRUE(second.attach(makeConfig(hash, 4, 1, 4, maxCalls)));
+
+  std::vector<size_t> counts(maxCalls, 3);
+  RelayPlanInfo info{};
+  info.nCalls = 1;
+  info.opCode = kRelayOpAllReduce;
+  ASSERT_EQ(
+      first.publish(0, info, counts.data(), kGenerousTimeoutNs), ncclSuccess);
+  // One ring means one publisher. A second one would drive the seqlock
+  // backwards, and since both plans are byte-identical the damage would be
+  // invisible in the data.
+  EXPECT_EQ(
+      second.publish(1, info, counts.data(), kGenerousTimeoutNs),
+      ncclInvalidArgument);
+  // The rightful publisher is unaffected.
+  EXPECT_EQ(
+      first.publish(1, info, counts.data(), kGenerousTimeoutNs), ncclSuccess);
+}
+
+/**
+ * Test: an epoch that does not advance is refused.
+ *
+ * waitForSlotDrain() returns immediately for any epoch below ringDepth, so a
+ * publisher that restarts its counter walks back over slots holding plans no
+ * consumer has taken and the overwrite is silent. Re-publishing an epoch is the
+ * same defect seen from the other side: it drives the slot's seqlock backwards
+ * from 2e+2 to 2e+1, which a concurrent reader observes as a tear on a slot
+ * nobody is tearing.
+ *
+ * The class already enforces a single publisher so that two ranks cannot race
+ * one slot; this is the other half of that invariant -- one publisher cannot
+ * race itself across calls.
+ */
+TEST(RelayControlBlockTest, RejectsAnEpochThatDoesNotAdvance) {
+  const uint64_t hash = uniqueHash(21);
+  const uint32_t maxCalls = 4;
+  RelayControlBlock writer;
+  ASSERT_TRUE(writer.create(makeConfig(hash, 2, 0, 4, maxCalls)));
+
+  std::vector<size_t> counts(maxCalls, 7);
+  RelayPlanInfo info{};
+  info.nCalls = 1;
+  info.opCode = kRelayOpAllReduce;
+
+  ASSERT_EQ(
+      writer.publish(0, info, counts.data(), kGenerousTimeoutNs), ncclSuccess);
+  // Same epoch again.
+  EXPECT_EQ(
+      writer.publish(0, info, counts.data(), kGenerousTimeoutNs),
+      ncclInvalidArgument);
+
+  ASSERT_EQ(
+      writer.publish(1, info, counts.data(), kGenerousTimeoutNs), ncclSuccess);
+  // Rewound below what has already been published.
+  EXPECT_EQ(
+      writer.publish(0, info, counts.data(), kGenerousTimeoutNs),
+      ncclInvalidArgument);
+  // Advancing still works, so the rejections above are not a wedged publisher.
+  EXPECT_EQ(
+      writer.publish(2, info, counts.data(), kGenerousTimeoutNs), ncclSuccess);
+}
+
+/**
+ * Test: a publisher stops once the segment is poisoned.
+ *
+ * consume() checks the abort flag on every iteration, but publish() only used
+ * to observe it indirectly through waitForSlotDrain()'s wait loop -- which is
+ * never entered when the slot is already drained. A publisher on a poisoned
+ * segment therefore kept filling slots that no consumer would ever read.
+ */
+TEST(RelayControlBlockTest, PublishStopsOnAPoisonedSegment) {
+  const uint64_t hash = uniqueHash(22);
+  const uint32_t maxCalls = 4;
+  RelayControlBlock writer;
+  ASSERT_TRUE(writer.create(makeConfig(hash, 2, 0, 4, maxCalls)));
+  RelayControlBlock reader;
+  ASSERT_TRUE(reader.attach(makeConfig(hash, 2, 1, 4, maxCalls)));
+
+  std::vector<size_t> counts(maxCalls, 5);
+  RelayPlanInfo info{};
+  info.nCalls = 1;
+  info.opCode = kRelayOpAllReduce;
+  ASSERT_EQ(
+      writer.publish(0, info, counts.data(), kGenerousTimeoutNs), ncclSuccess);
+
+  // The consumer gives up and poisons the segment for everyone.
+  reader.setAbort(kRelayAbortCaller);
+  EXPECT_EQ(reader.abortRank(), 1u);
+
+  // Epoch 1's slot is untouched and drained, so without an explicit check this
+  // would publish happily.
+  EXPECT_EQ(
+      writer.publish(1, info, counts.data(), kGenerousTimeoutNs),
+      ncclInternalError);
+}
+
+TEST(RelayControlBlockTest, RejectsMalformedPlans) {
+  const uint64_t hash = uniqueHash(12);
+  RelayControlBlock writer;
+  ASSERT_TRUE(writer.create(makeConfig(hash, 2, 0, 4, 8)));
+  std::vector<size_t> counts(8, 1);
+
+  RelayPlanInfo badFlags{};
+  badFlags.nCalls = 1;
+  badFlags.opCode = kRelayOpAllReduce;
+  badFlags.flags = 1; // reserved, must be 0 so it can mean something later
+  EXPECT_EQ(
+      writer.publish(0, badFlags, counts.data(), kGenerousTimeoutNs),
+      ncclInvalidArgument);
+
+  RelayPlanInfo badOp{};
+  badOp.nCalls = 1;
+  badOp.opCode = kRelayOpCount; // one past the last valid opcode
+  EXPECT_EQ(
+      writer.publish(0, badOp, counts.data(), kGenerousTimeoutNs),
+      ncclInvalidArgument);
+
+  RelayPlanInfo nullCounts{};
+  nullCounts.nCalls = 1;
+  nullCounts.opCode = kRelayOpAllReduce;
+  EXPECT_EQ(
+      writer.publish(0, nullCounts, nullptr, kGenerousTimeoutNs),
+      ncclInvalidArgument);
+}
+
+TEST(RelayControlBlockTest, ShutdownPlanRoundTrips) {
+  const uint64_t hash = uniqueHash(13);
+  RelayControlBlock writer;
+  ASSERT_TRUE(writer.create(makeConfig(hash, 2, 0, 4, 8)));
+  RelayControlBlock reader;
+  ASSERT_TRUE(reader.attach(makeConfig(hash, 2, 1, 4, 8)));
+
+  ASSERT_EQ(writer.publishShutdown(0, kGenerousTimeoutNs), ncclSuccess);
+  RelayPlanInfo got{};
+  std::vector<size_t> counts(8, 0);
+  ASSERT_EQ(
+      reader.consume(0, &got, counts.data(), 8, kGenerousTimeoutNs),
+      ncclSuccess);
+  // Shutdown is an opcode, not a separate entry point, so a graceful stop needs
+  // no extra API and cannot be confused with a zero-call forward.
+  EXPECT_EQ(got.opCode, static_cast<uint32_t>(kRelayOpShutdown));
+  EXPECT_EQ(got.nCalls, 0u);
+}
+
+TEST(RelayControlBlockTest, AttachRejectsAGeometryMismatch) {
+  const uint64_t hash = uniqueHash(14);
+  RelayControlBlock writer;
+  ASSERT_TRUE(writer.create(makeConfig(hash, 8, 0, 4, 128)));
+
+  // Each of these is what a rank launched with a different environment would
+  // present. All must fail at attach, because the alternative is reading a
+  // differently shaped slot at runtime.
+  RelayControlBlock wrongCapacity;
+  EXPECT_FALSE(wrongCapacity.attach(makeConfig(hash, 8, 1, 4, 256)));
+  RelayControlBlock wrongDepth;
+  EXPECT_FALSE(wrongDepth.attach(makeConfig(hash, 8, 1, 8, 128)));
+  RelayControlBlock wrongRanks;
+  EXPECT_FALSE(wrongRanks.attach(makeConfig(hash, 4, 1, 4, 128)));
+
+  // The matching configuration still works, so the rejections above are
+  // specific rather than a segment that was broken all along.
+  RelayControlBlock right;
+  EXPECT_TRUE(right.attach(makeConfig(hash, 8, 1, 4, 128)));
+}
+
+TEST(RelayControlBlockTest, AttachFailsWhenThereIsNoSegment) {
+  RelayControlBlock reader;
+  EXPECT_FALSE(reader.attach(makeConfig(uniqueHash(15), 8, 1, 4, 128)));
+}
+
+TEST(RelayControlBlockTest, RefusesToStealASegmentFromALiveCreator) {
+  const uint64_t hash = uniqueHash(16);
+  RelayControlBlock first;
+  ASSERT_TRUE(first.create(makeConfig(hash, 8, 0, 4, 128)));
+  // Same name, and the recorded creator is this very much alive process.
+  // Reclaiming here would corrupt a running job.
+  RelayControlBlock second;
+  EXPECT_FALSE(second.create(makeConfig(hash, 8, 0, 4, 128)));
+}
+
+TEST(RelayControlBlockTest, ReclaimsASegmentWhoseCreatorIsGone) {
+  const uint64_t hash = uniqueHash(17);
+  const pid_t pid = fork();
+  ASSERT_GE(pid, 0);
+  if (pid == 0) {
+    RelayControlBlock leaked;
+    const bool ok = leaked.create(makeConfig(hash, 8, 0, 4, 128));
+    // _exit skips the destructor, so the segment outlives this process exactly
+    // as it would after a crash. That is the state being set up.
+    _exit(ok ? kChildOk : kChildCreateFailed);
+  }
+  // Reap before probing: a zombie still answers kill(pid, 0), so an unreaped
+  // child would look alive and the reclaim would (correctly) be refused.
+  expectChildOk(pid);
+
+  RelayControlBlock reclaimed;
+  EXPECT_TRUE(reclaimed.create(makeConfig(hash, 8, 0, 4, 128)));
+}
+
+TEST(RelayControlBlockTest, DetachUnlinksOnlyForTheCreator) {
+  const uint64_t hash = uniqueHash(18);
+  {
+    RelayControlBlock writer;
+    ASSERT_TRUE(writer.create(makeConfig(hash, 2, 0, 4, 8)));
+    RelayControlBlock reader;
+    ASSERT_TRUE(reader.attach(makeConfig(hash, 2, 1, 4, 8)));
+    reader.detach();
+    // A consumer detaching must not remove the segment from under the others.
+    RelayControlBlock again;
+    EXPECT_TRUE(again.attach(makeConfig(hash, 2, 1, 4, 8)));
+  }
+  // The creator's destructor unlinked it, so nothing is left behind for the
+  // next run to trip over.
+  RelayControlBlock afterCreatorGone;
+  EXPECT_FALSE(afterCreatorGone.attach(makeConfig(hash, 2, 1, 4, 8)));
+}
+
+TEST(RelayControlBlockTest, HandlesALargeNonDefaultCapacity) {
+  // The capacity is a runtime parameter precisely so it can be raised for
+  // workloads with many calls per forward; 1024 is above the 124-call figure
+  // that motivated making it configurable.
+  const uint64_t hash = uniqueHash(19);
+  const uint32_t maxCalls = 1024;
+  RelayControlBlock writer;
+  ASSERT_TRUE(writer.create(makeConfig(hash, 2, 0, 2, maxCalls)));
+  RelayControlBlock reader;
+  ASSERT_TRUE(reader.attach(makeConfig(hash, 2, 1, 2, maxCalls)));
+
+  std::vector<size_t> counts(maxCalls);
+  RelayPlanInfo info{};
+  info.nCalls = maxCalls;
+  info.opCode = kRelayOpAllToAll;
+  for (uint32_t i = 0; i < maxCalls; i++) {
+    counts[i] = planCount(5, i);
+  }
+  ASSERT_EQ(
+      writer.publish(5, info, counts.data(), kGenerousTimeoutNs), ncclSuccess);
+
+  RelayPlanInfo got{};
+  std::vector<size_t> out(maxCalls, 0);
+  ASSERT_EQ(
+      reader.consume(5, &got, out.data(), maxCalls, kGenerousTimeoutNs),
+      ncclSuccess);
+  ASSERT_EQ(got.nCalls, maxCalls);
+  for (uint32_t i = 0; i < maxCalls; i++) {
+    ASSERT_EQ(out[i], planCount(5, i)) << "count " << i;
+  }
+}
+
+TEST(RelayControlBlockTest, ConfiguredGeometryIsClampedToSaneValues) {
+  // Defaults, absent any environment override in this binary.
+  EXPECT_GE(relayControlConfiguredMaxCalls(), 1u);
+  EXPECT_LE(relayControlConfiguredMaxCalls(), 65536u);
+  EXPECT_GE(relayControlConfiguredRingDepth(), 2u);
+  EXPECT_LE(relayControlConfiguredRingDepth(), 1024u);
+}
+
+// Reports the per-operation cost being traded against the ~0.9 ms per call that
+// the TCP store transport spent. Not a threshold test -- the harness is shared
+// and timing there is not trustworthy enough to gate on -- but the number is
+// the whole reason this exists, so it gets printed.
+TEST(RelayControlBlockTest, Z_ReportsPublishAndConsumeCost) {
+  const uint64_t hash = uniqueHash(20);
+  const uint32_t maxCalls = 128;
+  const uint32_t ringDepth = 4;
+  const int kIters = 2000;
+
+  RelayControlBlock writer;
+  ASSERT_TRUE(writer.create(makeConfig(hash, 2, 0, ringDepth, maxCalls)));
+  RelayControlBlock reader;
+  ASSERT_TRUE(reader.attach(makeConfig(hash, 2, 1, ringDepth, maxCalls)));
+
+  std::vector<size_t> counts(maxCalls);
+  std::vector<size_t> out(maxCalls);
+  RelayPlanInfo info{};
+  info.nCalls = 8; // a realistic chunked-prefill forward
+  info.opCode = kRelayOpAllReduce;
+  fillCounts(0, info.nCalls, counts);
+
+  double publishNs = 0.0;
+  double consumeNs = 0.0;
+  for (int i = 0; i < kIters; i++) {
+    const uint64_t epoch = static_cast<uint64_t>(i);
+    auto t0 = std::chrono::steady_clock::now();
+    ASSERT_EQ(
+        writer.publish(epoch, info, counts.data(), kGenerousTimeoutNs),
+        ncclSuccess);
+    auto t1 = std::chrono::steady_clock::now();
+    RelayPlanInfo got{};
+    ASSERT_EQ(
+        reader.consume(epoch, &got, out.data(), maxCalls, kGenerousTimeoutNs),
+        ncclSuccess);
+    auto t2 = std::chrono::steady_clock::now();
+    publishNs +=
+        std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+    consumeNs +=
+        std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count();
+  }
+  printf(
+      "[relay control] publish %.2f us/plan, consume %.2f us/plan (%d iters, %u calls/plan)\n",
+      publishNs / kIters / 1000.0,
+      consumeNs / kIters / 1000.0,
+      kIters,
+      info.nCalls);
+  fflush(stdout);
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/rcclx/develop/meta/relay/tests/RelayControlTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/RelayControlTest.cu
@@ -25,6 +25,7 @@
 #include <unistd.h>
 
 #include <chrono>
+#include <cstddef>
 #include <cstdlib>
 #include <string>
 #include <vector>
@@ -854,6 +855,63 @@ TEST(RelayControlBlockTest, ConfiguredGeometryIsClampedToSaneValues) {
   EXPECT_LE(relayControlConfiguredMaxCalls(), 65536u);
   EXPECT_GE(relayControlConfiguredRingDepth(), 2u);
   EXPECT_LE(relayControlConfiguredRingDepth(), 1024u);
+}
+
+/**
+ * The exported struct and the internal one are the same wire format. If they
+ * ever diverge, a plan written through one and read through the other is
+ * silently misinterpreted -- no crash, no error, just wrong counts -- so this
+ * is asserted at compile time rather than left to review.
+ */
+TEST(RelayControlExportTest, PublicPlanInfoMatchesTheInternalRecord) {
+  static_assert(
+      sizeof(ncclRelayPlanInfo) == sizeof(RelayPlanInfo),
+      "the exported and internal plan records must be the same wire format");
+  static_assert(
+      offsetof(ncclRelayPlanInfo, nCalls) == offsetof(RelayPlanInfo, nCalls) &&
+          offsetof(ncclRelayPlanInfo, opCode) ==
+              offsetof(RelayPlanInfo, opCode) &&
+          offsetof(ncclRelayPlanInfo, dtype) ==
+              offsetof(RelayPlanInfo, dtype) &&
+          offsetof(ncclRelayPlanInfo, redOp) ==
+              offsetof(RelayPlanInfo, redOp) &&
+          offsetof(ncclRelayPlanInfo, flags) == offsetof(RelayPlanInfo, flags),
+      "field offsets must agree between the exported and internal records");
+  // The opcodes are two enumerations of one protocol; a mismatch would route a
+  // plan to the wrong collective.
+  EXPECT_EQ(static_cast<uint32_t>(ncclRelayOpShutdown), kRelayOpShutdown);
+  EXPECT_EQ(static_cast<uint32_t>(ncclRelayOpAllReduce), kRelayOpAllReduce);
+  EXPECT_EQ(
+      static_cast<uint32_t>(ncclRelayOpReduceScatter), kRelayOpReduceScatter);
+  EXPECT_EQ(static_cast<uint32_t>(ncclRelayOpAllGather), kRelayOpAllGather);
+  EXPECT_EQ(static_cast<uint32_t>(ncclRelayOpAllToAll), kRelayOpAllToAll);
+}
+
+/**
+ * Exercises the two exported entry points through their public declarations.
+ *
+ * This is the check that the export actually works: it only links if the C
+ * signature in nccl.h matches the definition and the symbol resolves. Reading
+ * the library with nm would show a name and prove neither.
+ */
+TEST(RelayControlExportTest, ExportedEntryPointsRejectBadArguments) {
+  ncclRelayPlanInfo info{};
+  info.nCalls = 1;
+  info.opCode = ncclRelayOpAllReduce;
+  size_t counts[1] = {1024};
+
+  EXPECT_EQ(
+      ncclRelayControlPublish(nullptr, 0, &info, counts, kShortTimeoutNs),
+      ncclInvalidArgument);
+  EXPECT_EQ(
+      ncclRelayControlPublish(nullptr, 0, nullptr, counts, kShortTimeoutNs),
+      ncclInvalidArgument);
+  EXPECT_EQ(
+      ncclRelayControlConsume(nullptr, 0, &info, counts, 1, kShortTimeoutNs),
+      ncclInvalidArgument);
+  EXPECT_EQ(
+      ncclRelayControlConsume(nullptr, 0, nullptr, counts, 1, kShortTimeoutNs),
+      ncclInvalidArgument);
 }
 
 // Reports the per-operation cost being traded against the ~0.9 ms per call that

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
@@ -1405,6 +1405,145 @@ TEST_F(ShardedRelayMultiGroupAllGatherTest, Z_BusBW_4Groups_InPlace_1GB) {
 }
 
 /**
+ * Test: single group (nGroups == 1) at 4 active ranks, both placements.
+ *
+ * nGroups == 1 makes the active ranks {0,1,2,3} and the helpers {4,5,6,7}
+ * disjoint, which is what puts the flat relay on its software-pipelined
+ * schedule: the offload scatter and the helper fan-out share a group so each
+ * cross link runs duplex. 64 MB is above the offload threshold and deep enough
+ * for the cost model to tile, so this is the only coverage of that path -- the
+ * other 4-active cases all run 2 groups, where the relay stays unpipelined.
+ */
+class ShardedRelayAllGatherSingleGroupA4Test
+    : public ShardedRelayMultiGroupAllGatherTest {
+ protected:
+  void runSingleGroupA4Case(bool inPlace) {
+    const int nGroups = 1;
+    const int nActiveRanksPerGroup = 4;
+    const size_t sendBytes = 64ULL * 1024 * 1024;
+    const size_t sendCount = sendBytes / sizeof(int32_t);
+    const size_t outBytes =
+        static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+
+    const int activeRanks[] = {0, 1, 2, 3};
+    const int* allActiveRanks[] = {activeRanks};
+    const bool isActive = this->globalRank < nActiveRanksPerGroup;
+    const int myActiveIndex = this->globalRank;
+
+    // Helpers hand in a placeholder; the kernel stages into its own scratch.
+    int32_t* recvBuff = nullptr;
+    int32_t* sendBuff = nullptr;
+    HIPCHECK_TEST(hipMalloc(&recvBuff, outBytes));
+    if (isActive && !inPlace) {
+      HIPCHECK_TEST(hipMalloc(&sendBuff, sendBytes));
+    }
+
+    barrierSyncOn(recvBuff);
+
+    HIPCHECK_TEST(hipMemset(recvBuff, 0, outBytes));
+    // Only the active ranks have a slot in recvBuff; forming the pointer on a
+    // helper (globalRank 4..7) would run past the A=4 slots allocated.
+    int32_t* mySlot = isActive
+        ? recvBuff + static_cast<size_t>(myActiveIndex) * sendCount
+        : nullptr;
+    if (isActive) {
+      // In-place: the contribution already sits in this rank's output slot.
+      fillDeviceRegion(
+          inPlace ? mySlot : sendBuff, sendCount, rankFillValue(myActiveIndex));
+    }
+
+    const void* sendPtrs[1] = {
+        isActive ? (inPlace ? mySlot : sendBuff) : recvBuff};
+    void* recvPtrs[1] = {recvBuff};
+    size_t sendCounts[1] = {sendCount};
+
+    const ncclResult_t result = callAllGatherCompat(
+        sendPtrs,
+        recvPtrs,
+        sendCounts,
+        ncclInt32,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+    if (isActive) {
+      verifyAllGatherOutput(recvBuff, sendCount, 0, nActiveRanksPerGroup);
+    }
+
+    HIPCHECK_TEST(hipFree(recvBuff));
+    if (sendBuff != nullptr) {
+      HIPCHECK_TEST(hipFree(sendBuff));
+    }
+  }
+};
+
+TEST_F(ShardedRelayAllGatherSingleGroupA4Test, Correctness_OutOfPlace_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runSingleGroupA4Case(/*inPlace=*/false);
+}
+
+TEST_F(ShardedRelayAllGatherSingleGroupA4Test, Correctness_InPlace_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runSingleGroupA4Case(/*inPlace=*/true);
+}
+
+/**
+ * Test: the pipelined fanout layout fits inside the count at EVERY geometry
+ * buildShardedRelayRankConfig() accepts, not just the A = H = 4 one the 8-rank
+ * cases above exercise.
+ *
+ * The GPU cases here are pinned to 8 ranks, so a single-group A = 4 call always
+ * has exactly 4 helpers and the A + H combinations that a 9-to-16-rank comm
+ * would produce (A = 4 with H = 5..8, or A = 8 with H = 8) are unreachable from
+ * this harness. What those geometries can break is arithmetic, not scheduling:
+ * shardedRelayAllGatherFlatPipelined() lays out H*T + 1 + (T-1)*(A-1) units
+ * before its final direct chunk, and if totalUnits(T) is smaller than that then
+ * directSize(T) = sc - directOffset(T) underflows as size_t and a wild count
+ * reaches ncclSend/ncclRecv. So assert the invariant against the shape directly
+ * over the whole accepted (A, H) space, which needs no ranks at all.
+ */
+TEST(ShardedRelayAllGatherFanoutShape, LayoutFitsAtEveryAcceptedGeometry) {
+  // Mirrors SHARDED_RELAY_MAX_ACTIVE / SHARDED_RELAY_MAX_HELPERS.
+  constexpr int kMaxActive = 8;
+  constexpr int kMaxHelpers = 8;
+
+  for (int a = 2; a <= kMaxActive; a *= 2) {
+    for (int h = 1; h <= kMaxHelpers; h++) {
+      const rcclx::relay::RelayPipelineShape shape =
+          rcclx::relay::relayShapeFanout(a, h);
+      for (int t = 1; t <= 8; t *= 2) {
+        const int totalUnits = shape.totalPerTile * t + shape.totalFixed;
+        // Units the layout consumes before the final direct chunk, which must
+        // itself be at least one heavy chunk of A-1 units.
+        const int consumed = h * t + 1 + (t - 1) * (a - 1);
+        EXPECT_LE(consumed + (a - 1), totalUnits)
+            << "fanout layout overruns the count at A=" << a << " H=" << h
+            << " T=" << t << ": consumes " << consumed << " units plus a final "
+            << (a - 1) << "-unit chunk out of " << totalUnits;
+      }
+    }
+  }
+
+  // Depth 1 must reproduce the two-group schedule, and the shipped 8-GPU
+  // geometry must still resolve to the constants the perf numbers were measured
+  // at, so the parameterization is a generalization and not a change.
+  const rcclx::relay::RelayPipelineShape shipped =
+      rcclx::relay::relayShapeFanout(4, 4);
+  EXPECT_EQ(shipped.linkPerTile, 3);
+  EXPECT_EQ(shipped.linkFixed, 1);
+  EXPECT_EQ(shipped.totalPerTile, 7);
+  EXPECT_EQ(shipped.totalFixed, 1);
+}
+
+/**
  * 4-ACTIVE tests (2 groups of 4 active ranks each).
  *   Group 0: active {0,1,2,3}, helpers {4,5,6,7}
  *   Group 1: active {4,5,6,7}, helpers {0,1,2,3}

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
@@ -170,33 +170,79 @@ class ShardedRelayMultiGroupAllGatherTest : public ::testing::Test {
  public:
   ShardedRelayMultiGroupAllGatherTest() = default;
 
-  void SetUp() override {
+  // Comms live for the whole binary instead of being rebuilt per case. They
+  // used to be created in SetUp and destroyed in TearDown, so every case freed
+  // everything an 8-rank comm owns. On MI350 freeing VRAM makes amdgpu wipe it
+  // (amdgpu_bo_release_notify -> amdgpu_fill_buffer) while holding mmap_lock
+  // for write, so 8 ranks cycling multi-GB comms serialise into a stall that
+  // takes the whole host down. Reusing also matches how comms are really used:
+  // a handful, kept for the life of the process.
+  //
+  // One comm per active-rank shape, because relay state is per-comm and a comm
+  // cannot be shared between the 2- and 4-active-rank configurations, plus a
+  // dedicated one for the rank barrier. A single store serves all three, with
+  // incrTestCount() between them: the unique-ID rendezvous key is derived from
+  // that counter, so without bumping it the second comm would read the first
+  // one's stale ID. Built eagerly in a fixed order so every rank consumes the
+  // same keys in the same sequence.
+  static void SetUpTestSuite() {
     int localSize;
-    std::tie(this->localRank, this->globalRank, this->numRanks, localSize) =
+    std::tie(localRank, globalRank, numRanks, localSize) =
         getTcpStoreOrMpiInfo();
-    bool isServer = (this->globalRank == 0);
+    const bool isServer = (globalRank == 0);
     if (checkTcpStoreEnv()) {
       server = createTcpStore(isServer);
     } else if (isServer) {
       server = createTcpStore(true);
     }
-    this->comm = createNcclComm(
-        this->globalRank,
-        this->numRanks,
-        this->localRank,
-        false,
-        nullptr,
-        server.get());
+    barrierComm = makeComm();
+    incrTestCount();
+    commA2 = makeComm();
+    incrTestCount();
+    commA4 = makeComm();
+  }
+
+  static ncclComm_t makeComm() {
+    return createNcclComm(
+        globalRank, numRanks, localRank, false, nullptr, server.get());
+  }
+
+  // The comm for a given active-rank shape. Every collective call site has
+  // nActiveRanksPerGroup in scope, which is how a test reaches its comm.
+  static ncclComm_t commFor(int nActiveRanksPerGroup) {
+    switch (nActiveRanksPerGroup) {
+      case 2:
+        return commA2;
+      case 4:
+        return commA4;
+      default:
+        ADD_FAILURE() << "no comm cached for nActiveRanksPerGroup="
+                      << nActiveRanksPerGroup;
+        return nullptr;
+    }
+  }
+
+  static void TearDownTestSuite() {
+    if (server && checkTcpStoreEnv()) {
+      finalizeNcclComm(globalRank, server.get());
+    }
+    for (ncclComm_t* c : {&commA4, &commA2, &barrierComm}) {
+      if (*c != nullptr) {
+        NCCLCHECK_TEST(ncclCommDestroy(*c));
+        *c = nullptr;
+      }
+    }
+    server.reset();
+  }
+
+  void SetUp() override {
+    ASSERT_NE(this->commA2, nullptr)
+        << "suite-scoped comms were not created; SetUpTestSuite did not run";
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
 
   void TearDown() override {
     CUDACHECK_TEST(cudaStreamDestroy(this->stream));
-    if (server && checkTcpStoreEnv()) {
-      finalizeNcclComm(this->globalRank, server.get());
-    }
-    NCCLCHECK_TEST(ncclCommDestroy(this->comm));
-    server.reset();
   }
 
   // Standard 8-rank, 4-group, 2-active-per-group sparse parallelism layout.
@@ -253,7 +299,7 @@ class ShardedRelayMultiGroupAllGatherTest : public ::testing::Test {
         1,
         ncclInt32,
         ncclSum,
-        this->comm,
+        this->barrierComm,
         this->stream));
     HIPCHECK_TEST(hipStreamSynchronize(this->stream));
     HIPCHECK_TEST(hipFree(barrierScratch));
@@ -414,7 +460,7 @@ class ShardedRelayMultiGroupAllGatherTest : public ::testing::Test {
           recvPtrs.data(),
           sendCounts.data(),
           ncclInt32,
-          this->comm,
+          this->commFor(nActiveRanksPerGroup),
           this->stream,
           allActiveRanks,
           nActiveRanksPerGroup,
@@ -450,12 +496,14 @@ class ShardedRelayMultiGroupAllGatherTest : public ::testing::Test {
     }
   }
 
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
-  ncclComm_t comm;
+  static inline int localRank{0};
+  static inline int globalRank{0};
+  static inline int numRanks{0};
+  static inline ncclComm_t barrierComm{nullptr};
+  static inline ncclComm_t commA2{nullptr};
+  static inline ncclComm_t commA4{nullptr};
+  static inline std::unique_ptr<c10d::TCPStore> server{nullptr};
   cudaStream_t stream;
-  std::unique_ptr<c10d::TCPStore> server{nullptr};
 };
 
 TEST_F(
@@ -611,7 +659,7 @@ TEST_F(
       recvPtrs,
       sendCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -699,7 +747,7 @@ TEST_F(ShardedRelayMultiGroupAllGatherTest, Correctness_4Groups_InPlace_64MB) {
       recvPtrs,
       sendCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -768,7 +816,7 @@ TEST_F(ShardedRelayMultiGroupAllGatherTest, Correctness_SingleGroup_64MB) {
       recvPtrs,
       sendCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -838,7 +886,7 @@ TEST_F(
       recvPtrs,
       sendCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -932,7 +980,7 @@ TEST_F(
       recvPtrs,
       sendCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1028,7 +1076,7 @@ TEST_F(
       recvPtrs,
       sendCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1138,7 +1186,7 @@ TEST_F(
       recvPtrs,
       sendCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1237,7 +1285,7 @@ TEST_F(ShardedRelayMultiGroupAllGatherTest, Z_BusBW_4Groups_OutOfPlace_1GB) {
         recvPtrs,
         sendCounts,
         ncclInt32,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,
@@ -1356,7 +1404,7 @@ TEST_F(ShardedRelayMultiGroupAllGatherTest, Z_BusBW_4Groups_InPlace_1GB) {
         recvPtrs,
         sendCounts,
         ncclInt32,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,
@@ -1462,7 +1510,7 @@ class ShardedRelayAllGatherSingleGroupA4Test
         recvPtrs,
         sendCounts,
         ncclInt32,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,
@@ -1617,7 +1665,7 @@ TEST_F(
       recvPtrs,
       sendCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1697,7 +1745,7 @@ TEST_F(
       recvPtrs,
       sendCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1779,7 +1827,7 @@ TEST_F(
       recvPtrs,
       sendCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1876,7 +1924,7 @@ TEST_F(
       recvPtrs,
       sendCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1976,7 +2024,7 @@ TEST_F(
         recvPtrs,
         sendCounts,
         ncclInt32,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
@@ -496,7 +496,7 @@ TEST_F(
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t kThresholdElements = (9ULL * 1024 * 1024) / sizeof(int32_t);
+  constexpr size_t kThresholdElements = (2ULL * 1024 * 1024) / sizeof(int32_t);
   const int activeRanks[] = {0, 1};
   const int* allActiveRanks[] = {activeRanks};
   runOutOfPlaceRoutingCases(
@@ -531,7 +531,7 @@ TEST_F(
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t kThresholdElements = (8ULL * 1024 * 1024) / sizeof(int32_t);
+  constexpr size_t kThresholdElements = (3ULL * 1024 * 1024) / sizeof(int32_t);
   const int activeRanks[] = {0, 1, 2, 3};
   const int* allActiveRanks[] = {activeRanks};
   runOutOfPlaceRoutingCases(

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
@@ -787,6 +787,73 @@ TEST_F(ShardedRelayMultiGroupAllGatherTest, Correctness_SingleGroup_64MB) {
 }
 
 /**
+ * Test: Single group, IN-PLACE, at a size the software pipeline covers.
+ *
+ * nGroups == 1 puts the relay on the pipelined schedule (the active ranks and
+ * the helpers are disjoint there, so the scatter and the forward run on
+ * opposite directions of each cross link and are interleaved). 64 MB clears the
+ * pipeline floor, so this pins the pipelined path's in-place handling -- the
+ * diagonal is already in the send slot and must not be re-copied, while the
+ * gather slot is written tile by tile across the pipeline stages.
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllGatherTest,
+    Correctness_SingleGroup_InPlace_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks
+                 << " available";
+  }
+
+  const int nGroups = 1;
+  const int nActiveRanksPerGroup = 2;
+  const size_t sendBytes = 64ULL * 1024 * 1024;
+  const size_t sendCount = sendBytes / sizeof(int32_t);
+
+  const int activeRanks[] = {0, 1};
+  const int* allActiveRanks[] = {activeRanks};
+
+  const bool isActive = (this->globalRank == 0 || this->globalRank == 1);
+  const int myActiveIndex = this->globalRank;
+
+  int32_t* buff = nullptr;
+  const size_t buffBytes =
+      static_cast<size_t>(nActiveRanksPerGroup) * sendBytes;
+  HIPCHECK_TEST(hipMalloc(&buff, buffBytes));
+
+  barrierSyncOn(buff);
+
+  HIPCHECK_TEST(hipMemset(buff, 0, buffBytes));
+  // In-place: this rank's contribution already sits in its own output slot.
+  int32_t* mySlot = buff + static_cast<size_t>(myActiveIndex) * sendCount;
+  if (isActive) {
+    fillDeviceRegion(mySlot, sendCount, rankFillValue(myActiveIndex));
+  }
+
+  const void* sendPtrs[1] = {isActive ? mySlot : buff};
+  void* recvPtrs[1] = {buff};
+  size_t sendCounts[] = {sendCount};
+
+  const ncclResult_t result = callAllGatherCompat(
+      sendPtrs,
+      recvPtrs,
+      sendCounts,
+      ncclInt32,
+      this->comm,
+      this->stream,
+      allActiveRanks,
+      nActiveRanksPerGroup,
+      nGroups);
+  ASSERT_EQ(result, ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  if (isActive) {
+    verifyAllGatherOutput(buff, sendCount, 0);
+  }
+
+  HIPCHECK_TEST(hipFree(buff));
+}
+
+/**
  * Test: Correctness with minimum passthrough helper buffers (OUT-OF-PLACE)
  */
 TEST_F(

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
@@ -1557,6 +1557,160 @@ TEST_F(
  * Each active rank fills its buffer with a distinct value (myActiveIndex+1) so
  * the SUM (1+2+3+4 = 10) detects a missing partner / mis-routed contribution.
  */
+/**
+ * Test: single group (nGroups == 1) at 4 active ranks, SUM and AVG, both
+ * placements.
+ *
+ * nGroups == 1 makes the active ranks {0,1,2,3} and the helpers {4,5,6,7}
+ * disjoint, which is what puts the flat allreduce on its software-pipelined
+ * schedule -- the only path that pipelines TWO dependencies at once (the
+ * offload's reduce-and-broadcast and the direct region's reduce-scatter into
+ * all-gather), and the only one using a tile-major dScratch. 128 MB clears the
+ * crossover where that schedule starts beating the two-group one, so this is
+ * its only coverage: every other 4-active case runs 2 groups and stays
+ * unpipelined.
+ *
+ * AVG is what pins the divisor, which the pipelined path applies once per tile
+ * at the owner and once per tile at the helper. Values are chosen so the
+ * average is exact in integers: contributions 1..4 average to 2 with A = 4...
+ * deliberately 2 + 8 + 14 + 16 = 40, so SUM is 40 and AVG is exactly 10.
+ */
+class ShardedRelayAllReduceSingleGroupA4Test
+    : public ShardedRelayMultiGroupAllReduceTest {
+ protected:
+  static int32_t contribution(int activeIndex) {
+    static const int32_t values[4] = {2, 8, 14, 16};
+    return values[activeIndex];
+  }
+
+  void runSingleGroupA4Case(bool inPlace, ncclRedOp_t op) {
+    const int nGroups = 1;
+    const int nActiveRanksPerGroup = 4;
+    const size_t dataBytes = 128ULL * 1024 * 1024;
+    const size_t count = dataBytes / sizeof(int32_t);
+    const int32_t sum =
+        contribution(0) + contribution(1) + contribution(2) + contribution(3);
+    const int32_t expected =
+        (op == ncclAvg) ? (sum / nActiveRanksPerGroup) : sum;
+
+    const int activeRanks[] = {0, 1, 2, 3};
+    const int* allActiveRanks[] = {activeRanks};
+    const bool isActive = this->globalRank < nActiveRanksPerGroup;
+    const int myActiveIndex = this->globalRank;
+
+    int32_t* sendBuff = nullptr;
+    int32_t* recvBuff = nullptr;
+    HIPCHECK_TEST(hipMalloc(&sendBuff, dataBytes));
+    if (isActive && !inPlace) {
+      HIPCHECK_TEST(hipMalloc(&recvBuff, dataBytes));
+    }
+
+    barrierSyncOn(sendBuff);
+
+    if (isActive) {
+      std::vector<int32_t> hostData(count, contribution(myActiveIndex));
+      HIPCHECK_TEST(hipMemcpy(
+          sendBuff, hostData.data(), dataBytes, hipMemcpyHostToDevice));
+      if (!inPlace) {
+        HIPCHECK_TEST(hipMemset(recvBuff, 0, dataBytes));
+      }
+    } else {
+      HIPCHECK_TEST(hipMemset(sendBuff, 0, dataBytes));
+    }
+    int32_t* out = inPlace ? sendBuff : recvBuff;
+
+    const void* sendPtrs[1] = {sendBuff};
+    void* recvPtrs[1] = {isActive ? out : sendBuff};
+    size_t counts[1] = {count};
+
+    const ncclResult_t result = callAllReduceCompat(
+        sendPtrs,
+        recvPtrs,
+        counts,
+        ncclInt32,
+        op,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+    if (isActive) {
+      verifyDeviceBufferEquals(
+          out, count, expected, 0, "4-active single-group allreduce mismatch");
+    }
+
+    HIPCHECK_TEST(hipFree(sendBuff));
+    if (recvBuff != nullptr) {
+      HIPCHECK_TEST(hipFree(recvBuff));
+    }
+  }
+};
+
+TEST_F(ShardedRelayAllReduceSingleGroupA4Test, Correctness_Sum_OutOfPlace) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runSingleGroupA4Case(/*inPlace=*/false, ncclSum);
+}
+
+TEST_F(ShardedRelayAllReduceSingleGroupA4Test, Correctness_Sum_InPlace) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runSingleGroupA4Case(/*inPlace=*/true, ncclSum);
+}
+
+TEST_F(ShardedRelayAllReduceSingleGroupA4Test, Correctness_Avg_InPlace) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runSingleGroupA4Case(/*inPlace=*/true, ncclAvg);
+}
+
+/**
+ * Test: the pipelined allreduce's region split fits inside the count at EVERY
+ * geometry buildShardedRelayRankConfig() accepts, not just the A = H = 4 one
+ * the 8-rank cases above exercise.
+ *
+ * The GPU cases here are pinned to 8 ranks, so a single-group A = 4 call always
+ * has exactly 4 helpers; the combinations a 9-to-16-rank comm would produce
+ * (A = 4 with H = 5..8, or A = 8 with H = 8) cannot be built from this harness.
+ * What those geometries break is arithmetic, not scheduling:
+ * shardedRelayAllReduceFlatPipelined() takes pO = 2*H*T*y and pD = count - pO,
+ * then dShard = pD/A with a last tile of dShard - (T-1)*y. If the unit count
+ * per tile is below 2H + A both subtractions underflow as size_t and a wild
+ * dShard reaches the reduce kernels and ncclSend. Assert the invariant directly
+ * over the whole accepted (A, H) space, which needs no ranks at all.
+ */
+TEST(ShardedRelayAllReducePipelineUnits, LayoutFitsAtEveryAcceptedGeometry) {
+  // Mirrors SHARDED_RELAY_MAX_ACTIVE / SHARDED_RELAY_MAX_HELPERS.
+  constexpr int kMaxActive = 8;
+  constexpr int kMaxHelpers = 8;
+
+  for (int a = 2; a <= kMaxActive; a *= 2) {
+    for (int h = 1; h <= kMaxHelpers; h++) {
+      const int unitsPerTile =
+          rcclx::relay::relayAllReducePipelineUnitsPerTile(a, h);
+      for (int t = 1; t <= 8; t *= 2) {
+        // Offload takes 2*H*T units; the direct region needs A*T so every
+        // owner's shard can still tile into T pieces of y.
+        EXPECT_LE(2 * h * t + a * t, unitsPerTile * t)
+            << "pipelined allreduce layout overruns the count at A=" << a
+            << " H=" << h << " T=" << t << ": needs " << (2 * h * t + a * t)
+            << " units out of " << (unitsPerTile * t);
+      }
+    }
+  }
+
+  // The shipped 8-GPU geometry must still resolve to the 12 the perf numbers
+  // were measured at, so the parameterization is a generalization and not a
+  // change.
+  EXPECT_EQ(rcclx::relay::relayAllReducePipelineUnitsPerTile(4, 4), 12);
+}
+
 TEST_F(
     ShardedRelayMultiGroupAllReduceTest,
     Correctness_4Active_2Groups_InPlace) {

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
@@ -571,7 +571,7 @@ class ShardedRelayMultiGroupAllReduceTest : public ::testing::Test {
     const void* sendPtrs[1] = {buff};
     void* recvPtrs[1] = {buff};
     size_t counts[1] = {count};
-    // 64 MiB single-group A=4 sits far above the 9 MiB independent crossover,
+    // 64 MiB single-group A=4 sits far above the 1 MiB independent crossover,
     // so this case must exercise the helper offload rather than the
     // pure-direct reduce-scatter + all-gather.
     expectAllReduceRoute(
@@ -2231,18 +2231,18 @@ TEST_F(
 
 TEST_F(
     ShardedRelayMultiGroupAllReduceTest,
-    Correctness_Phase2C02_BFloat16_A4_Independent9MiBBoundary) {
+    Correctness_Phase2C02_BFloat16_A4_Independent1MiBBoundary) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t thresholdCount = (9ULL * 1024 * 1024) / sizeof(uint16_t);
+  constexpr size_t thresholdCount = (1ULL * 1024 * 1024) / sizeof(uint16_t);
   const int activeRanks[4] = {0, 1, 2, 3};
   const int* allActiveRanks[1] = {activeRanks};
   const std::vector<Bfloat16AllReduceCase> cases = {
-      {thresholdCount - 4, ncclSum, "A=4 9 MiB below-threshold BF16 SUM"},
-      {thresholdCount, ncclSum, "A=4 9 MiB at-threshold BF16 SUM"},
-      {thresholdCount + 4, ncclSum, "A=4 9 MiB above-threshold BF16 SUM"},
+      {thresholdCount - 4, ncclSum, "A=4 1 MiB below-threshold BF16 SUM"},
+      {thresholdCount, ncclSum, "A=4 1 MiB at-threshold BF16 SUM"},
+      {thresholdCount + 4, ncclSum, "A=4 1 MiB above-threshold BF16 SUM"},
   };
 
   runBfloat16AllReduceCases(allActiveRanks, 4, 1, cases);
@@ -2367,19 +2367,19 @@ TEST_F(ShardedRelayMultiGroupAllReduceTest, Routing_SizeAdaptiveCrossovers) {
     size_t thresholdBytes;
     rcclx::relay::AllReduceRoute atOrAbove;
   };
-  // A==2: 2 MB fused / 6 MB independent. A>2: 2 MB fused / 9 MB independent.
+  // A==2: 2 MB fused / 2 MB independent. A>2: 2 MB fused / 1 MB independent.
   const Crossover crossovers[] = {
       {"A2 fused", 2, 4, 2ULL << 20, rcclx::relay::AllReduceRoute::A2Relay},
       {"A2 independent",
        2,
        1,
-       6ULL << 20,
+       2ULL << 20,
        rcclx::relay::AllReduceRoute::A2Relay},
       {"A4 fused", 4, 2, 2ULL << 20, rcclx::relay::AllReduceRoute::FlatOffload},
       {"A4 independent",
        4,
        1,
-       9ULL << 20,
+       1ULL << 20,
        rcclx::relay::AllReduceRoute::FlatOffload},
   };
 

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
@@ -200,33 +200,79 @@ class ShardedRelayMultiGroupAllReduceTest : public ::testing::Test {
  public:
   ShardedRelayMultiGroupAllReduceTest() = default;
 
-  void SetUp() override {
+  // Comms live for the whole binary instead of being rebuilt per case. They
+  // used to be created in SetUp and destroyed in TearDown, so every case freed
+  // everything an 8-rank comm owns. On MI350 freeing VRAM makes amdgpu wipe it
+  // (amdgpu_bo_release_notify -> amdgpu_fill_buffer) while holding mmap_lock
+  // for write, so 8 ranks cycling multi-GB comms serialise into a stall that
+  // takes the whole host down. Reusing also matches how comms are really used:
+  // a handful, kept for the life of the process.
+  //
+  // One comm per active-rank shape, because relay state is per-comm and a comm
+  // cannot be shared between the 2- and 4-active-rank configurations, plus a
+  // dedicated one for the rank barrier. A single store serves all three, with
+  // incrTestCount() between them: the unique-ID rendezvous key is derived from
+  // that counter, so without bumping it the second comm would read the first
+  // one's stale ID. Built eagerly in a fixed order so every rank consumes the
+  // same keys in the same sequence.
+  static void SetUpTestSuite() {
     int localSize;
-    std::tie(this->localRank, this->globalRank, this->numRanks, localSize) =
+    std::tie(localRank, globalRank, numRanks, localSize) =
         getTcpStoreOrMpiInfo();
-    bool isServer = (this->globalRank == 0);
+    const bool isServer = (globalRank == 0);
     if (checkTcpStoreEnv()) {
       server = createTcpStore(isServer);
     } else if (isServer) {
       server = createTcpStore(true);
     }
-    this->comm = createNcclComm(
-        this->globalRank,
-        this->numRanks,
-        this->localRank,
-        false,
-        nullptr,
-        server.get());
+    barrierComm = makeComm();
+    incrTestCount();
+    commA2 = makeComm();
+    incrTestCount();
+    commA4 = makeComm();
+  }
+
+  static ncclComm_t makeComm() {
+    return createNcclComm(
+        globalRank, numRanks, localRank, false, nullptr, server.get());
+  }
+
+  // The comm for a given active-rank shape. Every collective call site has
+  // nActiveRanksPerGroup in scope, which is how a test reaches its comm.
+  static ncclComm_t commFor(int nActiveRanksPerGroup) {
+    switch (nActiveRanksPerGroup) {
+      case 2:
+        return commA2;
+      case 4:
+        return commA4;
+      default:
+        ADD_FAILURE() << "no comm cached for nActiveRanksPerGroup="
+                      << nActiveRanksPerGroup;
+        return nullptr;
+    }
+  }
+
+  static void TearDownTestSuite() {
+    if (server && checkTcpStoreEnv()) {
+      finalizeNcclComm(globalRank, server.get());
+    }
+    for (ncclComm_t* c : {&commA4, &commA2, &barrierComm}) {
+      if (*c != nullptr) {
+        NCCLCHECK_TEST(ncclCommDestroy(*c));
+        *c = nullptr;
+      }
+    }
+    server.reset();
+  }
+
+  void SetUp() override {
+    ASSERT_NE(this->commA2, nullptr)
+        << "suite-scoped comms were not created; SetUpTestSuite did not run";
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
 
   void TearDown() override {
     CUDACHECK_TEST(cudaStreamDestroy(this->stream));
-    if (server && checkTcpStoreEnv()) {
-      finalizeNcclComm(this->globalRank, server.get());
-    }
-    NCCLCHECK_TEST(ncclCommDestroy(this->comm));
-    server.reset();
   }
 
   // Standard 8-rank, 4-group, 2-active-per-group sparse parallelism layout:
@@ -287,7 +333,7 @@ class ShardedRelayMultiGroupAllReduceTest : public ::testing::Test {
         1,
         ncclInt32,
         ncclSum,
-        this->comm,
+        this->barrierComm,
         this->stream));
     HIPCHECK_TEST(hipStreamSynchronize(this->stream));
     HIPCHECK_TEST(hipFree(barrierScratch));
@@ -498,7 +544,7 @@ class ShardedRelayMultiGroupAllReduceTest : public ::testing::Test {
           counts,
           ncclBfloat16,
           testCase.op,
-          this->comm,
+          this->commFor(nActiveRanksPerGroup),
           this->stream,
           allActiveRanks,
           nActiveRanksPerGroup,
@@ -587,7 +633,7 @@ class ShardedRelayMultiGroupAllReduceTest : public ::testing::Test {
         counts,
         ncclInt32,
         op,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,
@@ -603,12 +649,14 @@ class ShardedRelayMultiGroupAllReduceTest : public ::testing::Test {
     HIPCHECK_TEST(hipFree(buff));
   }
 
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
-  ncclComm_t comm;
+  static inline int localRank{0};
+  static inline int globalRank{0};
+  static inline int numRanks{0};
+  static inline ncclComm_t barrierComm{nullptr};
+  static inline ncclComm_t commA2{nullptr};
+  static inline ncclComm_t commA4{nullptr};
+  static inline std::unique_ptr<c10d::TCPStore> server{nullptr};
   cudaStream_t stream;
-  std::unique_ptr<c10d::TCPStore> server{nullptr};
 };
 
 /**
@@ -703,7 +751,7 @@ TEST_F(ShardedRelayMultiGroupAllReduceTest, Correctness_4Groups_InPlace_64MB) {
       counts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -810,7 +858,7 @@ TEST_F(
       counts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -909,7 +957,7 @@ TEST_F(
       counts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1024,7 +1072,7 @@ TEST_F(ShardedRelayMultiGroupAllReduceTest, Z_BusBW_4Groups_InPlace_1GB) {
         counts,
         ncclInt32,
         ncclSum,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,
@@ -1163,7 +1211,7 @@ TEST_F(ShardedRelayMultiGroupAllReduceTest, Z_BusBW_4Groups_OutOfPlace_1GB) {
         counts,
         ncclInt32,
         ncclSum,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,
@@ -1282,7 +1330,7 @@ TEST_F(ShardedRelayMultiGroupAllReduceTest, Correctness_SingleGroup_64MB) {
       counts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1396,7 +1444,7 @@ TEST_F(
       counts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1525,7 +1573,7 @@ TEST_F(
       counts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1631,7 +1679,7 @@ class ShardedRelayAllReduceSingleGroupA4Test
         counts,
         ncclInt32,
         op,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,
@@ -1823,7 +1871,7 @@ TEST_F(
       counts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1910,7 +1958,7 @@ TEST_F(
       counts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1993,7 +2041,7 @@ TEST_F(
       counts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -2074,7 +2122,7 @@ TEST_F(ShardedRelayMultiGroupAllReduceTest, Correctness_4Active_2Groups_Avg) {
       counts,
       ncclInt32,
       ncclAvg,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -2185,7 +2233,7 @@ TEST_F(
       counts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -2392,7 +2440,7 @@ TEST_F(
         counts,
         ncclInt32,
         ncclSum,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
@@ -1713,6 +1713,33 @@ TEST(ShardedRelayAllReducePipelineUnits, LayoutFitsAtEveryAcceptedGeometry) {
   EXPECT_EQ(rcclx::relay::relayAllReducePipelineUnitsPerTile(4, 4), 12);
 }
 
+// The two cases below sit BELOW the 1 MiB A=4 independent crossover, where the
+// full-exchange fast path replaces the direct reduce-scatter + all-gather: one
+// group in which each active rank ships its whole buffer to the other three,
+// then one fused reduce over all four contributions. Both aliasing forms are
+// covered because they take different kernels (in-place seeds the reduce from
+// the destination, out-of-place seeds it from sendbuff), and AVG is covered
+// because the divisor is folded into that single reduce.
+TEST_F(
+    ShardedRelayAllReduceSingleGroupA4Test,
+    Correctness_Sum_OutOfPlace_FullExchange) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runSingleGroupA4Case(
+      /*inPlace=*/false, ncclSum, /*dataBytes=*/256ULL * 1024);
+}
+
+TEST_F(
+    ShardedRelayAllReduceSingleGroupA4Test,
+    Correctness_Avg_InPlace_FullExchange) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runSingleGroupA4Case(
+      /*inPlace=*/true, ncclAvg, /*dataBytes=*/256ULL * 1024);
+}
+
 // The two cases below sit ABOVE kRelayUniformDirectOpMinBytes (256 MiB), where
 // the offload is issued as two half-sized operations per link instead of one,
 // so that every operation in a group matches the direct tiles. The 128 MB cases

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
@@ -2256,6 +2256,57 @@ TEST_F(
   runBfloat16AllReduceCases(groupConfig.allActiveRanks, 4, 2, cases);
 }
 
+// One-shot IPC coverage. Below kRelayOneShotMaxBytes (1 MiB of per-rank count)
+// the allreduce runs a single kernel that pushes each rank's whole buffer into
+// every peer's staging, handshakes per block, and reduces all A contributions
+// -- replacing the group-plus-reduce pair.
+//
+// useShardPattern is the point: it fingerprints the contribution by active
+// index AND element offset. The constant fill the other cases use cannot see an
+// offset error inside a staging slot, because every element of a block holds
+// the same value, and that offset is exactly what the vectorized bulk / scalar
+// tail split could get wrong. 65535 is deliberately not a multiple of
+// 16/sizeof(bf16), so it drives the tail and the misaligned fallback rather
+// than the vector path.
+TEST_F(
+    ShardedRelayMultiGroupAllReduceTest,
+    Correctness_OneShot_A2_SingleGroup_ShardPattern) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int activeRanks[2] = {0, 1};
+  const int* allActiveRanks[1] = {activeRanks};
+  const std::vector<Bfloat16AllReduceCase> cases = {
+      {65536, ncclSum, "A=2 one-shot BF16 SUM", true},
+      {65536, ncclAvg, "A=2 one-shot BF16 AVG", true},
+      {65535, ncclSum, "A=2 one-shot BF16 SUM unaligned tail", true},
+  };
+
+  runBfloat16AllReduceCases(allActiveRanks, 2, 1, cases);
+}
+
+TEST_F(
+    ShardedRelayMultiGroupAllReduceTest,
+    Correctness_OneShot_A4_SingleGroup_ShardPattern) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  const int activeRanks[4] = {0, 1, 2, 3};
+  const int* allActiveRanks[1] = {activeRanks};
+  const std::vector<Bfloat16AllReduceCase> cases = {
+      {65536, ncclSum, "A=4 one-shot BF16 SUM", true},
+      {65536, ncclAvg, "A=4 one-shot BF16 AVG", true},
+      // 65532 is divisible by A (the A>2 allreduce rejects counts that are
+      // not) yet not by 8, so rc*sizeof(bf16) is not a multiple of 16 and the
+      // scalar fallback runs. 65535 would be rejected as invalid input.
+      {65532, ncclSum, "A=4 one-shot BF16 SUM unaligned tail", true},
+  };
+
+  runBfloat16AllReduceCases(allActiveRanks, 4, 1, cases);
+}
+
 TEST_F(
     ShardedRelayMultiGroupAllReduceTest,
     Correctness_Phase2C02_BFloat16_A4_Independent1MiBBoundary) {

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
@@ -1583,10 +1583,12 @@ class ShardedRelayAllReduceSingleGroupA4Test
     return values[activeIndex];
   }
 
-  void runSingleGroupA4Case(bool inPlace, ncclRedOp_t op) {
+  void runSingleGroupA4Case(
+      bool inPlace,
+      ncclRedOp_t op,
+      size_t dataBytes = 128ULL * 1024 * 1024) {
     const int nGroups = 1;
     const int nActiveRanksPerGroup = 4;
-    const size_t dataBytes = 128ULL * 1024 * 1024;
     const size_t count = dataBytes / sizeof(int32_t);
     const int32_t sum =
         contribution(0) + contribution(1) + contribution(2) + contribution(3);
@@ -1709,6 +1711,31 @@ TEST(ShardedRelayAllReducePipelineUnits, LayoutFitsAtEveryAcceptedGeometry) {
   // were measured at, so the parameterization is a generalization and not a
   // change.
   EXPECT_EQ(rcclx::relay::relayAllReducePipelineUnitsPerTile(4, 4), 12);
+}
+
+// The two cases below sit ABOVE kRelayUniformDirectOpMinBytes (256 MiB), where
+// the offload is issued as two half-sized operations per link instead of one,
+// so that every operation in a group matches the direct tiles. The 128 MB cases
+// above stay below that threshold, so between them both sides of the gate are
+// covered. AVG is included because the divisor is applied per piece.
+TEST_F(
+    ShardedRelayAllReduceSingleGroupA4Test,
+    Correctness_Sum_OutOfPlace_UniformOps) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runSingleGroupA4Case(
+      /*inPlace=*/false, ncclSum, /*dataBytes=*/256ULL * 1024 * 1024);
+}
+
+TEST_F(
+    ShardedRelayAllReduceSingleGroupA4Test,
+    Correctness_Avg_InPlace_UniformOps) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runSingleGroupA4Case(
+      /*inPlace=*/true, ncclAvg, /*dataBytes=*/256ULL * 1024 * 1024);
 }
 
 TEST_F(

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
@@ -894,7 +894,7 @@ TEST_F(
       std::vector<size_t>(4, 262145), groupConfig.allActiveRanks, true);
 }
 
-// The independent A=2 cutoff is 27 MiB, or 3538944 int32 elements per segment.
+// The independent A=2 cutoff is 3 MiB, or 393216 int32 elements per segment.
 TEST_F(
     ShardedRelayMultiGroupAllToAllTest,
     Correctness_A2_IndependentThreshold_Below_UnalignedTail) {
@@ -905,7 +905,7 @@ TEST_F(
 
   const int activeRanks[] = {0, 1};
   const int* allActiveRanks[] = {activeRanks};
-  runA2CorrectnessCase({3538943}, allActiveRanks, false);
+  runA2CorrectnessCase({393215}, allActiveRanks, false);
 }
 
 TEST_F(
@@ -918,7 +918,7 @@ TEST_F(
 
   const int activeRanks[] = {0, 1};
   const int* allActiveRanks[] = {activeRanks};
-  runA2CorrectnessCase({3538944}, allActiveRanks, true);
+  runA2CorrectnessCase({393216}, allActiveRanks, true);
 }
 
 TEST_F(
@@ -931,7 +931,7 @@ TEST_F(
 
   const int activeRanks[] = {0, 1};
   const int* allActiveRanks[] = {activeRanks};
-  runA2CorrectnessCase({3538945}, allActiveRanks, true);
+  runA2CorrectnessCase({393217}, allActiveRanks, true);
 }
 
 TEST_F(
@@ -1564,12 +1564,12 @@ TEST_F(
 // tests cover, across the routed and direct regimes.
 TEST_F(
     ShardedRelayMultiGroupAllToAllTest,
-    Correctness_4Active_SingleGroup_Routed_9MiB) {
+    Correctness_4Active_SingleGroup_Routed_10MiB) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 9ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 10ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t));
   runA4SingleGroupCorrectnessCase(segmentCount, true);
 }
@@ -1581,7 +1581,7 @@ TEST_F(
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 9ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 10ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t)) - 1;
   runA4SingleGroupCorrectnessCase(segmentCount, false);
 }
@@ -1593,7 +1593,7 @@ TEST_F(
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 9ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 10ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t)) + 1;
   runA4SingleGroupCorrectnessCase(segmentCount, true, true);
 }
@@ -1601,7 +1601,7 @@ TEST_F(
 /**
  * A=4 single group at a size the software pipeline covers.
  *
- * The 9 MiB single-group cases above are just above the routing threshold,
+ * The 10 MiB single-group cases above are just above the routing threshold,
  * which the depth cost model resolves to depth 1 -- so they exercise the
  * unpipelined XOR schedule. 64 MiB per active rank is the first swept size deep
  * enough to tile, so this is the coverage for the pipelined schedule, where

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
@@ -167,33 +167,79 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
  public:
   ShardedRelayMultiGroupAllToAllTest() = default;
 
-  void SetUp() override {
+  // Comms live for the whole binary instead of being rebuilt per case. They
+  // used to be created in SetUp and destroyed in TearDown, so every case freed
+  // everything an 8-rank comm owns. On MI350 freeing VRAM makes amdgpu wipe it
+  // (amdgpu_bo_release_notify -> amdgpu_fill_buffer) while holding mmap_lock
+  // for write, so 8 ranks cycling multi-GB comms serialise into a stall that
+  // takes the whole host down. Reusing also matches how comms are really used:
+  // a handful, kept for the life of the process.
+  //
+  // One comm per active-rank shape, because relay state is per-comm and a comm
+  // cannot be shared between the 2- and 4-active-rank configurations, plus a
+  // dedicated one for the rank barrier. A single store serves all three, with
+  // incrTestCount() between them: the unique-ID rendezvous key is derived from
+  // that counter, so without bumping it the second comm would read the first
+  // one's stale ID. Built eagerly in a fixed order so every rank consumes the
+  // same keys in the same sequence.
+  static void SetUpTestSuite() {
     int localSize;
-    std::tie(this->localRank, this->globalRank, this->numRanks, localSize) =
+    std::tie(localRank, globalRank, numRanks, localSize) =
         getTcpStoreOrMpiInfo();
-    bool isServer = (this->globalRank == 0);
+    const bool isServer = (globalRank == 0);
     if (checkTcpStoreEnv()) {
       server = createTcpStore(isServer);
     } else if (isServer) {
       server = createTcpStore(true);
     }
-    this->comm = createNcclComm(
-        this->globalRank,
-        this->numRanks,
-        this->localRank,
-        false,
-        nullptr,
-        server.get());
+    barrierComm = makeComm();
+    incrTestCount();
+    commA2 = makeComm();
+    incrTestCount();
+    commA4 = makeComm();
+  }
+
+  static ncclComm_t makeComm() {
+    return createNcclComm(
+        globalRank, numRanks, localRank, false, nullptr, server.get());
+  }
+
+  // The comm for a given active-rank shape. Every collective call site has
+  // nActiveRanksPerGroup in scope, which is how a test reaches its comm.
+  static ncclComm_t commFor(int nActiveRanksPerGroup) {
+    switch (nActiveRanksPerGroup) {
+      case 2:
+        return commA2;
+      case 4:
+        return commA4;
+      default:
+        ADD_FAILURE() << "no comm cached for nActiveRanksPerGroup="
+                      << nActiveRanksPerGroup;
+        return nullptr;
+    }
+  }
+
+  static void TearDownTestSuite() {
+    if (server && checkTcpStoreEnv()) {
+      finalizeNcclComm(globalRank, server.get());
+    }
+    for (ncclComm_t* c : {&commA4, &commA2, &barrierComm}) {
+      if (*c != nullptr) {
+        NCCLCHECK_TEST(ncclCommDestroy(*c));
+        *c = nullptr;
+      }
+    }
+    server.reset();
+  }
+
+  void SetUp() override {
+    ASSERT_NE(this->commA2, nullptr)
+        << "suite-scoped comms were not created; SetUpTestSuite did not run";
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
 
   void TearDown() override {
     CUDACHECK_TEST(cudaStreamDestroy(this->stream));
-    if (server && checkTcpStoreEnv()) {
-      finalizeNcclComm(this->globalRank, server.get());
-    }
-    NCCLCHECK_TEST(ncclCommDestroy(this->comm));
-    server.reset();
   }
 
   // Standard 8-rank, 4-group, 2-active-per-group sparse parallelism layout.
@@ -272,7 +318,7 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
         1,
         ncclInt32,
         ncclSum,
-        this->comm,
+        this->barrierComm,
         this->stream));
     HIPCHECK_TEST(hipStreamSynchronize(this->stream));
     HIPCHECK_TEST(hipFree(barrierScratch));
@@ -438,7 +484,7 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
         recvPtrs.data(),
         segmentCounts.data(),
         ncclInt32,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,
@@ -552,7 +598,7 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
         recvPtrs,
         segmentCounts,
         ncclInt32,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,
@@ -693,7 +739,7 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
         recvPtrs,
         segmentCounts,
         ncclInt32,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,
@@ -741,12 +787,14 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
     }
   }
 
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
-  ncclComm_t comm;
+  static inline int localRank{0};
+  static inline int globalRank{0};
+  static inline int numRanks{0};
+  static inline ncclComm_t barrierComm{nullptr};
+  static inline ncclComm_t commA2{nullptr};
+  static inline ncclComm_t commA4{nullptr};
+  static inline std::unique_ptr<c10d::TCPStore> server{nullptr};
   cudaStream_t stream;
-  std::unique_ptr<c10d::TCPStore> server{nullptr};
 };
 
 /**
@@ -820,7 +868,7 @@ TEST_F(
       recvPtrs,
       segmentCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1003,7 +1051,7 @@ TEST_F(
       recvPtrs,
       segmentCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1075,7 +1123,7 @@ TEST_F(ShardedRelayMultiGroupAllToAllTest, InPlace_Rejected) {
       recvPtrs,
       segmentCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1144,7 +1192,7 @@ TEST_F(ShardedRelayMultiGroupAllToAllTest, Correctness_SingleGroup_64MB) {
       recvPtrs,
       segmentCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1242,7 +1290,7 @@ TEST_F(
       recvPtrs,
       segmentCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1340,7 +1388,7 @@ TEST_F(ShardedRelayMultiGroupAllToAllTest, Correctness_PartialGroupsZeroCount) {
       recvPtrs,
       segmentCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1446,7 +1494,7 @@ TEST_F(ShardedRelayMultiGroupAllToAllTest, Z_BusBW_4Groups_OutOfPlace_1GB) {
         recvPtrs,
         segmentCounts,
         ncclInt32,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,
@@ -1683,7 +1731,7 @@ TEST_F(
       recvPtrs,
       segmentCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1755,7 +1803,7 @@ TEST_F(
       recvPtrs,
       segmentCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1849,7 +1897,7 @@ TEST_F(
       recvPtrs,
       segmentCounts,
       ncclInt32,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1946,7 +1994,7 @@ TEST_F(
         recvPtrs,
         segmentCounts,
         ncclInt32,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
@@ -1599,6 +1599,29 @@ TEST_F(
 }
 
 /**
+ * A=4 single group at a size the software pipeline covers.
+ *
+ * The 9 MiB single-group cases above are just above the routing threshold,
+ * which the depth cost model resolves to depth 1 -- so they exercise the
+ * unpipelined XOR schedule. 64 MiB per active rank is the first swept size deep
+ * enough to tile, so this is the coverage for the pipelined schedule, where
+ * each cross link carries the relay's two hops at once in opposite directions.
+ * Verified over whole segments rather than at region boundaries, since the
+ * pipelined layout splits the segment differently.
+ */
+TEST_F(
+    ShardedRelayMultiGroupAllToAllTest,
+    Correctness_4Active_SingleGroup_Pipelined_64MiB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+
+  constexpr size_t perActiveBytes = 64ULL * 1024 * 1024;
+  constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t));
+  runA4SingleGroupCorrectnessCase(segmentCount, true);
+}
+
+/**
  * Tiny-segment regression for the exact direct fallback below the retained
  * A=4 XOR/Latin routing window.
  */

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
@@ -512,7 +512,7 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
         initActiveSendBuffer(
             sendBuffs[g], segmentCount, myActiveIndex, nActiveRanksPerGroup);
         if (checkRegionBoundaries) {
-          const size_t directA = segmentCount / 3;
+          const size_t directA = relayCount;
           const size_t regionOffsets[5] = {
               directA - 1,
               directA,
@@ -561,7 +561,7 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
     HIPCHECK_TEST(hipStreamSynchronize(this->stream));
 
     if (checkRegionBoundaries) {
-      const size_t directA = segmentCount / 3;
+      const size_t directA = relayCount;
       const size_t regionOffsets[5] = {
           directA - 1,
           directA,
@@ -654,7 +654,7 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
       initActiveSendBuffer(
           sendBuff, segmentCount, myActiveIndex, nActiveRanksPerGroup);
       if (checkRegionBoundaries) {
-        const size_t directA = segmentCount / 3;
+        const size_t directA = relayCount;
         const size_t regionOffsets[5] = {
             directA - 1,
             directA,
@@ -703,7 +703,7 @@ class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {
 
     if (isActive) {
       if (checkRegionBoundaries) {
-        const size_t directA = segmentCount / 3;
+        const size_t directA = relayCount;
         const size_t regionOffsets[5] = {
             directA - 1,
             directA,
@@ -1508,12 +1508,12 @@ TEST_F(ShardedRelayMultiGroupAllToAllTest, Z_BusBW_4Groups_OutOfPlace_1GB) {
  */
 TEST_F(
     ShardedRelayMultiGroupAllToAllTest,
-    Correctness_4Active_RoutedLowerBoundary_63MiB) {
+    Correctness_4Active_RoutedLowerBoundary_27MiB) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 27ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t));
   runA4CorrectnessCase(segmentCount, true);
 }
@@ -1525,7 +1525,7 @@ TEST_F(
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 27ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t)) - 1;
   runA4CorrectnessCase(segmentCount, false);
 }
@@ -1537,21 +1537,26 @@ TEST_F(
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 27ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t)) + 1;
   runA4CorrectnessCase(segmentCount, true, true);
 }
 
+// 256 MiB is a power of two, so segmentCount is not divisible by 3 and the
+// relay's leading direct region has to be aligned down rather than taken as an
+// exact third. Routed here (this size used to be the top of the window), with
+// the region boundaries checked so a misaligned split is caught.
 TEST_F(
     ShardedRelayMultiGroupAllToAllTest,
-    Correctness_4Active_DirectUpperBoundary_256MiB) {
+    Correctness_4Active_RoutedPowerOfTwo_256MiB) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
   constexpr size_t perActiveBytes = 256ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t));
-  runA4CorrectnessCase(segmentCount, false);
+  static_assert(segmentCount % 3 != 0, "256 MiB must not divide into thirds");
+  runA4CorrectnessCase(segmentCount, true, true);
 }
 
 // Single-group (nGroups=1) A=4 all-to-all: ranks {0,1,2,3} active, {4,5,6,7}
@@ -1559,12 +1564,12 @@ TEST_F(
 // tests cover, across the routed and direct regimes.
 TEST_F(
     ShardedRelayMultiGroupAllToAllTest,
-    Correctness_4Active_SingleGroup_Routed_63MiB) {
+    Correctness_4Active_SingleGroup_Routed_9MiB) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 9ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t));
   runA4SingleGroupCorrectnessCase(segmentCount, true);
 }
@@ -1576,7 +1581,7 @@ TEST_F(
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 9ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t)) - 1;
   runA4SingleGroupCorrectnessCase(segmentCount, false);
 }
@@ -1588,7 +1593,7 @@ TEST_F(
     GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
   }
 
-  constexpr size_t perActiveBytes = 63ULL * 1024 * 1024;
+  constexpr size_t perActiveBytes = 9ULL * 1024 * 1024;
   constexpr size_t segmentCount = perActiveBytes / (4 * sizeof(int32_t)) + 1;
   runA4SingleGroupCorrectnessCase(segmentCount, true, true);
 }

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayControlPlaneTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayControlPlaneTest.cu
@@ -1,0 +1,871 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/**
+ * Production-shape tests for the relay control plane.
+ *
+ * RelayControlTest covers the protocol in isolation, with forked children
+ * standing in for peers. This file covers what that deliberately cannot: the
+ * communicator-bound layer, on a real 8-rank comm, driving real relay
+ * collectives.
+ *
+ * The shape is the deployment's, not a convenience:
+ *
+ *   ranks 0..nActive-1   ACTIVE   run the model, know the plan
+ *   rank  0              PUBLISHER  the one rank that writes it
+ *   ranks nActive..7     HELPER   know nothing until they consume a plan
+ *
+ * A helper here is given no counts, no opcode and no call count by the test. It
+ * learns all three from the segment and then enqueues collectives on that basis
+ * alone. That is the property under test: if the plan did not arrive intact,
+ * the helper's relay calls would not match its peers' and the collective would
+ * hang or corrupt rather than quietly pass.
+ *
+ * Correctness of the collectives themselves is covered by the four
+ * ShardedRelay*Test suites. What is checked here is that a published plan
+ * drives them -- so allreduce is verified numerically as the representative
+ * case, and the other three are required to complete, which for a symmetric
+ * collective across 8 ranks already means every rank agreed on counts and
+ * route.
+ *
+ * NOTHING IN THIS FILE USES A FATAL ASSERTION. ASSERT_* returns from the test
+ * body, which on one rank of eight means the other seven are left waiting
+ * inside a collective that rank will never join: a single-rank control-plane
+ * failure would present as an eight-rank hang with no attribution instead of a
+ * named failure on the rank that caused it. Every check is therefore EXPECT_*,
+ * the decision to enter the collectives is taken unanimously through a
+ * reduction, and loop bounds come from values every rank holds locally.
+ *
+ * That applies to SetUp and TearDown too, which is easy to miss because the
+ * FAIL()-based *CHECK_TEST macros read like the ones every other test in this
+ * directory uses. They are deliberately NOT defined here so the rule cannot be
+ * broken by habit -- only the ADD_FAILURE()-based *EXPECT_TEST forms exist.
+ * SetUp records its outcome in setupOk instead, and requireEightRanks() gates
+ * every body on it.
+ *
+ * One case is beyond rescue: a rank that fails to CREATE its communicator can
+ * never join the collective its peers are already in, and nothing checkable
+ * from inside a single rank can detect a peer that will never arrive. Non-fatal
+ * handling still turns that into an attributed skip plus a clean teardown
+ * rather than a null dereference.
+ */
+
+#include <folly/init/Init.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include "comm.h"
+#include "comms/rcclx/develop/meta/testinfra/TestUtils.h"
+#include "comms/rcclx/develop/meta/testinfra/TestsDistUtils.h"
+#include "meta/relay/relay_control.h"
+#include "nccl.h"
+
+// FAIL() is only usable in a void function, and the reductions below have to
+// return a value to every rank.
+#define HIPEXPECT_TEST(cmd)                                                \
+  do {                                                                     \
+    hipError_t error = cmd;                                                \
+    if (error != hipSuccess) {                                             \
+      ADD_FAILURE() << "HIP error: " << hipGetErrorString(error) << " at " \
+                    << __FILE__ << ":" << __LINE__;                        \
+    }                                                                      \
+  } while (0)
+
+#define NCCLEXPECT_TEST(cmd)                                                  \
+  do {                                                                        \
+    ncclResult_t result = cmd;                                                \
+    if (result != ncclSuccess) {                                              \
+      ADD_FAILURE() << "NCCL error: " << ncclGetErrorString(result) << " at " \
+                    << __FILE__ << ":" << __LINE__;                           \
+    }                                                                         \
+  } while (0)
+
+#define CUDAEXPECT_TEST(cmd)                                                 \
+  do {                                                                       \
+    cudaError_t error = cmd;                                                 \
+    if (error != cudaSuccess) {                                              \
+      ADD_FAILURE() << "CUDA error: " << cudaGetErrorString(error) << " at " \
+                    << __FILE__ << ":" << __LINE__;                          \
+    }                                                                        \
+  } while (0)
+
+namespace {
+
+constexpr int64_t kMs = 1000LL * 1000LL;
+// Generous, because a helper waits here while its peers do real GPU work.
+constexpr int64_t kForwardTimeoutNs = 60LL * 1000LL * kMs;
+// Used only where a timeout is the expected outcome.
+constexpr int64_t kShortTimeoutNs = 300LL * kMs;
+
+constexpr uint32_t kMaxCallsPerPlan = 8;
+constexpr size_t kElemsPerCall = 64ULL * 1024;
+
+} // namespace
+
+/**
+ * Parameterised on the number of ACTIVE ranks: 4 active + 4 helper, and 2
+ * active
+ * + 6 helper. Both are real deployment shapes, they select different relay
+ * routes, and the 2-active case puts six ranks on the consume path rather than
+ * four -- so a bug in how helpers are counted or waited on shows up in one and
+ * not the other.
+ *
+ * gtest runs cases in a fixed order, so every rank walks the two configurations
+ * in the same sequence. The parameter is never communicated and never needs to
+ * be: it is derived identically on every rank.
+ */
+class ShardedRelayControlPlaneTest : public ::testing::TestWithParam<int> {
+ public:
+  void SetUp() override {
+    int localSize;
+    std::tie(this->localRank, this->globalRank, this->numRanks, localSize) =
+        getTcpStoreOrMpiInfo();
+    const bool isServer = (this->globalRank == 0);
+    if (checkTcpStoreEnv()) {
+      server = createTcpStore(isServer);
+    } else if (isServer) {
+      server = createTcpStore(true);
+    }
+    this->comm = createNcclComm(
+        this->globalRank,
+        this->numRanks,
+        this->localRank,
+        false,
+        nullptr,
+        server.get());
+    // Non-fatal from here down. This file's whole premise is that no rank may
+    // abandon a collective its peers are entering, and FAIL() returns from
+    // SetUp() on one rank while the other seven walk into the test body's first
+    // all-reduce -- producing exactly the eight-rank hang the rule exists to
+    // prevent, with the real cause buried behind a harness timeout.
+    CUDAEXPECT_TEST(cudaStreamCreate(&stream));
+    // Two dedicated, persistent scratch words, never aliased with each other.
+    //
+    // Allocating these per call is a real hazard rather than a style point:
+    // hipFree followed by hipMalloc readily returns the SAME device address, so
+    // one all-reduce's write -- not guaranteed to be retired when the host
+    // stages the next value -- can land on top of that value. That is the
+    // documented flaky "expected X but got 0" mode called out in
+    // ShardedRelayAllReduceTest's barrierSyncOn, and an earlier version of this
+    // file hit exactly it.
+    HIPEXPECT_TEST(hipMalloc(&barrierScratch, sizeof(int32_t)));
+    HIPEXPECT_TEST(hipMalloc(&reduceScratch, sizeof(int32_t)));
+
+    setupOk = this->comm != nullptr && this->stream != nullptr &&
+        barrierScratch != nullptr && reduceScratch != nullptr;
+  }
+
+  void TearDown() override {
+    // Non-fatal for the same reason as SetUp: a rank that returns early from
+    // teardown skips ncclCommDestroy, and a comm destroyed on seven of eight
+    // ranks is its own hang.
+    if (barrierScratch != nullptr) {
+      HIPEXPECT_TEST(hipFree(barrierScratch));
+    }
+    if (reduceScratch != nullptr) {
+      HIPEXPECT_TEST(hipFree(reduceScratch));
+    }
+    if (server && checkTcpStoreEnv()) {
+      finalizeNcclComm(this->globalRank, server.get());
+    }
+    // Comm BEFORE stream. A comm holds internal references to the streams it
+    // was used with, so destroying the stream first can leave teardown touching
+    // a freed stream; the reverse order has nothing depending on it.
+    if (this->comm != nullptr) {
+      NCCLEXPECT_TEST(ncclCommDestroy(this->comm));
+      this->comm = nullptr;
+    }
+    if (this->stream != nullptr) {
+      CUDAEXPECT_TEST(cudaStreamDestroy(this->stream));
+      this->stream = nullptr;
+    }
+    server.reset();
+  }
+
+ protected:
+  // False if any part of SetUp() failed. Every test body checks it before
+  // entering a collective, so a rank whose setup failed reports that cause and
+  // skips instead of dereferencing a null comm.
+  //
+  // This does NOT rescue a comm-creation failure: a rank that never built a
+  // comm cannot join the collective its peers are already in, and no gate
+  // reachable from inside one rank can detect a peer that will never arrive.
+  // What it does buy is a clean, attributed skip instead of a segfault, and a
+  // teardown that still runs.
+  bool setupOk{false};
+  int localRank{0};
+  int globalRank{0};
+  int numRanks{0};
+  ncclComm_t comm{nullptr};
+  cudaStream_t stream{nullptr};
+  int32_t* barrierScratch{nullptr};
+  int32_t* reduceScratch{nullptr};
+  std::shared_ptr<c10d::TCPStore> server;
+
+  bool requireEightRanks() {
+    if (this->numRanks != 8) {
+      return false;
+    }
+    return setupOk;
+  }
+
+  // Cross-rank barrier. Also the mechanism for the unanimity checks below: a
+  // sum over a per-rank 0/1 tells every rank what every other rank saw, which
+  // is the only way to assert a property of the whole comm from inside one
+  // rank.
+  void barrier() {
+    HIPEXPECT_TEST(
+        hipMemsetAsync(barrierScratch, 0, sizeof(int32_t), this->stream));
+    NCCLEXPECT_TEST(ncclAllReduce(
+        barrierScratch,
+        barrierScratch,
+        1,
+        ncclInt32,
+        ncclSum,
+        this->comm,
+        this->stream));
+    HIPEXPECT_TEST(hipStreamSynchronize(this->stream));
+  }
+
+  // Everything is enqueued on the one stream, so the staging copy, the
+  // reduction and the read-back are ordered against each other by construction
+  // rather than by the host happening to be ahead.
+  int sumAcrossRanks(int value) {
+    const int32_t host = static_cast<int32_t>(value);
+    int32_t out = 0;
+    HIPEXPECT_TEST(hipMemcpyAsync(
+        reduceScratch,
+        &host,
+        sizeof(int32_t),
+        hipMemcpyHostToDevice,
+        this->stream));
+    NCCLEXPECT_TEST(ncclAllReduce(
+        reduceScratch,
+        reduceScratch,
+        1,
+        ncclInt32,
+        ncclSum,
+        this->comm,
+        this->stream));
+    HIPEXPECT_TEST(hipMemcpyAsync(
+        &out,
+        reduceScratch,
+        sizeof(int32_t),
+        hipMemcpyDeviceToHost,
+        this->stream));
+    HIPEXPECT_TEST(hipStreamSynchronize(this->stream));
+    return static_cast<int>(out);
+  }
+
+  static int32_t contribution(int activeIndex) {
+    return static_cast<int32_t>(activeIndex + 1);
+  }
+
+  static int32_t expectedAllReduceSum(int nActive) {
+    return static_cast<int32_t>(nActive * (nActive + 1) / 2);
+  }
+
+  // One relay call, dispatched on the opcode the plan carried. Buffers are
+  // sized for the widest of the four (count * nActive elements), so the same
+  // pair serves every opcode.
+  ncclResult_t enqueueRelayCall(
+      uint32_t opCode,
+      const void* sendBuff,
+      void* recvBuff,
+      size_t count,
+      const int* const* allActiveRanks,
+      int nActive) {
+    const void* sendPtrs[1] = {sendBuff};
+    void* recvPtrs[1] = {recvBuff};
+    size_t counts[1] = {count};
+    switch (opCode) {
+      case rcclx::relay::kRelayOpAllReduce:
+        return ncclShardedRelayMultiGroupAllReduce(
+            sendPtrs,
+            recvPtrs,
+            counts,
+            ncclInt32,
+            ncclSum,
+            this->comm,
+            this->stream,
+            allActiveRanks,
+            nActive,
+            1);
+      case rcclx::relay::kRelayOpReduceScatter:
+        return ncclShardedRelayMultiGroupReduceScatter(
+            sendPtrs,
+            recvPtrs,
+            counts,
+            ncclInt32,
+            ncclSum,
+            this->comm,
+            this->stream,
+            allActiveRanks,
+            nActive,
+            1);
+      case rcclx::relay::kRelayOpAllGather:
+        return ncclShardedRelayMultiGroupAllGather(
+            sendPtrs,
+            recvPtrs,
+            counts,
+            ncclInt32,
+            this->comm,
+            this->stream,
+            allActiveRanks,
+            nActive,
+            1);
+      case rcclx::relay::kRelayOpAllToAll:
+        return ncclShardedRelayMultiGroupAllToAll(
+            sendPtrs,
+            recvPtrs,
+            counts,
+            ncclInt32,
+            this->comm,
+            this->stream,
+            allActiveRanks,
+            nActive,
+            1);
+      default:
+        return ncclInvalidArgument;
+    }
+  }
+
+  /**
+   * One forward, exactly as the deployment runs it.
+   *
+   * `counts` is what the ACTIVE side decided. The helper side is handed
+   * nothing: it is passed only the epoch and must recover opcode, call count
+   * and counts from the segment. `verifySum` is honoured on active ranks for
+   * allreduce.
+   *
+   * Each call gets its own buffers. Sharing one pair across the calls of a plan
+   * would be a write-after-read hazard between ranks -- a rank that finished
+   * call i racing ahead to overwrite the send buffer a peer is still reading --
+   * which is an artifact of the test, not of the deployment, where every relay
+   * call has its own tensor.
+   */
+  void runForward(
+      uint64_t epoch,
+      uint32_t opCode,
+      const std::vector<size_t>& counts,
+      int nActive,
+      bool verifySum) {
+    std::vector<int> activeStorage(nActive);
+    for (int i = 0; i < nActive; i++) {
+      activeStorage[i] = i;
+    }
+    const int* allActiveRanks[1] = {activeStorage.data()};
+    const bool isActive = this->globalRank < nActive;
+    const bool isPublisher = (this->globalRank == 0);
+
+    bool localOk = true;
+    ncclRelayPlanInfo info{};
+    info.nCalls = static_cast<uint32_t>(counts.size());
+    info.opCode = opCode;
+    info.dtype = ncclInt32;
+    info.redOp = ncclSum;
+
+    if (isPublisher) {
+      const ncclResult_t res = ncclRelayControlPublish(
+          this->comm, epoch, &info, counts.data(), kForwardTimeoutNs);
+      EXPECT_EQ(res, ncclSuccess) << "publish failed at epoch " << epoch;
+      localOk = (res == ncclSuccess);
+    }
+
+    if (!isActive) {
+      // The helper's entire knowledge of this forward comes from here.
+      ncclRelayPlanInfo got{};
+      std::vector<size_t> gotCounts(kMaxCallsPerPlan, 0);
+      const ncclResult_t res = ncclRelayControlConsume(
+          this->comm,
+          epoch,
+          &got,
+          gotCounts.data(),
+          kMaxCallsPerPlan,
+          kForwardTimeoutNs);
+      EXPECT_EQ(res, ncclSuccess) << "consume failed at epoch " << epoch
+                                  << " on rank " << this->globalRank;
+      if (res == ncclSuccess) {
+        EXPECT_EQ(got.opCode, opCode);
+        EXPECT_EQ(got.nCalls, counts.size());
+        EXPECT_EQ(got.dtype, static_cast<uint32_t>(ncclInt32));
+        if (got.nCalls == counts.size()) {
+          gotCounts.resize(got.nCalls);
+          // Only meaningful because the test knows the answer; the helper does
+          // not. This is the assertion the whole file exists for.
+          EXPECT_EQ(gotCounts, counts) << "plan did not survive the segment";
+        }
+      } else {
+        localOk = false;
+      }
+    }
+
+    // Deciding to proceed has to be unanimous. Every assertion above is
+    // non-fatal on purpose: a fatal one returns from the test body on the rank
+    // that tripped it, leaving the other seven waiting in a collective it will
+    // never join, so a one-rank control-plane failure would present as an
+    // eight-rank hang instead of a named failure. This gate is itself a
+    // collective every rank reaches, and either all ranks continue or all
+    // return.
+    if (sumAcrossRanks(localOk ? 1 : 0) != this->numRanks) {
+      return;
+    }
+
+    // Loop control comes from the test's own plan, which every rank holds
+    // locally, rather than from the consumed copy: the number of collectives a
+    // rank enters must never be able to differ from its peers'. Whether the
+    // consumed copy matched is asserted above, where a mismatch is a named
+    // failure rather than a divergence.
+    for (size_t i = 0; i < counts.size(); i++) {
+      const size_t count = counts[i];
+      const size_t bytes = count * nActive * sizeof(int32_t);
+      int32_t* sendBuff = nullptr;
+      int32_t* recvBuff = nullptr;
+      HIPEXPECT_TEST(hipMalloc(&sendBuff, bytes));
+      HIPEXPECT_TEST(hipMalloc(&recvBuff, bytes));
+      HIPEXPECT_TEST(hipMemset(sendBuff, 0, bytes));
+      HIPEXPECT_TEST(hipMemset(recvBuff, 0, bytes));
+
+      if (isActive) {
+        std::vector<int32_t> host(count, contribution(this->globalRank));
+        HIPEXPECT_TEST(hipMemcpy(
+            sendBuff,
+            host.data(),
+            count * sizeof(int32_t),
+            hipMemcpyHostToDevice));
+      }
+      // Every rank is at the same call before any of them starts it, so a
+      // mismatch is a plan-delivery failure rather than a straggler.
+      barrier();
+
+      // Non-fatal for the same reason as above: bailing here would leave the
+      // buffers unfreed and, worse, the peers inside the next barrier.
+      EXPECT_EQ(
+          enqueueRelayCall(
+              opCode,
+              sendBuff,
+              isActive ? recvBuff : sendBuff,
+              count,
+              allActiveRanks,
+              nActive),
+          ncclSuccess)
+          << "relay call " << i << " failed at epoch " << epoch;
+      HIPEXPECT_TEST(hipStreamSynchronize(this->stream));
+
+      if (verifySum && isActive && opCode == rcclx::relay::kRelayOpAllReduce) {
+        std::vector<int32_t> out(count, 0);
+        HIPEXPECT_TEST(hipMemcpy(
+            out.data(),
+            recvBuff,
+            count * sizeof(int32_t),
+            hipMemcpyDeviceToHost));
+        const int32_t expected = expectedAllReduceSum(nActive);
+        // Spot-check the ends and the middle rather than every element: a
+        // control-plane fault shows up as a whole-buffer disagreement, and the
+        // element-exact case is already covered by the allreduce suite.
+        EXPECT_EQ(out[0], expected) << "epoch " << epoch << " call " << i;
+        EXPECT_EQ(out[count / 2], expected) << "epoch " << epoch;
+        EXPECT_EQ(out[count - 1], expected) << "epoch " << epoch;
+      }
+
+      HIPEXPECT_TEST(hipFree(sendBuff));
+      HIPEXPECT_TEST(hipFree(recvBuff));
+    }
+  }
+};
+
+/**
+ * The setup path, asserted across the whole comm rather than locally.
+ *
+ * A control plane that came up on only some ranks is the failure mode the
+ * unanimity vote exists to prevent, and it is precisely the one a per-rank
+ * EXPECT_TRUE cannot see: the ranks that have a segment would wait for peers
+ * that took the other path. Summing the flag is what turns "I am ready" into
+ * "we are all ready".
+ */
+TEST_P(ShardedRelayControlPlaneTest, ControlPlaneComesUpOnEveryRankOrNone) {
+  if (!requireEightRanks()) {
+    GTEST_SKIP() << "requires exactly 8 ranks, got " << this->numRanks;
+  }
+  const bool ready = rcclx::relay::relayControlReady(this->comm);
+  EXPECT_TRUE(ready) << "rank " << this->globalRank << " has no control plane";
+  const int readyCount = sumAcrossRanks(ready ? 1 : 0);
+  EXPECT_EQ(readyCount, this->numRanks)
+      << "control plane is up on " << readyCount << " of " << this->numRanks
+      << " ranks, which is the split state unanimity is meant to exclude";
+}
+
+TEST_P(ShardedRelayControlPlaneTest, AllReduceForwardDrivenByThePublishedPlan) {
+  if (!requireEightRanks()) {
+    GTEST_SKIP() << "requires exactly 8 ranks, got " << this->numRanks;
+  }
+  const int nActive = GetParam();
+  barrier();
+  runForward(
+      /*epoch=*/0,
+      rcclx::relay::kRelayOpAllReduce,
+      {kElemsPerCall, kElemsPerCall / 2, kElemsPerCall / 4},
+      nActive,
+      /*verifySum=*/true);
+  barrier();
+}
+
+/**
+ * Counts change every forward, which is the case the TCP-store design existed
+ * to serve and the reason none of this can be hoisted to init.
+ */
+TEST_P(ShardedRelayControlPlaneTest, CountsAndCallCountVaryAcrossForwards) {
+  if (!requireEightRanks()) {
+    GTEST_SKIP() << "requires exactly 8 ranks, got " << this->numRanks;
+  }
+  const int nActive = GetParam();
+  barrier();
+
+  const std::vector<std::vector<size_t>> plans = {
+      {kElemsPerCall},
+      {1024, 2048, 4096},
+      {kElemsPerCall / 8},
+      {512, 512, 512, 512, 512},
+      {kElemsPerCall, 64},
+  };
+  for (uint64_t epoch = 0; epoch < plans.size(); epoch++) {
+    runForward(
+        epoch,
+        rcclx::relay::kRelayOpAllReduce,
+        plans[epoch],
+        nActive,
+        /*verifySum=*/true);
+  }
+  barrier();
+}
+
+/**
+ * All four entry points, at whichever width the parameter selects. Only the
+ * allreduce is verified numerically; the other three are required to complete,
+ * which for a symmetric collective across 8 ranks already means every rank
+ * agreed on counts and route.
+ */
+TEST_P(ShardedRelayControlPlaneTest, AllFourCollectives) {
+  if (!requireEightRanks()) {
+    GTEST_SKIP() << "requires exactly 8 ranks, got " << this->numRanks;
+  }
+  const int nActive = GetParam();
+  barrier();
+
+  const uint32_t opCodes[] = {
+      rcclx::relay::kRelayOpAllReduce,
+      rcclx::relay::kRelayOpReduceScatter,
+      rcclx::relay::kRelayOpAllGather,
+      rcclx::relay::kRelayOpAllToAll};
+  for (uint64_t epoch = 0; epoch < 4; epoch++) {
+    runForward(
+        epoch,
+        opCodes[epoch],
+        {kElemsPerCall / 4, kElemsPerCall / 8},
+        nActive,
+        /*verifySum=*/epoch == 0);
+  }
+  barrier();
+}
+
+/**
+ * Shutdown is an opcode, not a third entry point, so this is the check that a
+ * graceful stop needs no extra API.
+ */
+TEST_P(ShardedRelayControlPlaneTest, ShutdownOpCodeReachesEveryHelper) {
+  if (!requireEightRanks()) {
+    GTEST_SKIP() << "requires exactly 8 ranks, got " << this->numRanks;
+  }
+  const int nActive = GetParam();
+  barrier();
+
+  int sawShutdown = 0;
+  if (this->globalRank == 0) {
+    ncclRelayPlanInfo info{};
+    info.opCode = ncclRelayOpShutdown;
+    info.nCalls = 0;
+    EXPECT_EQ(
+        ncclRelayControlPublish(
+            this->comm, 0, &info, nullptr, kForwardTimeoutNs),
+        ncclSuccess);
+  }
+  if (this->globalRank >= nActive) {
+    ncclRelayPlanInfo got{};
+    std::vector<size_t> counts(kMaxCallsPerPlan, 0);
+    const ncclResult_t res = ncclRelayControlConsume(
+        this->comm,
+        0,
+        &got,
+        counts.data(),
+        kMaxCallsPerPlan,
+        kForwardTimeoutNs);
+    EXPECT_EQ(res, ncclSuccess);
+    if (res == ncclSuccess) {
+      EXPECT_EQ(got.opCode, static_cast<uint32_t>(ncclRelayOpShutdown));
+      EXPECT_EQ(got.nCalls, 0u);
+      sawShutdown = 1;
+    }
+  }
+
+  EXPECT_EQ(sumAcrossRanks(sawShutdown), this->numRanks - nActive);
+  barrier();
+}
+
+/**
+ * Only rank 0 may publish. There is one ring per communicator, so a second
+ * publisher would race the same seqlock -- and because every active rank knows
+ * the same token count their plans are byte-identical, which means the damage
+ * would be invisible in the data and would surface as a spurious desync
+ * somewhere else entirely. Rejecting it makes the misuse an error at the call
+ * site.
+ */
+TEST_P(ShardedRelayControlPlaneTest, OnlyOneRankMayPublish) {
+  if (!requireEightRanks()) {
+    GTEST_SKIP() << "requires exactly 8 ranks, got " << this->numRanks;
+  }
+  barrier();
+
+  ncclRelayPlanInfo info{};
+  info.nCalls = 1;
+  info.opCode = ncclRelayOpAllReduce;
+  info.dtype = ncclInt32;
+  size_t counts[1] = {kElemsPerCall};
+
+  if (this->globalRank == 0) {
+    EXPECT_EQ(
+        ncclRelayControlPublish(
+            this->comm, 0, &info, counts, kForwardTimeoutNs),
+        ncclSuccess);
+  }
+  barrier();
+  if (this->globalRank == 1) {
+    // Active, and it knows the plan, but it is not the publisher.
+    EXPECT_EQ(
+        ncclRelayControlPublish(this->comm, 1, &info, counts, kShortTimeoutNs),
+        ncclInvalidArgument);
+  }
+  barrier();
+}
+
+/**
+ * Capacity is a runtime parameter, so exceeding it must be a clean rejection
+ * naming the parameter rather than a truncated plan -- a truncated plan is a
+ * hang, since the helper would enqueue fewer calls than its peers.
+ */
+TEST_P(ShardedRelayControlPlaneTest, PlanBeyondCapacityIsRejected) {
+  if (!requireEightRanks()) {
+    GTEST_SKIP() << "requires exactly 8 ranks, got " << this->numRanks;
+  }
+  barrier();
+  if (this->globalRank == 0) {
+    const uint32_t capacity = rcclx::relay::relayControlConfiguredMaxCalls();
+    std::vector<size_t> counts(capacity + 1, 64);
+    ncclRelayPlanInfo info{};
+    info.nCalls = capacity + 1;
+    info.opCode = ncclRelayOpAllReduce;
+    info.dtype = ncclInt32;
+    EXPECT_EQ(
+        ncclRelayControlPublish(
+            this->comm, 0, &info, counts.data(), kShortTimeoutNs),
+        ncclInvalidArgument);
+  }
+  barrier();
+}
+
+/**
+ * Test: the exported wrappers enforce the contract their own header states.
+ *
+ * flags and reserved are both documented "must be 0". flags was validated
+ * downstream, so a violation was at least reported; reserved was inspected by
+ * nothing at all, so non-zero bytes in a field reserved for future meaning were
+ * accepted and then silently dropped on the way to the internal record. Once
+ * something does start using them, that silence is the bug: a caller compiled
+ * against a newer header would set a field the library quietly discards.
+ *
+ * Only rank 0 publishes, and the calls are rejected before touching the
+ * segment, so no epoch is consumed and the barriers keep every other rank in
+ * step.
+ */
+TEST_P(
+    ShardedRelayControlPlaneTest,
+    ExportedPublishRejectsReservedFieldMisuse) {
+  if (!requireEightRanks()) {
+    GTEST_SKIP() << "requires exactly 8 ranks, got " << this->numRanks;
+  }
+  barrier();
+  if (this->globalRank == 0) {
+    size_t counts[1] = {64};
+    ncclRelayPlanInfo base{};
+    base.nCalls = 1;
+    base.opCode = ncclRelayOpAllReduce;
+    base.dtype = ncclInt32;
+
+    ncclRelayPlanInfo badFlags = base;
+    badFlags.flags = 1;
+    EXPECT_EQ(
+        ncclRelayControlPublish(
+            this->comm, 0, &badFlags, counts, kShortTimeoutNs),
+        ncclInvalidArgument);
+
+    for (size_t i = 0; i < sizeof(base.reserved) / sizeof(base.reserved[0]);
+         i++) {
+      ncclRelayPlanInfo badReserved = base;
+      badReserved.reserved[i] = 1;
+      EXPECT_EQ(
+          ncclRelayControlPublish(
+              this->comm, 0, &badReserved, counts, kShortTimeoutNs),
+          ncclInvalidArgument)
+          << "reserved[" << i << "] must be rejected, not silently dropped";
+    }
+
+    // nCalls > 0 with no counts array, caught at the boundary so the diagnostic
+    // names the exported symbol the caller actually called.
+    EXPECT_EQ(
+        ncclRelayControlPublish(this->comm, 0, &base, nullptr, kShortTimeoutNs),
+        ncclInvalidArgument);
+  }
+  barrier();
+}
+
+/**
+ * Fault injection: the publisher stops. The store this replaced had a wait()
+ * timeout, so removing the store must not remove that property -- the helpers
+ * must fail, bounded, rather than wait forever.
+ *
+ * Runs last (Z_ prefix) because a timeout deliberately poisons the segment for
+ * every rank, which is the point: one stuck rank should produce a single
+ * attributed cause rather than eight independent timeouts.
+ */
+TEST_P(ShardedRelayControlPlaneTest, Z_HelpersTimeOutWhenThePublisherStops) {
+  if (!requireEightRanks()) {
+    GTEST_SKIP() << "requires exactly 8 ranks, got " << this->numRanks;
+  }
+  const int nActive = GetParam();
+  barrier();
+
+  // Epoch 0 is published and consumed normally, so the helpers are registered
+  // and the failure below is a stalled publisher rather than a cold start.
+  if (this->globalRank == 0) {
+    ncclRelayPlanInfo info{};
+    info.nCalls = 1;
+    info.opCode = ncclRelayOpAllReduce;
+    info.dtype = ncclInt32;
+    size_t counts[1] = {kElemsPerCall};
+    EXPECT_EQ(
+        ncclRelayControlPublish(
+            this->comm, 0, &info, counts, kForwardTimeoutNs),
+        ncclSuccess);
+  }
+  if (this->globalRank >= nActive) {
+    ncclRelayPlanInfo got{};
+    std::vector<size_t> counts(kMaxCallsPerPlan, 0);
+    EXPECT_EQ(
+        ncclRelayControlConsume(
+            this->comm,
+            0,
+            &got,
+            counts.data(),
+            kMaxCallsPerPlan,
+            kForwardTimeoutNs),
+        ncclSuccess);
+  }
+  barrier();
+
+  // Epoch 1 is never published.
+  int failed = 0;
+  if (this->globalRank >= nActive) {
+    ncclRelayPlanInfo got{};
+    std::vector<size_t> counts(kMaxCallsPerPlan, 0);
+    const ncclResult_t res = ncclRelayControlConsume(
+        this->comm, 1, &got, counts.data(), kMaxCallsPerPlan, kShortTimeoutNs);
+    EXPECT_EQ(res, ncclInternalError)
+        << "rank " << this->globalRank << " should have timed out";
+    failed = (res == ncclInternalError) ? 1 : 0;
+  }
+  EXPECT_EQ(sumAcrossRanks(failed), this->numRanks - nActive);
+  barrier();
+}
+
+// Both shapes, so a failure names the configuration it happened in.
+/**
+ * Test: a consume that produces no plan leaves the caller's record ALONE.
+ *
+ * The failure mode this pins down is specific. A zeroed ncclRelayPlanInfo is
+ * nCalls 0 with opCode 0, and opCode 0 is ncclRelayOpShutdown -- a perfectly
+ * valid instruction to stop. So a wrapper that copies out an untouched local on
+ * every failure hands a timed-out or aborted helper something indistinguishable
+ * from "the publisher told you to shut down". A caller that logged the plan
+ * before checking the result would report an orderly shutdown for what was
+ * actually a stalled peer.
+ *
+ * The sentinel below is deliberately not a plausible plan, so the assertion
+ * fails whether the wrapper zeroes the record or writes a real one.
+ *
+ * Z_ prefixed and declared LAST in this file: it times out on purpose, which
+ * poisons the segment for every rank, so nothing that expects a healthy segment
+ * may run after it.
+ */
+TEST_P(
+    ShardedRelayControlPlaneTest,
+    Z_ExportedConsumeLeavesThePlanUntouchedOnFailure) {
+  if (!requireEightRanks()) {
+    GTEST_SKIP() << "requires exactly 8 ranks, got " << this->numRanks;
+  }
+  barrier();
+
+  // Nobody publishes this epoch, so every rank's consume must time out. Rank 0
+  // is the publisher and does not consume, so it just waits at the barrier.
+  if (this->globalRank != 0) {
+    constexpr uint32_t kSentinel = 0xABCDu;
+    ncclRelayPlanInfo info{};
+    info.nCalls = kSentinel;
+    info.opCode = kSentinel;
+    info.dtype = kSentinel;
+    info.redOp = kSentinel;
+    size_t counts[kMaxCallsPerPlan] = {};
+
+    const ncclResult_t res = ncclRelayControlConsume(
+        this->comm,
+        /*epoch=*/0,
+        &info,
+        counts,
+        kMaxCallsPerPlan,
+        kShortTimeoutNs);
+    EXPECT_NE(res, ncclSuccess);
+    EXPECT_EQ(info.nCalls, kSentinel)
+        << "a failed consume must not overwrite the caller's plan record";
+    EXPECT_EQ(info.opCode, kSentinel)
+        << "opCode 0 would be ncclRelayOpShutdown, i.e. a failure that reads as "
+           "a valid instruction to stop";
+    EXPECT_EQ(info.dtype, kSentinel);
+    EXPECT_EQ(info.redOp, kSentinel);
+  }
+  barrier();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ActiveWidth,
+    ShardedRelayControlPlaneTest,
+    ::testing::Values(2, 4),
+    [](const ::testing::TestParamInfo<int>& info) {
+      return std::to_string(info.param) + "Active";
+    });
+
+int main(int argc, char* argv[]) {
+  // The control plane is built at commInitRank under the same switch as eager
+  // one-shot region creation, and NCCL caches the parameter on first read, so
+  // this has to happen before any comm exists.
+  setenv("NCCL_SHARDED_RELAY_MODE_ENABLE", "1", /*overwrite=*/1);
+  setenv(
+      "NCCL_RELAY_CONTROL_MAX_CALLS",
+      std::to_string(kMaxCallsPerPlan).c_str(),
+      /*overwrite=*/1);
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayGraphCaptureTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayGraphCaptureTest.cu
@@ -55,6 +55,7 @@
 #include "comm.h"
 #include "comms/rcclx/develop/meta/testinfra/TestUtils.h"
 #include "comms/rcclx/develop/meta/testinfra/TestsDistUtils.h"
+#include "meta/relay/sharded_relay_oneshot.h"
 #include "nccl.h"
 
 #define HIPCHECK_TEST(cmd)                                          \
@@ -136,23 +137,48 @@ int32_t expectedAllReduce(int replay) {
 
 class ShardedRelayGraphCaptureTest : public ::testing::Test {
  protected:
-  void SetUp() override {
+  // The comm lives for the whole binary instead of being rebuilt per case. It
+  // used to be created in SetUp and destroyed in TearDown, so every case freed
+  // everything an 8-rank comm owns. On MI350 freeing VRAM makes amdgpu wipe it
+  // (amdgpu_bo_release_notify -> amdgpu_fill_buffer) while holding mmap_lock
+  // for write, so 8 ranks cycling multi-GB comms serialise into a stall that
+  // takes the whole host down. Reusing also matches how comms are really used:
+  // a handful, kept for the life of the process. Only the comm moves here; the
+  // per-case stream and scratch stay in SetUp.
+  //
+  // Guarded so a derived fixture, which is a separate suite and so runs these
+  // hooks again, rebuilds rather than leaks.
+  static void SetUpTestSuite() {
+    if (comm != nullptr) {
+      return;
+    }
     int localSize;
-    std::tie(this->localRank, this->globalRank, this->numRanks, localSize) =
+    std::tie(localRank, globalRank, numRanks, localSize) =
         getTcpStoreOrMpiInfo();
-    const bool isServer = (this->globalRank == 0);
+    const bool isServer = (globalRank == 0);
     if (checkTcpStoreEnv()) {
       server = createTcpStore(isServer);
     } else if (isServer) {
       server = createTcpStore(true);
     }
-    this->comm = createNcclComm(
-        this->globalRank,
-        this->numRanks,
-        this->localRank,
-        false,
-        nullptr,
-        server.get());
+    comm = createNcclComm(
+        globalRank, numRanks, localRank, false, nullptr, server.get());
+  }
+
+  static void TearDownTestSuite() {
+    if (server && checkTcpStoreEnv()) {
+      finalizeNcclComm(globalRank, server.get());
+    }
+    if (comm != nullptr) {
+      NCCLCHECK_TEST(ncclCommDestroy(comm));
+      comm = nullptr;
+    }
+    server.reset();
+  }
+
+  void SetUp() override {
+    ASSERT_NE(this->comm, nullptr)
+        << "suite-scoped comm was not created; SetUpTestSuite did not run";
     HIPCHECK_TEST(hipStreamCreate(&stream));
     this->isActive = this->globalRank < kActive;
     this->myActiveIndex = this->globalRank;
@@ -165,11 +191,6 @@ class ShardedRelayGraphCaptureTest : public ::testing::Test {
 
   void TearDown() override {
     HIPEXPECT_TEST(hipStreamDestroy(this->stream));
-    if (server && checkTcpStoreEnv()) {
-      finalizeNcclComm(this->globalRank, server.get());
-    }
-    NCCLCHECK_TEST(ncclCommDestroy(this->comm));
-    server.reset();
   }
 
   // Bounded replacement for hipStreamSynchronize.
@@ -303,11 +324,11 @@ class ShardedRelayGraphCaptureTest : public ::testing::Test {
     }
   }
 
-  ncclComm_t comm{nullptr};
+  static inline ncclComm_t comm{nullptr};
   hipStream_t stream{};
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
+  static inline int localRank{0};
+  static inline int globalRank{0};
+  static inline int numRanks{0};
   bool isActive{false};
   int myActiveIndex{0};
   int activeRanks[kActive]{};
@@ -316,7 +337,7 @@ class ShardedRelayGraphCaptureTest : public ::testing::Test {
   // call sequence, so a plain counter does.
   int barrierTag{0};
   bool streamWedged{false};
-  std::unique_ptr<c10d::TCPStore> server{nullptr};
+  static inline std::unique_ptr<c10d::TCPStore> server{nullptr};
 };
 
 namespace {
@@ -546,6 +567,23 @@ TEST_F(
 
   HIPEXPECT_TEST(hipGraphExecDestroy(exec));
   release(small);
+}
+
+// Whether the region exists before any relay call is the whole of G3, and it is
+// directly observable, so assert it rather than inferring it from a timing or a
+// pass. The eager binary (-DRCCLX_RELAY_TEST_EAGER_ONESHOT, which sets
+// NCCL_SHARDED_RELAY_MODE_ENABLE=1 before the first comm is built) must have
+// one already; the default binary must not, because that is still the lazy
+// path.
+TEST_F(ShardedRelayGraphCaptureReduceScatterTest, OneShotRegionReadyAtInit) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, got " << this->numRanks;
+  }
+#ifdef RCCLX_RELAY_TEST_EAGER_ONESHOT
+  EXPECT_TRUE(rcclx::relay::oneShotReady(this->comm));
+#else
+  EXPECT_FALSE(rcclx::relay::oneShotReady(this->comm));
+#endif
 }
 
 // Baseline sanity: capture and replay work at all on this build and stream.
@@ -801,6 +839,16 @@ TEST_F(ShardedRelayGraphCaptureOtherCollectivesTest, AllToAllMultiReplay) {
 }
 
 int main(int argc, char* argv[]) {
+#ifdef RCCLX_RELAY_TEST_EAGER_ONESHOT
+  // Has to happen before the first communicator is built, and NCCL caches the
+  // parameter on first read, so covering both settings needs two binaries
+  // rather than two cases.
+  setenv("NCCL_SHARDED_RELAY_MODE_ENABLE", "1", /*overwrite=*/1);
+#else
+  // This binary is the lazy half of the pair and asserts the region is NOT up
+  // at init, so it must not inherit the variable from whoever invoked it.
+  unsetenv("NCCL_SHARDED_RELAY_MODE_ENABLE");
+#endif
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
   folly::Init init(&argc, &argv);

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayGraphCaptureTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayGraphCaptureTest.cu
@@ -1,0 +1,702 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/**
+ * HIP-graph capture coverage for the sharded-relay collectives.
+ *
+ * The relay had no graph-capture coverage at all, which made four separate
+ * graph hazards unverifiable:
+ *
+ *   G1 ScratchBufferCache uses hipMallocAsync/hipFreeAsync keyed on
+ *      (device, stream, key). Capturing turns the allocation into a graph
+ *      allocation node whose address is only valid while that graph executes,
+ *      and a later cache growth can hipFreeAsync a pointer a live graph still
+ *      references.
+ *   G2 The one-shot IPC handshake advances a host-side epoch that is passed to
+ *      the kernel by value, so a replay would spin on a baked epoch that every
+ *      flag already satisfies and reduce capture-time staging.
+ *   G3 One-shot region creation does a synchronous hipMemset plus two
+ *      bootstrapAllGather calls, none of which are capturable.
+ *   G4 The reduce-scatter overlap side stream is forked from the caller stream,
+ *      which has no defined relationship to its captured form.
+ *
+ * G1..G4 are all currently guarded by explicit bail-outs or are latent, so
+ * every case in this file passes as-is: they are the regression guard the four
+ * fixes are checked against, not a demonstration of a live bug. Each fix brings
+ * its own failing-before/passing-after case with it.
+ *
+ * One ordering constraint worth knowing before adding a case:
+ * ScratchBufferCache is a process-global keyed on (device, stream, key), so a
+ * case that runs after a larger one finds an entry big enough to satisfy it and
+ * never allocates under capture. Anything meant to exercise a cold cache has to
+ * run first, on its own stream.
+ *
+ * Every multi-replay case varies its input per replay and skews odd ranks with
+ * a host sleep before the launch. The skew is what makes a stale-epoch or
+ * stale-staging bug deterministic rather than a race: the unskewed rank pushes,
+ * flags, falls through the handshake and reduces data the skewed rank has not
+ * written yet.
+ *
+ * Capture uses hipStreamCaptureModeRelaxed to match RCCL's own allocation path
+ * (enqueue.cc), so these tests measure data-path correctness rather than
+ * capture-mode policy.
+ */
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+#include "bootstrap.h"
+#include "comm.h"
+#include "comms/rcclx/develop/meta/testinfra/TestUtils.h"
+#include "comms/rcclx/develop/meta/testinfra/TestsDistUtils.h"
+#include "nccl.h"
+
+#define HIPCHECK_TEST(cmd)                                          \
+  do {                                                              \
+    hipError_t error = cmd;                                         \
+    if (error != hipSuccess) {                                      \
+      FAIL() << "HIP error: " << hipGetErrorString(error) << " at " \
+             << __FILE__ << ":" << __LINE__;                        \
+    }                                                               \
+  } while (0)
+
+#define HIPEXPECT_TEST(cmd)                                                \
+  do {                                                                     \
+    hipError_t error = cmd;                                                \
+    if (error != hipSuccess) {                                             \
+      ADD_FAILURE() << "HIP error: " << hipGetErrorString(error) << " at " \
+                    << __FILE__ << ":" << __LINE__;                        \
+    }                                                                      \
+  } while (0)
+
+#define NCCLCHECK_TEST(cmd)                                            \
+  do {                                                                 \
+    ncclResult_t result = cmd;                                         \
+    if (result != ncclSuccess) {                                       \
+      FAIL() << "NCCL error: " << ncclGetErrorString(result) << " at " \
+             << __FILE__ << ":" << __LINE__;                           \
+    }                                                                  \
+  } while (0)
+
+namespace {
+
+constexpr int kActive = 4;
+constexpr int kGroups = 1;
+constexpr int kSkewMs = 20;
+// A graph-compat regression shows up as a kernel that never retires. Cap the
+// wait so the case reports a failure instead of burning the harness timeout
+// and taking every later case down with it.
+constexpr int kSyncTimeoutSec = 20;
+
+// Element count whose single-group A=4 footprint stays inside
+// kRelayOneShotMaxBytes (1 MiB): 4 * 16384 * 4 B = 256 KiB.
+constexpr size_t kOneShotBandCount = 16 * 1024;
+// Comfortably above the one-shot band, below the side-stream threshold.
+constexpr size_t kMidCount = 1024 * 1024;
+// 4 * (1 << 24) * 4 B = 256 MiB, exactly kRelayOverlapReduceMinBytes, so the
+// reduce-scatter overlap side stream is eligible.
+constexpr size_t kSideStreamCount = 1ULL << 24;
+
+// Uncaptured sizes below the one-shot band take the one-shot path, so warming
+// up at the size under test leaves the PureDirect scratch cache cold and the
+// capture then allocates inside itself. Priming at this larger size fills that
+// cache first, so the cases below measure the hazard they name rather than G1.
+constexpr size_t kScratchPrimeCount = kMidCount;
+
+// Value active rank `rank` contributes for block `block` on `replay`. Varying
+// with the replay is what makes a graph that re-reduces capture-time staging
+// detectable; varying with the block catches a mis-routed slice.
+int32_t fillValue(int rank, int block, int replay) {
+  return (rank + 1) * 100 + (block + 1) * 10 + (replay + 1);
+}
+
+int32_t expectedReduceScatter(int myActiveIndex, int replay) {
+  int32_t sum = 0;
+  for (int r = 0; r < kActive; r++) {
+    sum += fillValue(r, myActiveIndex, replay);
+  }
+  return sum;
+}
+
+int32_t expectedAllReduce(int replay) {
+  int32_t sum = 0;
+  for (int r = 0; r < kActive; r++) {
+    sum += fillValue(r, 0, replay);
+  }
+  return sum;
+}
+
+} // namespace
+
+class ShardedRelayGraphCaptureTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int localSize;
+    std::tie(this->localRank, this->globalRank, this->numRanks, localSize) =
+        getTcpStoreOrMpiInfo();
+    const bool isServer = (this->globalRank == 0);
+    if (checkTcpStoreEnv()) {
+      server = createTcpStore(isServer);
+    } else if (isServer) {
+      server = createTcpStore(true);
+    }
+    this->comm = createNcclComm(
+        this->globalRank,
+        this->numRanks,
+        this->localRank,
+        false,
+        nullptr,
+        server.get());
+    HIPCHECK_TEST(hipStreamCreate(&stream));
+    this->isActive = this->globalRank < kActive;
+    this->myActiveIndex = this->globalRank;
+    this->activeRanks[0] = 0;
+    this->activeRanks[1] = 1;
+    this->activeRanks[2] = 2;
+    this->activeRanks[3] = 3;
+    this->allActiveRanks[0] = this->activeRanks;
+  }
+
+  void TearDown() override {
+    HIPEXPECT_TEST(hipStreamDestroy(this->stream));
+    if (server && checkTcpStoreEnv()) {
+      finalizeNcclComm(this->globalRank, server.get());
+    }
+    NCCLCHECK_TEST(ncclCommDestroy(this->comm));
+    server.reset();
+  }
+
+  // Bounded replacement for hipStreamSynchronize.
+  void syncStream(const char* what) {
+    if (this->streamWedged) {
+      return;
+    }
+    const auto deadline = std::chrono::steady_clock::now() +
+        std::chrono::seconds(kSyncTimeoutSec);
+    for (;;) {
+      const hipError_t status = hipStreamQuery(this->stream);
+      if (status == hipSuccess) {
+        return;
+      }
+      if (status != hipErrorNotReady) {
+        ADD_FAILURE() << "R" << this->globalRank << " " << what << ": "
+                      << hipGetErrorString(status);
+        return;
+      }
+      if (std::chrono::steady_clock::now() > deadline) {
+        ADD_FAILURE() << "R" << this->globalRank << " " << what
+                      << ": stream did not drain within " << kSyncTimeoutSec
+                      << "s";
+        // Everything after this would just time out again on a stream that is
+        // never going to drain, so record it and let the case bail out.
+        this->streamWedged = true;
+        return;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  }
+
+  // Host-side barrier. Deliberately NOT an ncclAllReduce: issuing a
+  // non-captured collective on this comm between graph replays interleaves with
+  // the work descriptors the captured graph replays, and the correctness suites
+  // do not exercise that combination. The stream is idle at every call site, so
+  // a host barrier is also a stream barrier.
+  void barrier() {
+    syncStream("stream drain");
+    NCCLCHECK_TEST(bootstrapBarrier(
+        this->comm->bootstrap,
+        this->comm->rank,
+        this->comm->nRanks,
+        this->barrierTag++));
+  }
+
+  // Capture `body` on the fixture stream and instantiate it. Returns nullptr on
+  // failure; EndCapture always runs so a failure inside `body` cannot leave the
+  // stream stuck in capture mode.
+  template <typename Body>
+  hipGraphExec_t captureGraph(Body&& body) {
+    syncStream("stream drain");
+    hipGraph_t graph = nullptr;
+    HIPEXPECT_TEST(
+        hipStreamBeginCapture(this->stream, hipStreamCaptureModeRelaxed));
+    body();
+    const hipError_t endErr = hipStreamEndCapture(this->stream, &graph);
+    if (endErr != hipSuccess || graph == nullptr) {
+      ADD_FAILURE() << "hipStreamEndCapture failed: "
+                    << hipGetErrorString(endErr);
+      return nullptr;
+    }
+    hipGraphExec_t exec = nullptr;
+    const hipError_t instErr =
+        hipGraphInstantiate(&exec, graph, nullptr, nullptr, 0);
+    HIPEXPECT_TEST(hipGraphDestroy(graph));
+    if (instErr != hipSuccess) {
+      ADD_FAILURE() << "hipGraphInstantiate failed: "
+                    << hipGetErrorString(instErr);
+      return nullptr;
+    }
+    return exec;
+  }
+
+  // Launch a replay, skewing odd ranks so an unskewed peer reaches the
+  // handshake before the skewed rank has written anything for this replay.
+  void replay(hipGraphExec_t exec, bool skew) {
+    if (this->streamWedged) {
+      return;
+    }
+    if (skew && (this->globalRank % 2) == 1) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(kSkewMs));
+    }
+    HIPEXPECT_TEST(hipGraphLaunch(exec, this->stream));
+    syncStream("stream drain");
+  }
+
+  void fillUniform(int32_t* deviceBuf, size_t count, int32_t value) {
+    const std::vector<int32_t> host(count, value);
+    HIPEXPECT_TEST(hipMemcpy(
+        deviceBuf,
+        host.data(),
+        count * sizeof(int32_t),
+        hipMemcpyHostToDevice));
+  }
+
+  // Fill an A-block buffer so block j holds fillValue(myActiveIndex, j,
+  // replay).
+  void fillBlocks(int32_t* deviceBuf, size_t blockCount, int replay) {
+    std::vector<int32_t> host(static_cast<size_t>(kActive) * blockCount);
+    for (int j = 0; j < kActive; j++) {
+      std::fill_n(
+          host.data() + static_cast<size_t>(j) * blockCount,
+          blockCount,
+          fillValue(this->myActiveIndex, j, replay));
+    }
+    HIPEXPECT_TEST(hipMemcpy(
+        deviceBuf,
+        host.data(),
+        host.size() * sizeof(int32_t),
+        hipMemcpyHostToDevice));
+  }
+
+  void expectUniform(
+      const int32_t* deviceBuf,
+      size_t count,
+      int32_t expected,
+      const char* what) {
+    std::vector<int32_t> host(count);
+    HIPEXPECT_TEST(hipMemcpy(
+        host.data(),
+        deviceBuf,
+        count * sizeof(int32_t),
+        hipMemcpyDeviceToHost));
+    for (size_t i = 0; i < count; i++) {
+      if (host[i] != expected) {
+        ADD_FAILURE() << "R" << this->globalRank << " " << what << ": index "
+                      << i << " expected " << expected << " got " << host[i];
+        return;
+      }
+    }
+  }
+
+  ncclComm_t comm{nullptr};
+  hipStream_t stream{};
+  int localRank{0};
+  int globalRank{0};
+  int numRanks{0};
+  bool isActive{false};
+  int myActiveIndex{0};
+  int activeRanks[kActive]{};
+  const int* allActiveRanks[kGroups]{};
+  // Bootstrap barrier tags must agree across ranks; every rank walks the same
+  // call sequence, so a plain counter does.
+  int barrierTag{0};
+  bool streamWedged{false};
+  std::unique_ptr<c10d::TCPStore> server{nullptr};
+};
+
+namespace {
+
+// Single-group A=4 reduce-scatter buffers. Helpers hand in an A-block scratch
+// and alias their output onto it, matching the helper contract the
+// correctness suites use.
+struct ReduceScatterBuffers {
+  int32_t* send{nullptr};
+  int32_t* recv{nullptr};
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Reduce-scatter
+// ---------------------------------------------------------------------------
+
+class ShardedRelayGraphCaptureReduceScatterTest
+    : public ShardedRelayGraphCaptureTest {
+ protected:
+  ReduceScatterBuffers allocate(size_t recvCount) {
+    ReduceScatterBuffers b;
+    const size_t sendBytes =
+        static_cast<size_t>(kActive) * recvCount * sizeof(int32_t);
+    HIPEXPECT_TEST(hipMalloc(&b.send, sendBytes));
+    HIPEXPECT_TEST(hipMemset(b.send, 0, sendBytes));
+    if (this->isActive) {
+      HIPEXPECT_TEST(hipMalloc(&b.recv, recvCount * sizeof(int32_t)));
+      HIPEXPECT_TEST(hipMemset(b.recv, 0, recvCount * sizeof(int32_t)));
+    } else {
+      b.recv = b.send;
+    }
+    return b;
+  }
+
+  void release(ReduceScatterBuffers& b) {
+    if (this->isActive && b.recv != nullptr) {
+      HIPEXPECT_TEST(hipFree(b.recv));
+    }
+    if (b.send != nullptr) {
+      HIPEXPECT_TEST(hipFree(b.send));
+    }
+  }
+
+  ncclResult_t enqueue(const ReduceScatterBuffers& b, size_t recvCount) {
+    const void* sendPtrs[kGroups] = {b.send};
+    void* recvPtrs[kGroups] = {b.recv};
+    const size_t recvCounts[kGroups] = {recvCount};
+    return ncclShardedRelayMultiGroupReduceScatter(
+        sendPtrs,
+        recvPtrs,
+        recvCounts,
+        ncclInt32,
+        ncclSum,
+        this->comm,
+        this->stream,
+        this->allActiveRanks,
+        kActive,
+        kGroups);
+  }
+
+  // Run one uncaptured reduce-scatter and verify it, with a barrier either
+  // side.
+  void runUncaptured(
+      ReduceScatterBuffers& b,
+      size_t recvCount,
+      int replayIndex,
+      const char* what) {
+    if (this->isActive) {
+      fillBlocks(b.send, recvCount, replayIndex);
+    }
+    barrier();
+    ASSERT_EQ(enqueue(b, recvCount), ncclSuccess);
+    syncStream("stream drain");
+    if (this->isActive) {
+      expectUniform(
+          b.recv,
+          recvCount,
+          expectedReduceScatter(this->myActiveIndex, replayIndex),
+          what);
+    }
+    barrier();
+  }
+
+  // Capture one reduce-scatter at `recvCount`, then replay it `replays` times
+  // with per-replay-varying input, verifying after each replay.
+  void runCaptureReplay(size_t recvCount, int replays, bool warmUp, bool skew) {
+    // Size the buffers for the priming call so the same allocation serves both.
+    const size_t primeCount = std::max(recvCount, kScratchPrimeCount);
+    ReduceScatterBuffers b = allocate(primeCount);
+    barrier();
+
+    if (warmUp) {
+      if (primeCount != recvCount) {
+        runUncaptured(b, primeCount, 0, "reduce-scatter scratch prime");
+      }
+      runUncaptured(b, recvCount, 0, "reduce-scatter warm-up");
+    }
+
+    ncclResult_t captured = ncclSuccess;
+    hipGraphExec_t exec =
+        captureGraph([&]() { captured = enqueue(b, recvCount); });
+    ASSERT_EQ(captured, ncclSuccess);
+    ASSERT_NE(exec, nullptr);
+
+    for (int r = 0; r < replays; r++) {
+      if (this->isActive) {
+        fillBlocks(b.send, recvCount, r + 1);
+      }
+      barrier();
+      replay(exec, skew);
+      if (this->isActive) {
+        expectUniform(
+            b.recv,
+            recvCount,
+            expectedReduceScatter(this->myActiveIndex, r + 1),
+            "reduce-scatter replay");
+      }
+    }
+
+    HIPEXPECT_TEST(hipGraphExecDestroy(exec));
+    release(b);
+  }
+};
+
+// Baseline sanity: capture and replay work at all on this build and stream.
+TEST_F(ShardedRelayGraphCaptureReduceScatterTest, SmokeCaptureAndReplay) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, got " << this->numRanks;
+  }
+  runCaptureReplay(kMidCount, /*replays=*/1, /*warmUp=*/true, /*skew=*/false);
+}
+
+// Regression guard for G2: sizes inside the one-shot band, replayed with a skew
+// that would surface a stale baked epoch.
+TEST_F(
+    ShardedRelayGraphCaptureReduceScatterTest,
+    MultiReplayInOneShotBandWithSkew) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, got " << this->numRanks;
+  }
+  runCaptureReplay(
+      kOneShotBandCount, /*replays=*/3, /*warmUp=*/true, /*skew=*/true);
+}
+
+TEST_F(
+    ShardedRelayGraphCaptureReduceScatterTest,
+    MultiReplayAboveOneShotBandWithSkew) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, got " << this->numRanks;
+  }
+  runCaptureReplay(kMidCount, /*replays=*/3, /*warmUp=*/true, /*skew=*/true);
+}
+
+// Regression guard for G4: at exactly kRelayOverlapReduceMinBytes the owner
+// would fork the overlap side stream, which today is suppressed under capture.
+TEST_F(
+    ShardedRelayGraphCaptureReduceScatterTest,
+    MultiReplayAtSideStreamThreshold) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, got " << this->numRanks;
+  }
+  runCaptureReplay(
+      kSideStreamCount, /*replays=*/2, /*warmUp=*/true, /*skew=*/false);
+}
+
+// ---------------------------------------------------------------------------
+// All-reduce, all-gather, all-to-all
+// ---------------------------------------------------------------------------
+
+class ShardedRelayGraphCaptureOtherCollectivesTest
+    : public ShardedRelayGraphCaptureTest {};
+
+// All-reduce is in-place; helpers hand in an A-block scratch.
+TEST_F(ShardedRelayGraphCaptureOtherCollectivesTest, AllReduceMultiReplay) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, got " << this->numRanks;
+  }
+  const size_t count = kMidCount;
+  const size_t bytes = count * sizeof(int32_t);
+
+  int32_t* buff = nullptr;
+  HIPCHECK_TEST(hipMalloc(
+      &buff, this->isActive ? bytes : static_cast<size_t>(kActive) * bytes));
+  barrier();
+  if (!this->isActive) {
+    HIPCHECK_TEST(hipMemset(buff, 0, static_cast<size_t>(kActive) * bytes));
+  }
+
+  const void* sendPtrs[kGroups] = {buff};
+  void* recvPtrs[kGroups] = {buff};
+  const size_t counts[kGroups] = {count};
+  auto enqueue = [&]() {
+    return ncclShardedRelayMultiGroupAllReduce(
+        sendPtrs,
+        recvPtrs,
+        counts,
+        ncclInt32,
+        ncclSum,
+        this->comm,
+        this->stream,
+        this->allActiveRanks,
+        kActive,
+        kGroups);
+  };
+
+  if (this->isActive) {
+    fillUniform(buff, count, fillValue(this->myActiveIndex, 0, 0));
+  }
+  ASSERT_EQ(enqueue(), ncclSuccess);
+  syncStream("stream drain");
+  barrier();
+
+  ncclResult_t captured = ncclSuccess;
+  hipGraphExec_t exec = captureGraph([&]() { captured = enqueue(); });
+  ASSERT_EQ(captured, ncclSuccess);
+  ASSERT_NE(exec, nullptr);
+
+  for (int r = 0; r < 3; r++) {
+    if (this->isActive) {
+      fillUniform(buff, count, fillValue(this->myActiveIndex, 0, r + 1));
+    }
+    barrier();
+    replay(exec, /*skew=*/true);
+    if (this->isActive) {
+      expectUniform(buff, count, expectedAllReduce(r + 1), "all-reduce replay");
+    }
+  }
+
+  HIPEXPECT_TEST(hipGraphExecDestroy(exec));
+  HIPEXPECT_TEST(hipFree(buff));
+}
+
+// All-gather out-of-place: every rank owns an A-slot output; helpers pass the
+// output as their placeholder input.
+TEST_F(ShardedRelayGraphCaptureOtherCollectivesTest, AllGatherMultiReplay) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, got " << this->numRanks;
+  }
+  const size_t sendCount = kMidCount;
+  const size_t outCount = static_cast<size_t>(kActive) * sendCount;
+
+  int32_t* recvBuff = nullptr;
+  int32_t* sendBuff = nullptr;
+  HIPCHECK_TEST(hipMalloc(&recvBuff, outCount * sizeof(int32_t)));
+  if (this->isActive) {
+    HIPCHECK_TEST(hipMalloc(&sendBuff, sendCount * sizeof(int32_t)));
+  }
+  barrier();
+  HIPCHECK_TEST(hipMemset(recvBuff, 0, outCount * sizeof(int32_t)));
+
+  const void* sendPtrs[kGroups] = {this->isActive ? sendBuff : recvBuff};
+  void* recvPtrs[kGroups] = {recvBuff};
+  const size_t sendCounts[kGroups] = {sendCount};
+  auto enqueue = [&]() {
+    return ncclShardedRelayMultiGroupAllGather(
+        sendPtrs,
+        recvPtrs,
+        sendCounts,
+        ncclInt32,
+        this->comm,
+        this->stream,
+        this->allActiveRanks,
+        kActive,
+        kGroups);
+  };
+
+  if (this->isActive) {
+    fillUniform(sendBuff, sendCount, fillValue(this->myActiveIndex, 0, 0));
+  }
+  ASSERT_EQ(enqueue(), ncclSuccess);
+  syncStream("stream drain");
+  barrier();
+
+  ncclResult_t captured = ncclSuccess;
+  hipGraphExec_t exec = captureGraph([&]() { captured = enqueue(); });
+  ASSERT_EQ(captured, ncclSuccess);
+  ASSERT_NE(exec, nullptr);
+
+  for (int r = 0; r < 3; r++) {
+    if (this->isActive) {
+      fillUniform(
+          sendBuff, sendCount, fillValue(this->myActiveIndex, 0, r + 1));
+    }
+    barrier();
+    replay(exec, /*skew=*/true);
+    if (this->isActive) {
+      for (int slot = 0; slot < kActive; slot++) {
+        expectUniform(
+            recvBuff + static_cast<size_t>(slot) * sendCount,
+            sendCount,
+            fillValue(slot, 0, r + 1),
+            "all-gather replay");
+      }
+    }
+  }
+
+  HIPEXPECT_TEST(hipGraphExecDestroy(exec));
+  HIPEXPECT_TEST(hipFree(recvBuff));
+  if (sendBuff != nullptr) {
+    HIPEXPECT_TEST(hipFree(sendBuff));
+  }
+}
+
+// All-to-all: in-place is unsupported, so send and recv are distinct A-segment
+// buffers. Helpers get a generously sized A-segment scratch.
+TEST_F(ShardedRelayGraphCaptureOtherCollectivesTest, AllToAllMultiReplay) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, got " << this->numRanks;
+  }
+  const size_t segmentCount = kMidCount;
+  const size_t bufCount = static_cast<size_t>(kActive) * segmentCount;
+
+  int32_t* sendBuff = nullptr;
+  int32_t* recvBuff = nullptr;
+  HIPCHECK_TEST(hipMalloc(&sendBuff, (bufCount + 1) * sizeof(int32_t)));
+  if (this->isActive) {
+    HIPCHECK_TEST(hipMalloc(&recvBuff, bufCount * sizeof(int32_t)));
+  } else {
+    recvBuff = sendBuff;
+  }
+  barrier();
+  HIPCHECK_TEST(hipMemset(sendBuff, 0, (bufCount + 1) * sizeof(int32_t)));
+
+  const void* sendPtrs[kGroups] = {sendBuff};
+  void* recvPtrs[kGroups] = {recvBuff};
+  const size_t segmentCounts[kGroups] = {segmentCount};
+  auto enqueue = [&]() {
+    return ncclShardedRelayMultiGroupAllToAll(
+        sendPtrs,
+        recvPtrs,
+        segmentCounts,
+        ncclInt32,
+        this->comm,
+        this->stream,
+        this->allActiveRanks,
+        kActive,
+        kGroups);
+  };
+
+  if (this->isActive) {
+    fillBlocks(sendBuff, segmentCount, /*replay=*/0);
+  }
+  ASSERT_EQ(enqueue(), ncclSuccess);
+  syncStream("stream drain");
+  barrier();
+
+  ncclResult_t captured = ncclSuccess;
+  hipGraphExec_t exec = captureGraph([&]() { captured = enqueue(); });
+  ASSERT_EQ(captured, ncclSuccess);
+  ASSERT_NE(exec, nullptr);
+
+  for (int r = 0; r < 3; r++) {
+    if (this->isActive) {
+      fillBlocks(sendBuff, segmentCount, r + 1);
+    }
+    barrier();
+    replay(exec, /*skew=*/true);
+    if (this->isActive) {
+      // recvSeg[i] holds the segment source i addressed to me.
+      for (int src = 0; src < kActive; src++) {
+        expectUniform(
+            recvBuff + static_cast<size_t>(src) * segmentCount,
+            segmentCount,
+            fillValue(src, this->myActiveIndex, r + 1),
+            "all-to-all replay");
+      }
+    }
+  }
+
+  HIPEXPECT_TEST(hipGraphExecDestroy(exec));
+  if (this->isActive) {
+    HIPEXPECT_TEST(hipFree(recvBuff));
+  }
+  HIPEXPECT_TEST(hipFree(sendBuff));
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayGraphCaptureTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayGraphCaptureTest.cu
@@ -19,10 +19,11 @@
  *   G4 The reduce-scatter overlap side stream is forked from the caller stream,
  *      which has no defined relationship to its captured form.
  *
- * G1..G4 are all currently guarded by explicit bail-outs or are latent, so
- * every case in this file passes as-is: they are the regression guard the four
- * fixes are checked against, not a demonstration of a live bug. Each fix brings
- * its own failing-before/passing-after case with it.
+ * G2, G3 and G4 currently sit behind explicit capture bail-outs, so the cases
+ * covering them pass as-is and are the regression guard their fixes get
+ * measured against. The two ShardedRelayGraphCaptureScratchHazardTest cases are
+ * the exception: they fail without a graph-aware scratch cache, and landed with
+ * the fix for it.
  *
  * One ordering constraint worth knowing before adding a case:
  * ScratchBufferCache is a process-global keyed on (device, stream, key), so a
@@ -441,6 +442,111 @@ class ShardedRelayGraphCaptureReduceScatterTest
     release(b);
   }
 };
+
+// ---------------------------------------------------------------------------
+// Scratch-cache hazards
+//
+// These are the cases that fail on a relay without a graph-aware scratch cache.
+// ScratchBufferCache is a process-global keyed on (device, stream, key), so
+// they must run FIRST: a single earlier case at a larger size leaves an entry
+// big enough to satisfy them, the capture then allocates nothing, and they
+// silently stop testing anything. gtest runs suites in the order their first
+// TEST_F appears, which is why this block sits above the others.
+// ---------------------------------------------------------------------------
+
+class ShardedRelayGraphCaptureScratchHazardTest
+    : public ShardedRelayGraphCaptureReduceScatterTest {
+ protected:
+  void SetUp() override {
+    ShardedRelayGraphCaptureReduceScatterTest::SetUp();
+    // Run on a second, still-live stream. Keying the cache on the stream means
+    // a distinct live handle cannot collide with an entry left by the fixture
+    // stream, which hipStreamCreate is free to hand back after a destroy.
+    HIPCHECK_TEST(hipStreamCreate(&hazardStream));
+    baseStream = this->stream;
+    this->stream = hazardStream;
+  }
+
+  void TearDown() override {
+    this->stream = baseStream;
+    HIPEXPECT_TEST(hipStreamDestroy(hazardStream));
+    ShardedRelayGraphCaptureReduceScatterTest::TearDown();
+  }
+
+  hipStream_t hazardStream{};
+  hipStream_t baseStream{};
+};
+
+// G1 mode 1 and G3: the capture is the FIRST relay call on this comm, so the
+// scratch cache is cold and the one-shot region has never been created. Any
+// hipMallocAsync or region bootstrap the relay does lands inside the capture.
+TEST_F(ShardedRelayGraphCaptureScratchHazardTest, CaptureAsFirstRelayCall) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, got " << this->numRanks;
+  }
+  runCaptureReplay(
+      kOneShotBandCount, /*replays=*/2, /*warmUp=*/false, /*skew=*/true);
+}
+
+// G1 mode 3: growing the scratch cache AFTER a capture hipFreeAsyncs the
+// pointer the graph baked, handing it back to the pool while a live graph still
+// references it. The replay must still be correct.
+TEST_F(
+    ShardedRelayGraphCaptureScratchHazardTest,
+    ScratchGrowthAfterCaptureThenReplay) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, got " << this->numRanks;
+  }
+
+  const size_t smallCount = 256 * 1024; // 1 MiB out, 4 MiB in
+  const size_t largeCount = kSideStreamCount; // 64 MiB out, 256 MiB in
+
+  ReduceScatterBuffers small = allocate(smallCount);
+  barrier();
+
+  if (this->isActive) {
+    fillBlocks(small.send, smallCount, /*replay=*/0);
+  }
+  ASSERT_EQ(enqueue(small, smallCount), ncclSuccess);
+  syncStream("stream drain");
+  barrier();
+
+  ncclResult_t captured = ncclSuccess;
+  hipGraphExec_t exec =
+      captureGraph([&]() { captured = enqueue(small, smallCount); });
+  ASSERT_EQ(captured, ncclSuccess);
+  ASSERT_NE(exec, nullptr);
+
+  // Uncaptured call at a much larger size on the same stream. This is what
+  // forces the cache to free the entry the graph above captured.
+  ReduceScatterBuffers large = allocate(largeCount);
+  barrier();
+  if (this->isActive) {
+    fillBlocks(large.send, largeCount, /*replay=*/0);
+  }
+  ASSERT_EQ(enqueue(large, largeCount), ncclSuccess);
+  syncStream("stream drain");
+  release(large);
+  barrier();
+
+  for (int r = 0; r < 2; r++) {
+    if (this->isActive) {
+      fillBlocks(small.send, smallCount, r + 1);
+    }
+    barrier();
+    replay(exec, /*skew=*/true);
+    if (this->isActive) {
+      expectUniform(
+          small.recv,
+          smallCount,
+          expectedReduceScatter(this->myActiveIndex, r + 1),
+          "reduce-scatter replay after scratch growth");
+    }
+  }
+
+  HIPEXPECT_TEST(hipGraphExecDestroy(exec));
+  release(small);
+}
 
 // Baseline sanity: capture and replay work at all on this build and stream.
 TEST_F(ShardedRelayGraphCaptureReduceScatterTest, SmokeCaptureAndReplay) {

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayOneShotIpcProbeTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayOneShotIpcProbeTest.cu
@@ -1,0 +1,566 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/**
+ * Feasibility probe for a one-shot IPC small-message collective.
+ *
+ * The sharded-relay small-message paths are launch-bound: below 576 KB the
+ * relay time is flat, so the only unit of cost is a launch. Every collective
+ * except reduce-scatter is now above 1x there, and reduce-scatter cannot get
+ * there with ncclSend/ncclRecv: measured, one ncclGroup of P2P ops costs ~0.038
+ * ms while NCCL's ENTIRE fused reduce_scatter kernel costs ~0.035 ms, so even
+ * deleting our trailing reduce leaves us behind.
+ *
+ * The only way out is a single kernel that moves the data AND reduces it, with
+ * no group machinery at all. RCCL ships exactly that
+ * (ncclSymRun_ReduceScatter_LL) but it is unreachable here:
+ * comm->symmetricSupport requires ncclCuMemEnable(), and ncclIsCuMemSupported()
+ * returns 0 unconditionally on AMD, so the symmetric window registration that
+ * supplies peer pointers can never be enabled.
+ *
+ * This probe answers, with numbers rather than assumptions, whether the manual
+ * route works:
+ *
+ *   1. Does hipIpcGetMemHandle / hipIpcOpenMemHandle work across the 8 ranks
+ *      (separate processes) on this node, and what does the setup cost?
+ *   2. Can a kernel STORE into a peer's IPC-mapped buffer and have the peer
+ * read it correctly, with a flag-based handshake and system-scope fences?
+ *   3. Does ncclCommRegister accept a user buffer here, and what does it cost?
+ *      (If user buffers can be registered we could read peer sendbuffs directly
+ *      and skip the staging store entirely.)
+ *   4. What is the end-to-end latency of a one-shot reduce-scatter against
+ *      ncclReduceScatter on the same 2 ranks, over the sizes that are below 1x?
+ *
+ * Everything here is measurement scaffolding. The numbers, not this file, are
+ * the deliverable.
+ */
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+#include "bootstrap.h"
+#include "comm.h"
+#include "comms/rcclx/develop/meta/testinfra/TestUtils.h"
+#include "comms/rcclx/develop/meta/testinfra/TestsDistUtils.h"
+#include "nccl.h"
+
+#define HIPCHECK_TEST(cmd)                                          \
+  do {                                                              \
+    hipError_t error = cmd;                                         \
+    if (error != hipSuccess) {                                      \
+      FAIL() << "HIP error: " << hipGetErrorString(error) << " at " \
+             << __FILE__ << ":" << __LINE__;                        \
+    }                                                               \
+  } while (0)
+
+#define HIPCHECK_SOFT(cmd, okFlag) \
+  do {                             \
+    hipError_t error = cmd;        \
+    if (error != hipSuccess) {     \
+      okFlag = false;              \
+    }                              \
+  } while (0)
+
+#define NCCLCHECK_TEST(cmd)                                            \
+  do {                                                                 \
+    ncclResult_t result = cmd;                                         \
+    if (result != ncclSuccess) {                                       \
+      FAIL() << "NCCL error: " << ncclGetErrorString(result) << " at " \
+             << __FILE__ << ":" << __LINE__;                           \
+    }                                                                  \
+  } while (0)
+
+namespace {
+
+// Largest per-rank output the probe stages, in elements. The staging region is
+// nRanks slots of this, allocated once.
+constexpr size_t kMaxSlotElems = 2 * 1024 * 1024; // 8 MiB of float
+constexpr int kMaxRanks = 8;
+// One flag per (source slot, block). Blocks handshake independently, so no
+// global barrier and no co-residency requirement.
+constexpr int kMaxBlocks = 32;
+constexpr int kThreadsPerBlock = 256;
+
+struct OneShotIpcMem {
+  // Peer-visible: [nRanks slots of kMaxSlotElems floats][flags]
+  float* staging{nullptr};
+  uint32_t* flags{nullptr};
+};
+
+// Device view: for each rank, where its staging and flags live in OUR address
+// space (self entry is the local allocation, peers are IPC-mapped).
+struct PeerTable {
+  float* staging[kMaxRanks];
+  uint32_t* flags[kMaxRanks];
+};
+
+__device__ __forceinline__ bool epochReached(uint32_t got, uint32_t want) {
+  // Wraparound-safe "got >= want", same trick RCCL's barrier uses.
+  return (got - want) <= (uint32_t(-1) >> 1);
+}
+
+/**
+ * One-shot 2-rank reduce-scatter.
+ *
+ * sendBuff holds 2*rc elements. Rank m must produce
+ *   out[i] = (sendBuff[m*rc + i] + peerSendBuff[m*rc + i]) / divisor
+ *
+ * Step 1: store my foreign block (block 1-m) into the PEER's staging slot m.
+ * Step 2: fence, then flag the peer's slot-m flag for this block.
+ * Step 3: spin on MY slot-(1-m) flag for this block.
+ * Step 4: out = own block m + my staging slot (1-m).
+ *
+ * All four steps in one launch. Each block handshakes only with the peer's
+ * block of the same index, so progress does not require co-residency.
+ */
+__global__ void oneShotReduceScatter2(
+    const float* __restrict__ sendBuff,
+    float* __restrict__ out,
+    PeerTable table,
+    int myRank,
+    int peerRank,
+    int mySlot, // index the peer files my data under == my active index
+    int peerSlot,
+    size_t rc,
+    uint32_t epoch,
+    int divisor) {
+  const size_t chunk = (rc + gridDim.x - 1) / gridDim.x;
+  const size_t begin = chunk * blockIdx.x;
+  const size_t end = (begin + chunk < rc) ? (begin + chunk) : rc;
+
+  // Step 1: push my foreign block into the peer's staging slot.
+  float* dst =
+      table.staging[peerRank] + static_cast<size_t>(mySlot) * kMaxSlotElems;
+  const float* src = sendBuff + static_cast<size_t>(peerSlot) * rc;
+  for (size_t i = begin + threadIdx.x; i < end; i += blockDim.x) {
+    dst[i] = src[i];
+  }
+
+  // Step 2: make those stores visible, then raise the peer's flag.
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    __threadfence_system();
+    __atomic_store_n(
+        &table.flags[peerRank][mySlot * kMaxBlocks + blockIdx.x],
+        epoch,
+        __ATOMIC_RELEASE);
+  }
+
+  // Step 3: wait for the peer's matching block.
+  if (threadIdx.x == 0) {
+    volatile uint32_t* mine =
+        &table.flags[myRank][peerSlot * kMaxBlocks + blockIdx.x];
+    while (!epochReached(
+        __atomic_load_n(const_cast<uint32_t*>(mine), __ATOMIC_ACQUIRE),
+        epoch)) {
+    }
+  }
+  __syncthreads();
+
+  // Step 4: reduce own contribution with what the peer staged.
+  const float* staged =
+      table.staging[myRank] + static_cast<size_t>(peerSlot) * kMaxSlotElems;
+  const float* own = sendBuff + static_cast<size_t>(mySlot) * rc;
+  const float scale = 1.0f / static_cast<float>(divisor);
+  for (size_t i = begin + threadIdx.x; i < end; i += blockDim.x) {
+    float v = own[i] + staged[i];
+    out[i] = (divisor > 1) ? (v * scale) : v;
+  }
+}
+
+double nowMs() {
+  return std::chrono::duration<double, std::milli>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+
+} // namespace
+
+class OneShotIpcProbeTest : public ::testing::Test {
+ public:
+  OneShotIpcProbeTest() = default;
+
+  void SetUp() override {
+    int localSize;
+    std::tie(this->localRank, this->globalRank, this->numRanks, localSize) =
+        getTcpStoreOrMpiInfo();
+    bool isServer = (this->globalRank == 0);
+    if (checkTcpStoreEnv()) {
+      server = createTcpStore(isServer);
+    } else if (isServer) {
+      server = createTcpStore(true);
+    }
+    this->comm = createNcclComm(
+        this->globalRank,
+        this->numRanks,
+        this->localRank,
+        false,
+        nullptr,
+        server.get());
+    HIPCHECK_TEST(hipStreamCreate(&stream));
+  }
+
+  void TearDown() override {
+    HIPCHECK_TEST(hipStreamDestroy(this->stream));
+    if (server && checkTcpStoreEnv()) {
+      finalizeNcclComm(this->globalRank, server.get());
+    }
+    NCCLCHECK_TEST(ncclCommDestroy(this->comm));
+    server.reset();
+  }
+
+  template <typename T>
+  void allGatherFixed(std::vector<T>& data) {
+    NCCLCHECK_TEST(bootstrapAllGather(comm->bootstrap, data.data(), sizeof(T)));
+  }
+
+  ncclComm_t comm{nullptr};
+  hipStream_t stream{};
+  int localRank{0};
+  int globalRank{0};
+  int numRanks{0};
+  std::unique_ptr<c10d::TCPStore> server{nullptr};
+};
+
+/**
+ * Q1 + Q2: does cross-process IPC work here, what does setup cost, and can a
+ * kernel store into a peer's mapped buffer correctly?
+ */
+TEST_F(OneShotIpcProbeTest, IpcSetupCostAndPeerStore) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, got " << this->numRanks;
+  }
+
+  const size_t stagingBytes = kMaxRanks * kMaxSlotElems * sizeof(float);
+  const size_t flagBytes = kMaxRanks * kMaxBlocks * sizeof(uint32_t);
+
+  // IPC requires plain hipMalloc; the relay's ScratchBufferCache uses
+  // cudaMallocAsync (mempool-backed), which CANNOT be exported. That is the
+  // first concrete constraint this probe establishes.
+  void* base = nullptr;
+  HIPCHECK_TEST(hipMalloc(&base, stagingBytes + flagBytes));
+  HIPCHECK_TEST(hipMemset(base, 0, stagingBytes + flagBytes));
+
+  OneShotIpcMem local;
+  local.staging = static_cast<float*>(base);
+  local.flags =
+      reinterpret_cast<uint32_t*>(static_cast<char*>(base) + stagingBytes);
+
+  // --- hipIpcGetMemHandle ---
+  double t0 = nowMs();
+  hipIpcMemHandle_t myHandle{};
+  bool exportOk = true;
+  HIPCHECK_SOFT(hipIpcGetMemHandle(&myHandle, base), exportOk);
+  double tExport = nowMs() - t0;
+  ASSERT_TRUE(exportOk) << "hipIpcGetMemHandle failed -- one-shot IPC is not "
+                        << "available on this platform";
+
+  // --- exchange handles over the existing bootstrap ---
+  std::vector<hipIpcMemHandle_t> handles(this->numRanks);
+  handles[this->globalRank] = myHandle;
+  t0 = nowMs();
+  allGatherFixed(handles);
+  double tExchange = nowMs() - t0;
+
+  // --- hipIpcOpenMemHandle for each peer ---
+  PeerTable table{};
+  t0 = nowMs();
+  int opened = 0;
+  bool openOk = true;
+  for (int r = 0; r < this->numRanks; r++) {
+    if (r == this->globalRank) {
+      table.staging[r] = local.staging;
+      table.flags[r] = local.flags;
+      continue;
+    }
+    void* peerBase = nullptr;
+    hipError_t e = hipIpcOpenMemHandle(
+        &peerBase, handles[r], hipIpcMemLazyEnablePeerAccess);
+    if (e != hipSuccess) {
+      openOk = false;
+      break;
+    }
+    opened++;
+    table.staging[r] = static_cast<float*>(peerBase);
+    table.flags[r] = reinterpret_cast<uint32_t*>(
+        static_cast<char*>(peerBase) + stagingBytes);
+  }
+  double tOpen = nowMs() - t0;
+  ASSERT_TRUE(openOk) << "hipIpcOpenMemHandle failed after " << opened
+                      << " peers";
+
+  if (this->globalRank == 0) {
+    std::cout << "\n[probe] IPC setup, one-time, 8 ranks:\n"
+              << "  hipIpcGetMemHandle       " << std::fixed
+              << std::setprecision(3) << tExport << " ms\n"
+              << "  bootstrapAllGather(8x64B) " << tExchange << " ms\n"
+              << "  hipIpcOpenMemHandle x7    " << tOpen << " ms\n"
+              << "  staging+flags allocated   "
+              << (stagingBytes + flagBytes) / 1024 << " KiB\n";
+  }
+
+  // --- Q2: correctness of a peer store + flag handshake ---
+  // Ranks 0 and 1 act as the 2-rank active pair; everyone else idles.
+  const bool active = this->globalRank < 2;
+  if (active) {
+    const size_t rc = 4096;
+    const int mySlot = this->globalRank;
+    const int peerSlot = 1 - this->globalRank;
+    const int peerRank = 1 - this->globalRank;
+
+    float* sendBuff = nullptr;
+    float* out = nullptr;
+    HIPCHECK_TEST(hipMalloc(&sendBuff, 2 * rc * sizeof(float)));
+    HIPCHECK_TEST(hipMalloc(&out, rc * sizeof(float)));
+
+    // Position-dependent fill so a block/offset permutation cannot pass: block
+    // b of rank r holds r*1000 + b*100 + (i % 97).
+    std::vector<float> host(2 * rc);
+    for (int b = 0; b < 2; b++) {
+      for (size_t i = 0; i < rc; i++) {
+        host[b * rc + i] = static_cast<float>(this->globalRank) * 1000.0f +
+            static_cast<float>(b) * 100.0f + static_cast<float>(i % 97);
+      }
+    }
+    HIPCHECK_TEST(hipMemcpy(
+        sendBuff, host.data(), 2 * rc * sizeof(float), hipMemcpyHostToDevice));
+
+    const int blocks = 8;
+    hipLaunchKernelGGL(
+        oneShotReduceScatter2,
+        dim3(blocks),
+        dim3(kThreadsPerBlock),
+        0,
+        stream,
+        sendBuff,
+        out,
+        table,
+        this->globalRank,
+        peerRank,
+        mySlot,
+        peerSlot,
+        rc,
+        /*epoch=*/1u,
+        /*divisor=*/1);
+    HIPCHECK_TEST(hipStreamSynchronize(stream));
+
+    std::vector<float> got(rc);
+    HIPCHECK_TEST(
+        hipMemcpy(got.data(), out, rc * sizeof(float), hipMemcpyDeviceToHost));
+
+    // out[i] = own block[mySlot] + peer block[mySlot]
+    //        = (me*1000 + mySlot*100 + i%97) + (peer*1000 + mySlot*100 + i%97)
+    int mismatches = 0;
+    for (size_t i = 0; i < rc; i++) {
+      const float expected = static_cast<float>(this->globalRank) * 1000.0f +
+          static_cast<float>(mySlot) * 100.0f + static_cast<float>(i % 97) +
+          static_cast<float>(peerRank) * 1000.0f +
+          static_cast<float>(mySlot) * 100.0f + static_cast<float>(i % 97);
+      if (got[i] != expected) {
+        if (mismatches < 4) {
+          std::cout << "[probe] R" << this->globalRank << " mismatch at " << i
+                    << ": got " << got[i] << " want " << expected << "\n";
+        }
+        mismatches++;
+      }
+    }
+    EXPECT_EQ(mismatches, 0)
+        << "one-shot peer store + handshake produced wrong results on rank "
+        << this->globalRank;
+
+    HIPCHECK_TEST(hipFree(sendBuff));
+    HIPCHECK_TEST(hipFree(out));
+  }
+
+  // --- Q4: latency against ncclReduceScatter over the sub-1x sizes ---
+  {
+    // One 2-rank sub-comm for the whole sweep. ncclCommSplit is collective over
+    // the parent, so every rank calls it; ranks >= 2 get NOCOLOR and a null
+    // comm back.
+    ncclComm_t sub = nullptr;
+    const int color = (this->globalRank < 2) ? 0 : NCCL_SPLIT_NOCOLOR;
+    NCCLCHECK_TEST(
+        ncclCommSplit(this->comm, color, this->globalRank, &sub, nullptr));
+
+    hipEvent_t evStart, evStop;
+    HIPCHECK_TEST(hipEventCreate(&evStart));
+    HIPCHECK_TEST(hipEventCreate(&evStop));
+
+    const std::vector<size_t> inputBytes = {
+        4u << 10,
+        9u << 10,
+        18u << 10,
+        36u << 10,
+        72u << 10,
+        144u << 10,
+        288u << 10,
+        576u << 10,
+        1152u << 10,
+        2304u << 10,
+        4608u << 10,
+        9216u << 10,
+        13824u << 10};
+
+    if (this->globalRank == 0) {
+      std::cout << "\n[probe] 2-rank reduce-scatter, float, median of 10 reps"
+                << " (ms)\n"
+                << "    input    oneshot       nccl   kernel speedup\n";
+    }
+
+    const bool act = this->globalRank < 2;
+    for (size_t ib : inputBytes) {
+      const size_t rc = ib / 2 / sizeof(float);
+      if (rc > kMaxSlotElems) {
+        if (this->globalRank == 0) {
+          std::cout << std::setw(8) << (ib >> 10) << "K   (over staging cap)\n";
+        }
+        continue;
+      }
+      float* sendBuff = nullptr;
+      float* out = nullptr;
+      HIPCHECK_TEST(hipMalloc(&sendBuff, 2 * rc * sizeof(float)));
+      HIPCHECK_TEST(hipMalloc(&out, rc * sizeof(float)));
+      HIPCHECK_TEST(hipMemset(sendBuff, 1, 2 * rc * sizeof(float)));
+
+      const int mySlot = this->globalRank;
+      const int peerSlot = 1 - this->globalRank;
+      const int peerRank = 1 - this->globalRank;
+      uint32_t epoch = 16;
+
+      auto launchOneShot = [&]() {
+        hipLaunchKernelGGL(
+            oneShotReduceScatter2,
+            dim3(kMaxBlocks),
+            dim3(kThreadsPerBlock),
+            0,
+            stream,
+            sendBuff,
+            out,
+            table,
+            this->globalRank,
+            peerRank,
+            mySlot,
+            peerSlot,
+            rc,
+            epoch++,
+            1);
+      };
+
+      // Streamed regime: 20 back-to-back launches / 20. Successive calls
+      // pipeline, so this isolates the KERNEL cost and strips the per-call
+      // launch overhead. That is deliberate -- it is the number that says
+      // whether a one-shot kernel is intrinsically cheaper than NCCL's fused
+      // one, and where the crossover sits. The per-call regime a caller
+      // actually pays is measured by the checked-in single-group sweep, so it
+      // is not duplicated here.
+      double oneShotMs = 0.0;
+      if (act) {
+        for (int it = 0; it < 20; it++) {
+          launchOneShot();
+        }
+        HIPCHECK_TEST(hipStreamSynchronize(stream));
+        // A silently-failed launch makes the timing read ~0, so check.
+        HIPCHECK_TEST(hipGetLastError());
+        std::vector<double> reps;
+        for (int rep = 0; rep < 10; rep++) {
+          HIPCHECK_TEST(hipEventRecord(evStart, stream));
+          for (int it = 0; it < 20; it++) {
+            launchOneShot();
+          }
+          HIPCHECK_TEST(hipEventRecord(evStop, stream));
+          HIPCHECK_TEST(hipEventSynchronize(evStop));
+          float ms = 0.f;
+          HIPCHECK_TEST(hipEventElapsedTime(&ms, evStart, evStop));
+          reps.push_back(static_cast<double>(ms) / 20.0);
+        }
+        std::sort(reps.begin(), reps.end());
+        oneShotMs = reps[reps.size() / 2];
+      }
+
+      double ncclMs = 0.0;
+      if (sub != nullptr) {
+        for (int it = 0; it < 20; it++) {
+          NCCLCHECK_TEST(ncclReduceScatter(
+              sendBuff, out, rc, ncclFloat, ncclSum, sub, stream));
+        }
+        HIPCHECK_TEST(hipStreamSynchronize(stream));
+        std::vector<double> reps;
+        for (int rep = 0; rep < 10; rep++) {
+          HIPCHECK_TEST(hipEventRecord(evStart, stream));
+          for (int it = 0; it < 20; it++) {
+            NCCLCHECK_TEST(ncclReduceScatter(
+                sendBuff, out, rc, ncclFloat, ncclSum, sub, stream));
+          }
+          HIPCHECK_TEST(hipEventRecord(evStop, stream));
+          HIPCHECK_TEST(hipEventSynchronize(evStop));
+          float ms = 0.f;
+          HIPCHECK_TEST(hipEventElapsedTime(&ms, evStart, evStop));
+          reps.push_back(static_cast<double>(ms) / 20.0);
+        }
+        std::sort(reps.begin(), reps.end());
+        ncclMs = reps[reps.size() / 2];
+      }
+
+      if (this->globalRank == 0) {
+        std::cout << std::setw(8) << (ib >> 10) << "K " << std::fixed
+                  << std::setprecision(4) << std::setw(10) << oneShotMs << " "
+                  << std::setw(10) << ncclMs << "   " << std::setprecision(2)
+                  << (oneShotMs > 0 ? ncclMs / oneShotMs : 0.0) << "x\n";
+      }
+
+      HIPCHECK_TEST(hipFree(sendBuff));
+      HIPCHECK_TEST(hipFree(out));
+    }
+
+    HIPCHECK_TEST(hipEventDestroy(evStart));
+    HIPCHECK_TEST(hipEventDestroy(evStop));
+    if (sub != nullptr) {
+      ncclCommDestroy(sub);
+    }
+  }
+
+  // --- Q3: does ncclCommRegister work here, and what does it cost? ---
+  {
+    void* ub = nullptr;
+    HIPCHECK_TEST(hipMalloc(&ub, 1 << 20));
+    void* handle = nullptr;
+    double t = nowMs();
+    ncclResult_t rr = ncclCommRegister(this->comm, ub, 1 << 20, &handle);
+    double tReg = nowMs() - t;
+    if (this->globalRank == 0) {
+      std::cout << "\n[probe] ncclCommRegister(1 MiB): "
+                << ncclGetErrorString(rr) << ", " << std::setprecision(3)
+                << tReg << " ms, handle=" << (handle ? "non-null" : "null")
+                << "\n";
+    }
+    if (rr == ncclSuccess && handle != nullptr) {
+      t = nowMs();
+      ncclResult_t dr = ncclCommDeregister(this->comm, handle);
+      if (this->globalRank == 0) {
+        std::cout << "[probe] ncclCommDeregister: " << ncclGetErrorString(dr)
+                  << ", " << (nowMs() - t) << " ms\n";
+      }
+    }
+    HIPCHECK_TEST(hipFree(ub));
+  }
+
+  for (int r = 0; r < this->numRanks; r++) {
+    if (r != this->globalRank && table.staging[r] != nullptr) {
+      hipIpcCloseMemHandle(table.staging[r]);
+    }
+  }
+  HIPCHECK_TEST(hipFree(base));
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
@@ -2040,9 +2040,10 @@ class ShardedRelayReduceScatterOverlapA2Test
       bool inPlace,
       ncclRedOp_t op,
       size_t recvCountOverride = 0,
-      size_t misalignElemsOnOddRanks = 0) {
+      size_t misalignElemsOnOddRanks = 0,
+      int activeRanksPerGroup = 2) {
     const int nGroups = 1;
-    const int A = 2;
+    const int A = activeRanksPerGroup;
     // Default: A * recvBytes reaches kRelayOverlapReduceMinBytes (256 MiB) so
     // the side-stream path engages. recvCountOverride instead pins a small
     // count so the one-shot IPC path is exercised (it needs A * recvCount *
@@ -2053,7 +2054,7 @@ class ShardedRelayReduceScatterOverlapA2Test
     const size_t recvBytes = recvCount * sizeof(int32_t);
     const size_t inBytes = static_cast<size_t>(A) * recvBytes;
 
-    const int activeRanks[] = {0, 1};
+    const int activeRanks[] = {0, 1, 2, 3};
     const int* allActiveRanks[] = {activeRanks};
     const bool isActive = this->globalRank < A;
     const int myActiveIndex = this->globalRank;
@@ -2136,9 +2137,8 @@ class ShardedRelayReduceScatterOverlapA2Test
         }
       }
       ASSERT_EQ(mismatches, 0u)
-          << "2-active single-group overlapped reduce-scatter mismatch: "
-          << mismatches << " of " << recvCount << " elements, first at index "
-          << firstBad;
+          << A << "-active single-group reduce-scatter mismatch: " << mismatches
+          << " of " << recvCount << " elements, first at index " << firstBad;
     }
 
     HIPCHECK_TEST(hipFree(sendBuff));
@@ -2251,6 +2251,56 @@ TEST_F(
       ncclAvg,
       /*recvCountOverride=*/16389,
       /*misalignElemsOnOddRanks=*/1);
+}
+
+// A=4 counterparts of the one-shot cases above. The one-shot kernel indexes
+// peer staging by ACTIVE INDEX, so a slot permutation is the characteristic
+// bug, and at A=4 there are three sources to get wrong instead of one. The A=4
+// fixture elsewhere in this file fills each block with a constant, which cannot
+// see such a bug -- these reuse this fixture's position-dependent fill instead.
+//
+// AVG stays integer-exact at A=4: the per-element sum is
+// kBase*A*(A+1)/2 + A*(i%kPeriod), so dividing by 4 gives 2500 + (i%kPeriod).
+TEST_F(
+    ShardedRelayReduceScatterOverlapA2Test,
+    Correctness_OneShot_A4_OutOfPlace_Sum) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runOverlapCase(
+      /*inPlace=*/false,
+      ncclSum,
+      /*recvCountOverride=*/32768,
+      /*misalignElemsOnOddRanks=*/0,
+      /*activeRanksPerGroup=*/4);
+}
+
+TEST_F(
+    ShardedRelayReduceScatterOverlapA2Test,
+    Correctness_OneShot_A4_InPlace_Avg) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runOverlapCase(
+      /*inPlace=*/true,
+      ncclAvg,
+      /*recvCountOverride=*/32768,
+      /*misalignElemsOnOddRanks=*/0,
+      /*activeRanksPerGroup=*/4);
+}
+
+TEST_F(
+    ShardedRelayReduceScatterOverlapA2Test,
+    Correctness_OneShot_A4_OutOfPlace_Sum_UnalignedTail) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runOverlapCase(
+      /*inPlace=*/false,
+      ncclSum,
+      /*recvCountOverride=*/32767,
+      /*misalignElemsOnOddRanks=*/0,
+      /*activeRanksPerGroup=*/4);
 }
 
 TEST_F(ShardedRelayReduceScatterOverlapA2Test, Correctness_OutOfPlace_Sum) {

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
@@ -2003,6 +2003,160 @@ TEST(ShardedRelayReduceScatterFanoutShape, LayoutFitsAtEveryAcceptedGeometry) {
   EXPECT_EQ(shipped.totalFixed, 1);
 }
 
+/**
+ * Test: single group at 2 active ranks, large enough to overlap the owner
+ * reduce, with a POSITION-DEPENDENT fill.
+ *
+ * Above kRelayOverlapReduceMinBytes the pipelined 2-active relay stops reducing
+ * once at the end and instead reduces each pipeline region on a side stream as
+ * that region lands. That required re-indexing the shipped block from
+ * helper-major to stage-major, so region k holds exactly what group k receives.
+ *
+ * Every other reduce-scatter test fills a contribution block with a CONSTANT
+ * value, which means a region that arrives at the wrong offset still sums to
+ * the right number and the bug is invisible. These cases fill position
+ * dependently instead, so any permutation, shift, overlap or omission of a
+ * region changes the output and fails.
+ *
+ * Element i of every block on active rank r holds (r + 1) * kBase +
+ * (i % kPeriod). Owner m's output element i is the sum over r, which at A == 2
+ * is 3 * kBase + 2 * (i % kPeriod) -- always even, so AVG is exact in integer
+ * arithmetic and a divisor applied twice, or to the wrong region, is caught.
+ * kPeriod is coprime with the 128-element chunk alignment, so a misplacement by
+ * any whole number of chunks shifts the pattern rather than aliasing onto it.
+ */
+class ShardedRelayReduceScatterOverlapA2Test
+    : public ShardedRelayMultiGroupReduceScatterTest {
+ protected:
+  static constexpr int32_t kBase = 1000;
+  static constexpr int32_t kPeriod = 977;
+
+  static int32_t fillValue(int activeIndex, size_t i) {
+    return static_cast<int32_t>(activeIndex + 1) * kBase +
+        static_cast<int32_t>(i % static_cast<size_t>(kPeriod));
+  }
+
+  void runOverlapCase(bool inPlace, ncclRedOp_t op) {
+    const int nGroups = 1;
+    const int A = 2;
+    // A * recvBytes must reach kRelayOverlapReduceMinBytes (256 MiB) for the
+    // side-stream path to engage at all.
+    const size_t recvBytes = 128ULL * 1024 * 1024;
+    const size_t recvCount = recvBytes / sizeof(int32_t);
+    const size_t inBytes = static_cast<size_t>(A) * recvBytes;
+
+    const int activeRanks[] = {0, 1};
+    const int* allActiveRanks[] = {activeRanks};
+    const bool isActive = this->globalRank < A;
+    const int myActiveIndex = this->globalRank;
+
+    int32_t* sendBuff = nullptr;
+    int32_t* recvBuff = nullptr;
+    HIPCHECK_TEST(hipMalloc(&sendBuff, inBytes));
+    if (isActive && !inPlace) {
+      HIPCHECK_TEST(hipMalloc(&recvBuff, recvBytes));
+    }
+
+    barrierSyncOn(sendBuff);
+
+    HIPCHECK_TEST(hipMemset(sendBuff, 0, inBytes));
+    if (isActive) {
+      std::vector<int32_t> host(static_cast<size_t>(A) * recvCount);
+      for (int j = 0; j < A; j++) {
+        int32_t* block = host.data() + static_cast<size_t>(j) * recvCount;
+        for (size_t i = 0; i < recvCount; i++) {
+          block[i] = fillValue(myActiveIndex, i);
+        }
+      }
+      HIPCHECK_TEST(
+          hipMemcpy(sendBuff, host.data(), inBytes, hipMemcpyHostToDevice));
+      if (!inPlace) {
+        HIPCHECK_TEST(hipMemset(recvBuff, 0, recvBytes));
+      }
+    }
+
+    int32_t* out = inPlace
+        ? sendBuff + static_cast<size_t>(myActiveIndex) * recvCount
+        : recvBuff;
+
+    const void* sendPtrs[1] = {sendBuff};
+    void* recvPtrs[1] = {isActive ? out : sendBuff};
+    size_t recvCounts[1] = {recvCount};
+
+    const ncclResult_t result = callReduceScatterCompat(
+        sendPtrs,
+        recvPtrs,
+        recvCounts,
+        ncclInt32,
+        op,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        A,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+    if (isActive) {
+      std::vector<int32_t> got(recvCount);
+      HIPCHECK_TEST(
+          hipMemcpy(got.data(), out, recvBytes, hipMemcpyDeviceToHost));
+      size_t mismatches = 0;
+      size_t firstBad = 0;
+      for (size_t i = 0; i < recvCount; i++) {
+        int32_t sum = 0;
+        for (int r = 0; r < A; r++) {
+          sum += fillValue(r, i);
+        }
+        const int32_t want = (op == ncclAvg) ? sum / A : sum;
+        if (got[i] != want) {
+          if (mismatches == 0) {
+            firstBad = i;
+          }
+          mismatches++;
+        }
+      }
+      ASSERT_EQ(mismatches, 0u)
+          << "2-active single-group overlapped reduce-scatter mismatch: "
+          << mismatches << " of " << recvCount << " elements, first at index "
+          << firstBad;
+    }
+
+    HIPCHECK_TEST(hipFree(sendBuff));
+    if (recvBuff != nullptr) {
+      HIPCHECK_TEST(hipFree(recvBuff));
+    }
+  }
+};
+
+TEST_F(ShardedRelayReduceScatterOverlapA2Test, Correctness_OutOfPlace_Sum) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runOverlapCase(/*inPlace=*/false, ncclSum);
+}
+
+TEST_F(ShardedRelayReduceScatterOverlapA2Test, Correctness_InPlace_Sum) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runOverlapCase(/*inPlace=*/true, ncclSum);
+}
+
+TEST_F(ShardedRelayReduceScatterOverlapA2Test, Correctness_OutOfPlace_Avg) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runOverlapCase(/*inPlace=*/false, ncclAvg);
+}
+
+TEST_F(ShardedRelayReduceScatterOverlapA2Test, Correctness_InPlace_Avg) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runOverlapCase(/*inPlace=*/true, ncclAvg);
+}
+
 TEST_F(
     ShardedRelayMultiGroupReduceScatterTest,
     Correctness_4Active_2Groups_OutOfPlace) {

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
@@ -190,33 +190,79 @@ class ShardedRelayMultiGroupReduceScatterTest : public ::testing::Test {
  public:
   ShardedRelayMultiGroupReduceScatterTest() = default;
 
-  void SetUp() override {
+  // One comm per active-rank shape, created once for the whole binary and
+  // reused by every case, plus a dedicated one for the rank barrier. These used
+  // to be created in SetUp and destroyed in TearDown, so each of the 37 cases
+  // freed everything an 8-rank comm owns. On MI350 freeing VRAM makes amdgpu
+  // wipe it (amdgpu_bo_release_notify -> amdgpu_fill_buffer) while holding
+  // mmap_lock for write, so 8 ranks cycling multi-GB comms serialise into a
+  // stall that takes the whole host down. Reusing also matches how comms are
+  // really used: a handful, kept for the life of the process.
+  //
+  // Shapes are kept apart because relay state is per-comm and a comm cannot be
+  // shared between the 2- and 4-active-rank configurations. One store serves
+  // all three, with incrTestCount() between them: the unique-ID rendezvous key
+  // is derived from that counter, so without bumping it the second comm would
+  // read the first one's stale ID. Built eagerly in a fixed order so every rank
+  // consumes the same keys in the same sequence.
+  static void SetUpTestSuite() {
     int localSize;
-    std::tie(this->localRank, this->globalRank, this->numRanks, localSize) =
+    std::tie(localRank, globalRank, numRanks, localSize) =
         getTcpStoreOrMpiInfo();
-    bool isServer = (this->globalRank == 0);
+    const bool isServer = (globalRank == 0);
     if (checkTcpStoreEnv()) {
       server = createTcpStore(isServer);
     } else if (isServer) {
       server = createTcpStore(true);
     }
-    this->comm = createNcclComm(
-        this->globalRank,
-        this->numRanks,
-        this->localRank,
-        false,
-        nullptr,
-        server.get());
+    barrierComm = makeComm();
+    incrTestCount();
+    commA2 = makeComm();
+    incrTestCount();
+    commA4 = makeComm();
+  }
+
+  static ncclComm_t makeComm() {
+    return createNcclComm(
+        globalRank, numRanks, localRank, false, nullptr, server.get());
+  }
+
+  // The comm for a given active-rank shape. Every collective call site has
+  // nActiveRanksPerGroup in scope, which is how a test reaches its comm.
+  static ncclComm_t commFor(int nActiveRanksPerGroup) {
+    switch (nActiveRanksPerGroup) {
+      case 2:
+        return commA2;
+      case 4:
+        return commA4;
+      default:
+        ADD_FAILURE() << "no comm cached for nActiveRanksPerGroup="
+                      << nActiveRanksPerGroup;
+        return nullptr;
+    }
+  }
+
+  static void TearDownTestSuite() {
+    if (server && checkTcpStoreEnv()) {
+      finalizeNcclComm(globalRank, server.get());
+    }
+    for (ncclComm_t* c : {&commA4, &commA2, &barrierComm}) {
+      if (*c != nullptr) {
+        NCCLCHECK_TEST(ncclCommDestroy(*c));
+        *c = nullptr;
+      }
+    }
+    server.reset();
+  }
+
+  void SetUp() override {
+    ASSERT_NE(this->commA2, nullptr)
+        << "suite-scoped comms were not created; SetUpTestSuite did not run";
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
 
   void TearDown() override {
     CUDACHECK_TEST(cudaStreamDestroy(this->stream));
-    if (server && checkTcpStoreEnv()) {
-      finalizeNcclComm(this->globalRank, server.get());
-    }
-    NCCLCHECK_TEST(ncclCommDestroy(this->comm));
-    server.reset();
   }
 
   // Standard 8-rank, 4-group, 2-active-per-group sparse parallelism layout.
@@ -435,7 +481,7 @@ class ShardedRelayMultiGroupReduceScatterTest : public ::testing::Test {
           recvCounts.data(),
           ncclBfloat16,
           op,
-          this->comm,
+          this->commFor(nActiveRanksPerGroup),
           this->stream,
           allActiveRanks,
           nActiveRanksPerGroup,
@@ -548,7 +594,7 @@ class ShardedRelayMultiGroupReduceScatterTest : public ::testing::Test {
         recvCounts,
         ncclInt32,
         op,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,
@@ -641,7 +687,7 @@ class ShardedRelayMultiGroupReduceScatterTest : public ::testing::Test {
         recvCounts,
         ncclBfloat16,
         op,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         groupConfig.allActiveRanks,
         nActiveRanksPerGroup,
@@ -697,7 +743,7 @@ class ShardedRelayMultiGroupReduceScatterTest : public ::testing::Test {
         1,
         ncclInt32,
         ncclSum,
-        this->comm,
+        this->barrierComm,
         this->stream));
     HIPCHECK_TEST(hipStreamSynchronize(this->stream));
     HIPCHECK_TEST(hipFree(barrierScratch));
@@ -737,12 +783,14 @@ class ShardedRelayMultiGroupReduceScatterTest : public ::testing::Test {
     return errorCount;
   }
 
-  int localRank{0};
-  int globalRank{0};
-  int numRanks{0};
-  ncclComm_t comm;
+  static inline int localRank{0};
+  static inline int globalRank{0};
+  static inline int numRanks{0};
+  static inline ncclComm_t barrierComm{nullptr};
+  static inline ncclComm_t commA2{nullptr};
+  static inline ncclComm_t commA4{nullptr};
+  static inline std::unique_ptr<c10d::TCPStore> server{nullptr};
   cudaStream_t stream;
-  std::unique_ptr<c10d::TCPStore> server{nullptr};
 };
 
 /**
@@ -819,7 +867,7 @@ TEST_F(
       recvCounts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -914,7 +962,7 @@ TEST_F(
       recvCounts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1007,7 +1055,7 @@ TEST_F(ShardedRelayMultiGroupReduceScatterTest, Correctness_4Groups_Avg_64MB) {
       recvCounts,
       ncclInt32,
       ncclAvg,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1121,7 +1169,7 @@ TEST_F(ShardedRelayMultiGroupReduceScatterTest, Z_BusBW_4Groups_InPlace_1GB) {
         recvCounts,
         ncclInt32,
         ncclSum,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,
@@ -1253,7 +1301,7 @@ TEST_F(
         recvCounts,
         ncclInt32,
         ncclSum,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,
@@ -1361,7 +1409,7 @@ TEST_F(ShardedRelayMultiGroupReduceScatterTest, Correctness_SingleGroup_64MB) {
       recvCounts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1469,7 +1517,7 @@ TEST_F(
       recvCounts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1606,7 +1654,7 @@ TEST_F(
       recvCounts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1715,7 +1763,7 @@ TEST_F(
       recvCounts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1814,7 +1862,7 @@ TEST_F(
       recvCounts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -1915,7 +1963,7 @@ class ShardedRelayReduceScatterSingleGroupA4Test
         recvCounts,
         ncclInt32,
         ncclSum,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,
@@ -2109,7 +2157,7 @@ class ShardedRelayReduceScatterOverlapA2Test
         recvCounts,
         ncclInt32,
         op,
-        this->comm,
+        this->commFor(activeRanksPerGroup),
         this->stream,
         allActiveRanks,
         A,
@@ -2394,7 +2442,7 @@ TEST_F(
       recvCounts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -2487,7 +2535,7 @@ TEST_F(
       recvCounts,
       ncclInt32,
       ncclAvg,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -2611,7 +2659,7 @@ TEST_F(
       recvCounts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -2707,7 +2755,7 @@ TEST_F(
       recvCounts,
       ncclInt32,
       ncclSum,
-      this->comm,
+      this->commFor(nActiveRanksPerGroup),
       this->stream,
       allActiveRanks,
       nActiveRanksPerGroup,
@@ -2799,7 +2847,7 @@ TEST_F(
         recvCounts,
         ncclInt32,
         ncclSum,
-        this->comm,
+        this->commFor(nActiveRanksPerGroup),
         this->stream,
         allActiveRanks,
         nActiveRanksPerGroup,

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
@@ -1532,7 +1532,7 @@ TEST_F(
                  << " available";
   }
 
-  runBfloat16A2RoutingThreshold(1, static_cast<size_t>(27) << 20, ncclSum);
+  runBfloat16A2RoutingThreshold(1, static_cast<size_t>(3) << 20, ncclSum);
 }
 
 TEST_F(
@@ -1543,7 +1543,7 @@ TEST_F(
                  << " available";
   }
 
-  runBfloat16A2RoutingThreshold(1, static_cast<size_t>(27) << 20, ncclAvg);
+  runBfloat16A2RoutingThreshold(1, static_cast<size_t>(3) << 20, ncclAvg);
 }
 
 TEST_F(

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
@@ -1854,6 +1854,155 @@ TEST_F(
   runBfloat16A4SeededDirect(ncclAvg);
 }
 
+/**
+ * Test: single group (nGroups == 1) at 4 active ranks, both placements.
+ *
+ * nGroups == 1 makes the active ranks {0,1,2,3} and the helpers {4,5,6,7}
+ * disjoint, which is what puts the flat relay on its software-pipelined
+ * schedule: the offload scatter and the helper's reduced return share a group
+ * so each cross link runs duplex, and the helper's reduce runs per tile between
+ * the group that receives it and the group that ships it. 64 MB is above the
+ * offload threshold and deep enough for the cost model to tile, so this is the
+ * only coverage of that path -- every other 4-active case runs 2 groups, where
+ * the relay stays unpipelined.
+ */
+class ShardedRelayReduceScatterSingleGroupA4Test
+    : public ShardedRelayMultiGroupReduceScatterTest {
+ protected:
+  void runSingleGroupA4Case(bool inPlace) {
+    const int nGroups = 1;
+    const int nActiveRanksPerGroup = 4;
+    const size_t recvBytes = 64ULL * 1024 * 1024;
+    const size_t recvCount = recvBytes / sizeof(int32_t);
+    const size_t inBytes =
+        static_cast<size_t>(nActiveRanksPerGroup) * recvBytes;
+
+    const int activeRanks[] = {0, 1, 2, 3};
+    const int* allActiveRanks[] = {activeRanks};
+    const bool isActive = this->globalRank < nActiveRanksPerGroup;
+    const int myActiveIndex = this->globalRank;
+
+    // Helpers hand in a placeholder; the kernel stages into its own scratch.
+    int32_t* sendBuff = nullptr;
+    int32_t* recvBuff = nullptr;
+    HIPCHECK_TEST(hipMalloc(&sendBuff, inBytes));
+    if (isActive && !inPlace) {
+      HIPCHECK_TEST(hipMalloc(&recvBuff, recvBytes));
+    }
+
+    barrierSyncOn(sendBuff);
+
+    HIPCHECK_TEST(hipMemset(sendBuff, 0, inBytes));
+    if (isActive) {
+      initActiveSendBuffer(
+          sendBuff, recvCount, myActiveIndex, nActiveRanksPerGroup);
+      if (!inPlace) {
+        HIPCHECK_TEST(hipMemset(recvBuff, 0, recvBytes));
+      }
+    }
+    // In-place: the output aliases this rank's own contribution block.
+    int32_t* out = inPlace
+        ? sendBuff + static_cast<size_t>(myActiveIndex) * recvCount
+        : recvBuff;
+
+    const void* sendPtrs[1] = {sendBuff};
+    void* recvPtrs[1] = {isActive ? out : sendBuff};
+    size_t recvCounts[1] = {recvCount};
+
+    const ncclResult_t result = callReduceScatterCompat(
+        sendPtrs,
+        recvPtrs,
+        recvCounts,
+        ncclInt32,
+        ncclSum,
+        this->comm,
+        this->stream,
+        allActiveRanks,
+        nActiveRanksPerGroup,
+        nGroups);
+    ASSERT_EQ(result, ncclSuccess);
+    HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+    if (isActive) {
+      verifyDeviceBufferEquals(
+          out,
+          recvCount,
+          expectedReduceScatterSum(myActiveIndex, nActiveRanksPerGroup),
+          0,
+          "4-active single-group reduce-scatter SUM mismatch");
+    }
+
+    HIPCHECK_TEST(hipFree(sendBuff));
+    if (recvBuff != nullptr) {
+      HIPCHECK_TEST(hipFree(recvBuff));
+    }
+  }
+};
+
+TEST_F(
+    ShardedRelayReduceScatterSingleGroupA4Test,
+    Correctness_OutOfPlace_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runSingleGroupA4Case(/*inPlace=*/false);
+}
+
+TEST_F(ShardedRelayReduceScatterSingleGroupA4Test, Correctness_InPlace_64MB) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runSingleGroupA4Case(/*inPlace=*/true);
+}
+
+/**
+ * Test: the pipelined relay's block layout fits inside recvCount at EVERY
+ * geometry buildShardedRelayRankConfig() accepts, not just the A = H = 4 one
+ * the 8-rank cases above exercise.
+ *
+ * The GPU cases here are pinned to 8 ranks, so a single-group A = 4 call always
+ * has exactly 4 helpers; the combinations a 9-to-16-rank comm would produce
+ * (A = 4 with H = 5..8, or A = 8 with H = 8) cannot be built from this harness.
+ * What those geometries break is arithmetic, not scheduling:
+ * shardedRelayReduceScatterFlatPipelined() takes directSz = rc - H*T*w and then
+ * directSize(T) = directSz - T*(A-1)*w, so if totalUnits(T) is smaller than
+ * H*T + (A-1)*T + 1 both subtractions underflow as size_t and a wild count
+ * reaches ncclSend/ncclRecv. Assert the invariant against the shape directly
+ * over the whole accepted (A, H) space, which needs no ranks at all.
+ */
+TEST(ShardedRelayReduceScatterFanoutShape, LayoutFitsAtEveryAcceptedGeometry) {
+  // Mirrors SHARDED_RELAY_MAX_ACTIVE / SHARDED_RELAY_MAX_HELPERS.
+  constexpr int kMaxActive = 8;
+  constexpr int kMaxHelpers = 8;
+
+  for (int a = 2; a <= kMaxActive; a *= 2) {
+    for (int h = 1; h <= kMaxHelpers; h++) {
+      const rcclx::relay::RelayPipelineShape shape =
+          rcclx::relay::relayShapeFanout(a, h);
+      for (int t = 1; t <= 8; t *= 2) {
+        const int totalUnits = shape.totalPerTile * t + shape.totalFixed;
+        // Offload region, plus the T heavy direct chunks, plus at least one
+        // unit for the last chunk to absorb.
+        const int consumed = h * t + (a - 1) * t + 1;
+        EXPECT_LE(consumed, totalUnits)
+            << "pipelined block layout overruns recvCount at A=" << a
+            << " H=" << h << " T=" << t << ": needs " << consumed
+            << " units out of " << totalUnits;
+      }
+    }
+  }
+
+  // The shipped 8-GPU geometry must still resolve to the constants the perf
+  // numbers were measured at, so the parameterization is a generalization and
+  // not a change.
+  const rcclx::relay::RelayPipelineShape shipped =
+      rcclx::relay::relayShapeFanout(4, 4);
+  EXPECT_EQ(shipped.linkPerTile, 3);
+  EXPECT_EQ(shipped.linkFixed, 1);
+  EXPECT_EQ(shipped.totalPerTile, 7);
+  EXPECT_EQ(shipped.totalFixed, 1);
+}
+
 TEST_F(
     ShardedRelayMultiGroupReduceScatterTest,
     Correctness_4Active_2Groups_OutOfPlace) {

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
@@ -2036,13 +2036,21 @@ class ShardedRelayReduceScatterOverlapA2Test
         static_cast<int32_t>(i % static_cast<size_t>(kPeriod));
   }
 
-  void runOverlapCase(bool inPlace, ncclRedOp_t op) {
+  void runOverlapCase(
+      bool inPlace,
+      ncclRedOp_t op,
+      size_t recvCountOverride = 0,
+      size_t misalignElemsOnOddRanks = 0) {
     const int nGroups = 1;
     const int A = 2;
-    // A * recvBytes must reach kRelayOverlapReduceMinBytes (256 MiB) for the
-    // side-stream path to engage at all.
-    const size_t recvBytes = 128ULL * 1024 * 1024;
-    const size_t recvCount = recvBytes / sizeof(int32_t);
+    // Default: A * recvBytes reaches kRelayOverlapReduceMinBytes (256 MiB) so
+    // the side-stream path engages. recvCountOverride instead pins a small
+    // count so the one-shot IPC path is exercised (it needs A * recvCount *
+    // elemSize <= kRelayOneShotMaxBytes).
+    const size_t recvCount = (recvCountOverride != 0)
+        ? recvCountOverride
+        : (128ULL * 1024 * 1024) / sizeof(int32_t);
+    const size_t recvBytes = recvCount * sizeof(int32_t);
     const size_t inBytes = static_cast<size_t>(A) * recvBytes;
 
     const int activeRanks[] = {0, 1};
@@ -2050,12 +2058,23 @@ class ShardedRelayReduceScatterOverlapA2Test
     const bool isActive = this->globalRank < A;
     const int myActiveIndex = this->globalRank;
 
-    int32_t* sendBuff = nullptr;
-    int32_t* recvBuff = nullptr;
-    HIPCHECK_TEST(hipMalloc(&sendBuff, inBytes));
+    // Shift only the ODD active rank's buffers, so the two peers disagree on
+    // whether 16-byte accesses are usable. hipMalloc always returns a
+    // 16-byte-aligned pointer, so every other case here has both ranks aligned.
+    const size_t skew =
+        (misalignElemsOnOddRanks != 0 && (myActiveIndex % 2) == 1)
+        ? misalignElemsOnOddRanks
+        : 0;
+    const size_t skewBytes = skew * sizeof(int32_t);
+
+    int32_t* sendAlloc = nullptr;
+    int32_t* recvAlloc = nullptr;
+    HIPCHECK_TEST(hipMalloc(&sendAlloc, inBytes + skewBytes));
     if (isActive && !inPlace) {
-      HIPCHECK_TEST(hipMalloc(&recvBuff, recvBytes));
+      HIPCHECK_TEST(hipMalloc(&recvAlloc, recvBytes + skewBytes));
     }
+    int32_t* sendBuff = sendAlloc + skew;
+    int32_t* recvBuff = (recvAlloc != nullptr) ? recvAlloc + skew : nullptr;
 
     barrierSyncOn(sendBuff);
 
@@ -2128,6 +2147,111 @@ class ShardedRelayReduceScatterOverlapA2Test
     }
   }
 };
+
+// The four cases below sit BELOW kRelayOneShotMaxBytes (1 MiB of
+// per-active-rank input), where the one-shot IPC kernel replaces the ncclGroup
+// + reduce pair entirely: it pushes into the peer's staging, handshakes on a
+// per-block flag, and reduces in registers, in a single launch.
+//
+// This fixture is the right home because its fill is POSITION-DEPENDENT. The
+// older A=2 tests fill each block with a constant, which cannot catch an offset
+// or slot permutation -- and the one-shot path is exactly where such a bug
+// would live, since it indexes peer staging by active index.
+//
+// 65536 int32 = 256 KiB per rank, so 512 KiB of input: inside the gate, and
+// 16-byte aligned so the vectorized bulk path runs. 65535 is deliberately NOT a
+// multiple of 16/sizeof(int32_t), so it drives the scalar tail and the
+// misaligned-pointer fallback instead.
+TEST_F(
+    ShardedRelayReduceScatterOverlapA2Test,
+    Correctness_OneShot_OutOfPlace_Sum) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runOverlapCase(/*inPlace=*/false, ncclSum, /*recvCountOverride=*/65536);
+}
+
+TEST_F(
+    ShardedRelayReduceScatterOverlapA2Test,
+    Correctness_OneShot_InPlace_Sum) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runOverlapCase(/*inPlace=*/true, ncclSum, /*recvCountOverride=*/65536);
+}
+
+TEST_F(
+    ShardedRelayReduceScatterOverlapA2Test,
+    Correctness_OneShot_InPlace_Avg) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runOverlapCase(/*inPlace=*/true, ncclAvg, /*recvCountOverride=*/65536);
+}
+
+TEST_F(
+    ShardedRelayReduceScatterOverlapA2Test,
+    Correctness_OneShot_OutOfPlace_Sum_UnalignedTail) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runOverlapCase(/*inPlace=*/false, ncclSum, /*recvCountOverride=*/65535);
+}
+
+// The two cases below give ONE of the two peers 16-byte-misaligned caller
+// buffers and leave the other aligned, so the peers disagree about whether
+// vectorized accesses are usable. hipMalloc always returns a 16-byte-aligned
+// pointer, so in every other case here both ranks vectorize and that mixed
+// state is never reached at all.
+//
+// The count is chosen so the two ranks would also PARTITION differently if the
+// alignment decision were allowed to pick the block range. Vector partitioning
+// splits rc/kEvec vectors across gridDim blocks, element partitioning splits
+// rc, and the two agree whenever ceil((rc/kEvec)/G)*kEvec == ceil(rc/G) --
+// which is the case at 65536 and 65535 (both 1024). At 16388 int32 with
+// kEvec = 4 and G = 64 the vector stride is ceil(4097/64)*4 = 260 against an
+// element stride of ceil(16388/64) = 257, so the ranges diverge from block 1
+// onward. 16389 adds a ragged rc % kEvec tail on top of the same skew.
+//
+// WHAT THESE DO AND DO NOT GUARANTEE. They cover the mixed-alignment path --
+// one rank on the vector loops, its peer on the element-wise loops -- and they
+// would fail outright on a partition that overlapped or left a gap. They are
+// NOT a regression test for the ordering hazard that motivated deriving the
+// range from rank-agreed values only. With a divergent partition, block b
+// reduces a range wider than the one block b's flag covers, so it can read
+// staging its peer has not pushed yet. That read is a race and it is not
+// reliably observable here: the window is a few elements at a block seam, the
+// peer's block is doing the same work at the same time, and this fixture writes
+// the same fill on every call, so a premature read returns the value that is
+// about to be written anyway. Confirmed empirically -- with the
+// alignment-dependent partition restored, both cases below still pass. The
+// invariant is held by the kernel deriving [begin, end) from rc, kEvec and
+// gridDim alone; do not read a green run here as licence to relax that.
+TEST_F(
+    ShardedRelayReduceScatterOverlapA2Test,
+    Correctness_OneShot_OutOfPlace_Sum_AsymmetricAlignment) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runOverlapCase(
+      /*inPlace=*/false,
+      ncclSum,
+      /*recvCountOverride=*/16388,
+      /*misalignElemsOnOddRanks=*/1);
+}
+
+TEST_F(
+    ShardedRelayReduceScatterOverlapA2Test,
+    Correctness_OneShot_InPlace_Avg_AsymmetricAlignmentUnalignedTail) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks, but got " << this->numRanks;
+  }
+  runOverlapCase(
+      /*inPlace=*/true,
+      ncclAvg,
+      /*recvCountOverride=*/16389,
+      /*misalignElemsOnOddRanks=*/1);
+}
 
 TEST_F(ShardedRelayReduceScatterOverlapA2Test, Correctness_OutOfPlace_Sum) {
   if (this->numRanks != 8) {

--- a/comms/rcclx/develop/projects/rccl/src/collectives.cc
+++ b/comms/rcclx/develop/projects/rccl/src/collectives.cc
@@ -22,6 +22,11 @@
 #include "meta/relay/sharded_relay_reduce_scatter.h"
 #include "meta/relay/sharded_relay_all_to_all.h"
 #include "meta/relay/sharded_relay_all_gather.h"
+#include "meta/relay/relay_control.h"
+
+#include <cstddef>
+#include <cstring>
+#include <type_traits>
 #include "comms/ctran/Ctran.h"
 #include "MetaFactory.h"
 
@@ -670,6 +675,132 @@ ncclResult_t ncclShardedRelayMultiGroupAllGather(
   return ncclShardedRelayMultiGroupAllGather_impl(
       sendBuffs, recvBuffs, sendCounts,
       datatype, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
+}
+
+// Host control plane for the relay collectives. Two functions and one struct is
+// the entire surface: everything else rides hooks that already exist. Setup and
+// teardown are not exported because commInitRank and commFree already run them,
+// capacity is not queryable because it is validated at attach so a mismatch
+// fails at init rather than at runtime, abort is folded into Consume's return,
+// and shutdown is an opCode rather than a third entry point.
+//
+// Both take ncclComm_t instead of a handle, so there is no object for a caller
+// to own, thread through, or leak.
+
+NCCL_API(ncclResult_t, ncclRelayControlPublish,
+    ncclComm_t comm, uint64_t epoch,
+    const ncclRelayPlanInfo* info, const size_t* counts, int64_t timeoutNs);
+
+// The exported record and the internal one are the SAME 32-byte wire format, so
+// the conversions below are a memcpy rather than a field list. This is the only
+// translation unit where both types are visible, which makes it the only place
+// these assertions can live -- and a memcpy behind them cannot silently drop a
+// field the way a hand-written field list does the moment one is added to both.
+static_assert(
+    sizeof(ncclRelayPlanInfo) == sizeof(rcclx::relay::RelayPlanInfo),
+    "the exported and internal relay plan records must be the same size");
+static_assert(
+    offsetof(ncclRelayPlanInfo, nCalls) ==
+            offsetof(rcclx::relay::RelayPlanInfo, nCalls) &&
+        offsetof(ncclRelayPlanInfo, opCode) ==
+            offsetof(rcclx::relay::RelayPlanInfo, opCode) &&
+        offsetof(ncclRelayPlanInfo, dtype) ==
+            offsetof(rcclx::relay::RelayPlanInfo, dtype) &&
+        offsetof(ncclRelayPlanInfo, redOp) ==
+            offsetof(rcclx::relay::RelayPlanInfo, redOp) &&
+        offsetof(ncclRelayPlanInfo, flags) ==
+            offsetof(rcclx::relay::RelayPlanInfo, flags) &&
+        offsetof(ncclRelayPlanInfo, reserved) ==
+            offsetof(rcclx::relay::RelayPlanInfo, reserved),
+    "the exported and internal relay plan records must agree field for field");
+static_assert(
+    std::is_trivially_copyable<ncclRelayPlanInfo>::value &&
+        std::is_trivially_copyable<rcclx::relay::RelayPlanInfo>::value,
+    "the relay plan records are memcpy'd between exported and internal form");
+
+ncclResult_t ncclRelayControlPublish_impl(
+    ncclComm_t comm, uint64_t epoch,
+    const ncclRelayPlanInfo* info, const size_t* counts, int64_t timeoutNs) {
+  if (comm == nullptr || info == nullptr) {
+    WARN("ncclRelayControlPublish: comm and info must be non-null");
+    return ncclInvalidArgument;
+  }
+  // Validated HERE, at the boundary, even though relayControlPublish checks
+  // flags again: the public contract declares flags and reserved "must be 0",
+  // and a caller that violates it should see the diagnostic attributed to the
+  // symbol it called. reserved had no check at all before, so non-zero bytes in
+  // a field documented as reserved were accepted and then silently dropped.
+  if (info->flags != 0) {
+    WARN(
+        "ncclRelayControlPublish: info->flags must be 0, got %u", info->flags);
+    return ncclInvalidArgument;
+  }
+  for (size_t i = 0; i < sizeof(info->reserved) / sizeof(info->reserved[0]);
+       i++) {
+    if (info->reserved[i] != 0) {
+      WARN(
+          "ncclRelayControlPublish: info->reserved must be 0, got reserved[%zu]=%u",
+          i, info->reserved[i]);
+      return ncclInvalidArgument;
+    }
+  }
+  if (info->nCalls > 0 && counts == nullptr) {
+    WARN(
+        "ncclRelayControlPublish: counts must be non-null when nCalls is %u",
+        info->nCalls);
+    return ncclInvalidArgument;
+  }
+  rcclx::relay::RelayPlanInfo plan;
+  memcpy(&plan, info, sizeof(plan));
+  return rcclx::relay::relayControlPublish(
+      comm, epoch, plan, counts, timeoutNs);
+}
+
+ncclResult_t ncclRelayControlPublish(
+    ncclComm_t comm, uint64_t epoch,
+    const ncclRelayPlanInfo* info, const size_t* counts, int64_t timeoutNs) {
+  return ncclRelayControlPublish_impl(comm, epoch, info, counts, timeoutNs);
+}
+
+NCCL_API(ncclResult_t, ncclRelayControlConsume,
+    ncclComm_t comm, uint64_t epoch,
+    ncclRelayPlanInfo* info, size_t* counts, uint32_t countsCapacity,
+    int64_t timeoutNs);
+
+ncclResult_t ncclRelayControlConsume_impl(
+    ncclComm_t comm, uint64_t epoch,
+    ncclRelayPlanInfo* info, size_t* counts, uint32_t countsCapacity,
+    int64_t timeoutNs) {
+  if (comm == nullptr || info == nullptr) {
+    WARN("ncclRelayControlConsume: comm and info must be non-null");
+    return ncclInvalidArgument;
+  }
+  rcclx::relay::RelayPlanInfo plan{};
+  const ncclResult_t res = rcclx::relay::relayControlConsume(
+      comm, epoch, &plan, counts, countsCapacity, timeoutNs);
+  // Copied out on success, and on the ONE failure that carries information: an
+  // over-capacity plan reports the size the caller needed, which is only
+  // actionable if the caller can see it.
+  //
+  // Every other failure -- timeout, a peer abort, no control plane on this comm
+  // -- leaves `plan` untouched, so copying it out unconditionally would hand the
+  // caller a zeroed record. That is NOT a neutral value: nCalls 0 with opCode 0
+  // is exactly ncclRelayOpShutdown, so a failure would be indistinguishable from
+  // a valid instruction to stop. The caller's buffer is therefore left alone,
+  // which the header documents.
+  if (res == ncclSuccess ||
+      (res == ncclInvalidArgument && plan.nCalls > countsCapacity)) {
+    memcpy(info, &plan, sizeof(*info));
+  }
+  return res;
+}
+
+ncclResult_t ncclRelayControlConsume(
+    ncclComm_t comm, uint64_t epoch,
+    ncclRelayPlanInfo* info, size_t* counts, uint32_t countsCapacity,
+    int64_t timeoutNs) {
+  return ncclRelayControlConsume_impl(
+      comm, epoch, info, counts, countsCapacity, timeoutNs);
 }
 
 NCCL_API(ncclResult_t, ncclBroadcast, const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root,

--- a/comms/rcclx/develop/projects/rccl/src/init.cc
+++ b/comms/rcclx/develop/projects/rccl/src/init.cc
@@ -71,6 +71,7 @@
 #endif
 #include "rccl_common.h"
 #include "meta/lpcoll/low_precision_buffer_pool.h"
+#include "meta/relay/sharded_relay_oneshot.h"
 // [/RCCL]
 
 #ifdef ENABLE_ROCSHMEM
@@ -521,6 +522,15 @@ static ncclResult_t commFree(ncclComm_t comm) {
     NCCLCHECK(ncclCudaFree(comm->tempBuff));
     comm->tempBuff = nullptr;
   }
+
+  // Release the sharded-relay one-shot IPC region for this communicator. It holds
+  // an exported device allocation plus a mapping of every peer's, and there is no
+  // other point at which the relay learns the comm is going away -- without this
+  // the region outlives the comm and its mappings accumulate. Purely local (an
+  // hipIpcCloseMemHandle per peer and one hipFree), so it respects the
+  // no-sync-among-ranks contract of commFree(); a no-op for a comm that never
+  // took the one-shot path.
+  rcclx::relay::oneShotRelease(comm);
 
   if (comm->symmetricSupport) {
     NCCLCHECK(ncclSymkFinalize(comm));

--- a/comms/rcclx/develop/projects/rccl/src/init.cc
+++ b/comms/rcclx/develop/projects/rccl/src/init.cc
@@ -72,6 +72,7 @@
 #include "rccl_common.h"
 #include "meta/lpcoll/low_precision_buffer_pool.h"
 #include "meta/relay/sharded_relay_oneshot.h"
+#include "meta/relay/relay_control.h"
 // [/RCCL]
 
 #ifdef ENABLE_ROCSHMEM
@@ -531,6 +532,12 @@ static ncclResult_t commFree(ncclComm_t comm) {
   // no-sync-among-ranks contract of commFree(); a no-op for a comm that never
   // took the one-shot path.
   rcclx::relay::oneShotRelease(comm);
+
+  // Same reasoning, and the same single point of truth: commFree() is where the
+  // relay learns the comm is going away. Purely local -- an munmap plus, for the
+  // creating rank, an shm_unlink -- so it respects commFree()'s
+  // no-sync-among-ranks contract, and a no-op for a comm that never built one.
+  rcclx::relay::relayControlRelease(comm);
 
   if (comm->symmetricSupport) {
     NCCLCHECK(ncclSymkFinalize(comm));
@@ -2494,6 +2501,13 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   // every rank is in init already, and no later call has to run a bootstrap
   // all-gather it cannot capture.
   rcclx::relay::oneShotInit(comm);
+
+  // And the control plane segment, for the same reason: setup is collective (two
+  // bootstrap all-gathers, enabled only on unanimity), so init is the one place
+  // it is free. Every rank is already here, and no later call has to run a
+  // bootstrap all-gather it cannot capture -- which is exactly the position the
+  // first call of a graph capture would be in.
+  rcclx::relay::relayControlInit(comm);
 
   NCCLCHECKGOTO(latency_profiler::collTraceInit(comm), res, fail);
   // update communicator state

--- a/comms/rcclx/develop/projects/rccl/src/init.cc
+++ b/comms/rcclx/develop/projects/rccl/src/init.cc
@@ -2489,6 +2489,12 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   // Initialize the AlgoFactory which handles customized collective algorithms
   comm->algoFactory = initAlgoFactory(comm);
 
+  // Build the sharded-relay one-shot region now, if it was asked for. Creation
+  // is collective, so doing it here is what lets a captured call use the path:
+  // every rank is in init already, and no later call has to run a bootstrap
+  // all-gather it cannot capture.
+  rcclx::relay::oneShotInit(comm);
+
   NCCLCHECKGOTO(latency_profiler::collTraceInit(comm), res, fail);
   // update communicator state
   comm->initState = ncclSuccess;

--- a/comms/rcclx/develop/projects/rccl/src/nccl.h
+++ b/comms/rcclx/develop/projects/rccl/src/nccl.h
@@ -32,6 +32,7 @@ extern "C" {
 #endif
 
 #include <limits.h>
+#include <stdint.h>
 
 /*! @brief      Opaque handle to communicator
     @details    A communicator contains information required to facilitate collective communications calls */
@@ -789,6 +790,130 @@ ncclResult_t pncclShardedRelayMultiGroupAllToAll(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
     ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
     const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @endcond */
+
+/*! @brief      Relay operation codes used by @ref ncclRelayPlanInfo */
+typedef enum {
+  ncclRelayOpShutdown     = 0, /*!< Helpers should stop; nCalls is 0 */
+  ncclRelayOpAllReduce    = 1,
+  ncclRelayOpReduceScatter = 2,
+  ncclRelayOpAllGather    = 3,
+  ncclRelayOpAllToAll     = 4
+} ncclRelayOp_t;
+
+/*! @brief      One forward pass worth of sharded-relay plan
+    @details    Fixed 32 bytes with reserved space to grow into. The per-call
+                element counts travel separately, as a caller-owned array, rather
+                than inline. That is what lets this record stay a fixed size while
+                the per-plan call capacity remains a *runtime* parameter
+                (NCCL_RELAY_CONTROL_MAX_CALLS): the number of relay calls in one
+                forward is the chunk count of a chunked prefill, which is
+                deployment configuration rather than a bounded property of the
+                algorithm.
+
+                Publish the decision, not the input. Only the ranks running the
+                model can know whether a given call happens at all -- it depends
+                on contiguity, alignment, compile state and phase -- so the plan
+                carries resolved counts and never a token count for the helper to
+                re-derive. */
+typedef struct {
+  uint32_t nCalls;      /*!< Relay calls in this forward; 0 with ncclRelayOpShutdown means shut down */
+  uint32_t opCode;      /*!< An @ref ncclRelayOp_t value */
+  uint32_t dtype;       /*!< An @ref ncclDataType_t value */
+  uint32_t redOp;       /*!< An @ref ncclRedOp_t value */
+  uint32_t flags;       /*!< Reserved; must be 0 */
+  uint32_t reserved[3]; /*!< Reserved; must be 0 */
+} ncclRelayPlanInfo;
+
+/*! @brief      Publish one forward's relay plan for this node's helper ranks
+    @details    A sharded relay collective is symmetric over the whole
+                communicator: it happens only when every rank's host thread
+                independently enqueues it. But a communicator is a data plane, not
+                a scheduler. Where the helper ranks are separate processes that do
+                not run the model -- no batch, no forward pass, no scheduler --
+                nothing in the communicator can make them post a call, and their
+                buffers are a one-element placeholder the kernel never reads.
+
+                This publishes the two things a helper cannot derive for itself:
+                the resolved per-call counts, and which calls happen at all. Call
+                it ONCE PER FORWARD, ORDERED BEFORE the forward's first
+                ncclShardedRelay* call. That ordering is the whole contract: the
+                decision point is strictly before the collective, because a rank
+                already blocked inside a collective cannot be rescued by anything
+                this function does.
+
+                Exactly one rank of the communicator may publish. Route selection
+                is deliberately absent: it is a pure function of size, so every
+                rank derives the same route from the published counts with zero
+                communication.
+
+                Requires NCCL_SHARDED_RELAY_MODE_ENABLE=1 at communicator
+                creation, which is also the switch for eager one-shot region
+                creation. Returns ncclInvalidArgument if this communicator has no
+                control plane, so callers keep whatever fallback they had.
+
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  comm      Communicator group object to publish on
+    @param[in]  epoch     Monotonic forward counter, shared with the consumers. Explicit rather than internal so a skipped forward is a detectable desync instead of a silent one
+    @param[in]  info      The plan; info->nCalls must not exceed NCCL_RELAY_CONTROL_MAX_CALLS
+    @param[in]  counts    Array of info->nCalls element counts, one per relay call
+    @param[in]  timeoutNs Wait budget in nanoseconds. Only ever consumed if a helper has fallen more than NCCL_RELAY_CONTROL_RING_DEPTH forwards behind, which means it is stuck; the wait exists because dropping a plan would desynchronize the communicator */
+ncclResult_t  ncclRelayControlPublish(
+    ncclComm_t comm, uint64_t epoch,
+    const ncclRelayPlanInfo* info, const size_t* counts, int64_t timeoutNs);
+/*! @cond       include_hidden */
+ncclResult_t pncclRelayControlPublish(
+    ncclComm_t comm, uint64_t epoch,
+    const ncclRelayPlanInfo* info, const size_t* counts, int64_t timeoutNs);
+/*! @endcond */
+
+/*! @brief      Take one forward's relay plan on a helper rank
+    @details    Blocks until the plan for `epoch` is available, then returns the
+                calls to enqueue. The wait is BOUNDED: it spins briefly, backs off,
+                and then fails while setting an abort flag that every other rank
+                observes -- so one stuck rank produces a single attributed cause
+                rather than a hang, or N independent timeouts.
+
+                In steady state this does not wait at all. The active rank runs a
+                forward ahead, so the plan is already published; the per-call
+                rendezvous is handled on the device, where the send/recv pairs
+                inside a relay schedule already block until peers arrive. This
+                function therefore needs to deliver correct program order and
+                arguments, not low-latency wake-up.
+
+                A rank becomes a consumer by calling this. It must do so before the
+                publisher completes NCCL_RELAY_CONTROL_RING_DEPTH forwards, which
+                communicator creation makes free: it is a barrier both sides leave
+                together, and the publisher's first forward costs orders of
+                magnitude more than reaching this call. Violating it returns an
+                error rather than corrupting anything.
+
+    @return     Result code. ncclInvalidArgument if countsCapacity is too small for
+                the published plan, in which case info IS filled in so the caller
+                can see the size it needed in info->nCalls. On any OTHER failure
+                (timeout, a peer abort, no control plane on this communicator)
+                info is left UNCHANGED -- it is not zeroed, because a zeroed
+                record is nCalls 0 with opCode ncclRelayOpShutdown, which is a
+                valid instruction to stop rather than a marker for "no plan".
+                Check the result code before reading info. See @ref
+                rccl_result_code.
+
+    @param[in]  comm           Communicator group object to consume from
+    @param[in]  epoch          Monotonic forward counter, matching the publisher
+    @param[out] info           Receives the plan
+    @param[out] counts         Receives info->nCalls element counts
+    @param[in]  countsCapacity Elements available in counts
+    @param[in]  timeoutNs      Wait budget in nanoseconds before failing */
+ncclResult_t  ncclRelayControlConsume(
+    ncclComm_t comm, uint64_t epoch,
+    ncclRelayPlanInfo* info, size_t* counts, uint32_t countsCapacity,
+    int64_t timeoutNs);
+/*! @cond       include_hidden */
+ncclResult_t pncclRelayControlConsume(
+    ncclComm_t comm, uint64_t epoch,
+    ncclRelayPlanInfo* info, size_t* counts, uint32_t countsCapacity,
+    int64_t timeoutNs);
 /*! @endcond */
 
 /*! @brief      Fused Multi-Group Sharded Relay All-Gather for 2D Sparse Parallelism

--- a/comms/rcclx/develop/projects/rccl/src/nccl.h.in
+++ b/comms/rcclx/develop/projects/rccl/src/nccl.h.in
@@ -32,6 +32,7 @@ extern "C" {
 #endif
 
 #include <limits.h>
+#include <stdint.h>
 
 /*! @brief      Opaque handle to communicator
     @details    A communicator contains information required to facilitate collective communications calls */
@@ -789,6 +790,130 @@ ncclResult_t pncclShardedRelayMultiGroupAllToAll(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
     ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
     const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @endcond */
+
+/*! @brief      Relay operation codes used by @ref ncclRelayPlanInfo */
+typedef enum {
+  ncclRelayOpShutdown     = 0, /*!< Helpers should stop; nCalls is 0 */
+  ncclRelayOpAllReduce    = 1,
+  ncclRelayOpReduceScatter = 2,
+  ncclRelayOpAllGather    = 3,
+  ncclRelayOpAllToAll     = 4
+} ncclRelayOp_t;
+
+/*! @brief      One forward pass worth of sharded-relay plan
+    @details    Fixed 32 bytes with reserved space to grow into. The per-call
+                element counts travel separately, as a caller-owned array, rather
+                than inline. That is what lets this record stay a fixed size while
+                the per-plan call capacity remains a *runtime* parameter
+                (NCCL_RELAY_CONTROL_MAX_CALLS): the number of relay calls in one
+                forward is the chunk count of a chunked prefill, which is
+                deployment configuration rather than a bounded property of the
+                algorithm.
+
+                Publish the decision, not the input. Only the ranks running the
+                model can know whether a given call happens at all -- it depends
+                on contiguity, alignment, compile state and phase -- so the plan
+                carries resolved counts and never a token count for the helper to
+                re-derive. */
+typedef struct {
+  uint32_t nCalls;      /*!< Relay calls in this forward; 0 with ncclRelayOpShutdown means shut down */
+  uint32_t opCode;      /*!< An @ref ncclRelayOp_t value */
+  uint32_t dtype;       /*!< An @ref ncclDataType_t value */
+  uint32_t redOp;       /*!< An @ref ncclRedOp_t value */
+  uint32_t flags;       /*!< Reserved; must be 0 */
+  uint32_t reserved[3]; /*!< Reserved; must be 0 */
+} ncclRelayPlanInfo;
+
+/*! @brief      Publish one forward's relay plan for this node's helper ranks
+    @details    A sharded relay collective is symmetric over the whole
+                communicator: it happens only when every rank's host thread
+                independently enqueues it. But a communicator is a data plane, not
+                a scheduler. Where the helper ranks are separate processes that do
+                not run the model -- no batch, no forward pass, no scheduler --
+                nothing in the communicator can make them post a call, and their
+                buffers are a one-element placeholder the kernel never reads.
+
+                This publishes the two things a helper cannot derive for itself:
+                the resolved per-call counts, and which calls happen at all. Call
+                it ONCE PER FORWARD, ORDERED BEFORE the forward's first
+                ncclShardedRelay* call. That ordering is the whole contract: the
+                decision point is strictly before the collective, because a rank
+                already blocked inside a collective cannot be rescued by anything
+                this function does.
+
+                Exactly one rank of the communicator may publish. Route selection
+                is deliberately absent: it is a pure function of size, so every
+                rank derives the same route from the published counts with zero
+                communication.
+
+                Requires NCCL_SHARDED_RELAY_MODE_ENABLE=1 at communicator
+                creation, which is also the switch for eager one-shot region
+                creation. Returns ncclInvalidArgument if this communicator has no
+                control plane, so callers keep whatever fallback they had.
+
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  comm      Communicator group object to publish on
+    @param[in]  epoch     Monotonic forward counter, shared with the consumers. Explicit rather than internal so a skipped forward is a detectable desync instead of a silent one
+    @param[in]  info      The plan; info->nCalls must not exceed NCCL_RELAY_CONTROL_MAX_CALLS
+    @param[in]  counts    Array of info->nCalls element counts, one per relay call
+    @param[in]  timeoutNs Wait budget in nanoseconds. Only ever consumed if a helper has fallen more than NCCL_RELAY_CONTROL_RING_DEPTH forwards behind, which means it is stuck; the wait exists because dropping a plan would desynchronize the communicator */
+ncclResult_t  ncclRelayControlPublish(
+    ncclComm_t comm, uint64_t epoch,
+    const ncclRelayPlanInfo* info, const size_t* counts, int64_t timeoutNs);
+/*! @cond       include_hidden */
+ncclResult_t pncclRelayControlPublish(
+    ncclComm_t comm, uint64_t epoch,
+    const ncclRelayPlanInfo* info, const size_t* counts, int64_t timeoutNs);
+/*! @endcond */
+
+/*! @brief      Take one forward's relay plan on a helper rank
+    @details    Blocks until the plan for `epoch` is available, then returns the
+                calls to enqueue. The wait is BOUNDED: it spins briefly, backs off,
+                and then fails while setting an abort flag that every other rank
+                observes -- so one stuck rank produces a single attributed cause
+                rather than a hang, or N independent timeouts.
+
+                In steady state this does not wait at all. The active rank runs a
+                forward ahead, so the plan is already published; the per-call
+                rendezvous is handled on the device, where the send/recv pairs
+                inside a relay schedule already block until peers arrive. This
+                function therefore needs to deliver correct program order and
+                arguments, not low-latency wake-up.
+
+                A rank becomes a consumer by calling this. It must do so before the
+                publisher completes NCCL_RELAY_CONTROL_RING_DEPTH forwards, which
+                communicator creation makes free: it is a barrier both sides leave
+                together, and the publisher's first forward costs orders of
+                magnitude more than reaching this call. Violating it returns an
+                error rather than corrupting anything.
+
+    @return     Result code. ncclInvalidArgument if countsCapacity is too small for
+                the published plan, in which case info IS filled in so the caller
+                can see the size it needed in info->nCalls. On any OTHER failure
+                (timeout, a peer abort, no control plane on this communicator)
+                info is left UNCHANGED -- it is not zeroed, because a zeroed
+                record is nCalls 0 with opCode ncclRelayOpShutdown, which is a
+                valid instruction to stop rather than a marker for "no plan".
+                Check the result code before reading info. See @ref
+                rccl_result_code.
+
+    @param[in]  comm           Communicator group object to consume from
+    @param[in]  epoch          Monotonic forward counter, matching the publisher
+    @param[out] info           Receives the plan
+    @param[out] counts         Receives info->nCalls element counts
+    @param[in]  countsCapacity Elements available in counts
+    @param[in]  timeoutNs      Wait budget in nanoseconds before failing */
+ncclResult_t  ncclRelayControlConsume(
+    ncclComm_t comm, uint64_t epoch,
+    ncclRelayPlanInfo* info, size_t* counts, uint32_t countsCapacity,
+    int64_t timeoutNs);
+/*! @cond       include_hidden */
+ncclResult_t pncclRelayControlConsume(
+    ncclComm_t comm, uint64_t epoch,
+    ncclRelayPlanInfo* info, size_t* counts, uint32_t countsCapacity,
+    int64_t timeoutNs);
 /*! @endcond */
 
 /*! @brief      Fused Multi-Group Sharded Relay All-Gather for 2D Sparse Parallelism

--- a/comms/rcclx/develop/projects/rccl/src/rccl.h
+++ b/comms/rcclx/develop/projects/rccl/src/rccl.h
@@ -32,6 +32,7 @@ extern "C" {
 #endif
 
 #include <limits.h>
+#include <stdint.h>
 
 /*! @brief      Opaque handle to communicator
     @details    A communicator contains information required to facilitate collective communications calls */
@@ -789,6 +790,130 @@ ncclResult_t pncclShardedRelayMultiGroupAllToAll(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
     ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
     const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+/*! @endcond */
+
+/*! @brief      Relay operation codes used by @ref ncclRelayPlanInfo */
+typedef enum {
+  ncclRelayOpShutdown     = 0, /*!< Helpers should stop; nCalls is 0 */
+  ncclRelayOpAllReduce    = 1,
+  ncclRelayOpReduceScatter = 2,
+  ncclRelayOpAllGather    = 3,
+  ncclRelayOpAllToAll     = 4
+} ncclRelayOp_t;
+
+/*! @brief      One forward pass worth of sharded-relay plan
+    @details    Fixed 32 bytes with reserved space to grow into. The per-call
+                element counts travel separately, as a caller-owned array, rather
+                than inline. That is what lets this record stay a fixed size while
+                the per-plan call capacity remains a *runtime* parameter
+                (NCCL_RELAY_CONTROL_MAX_CALLS): the number of relay calls in one
+                forward is the chunk count of a chunked prefill, which is
+                deployment configuration rather than a bounded property of the
+                algorithm.
+
+                Publish the decision, not the input. Only the ranks running the
+                model can know whether a given call happens at all -- it depends
+                on contiguity, alignment, compile state and phase -- so the plan
+                carries resolved counts and never a token count for the helper to
+                re-derive. */
+typedef struct {
+  uint32_t nCalls;      /*!< Relay calls in this forward; 0 with ncclRelayOpShutdown means shut down */
+  uint32_t opCode;      /*!< An @ref ncclRelayOp_t value */
+  uint32_t dtype;       /*!< An @ref ncclDataType_t value */
+  uint32_t redOp;       /*!< An @ref ncclRedOp_t value */
+  uint32_t flags;       /*!< Reserved; must be 0 */
+  uint32_t reserved[3]; /*!< Reserved; must be 0 */
+} ncclRelayPlanInfo;
+
+/*! @brief      Publish one forward's relay plan for this node's helper ranks
+    @details    A sharded relay collective is symmetric over the whole
+                communicator: it happens only when every rank's host thread
+                independently enqueues it. But a communicator is a data plane, not
+                a scheduler. Where the helper ranks are separate processes that do
+                not run the model -- no batch, no forward pass, no scheduler --
+                nothing in the communicator can make them post a call, and their
+                buffers are a one-element placeholder the kernel never reads.
+
+                This publishes the two things a helper cannot derive for itself:
+                the resolved per-call counts, and which calls happen at all. Call
+                it ONCE PER FORWARD, ORDERED BEFORE the forward's first
+                ncclShardedRelay* call. That ordering is the whole contract: the
+                decision point is strictly before the collective, because a rank
+                already blocked inside a collective cannot be rescued by anything
+                this function does.
+
+                Exactly one rank of the communicator may publish. Route selection
+                is deliberately absent: it is a pure function of size, so every
+                rank derives the same route from the published counts with zero
+                communication.
+
+                Requires NCCL_SHARDED_RELAY_MODE_ENABLE=1 at communicator
+                creation, which is also the switch for eager one-shot region
+                creation. Returns ncclInvalidArgument if this communicator has no
+                control plane, so callers keep whatever fallback they had.
+
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  comm      Communicator group object to publish on
+    @param[in]  epoch     Monotonic forward counter, shared with the consumers. Explicit rather than internal so a skipped forward is a detectable desync instead of a silent one
+    @param[in]  info      The plan; info->nCalls must not exceed NCCL_RELAY_CONTROL_MAX_CALLS
+    @param[in]  counts    Array of info->nCalls element counts, one per relay call
+    @param[in]  timeoutNs Wait budget in nanoseconds. Only ever consumed if a helper has fallen more than NCCL_RELAY_CONTROL_RING_DEPTH forwards behind, which means it is stuck; the wait exists because dropping a plan would desynchronize the communicator */
+ncclResult_t  ncclRelayControlPublish(
+    ncclComm_t comm, uint64_t epoch,
+    const ncclRelayPlanInfo* info, const size_t* counts, int64_t timeoutNs);
+/*! @cond       include_hidden */
+ncclResult_t pncclRelayControlPublish(
+    ncclComm_t comm, uint64_t epoch,
+    const ncclRelayPlanInfo* info, const size_t* counts, int64_t timeoutNs);
+/*! @endcond */
+
+/*! @brief      Take one forward's relay plan on a helper rank
+    @details    Blocks until the plan for `epoch` is available, then returns the
+                calls to enqueue. The wait is BOUNDED: it spins briefly, backs off,
+                and then fails while setting an abort flag that every other rank
+                observes -- so one stuck rank produces a single attributed cause
+                rather than a hang, or N independent timeouts.
+
+                In steady state this does not wait at all. The active rank runs a
+                forward ahead, so the plan is already published; the per-call
+                rendezvous is handled on the device, where the send/recv pairs
+                inside a relay schedule already block until peers arrive. This
+                function therefore needs to deliver correct program order and
+                arguments, not low-latency wake-up.
+
+                A rank becomes a consumer by calling this. It must do so before the
+                publisher completes NCCL_RELAY_CONTROL_RING_DEPTH forwards, which
+                communicator creation makes free: it is a barrier both sides leave
+                together, and the publisher's first forward costs orders of
+                magnitude more than reaching this call. Violating it returns an
+                error rather than corrupting anything.
+
+    @return     Result code. ncclInvalidArgument if countsCapacity is too small for
+                the published plan, in which case info IS filled in so the caller
+                can see the size it needed in info->nCalls. On any OTHER failure
+                (timeout, a peer abort, no control plane on this communicator)
+                info is left UNCHANGED -- it is not zeroed, because a zeroed
+                record is nCalls 0 with opCode ncclRelayOpShutdown, which is a
+                valid instruction to stop rather than a marker for "no plan".
+                Check the result code before reading info. See @ref
+                rccl_result_code.
+
+    @param[in]  comm           Communicator group object to consume from
+    @param[in]  epoch          Monotonic forward counter, matching the publisher
+    @param[out] info           Receives the plan
+    @param[out] counts         Receives info->nCalls element counts
+    @param[in]  countsCapacity Elements available in counts
+    @param[in]  timeoutNs      Wait budget in nanoseconds before failing */
+ncclResult_t  ncclRelayControlConsume(
+    ncclComm_t comm, uint64_t epoch,
+    ncclRelayPlanInfo* info, size_t* counts, uint32_t countsCapacity,
+    int64_t timeoutNs);
+/*! @cond       include_hidden */
+ncclResult_t pncclRelayControlConsume(
+    ncclComm_t comm, uint64_t epoch,
+    ncclRelayPlanInfo* info, size_t* counts, uint32_t countsCapacity,
+    int64_t timeoutNs);
 /*! @endcond */
 
 /*! @brief      Fused Multi-Group Sharded Relay All-Gather for 2D Sparse Parallelism


### PR DESCRIPTION
Summary:

RelayControlTest covers the protocol in isolation, with forked children standing
in for peers. This covers what that deliberately cannot: the communicator-bound
layer, on a real 8-rank comm, driving real relay collectives.

The shape is the deployment's rather than a convenience:

  ranks 0..nActive-1   ACTIVE     run the model, know the plan
  rank  0              PUBLISHER  the one rank that writes it
  ranks nActive..7     HELPER     know nothing until they consume a plan

A helper here is handed no counts, no opcode and no call count by the test. It
recovers all three from the segment and enqueues collectives on that basis alone.
That is the property under test: if the plan did not arrive intact, a helper's
relay calls would not match its peers' and the collective would hang or corrupt
rather than quietly pass.

Every case runs at both deployment widths -- 4 active + 4 helper and 2 active +
6 helper -- through a parameterised fixture rather than duplicated bodies. The
two select different relay routes, and the 2-active case puts six ranks on the
consume path instead of four, so a bug in how helpers are counted or waited on
shows up in one and not the other. gtest runs cases in a fixed order, so every
rank walks the two configurations in the same sequence; the parameter is never
communicated and never needs to be.

Eight cases at each width: init unanimity across the whole comm; an allreduce
forward driven end to end by a published plan; counts and call count varying
across five forwards; all four collectives; shutdown as an opcode; the
second-publisher rejection; an over-capacity plan; and a publisher that stops,
where the helpers must fail bounded rather than wait forever.

Correctness of the collectives themselves belongs to the four ShardedRelay*
suites, so allreduce is verified numerically as the representative case and the
other three are required to complete -- which for a symmetric collective over 8
ranks already means every rank agreed on counts and route.

Three things this file does deliberately, each of which cost a debugging cycle:

- Every relay call in a plan gets its own buffers. Sharing one pair across the
  calls of a forward is a cross-rank write-after-read -- a rank that finished call
  i racing ahead to overwrite a send buffer a peer is still reading. That is an
  artifact of the test, not of the deployment, where every relay call has its own
  tensor. Sharing produced a real failure: a rank read its own contribution
  instead of the reduced sum.

- The barrier and reduction words are allocated once and never aliased. Doing
  them per call is a hazard rather than a style point: hipFree followed by
  hipMalloc readily returns the SAME device address, so one all-reduce's write --
  not guaranteed to be retired when the host stages the next value -- lands on top
  of that value. This is the flaky "expected X but got 0" mode that
  ShardedRelayAllReduceTest's barrierSyncOn already documents, and it reproduced
  here exactly, as expected-4-got-0 on one rank of eight while the other seven
  agreed on 4.

- No fatal assertions anywhere. ASSERT_* returns from the test body, which on one
  rank of eight leaves the other seven waiting inside a collective that rank will
  never join, so a single-rank control-plane failure presents as an eight-rank
  hang with no attribution instead of a named failure on the rank that caused it.
  An earlier version of this file did exactly that and deadlocked. Every check is
  EXPECT_*, the decision to enter the collectives is taken unanimously through a
  reduction, and loop bounds come from the plan each rank holds locally rather
  than from the consumed copy -- so the number of collectives a rank enters cannot
  diverge from its peers', while whether the consumed copy matched is still
  asserted.

ppn=8 and its own target rather than cases bolted onto an existing suite, because
this needs the helper ranks to be genuinely uninformed, which the other suites'
fixtures do not arrange.

Differential Revision: D117629717
