### PR TITLE
Rename Timeout to AbortDevice in prims/transport/nvl (#3843)

### DIFF
--- a/comms/prims/core/BarrierState.cuh
+++ b/comms/prims/core/BarrierState.cuh
@@ -72,16 +72,17 @@ struct alignas(128) BarrierState {
    * - 2nd wait: expects current_counter >= 2
    * - etc.
    *
-   * Blocking: Spins until the condition is met (or timeout expires).
+   * Blocking: Spins until the condition is met (or abortDevice expires).
    * Warning: Only one thread should call wait() per synchronization round.
    *
-   * @param timeout Optional timeout (default: no timeout, infinite wait)
+   * @param abortDevice Optional abort handle (default: disabled, infinite wait)
    */
-  __device__ __forceinline__ void wait(const Timeout& timeout = Timeout()) {
+  __device__ __forceinline__ void wait(
+      const AbortDevice& abortDevice = AbortDevice()) {
     uint64_t expected = expected_counter_.atomic_fetch_add(1) + 1;
     while (current_counter_.load() < expected) {
       FT_ABORT_BREAK(
-          timeout,
+          abortDevice,
           "BarrierState::wait timed out (expected=%llu, current=%llu)",
           static_cast<unsigned long long>(expected),
           static_cast<unsigned long long>(current_counter_.load()));
@@ -114,15 +115,15 @@ struct alignas(128) BarrierState {
    * barrier before proceeding.
    *
    * @param group ThreadGroup for cooperative synchronization
-   * @param timeout Optional timeout (default: no timeout, infinite wait)
+   * @param abortDevice Optional abort handle (default: disabled, infinite wait)
    *
    * All threads in the group must call this function (collective operation).
    */
   __device__ __forceinline__ void wait(
       ThreadGroup& group,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     if (group.is_leader()) {
-      wait(timeout);
+      wait(abortDevice);
     }
     group.sync();
   }

--- a/comms/prims/core/LLImpl.cuh
+++ b/comms/prims/core/LLImpl.cuh
@@ -33,8 +33,8 @@ template <typename P>
 struct LLImpl {
   using FlagType = typename P::FlagType;
 
-  // Spins between timeout clock reads. A power-of-two minus one so the check
-  // is a mask, not a modulo.
+  // Spins between abortDevice clock reads. A power-of-two minus one so the
+  // check is a mask, not a modulo.
   static constexpr uint32_t kTimeoutPollMask = 1023;
 
   // Replicate the (32-bit) flagVal across a 64-bit flag word, so an 8 B flag
@@ -212,11 +212,11 @@ struct LLImpl {
   /// Wait until every packet covering `nbytes` carries flag == `flagVal`, then
   /// decode its payload into `dst`. Cooperative across `group`; each thread
   /// spins only on the packets it owns.
-  // `timeout` bounds the readiness spin. Unlike Simple, LL's readiness lives in
-  // the payload, so the wait happens HERE rather than in wait_signal -- without
-  // a deadline a lost WQE, a dead peer, or a flagVal desync spins forever and
-  // then holds the whole group at the group.sync() below. Each thread polls
-  // only the packets it owns, so the check is per-thread
+  // `abortDevice` bounds the readiness spin. Unlike Simple, LL's readiness
+  // lives in the payload, so the wait happens HERE rather than in wait_signal
+  // -- without a deadline a lost WQE, a dead peer, or a flagVal desync spins
+  // forever and then holds the whole group at the group.sync() below. Each
+  // thread polls only the packets it owns, so the check is per-thread
   // (FT_ABORT_BREAK) and not the leader-only group form. The
   // clock is read once per kTimeoutPollMask+1 spins: LL is the latency path,
   // and a clock64() on every poll is a measurable cost on a hot loop.
@@ -232,7 +232,7 @@ struct LLImpl {
       const void* staging,
       std::size_t nbytes,
       FlagType flagVal,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
 #ifdef __CUDA_ARCH__
     const std::size_t nPackets = P::packet_count(nbytes);
     const auto* base = reinterpret_cast<const char*>(staging);
@@ -249,7 +249,7 @@ struct LLImpl {
         // single abort-aware spin loop in this file.
         bool abandoned = false;
         const uint32_t data =
-            load_ready_payload(pkt, flagVal, timeout, abandoned);
+            load_ready_payload(pkt, flagVal, abortDevice, abandoned);
         // Leaves the packet loop as well: load_ready_payload only exits its own
         // spin. `dst` is undefined from here, which the abort contract permits.
         if (abandoned) {
@@ -270,7 +270,7 @@ struct LLImpl {
           // Spin until this packet's flag reaches the current flagVal.
           if ((++spins & kTimeoutPollMask) == 0) {
             FT_ABORT_BREAK(
-                timeout,
+                abortDevice,
                 "LLImpl::unpack waiting for LL flag %u on packet %llu",
                 (unsigned)flagVal,
                 (unsigned long long)i);
@@ -278,7 +278,7 @@ struct LLImpl {
         }
         if (spins >= kTimeoutPollMask) {
           FT_ABORT_BREAK(
-              timeout,
+              abortDevice,
               "LLImpl::unpack abandoning decode at packet %llu",
               (unsigned long long)i);
         }
@@ -324,7 +324,7 @@ struct LLImpl {
   __device__ __forceinline__ static uint32_t load_ready_payload(
       const char* pkt,
       FlagType flagVal,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       bool& abandoned) {
 #ifdef __CUDA_ARCH__
     const auto* p = reinterpret_cast<const volatile uint64_t*>(pkt);
@@ -337,7 +337,7 @@ struct LLImpl {
         // unwind, not kill the CUDA context from inside LL decode. CHECK rather
         // than BREAK so the flag can be raised before leaving the spin.
         if (FT_ABORT_CHECK(
-                timeout,
+                abortDevice,
                 "LLImpl::load_ready_payload waiting for LL flag %u",
                 (unsigned)flagVal)) {
           abandoned = true;
@@ -350,7 +350,7 @@ struct LLImpl {
 #else
     (void)pkt;
     (void)flagVal;
-    (void)timeout;
+    (void)abortDevice;
     (void)abandoned;
     return 0;
 #endif
@@ -392,7 +392,7 @@ struct LLImpl {
       const void* staging,
       std::size_t nbytes,
       FlagType flagVal,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
 #ifdef __CUDA_ARCH__
     constexpr std::size_t kData = static_cast<std::size_t>(P::kData);
     constexpr std::size_t kPacket = static_cast<std::size_t>(P::kPacketBytes);
@@ -404,8 +404,8 @@ struct LLImpl {
       for (std::size_t i = group.thread_id_in_group; i < nPackets;
            i += group.group_size) {
         bool abandoned = false;
-        const uint32_t data =
-            load_ready_payload(base + i * kPacket, flagVal, timeout, abandoned);
+        const uint32_t data = load_ready_payload(
+            base + i * kPacket, flagVal, abortDevice, abandoned);
         // `accum` is undefined from here, which the abort contract permits.
         if (abandoned) {
           break;
@@ -450,7 +450,7 @@ struct LLImpl {
           const uint32_t word = load_ready_payload(
               base + (e * kPacketsPerElem + k) * kPacket,
               flagVal,
-              timeout,
+              abortDevice,
               abandoned);
           if (abandoned) {
             break;
@@ -477,7 +477,7 @@ struct LLImpl {
     (void)staging;
     (void)nbytes;
     (void)flagVal;
-    (void)timeout;
+    (void)abortDevice;
 #endif
   }
 };

--- a/comms/prims/core/MemcpyCopyOp.cuh
+++ b/comms/prims/core/MemcpyCopyOp.cuh
@@ -85,9 +85,10 @@ struct Memcpy {
   }
 
   template <typename P, typename... Args>
-  // Takes a Timeout where recv()/sendLL() do not: LL's readiness wait happens
-  // inside the codec (the flag is in the payload), so this is the one hook that
-  // can block indefinitely and therefore the one that needs a deadline.
+  // Takes an AbortDevice where recv()/sendLL() do not: LL's readiness wait
+  // happens inside the codec (the flag is in the payload), so this is the one
+  // hook that can block indefinitely and therefore the one that needs a
+  // deadline.
   __device__ __forceinline__ static void recvLL(
       ThreadGroup& group,
       char* dst,
@@ -95,9 +96,9 @@ struct Memcpy {
       std::size_t nbytes,
       std::size_t /*byte_offset*/,
       typename P::FlagType flagVal,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       Args...) {
-    LLImpl<P>::unpack(group, dst, staging, nbytes, flagVal, timeout);
+    LLImpl<P>::unpack(group, dst, staging, nbytes, flagVal, abortDevice);
   }
 };
 
@@ -133,6 +134,6 @@ inline constexpr bool has_recvLL_v<
         std::declval<std::size_t>(),
         std::declval<std::size_t>(),
         std::declval<typename P::FlagType>(),
-        std::declval<const Timeout&>()))>> = true;
+        std::declval<const AbortDevice&>()))>> = true;
 
 } // namespace comms::prims

--- a/comms/prims/core/SignalState.cuh
+++ b/comms/prims/core/SignalState.cuh
@@ -180,15 +180,17 @@ struct alignas(128) SignalState {
    *
    * @param op The comparison operation (CMP_EQ, CMP_GT, CMP_LT, CMP_GE, etc.)
    * @param expected The expected value to compare against
-   * @param timeout Timeout config (default: no timeout)
+   * @param abortDevice Abort handle (default: disabled, infinite wait)
    */
-  __device__ __forceinline__ void
-  wait_until(CmpOp op, uint64_t expected, const Timeout& timeout = Timeout()) {
+  __device__ __forceinline__ void wait_until(
+      CmpOp op,
+      uint64_t expected,
+      const AbortDevice& abortDevice = AbortDevice()) {
     switch (op) {
       case CmpOp::CMP_EQ:
         while (load() != expected) {
           FT_ABORT_BREAK(
-              timeout,
+              abortDevice,
               "SignalState::wait_until waiting for signal %s %llu "
               "(current=%llu)",
               cmpOpToString(op),
@@ -199,7 +201,7 @@ struct alignas(128) SignalState {
       case CmpOp::CMP_GT:
         while (load() <= expected) {
           FT_ABORT_BREAK(
-              timeout,
+              abortDevice,
               "SignalState::wait_until waiting for signal %s %llu "
               "(current=%llu)",
               cmpOpToString(op),
@@ -210,7 +212,7 @@ struct alignas(128) SignalState {
       case CmpOp::CMP_LT:
         while (load() >= expected) {
           FT_ABORT_BREAK(
-              timeout,
+              abortDevice,
               "SignalState::wait_until waiting for signal %s %llu "
               "(current=%llu)",
               cmpOpToString(op),
@@ -221,7 +223,7 @@ struct alignas(128) SignalState {
       case CmpOp::CMP_GE:
         while (load() < expected) {
           FT_ABORT_BREAK(
-              timeout,
+              abortDevice,
               "SignalState::wait_until waiting for signal %s %llu "
               "(current=%llu)",
               cmpOpToString(op),
@@ -232,7 +234,7 @@ struct alignas(128) SignalState {
       case CmpOp::CMP_LE:
         while (load() > expected) {
           FT_ABORT_BREAK(
-              timeout,
+              abortDevice,
               "SignalState::wait_until waiting for signal %s %llu "
               "(current=%llu)",
               cmpOpToString(op),
@@ -243,7 +245,7 @@ struct alignas(128) SignalState {
       case CmpOp::CMP_NE:
         while (load() == expected) {
           FT_ABORT_BREAK(
-              timeout,
+              abortDevice,
               "SignalState::wait_until waiting for signal %s %llu "
               "(current=%llu)",
               cmpOpToString(op),
@@ -292,14 +294,14 @@ struct alignas(128) SignalState {
    * @param group ThreadGroup for cooperative processing
    * @param op The comparison operation (CMP_EQ, CMP_GE, etc.)
    * @param expected The expected value to compare against
-   * @param timeout Timeout config (default: no timeout)
+   * @param abortDevice Abort handle (default: disabled, infinite wait)
    */
   __device__ __forceinline__ void wait_until(
       ThreadGroup& group,
       CmpOp op,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
-    wait_until(op, expected, timeout);
+      const AbortDevice& abortDevice = AbortDevice()) {
+    wait_until(op, expected, abortDevice);
   }
 };
 

--- a/comms/prims/transport/nvl/MultimemNvlSignal.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlSignal.cuh
@@ -8,7 +8,6 @@
 
 #include "comms/common/fault_tolerance/AbortMacros.cuh"
 #include "comms/prims/core/ThreadGroup.cuh"
-#include "comms/prims/core/Timeout.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
 
 namespace comms::prims {
@@ -192,10 +191,10 @@ __device__ __forceinline__ void validate_protocol() {
 __device__ __forceinline__ void wait_until_reached(
     const SignalState& signal,
     uint64_t expected,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   while (!sequence_reached(signal.load(), expected)) {
     if (FT_ABORT_CHECK(
-            timeout,
+            abortDevice,
             "NVL signal wait for sequence=%llu",
             static_cast<unsigned long long>(expected))) {
       FT_DEVICE_TRAP();
@@ -342,7 +341,7 @@ __device__ __forceinline__ void wait_per_peer_all(
     const StageRound& round,
     const NvlSignalParticipants& participants,
     ThreadGroup& group,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   const int source = static_cast<int>(group.thread_id_in_group);
   if (source < transport.nvlRanks &&
       rank_selected(participants.publisherMask, source)) {
@@ -350,7 +349,7 @@ __device__ __forceinline__ void wait_per_peer_all(
         transport.internalLocalSignals[peer_signal_id<phase>(
             transport, round, source)],
         round.value,
-        timeout);
+        abortDevice);
   }
   group.sync();
 }
@@ -361,7 +360,7 @@ __device__ __forceinline__ void wait_per_peer_serial(
     const StageRound& round,
     const NvlSignalParticipants& participants,
     ThreadGroup& group,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   if (group.is_leader()) {
     bool complete = false;
     while (!complete) {
@@ -379,7 +378,7 @@ __device__ __forceinline__ void wait_per_peer_serial(
       }
       if (!complete) {
         if (FT_ABORT_CHECK(
-                timeout,
+                abortDevice,
                 "NVL serial per-peer wait for round=%llu",
                 static_cast<unsigned long long>(round.value))) {
           FT_DEVICE_TRAP();
@@ -396,7 +395,7 @@ __device__ __forceinline__ void wait_per_peer_tree(
     const StageRound& round,
     const NvlSignalParticipants& participants,
     ThreadGroup& group,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   __shared__ uint32_t completeByThread[kMaxNvlSignalPerPeerThreads];
   const uint32_t thread = group.thread_id_in_group;
   bool complete = false;
@@ -421,7 +420,7 @@ __device__ __forceinline__ void wait_per_peer_tree(
     complete = completeByThread[0] != 0;
     if (!complete && group.is_leader()) {
       if (FT_ABORT_CHECK(
-              timeout,
+              abortDevice,
               "NVL tree per-peer wait for round=%llu",
               static_cast<unsigned long long>(round.value))) {
         FT_DEVICE_TRAP();
@@ -437,7 +436,7 @@ __device__ __forceinline__ void wait_per_peer_butterfly(
     const StageRound& round,
     const NvlSignalParticipants& participants,
     ThreadGroup& group,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   __shared__ uint32_t completeByWarp[kMaxNvlSignalPerPeerWarps];
   const uint32_t thread = group.thread_id_in_group;
   const uint32_t lane = thread % kWarpSize;
@@ -469,7 +468,7 @@ __device__ __forceinline__ void wait_per_peer_butterfly(
     }
     if (!complete && group.is_leader()) {
       if (FT_ABORT_CHECK(
-              timeout,
+              abortDevice,
               "NVL butterfly per-peer wait for round=%llu",
               static_cast<unsigned long long>(round.value))) {
         FT_DEVICE_TRAP();
@@ -637,14 +636,14 @@ __device__ __forceinline__ void signal_publish(
 /**
  * Waits for the selected publishers on every selected waiter rank.
  *
- * A caller that enables timeout checking must call `Timeout::start()` before
- * this function.
+ * A caller that enables abortDevice checking must call `Timeout::start()`
+ * before this function.
  *
  * @param transport Exchanged multimem transport device view.
  * @param round Logical channel and per-peer round value.
  * @param participants Rank masks and expected arrival count.
  * @param group Topology-specific cooperative thread group.
- * @param timeout Started timeout or the disabled default timeout.
+ * @param abortDevice Started abortDevice or the disabled default abortDevice.
  */
 namespace nvl_signal_detail {
 
@@ -658,7 +657,7 @@ __device__ __forceinline__ void signal_wait_impl(
     const StageRound& round,
     const NvlSignalParticipants& participants,
     ThreadGroup& group,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   nvl_signal_detail::validate_protocol<access, topology, phase, waitPolicy>();
   nvl_signal_detail::validate_common(transport, round, participants);
   if constexpr (topology == NvlSignalTopology::Aggregate) {
@@ -679,7 +678,7 @@ __device__ __forceinline__ void signal_wait_impl(
       const uint64_t expected =
           epoch->load() + static_cast<uint64_t>(participants.expectedArrivals);
       if (isWaiter) {
-        nvl_signal_detail::wait_until_reached(*counter, expected, timeout);
+        nvl_signal_detail::wait_until_reached(*counter, expected, abortDevice);
       }
       if constexpr (access == NvlSignalAccess::Multimem) {
         epoch->store(expected);
@@ -692,16 +691,16 @@ __device__ __forceinline__ void signal_wait_impl(
     return;
   } else if constexpr (waitPolicy == NvlPerPeerWaitPolicy::WaitAll) {
     nvl_signal_detail::wait_per_peer_all<phase>(
-        transport, round, participants, group, timeout);
+        transport, round, participants, group, abortDevice);
   } else if constexpr (waitPolicy == NvlPerPeerWaitPolicy::SerialMin) {
     nvl_signal_detail::wait_per_peer_serial<phase>(
-        transport, round, participants, group, timeout);
+        transport, round, participants, group, abortDevice);
   } else if constexpr (waitPolicy == NvlPerPeerWaitPolicy::TreeMin) {
     nvl_signal_detail::wait_per_peer_tree<phase>(
-        transport, round, participants, group, timeout);
+        transport, round, participants, group, abortDevice);
   } else {
     nvl_signal_detail::wait_per_peer_butterfly<phase>(
-        transport, round, participants, group, timeout);
+        transport, round, participants, group, abortDevice);
   }
   (void)access;
 }
@@ -719,13 +718,13 @@ __device__ __forceinline__ void signal_wait(
     const StageRound& round,
     const NvlSignalParticipants& participants,
     ThreadGroup& group,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   static_assert(
       access != NvlSignalAccess::Multimem ||
           topology != NvlSignalTopology::Aggregate,
       "aggregate multimem requires signal_publish_and_wait on every rank");
   nvl_signal_detail::signal_wait_impl<access, topology, phase, waitPolicy>(
-      transport, round, participants, group, timeout);
+      transport, round, participants, group, abortDevice);
 }
 
 /**
@@ -735,7 +734,7 @@ __device__ __forceinline__ void signal_wait(
  * @param round Logical channel and per-peer round value.
  * @param participants Rank masks and expected arrival count.
  * @param group Topology-specific cooperative thread group.
- * @param timeout Started timeout or the disabled default timeout.
+ * @param abortDevice Started abortDevice or the disabled default abortDevice.
  */
 template <
     NvlSignalAccess access,
@@ -747,11 +746,11 @@ __device__ __forceinline__ void signal_publish_and_wait(
     const StageRound& round,
     const NvlSignalParticipants& participants,
     ThreadGroup& group,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   nvl_signal_detail::signal_publish_impl<access, topology, phase, waitPolicy>(
       transport, round, participants, group);
   nvl_signal_detail::signal_wait_impl<access, topology, phase, waitPolicy>(
-      transport, round, participants, group, timeout);
+      transport, round, participants, group, abortDevice);
 }
 
 } // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -109,8 +109,9 @@ struct MultimemNvlTransportDevice {
       uint64_t signal_id,
       CmpOp op,
       uint64_t expected,
-      const AbortDevice& timeout = AbortDevice()) const {
-    user_local_signal_ptr(signal_id)->wait_until(group, op, expected, timeout);
+      const AbortDevice& abortDevice = AbortDevice()) const {
+    user_local_signal_ptr(signal_id)->wait_until(
+        group, op, expected, abortDevice);
   }
 
   __device__ __forceinline__ void signal_internal(
@@ -154,9 +155,9 @@ struct MultimemNvlTransportDevice {
       uint64_t signal_id,
       CmpOp op,
       uint64_t expected,
-      const AbortDevice& timeout = AbortDevice()) const {
+      const AbortDevice& abortDevice = AbortDevice()) const {
     internal_local_signal_ptr(signal_id)->wait_until(
-        group, op, expected, timeout);
+        group, op, expected, abortDevice);
   }
 
  private:

--- a/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
@@ -291,8 +291,9 @@ class P2pNvlTransportDevice {
       uint64_t signal_id,
       CmpOp op,
       uint64_t value,
-      const Timeout& timeout = Timeout()) {
-    localState_.signalBuffer[signal_id].wait_until(group, op, value, timeout);
+      const AbortDevice& abortDevice = AbortDevice()) {
+    localState_.signalBuffer[signal_id].wait_until(
+        group, op, value, abortDevice);
   }
 
   /**
@@ -341,7 +342,7 @@ class P2pNvlTransportDevice {
   __device__ __forceinline__ void barrier_sync(
       ThreadGroup& group,
       uint64_t barrier_id,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     // Ensure all prior memory operations are complete
     group.sync();
 
@@ -352,7 +353,7 @@ class P2pNvlTransportDevice {
       remoteState_.barrierBuffer[barrier_id].arrive();
 
       // Wait for peer - poll local barrier state until peer signals
-      localState_.barrierBuffer[barrier_id].wait(timeout);
+      localState_.barrierBuffer[barrier_id].wait(abortDevice);
     }
 
     // Ensure all threads wait for leader to complete barrier
@@ -374,13 +375,13 @@ class P2pNvlTransportDevice {
    * @param group   ThreadGroup (auto-converted to warp scope)
    * @param src     Local source buffer (16-byte aligned)
    * @param nbytes  Total bytes (must be a multiple of 16)
-   * @param timeout Timeout for flag polling
+   * @param abortDevice Timeout for flag polling
    */
   __device__ __forceinline__ void ll128_send_group(
       const ThreadGroup& group,
       const char* src,
       size_t nbytes,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
 #if PIPES_IS_DEVICE_COMPILE
     PIPES_DEVICE_CHECK(remoteState_.ll128Buffer != nullptr);
     PIPES_DEVICE_CHECK(can_use_ll128(src, nbytes));
@@ -390,7 +391,7 @@ class P2pNvlTransportDevice {
         src,
         nbytes,
         remoteState_.ll128Buffer,
-        timeout,
+        abortDevice,
         options_.ll128BufferNumPackets);
 #endif
   }
@@ -406,13 +407,13 @@ class P2pNvlTransportDevice {
    * @param group   ThreadGroup (auto-converted to warp scope)
    * @param dst     Local output buffer (16-byte aligned)
    * @param nbytes  Total bytes (must be a multiple of 16)
-   * @param timeout Timeout for flag polling
+   * @param abortDevice Timeout for flag polling
    */
   __device__ __forceinline__ void ll128_recv_group(
       const ThreadGroup& group,
       char* dst,
       size_t nbytes,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
 #if PIPES_IS_DEVICE_COMPILE
     PIPES_DEVICE_CHECK(localState_.ll128Buffer != nullptr);
     PIPES_DEVICE_CHECK(can_use_ll128(dst, nbytes));
@@ -422,7 +423,7 @@ class P2pNvlTransportDevice {
         dst,
         nbytes,
         localState_.ll128Buffer,
-        timeout,
+        abortDevice,
         options_.ll128BufferNumPackets);
 #endif
   }
@@ -440,14 +441,14 @@ class P2pNvlTransportDevice {
    * @param dst                  Local output buffer (16-byte aligned)
    * @param nbytes               Total bytes (must be a multiple of 16)
    * @param successor_transport  Transport for the successor peer
-   * @param timeout              Timeout for flag polling
+   * @param abortDevice              Timeout for flag polling
    */
   __device__ __forceinline__ void ll128_forward_group(
       const ThreadGroup& group,
       char* dst,
       size_t nbytes,
       const P2pNvlTransportDevice& successor_transport,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
 #if PIPES_IS_DEVICE_COMPILE
     PIPES_DEVICE_CHECK(localState_.ll128Buffer != nullptr);
     PIPES_DEVICE_CHECK(successor_transport.remoteState_.ll128Buffer != nullptr);
@@ -474,7 +475,7 @@ class P2pNvlTransportDevice {
         nbytes,
         localState_.ll128Buffer,
         successor_transport.remoteState_.ll128Buffer,
-        timeout,
+        abortDevice,
         effective_packets);
 #endif
   }
@@ -494,7 +495,7 @@ class P2pNvlTransportDevice {
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
 #if PIPES_IS_DEVICE_COMPILE
     if (nbytes == 0) {
       return;
@@ -536,13 +537,13 @@ class P2pNvlTransportDevice {
             group,
             CmpOp::CMP_GE,
             protocolStreamEnd - layout.pipelineBytes,
-            timeout);
+            abortDevice);
       }
       // Leave before the staging write and the DATA_READY signal below. The
       // backpressure wait gave up, so the slot may still hold data the receiver
       // has not consumed; worse, signalling DATA_READY would release a receiver
       // that is correctly blocked and prevent it reaching its own deadline.
-      if (groupAborted(group, timeout)) {
+      if (groupAborted(group, abortDevice)) {
         break;
       }
 
@@ -576,7 +577,7 @@ class P2pNvlTransportDevice {
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      [[maybe_unused]] const Timeout& timeout = Timeout(),
+      [[maybe_unused]] const AbortDevice& abortDevice = AbortDevice(),
       [[maybe_unused]] Args... args) {
 #if PIPES_IS_DEVICE_COMPILE
     if (nbytes == 0) {
@@ -614,13 +615,14 @@ class P2pNvlTransportDevice {
       const uint64_t protocolStreamEnd =
           streamEnd + (isFinalChunk ? protocolTailPadding : 0);
 
-      local_ch.data_ready.wait_until(group, CmpOp::CMP_GE, streamEnd, timeout);
+      local_ch.data_ready.wait_until(
+          group, CmpOp::CMP_GE, streamEnd, abortDevice);
       // The wait above gave up rather than being satisfied, so this chunk was
       // never written. Leave before the copy and, critically, before the
       // SLOT_FREE credit below: signalling it would tell the sender we consumed
       // a chunk it never sent, releasing a peer that is correctly blocked and
       // stopping it from ever reaching its own deadline.
-      if (groupAborted(group, timeout)) {
+      if (groupAborted(group, abortDevice)) {
         break;
       }
 
@@ -683,7 +685,7 @@ class P2pNvlTransportDevice {
       std::size_t nbytes,
       P2pNvlTransportDevice& successor,
       std::size_t max_signal_bytes = 0,
-      [[maybe_unused]] const Timeout& timeout = Timeout(),
+      [[maybe_unused]] const AbortDevice& abortDevice = AbortDevice(),
       [[maybe_unused]] Args... args) {
 #if PIPES_IS_DEVICE_COMPILE
     if (nbytes == 0) {
@@ -748,7 +750,7 @@ class P2pNvlTransportDevice {
 
       // 1. Wait for predecessor data to be ready (recv side, every step).
       recv_local_ch.data_ready.wait_until(
-          group, CmpOp::CMP_GE, recvStreamEnd, timeout);
+          group, CmpOp::CMP_GE, recvStreamEnd, abortDevice);
 
       // 2. Wait for successor's staging slot to be free once we have wrapped
       //    around the pipeline.
@@ -757,7 +759,7 @@ class P2pNvlTransportDevice {
             group,
             CmpOp::CMP_GE,
             sendProtocolStreamEnd - layout.pipelineBytes,
-            timeout);
+            abortDevice);
       }
 
       // Either wait may have given up. Leave before the copy and before both
@@ -766,7 +768,7 @@ class P2pNvlTransportDevice {
       // *and* ACK the predecessor for a chunk we never consumed, releasing two
       // correctly-blocked peers and stopping both from reaching their own
       // deadlines.
-      if (groupAborted(group, timeout)) {
+      if (groupAborted(group, abortDevice)) {
         break;
       }
 
@@ -849,14 +851,14 @@ class P2pNvlTransportDevice {
    * @param active_groups Number of groups calling concurrently.
    *   0 = default to max groups the LL buffer can support.
    *   >0 = explicit group count; buffer partitioned per group.group_id.
-   * @param timeout       Timeout for flag polling
+   * @param abortDevice       Timeout for flag polling
    */
   __device__ __forceinline__ void ll_send(
       const ThreadGroup& group,
       const char* src,
       size_t nbytes,
       int active_groups = 0,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
 #ifdef __CUDA_ARCH__ // NVIDIA-only: depends on ll_send/ll_recv/ll128_* not yet
                      // ported to AMD
     PIPES_DEVICE_CHECK(remoteState_.llBuffer != nullptr);
@@ -882,14 +884,14 @@ class P2pNvlTransportDevice {
         src,
         nbytes,
         remoteState_.llBuffer + bufferOffset,
-        timeout,
+        abortDevice,
         perGroupLines);
 #else
     (void)group;
     (void)src;
     (void)nbytes;
     (void)active_groups;
-    (void)timeout;
+    (void)abortDevice;
 #endif
   }
 
@@ -907,14 +909,14 @@ class P2pNvlTransportDevice {
    * @param active_groups Number of groups calling concurrently.
    *   0 = default to max groups the LL buffer can support.
    *   >0 = explicit group count; buffer partitioned per group.group_id.
-   * @param timeout       Timeout for flag polling
+   * @param abortDevice       Timeout for flag polling
    */
   __device__ __forceinline__ void ll_recv(
       const ThreadGroup& group,
       char* dst,
       size_t nbytes,
       int active_groups = 0,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
 #ifdef __CUDA_ARCH__ // NVIDIA-only: depends on ll_send/ll_recv/ll128_* not yet
                      // ported to AMD
     PIPES_DEVICE_CHECK(localState_.llBuffer != nullptr);
@@ -940,14 +942,14 @@ class P2pNvlTransportDevice {
         dst,
         nbytes,
         localState_.llBuffer + bufferOffset,
-        timeout,
+        abortDevice,
         perGroupLines);
 #else
     (void)group;
     (void)dst;
     (void)nbytes;
     (void)active_groups;
-    (void)timeout;
+    (void)abortDevice;
 #endif
   }
 
@@ -967,7 +969,7 @@ class P2pNvlTransportDevice {
    * @param active_groups        Number of groups calling concurrently.
    *   0 = default to max groups the LL buffer can support.
    *   >0 = explicit group count; buffer partitioned per group.group_id.
-   * @param timeout              Timeout for flag polling
+   * @param abortDevice              Timeout for flag polling
    */
   __device__ __forceinline__ void ll_forward(
       const ThreadGroup& group,
@@ -975,7 +977,7 @@ class P2pNvlTransportDevice {
       size_t nbytes,
       const P2pNvlTransportDevice& successor_transport,
       int active_groups = 0,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
 #ifdef __CUDA_ARCH__ // NVIDIA-only: depends on ll_send/ll_recv/ll128_* not yet
                      // ported to AMD
     PIPES_DEVICE_CHECK(localState_.llBuffer != nullptr);
@@ -1028,7 +1030,7 @@ class P2pNvlTransportDevice {
         nbytes,
         localState_.llBuffer + myOffset,
         successor_transport.remoteState_.llBuffer + succOffset,
-        timeout,
+        abortDevice,
         effectiveLines);
 #else
     (void)group;
@@ -1036,7 +1038,7 @@ class P2pNvlTransportDevice {
     (void)nbytes;
     (void)successor_transport;
     (void)active_groups;
-    (void)timeout;
+    (void)abortDevice;
 #endif
   }
 

--- a/comms/prims/window/DeviceWindow.cuh
+++ b/comms/prims/window/DeviceWindow.cuh
@@ -524,20 +524,20 @@ class DeviceWindow {
    *
    * Thread-level API: any single thread may call this independently.
    * The caller spins on the inbox slot until the comparison is satisfied
-   * or the timeout expires.
+   * or the abortDevice expires.
    *
    * @param source_rank  Rank to wait on (must not be self).
    * @param signal_id    Signal slot index in [0, peerSignalCount).
    * @param cmp          Comparison operator (CMP_GE, CMP_EQ, etc.).
    * @param value        Threshold value for comparison.
-   * @param timeout      Optional timeout (traps on expiry).
+   * @param abortDevice      Optional abort handle (traps on expiry).
    */
   __device__ __forceinline__ void wait_signal_from(
       int source_rank,
       int signal_id,
       CmpOp cmp,
       uint64_t value,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     DEVICE_WINDOW_CHECK_RANK(source_rank, handle_.nRanks);
     DEVICE_WINDOW_CHECK_NOT_SELF(source_rank, handle_.myRank);
     DEVICE_WINDOW_CHECK_SIGNAL_ID(signal_id, peerSignalCount_);
@@ -546,7 +546,7 @@ class DeviceWindow {
       int slot = nvlIdx * peerSignalCount_ + signal_id;
       while (!compare(nvlPeerSignalInbox_[slot].load(), cmp, value)) {
         FT_ABORT_BREAK(
-            timeout,
+            abortDevice,
             "DeviceWindow::wait_signal_from(source_rank=%d,"
             " signal_id=%d, value=%llu) rank=%d",
             source_rank,
@@ -561,7 +561,7 @@ class DeviceWindow {
       volatile uint64_t* sig = &ibgdaPeerSignalInbox_[slot];
       while (!compare(*sig, cmp, value)) {
         FT_ABORT_BREAK(
-            timeout,
+            abortDevice,
             "DeviceWindow::wait_signal_from(source_rank=%d,"
             " signal_id=%d, value=%llu) rank=%d",
             source_rank,
@@ -585,7 +585,7 @@ class DeviceWindow {
    * @param signal_id    Signal slot index in [0, peerSignalCount).
    * @param cmp          Comparison operator (CMP_GE, CMP_EQ, etc.).
    * @param value        Threshold value for comparison.
-   * @param timeout      Optional timeout (traps on expiry).
+   * @param abortDevice      Optional abort handle (traps on expiry).
    */
   __device__ __forceinline__ void wait_signal_from(
       ThreadGroup& group,
@@ -593,9 +593,9 @@ class DeviceWindow {
       int signal_id,
       CmpOp cmp,
       uint64_t value,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     if (group.is_leader()) {
-      wait_signal_from(source_rank, signal_id, cmp, value, timeout);
+      wait_signal_from(source_rank, signal_id, cmp, value, abortDevice);
     }
     group.sync();
   }
@@ -613,14 +613,14 @@ class DeviceWindow {
    * @param signal_id  Signal slot index in [0, peerSignalCount).
    * @param cmp        Comparison operator (CMP_GE, CMP_EQ, etc.).
    * @param value      Threshold value for the aggregate sum.
-   * @param timeout    Optional timeout (traps on expiry).
+   * @param abortDevice    Optional abort handle (traps on expiry).
    */
   __device__ __forceinline__ void wait_signal(
       ThreadGroup& group,
       int signal_id,
       CmpOp cmp,
       uint64_t value,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     DEVICE_WINDOW_CHECK_SIGNAL_ID(signal_id, peerSignalCount_);
     if (group.is_leader()) {
       int nPeers = num_peers();
@@ -644,7 +644,7 @@ class DeviceWindow {
           break;
         }
         FT_ABORT_BREAK(
-            timeout,
+            abortDevice,
             "DeviceWindow::wait_signal(signal_id=%d, value=%llu)"
             " rank=%d",
             signal_id,
@@ -726,14 +726,14 @@ class DeviceWindow {
    * @param counter_id  Counter slot index.
    * @param cmp         Comparison operator.
    * @param value       Threshold value for comparison.
-   * @param timeout     Optional timeout (traps on expiry).
+   * @param abortDevice     Optional abort handle (traps on expiry).
    */
   __device__ __forceinline__ void wait_counter(
       int peer_rank,
       int counter_id,
       CmpOp cmp,
       uint64_t value,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     DEVICE_WINDOW_CHECK_RANK(peer_rank, handle_.nRanks);
     DEVICE_WINDOW_CHECK_NOT_SELF(peer_rank, handle_.myRank);
     // Counter operations are IB-only; no-op for NVL peers
@@ -745,7 +745,7 @@ class DeviceWindow {
     auto ib = handle_.get_ib(peer_rank);
     while (!compare(ib.read_counter(counterSlotBuf), cmp, value)) {
       FT_ABORT_BREAK(
-          timeout,
+          abortDevice,
           "DeviceWindow::wait_counter(peer_rank=%d,"
           " counter_id=%d, value=%llu) rank=%d",
           peer_rank,
@@ -768,7 +768,7 @@ class DeviceWindow {
    * @param counter_id  Counter slot index.
    * @param cmp         Comparison operator.
    * @param value       Threshold value for comparison.
-   * @param timeout     Optional timeout (traps on expiry).
+   * @param abortDevice     Optional abort handle (traps on expiry).
    */
   __device__ __forceinline__ void wait_counter(
       ThreadGroup& group,
@@ -776,9 +776,9 @@ class DeviceWindow {
       int counter_id,
       CmpOp cmp,
       uint64_t value,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     if (group.is_leader()) {
-      wait_counter(peer_rank, counter_id, cmp, value, timeout);
+      wait_counter(peer_rank, counter_id, cmp, value, abortDevice);
     }
     group.sync();
   }
@@ -841,12 +841,12 @@ class DeviceWindow {
    *
    * @param group       ThreadGroup for group coordination.
    * @param barrier_id  Barrier slot index.
-   * @param timeout     Optional timeout (traps on expiry).
+   * @param abortDevice     Optional abort handle (traps on expiry).
    */
   __device__ __forceinline__ void barrier(
       ThreadGroup& group,
       int barrier_id,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     barrier_arrive(group, barrier_id);
     // Only one thread updates barrierExpected_ to avoid races when
     // DeviceWindow is accessed via pointer (shared mutable state).
@@ -856,7 +856,8 @@ class DeviceWindow {
     // Broadcast the updated value to all threads via group sync so
     // barrier_wait sees a consistent threshold.
     group.sync();
-    barrier_wait(group, barrier_id, CmpOp::CMP_GE, barrierExpected_, timeout);
+    barrier_wait(
+        group, barrier_id, CmpOp::CMP_GE, barrierExpected_, abortDevice);
   }
 
   /**
@@ -868,19 +869,20 @@ class DeviceWindow {
    * @param target_rank  Peer rank to barrier with (must not be self).
    * @param group        ThreadGroup for group coordination.
    * @param barrier_id   Barrier slot index.
-   * @param timeout      Optional timeout (traps on expiry).
+   * @param abortDevice      Optional abort handle (traps on expiry).
    */
   __device__ __forceinline__ void barrier_peer(
       int target_rank,
       ThreadGroup& group,
       int barrier_id,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     barrier_arrive_peer(group, target_rank, barrier_id);
     if (group.is_leader()) {
       barrierExpected_ += 1;
     }
     group.sync();
-    barrier_wait(group, barrier_id, CmpOp::CMP_GE, barrierExpected_, timeout);
+    barrier_wait(
+        group, barrier_id, CmpOp::CMP_GE, barrierExpected_, abortDevice);
   }
 
   /**
@@ -958,14 +960,14 @@ class DeviceWindow {
    * @param barrier_id  Barrier slot index.
    * @param cmp         Comparison operator.
    * @param value       Threshold value for comparison.
-   * @param timeout     Optional timeout (traps on expiry).
+   * @param abortDevice     Optional abort handle (traps on expiry).
    */
   __device__ __forceinline__ void barrier_wait(
       ThreadGroup& group,
       int barrier_id,
       CmpOp cmp,
       uint64_t value,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     DEVICE_WINDOW_CHECK_BARRIER_ID(barrier_id, barrierCount_);
     if (group.is_leader()) {
       while (true) {
@@ -982,7 +984,7 @@ class DeviceWindow {
           break;
         }
         FT_ABORT_BREAK(
-            timeout,
+            abortDevice,
             "DeviceWindow::barrier_wait(barrier_id=%d, value=%llu)"
             " rank=%d",
             barrier_id,


### PR DESCRIPTION
Summary:

`Timeout` has been a bare alias for `AbortDevice` since `D115656601`:

```
namespace comms::prims {
using Timeout = AbortDevice;
}
```

It was introduced as a migration shim so the fault-tolerance stack could land
without a repo-wide rename in the middle of it. That stack is done, so the shim
is now just a second name for the same type, and a misleading one -- the handle
carries an abort latch and a reason, and a deadline is only one of the ways it
trips.

This series retires it, one subtree per diff. **Type-only**: parameter names stay
`timeout`, so nothing about call sites changes except the spelling of the type.
Ben's naming comments are handled per-diff where they already live.

Because both names denote the same type until the alias is deleted, **every diff
in this series is independently correct and landable, in any order**. Files also
keep their `#include "comms/prims/core/Timeout.cuh"` until the final cleanup
diff; the alias header includes `AbortCheck.cuh`, so `AbortDevice` resolves
either way.

Two things the mechanical pass deliberately does *not* touch:
- **`#include` lines** -- repointed in the cleanup diff, with the header deletion.
- **Comment prose.** `Timeout` is renamed in comments only where it is backticked
  or plainly names the type. Lines like `param timeout Timeout for flag polling`
  read as English and are left alone. The handful of prose references that really
  did mean the type were edited by hand.

This diff: `prims/transport/nvl` (`P2pNvlTransportDevice`, `MultimemNvlTransportDevice`, `MultimemNvlSignal`). 22 occurrences.

Reviewed By: arttianezhu

Differential Revision: D116810808


