### PR TITLE
Rename Timeout to AbortDevice in prims/collectives

### DIFF
--- a/comms/prims/collectives/AllGather.cuh
+++ b/comms/prims/collectives/AllGather.cuh
@@ -78,7 +78,7 @@ __device__ __forceinline__ void printAllGatherOperation(
  * @param my_rank_id Current rank ID
  * @param transports_per_rank Array of transport objects, one per rank
  *                            (self-transport for my_rank, P2P for others)
- * @param timeout Optional timeout for wait operations
+ * @param abortDevice Optional abortDevice for wait operations
  *
  * Buffer Layout:
  *   sendbuff_d: [my_data]
@@ -96,10 +96,11 @@ __device__ __forceinline__ void all_gather(
     std::size_t sendcount,
     int my_rank_id,
     DeviceSpan<Transport> transports_per_rank,
-    Timeout timeout = Timeout()) {
+    AbortDevice abortDevice = AbortDevice()) {
 #ifdef __CUDA_ARCH__
-  // Start the timeout timer - must be called once before any wait operations
-  timeout.start();
+  // Start the abortDevice timer - must be called once before any wait
+  // operations
+  abortDevice.start();
 
   auto group = make_warp_group();
   const auto nranks = transports_per_rank.size();
@@ -195,7 +196,7 @@ __device__ __forceinline__ void all_gather(
         tiles.tile_data(group_per_peer.group_id),
         tiles.tile_bytes(group_per_peer.group_id),
         /*max_signal_bytes=*/0,
-        timeout);
+        abortDevice);
   } else {
     // Receive peer's data into my recvbuff at appropriate offset
     TiledBuffer<char> tiles(
@@ -207,7 +208,7 @@ __device__ __forceinline__ void all_gather(
         tiles.tile_data(group_per_peer.group_id),
         tiles.tile_bytes(group_per_peer.group_id),
         /*max_signal_bytes=*/0,
-        timeout);
+        abortDevice);
   }
 
 #endif

--- a/comms/prims/collectives/AllGatherDirect.cu
+++ b/comms/prims/collectives/AllGatherDirect.cu
@@ -16,9 +16,9 @@ namespace comms::prims {
 template <int kBlockSize>
 __global__ __launch_bounds__(kBlockSize, 1) void direct_allgather_nvl_kernel(
     const __grid_constant__ DirectAllgatherNvlArgs args,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
 #ifdef __CUDA_ARCH__
-  timeout.start();
+  abortDevice.start();
 
   auto group = make_block_group();
   const int my_rank = args.my_rank;
@@ -56,7 +56,7 @@ __global__ __launch_bounds__(kBlockSize, 1) void direct_allgather_nvl_kernel(
         continue;
       }
       auto peer = args.peers[peer_rank];
-      peer.send(group, send_src, window, max_sig, timeout);
+      peer.send(group, send_src, window, max_sig, abortDevice);
     }
 
     for (int peer_rank = 0; peer_rank < W; ++peer_rank) {
@@ -65,7 +65,7 @@ __global__ __launch_bounds__(kBlockSize, 1) void direct_allgather_nvl_kernel(
       }
       char* dst = args.recvbuf + peer_rank * sendcount + tile_offset + off;
       auto peer = args.peers[peer_rank];
-      peer.recv(group, dst, window, max_sig, timeout);
+      peer.recv(group, dst, window, max_sig, abortDevice);
     }
   }
 #endif
@@ -75,9 +75,9 @@ template <int kBlockSize>
 __global__
 __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
     const __grid_constant__ HierarchicalAllgatherFusedArgs args,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
 #ifdef __CUDA_ARCH__
-  timeout.start();
+  abortDevice.start();
 
   auto group = make_block_group();
   const int W = args.ib_size;
@@ -109,7 +109,7 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
         args.nvl_signaling_data_size,
         args.nvl_peers,
         args.recvbuf,
-        timeout);
+        abortDevice);
     return;
   }
 
@@ -130,7 +130,7 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
 
     const char* send_src = tile_src + off;
     next.template send<MemcpyAndSelfCopy>(
-        group, send_src, window, max_sig, timeout, own_dst + off);
+        group, send_src, window, max_sig, abortDevice, own_dst + off);
 
     int fwd_current_rank = args.ib_rank;
     for (int step = 0; step < W - 1; step++) {
@@ -142,9 +142,9 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
           io_tile_offset + off;
 
       if (step < W - 2) {
-        prev.forward(group, dst, next, window, max_sig, timeout);
+        prev.forward(group, dst, next, window, max_sig, abortDevice);
       } else {
-        prev.recv(group, dst, window, max_sig, timeout);
+        prev.recv(group, dst, window, max_sig, abortDevice);
       }
     }
   }
@@ -160,7 +160,7 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
       args.nvl_signaling_data_size,
       args.nvl_peers,
       args.recvbuf,
-      timeout);
+      abortDevice);
 #endif
 }
 
@@ -207,7 +207,7 @@ __device__ __forceinline__ void wait_ready(
     const uint64_t* ready_counters,
     std::size_t idx,
     uint64_t sequence,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   // Per-thread check, not the group form: the group form is leader-only, so a
   // break driven by it would exit on the leader alone and leave the rest of the
   // group at the group.sync() below. Every thread reads the same shared abort
@@ -215,7 +215,7 @@ __device__ __forceinline__ void wait_ready(
   // and all reach the barrier together.
   while (load_ready_counter(ready_counters + idx) != sequence) {
     FT_ABORT_BREAK(
-        timeout,
+        abortDevice,
         "hierarchical allgather waiting for ready counter idx=%llu sequence=%llu",
         static_cast<unsigned long long>(idx),
         static_cast<unsigned long long>(sequence));
@@ -246,9 +246,9 @@ template <int kBlockSize>
 __global__
 __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
     const __grid_constant__ HierarchicalAllgatherOverlapArgs args,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
 #ifdef __CUDA_ARCH__
-  timeout.start();
+  abortDevice.start();
 
   auto base_group = make_block_group();
   const std::size_t chunk_bytes = args.chunk_bytes;
@@ -318,7 +318,7 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
             send_src + chunk_off,
             window,
             args.ib_signaling_data_size,
-            timeout,
+            abortDevice,
             args.trace,
             static_cast<uint8_t>(args.ib_rank),
             own_dst + chunk_off);
@@ -339,7 +339,7 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
                 next,
                 window,
                 args.ib_signaling_data_size,
-                timeout,
+                abortDevice,
                 args.trace,
                 static_cast<uint8_t>(args.ib_rank));
           } else {
@@ -348,7 +348,7 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
                 dst,
                 window,
                 args.ib_signaling_data_size,
-                timeout,
+                abortDevice,
                 args.trace,
                 static_cast<uint8_t>(args.ib_rank));
           }
@@ -416,7 +416,7 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
         args.ready_counters,
         static_cast<std::size_t>(ib_src) * total_chunks + chunk,
         args.ready_sequence,
-        timeout);
+        abortDevice);
     trace_hierarchical_allgather(
         args.trace,
         group,
@@ -444,7 +444,7 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
             send_src + chunk_off,
             window,
             args.nvl_signaling_data_size,
-            timeout);
+            abortDevice);
       }
 
       for (int peer_rank = 0; peer_rank < args.nvl_size; ++peer_rank) {
@@ -456,7 +456,8 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
                 args.sendcount +
             off + chunk_off;
         auto peer = args.nvl_peers[peer_rank];
-        peer.recv(group, dst, window, args.nvl_signaling_data_size, timeout);
+        peer.recv(
+            group, dst, window, args.nvl_signaling_data_size, abortDevice);
       }
     }
     trace_hierarchical_allgather(
@@ -471,14 +472,14 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
 
 template __global__ void direct_allgather_nvl_kernel<512>(
     const __grid_constant__ DirectAllgatherNvlArgs,
-    Timeout);
+    AbortDevice);
 
 template __global__ void hierarchical_allgather_fused_kernel<512>(
     const __grid_constant__ HierarchicalAllgatherFusedArgs,
-    Timeout);
+    AbortDevice);
 
 template __global__ void hierarchical_allgather_overlap_kernel<512>(
     const __grid_constant__ HierarchicalAllgatherOverlapArgs,
-    Timeout);
+    AbortDevice);
 
 } // namespace comms::prims

--- a/comms/prims/collectives/AllGatherDirect.cuh
+++ b/comms/prims/collectives/AllGatherDirect.cuh
@@ -12,18 +12,18 @@ namespace comms::prims {
 template <int kBlockSize>
 __global__ __launch_bounds__(kBlockSize, 1) void direct_allgather_nvl_kernel(
     const __grid_constant__ DirectAllgatherNvlArgs args,
-    Timeout timeout);
+    AbortDevice abortDevice);
 
 template <int kBlockSize>
 __global__
     __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
         const __grid_constant__ HierarchicalAllgatherFusedArgs args,
-        Timeout timeout);
+        AbortDevice abortDevice);
 
 template <int kBlockSize>
 __global__
     __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
         const __grid_constant__ HierarchicalAllgatherOverlapArgs args,
-        Timeout timeout);
+        AbortDevice abortDevice);
 
 } // namespace comms::prims

--- a/comms/prims/collectives/AllToAllv.cuh
+++ b/comms/prims/collectives/AllToAllv.cuh
@@ -117,7 +117,7 @@ __device__ __forceinline__ void all_to_allv(
     DeviceSpan<Transport> transports_per_rank,
     DeviceSpan<ChunkInfo> send_chunk_infos,
     DeviceSpan<ChunkInfo> recv_chunk_infos,
-    Timeout timeout
+    AbortDevice abortDevice
     // all arguments below will eventually come from communicator
 ) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
@@ -245,7 +245,7 @@ __device__ __forceinline__ void all_to_allv(
         tiles.data(),
         tiles.bytes(),
         /*max_signal_bytes=*/0,
-        timeout);
+        abortDevice);
   } else {
     TiledBuffer<char> tiles(
         static_cast<char*>(recvbuff_d) + recv_info.offset,
@@ -256,7 +256,7 @@ __device__ __forceinline__ void all_to_allv(
         tiles.data(),
         tiles.bytes(),
         /*max_signal_bytes=*/0,
-        timeout);
+        abortDevice);
   }
 
 #endif

--- a/comms/prims/collectives/AllToAllvLl128.cuh
+++ b/comms/prims/collectives/AllToAllvLl128.cuh
@@ -34,7 +34,7 @@ namespace comms::prims {
  * @param transports_per_rank Array of transport objects per rank
  * @param send_chunk_infos Array of send chunk metadata per destination rank
  * @param recv_chunk_infos Array of recv chunk metadata per source rank
- * @param timeout Timeout configuration
+ * @param abortDevice Timeout configuration
  */
 __device__ __forceinline__ void all_to_allv_ll128(
     void* recvbuff_d,
@@ -43,7 +43,7 @@ __device__ __forceinline__ void all_to_allv_ll128(
     DeviceSpan<Transport> transports_per_rank,
     DeviceSpan<ChunkInfo> send_chunk_infos,
     DeviceSpan<ChunkInfo> recv_chunk_infos,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
 #ifdef __CUDA_ARCH__
   auto group = make_warp_group();
   const auto nranks = transports_per_rank.size();
@@ -107,13 +107,13 @@ __device__ __forceinline__ void all_to_allv_ll128(
         group_per_peer,
         static_cast<const char*>(sendbuff_d) + send_info.offset,
         send_info.nbytes,
-        timeout);
+        abortDevice);
   } else {
     transport.p2p_nvl.ll128_recv_group(
         group_per_peer,
         static_cast<char*>(recvbuff_d) + recv_info.offset,
         recv_info.nbytes,
-        timeout);
+        abortDevice);
   }
 #endif
 }

--- a/comms/prims/collectives/DirectCollectiveUtils.cuh
+++ b/comms/prims/collectives/DirectCollectiveUtils.cuh
@@ -53,7 +53,7 @@ hierarchical_allgather_nvl_broadcast_from_recvbuf(
     std::size_t max_sig,
     const P2pNvlTransportDevice* peers,
     char* recvbuf,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
 #ifdef __CUDA_ARCH__
   if (nvl_size <= 1) {
     return;
@@ -83,7 +83,7 @@ hierarchical_allgather_nvl_broadcast_from_recvbuf(
           continue;
         }
         auto peer = peers[peer_rank];
-        peer.send(group, send_src, window, max_sig, timeout);
+        peer.send(group, send_src, window, max_sig, abortDevice);
       }
 
       for (int peer_rank = 0; peer_rank < nvl_size; ++peer_rank) {
@@ -95,7 +95,7 @@ hierarchical_allgather_nvl_broadcast_from_recvbuf(
                 sendcount +
             tile_offset + off;
         auto peer = peers[peer_rank];
-        peer.recv(group, dst, window, max_sig, timeout);
+        peer.recv(group, dst, window, max_sig, abortDevice);
       }
     }
   }

--- a/comms/prims/collectives/ReduceScatterDirect.cu
+++ b/comms/prims/collectives/ReduceScatterDirect.cu
@@ -15,9 +15,9 @@ template <typename T, typename AccumOp, int kTileElems, int kBlockSize>
 __global__
 __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_nvl_kernel(
     const __grid_constant__ DirectReduceScatterNvlArgs<T> args,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
 #ifdef __CUDA_ARCH__
-  timeout.start();
+  abortDevice.start();
 
   auto group = make_block_group();
   const int my_rank = args.my_rank;
@@ -62,7 +62,7 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_nvl_kernel(
       const char* send_src =
           input_base + peer_rank * chunk_bytes + tile_offset + off;
       auto peer = args.peers[peer_rank];
-      peer.send(group, send_src, window, max_sig, timeout);
+      peer.send(group, send_src, window, max_sig, abortDevice);
     }
 
     for (int peer_rank = 0; peer_rank < W; ++peer_rank) {
@@ -71,7 +71,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_nvl_kernel(
       }
       char* dst = output_base + tile_offset + off;
       auto peer = args.peers[peer_rank];
-      peer.template recv<ReduceOp>(group, dst, window, max_sig, timeout, dst);
+      peer.template recv<ReduceOp>(
+          group, dst, window, max_sig, abortDevice, dst);
     }
   }
 #endif
@@ -80,6 +81,6 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_nvl_kernel(
 template __global__ void
 direct_reduce_scatter_nvl_kernel<float, SumOp, 16384, 512>(
     const __grid_constant__ DirectReduceScatterNvlArgs<float>,
-    Timeout);
+    AbortDevice);
 
 } // namespace comms::prims

--- a/comms/prims/collectives/ReduceScatterDirect.cuh
+++ b/comms/prims/collectives/ReduceScatterDirect.cuh
@@ -11,6 +11,6 @@ template <typename T, typename AccumOp, int kTileElems, int kBlockSize>
 __global__
     __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_nvl_kernel(
         const __grid_constant__ DirectReduceScatterNvlArgs<T> args,
-        Timeout timeout);
+        AbortDevice abortDevice);
 
 } // namespace comms::prims

--- a/comms/prims/collectives/ReduceScatterDirectIb.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIb.cu
@@ -27,9 +27,9 @@ template <
 __global__
 __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
     const __grid_constant__ DirectReduceScatterIbArgs<T> args,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
 #ifdef __CUDA_ARCH__
-  timeout.start();
+  abortDevice.start();
 
   static_assert(kSendThreads % comms::device::kWarpSize == 0);
   static_assert(kRecvThreads % comms::device::kWarpSize == 0);
@@ -109,10 +109,10 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
             .logical_element_base = 0,
         };
         transport.template recv<QuantOp>(
-            group, output_bytes, wire_bytes, max_sig, timeout, copy_args);
+            group, output_bytes, wire_bytes, max_sig, abortDevice, copy_args);
       } else {
         transport.template recv<ReduceOp>(
-            group, output_bytes, tile_bytes, max_sig, timeout, local_input);
+            group, output_bytes, tile_bytes, max_sig, abortDevice, local_input);
       }
     }
   } else {
@@ -151,7 +151,7 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
             reinterpret_cast<const char*>(send_tile.data()),
             wire_bytes,
             max_sig,
-            timeout,
+            abortDevice,
             copy_args);
       } else {
         transport.send(
@@ -159,7 +159,7 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
             reinterpret_cast<const char*>(send_tile.data()),
             send_tile.bytes(),
             max_sig,
-            timeout);
+            abortDevice);
       }
     }
   }
@@ -177,13 +177,13 @@ template __global__ void direct_reduce_scatter_ib_kernel<
     512,
     CpAsyncSmemReduce<float, SumOp, 8192, 384, 2>>(
     const __grid_constant__ DirectReduceScatterIbArgs<float>,
-    Timeout);
+    AbortDevice);
 
 void launch_direct_reduce_scatter_ib_impl(
     const DirectReduceScatterIbArgs<float>& args,
     int num_blocks,
     cudaStream_t stream,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto* kernel = direct_reduce_scatter_ib_kernel<
       false,
       false,
@@ -224,7 +224,7 @@ void launch_direct_reduce_scatter_ib_impl(
         cudaFuncAttributeMaxDynamicSharedMemorySize,
         static_cast<int>(dynamic_smem)));
   }
-  kernel<<<num_blocks, 512, dynamic_smem, stream>>>(args, timeout);
+  kernel<<<num_blocks, 512, dynamic_smem, stream>>>(args, abortDevice);
   PIPES_CUDA_CHECK(cudaGetLastError());
 }
 
@@ -238,7 +238,7 @@ void launch_quantized(
     const DirectReduceScatterIbArgs<float>& args,
     int num_blocks,
     cudaStream_t stream,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto* kernel = direct_reduce_scatter_ib_kernel<
       true,
       kTmaRecv,
@@ -259,7 +259,7 @@ void launch_quantized(
         cudaFuncAttributeMaxDynamicSharedMemorySize,
         static_cast<int>(dynamic_smem)));
   }
-  kernel<<<num_blocks, kBlock, dynamic_smem, stream>>>(args, timeout);
+  kernel<<<num_blocks, kBlock, dynamic_smem, stream>>>(args, abortDevice);
   PIPES_CUDA_CHECK(cudaGetLastError());
 }
 
@@ -318,11 +318,13 @@ void launch_direct_reduce_scatter_ib_quantized_impl(
     int num_blocks,
     bool use_tma,
     cudaStream_t stream,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   if (use_tma && tma_supported_on_device()) {
-    launch_quantized<true, 640, 128, 768>(args, num_blocks, stream, timeout);
+    launch_quantized<true, 640, 128, 768>(
+        args, num_blocks, stream, abortDevice);
   } else {
-    launch_quantized<false, 480, 160, 640>(args, num_blocks, stream, timeout);
+    launch_quantized<false, 480, 160, 640>(
+        args, num_blocks, stream, abortDevice);
   }
 }
 

--- a/comms/prims/collectives/ReduceScatterDirectIb.cuh
+++ b/comms/prims/collectives/ReduceScatterDirectIb.cuh
@@ -31,13 +31,13 @@ void launch_direct_reduce_scatter_ib_impl(
     const DirectReduceScatterIbArgs<float>& args,
     int num_blocks,
     cudaStream_t stream,
-    Timeout timeout);
+    AbortDevice abortDevice);
 
 void launch_direct_reduce_scatter_ib_quantized_impl(
     const DirectReduceScatterIbArgs<float>& args,
     int num_blocks,
     bool use_tma,
     cudaStream_t stream,
-    Timeout timeout);
+    AbortDevice abortDevice);
 
 } // namespace comms::prims

--- a/comms/prims/collectives/ReduceScatterDirectIbV2.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIbV2.cu
@@ -175,9 +175,9 @@ template <int kRecvThreads, int kBlockSize, int kUnroll>
 __global__
 __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
     const __grid_constant__ DirectReduceScatterIbV2Args args,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
 #ifdef __CUDA_ARCH__
-  timeout.start();
+  abortDevice.start();
 
   // The send only needs its leader to post a WQE; one warp keeps its sync at
   // __syncwarp() and hands every other thread to the reduce.
@@ -311,7 +311,7 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
                 detail::RecvChunkAcquisition view{};
                 auto transport = args.peers[rpeer_of[i]];
                 const auto st = transport.progress_recv_acquire_once(
-                    solo, wire_bytes, max_sig, timeout, view);
+                    solo, wire_bytes, max_sig, abortDevice, view);
                 // `Aborted` is terminal and must be handled explicitly. It used
                 // to fall through this chain: the acquire had already driven
                 // the slot to `Done` via abandon_progress_state(), so the NEXT
@@ -352,7 +352,7 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
               for (int i = 0; i < count; ++i) {
                 auto transport = args.peers[rpeer_of[i]];
                 transport.progress_recv_release_once(
-                    solo, timeout, rviews[ps][i]);
+                    solo, abortDevice, rviews[ps][i]);
                 rviews[ps][i] = detail::RecvChunkAcquisition{};
               }
               released = c - 1;
@@ -368,7 +368,7 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
             for (int i = 0; i < count; ++i) {
               auto transport = args.peers[rpeer_of[i]];
               transport.progress_recv_release_once(
-                  solo, timeout, rviews[ds][i]);
+                  solo, abortDevice, rviews[ds][i]);
               rviews[ds][i] = detail::RecvChunkAcquisition{};
             }
             released = d;
@@ -450,7 +450,7 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
                   send_offset_bytes(args, peer_of[i], tile_offset_elements)),
               wire_bytes,
               max_sig,
-              timeout);
+              abortDevice);
           if (st == IbgdaRegisteredSendProgressStatus::Posted) {
             posted[i] = true;
             --remaining;
@@ -463,8 +463,9 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
       // caller may reuse that buffer while it is still being read.
       for (int i = 0; i < count; ++i) {
         auto transport = args.peers[peer_of[i]];
-        while (transport.progress_registered_send_drain_once(solo, timeout) !=
-               IbgdaRegisteredSendProgressStatus::Drained) {
+        while (
+            transport.progress_registered_send_drain_once(solo, abortDevice) !=
+            IbgdaRegisteredSendProgressStatus::Drained) {
         }
       }
     }
@@ -474,39 +475,39 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
 
 template __global__ void direct_reduce_scatter_ib_v2_kernel<224, 256, 1>(
     const __grid_constant__ DirectReduceScatterIbV2Args,
-    Timeout);
+    AbortDevice);
 template __global__ void direct_reduce_scatter_ib_v2_kernel<480, 512, 1>(
     const __grid_constant__ DirectReduceScatterIbV2Args,
-    Timeout);
+    AbortDevice);
 template __global__ void direct_reduce_scatter_ib_v2_kernel<736, 768, 1>(
     const __grid_constant__ DirectReduceScatterIbV2Args,
-    Timeout);
+    AbortDevice);
 template __global__ void direct_reduce_scatter_ib_v2_kernel<992, 1024, 1>(
     const __grid_constant__ DirectReduceScatterIbV2Args,
-    Timeout);
+    AbortDevice);
 
 void launch_direct_reduce_scatter_ib_v2(
     const DirectReduceScatterIbV2Args& args,
     int num_blocks,
     int block_threads,
     cudaStream_t stream,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   switch (block_threads) {
     case 256:
       direct_reduce_scatter_ib_v2_kernel<224, 256, 1>
-          <<<num_blocks, 256, 0, stream>>>(args, timeout);
+          <<<num_blocks, 256, 0, stream>>>(args, abortDevice);
       break;
     case 512:
       direct_reduce_scatter_ib_v2_kernel<480, 512, 1>
-          <<<num_blocks, 512, 0, stream>>>(args, timeout);
+          <<<num_blocks, 512, 0, stream>>>(args, abortDevice);
       break;
     case 768:
       direct_reduce_scatter_ib_v2_kernel<736, 768, 1>
-          <<<num_blocks, 768, 0, stream>>>(args, timeout);
+          <<<num_blocks, 768, 0, stream>>>(args, abortDevice);
       break;
     default:
       direct_reduce_scatter_ib_v2_kernel<992, 1024, 1>
-          <<<num_blocks, 1024, 0, stream>>>(args, timeout);
+          <<<num_blocks, 1024, 0, stream>>>(args, abortDevice);
       break;
   }
   PIPES_CUDA_CHECK(cudaGetLastError());

--- a/comms/prims/collectives/ReduceScatterDirectIbV2.cuh
+++ b/comms/prims/collectives/ReduceScatterDirectIbV2.cuh
@@ -39,6 +39,6 @@ void launch_direct_reduce_scatter_ib_v2(
     int num_blocks,
     int block_threads,
     cudaStream_t stream,
-    Timeout timeout);
+    AbortDevice abortDevice);
 
 } // namespace comms::prims

--- a/comms/prims/collectives/RingAllgather.cu
+++ b/comms/prims/collectives/RingAllgather.cu
@@ -11,9 +11,9 @@ namespace comms::prims {
 template <int NumRings, int kBlockSize>
 __global__ __launch_bounds__(kBlockSize, 1) void ring_allgather_kernel(
     const __grid_constant__ RingAllgatherArgs<NumRings> args,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
 #ifdef __CUDA_ARCH__
-  timeout.start();
+  abortDevice.start();
 
   auto group = make_block_group();
   auto [ring_id, ring_group] = group.partition(NumRings);
@@ -56,7 +56,7 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_allgather_kernel(
     // Step 0: Send own chunk to next.
     char* send_src = args.recvbuf + my_rank * chunk_bytes + ring_offset +
         io_tile_offset + off;
-    next.send(group, send_src, window, max_sig, timeout);
+    next.send(group, send_src, window, max_sig, abortDevice);
 
     // Steps 1..W-1: receive and forward (or just receive on last step).
     int current_rank = my_rank;
@@ -66,9 +66,9 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_allgather_kernel(
           io_tile_offset + off;
 
       if (step < W - 2) {
-        prev.forward(group, dst, next, window, max_sig, timeout);
+        prev.forward(group, dst, next, window, max_sig, abortDevice);
       } else {
-        prev.recv(group, dst, window, max_sig, timeout);
+        prev.recv(group, dst, window, max_sig, abortDevice);
       }
     }
   }
@@ -78,12 +78,12 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_allgather_kernel(
 // Template instantiations
 template __global__ void ring_allgather_kernel<1, 512>(
     const __grid_constant__ RingAllgatherArgs<1>,
-    Timeout);
+    AbortDevice);
 template __global__ void ring_allgather_kernel<2, 512>(
     const __grid_constant__ RingAllgatherArgs<2>,
-    Timeout);
+    AbortDevice);
 template __global__ void ring_allgather_kernel<4, 512>(
     const __grid_constant__ RingAllgatherArgs<4>,
-    Timeout);
+    AbortDevice);
 
 } // namespace comms::prims

--- a/comms/prims/collectives/RingAllgather.cuh
+++ b/comms/prims/collectives/RingAllgather.cuh
@@ -10,6 +10,6 @@ namespace comms::prims {
 template <int NumRings, int kBlockSize>
 __global__ __launch_bounds__(kBlockSize, 1) void ring_allgather_kernel(
     const __grid_constant__ RingAllgatherArgs<NumRings> args,
-    Timeout timeout);
+    AbortDevice abortDevice);
 
 } // namespace comms::prims

--- a/comms/prims/collectives/RingAllgatherLauncher.cu
+++ b/comms/prims/collectives/RingAllgatherLauncher.cu
@@ -14,7 +14,9 @@ namespace comms::prims {
 namespace {
 
 template <int NumRings>
-void launch_impl(const RingAllgatherLaunchParams& params, Timeout timeout) {
+void launch_impl(
+    const RingAllgatherLaunchParams& params,
+    AbortDevice abortDevice) {
   RingAllgatherArgs<NumRings> args{};
   args.my_rank = params.my_rank;
   args.num_ranks = params.num_ranks;
@@ -34,7 +36,7 @@ void launch_impl(const RingAllgatherLaunchParams& params, Timeout timeout) {
   }
 
   ring_allgather_kernel<NumRings, 512>
-      <<<params.num_blocks, 512>>>(args, timeout);
+      <<<params.num_blocks, 512>>>(args, abortDevice);
 }
 
 } // namespace

--- a/comms/prims/collectives/benchmarks/AllGatherBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/AllGatherBenchmark.cc
@@ -247,8 +247,8 @@ class AllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     void* recvBuff_d = recvBuffer.get();
     void* sendBuff_d = sendBuffer.get();
 
-    // Create timeout (default = no timeout)
-    Timeout timeout;
+    // Create abort handle (default = disabled)
+    Timeout abortDevice;
 
     // Need non-const copy for kernel args
     std::size_t sendcount_arg = sendcount;
@@ -260,7 +260,7 @@ class AllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
         &sendcount_arg,
         &rank_arg,
         &transports_span,
-        &timeout};
+        &abortDevice};
 
     CudaEvent start, stop;
     const int nIter = 100;

--- a/comms/prims/collectives/benchmarks/CollectiveBenchmark.cu
+++ b/comms/prims/collectives/benchmarks/CollectiveBenchmark.cu
@@ -11,7 +11,7 @@ __global__ void all_to_allv_kernel(
     DeviceSpan<Transport> transports_per_rank,
     DeviceSpan<ChunkInfo> send_chunk_infos,
     DeviceSpan<ChunkInfo> recv_chunk_infos,
-    Timeout timeout) {
+    Timeout abortDevice) {
   all_to_allv(
       recvbuff_d,
       sendbuff_d,
@@ -19,7 +19,7 @@ __global__ void all_to_allv_kernel(
       transports_per_rank,
       send_chunk_infos,
       recv_chunk_infos,
-      timeout);
+      abortDevice);
 }
 
 __global__ void all_gather_kernel(
@@ -28,14 +28,14 @@ __global__ void all_gather_kernel(
     std::size_t sendcount,
     int my_rank_id,
     DeviceSpan<Transport> transports_per_rank,
-    Timeout timeout) {
+    Timeout abortDevice) {
   all_gather(
       recvbuff_d,
       sendbuff_d,
       sendcount,
       my_rank_id,
       transports_per_rank,
-      timeout);
+      abortDevice);
 }
 
 } // namespace comms::prims::benchmark

--- a/comms/prims/collectives/benchmarks/CollectiveBenchmark.cuh
+++ b/comms/prims/collectives/benchmarks/CollectiveBenchmark.cuh
@@ -21,7 +21,7 @@ __global__ void all_to_allv_kernel(
     DeviceSpan<Transport> transports_per_rank,
     DeviceSpan<ChunkInfo> send_chunk_infos,
     DeviceSpan<ChunkInfo> recv_chunk_infos,
-    Timeout timeout);
+    Timeout abortDevice);
 
 /**
  * AllGather benchmark kernel.
@@ -35,6 +35,6 @@ __global__ void all_gather_kernel(
     std::size_t sendcount,
     int my_rank_id,
     DeviceSpan<Transport> transports_per_rank,
-    Timeout timeout);
+    Timeout abortDevice);
 
 } // namespace comms::prims::benchmark

--- a/comms/prims/collectives/tests/AllToAllvLl128Test.cu
+++ b/comms/prims/collectives/tests/AllToAllvLl128Test.cu
@@ -17,8 +17,8 @@ __global__ void test_all_to_allv_ll128_kernel(
     DeviceSpan<Transport> transports,
     DeviceSpan<ChunkInfo> send_chunk_infos,
     DeviceSpan<ChunkInfo> recv_chunk_infos,
-    Timeout timeout) {
-  timeout.start();
+    Timeout abortDevice) {
+  abortDevice.start();
   all_to_allv_ll128(
       recvbuff_d,
       sendbuff_d,
@@ -26,7 +26,7 @@ __global__ void test_all_to_allv_ll128_kernel(
       transports,
       send_chunk_infos,
       recv_chunk_infos,
-      timeout);
+      abortDevice);
 }
 
 void test_all_to_allv_ll128(
@@ -39,7 +39,7 @@ void test_all_to_allv_ll128(
     DeviceSpan<ChunkInfo> recv_chunk_infos,
     int numBlocks,
     int blockSize,
-    Timeout timeout) {
+    Timeout abortDevice) {
   test_all_to_allv_ll128_kernel<<<numBlocks, blockSize>>>(
       recvbuff_d,
       sendbuff_d,
@@ -48,7 +48,7 @@ void test_all_to_allv_ll128(
       transports,
       send_chunk_infos,
       recv_chunk_infos,
-      timeout);
+      abortDevice);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/prims/collectives/tests/AllToAllvLl128Test.cuh
+++ b/comms/prims/collectives/tests/AllToAllvLl128Test.cuh
@@ -20,6 +20,6 @@ void test_all_to_allv_ll128(
     DeviceSpan<ChunkInfo> recv_chunk_infos,
     int numBlocks,
     int blockSize,
-    Timeout timeout = Timeout());
+    Timeout abortDevice = Timeout());
 
 } // namespace comms::prims::test

--- a/comms/prims/core/BarrierState.cuh
+++ b/comms/prims/core/BarrierState.cuh
@@ -72,16 +72,17 @@ struct alignas(128) BarrierState {
    * - 2nd wait: expects current_counter >= 2
    * - etc.
    *
-   * Blocking: Spins until the condition is met (or timeout expires).
+   * Blocking: Spins until the condition is met (or abortDevice expires).
    * Warning: Only one thread should call wait() per synchronization round.
    *
-   * @param timeout Optional timeout (default: no timeout, infinite wait)
+   * @param abortDevice Optional abort handle (default: disabled, infinite wait)
    */
-  __device__ __forceinline__ void wait(const Timeout& timeout = Timeout()) {
+  __device__ __forceinline__ void wait(
+      const AbortDevice& abortDevice = AbortDevice()) {
     uint64_t expected = expected_counter_.atomic_fetch_add(1) + 1;
     while (current_counter_.load() < expected) {
       FT_ABORT_BREAK(
-          timeout,
+          abortDevice,
           "BarrierState::wait timed out (expected=%llu, current=%llu)",
           static_cast<unsigned long long>(expected),
           static_cast<unsigned long long>(current_counter_.load()));
@@ -114,15 +115,15 @@ struct alignas(128) BarrierState {
    * barrier before proceeding.
    *
    * @param group ThreadGroup for cooperative synchronization
-   * @param timeout Optional timeout (default: no timeout, infinite wait)
+   * @param abortDevice Optional abort handle (default: disabled, infinite wait)
    *
    * All threads in the group must call this function (collective operation).
    */
   __device__ __forceinline__ void wait(
       ThreadGroup& group,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     if (group.is_leader()) {
-      wait(timeout);
+      wait(abortDevice);
     }
     group.sync();
   }

--- a/comms/prims/core/LLImpl.cuh
+++ b/comms/prims/core/LLImpl.cuh
@@ -33,8 +33,8 @@ template <typename P>
 struct LLImpl {
   using FlagType = typename P::FlagType;
 
-  // Spins between timeout clock reads. A power-of-two minus one so the check
-  // is a mask, not a modulo.
+  // Spins between abortDevice clock reads. A power-of-two minus one so the
+  // check is a mask, not a modulo.
   static constexpr uint32_t kTimeoutPollMask = 1023;
 
   // Replicate the (32-bit) flagVal across a 64-bit flag word, so an 8 B flag
@@ -212,11 +212,11 @@ struct LLImpl {
   /// Wait until every packet covering `nbytes` carries flag == `flagVal`, then
   /// decode its payload into `dst`. Cooperative across `group`; each thread
   /// spins only on the packets it owns.
-  // `timeout` bounds the readiness spin. Unlike Simple, LL's readiness lives in
-  // the payload, so the wait happens HERE rather than in wait_signal -- without
-  // a deadline a lost WQE, a dead peer, or a flagVal desync spins forever and
-  // then holds the whole group at the group.sync() below. Each thread polls
-  // only the packets it owns, so the check is per-thread
+  // `abortDevice` bounds the readiness spin. Unlike Simple, LL's readiness
+  // lives in the payload, so the wait happens HERE rather than in wait_signal
+  // -- without a deadline a lost WQE, a dead peer, or a flagVal desync spins
+  // forever and then holds the whole group at the group.sync() below. Each
+  // thread polls only the packets it owns, so the check is per-thread
   // (FT_ABORT_BREAK) and not the leader-only group form. The
   // clock is read once per kTimeoutPollMask+1 spins: LL is the latency path,
   // and a clock64() on every poll is a measurable cost on a hot loop.
@@ -232,7 +232,7 @@ struct LLImpl {
       const void* staging,
       std::size_t nbytes,
       FlagType flagVal,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
 #ifdef __CUDA_ARCH__
     const std::size_t nPackets = P::packet_count(nbytes);
     const auto* base = reinterpret_cast<const char*>(staging);
@@ -249,7 +249,7 @@ struct LLImpl {
         // single abort-aware spin loop in this file.
         bool abandoned = false;
         const uint32_t data =
-            load_ready_payload(pkt, flagVal, timeout, abandoned);
+            load_ready_payload(pkt, flagVal, abortDevice, abandoned);
         // Leaves the packet loop as well: load_ready_payload only exits its own
         // spin. `dst` is undefined from here, which the abort contract permits.
         if (abandoned) {
@@ -270,7 +270,7 @@ struct LLImpl {
           // Spin until this packet's flag reaches the current flagVal.
           if ((++spins & kTimeoutPollMask) == 0) {
             FT_ABORT_BREAK(
-                timeout,
+                abortDevice,
                 "LLImpl::unpack waiting for LL flag %u on packet %llu",
                 (unsigned)flagVal,
                 (unsigned long long)i);
@@ -278,7 +278,7 @@ struct LLImpl {
         }
         if (spins >= kTimeoutPollMask) {
           FT_ABORT_BREAK(
-              timeout,
+              abortDevice,
               "LLImpl::unpack abandoning decode at packet %llu",
               (unsigned long long)i);
         }
@@ -324,7 +324,7 @@ struct LLImpl {
   __device__ __forceinline__ static uint32_t load_ready_payload(
       const char* pkt,
       FlagType flagVal,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       bool& abandoned) {
 #ifdef __CUDA_ARCH__
     const auto* p = reinterpret_cast<const volatile uint64_t*>(pkt);
@@ -337,7 +337,7 @@ struct LLImpl {
         // unwind, not kill the CUDA context from inside LL decode. CHECK rather
         // than BREAK so the flag can be raised before leaving the spin.
         if (FT_ABORT_CHECK(
-                timeout,
+                abortDevice,
                 "LLImpl::load_ready_payload waiting for LL flag %u",
                 (unsigned)flagVal)) {
           abandoned = true;
@@ -350,7 +350,7 @@ struct LLImpl {
 #else
     (void)pkt;
     (void)flagVal;
-    (void)timeout;
+    (void)abortDevice;
     (void)abandoned;
     return 0;
 #endif
@@ -392,7 +392,7 @@ struct LLImpl {
       const void* staging,
       std::size_t nbytes,
       FlagType flagVal,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
 #ifdef __CUDA_ARCH__
     constexpr std::size_t kData = static_cast<std::size_t>(P::kData);
     constexpr std::size_t kPacket = static_cast<std::size_t>(P::kPacketBytes);
@@ -404,8 +404,8 @@ struct LLImpl {
       for (std::size_t i = group.thread_id_in_group; i < nPackets;
            i += group.group_size) {
         bool abandoned = false;
-        const uint32_t data =
-            load_ready_payload(base + i * kPacket, flagVal, timeout, abandoned);
+        const uint32_t data = load_ready_payload(
+            base + i * kPacket, flagVal, abortDevice, abandoned);
         // `accum` is undefined from here, which the abort contract permits.
         if (abandoned) {
           break;
@@ -450,7 +450,7 @@ struct LLImpl {
           const uint32_t word = load_ready_payload(
               base + (e * kPacketsPerElem + k) * kPacket,
               flagVal,
-              timeout,
+              abortDevice,
               abandoned);
           if (abandoned) {
             break;
@@ -477,7 +477,7 @@ struct LLImpl {
     (void)staging;
     (void)nbytes;
     (void)flagVal;
-    (void)timeout;
+    (void)abortDevice;
 #endif
   }
 };

--- a/comms/prims/core/MemcpyCopyOp.cuh
+++ b/comms/prims/core/MemcpyCopyOp.cuh
@@ -85,9 +85,10 @@ struct Memcpy {
   }
 
   template <typename P, typename... Args>
-  // Takes a Timeout where recv()/sendLL() do not: LL's readiness wait happens
-  // inside the codec (the flag is in the payload), so this is the one hook that
-  // can block indefinitely and therefore the one that needs a deadline.
+  // Takes an AbortDevice where recv()/sendLL() do not: LL's readiness wait
+  // happens inside the codec (the flag is in the payload), so this is the one
+  // hook that can block indefinitely and therefore the one that needs a
+  // deadline.
   __device__ __forceinline__ static void recvLL(
       ThreadGroup& group,
       char* dst,
@@ -95,9 +96,9 @@ struct Memcpy {
       std::size_t nbytes,
       std::size_t /*byte_offset*/,
       typename P::FlagType flagVal,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       Args...) {
-    LLImpl<P>::unpack(group, dst, staging, nbytes, flagVal, timeout);
+    LLImpl<P>::unpack(group, dst, staging, nbytes, flagVal, abortDevice);
   }
 };
 
@@ -133,6 +134,6 @@ inline constexpr bool has_recvLL_v<
         std::declval<std::size_t>(),
         std::declval<std::size_t>(),
         std::declval<typename P::FlagType>(),
-        std::declval<const Timeout&>()))>> = true;
+        std::declval<const AbortDevice&>()))>> = true;
 
 } // namespace comms::prims

--- a/comms/prims/core/SignalState.cuh
+++ b/comms/prims/core/SignalState.cuh
@@ -180,15 +180,17 @@ struct alignas(128) SignalState {
    *
    * @param op The comparison operation (CMP_EQ, CMP_GT, CMP_LT, CMP_GE, etc.)
    * @param expected The expected value to compare against
-   * @param timeout Timeout config (default: no timeout)
+   * @param abortDevice Abort handle (default: disabled, infinite wait)
    */
-  __device__ __forceinline__ void
-  wait_until(CmpOp op, uint64_t expected, const Timeout& timeout = Timeout()) {
+  __device__ __forceinline__ void wait_until(
+      CmpOp op,
+      uint64_t expected,
+      const AbortDevice& abortDevice = AbortDevice()) {
     switch (op) {
       case CmpOp::CMP_EQ:
         while (load() != expected) {
           FT_ABORT_BREAK(
-              timeout,
+              abortDevice,
               "SignalState::wait_until waiting for signal %s %llu "
               "(current=%llu)",
               cmpOpToString(op),
@@ -199,7 +201,7 @@ struct alignas(128) SignalState {
       case CmpOp::CMP_GT:
         while (load() <= expected) {
           FT_ABORT_BREAK(
-              timeout,
+              abortDevice,
               "SignalState::wait_until waiting for signal %s %llu "
               "(current=%llu)",
               cmpOpToString(op),
@@ -210,7 +212,7 @@ struct alignas(128) SignalState {
       case CmpOp::CMP_LT:
         while (load() >= expected) {
           FT_ABORT_BREAK(
-              timeout,
+              abortDevice,
               "SignalState::wait_until waiting for signal %s %llu "
               "(current=%llu)",
               cmpOpToString(op),
@@ -221,7 +223,7 @@ struct alignas(128) SignalState {
       case CmpOp::CMP_GE:
         while (load() < expected) {
           FT_ABORT_BREAK(
-              timeout,
+              abortDevice,
               "SignalState::wait_until waiting for signal %s %llu "
               "(current=%llu)",
               cmpOpToString(op),
@@ -232,7 +234,7 @@ struct alignas(128) SignalState {
       case CmpOp::CMP_LE:
         while (load() > expected) {
           FT_ABORT_BREAK(
-              timeout,
+              abortDevice,
               "SignalState::wait_until waiting for signal %s %llu "
               "(current=%llu)",
               cmpOpToString(op),
@@ -243,7 +245,7 @@ struct alignas(128) SignalState {
       case CmpOp::CMP_NE:
         while (load() == expected) {
           FT_ABORT_BREAK(
-              timeout,
+              abortDevice,
               "SignalState::wait_until waiting for signal %s %llu "
               "(current=%llu)",
               cmpOpToString(op),
@@ -292,14 +294,14 @@ struct alignas(128) SignalState {
    * @param group ThreadGroup for cooperative processing
    * @param op The comparison operation (CMP_EQ, CMP_GE, etc.)
    * @param expected The expected value to compare against
-   * @param timeout Timeout config (default: no timeout)
+   * @param abortDevice Abort handle (default: disabled, infinite wait)
    */
   __device__ __forceinline__ void wait_until(
       ThreadGroup& group,
       CmpOp op,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
-    wait_until(op, expected, timeout);
+      const AbortDevice& abortDevice = AbortDevice()) {
+    wait_until(op, expected, abortDevice);
   }
 };
 

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -127,22 +127,22 @@ __device__ __forceinline__ void P2pIbTransportDevice::wait_signal(
     ThreadGroup& group,
     int signalId,
     uint64_t expected,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->wait_signal(group, signalId, expected, timeout);
+    ibrc->wait_signal(group, signalId, expected, abortDevice);
   } else {
-    ibgda->wait_signal(group, signalId, expected, timeout);
+    ibgda->wait_signal(group, signalId, expected, abortDevice);
   }
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::wait_signal(
     int signalId,
     uint64_t expected,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->wait_signal(signalId, expected, timeout);
+    ibrc->wait_signal(signalId, expected, abortDevice);
   } else {
-    ibgda->wait_signal(signalId, expected, timeout);
+    ibgda->wait_signal(signalId, expected, abortDevice);
   }
 }
 
@@ -150,33 +150,33 @@ __device__ __forceinline__ void P2pIbTransportDevice::wait_counter(
     ThreadGroup& group,
     int counterId,
     uint64_t expected,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->wait_counter(group, counterId, expected, timeout);
+    ibrc->wait_counter(group, counterId, expected, abortDevice);
   } else {
-    ibgda->wait_counter(group, counterId, expected, timeout);
+    ibgda->wait_counter(group, counterId, expected, abortDevice);
   }
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::wait_counter(
     int counterId,
     uint64_t expected,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->wait_counter(counterId, expected, timeout);
+    ibrc->wait_counter(counterId, expected, abortDevice);
   } else {
-    ibgda->wait_counter(counterId, expected, timeout);
+    ibgda->wait_counter(counterId, expected, abortDevice);
   }
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::wait_local(
     ThreadGroup& group,
     const IbLocalCompletionTicket& ticket,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->wait_local(group, ticket, timeout);
+    ibrc->wait_local(group, ticket, abortDevice);
   } else {
-    ibgda->wait_local(group, ticket, timeout);
+    ibgda->wait_local(group, ticket, abortDevice);
   }
 }
 
@@ -379,22 +379,22 @@ __device__ __forceinline__ void P2pIbTransportDevice::wait_signal(
     ThreadGroup& group,
     const IbgdaLocalBuffer& signalBuf,
     uint64_t expected,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->wait_signal(group, signalBuf, expected, timeout);
+    ibrc->wait_signal(group, signalBuf, expected, abortDevice);
   } else {
-    ibgda->wait_signal(group, signalBuf, expected, timeout);
+    ibgda->wait_signal(group, signalBuf, expected, abortDevice);
   }
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::wait_signal(
     const IbgdaLocalBuffer& signalBuf,
     uint64_t expected,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->wait_signal(signalBuf, expected, timeout);
+    ibrc->wait_signal(signalBuf, expected, abortDevice);
   } else {
-    ibgda->wait_signal(signalBuf, expected, timeout);
+    ibgda->wait_signal(signalBuf, expected, abortDevice);
   }
 }
 
@@ -402,22 +402,22 @@ __device__ __forceinline__ void P2pIbTransportDevice::wait_counter(
     ThreadGroup& group,
     const IbgdaLocalBuffer& counterBuf,
     uint64_t expected,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->wait_counter(group, counterBuf, expected, timeout);
+    ibrc->wait_counter(group, counterBuf, expected, abortDevice);
   } else {
-    ibgda->wait_counter(group, counterBuf, expected, timeout);
+    ibgda->wait_counter(group, counterBuf, expected, abortDevice);
   }
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::wait_counter(
     const IbgdaLocalBuffer& counterBuf,
     uint64_t expected,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->wait_counter(counterBuf, expected, timeout);
+    ibrc->wait_counter(counterBuf, expected, abortDevice);
   } else {
-    ibgda->wait_counter(counterBuf, expected, timeout);
+    ibgda->wait_counter(counterBuf, expected, abortDevice);
   }
 }
 
@@ -483,32 +483,32 @@ P2pIbTransportDevice::read_counter(const IbgdaLocalBuffer& counterBuf) const {
 // no liveness. IBGDA is GPU-initiated with no proxy, so it uses the deadline.
 __device__ __forceinline__ void P2pIbTransportDevice::flush(
     ThreadGroup& group,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   if (type == P2pIbBackendType::IBRC) {
     ibrc->flush(group, IbDirection::Send);
   } else {
-    ibgda->flush(group, IbDirection::Send, timeout);
+    ibgda->flush(group, IbDirection::Send, abortDevice);
   }
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::flush(
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   if (type == P2pIbBackendType::IBRC) {
     ibrc->flush(IbDirection::Send);
   } else {
-    ibgda->flush(timeout);
+    ibgda->flush(abortDevice);
   }
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::fence(
     ThreadGroup& group,
-    const Timeout& timeout) {
-  flush(group, timeout);
+    const AbortDevice& abortDevice) {
+  flush(group, abortDevice);
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::fence(
-    const Timeout& timeout) {
-  flush(timeout);
+    const AbortDevice& abortDevice) {
+  flush(abortDevice);
 }
 
 // ===========================================================================
@@ -532,12 +532,14 @@ __device__ __forceinline__ void P2pIbTransportDevice::send(
     const void* __restrict__ src,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     Args... args) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->send<CopyOp>(group, src, nbytes, max_signal_bytes, timeout, args...);
+    ibrc->send<CopyOp>(
+        group, src, nbytes, max_signal_bytes, abortDevice, args...);
   } else {
-    ibgda->send<CopyOp>(group, src, nbytes, max_signal_bytes, timeout, args...);
+    ibgda->send<CopyOp>(
+        group, src, nbytes, max_signal_bytes, abortDevice, args...);
   }
 }
 
@@ -547,9 +549,9 @@ __device__ __forceinline__ void P2pIbTransportDevice::send_registered(
     const IbgdaLocalBuffer& src,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   require_ibgda(group, "registered-source send");
-  ibgda->send_registered(group, src, nbytes, max_signal_bytes, timeout);
+  ibgda->send_registered(group, src, nbytes, max_signal_bytes, abortDevice);
 }
 
 template <typename CopyOp, typename... Args>
@@ -558,12 +560,14 @@ __device__ __forceinline__ void P2pIbTransportDevice::recv(
     void* __restrict__ dst,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     Args... args) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->recv<CopyOp>(group, dst, nbytes, max_signal_bytes, timeout, args...);
+    ibrc->recv<CopyOp>(
+        group, dst, nbytes, max_signal_bytes, abortDevice, args...);
   } else {
-    ibgda->recv<CopyOp>(group, dst, nbytes, max_signal_bytes, timeout, args...);
+    ibgda->recv<CopyOp>(
+        group, dst, nbytes, max_signal_bytes, abortDevice, args...);
   }
 }
 
@@ -574,16 +578,16 @@ __device__ __forceinline__ void P2pIbTransportDevice::forward(
     P2pIbTransportDevice& fwd,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     Args... args) {
   if (type == P2pIbBackendType::IBRC && fwd.type == P2pIbBackendType::IBRC) {
     ibrc->forward<CopyOp>(
-        group, dst, *fwd.ibrc, nbytes, max_signal_bytes, timeout, args...);
+        group, dst, *fwd.ibrc, nbytes, max_signal_bytes, abortDevice, args...);
     return;
   }
   if (type == P2pIbBackendType::IBGDA && fwd.type == P2pIbBackendType::IBGDA) {
     ibgda->forward<CopyOp>(
-        group, dst, *fwd.ibgda, nbytes, max_signal_bytes, timeout, args...);
+        group, dst, *fwd.ibgda, nbytes, max_signal_bytes, abortDevice, args...);
     return;
   }
   if (group.is_leader()) {
@@ -656,14 +660,14 @@ P2pIbTransportDevice::progress_send_once(
     const void* __restrict__ src,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     Args... args) {
   if (type == P2pIbBackendType::IBRC) {
     return ibrc->progress_send_once<CopyOp, Proto>(
-        group, src, nbytes, max_signal_bytes, timeout, args...);
+        group, src, nbytes, max_signal_bytes, abortDevice, args...);
   }
   return ibgda->progress_send_once<CopyOp, Proto>(
-      group, src, nbytes, max_signal_bytes, timeout, args...);
+      group, src, nbytes, max_signal_bytes, abortDevice, args...);
 }
 
 template <typename>
@@ -673,19 +677,19 @@ P2pIbTransportDevice::progress_registered_send_once(
     const IbgdaLocalBuffer& src,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   require_ibgda(group, "registered-source send progress");
   return ibgda->progress_registered_send_once(
-      group, src, nbytes, max_signal_bytes, timeout);
+      group, src, nbytes, max_signal_bytes, abortDevice);
 }
 
 template <typename>
 __device__ __forceinline__ IbgdaRegisteredSendProgressStatus
 P2pIbTransportDevice::progress_registered_send_drain_once(
     ThreadGroup& group,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   require_ibgda(group, "registered-source send drain");
-  return ibgda->progress_registered_send_drain_once(group, timeout);
+  return ibgda->progress_registered_send_drain_once(group, abortDevice);
 }
 
 template <typename CopyOp, typename... Args>
@@ -695,20 +699,20 @@ P2pIbTransportDevice::progress_send_once_with_trace(
     const void* __restrict__ src,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     const PipesTraceAllReduceContext& traceContext,
     PipesTraceProgressState& traceState,
     Args... args) {
   if (type == P2pIbBackendType::IBRC) {
     return ibrc->progress_send_once<CopyOp>(
-        group, src, nbytes, max_signal_bytes, timeout, args...);
+        group, src, nbytes, max_signal_bytes, abortDevice, args...);
   }
   return ibgda->progress_send_once_with_trace<CopyOp>(
       group,
       src,
       nbytes,
       max_signal_bytes,
-      timeout,
+      abortDevice,
       traceContext,
       traceState,
       args...);
@@ -721,14 +725,14 @@ P2pIbTransportDevice::progress_recv_once(
     void* __restrict__ dst,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     Args... args) {
   if (type == P2pIbBackendType::IBRC) {
     return ibrc->progress_recv_once<CopyOp, Proto>(
-        group, dst, nbytes, max_signal_bytes, timeout, args...);
+        group, dst, nbytes, max_signal_bytes, abortDevice, args...);
   }
   return ibgda->progress_recv_once<CopyOp, Proto>(
-      group, dst, nbytes, max_signal_bytes, timeout, args...);
+      group, dst, nbytes, max_signal_bytes, abortDevice, args...);
 }
 
 template <typename CopyOp, typename... Args>
@@ -738,20 +742,20 @@ P2pIbTransportDevice::progress_recv_once_with_trace(
     void* __restrict__ dst,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     const PipesTraceAllReduceContext& traceContext,
     PipesTraceProgressState& traceState,
     Args... args) {
   if (type == P2pIbBackendType::IBRC) {
     return ibrc->progress_recv_once<CopyOp>(
-        group, dst, nbytes, max_signal_bytes, timeout, args...);
+        group, dst, nbytes, max_signal_bytes, abortDevice, args...);
   }
   return ibgda->progress_recv_once_with_trace<CopyOp>(
       group,
       dst,
       nbytes,
       max_signal_bytes,
-      timeout,
+      abortDevice,
       traceContext,
       traceState,
       args...);
@@ -763,26 +767,26 @@ P2pIbTransportDevice::progress_recv_acquire_once(
     ThreadGroup& group,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     detail::RecvChunkAcquisition& out) {
   if (type == P2pIbBackendType::IBRC) {
     return ibrc->progress_recv_acquire_once(
-        group, nbytes, max_signal_bytes, timeout, out);
+        group, nbytes, max_signal_bytes, abortDevice, out);
   }
   return ibgda->progress_recv_acquire_once(
-      group, nbytes, max_signal_bytes, timeout, out);
+      group, nbytes, max_signal_bytes, abortDevice, out);
 }
 
 template <typename>
 __device__ __forceinline__ void
 P2pIbTransportDevice::progress_recv_release_once(
     ThreadGroup& group,
-    const AbortDevice& timeout,
+    const AbortDevice& abortDevice,
     const detail::RecvChunkAcquisition& view) {
   if (type == P2pIbBackendType::IBRC) {
-    ibrc->progress_recv_release_once(group, timeout, view);
+    ibrc->progress_recv_release_once(group, abortDevice, view);
   } else {
-    ibgda->progress_recv_release_once(group, timeout, view);
+    ibgda->progress_recv_release_once(group, abortDevice, view);
   }
 }
 

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -78,14 +78,14 @@ progress_registered_send_once(
     const IbgdaLocalBuffer& src,
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
-    const Timeout& timeout = Timeout());
+    const AbortDevice& abortDevice = AbortDevice());
 
 template <typename Transport>
 __device__ __forceinline__ IbgdaRegisteredSendProgressStatus
 progress_registered_send_drain_once(
     Transport& transport,
     ThreadGroup& group,
-    const Timeout& timeout = Timeout());
+    const AbortDevice& abortDevice = AbortDevice());
 
 template <typename Transport, typename Proto>
 __device__ __forceinline__ IbgdaSendRecvProgressStatus
@@ -94,14 +94,14 @@ progress_recv_acquire_once(
     ThreadGroup& group,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     RecvChunkAcquisition& out);
 
 template <typename Transport, typename Proto>
 __device__ __forceinline__ void progress_recv_release_once(
     Transport& transport,
     ThreadGroup& group,
-    const AbortDevice& timeout,
+    const AbortDevice& abortDevice,
     const RecvChunkAcquisition& view);
 
 template <typename Transport>
@@ -111,7 +111,7 @@ __device__ __forceinline__ void send_registered(
     const IbgdaLocalBuffer& src,
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
-    const Timeout& timeout = Timeout());
+    const AbortDevice& abortDevice = AbortDevice());
 
 template <typename Transport, typename CopyOp, typename... Args>
 __device__ __forceinline__ IbgdaSendRecvProgressStatus
@@ -121,7 +121,7 @@ progress_send_once_with_trace(
     const void* __restrict__ src,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     const PipesTraceAllReduceContext& traceContext,
     PipesTraceProgressState& traceState,
     Args... args);
@@ -183,23 +183,23 @@ struct P2pIbTransportDevice {
       ThreadGroup& group,
       int signalId,
       uint64_t expected,
-      const Timeout& timeout = Timeout());
+      const AbortDevice& abortDevice = AbortDevice());
 
   __device__ void wait_signal(
       int signalId,
       uint64_t expected,
-      const Timeout& timeout = Timeout());
+      const AbortDevice& abortDevice = AbortDevice());
 
   __device__ void wait_counter(
       ThreadGroup& group,
       int counterId,
       uint64_t expected,
-      const Timeout& timeout = Timeout());
+      const AbortDevice& abortDevice = AbortDevice());
 
   __device__ void wait_counter(
       int counterId,
       uint64_t expected,
-      const Timeout& timeout = Timeout());
+      const AbortDevice& abortDevice = AbortDevice());
 
   __device__ void reset_signal(ThreadGroup& group, int signalId);
 
@@ -265,28 +265,28 @@ struct P2pIbTransportDevice {
       ThreadGroup& group,
       const IbgdaLocalBuffer& signalBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout());
+      const AbortDevice& abortDevice = AbortDevice());
 
   __device__ void wait_signal(
       const IbgdaLocalBuffer& signalBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout());
+      const AbortDevice& abortDevice = AbortDevice());
 
   __device__ void wait_counter(
       ThreadGroup& group,
       const IbgdaLocalBuffer& counterBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout());
+      const AbortDevice& abortDevice = AbortDevice());
 
   __device__ void wait_counter(
       const IbgdaLocalBuffer& counterBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout());
+      const AbortDevice& abortDevice = AbortDevice());
 
   __device__ void wait_local(
       ThreadGroup& group,
       const IbLocalCompletionTicket& ticket,
-      const Timeout& timeout = Timeout());
+      const AbortDevice& abortDevice = AbortDevice());
 
   __device__ void reset_signal(
       ThreadGroup& group,
@@ -307,13 +307,17 @@ struct P2pIbTransportDevice {
   // Takes the abort handle so the drain terminates on abort instead of waiting
   // on a NIC that will never complete. Stays void: the wait terminates itself,
   // and a caller draining its own WQEs has nothing to do with a status.
-  __device__ void flush(ThreadGroup& group, const Timeout& timeout = Timeout());
+  __device__ void flush(
+      ThreadGroup& group,
+      const AbortDevice& abortDevice = AbortDevice());
 
-  __device__ void flush(const Timeout& timeout = Timeout());
+  __device__ void flush(const AbortDevice& abortDevice = AbortDevice());
 
-  __device__ void fence(ThreadGroup& group, const Timeout& timeout = Timeout());
+  __device__ void fence(
+      ThreadGroup& group,
+      const AbortDevice& abortDevice = AbortDevice());
 
-  __device__ void fence(const Timeout& timeout = Timeout());
+  __device__ void fence(const AbortDevice& abortDevice = AbortDevice());
 
   __device__ __forceinline__ void require_ibgda(
       ThreadGroup& group,
@@ -325,7 +329,7 @@ struct P2pIbTransportDevice {
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const AbortDevice& abortDevice = AbortDevice(),
       Args... args);
 
   template <typename = void>
@@ -334,7 +338,7 @@ struct P2pIbTransportDevice {
       const IbgdaLocalBuffer& src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout());
+      const AbortDevice& abortDevice = AbortDevice());
 
   template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void recv(
@@ -342,7 +346,7 @@ struct P2pIbTransportDevice {
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const AbortDevice& abortDevice = AbortDevice(),
       Args... args);
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -352,7 +356,7 @@ struct P2pIbTransportDevice {
       P2pIbTransportDevice& fwd,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const AbortDevice& abortDevice = AbortDevice(),
       Args... args);
 
   __device__ __forceinline__ std::size_t pipeline_window() const;
@@ -388,7 +392,7 @@ struct P2pIbTransportDevice {
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const AbortDevice& abortDevice = AbortDevice(),
       Args... args);
 
   template <typename = void>
@@ -398,13 +402,13 @@ struct P2pIbTransportDevice {
       const IbgdaLocalBuffer& src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout());
+      const AbortDevice& abortDevice = AbortDevice());
 
   template <typename = void>
   __device__ __forceinline__ IbgdaRegisteredSendProgressStatus
   progress_registered_send_drain_once(
       ThreadGroup& group,
-      const Timeout& timeout = Timeout());
+      const AbortDevice& abortDevice = AbortDevice());
 
   template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ IbgdaSendRecvProgressStatus
@@ -413,7 +417,7 @@ struct P2pIbTransportDevice {
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       const PipesTraceAllReduceContext& traceContext,
       PipesTraceProgressState& traceState,
       Args... args);
@@ -423,13 +427,13 @@ struct P2pIbTransportDevice {
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       detail::RecvChunkAcquisition& out);
 
   template <typename = void>
   __device__ __forceinline__ void progress_recv_release_once(
       ThreadGroup& group,
-      const AbortDevice& timeout,
+      const AbortDevice& abortDevice,
       const detail::RecvChunkAcquisition& view);
 
   template <
@@ -441,7 +445,7 @@ struct P2pIbTransportDevice {
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const AbortDevice& abortDevice = AbortDevice(),
       Args... args);
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -451,7 +455,7 @@ struct P2pIbTransportDevice {
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       const PipesTraceAllReduceContext& traceContext,
       PipesTraceProgressState& traceState,
       Args... args);
@@ -465,8 +469,8 @@ class BlockingIbOps {
  public:
   static constexpr uint32_t kWorkerThreads = WorkerThreads;
 
-  __device__ BlockingIbOps(ThreadGroup workers, const Timeout& timeout)
-      : workers_(workers), timeout_(timeout) {}
+  __device__ BlockingIbOps(ThreadGroup workers, const AbortDevice& abortDevice)
+      : workers_(workers), timeout_(abortDevice) {}
 
   __device__ __forceinline__ ThreadGroup& group() {
     return workers_;
@@ -514,7 +518,7 @@ class BlockingIbOps {
 
  private:
   ThreadGroup workers_;
-  Timeout timeout_;
+  AbortDevice timeout_;
 };
 
 } // namespace comms::prims

--- a/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
@@ -221,7 +221,7 @@ template <typename P, typename Transport>
     ThreadGroup& group,
     uint32_t slotId,
     uint64_t generation,
-    const Timeout& timeout = Timeout());
+    const AbortDevice& abortDevice = AbortDevice());
 
 template <typename P, typename Transport>
 __device__ __forceinline__ void record_send_completion(
@@ -256,7 +256,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
     const void* __restrict__ src,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     Args... args);
 
 template <
@@ -270,7 +270,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
     void* __restrict__ dst,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     Args... args);
 
 template <typename Transport, typename CopyOp, typename... Args>
@@ -281,7 +281,7 @@ progress_recv_once_with_trace(
     void* __restrict__ dst,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     const PipesTraceAllReduceContext& traceContext,
     PipesTraceProgressState& traceState,
     Args... args);
@@ -326,7 +326,7 @@ __device__ __forceinline__ void wait_recv_data_ready(
     IbLocalChannel& localChannel,
     const IbgdaLocalBuffer& localDataReady,
     std::size_t chunkBytes,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   const uint32_t numLanes =
       static_cast<uint32_t>(transport.channel_layout().numLanes);
@@ -349,7 +349,7 @@ __device__ __forceinline__ void wait_recv_data_ready(
         sendRecvSignalSlotOffset(static_cast<int>(lane)));
     ThreadGroup solo{
         0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
-    transport.wait_signal(solo, laneBuf, expected, timeout);
+    transport.wait_signal(solo, laneBuf, expected, abortDevice);
     protoSlot.recvLaneExpected[lane] = expected;
     ++localChannel.recvDataReadyLaneCursor;
   }
@@ -360,7 +360,7 @@ __device__ __forceinline__ void wait_recv_data_ready(
   (void)localChannel;
   (void)localDataReady;
   (void)chunkBytes;
-  (void)timeout;
+  (void)abortDevice;
 #endif
 }
 
@@ -401,7 +401,7 @@ __device__ __forceinline__ void wait_recv_data_ready(
  *                        when max_signal_bytes is set.
  * @param max_signal_bytes Max bytes per signaled sub-chunk within one
  *                        perBlockSlot. 0 means one signal per perBlockSlot.
- * @param timeout         Optional timeout for wait operations.
+ * @param abortDevice         Optional abortDevice for wait operations.
  */
 // Per-call geometry for the blocking send()/recv() loops. One definition serves
 // both directions -- send and recv share the same layout, so the caller
@@ -576,7 +576,7 @@ __device__ __forceinline__ void consumeRecvBuf(
     std::size_t dataOff,
     uint64_t /*flagVal*/,
     uint64_t waitCredit,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     const PipesTraceAllReduceContext* traceContext,
     Args... args) {
 #if PIPES_IS_DEVICE_COMPILE
@@ -592,7 +592,7 @@ __device__ __forceinline__ void consumeRecvBuf(
         waitCredit);
   }
   wait_recv_data_ready(
-      transport, group, localChannel, localDataReady, waitCredit, timeout);
+      transport, group, localChannel, localDataReady, waitCredit, abortDevice);
   if (group.is_leader()) {
     trace_allreduce_event(
         traceContext,
@@ -631,7 +631,7 @@ __device__ __forceinline__ void consumeRecvBuf(
   (void)nbytes;
   (void)dataOff;
   (void)waitCredit;
-  (void)timeout;
+  (void)abortDevice;
   (void)traceContext;
   ((void)args, ...);
 #endif
@@ -666,7 +666,7 @@ __device__ __forceinline__ SendSignal prepareForwardBuf(
     uint64_t fwdSignalVal,
     uint32_t fwdSlot,
     uint64_t fwdPipelineCycle,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     const PipesTraceAllReduceContext* recvTraceContext,
     const PipesTraceAllReduceContext* sendTraceContext,
     Args... args) {
@@ -698,7 +698,7 @@ __device__ __forceinline__ SendSignal prepareForwardBuf(
       recvLocalChannel,
       recvDataReady,
       recvWaitCredit,
-      timeout);
+      abortDevice);
   if (group.is_leader()) {
     trace_allreduce_event(
         recvTraceContext,
@@ -712,7 +712,7 @@ __device__ __forceinline__ SendSignal prepareForwardBuf(
         fwdSignalVal);
   }
   if (prepare_send_slot<protocol::Simple>(
-          fwdTransport, group, fwdSlot, fwdPipelineCycle, timeout)) {
+          fwdTransport, group, fwdSlot, fwdPipelineCycle, abortDevice)) {
     // Slot not retired: a lane's completion was never observed, so the NIC may
     // still be reading this staging. Staging over it is the memory hazard the
     // retirement guard exists to prevent, so stop before CopyOp::forward.
@@ -773,7 +773,7 @@ __device__ __forceinline__ SendSignal prepareForwardBuf(
   (void)fwdSignalVal;
   (void)fwdSlot;
   (void)fwdPipelineCycle;
-  (void)timeout;
+  (void)abortDevice;
   (void)recvTraceContext;
   (void)sendTraceContext;
   ((void)args, ...);
@@ -858,7 +858,7 @@ __device__ __forceinline__ void consumeRecvBuf(
     std::size_t dataOff,
     uint64_t flagVal,
     uint64_t waitCredit,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     const PipesTraceAllReduceContext* traceContext,
     Args... args) {
   using P = LlxPacket<4, 4>;
@@ -887,7 +887,7 @@ __device__ __forceinline__ void consumeRecvBuf(
         validBytes,
         dataOff,
         static_cast<typename P::FlagType>(flagVal),
-        timeout,
+        abortDevice,
         args...);
   }
   if (group.is_leader()) {
@@ -913,7 +913,7 @@ __device__ __forceinline__ void consumeRecvBuf(
   (void)dataOff;
   (void)flagVal;
   (void)waitCredit;
-  (void)timeout;
+  (void)abortDevice;
   (void)traceContext;
   ((void)args, ...);
 #endif
@@ -932,7 +932,7 @@ __device__ __forceinline__ void send_impl(
     const void* __restrict__ src,
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
-    const Timeout& timeout = Timeout(),
+    const AbortDevice& abortDevice = AbortDevice(),
     const PipesTraceAllReduceContext* traceContext = nullptr,
     Args... args) {
   // The variable-size (compressed) loop below keeps its encode inline rather
@@ -958,7 +958,7 @@ __device__ __forceinline__ void send_impl(
   (void)src;
   (void)nbytes;
   (void)max_signal_bytes;
-  (void)timeout;
+  (void)abortDevice;
   (void)traceContext;
 #else
   (void)ibOps;
@@ -1135,7 +1135,7 @@ __device__ __forceinline__ void send_impl(
 
       // (1) Wait for NIC to finish with this slot's local sendStaging.
       if (prepare_send_slot<Proto>(
-              transport, group, ringSlot, pipelineCycle, timeout)) {
+              transport, group, ringSlot, pipelineCycle, abortDevice)) {
         // Unretired slot -- see prepare_send_slot. Breaking rather than
         // continuing keeps this loop from staging over a buffer the NIC may
         // still be reading, and from publishing chunks for an operation that
@@ -1158,7 +1158,10 @@ __device__ __forceinline__ void send_impl(
       // (3) Backpressure: wait for receiver to free this slot's recvStaging.
       if (protocolStreamEnd > pipelineBytes) {
         transport.wait_signal(
-            group, localSlotFree, protocolStreamEnd - pipelineBytes, timeout);
+            group,
+            localSlotFree,
+            protocolStreamEnd - pipelineBytes,
+            abortDevice);
       }
 
       // (4) Leader-only RDMA put with fused signal. The put length is the
@@ -1262,10 +1265,10 @@ __device__ __forceinline__ void send_impl(
       const bool slotUnretired = [&] {
         if constexpr (std::is_void_v<IbOps>) {
           return prepare_send_slot<Proto>(
-              transport, group, slot, pipelineCycle, timeout);
+              transport, group, slot, pipelineCycle, abortDevice);
         } else {
           return ibOps->prepare_send_slot(
-              transport, group, slot, pipelineCycle, timeout);
+              transport, group, slot, pipelineCycle, abortDevice);
         }
       }();
       if (slotUnretired) {
@@ -1322,7 +1325,7 @@ __device__ __forceinline__ void send_impl(
                 protocolBytesThis);
           }
           transport.wait_signal(
-              group, localSlotFree, slotFreeExpected, timeout);
+              group, localSlotFree, slotFreeExpected, abortDevice);
           if (group.is_leader()) {
             trace_allreduce_event(
                 traceContext,
@@ -1337,7 +1340,7 @@ __device__ __forceinline__ void send_impl(
         // that is correctly blocked and preventing it from ever reaching its
         // own deadline. The slot epilogue after this loop still runs, so the
         // progress slot is left idle for the next op.
-        if (groupAborted(group, timeout)) {
+        if (groupAborted(group, abortDevice)) {
           break;
         }
 
@@ -1417,7 +1420,7 @@ __device__ __forceinline__ void send_impl(
             static_cast<uint32_t>(slot),
             pipelineCycle,
             /*requiredRecvCredit=*/0,
-            timeout);
+            abortDevice);
       }
       dataOff += payloadBytes;
     }
@@ -1445,7 +1448,7 @@ __device__ __forceinline__ void send(
     const void* __restrict__ src,
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
-    const Timeout& timeout = Timeout(),
+    const AbortDevice& abortDevice = AbortDevice(),
     Args... args) {
   send_impl<Transport, CopyOp, void, Proto>(
       transport,
@@ -1454,7 +1457,7 @@ __device__ __forceinline__ void send(
       src,
       nbytes,
       max_signal_bytes,
-      timeout,
+      abortDevice,
       nullptr,
       args...);
 }
@@ -1470,7 +1473,7 @@ __device__ __forceinline__ void send_with_fine_trace(
     const void* __restrict__ src,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     const PipesTraceAllReduceContext& traceContext,
     Args... args) {
   send_impl<Transport, CopyOp, void, Proto>(
@@ -1480,7 +1483,7 @@ __device__ __forceinline__ void send_with_fine_trace(
       src,
       nbytes,
       max_signal_bytes,
-      timeout,
+      abortDevice,
       &traceContext,
       args...);
 }
@@ -1510,7 +1513,7 @@ __device__ __forceinline__ void send_with_fine_trace(
  * @param max_signal_bytes Max bytes per signaled sub-chunk within one
  *                        perBlockSlot. 0 means one signal per perBlockSlot.
  *                        Must match the sender's value.
- * @param timeout         Optional timeout for wait operations.
+ * @param abortDevice         Optional abortDevice for wait operations.
  */
 template <
     typename Transport,
@@ -1525,7 +1528,7 @@ __device__ __forceinline__ void recv_impl(
     void* __restrict__ dst,
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
-    const Timeout& timeout = Timeout(),
+    const AbortDevice& abortDevice = AbortDevice(),
     const PipesTraceAllReduceContext* traceContext = nullptr,
     Args... args) {
   // The variable-size (compressed) loop below keeps its encode inline rather
@@ -1551,7 +1554,7 @@ __device__ __forceinline__ void recv_impl(
   (void)dst;
   (void)nbytes;
   (void)max_signal_bytes;
-  (void)timeout;
+  (void)abortDevice;
   (void)traceContext;
 #else
   (void)ibOps;
@@ -1704,7 +1707,7 @@ __device__ __forceinline__ void recv_impl(
           localChannel,
           localDataReady,
           protocolBytesThis,
-          timeout);
+          abortDevice);
 
       // (2) Cooperative decompress: local recvStaging -> dst via CopyOp.
       CopyOp::recv(
@@ -1781,7 +1784,7 @@ __device__ __forceinline__ void recv_impl(
             dataOff,
             flagVal,
             protocolBytesThis,
-            timeout,
+            abortDevice,
             traceContext,
             args...);
         // The DATA_READY wait inside consumeRecvBuf may have given up rather
@@ -1789,7 +1792,7 @@ __device__ __forceinline__ void recv_impl(
         // Leave before the SLOT_FREE credit below: signalling it would tell the
         // sender we consumed a chunk it never sent, releasing a peer that is
         // correctly blocked and preventing it from reaching its own deadline.
-        if (groupAborted(group, timeout)) {
+        if (groupAborted(group, abortDevice)) {
           break;
         }
 
@@ -1814,7 +1817,7 @@ __device__ __forceinline__ void recv_impl(
         }
       } else {
         const uint64_t recvToken =
-            ibOps->wait_recv(transport, group, protocolBytesThis, timeout);
+            ibOps->wait_recv(transport, group, protocolBytesThis, abortDevice);
         const std::size_t validBytes =
             valid_payload_bytes(dataOff, payloadBytes, nbytes);
         if (validBytes > 0) {
@@ -1855,7 +1858,7 @@ __device__ __forceinline__ void recv(
     void* __restrict__ dst,
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
-    const Timeout& timeout = Timeout(),
+    const AbortDevice& abortDevice = AbortDevice(),
     Args... args) {
   recv_impl<Transport, CopyOp, void, Proto>(
       transport,
@@ -1864,7 +1867,7 @@ __device__ __forceinline__ void recv(
       dst,
       nbytes,
       max_signal_bytes,
-      timeout,
+      abortDevice,
       nullptr,
       args...);
 }
@@ -1880,7 +1883,7 @@ __device__ __forceinline__ void recv_with_fine_trace(
     void* __restrict__ dst,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     const PipesTraceAllReduceContext& traceContext,
     Args... args) {
   recv_impl<Transport, CopyOp, void, Proto>(
@@ -1890,7 +1893,7 @@ __device__ __forceinline__ void recv_with_fine_trace(
       dst,
       nbytes,
       max_signal_bytes,
-      timeout,
+      abortDevice,
       &traceContext,
       args...);
 }
@@ -1944,7 +1947,7 @@ __device__ __forceinline__ void recv_with_fine_trace(
  * @param nbytes          Bytes to receive and forward.
  * @param max_signal_bytes Max bytes per signaled sub-chunk. 0 =
  * perBlockSlot.
- * @param timeout         Optional timeout for wait operations.
+ * @param abortDevice         Optional abortDevice for wait operations.
  * @param args            Extra args forwarded to CopyOp::forward.
  */
 template <
@@ -1961,7 +1964,7 @@ __device__ __forceinline__ void forward_impl(
     Transport& fwdTransport,
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
-    const Timeout& timeout = Timeout(),
+    const AbortDevice& abortDevice = AbortDevice(),
     const PipesTraceAllReduceContext* recvTraceContext = nullptr,
     const PipesTraceAllReduceContext* sendTraceContext = nullptr,
     Args... args) {
@@ -2119,7 +2122,7 @@ __device__ __forceinline__ void forward_impl(
           fwdProtocolBytesThis,
           static_cast<uint32_t>(fwdSlot),
           fwdPipelineCycle,
-          timeout,
+          abortDevice,
           recvTraceContext,
           sendTraceContext,
           args...);
@@ -2140,7 +2143,7 @@ __device__ __forceinline__ void forward_impl(
           break;
         }
       }
-      if (groupAborted(group, timeout)) {
+      if (groupAborted(group, abortDevice)) {
         break;
       }
 
@@ -2161,7 +2164,7 @@ __device__ __forceinline__ void forward_impl(
               fwdProtocolBytesThis);
         }
         fwdTransport.wait_signal(
-            group, fwdSlotFree, fwdSlotFreeExpected, timeout);
+            group, fwdSlotFree, fwdSlotFreeExpected, abortDevice);
         if (group.is_leader()) {
           trace_allreduce_event(
               sendTraceContext,
@@ -2173,7 +2176,7 @@ __device__ __forceinline__ void forward_impl(
       // As in send_impl: the successor backpressure wait may have given up, and
       // the put below carries a fused DATA_READY that would release the
       // successor on data we never wrote.
-      if (groupAborted(group, timeout)) {
+      if (groupAborted(group, abortDevice)) {
         break;
       }
 
@@ -2238,14 +2241,14 @@ __device__ __forceinline__ void forward_impl(
       }
       group.sync();
     } else {
-      const uint64_t recvToken =
-          ibOps->wait_recv(transport, group, recvProtocolBytesThis, timeout);
+      const uint64_t recvToken = ibOps->wait_recv(
+          transport, group, recvProtocolBytesThis, abortDevice);
       if (ibOps->prepare_send_slot(
               fwdTransport,
               group,
               static_cast<uint32_t>(fwdSlot),
               fwdPipelineCycle,
-              timeout)) {
+              abortDevice)) {
         // Unretired forward slot -- stop before CopyOp::forward stages into a
         // buffer the NIC may still be reading.
         break;
@@ -2279,7 +2282,7 @@ __device__ __forceinline__ void forward_impl(
           static_cast<uint32_t>(fwdSlot),
           fwdPipelineCycle,
           recvToken + 1,
-          timeout);
+          abortDevice);
     }
     dataOff += payloadBytes;
   }
@@ -2308,7 +2311,7 @@ __device__ __forceinline__ void forward_impl(
   (void)fwdTransport;
   (void)nbytes;
   (void)max_signal_bytes;
-  (void)timeout;
+  (void)abortDevice;
   (void)recvTraceContext;
   (void)sendTraceContext;
 #endif
@@ -2326,7 +2329,7 @@ __device__ __forceinline__ void forward(
     Transport& fwdTransport,
     std::size_t nbytes,
     std::size_t max_signal_bytes = 0,
-    const Timeout& timeout = Timeout(),
+    const AbortDevice& abortDevice = AbortDevice(),
     Args... args) {
   forward_impl<CopyOp, Transport, void, Proto>(
       transport,
@@ -2336,7 +2339,7 @@ __device__ __forceinline__ void forward(
       fwdTransport,
       nbytes,
       max_signal_bytes,
-      timeout,
+      abortDevice,
       nullptr,
       nullptr,
       args...);
@@ -2354,7 +2357,7 @@ __device__ __forceinline__ void forward_with_fine_trace(
     Transport& fwdTransport,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     const PipesTraceAllReduceContext& recvTraceContext,
     const PipesTraceAllReduceContext& sendTraceContext,
     Args... args) {
@@ -2366,7 +2369,7 @@ __device__ __forceinline__ void forward_with_fine_trace(
       fwdTransport,
       nbytes,
       max_signal_bytes,
-      timeout,
+      abortDevice,
       &recvTraceContext,
       &sendTraceContext,
       args...);
@@ -2601,7 +2604,7 @@ template <typename P, typename Transport>
     ThreadGroup& group,
     uint32_t slotId,
     uint64_t generation,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   uint32_t unretired = 0;
   if (group.is_leader()) {
     auto& slot = transport.template local_channel_slot<P>(group.group_id)
@@ -2618,7 +2621,7 @@ template <typename P, typename Transport>
             .completionId = laneId,
             .value = slot.values[laneId],
         };
-        transport.wait_local_completion(group.group_id, ticket, timeout);
+        transport.wait_local_completion(group.group_id, ticket, abortDevice);
         // Confirm rather than assume: the wait above cannot report that it gave
         // up, and a lane earlier in this loop may already have latched the
         // abort, so later lanes can fall straight through it.
@@ -2665,9 +2668,9 @@ template <typename Transport>
     ThreadGroup& group,
     uint32_t slotId,
     uint64_t generation,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   return prepare_send_slot<protocol::Simple>(
-      transport, group, slotId, generation, timeout);
+      transport, group, slotId, generation, abortDevice);
 }
 
 template <typename Transport>

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -146,7 +146,7 @@ __device__ __forceinline__ uint32_t try_prepare_send_slot(
     ThreadGroup& group,
     uint32_t slotId,
     uint64_t generation,
-    const Timeout& timeout = Timeout());
+    const AbortDevice& abortDevice = AbortDevice());
 
 /**
  * Initialize transport-owned state for one pipelined send operation.
@@ -290,9 +290,9 @@ __device__ __forceinline__ void init_recv_progress(
  * This method advances at most one staged copy plus one RDMA put for the
  * current chunk. It never spins on local completion or SLOT_FREE: if either
  * dependency is not ready, it returns immediately so a higher-level scheduler
- * can try another independent lane. If a `Timeout` is enabled, it is checked
- * only at those readiness points and should already have been started by the
- * caller.
+ * can try another independent lane. If an `AbortDevice` is enabled, it is
+ * checked only at those readiness points and should already have been started
+ * by the caller.
  *
  * The send path first checks local completion before reusing the local
  * send-staging range, then copies user data into send-staging through
@@ -313,7 +313,8 @@ __device__ __forceinline__ void init_recv_progress(
  *            valid until `Done`.
  * @param nbytes Number of user-buffer bytes from the matching init call.
  * @param max_signal_bytes Maximum signaled sub-chunk size from init.
- * @param timeout Optional device timeout checked while dependencies wait.
+ * @param abortDevice Optional device abortDevice checked while dependencies
+ * wait.
  * @param args Additional arguments forwarded to `CopyOp::send`.
  */
 // ---- Resumable-progress protocol seams (tag-dispatched) ------------------
@@ -429,7 +430,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
     const void* __restrict__ src,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     const PipesTraceAllReduceContext* traceContext,
     PipesTraceProgressState* traceState,
     Args... args) {
@@ -482,7 +483,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
     const ProgressChunk chunk =
         next_chunk<Proto>(channelLayout, state, progress_params);
     const uint32_t slotReadiness = try_prepare_send_slot<Proto>(
-        transport, group, chunk.slotId, chunk.pipelineGeneration, timeout);
+        transport, group, chunk.slotId, chunk.pipelineGeneration, abortDevice);
     if (slotReadiness != kProgressReady) {
       if (fine_trace_enabled(traceContext) && traceState != nullptr &&
           !traceState->localCompletionWaitOpen && group.is_leader()) {
@@ -553,7 +554,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
         ready = current >= expected ? 1U : 0U;
         if (!ready) {
           if (FT_ABORT_CHECK(
-                  timeout,
+                  abortDevice,
                   "progress_send_once waiting for SLOT_FREE expected>=%llu, "
                   "current=%llu",
                   static_cast<unsigned long long>(expected),
@@ -611,7 +612,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
           static_cast<uint8_t>(kPipesTraceQpLaneMask),
           chunk.wireBytes);
       sendAborted =
-          FT_ABORT_CHECK(timeout, "send publish on an aborted communicator")
+          FT_ABORT_CHECK(abortDevice, "send publish on an aborted communicator")
           ? 1U
           : 0U;
     }
@@ -700,7 +701,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
   (void)src;
   (void)nbytes;
   (void)max_signal_bytes;
-  (void)timeout;
+  (void)abortDevice;
   (void)traceContext;
   (void)traceState;
   return IbgdaSendRecvProgressStatus::Done;
@@ -715,7 +716,7 @@ progress_registered_send_once(
     const IbgdaLocalBuffer& src,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   auto& channelLayout = transport.channel_layout();
   auto& progressSlot = progress_send_slot<protocol::Simple>(transport, group);
@@ -756,7 +757,7 @@ progress_registered_send_once(
     const ProgressChunk chunk =
         next_chunk<protocol::Simple>(channelLayout, state, geometry);
     const uint32_t slotReadiness = try_prepare_send_slot<protocol::Simple>(
-        transport, group, chunk.slotId, chunk.pipelineGeneration, timeout);
+        transport, group, chunk.slotId, chunk.pipelineGeneration, abortDevice);
     if (slotReadiness != kProgressReady) {
       if (slotReadiness == kProgressAborted) {
         abandon_progress_state(group, progressSlot, state);
@@ -786,7 +787,7 @@ progress_registered_send_once(
         ready = current >= expected ? 1U : 0U;
         if (!ready) {
           if (FT_ABORT_CHECK(
-                  timeout,
+                  abortDevice,
                   "progress_registered_send_once waiting for SLOT_FREE "
                   "expected>=%llu, current=%llu",
                   static_cast<unsigned long long>(expected),
@@ -823,7 +824,7 @@ progress_registered_send_once(
     if (group.is_leader()) {
       sendAborted =
           FT_ABORT_CHECK(
-              timeout, "registered send publish on an aborted communicator")
+              abortDevice, "registered send publish on an aborted communicator")
           ? 1U
           : 0U;
     }
@@ -877,7 +878,7 @@ progress_registered_send_once(
   (void)src;
   (void)nbytes;
   (void)max_signal_bytes;
-  (void)timeout;
+  (void)abortDevice;
   return IbgdaRegisteredSendProgressStatus::Drained;
 #endif
 }
@@ -911,11 +912,11 @@ __device__ __forceinline__ IbgdaRegisteredSendProgressStatus
 progress_registered_send_drain_once(
     Transport& transport,
     ThreadGroup& group,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t result =
       static_cast<uint32_t>(IbgdaRegisteredSendProgressStatus::Drained);
-  if (group.is_leader() && !timeout.isAborted()) {
+  if (group.is_leader() && !abortDevice.isAborted()) {
     bool foundPending = false;
     bool madeProgress = false;
     bool aborted = false;
@@ -937,14 +938,14 @@ progress_registered_send_drain_once(
             .value = slot.values[laneId],
         };
         if (transport.is_local_completion_ready(
-                group.group_id, ticket, timeout)) {
+                group.group_id, ticket, abortDevice)) {
           pending &= ~laneBit;
           madeProgress = true;
           continue;
         }
         foundPending = true;
         aborted = FT_ABORT_CHECK(
-            timeout,
+            abortDevice,
             "registered send local completion timed out slot=%d lane=%u",
             slotId,
             laneId);
@@ -971,7 +972,7 @@ progress_registered_send_drain_once(
 #else
   (void)transport;
   (void)group;
-  (void)timeout;
+  (void)abortDevice;
   return IbgdaRegisteredSendProgressStatus::Drained;
 #endif
 }
@@ -983,7 +984,7 @@ __device__ __forceinline__ void send_registered(
     const IbgdaLocalBuffer& src,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   init_registered_send_progress(transport, group, nbytes, max_signal_bytes);
   IbgdaRegisteredSendProgressStatus status;
@@ -993,13 +994,13 @@ __device__ __forceinline__ void send_registered(
   // failure this abort plumbing exists to break.
   do {
     status = progress_registered_send_once(
-        transport, group, src, nbytes, max_signal_bytes, timeout);
+        transport, group, src, nbytes, max_signal_bytes, abortDevice);
   } while (status != IbgdaRegisteredSendProgressStatus::Posted &&
            status != IbgdaRegisteredSendProgressStatus::Drained &&
            status != IbgdaRegisteredSendProgressStatus::Aborted);
   while (status != IbgdaRegisteredSendProgressStatus::Drained &&
          status != IbgdaRegisteredSendProgressStatus::Aborted) {
-    status = progress_registered_send_drain_once(transport, group, timeout);
+    status = progress_registered_send_drain_once(transport, group, abortDevice);
   }
 #else
   (void)transport;
@@ -1007,7 +1008,7 @@ __device__ __forceinline__ void send_registered(
   (void)src;
   (void)nbytes;
   (void)max_signal_bytes;
-  (void)timeout;
+  (void)abortDevice;
 #endif
 }
 
@@ -1018,7 +1019,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
     const void* __restrict__ src,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     Args... args) {
   return progress_send_once_impl<Transport, CopyOp, Proto>(
       transport,
@@ -1026,7 +1027,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
       src,
       nbytes,
       max_signal_bytes,
-      timeout,
+      abortDevice,
       nullptr,
       nullptr,
       args...);
@@ -1040,7 +1041,7 @@ progress_send_once_with_trace(
     const void* __restrict__ src,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     const PipesTraceAllReduceContext& traceContext,
     PipesTraceProgressState& traceState,
     Args... args) {
@@ -1050,7 +1051,7 @@ progress_send_once_with_trace(
       src,
       nbytes,
       max_signal_bytes,
-      timeout,
+      abortDevice,
       &traceContext,
       &traceState,
       args...);
@@ -1064,7 +1065,7 @@ progress_send_once_with_trace(
  * `recvDataReadyLaneCursor`/`recvLaneExpected` by exactly one chunk on that
  * (and only that) return. A false return leaves all receiver state untouched so
  * the caller can retry the same chunk on a later progress attempt.
- * `currentOut`/`expectedOut` are set for the caller's timeout diagnostic.
+ * `currentOut`/`expectedOut` are set for the caller's abortDevice diagnostic.
  */
 template <typename Transport>
 __device__ __forceinline__ bool poll_recv_data_ready(
@@ -1113,8 +1114,8 @@ __device__ __forceinline__ bool poll_recv_data_ready(
  *
  * This method advances at most one recv-staging copy for the current chunk.
  * It never spins on DATA_READY: if the sender has not signaled the next
- * chunk, it returns `Waiting` immediately. If a `Timeout` is enabled, it is
- * checked only while the DATA_READY dependency is not ready and should
+ * chunk, it returns `Waiting` immediately. If an `AbortDevice` is enabled, it
+ * is checked only while the DATA_READY dependency is not ready and should
  * already have been started by the caller.
  *
  * When DATA_READY reaches the chunk's `streamEnd`, the recv path copies from
@@ -1133,7 +1134,8 @@ __device__ __forceinline__ bool poll_recv_data_ready(
  *            remain valid until `Done`.
  * @param nbytes Number of user-buffer bytes from the matching init call.
  * @param max_signal_bytes Maximum signaled sub-chunk size from init.
- * @param timeout Optional device timeout checked while dependencies wait.
+ * @param abortDevice Optional device abortDevice checked while dependencies
+ * wait.
  * @param args Additional arguments forwarded to `CopyOp::recv`.
  */
 // Non-blocking readiness check for one recv chunk (Simple: poll the round-robin
@@ -1151,7 +1153,7 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
     IbLocalChannel& localChannel,
     const IbgdaLocalBuffer& localDataReady,
     uint64_t waitCredit,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     const PipesTraceAllReduceContext* traceContext,
     PipesTraceProgressState* traceState,
     uint8_t qpLane) {
@@ -1167,7 +1169,8 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
     // separate entry guard would add one to every healthy poll. Without it a
     // chunk whose data had arrived went on to consume it and credit SLOT_FREE
     // without ever consulting the abort.
-    if (FT_ABORT_CHECK(timeout, "recv progress on an aborted communicator")) {
+    if (FT_ABORT_CHECK(
+            abortDevice, "recv progress on an aborted communicator")) {
       ready = kProgressAborted;
     } else {
       ready = poll_recv_data_ready(
@@ -1190,7 +1193,7 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
           traceState->dataReadyWaitOpen = true;
         }
         if (FT_ABORT_CHECK(
-                timeout,
+                abortDevice,
                 "progress_recv_once waiting for DATA_READY expected>=%llu, "
                 "current=%llu",
                 expected,
@@ -1221,7 +1224,7 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
   (void)localChannel;
   (void)localDataReady;
   (void)waitCredit;
-  (void)timeout;
+  (void)abortDevice;
   (void)traceContext;
   (void)traceState;
   (void)qpLane;
@@ -1304,7 +1307,7 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
     IbLocalChannel& localChannel,
     const IbgdaLocalBuffer& localDataReady,
     uint64_t waitCredit,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     const PipesTraceAllReduceContext* traceContext,
     PipesTraceProgressState* traceState,
     uint8_t qpLane) {
@@ -1341,7 +1344,7 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
   uint32_t status = kProgressNotReady;
   if (group.is_leader()) {
     if (FT_ABORT_CHECK(
-            timeout,
+            abortDevice,
             "progress_recv_once(LL) waiting for packet flags flagVal=%llu, "
             "wireBytes=%llu",
             static_cast<unsigned long long>(chunk.flagVal),
@@ -1369,7 +1372,7 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
   (void)localChannel;
   (void)localDataReady;
   (void)waitCredit;
-  (void)timeout;
+  (void)abortDevice;
   return kProgressReady;
 #endif
 }
@@ -1409,8 +1412,8 @@ __device__ __forceinline__ void progress_recv_consume_buf(
       valid_payload_bytes(chunk.dataOff, chunk.payloadBytes, payloadBytes);
   // progress_recv_ready() above already confirmed every packet flag equals
   // chunk.flagVal, so unpack's readiness spin exits on its first load and a
-  // disabled Timeout cannot hang here. If that pre-check ever stops being
-  // exhaustive, thread progress_recv_once()'s timeout through instead.
+  // disabled AbortDevice cannot hang here. If that pre-check ever stops being
+  // exhaustive, thread progress_recv_once()'s abortDevice through instead.
   CopyOp::template recvLL<P>(
       group,
       static_cast<char*>(dst) + chunk.dataOff,
@@ -1418,7 +1421,7 @@ __device__ __forceinline__ void progress_recv_consume_buf(
       validBytes,
       chunk.dataOff,
       static_cast<typename P::FlagType>(chunk.flagVal),
-      Timeout(),
+      AbortDevice(),
       args...);
 #else
   (void)group;
@@ -1437,7 +1440,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once_impl(
     void* __restrict__ dst,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     const PipesTraceAllReduceContext* traceContext,
     PipesTraceProgressState* traceState,
     Args... args) {
@@ -1496,7 +1499,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once_impl(
       localChannel,
       localDataReady,
       protocolBytesThis,
-      timeout,
+      abortDevice,
       traceContext,
       traceState,
       qpLane);
@@ -1560,7 +1563,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once_impl(
   (void)dst;
   (void)nbytes;
   (void)max_signal_bytes;
-  (void)timeout;
+  (void)abortDevice;
   (void)traceContext;
   (void)traceState;
   return IbgdaSendRecvProgressStatus::Done;
@@ -1574,7 +1577,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
     void* __restrict__ dst,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     Args... args) {
   return progress_recv_once_impl<Transport, CopyOp, Proto>(
       transport,
@@ -1582,7 +1585,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
       dst,
       nbytes,
       max_signal_bytes,
-      timeout,
+      abortDevice,
       nullptr,
       nullptr,
       args...);
@@ -1596,7 +1599,7 @@ progress_recv_once_with_trace(
     void* __restrict__ dst,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     const PipesTraceAllReduceContext& traceContext,
     PipesTraceProgressState& traceState,
     Args... args) {
@@ -1606,7 +1609,7 @@ progress_recv_once_with_trace(
       dst,
       nbytes,
       max_signal_bytes,
-      timeout,
+      abortDevice,
       &traceContext,
       &traceState,
       args...);
@@ -1639,7 +1642,7 @@ progress_recv_acquire_once(
     ThreadGroup& group,
     std::size_t nbytes,
     std::size_t max_signal_bytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     RecvChunkAcquisition& out) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   auto& channelLayout = transport.channel_layout();
@@ -1694,7 +1697,7 @@ progress_recv_acquire_once(
       ch.channel,
       ch.local.dataReady,
       protocolBytesThis,
-      timeout,
+      abortDevice,
       nullptr,
       nullptr,
       qpLane);
@@ -1727,7 +1730,7 @@ progress_recv_acquire_once(
   (void)group;
   (void)nbytes;
   (void)max_signal_bytes;
-  (void)timeout;
+  (void)abortDevice;
   (void)out;
   return IbgdaSendRecvProgressStatus::Done;
 #endif
@@ -1757,7 +1760,7 @@ template <typename Transport, typename Proto>
 __device__ __forceinline__ void progress_recv_release_once(
     Transport& transport,
     ThreadGroup& group,
-    const AbortDevice& timeout,
+    const AbortDevice& abortDevice,
     const RecvChunkAcquisition& view) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   if (view.staging == nullptr) {
@@ -1774,8 +1777,8 @@ __device__ __forceinline__ void progress_recv_release_once(
   // the rest enter `transport.signal()` would split the group.
   uint32_t aborted = 0;
   if (group.is_leader()) {
-    aborted =
-        FT_ABORT_CHECK(timeout, "recv slot release on an aborted communicator")
+    aborted = FT_ABORT_CHECK(
+                  abortDevice, "recv slot release on an aborted communicator")
         ? 1U
         : 0U;
   }
@@ -1790,7 +1793,7 @@ __device__ __forceinline__ void progress_recv_release_once(
 #else
   (void)transport;
   (void)group;
-  (void)timeout;
+  (void)abortDevice;
   (void)view;
 #endif
 }
@@ -2189,7 +2192,7 @@ __device__ __forceinline__ uint32_t try_prepare_send_slot(
     ThreadGroup& group,
     uint32_t slotId,
     uint64_t generation,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t ready = kProgressReady;
   if (group.is_leader()) {
@@ -2204,7 +2207,7 @@ __device__ __forceinline__ uint32_t try_prepare_send_slot(
     // call that finds the slot already free never looked at the abort and went
     // on to stage the payload and issue the put with its fused DATA_READY.
     if (FT_ABORT_CHECK(
-            timeout, "send slot preparation on an aborted communicator")) {
+            abortDevice, "send slot preparation on an aborted communicator")) {
       ready = kProgressAborted;
     } else {
       auto& slot = transport.template local_channel_slot<P>(group.group_id)
@@ -2222,7 +2225,7 @@ __device__ __forceinline__ uint32_t try_prepare_send_slot(
               .value = slot.values[laneId],
           };
           if (transport.is_local_completion_ready(
-                  group.group_id, ticket, timeout)) {
+                  group.group_id, ticket, abortDevice)) {
             pending &= ~laneBit;
           }
         }
@@ -2232,7 +2235,7 @@ __device__ __forceinline__ uint32_t try_prepare_send_slot(
         } else {
           ready = kProgressNotReady;
           if (FT_ABORT_CHECK(
-                  timeout,
+                  abortDevice,
                   "send slot local completion timed out slot=%u generation=%llu "
                   "pending=0x%llx",
                   slotId,
@@ -2250,7 +2253,7 @@ __device__ __forceinline__ uint32_t try_prepare_send_slot(
   (void)group;
   (void)slotId;
   (void)generation;
-  (void)timeout;
+  (void)abortDevice;
   return kProgressReady;
 #endif
 }

--- a/comms/prims/transport/amd/HipDeviceCompat.h
+++ b/comms/prims/transport/amd/HipDeviceCompat.h
@@ -52,7 +52,7 @@
 //
 // Self-skip on non-HIP/non-AMD builds so this header can be included
 // unconditionally from cross-platform headers (e.g. `IbgdaBuffer.h`,
-// `Timeout.cuh`). All HIP-specific intrinsic shims and host-pass stubs
+// `AbortCheck.cuh`). All HIP-specific intrinsic shims and host-pass stubs
 // below are gated by this block.
 
 #ifdef __HIP_PLATFORM_AMD__

--- a/comms/prims/transport/amd/HipHostCompat.h
+++ b/comms/prims/transport/amd/HipHostCompat.h
@@ -8,7 +8,7 @@
 //
 // 1. **`__trap()` shim** — HIP doesn't expose `__trap()` in host pass the
 //    way nvcc does. Aliases `__trap()` to `abort()` in the device pass so
-//    cross-platform headers like `IbgdaBuffer.h` and `Timeout.cuh` that
+//    cross-platform headers like `IbgdaBuffer.h` and `AbortCheck.cuh` that
 //    use `__trap()` for fatal-error paths compile cleanly under hipcc.
 //    Kept here (not in `HipDeviceCompat.h`) because it's lightweight and
 //    used by cross-platform consumers that don't otherwise need AMD GCN

--- a/comms/prims/transport/amd/prims_amd_gda/PrimsAmdGdaShared.h
+++ b/comms/prims/transport/amd/prims_amd_gda/PrimsAmdGdaShared.h
@@ -4,9 +4,10 @@
 // PrimsAmdGdaShared — Re-exports shared comms::prims types into prims_amd_gda
 // =============================================================================
 //
-// The shared comms::prims headers (ThreadGroup.cuh, Timeout.cuh, IbgdaBuffer.h)
-// support both CUDA and HIP. This header re-exports all their types into the
-// prims_amd_gda namespace so AMD code can use a consistent namespace.
+// The shared comms::prims headers (ThreadGroup.cuh, AbortCheck.cuh,
+// IbgdaBuffer.h) support both CUDA and HIP. This header re-exports all their
+// types into the prims_amd_gda namespace so AMD code can use a consistent
+// namespace.
 
 #pragma once
 
@@ -57,13 +58,13 @@ using comms::prims::kMaxMultiwarpsPerBlock;
 using comms::prims::kMultiwarpSize;
 
 // ---------------------------------------------------------------------------
-// Timeout types and helpers
+// AbortDevice types and helpers
 // ---------------------------------------------------------------------------
+using comms::prims::AbortDevice;
 using comms::prims::gpu_clock64;
-using comms::prims::Timeout;
 
 } // namespace prims_amd_gda
 
 // The FT_ABORT_* checks come from
 // comms/common/fault_tolerance/AbortMacros.cuh, re-exported via
-// comms/prims/core/Timeout.cuh
+// comms/prims/core/AbortCheck.cuh

--- a/comms/prims/transport/ibgda/IbgdaWarpProxy.cuh
+++ b/comms/prims/transport/ibgda/IbgdaWarpProxy.cuh
@@ -234,10 +234,11 @@ class IbgdaWarpProxy {
         ThreadGroup& workers,
         uint32_t slot,
         uint64_t generation,
-        const Timeout& timeout) {
-      IbgdaWarpProxy::wait_prior_send_posted(storage_, workers, slot, timeout);
+        const AbortDevice& abortDevice) {
+      IbgdaWarpProxy::wait_prior_send_posted(
+          storage_, workers, slot, abortDevice);
       return detail::prepare_send_slot(
-          transport, workers, slot, generation, timeout);
+          transport, workers, slot, generation, abortDevice);
     }
 
     __device__ __forceinline__ void submit_send(
@@ -251,13 +252,13 @@ class IbgdaWarpProxy {
         uint32_t slot,
         uint64_t generation,
         uint64_t requiredRecvCredit,
-        const Timeout& timeout) {
+        const AbortDevice& abortDevice) {
       // The wait reports its own verdict through the barrier it already had,
       // so declining to enqueue costs no extra synchronization. Enqueuing here
       // would hand the service warp a command it turns into a peer-visible put
       // with a fused DATA_READY.
       if (IbgdaWarpProxy::template wait_queue_space<true>(
-              storage_, workers, timeout)) {
+              storage_, workers, abortDevice)) {
         return;
       }
       IbgdaWarpProxy::enqueue_send(
@@ -281,12 +282,12 @@ class IbgdaWarpProxy {
         P2pIbgdaTransportDevice& transport,
         ThreadGroup& workers,
         std::size_t protocolBytes,
-        const Timeout& timeout) {
+        const AbortDevice& abortDevice) {
       // Same shape as `submit_send()`. `kInvalidSequence` is what makes
       // `publish_recv()` free: it can decline on a register compare instead of
       // taking another barrier to re-ask.
       if (IbgdaWarpProxy::template wait_queue_space<false>(
-              storage_, workers, timeout)) {
+              storage_, workers, abortDevice)) {
         return kInvalidSequence;
       }
       const uint64_t sequence = IbgdaWarpProxy::enqueue_recv(
@@ -298,7 +299,7 @@ class IbgdaWarpProxy {
               .channel = static_cast<uint32_t>(workers.group_id),
           });
       if (IbgdaWarpProxy::wait_recv_ready(
-              storage_, workers, sequence, timeout)) {
+              storage_, workers, sequence, abortDevice)) {
         return kInvalidSequence;
       }
       return sequence;
@@ -327,25 +328,27 @@ class IbgdaWarpProxy {
    private:
     friend class IbgdaWarpProxy<WorkerThreads, MaxPipelineDepth>;
 
-    __device__
-    Ops(SharedState& storage, ThreadGroup workers, const Timeout& timeout)
-        : storage_(storage), workers_(workers), timeout_(timeout) {}
+    __device__ Ops(
+        SharedState& storage,
+        ThreadGroup workers,
+        const AbortDevice& abortDevice)
+        : storage_(storage), workers_(workers), timeout_(abortDevice) {}
 
     SharedState& storage_;
     ThreadGroup workers_;
-    Timeout timeout_;
+    AbortDevice timeout_;
   };
 
   template <typename WorkerFn>
   __device__ __forceinline__ static void run(
       SharedState& storage,
       ThreadGroup fullBlock,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       WorkerFn&& workerFn) {
     run(storage,
         fullBlock,
         Config{},
-        timeout,
+        abortDevice,
         static_cast<WorkerFn&&>(workerFn));
   }
 
@@ -354,7 +357,7 @@ class IbgdaWarpProxy {
       SharedState& storage,
       ThreadGroup fullBlock,
       const Config& config,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       WorkerFn&& workerFn) {
     validate_block(fullBlock);
     validate_config(config, fullBlock);
@@ -362,12 +365,12 @@ class IbgdaWarpProxy {
 
     if (fullBlock.thread_id_in_group < WorkerThreads) {
       ThreadGroup workers = make_worker_group(fullBlock);
-      Ops ops(storage, workers, timeout);
+      Ops ops(storage, workers, abortDevice);
       workerFn(ops);
       finish_workers(storage, workers);
     } else {
       ThreadGroup service = make_service_group(fullBlock);
-      run_service(storage, service, fullBlock, timeout);
+      run_service(storage, service, fullBlock, abortDevice);
     }
 
     fullBlock.sync();
@@ -489,7 +492,7 @@ class IbgdaWarpProxy {
   __device__ __forceinline__ static void drain_queues(
       SharedState& storage,
       ThreadGroup& workers,
-      const Timeout& timeout) {
+      const AbortDevice& abortDevice) {
     workers.sync();
     if (workers.is_leader()) {
       BlockAtomicU64 sendTail(storage.send.tail);
@@ -502,7 +505,7 @@ class IbgdaWarpProxy {
       uint64_t currentRecv = recvCredited.load(cuda::memory_order_acquire);
       while (currentSend < targetSend || currentRecv < targetRecv) {
         FT_ABORT_BREAK(
-            timeout,
+            abortDevice,
             "IbgdaWarpProxy drain waiting for service progress "
             "send=%llu/%llu recv=%llu/%llu",
             static_cast<unsigned long long>(currentSend),
@@ -536,7 +539,7 @@ class IbgdaWarpProxy {
   __device__ __forceinline__ static bool wait_queue_space(
       SharedState& storage,
       ThreadGroup& workers,
-      const Timeout& timeout) {
+      const AbortDevice& abortDevice) {
     uint32_t aborted = 0;
     if (workers.is_leader()) {
       uint64_t& tailValue = IsSend ? storage.send.tail : storage.recv.tail;
@@ -553,7 +556,7 @@ class IbgdaWarpProxy {
       }
       while (currentTail - currentHead >= storage.queueDepth) {
         if (FT_ABORT_CHECK(
-                timeout,
+                abortDevice,
                 "IbgdaWarpProxy %s queue full channel=%u head=%llu tail=%llu",
                 IsSend ? "send" : "recv",
                 workers.group_id,
@@ -572,7 +575,7 @@ class IbgdaWarpProxy {
       SharedState& storage,
       ThreadGroup& workers,
       uint32_t slot,
-      const Timeout& timeout) {
+      const AbortDevice& abortDevice) {
     auto& slotState = storage.send.slots[slot];
     if (workers.is_leader()) {
       const uint64_t requiredPosted = slotState.lastCommand == kInvalidSequence
@@ -582,7 +585,7 @@ class IbgdaWarpProxy {
       uint64_t currentPosted = posted.load(cuda::memory_order_acquire);
       while (currentPosted < requiredPosted) {
         FT_ABORT_BREAK(
-            timeout,
+            abortDevice,
             "IbgdaWarpProxy waiting for send WQE post channel=%u slot=%u "
             "posted=%llu required=%llu",
             workers.group_id,
@@ -628,14 +631,14 @@ class IbgdaWarpProxy {
       SharedState& storage,
       ThreadGroup& workers,
       uint64_t sequence,
-      const Timeout& timeout) {
+      const AbortDevice& abortDevice) {
     uint32_t aborted = 0;
     if (workers.is_leader()) {
       BlockAtomicU64 ready(storage.recv.ready);
       uint64_t current = ready.load(cuda::memory_order_acquire);
       while (current <= sequence) {
         if (FT_ABORT_CHECK(
-                timeout,
+                abortDevice,
                 "IbgdaWarpProxy waiting for DATA_READY channel=%u ready=%llu "
                 "required=%llu",
                 workers.group_id,
@@ -681,7 +684,7 @@ class IbgdaWarpProxy {
 
   __device__ __forceinline__ static void publish_recv_readiness(
       SharedState& storage,
-      const Timeout& timeout) {
+      const AbortDevice& abortDevice) {
     BlockAtomicU64 tail(storage.recv.tail);
     BlockAtomicU64 ready(storage.recv.ready);
     uint64_t currentReady = ready.load(cuda::memory_order_relaxed);
@@ -705,7 +708,7 @@ class IbgdaWarpProxy {
         // CHECK rather than BREAK: the `break` below is unconditional, so this
         // call is only here for the log-and-trap side effect on abort.
         (void)FT_ABORT_CHECK(
-            timeout,
+            abortDevice,
             "IbgdaWarpProxy waiting for DATA_READY channel=%u "
             "expected=%llu current=%llu",
             command.channel,
@@ -720,7 +723,7 @@ class IbgdaWarpProxy {
   __device__ __forceinline__ static void post_send_once(
       SharedState& storage,
       const ThreadGroup& fullBlock,
-      const Timeout& timeout) {
+      const AbortDevice& abortDevice) {
     BlockAtomicU64 tail(storage.send.tail);
     BlockAtomicU64 posted(storage.send.posted);
     const uint64_t head = posted.load(cuda::memory_order_relaxed);
@@ -741,7 +744,7 @@ class IbgdaWarpProxy {
       // Not a loop: `post_send_once` returns to its caller's polling loop, so
       // this only needs the log-and-trap side effect on abort.
       (void)FT_ABORT_CHECK(
-          timeout,
+          abortDevice,
           "IbgdaWarpProxy waiting for receive credit channel=%u "
           "credited=%llu required=%llu",
           command.channel,
@@ -758,7 +761,7 @@ class IbgdaWarpProxy {
       if (current < command.slotFreeExpected) {
         // As above: the return is unconditional; this is the log-and-trap.
         (void)FT_ABORT_CHECK(
-            timeout,
+            abortDevice,
             "IbgdaWarpProxy waiting for SLOT_FREE channel=%u "
             "expected=%llu current=%llu",
             command.channel,
@@ -794,7 +797,7 @@ class IbgdaWarpProxy {
       SharedState& storage,
       ThreadGroup& service,
       const ThreadGroup& fullBlock,
-      const Timeout& timeout) {
+      const AbortDevice& abortDevice) {
     BlockAtomicU32 producerDone(storage.producerDone);
     while (true) {
       uint32_t stop = 0;
@@ -838,7 +841,7 @@ class IbgdaWarpProxy {
         // it keeps the change to control flow instead of threading a status
         // through `publish_recv_readiness()`.
         bool aborted = FT_ABORT_CHECK(
-            timeout, "IbgdaWarpProxy::run_service abandoning drain");
+            abortDevice, "IbgdaWarpProxy::run_service abandoning drain");
         // Each step runs only if nothing has aborted yet, and re-reads the flag
         // afterwards because the step itself may have given up inside.
         const auto step = [&](auto&& emit) {
@@ -846,11 +849,11 @@ class IbgdaWarpProxy {
             return;
           }
           emit();
-          aborted = timeout.isAborted();
+          aborted = abortDevice.isAborted();
         };
         step([&] { post_recv_credits(storage, fullBlock); });
-        step([&] { publish_recv_readiness(storage, timeout); });
-        step([&] { post_send_once(storage, fullBlock, timeout); });
+        step([&] { publish_recv_readiness(storage, abortDevice); });
+        step([&] { post_send_once(storage, fullBlock, abortDevice); });
 
         if (aborted) {
           stop = 1U;

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -365,24 +365,25 @@ class P2pIbgdaTransportDevice {
    *                  sync after.
    * @param signalId  Slot index into the local signal inbox.
    * @param expected  Threshold; wait returns when slot value >= expected.
-   * @param timeout   Optional spin timeout. On expiry, prints diagnostic and
+   * @param abortDevice   Optional spin abortDevice. On expiry, prints
+   * diagnostic and
    *                  __trap()s.
    */
   __device__ void wait_signal(
       ThreadGroup& group,
       int signalId,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
-    wait_signal(group, local_signal_slot(signalId), expected, timeout);
+      const AbortDevice& abortDevice = AbortDevice()) {
+    wait_signal(group, local_signal_slot(signalId), expected, abortDevice);
   }
 
   /** wait_signal (thread-scope, slot-index) - Single-thread variant. */
   __device__ void wait_signal(
       int signalId,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     ThreadGroup solo = make_thread_solo();
-    wait_signal(solo, signalId, expected, timeout);
+    wait_signal(solo, signalId, expected, abortDevice);
   }
 
   /**
@@ -392,23 +393,23 @@ class P2pIbgdaTransportDevice {
    * @param group     Thread group; all threads must call. Leader spins.
    * @param counterId Slot index into the local counter buffer.
    * @param expected  Threshold; wait returns when slot value >= expected.
-   * @param timeout   Optional spin timeout.
+   * @param abortDevice   Optional spin abortDevice.
    */
   __device__ void wait_counter(
       ThreadGroup& group,
       int counterId,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
-    wait_counter(group, counter_slot(counterId), expected, timeout);
+      const AbortDevice& abortDevice = AbortDevice()) {
+    wait_counter(group, counter_slot(counterId), expected, abortDevice);
   }
 
   /** wait_counter (thread-scope, slot-index) - Single-thread variant. */
   __device__ void wait_counter(
       int counterId,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     ThreadGroup solo = make_thread_solo();
-    wait_counter(solo, counterId, expected, timeout);
+    wait_counter(solo, counterId, expected, abortDevice);
   }
 
   /**
@@ -634,24 +635,25 @@ class P2pIbgdaTransportDevice {
    *                  sync after.
    * @param signalBuf Pre-resolved local signal slot.
    * @param expected  Threshold; returns when slot value >= expected.
-   * @param timeout   Optional spin timeout. On expiry, prints diagnostic and
+   * @param abortDevice   Optional spin abortDevice. On expiry, prints
+   * diagnostic and
    *                  __trap()s.
    */
   __device__ void wait_signal(
       ThreadGroup& group,
       const IbgdaLocalBuffer& signalBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
-    wait_signal_impl(group, signalBuf, expected, timeout);
+      const AbortDevice& abortDevice = AbortDevice()) {
+    wait_signal_impl(group, signalBuf, expected, abortDevice);
   }
 
   /** wait_signal (thread-scope) - Single-thread variant. */
   __device__ void wait_signal(
       const IbgdaLocalBuffer& signalBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     ThreadGroup solo = make_thread_solo();
-    wait_signal(solo, signalBuf, expected, timeout);
+    wait_signal(solo, signalBuf, expected, abortDevice);
   }
 
   /**
@@ -660,24 +662,24 @@ class P2pIbgdaTransportDevice {
    * @param group      Thread group; all threads must call. Leader spins.
    * @param counterBuf Pre-resolved local counter slot.
    * @param expected   Threshold; returns when slot value >= expected.
-   * @param timeout    Optional spin timeout.
+   * @param abortDevice    Optional spin abortDevice.
    */
   __device__ void wait_counter(
       ThreadGroup& group,
       const IbgdaLocalBuffer& counterBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
-    wait_counter_impl(group, counterBuf, expected, timeout);
+      const AbortDevice& abortDevice = AbortDevice()) {
+    wait_counter_impl(group, counterBuf, expected, abortDevice);
   }
 
   __device__ void wait_local(
       ThreadGroup& group,
       const IbLocalCompletionTicket& ticket,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     if (group.is_leader()) {
       IbgdaLane lane = lane_from_ordinal(
           group.group_id, IbDirection::Send, ticket.completionId);
-      wait_local_on_qp(lane.qp, ticket.value, timeout);
+      wait_local_on_qp(lane.qp, ticket.value, abortDevice);
     }
     group.sync();
   }
@@ -685,7 +687,7 @@ class P2pIbgdaTransportDevice {
   __device__ __forceinline__ bool is_local_completion_ready(
       uint32_t channelId,
       const IbLocalCompletionTicket& ticket,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     IbgdaLane lane =
         lane_from_ordinal(channelId, IbDirection::Send, ticket.completionId);
     const int status = doca_gpu_dev_verbs_poll_one_cq_at<
@@ -712,7 +714,7 @@ class P2pIbgdaTransportDevice {
     //
     // Mirrors `P2pIbrcTransportDevice::check_status`, which is the reference
     // implementation for this pattern.
-    if (!timeout.isEnabled()) {
+    if (!abortDevice.isEnabled()) {
       PIPES_DEVICE_TRAP();
       return false;
     }
@@ -724,7 +726,7 @@ class P2pIbgdaTransportDevice {
     // using ABORTED here permanently misfiled every completion fault as a user
     // abort. It also sharpens `BadRkeyCompletionErrorUnwinds`, which asserts
     // the reason to tell the CQE path from the deadline path.
-    (void)timeout.setAbort(
+    (void)abortDevice.setAbort(
         comms::fault_tolerance::AbortReason::NETWORK_ERROR,
         "IBGDA local completion error CQE");
     // Deliberately "not ready": the caller polls this inside a loop that
@@ -736,10 +738,10 @@ class P2pIbgdaTransportDevice {
   __device__ __forceinline__ void wait_local_completion(
       uint32_t channelId,
       const IbLocalCompletionTicket& ticket,
-      const Timeout& timeout) {
+      const AbortDevice& abortDevice) {
     IbgdaLane lane =
         lane_from_ordinal(channelId, IbDirection::Send, ticket.completionId);
-    wait_local_on_qp(lane.qp, ticket.value, timeout);
+    wait_local_on_qp(lane.qp, ticket.value, abortDevice);
   }
 
   __device__ __forceinline__ uint32_t send_completion_lane_count() const {
@@ -750,9 +752,9 @@ class P2pIbgdaTransportDevice {
   __device__ void wait_counter(
       const IbgdaLocalBuffer& counterBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     ThreadGroup solo = make_thread_solo();
-    wait_counter(solo, counterBuf, expected, timeout);
+    wait_counter(solo, counterBuf, expected, abortDevice);
   }
 
   /**
@@ -770,18 +772,18 @@ class P2pIbgdaTransportDevice {
   __device__ void flush(
       ThreadGroup& group,
       IbDirection direction = IbDirection::Send,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     if (group.is_leader()) {
       validate_group_scope(group);
-      drain_flush_lanes(group, direction, timeout);
+      drain_flush_lanes(group, direction, abortDevice);
     }
     group.sync();
   }
 
   /** flush (thread-scope) - Single-thread variant. */
-  __device__ void flush(const Timeout& timeout = Timeout()) {
+  __device__ void flush(const AbortDevice& abortDevice = AbortDevice()) {
     ThreadGroup solo = make_thread_solo();
-    flush(solo, IbDirection::Send, timeout);
+    flush(solo, IbDirection::Send, abortDevice);
   }
 
   /**
@@ -795,13 +797,13 @@ class P2pIbgdaTransportDevice {
   __device__ void fence(
       ThreadGroup& group,
       IbDirection direction = IbDirection::Send,
-      const Timeout& timeout = Timeout()) {
-    flush(group, direction, timeout);
+      const AbortDevice& abortDevice = AbortDevice()) {
+    flush(group, direction, abortDevice);
   }
 
   /** fence (thread-scope) - Single-thread variant. */
-  __device__ void fence(const Timeout& timeout = Timeout()) {
-    flush(timeout);
+  __device__ void fence(const AbortDevice& abortDevice = AbortDevice()) {
+    flush(abortDevice);
   }
 
   // =========================================================================
@@ -1101,8 +1103,8 @@ class P2pIbgdaTransportDevice {
   __device__ void wait_local_on_qp(
       doca_gpu_dev_verbs_qp* qp,
       doca_gpu_dev_verbs_ticket_t ticket,
-      Timeout timeout = Timeout()) {
-    if (!timeout.isEnabled()) {
+      AbortDevice abortDevice = AbortDevice()) {
+    if (!abortDevice.isEnabled()) {
       doca_gpu_dev_verbs_wait<
           DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
           DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp, ticket);
@@ -1114,7 +1116,7 @@ class P2pIbgdaTransportDevice {
             doca_gpu_dev_verbs_qp_get_cq_sq(qp), ticket);
         if (status == EBUSY) {
           FT_ABORT_BREAK(
-              timeout,
+              abortDevice,
               "wait_local_on_qp timed out (ticket=%llu)",
               static_cast<unsigned long long>(ticket));
         } else if (status != 0) {
@@ -1141,7 +1143,7 @@ class P2pIbgdaTransportDevice {
           // The message stays a printf rather than a `context` string because
           // it carries the ticket and status; `context` is a plain `const
           // char*` and cannot format them.
-          if (timeout.setAbort(
+          if (abortDevice.setAbort(
                   comms::fault_tolerance::AbortReason::NETWORK_ERROR)) {
             printf(
                 "P2pIbgdaTransportDevice: wait_local_on_qp completion failed "
@@ -1160,24 +1162,25 @@ class P2pIbgdaTransportDevice {
       IbDirection direction,
       uint64_t mask,
       const uint64_t* tickets,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     const uint32_t numLanes = num_qp_lanes();
     for (uint32_t laneId = 0; laneId < numLanes; ++laneId) {
       if ((mask & (1ULL << laneId)) == 0) {
         continue;
       }
       IbgdaLane lane = lane_from_ordinal(channelId, direction, laneId);
-      wait_local_on_qp(lane.qp, tickets[laneId], timeout);
+      wait_local_on_qp(lane.qp, tickets[laneId], abortDevice);
     }
   }
 
   __device__ void drain_flush_lanes(
       ThreadGroup& group,
       IbDirection direction,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     auto& state = qp_state(group.group_id, direction);
     const uint64_t mask = atomic_exchange_u64(&state.pendingFlushLanesMask, 0);
-    wait_lanes(group.group_id, direction, mask, state.lastFlushWqe, timeout);
+    wait_lanes(
+        group.group_id, direction, mask, state.lastFlushWqe, abortDevice);
   }
 
   __device__ IbLocalCompletionTicket put_impl(
@@ -1313,12 +1316,12 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       const IbgdaLocalBuffer& signalBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     if (group.is_leader()) {
       uint64_t current = load_acquire_system_u64(signalBuf.ptr);
       while (current < expected) {
         FT_ABORT_BREAK(
-            timeout,
+            abortDevice,
             "wait_signal: expected>=%llu, current=%llu",
             static_cast<unsigned long long>(expected),
             static_cast<unsigned long long>(current));
@@ -1334,12 +1337,12 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       const IbgdaLocalBuffer& counterBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     if (group.is_leader()) {
       uint64_t current = load_acquire_system_u64(counterBuf.ptr);
       while (current < expected) {
         FT_ABORT_BREAK(
-            timeout,
+            abortDevice,
             "wait_counter: expected>=%llu, current=%llu",
             static_cast<unsigned long long>(expected),
             static_cast<unsigned long long>(current));
@@ -2091,7 +2094,7 @@ class P2pIbgdaTransportDevice {
    *
    *   transport->init_send_progress(group, nbytes, max_signal_bytes);
    *   while (transport->progress_send_once(
-   *              group, src, nbytes, max_signal_bytes, timeout)
+   *              group, src, nbytes, max_signal_bytes, abortDevice)
    *          != IbgdaSendRecvProgressStatus::Done) {
    *     // Try another independent lane or return to the scheduler.
    *   }
@@ -2201,9 +2204,9 @@ class P2pIbgdaTransportDevice {
    * This method advances at most one staged copy plus one RDMA put for the
    * current chunk. It never spins on NIC_DONE or SLOT_FREE: if either
    * dependency is not ready, it returns immediately so a higher-level scheduler
-   * can try another independent lane. If a `Timeout` is enabled, it is checked
-   * only at those readiness points and should already have been started by the
-   * caller.
+   * can try another independent lane. If a `AbortDevice` is enabled, it is
+   * checked only at those readiness points and should already have been started
+   * by the caller.
    *
    * The send path first waits for NIC_DONE before reusing the local
    * send-staging range, then copies user data into send-staging through
@@ -2224,7 +2227,8 @@ class P2pIbgdaTransportDevice {
    *            valid until `Done`.
    * @param nbytes Number of user-buffer bytes from the matching init call.
    * @param max_signal_bytes Maximum signaled sub-chunk size from init.
-   * @param timeout Optional device timeout checked while dependencies wait.
+   * @param abortDevice Optional device abortDevice checked while dependencies
+   * wait.
    * @param args Additional arguments forwarded to `CopyOp::send`.
    */
   template <
@@ -2236,10 +2240,10 @@ class P2pIbgdaTransportDevice {
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const AbortDevice& abortDevice = AbortDevice(),
       Args... args) {
     return detail::progress_send_once<P2pIbgdaTransportDevice, CopyOp, Proto>(
-        *this, group, src, nbytes, max_signal_bytes, timeout, args...);
+        *this, group, src, nbytes, max_signal_bytes, abortDevice, args...);
   }
 
   /**
@@ -2253,9 +2257,9 @@ class P2pIbgdaTransportDevice {
       const IbgdaLocalBuffer& src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     return detail::progress_registered_send_once(
-        *this, group, src, nbytes, max_signal_bytes, timeout);
+        *this, group, src, nbytes, max_signal_bytes, abortDevice);
   }
 
   /**
@@ -2266,8 +2270,9 @@ class P2pIbgdaTransportDevice {
   __device__ __forceinline__ IbgdaRegisteredSendProgressStatus
   progress_registered_send_drain_once(
       ThreadGroup& group,
-      const Timeout& timeout = Timeout()) {
-    return detail::progress_registered_send_drain_once(*this, group, timeout);
+      const AbortDevice& abortDevice = AbortDevice()) {
+    return detail::progress_registered_send_drain_once(
+        *this, group, abortDevice);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -2277,7 +2282,7 @@ class P2pIbgdaTransportDevice {
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       const PipesTraceAllReduceContext& traceContext,
       PipesTraceProgressState& traceState,
       Args... args) {
@@ -2288,7 +2293,7 @@ class P2pIbgdaTransportDevice {
             src,
             nbytes,
             max_signal_bytes,
-            timeout,
+            abortDevice,
             traceContext,
             traceState,
             args...);
@@ -2299,8 +2304,8 @@ class P2pIbgdaTransportDevice {
    *
    * This method advances at most one recv-staging copy for the current chunk.
    * It never spins on DATA_READY: if the sender has not signaled the next
-   * chunk, it returns `Waiting` immediately. If a `Timeout` is enabled, it is
-   * checked only while the DATA_READY dependency is not ready and should
+   * chunk, it returns `Waiting` immediately. If a `AbortDevice` is enabled, it
+   * is checked only while the DATA_READY dependency is not ready and should
    * already have been started by the caller.
    *
    * When DATA_READY reaches the chunk's `streamEnd`, the recv path copies from
@@ -2320,7 +2325,8 @@ class P2pIbgdaTransportDevice {
    *            remain valid until `Done`.
    * @param nbytes Number of user-buffer bytes from the matching init call.
    * @param max_signal_bytes Maximum signaled sub-chunk size from init.
-   * @param timeout Optional device timeout checked while dependencies wait.
+   * @param abortDevice Optional device abortDevice checked while dependencies
+   * wait.
    * @param args Additional arguments forwarded to `CopyOp::recv`.
    */
   template <
@@ -2332,10 +2338,10 @@ class P2pIbgdaTransportDevice {
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const AbortDevice& abortDevice = AbortDevice(),
       Args... args) {
     return detail::progress_recv_once<P2pIbgdaTransportDevice, CopyOp, Proto>(
-        *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
+        *this, group, dst, nbytes, max_signal_bytes, abortDevice, args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -2345,7 +2351,7 @@ class P2pIbgdaTransportDevice {
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       const PipesTraceAllReduceContext& traceContext,
       PipesTraceProgressState& traceState,
       Args... args) {
@@ -2356,7 +2362,7 @@ class P2pIbgdaTransportDevice {
             dst,
             nbytes,
             max_signal_bytes,
-            timeout,
+            abortDevice,
             traceContext,
             traceState,
             args...);
@@ -2375,21 +2381,21 @@ class P2pIbgdaTransportDevice {
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       detail::RecvChunkAcquisition& out) {
     return detail::
         progress_recv_acquire_once<P2pIbgdaTransportDevice, protocol::Simple>(
-            *this, group, nbytes, max_signal_bytes, timeout, out);
+            *this, group, nbytes, max_signal_bytes, abortDevice, out);
   }
 
   template <typename = void>
   __device__ __forceinline__ void progress_recv_release_once(
       ThreadGroup& group,
-      const AbortDevice& timeout,
+      const AbortDevice& abortDevice,
       const detail::RecvChunkAcquisition& view) {
     detail::
         progress_recv_release_once<P2pIbgdaTransportDevice, protocol::Simple>(
-            *this, group, timeout, view);
+            *this, group, abortDevice, view);
   }
 
   /**
@@ -2439,7 +2445,7 @@ class P2pIbgdaTransportDevice {
    * @param max_signal_bytes Max bytes per signaled sub-chunk within one
    *                        perBlockSlot. 0 means one signal per
    * perBlockSlot.
-   * @param timeout         Optional timeout for wait operations.
+   * @param abortDevice         Optional abortDevice for wait operations.
    */
   template <
       typename CopyOp = Memcpy,
@@ -2450,10 +2456,10 @@ class P2pIbgdaTransportDevice {
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const AbortDevice& abortDevice = AbortDevice(),
       Args... args) {
     sendWithTrace<CopyOp, Proto>(
-        group, src, nbytes, max_signal_bytes, timeout, {}, 0, args...);
+        group, src, nbytes, max_signal_bytes, abortDevice, {}, 0, args...);
   }
 
   /**
@@ -2465,9 +2471,9 @@ class P2pIbgdaTransportDevice {
       const IbgdaLocalBuffer& src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     detail::send_registered(
-        *this, group, src, nbytes, max_signal_bytes, timeout);
+        *this, group, src, nbytes, max_signal_bytes, abortDevice);
   }
 
   template <
@@ -2479,7 +2485,7 @@ class P2pIbgdaTransportDevice {
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       PipesTraceHandle trace,
       uint8_t self_rank,
       Args... args) {
@@ -2488,7 +2494,7 @@ class P2pIbgdaTransportDevice {
     (void)src;
     (void)nbytes;
     (void)max_signal_bytes;
-    (void)timeout;
+    (void)abortDevice;
     (void)trace;
     (void)self_rank;
 #else
@@ -2504,7 +2510,7 @@ class P2pIbgdaTransportDevice {
           static_cast<uint16_t>(group.group_id));
     }
     detail::send<P2pIbgdaTransportDevice, CopyOp, Proto>(
-        *this, group, src, nbytes, max_signal_bytes, timeout, args...);
+        *this, group, src, nbytes, max_signal_bytes, abortDevice, args...);
     if (group.is_leader()) {
       trace_ibgda_event(
           trace,
@@ -2522,7 +2528,7 @@ class P2pIbgdaTransportDevice {
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       const PipesTraceAllReduceContext& traceContext,
       Args... args) {
     detail::send_with_fine_trace<P2pIbgdaTransportDevice, CopyOp>(
@@ -2531,7 +2537,7 @@ class P2pIbgdaTransportDevice {
         src,
         nbytes,
         max_signal_bytes,
-        timeout,
+        abortDevice,
         traceContext,
         args...);
   }
@@ -2561,7 +2567,7 @@ class P2pIbgdaTransportDevice {
    * @param max_signal_bytes Max bytes per signaled sub-chunk within one
    *                        perBlockSlot. 0 means one signal per
    * perBlockSlot. Must match the sender's value.
-   * @param timeout         Optional timeout for wait operations.
+   * @param abortDevice         Optional abortDevice for wait operations.
    */
   template <
       typename CopyOp = Memcpy,
@@ -2572,10 +2578,10 @@ class P2pIbgdaTransportDevice {
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const AbortDevice& abortDevice = AbortDevice(),
       Args... args) {
     recvWithTrace<CopyOp, Proto>(
-        group, dst, nbytes, max_signal_bytes, timeout, {}, 0, args...);
+        group, dst, nbytes, max_signal_bytes, abortDevice, {}, 0, args...);
   }
 
   template <
@@ -2587,7 +2593,7 @@ class P2pIbgdaTransportDevice {
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       PipesTraceHandle trace,
       uint8_t self_rank,
       Args... args) {
@@ -2596,7 +2602,7 @@ class P2pIbgdaTransportDevice {
     (void)dst;
     (void)nbytes;
     (void)max_signal_bytes;
-    (void)timeout;
+    (void)abortDevice;
     (void)trace;
     (void)self_rank;
 #else
@@ -2612,7 +2618,7 @@ class P2pIbgdaTransportDevice {
           static_cast<uint16_t>(group.group_id));
     }
     detail::recv<P2pIbgdaTransportDevice, CopyOp, Proto>(
-        *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
+        *this, group, dst, nbytes, max_signal_bytes, abortDevice, args...);
     if (group.is_leader()) {
       trace_ibgda_event(
           trace,
@@ -2630,7 +2636,7 @@ class P2pIbgdaTransportDevice {
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       const PipesTraceAllReduceContext& traceContext,
       Args... args) {
     detail::recv_with_fine_trace<P2pIbgdaTransportDevice, CopyOp>(
@@ -2639,7 +2645,7 @@ class P2pIbgdaTransportDevice {
         dst,
         nbytes,
         max_signal_bytes,
-        timeout,
+        abortDevice,
         traceContext,
         args...);
   }
@@ -2693,7 +2699,7 @@ class P2pIbgdaTransportDevice {
    *                        protocol byte count is rounded up to 16 bytes.
    * @param max_signal_bytes Max bytes per signaled sub-chunk. 0 =
    * perBlockSlot.
-   * @param timeout         Optional timeout for wait operations.
+   * @param abortDevice         Optional abortDevice for wait operations.
    * @param args            Extra args forwarded to CopyOp::forward.
    */
   template <typename CopyOp = Memcpy, typename... Args>
@@ -2703,10 +2709,10 @@ class P2pIbgdaTransportDevice {
       P2pIbgdaTransportDevice& fwd,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const AbortDevice& abortDevice = AbortDevice(),
       Args... args) {
     forwardWithTrace<CopyOp>(
-        group, dst, fwd, nbytes, max_signal_bytes, timeout, {}, 0, args...);
+        group, dst, fwd, nbytes, max_signal_bytes, abortDevice, {}, 0, args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -2716,7 +2722,7 @@ class P2pIbgdaTransportDevice {
       P2pIbgdaTransportDevice& fwd,
       std::size_t nbytes,
       std::size_t max_signal_bytes,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       PipesTraceHandle trace,
       uint8_t self_rank,
       Args... args) {
@@ -2733,7 +2739,7 @@ class P2pIbgdaTransportDevice {
           static_cast<uint16_t>(group.group_id));
     }
     detail::forward<CopyOp>(
-        *this, group, dst, fwd, nbytes, max_signal_bytes, timeout, args...);
+        *this, group, dst, fwd, nbytes, max_signal_bytes, abortDevice, args...);
     if (group.is_leader()) {
       trace_ibgda_event(
           trace,
@@ -2752,7 +2758,7 @@ class P2pIbgdaTransportDevice {
       P2pIbgdaTransportDevice& fwd,
       std::size_t nbytes,
       std::size_t max_signal_bytes,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       const PipesTraceAllReduceContext& recvTraceContext,
       const PipesTraceAllReduceContext& sendTraceContext,
       Args... args) {
@@ -2763,7 +2769,7 @@ class P2pIbgdaTransportDevice {
         fwd,
         nbytes,
         max_signal_bytes,
-        timeout,
+        abortDevice,
         recvTraceContext,
         sendTraceContext,
         args...);

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -193,32 +193,32 @@ class P2pIbrcTransportDevice {
       ThreadGroup& group,
       int signalId,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) const {
-    wait_signal(group, local_signal_slot(signalId), expected, timeout);
+      const AbortDevice& abortDevice = AbortDevice()) const {
+    wait_signal(group, local_signal_slot(signalId), expected, abortDevice);
   }
 
   __device__ void wait_signal(
       int signalId,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) const {
+      const AbortDevice& abortDevice = AbortDevice()) const {
     ThreadGroup solo = make_thread_solo();
-    wait_signal(solo, signalId, expected, timeout);
+    wait_signal(solo, signalId, expected, abortDevice);
   }
 
   __device__ void wait_counter(
       ThreadGroup& group,
       int counterId,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) const {
-    wait_counter(group, counter_device_slot(counterId), expected, timeout);
+      const AbortDevice& abortDevice = AbortDevice()) const {
+    wait_counter(group, counter_device_slot(counterId), expected, abortDevice);
   }
 
   __device__ void wait_counter(
       int counterId,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) const {
+      const AbortDevice& abortDevice = AbortDevice()) const {
     ThreadGroup solo = make_thread_solo();
-    wait_counter(solo, counterId, expected, timeout);
+    wait_counter(solo, counterId, expected, abortDevice);
   }
 
   __device__ void reset_signal(ThreadGroup& group, int signalId) {
@@ -388,7 +388,7 @@ class P2pIbrcTransportDevice {
   __device__ void wait_local(
       ThreadGroup& group,
       const IbLocalCompletionTicket& ticket,
-      const Timeout& timeout = Timeout()) const {
+      const AbortDevice& abortDevice = AbortDevice()) const {
     if (group.is_leader()) {
       const auto& queue = cmdQueues[queue_for_lane(
           group.group_id, IbDirection::Send, ticket.completionId)];
@@ -396,7 +396,7 @@ class P2pIbrcTransportDevice {
                  load_acquire_system_u64(queue.ci) - ticket.value) < 0) {
         check_status(queue);
         FT_ABORT_BREAK(
-            timeout,
+            abortDevice,
             "P2pIbrcTransportDevice: wait_local lane=%u expected=%llu",
             ticket.completionId,
             static_cast<unsigned long long>(ticket.value));
@@ -405,7 +405,7 @@ class P2pIbrcTransportDevice {
     group.sync();
   }
 
-  // The `timeout` parameter exists for signature parity with the IBGDA
+  // The `abortDevice` parameter exists for signature parity with the IBGDA
   // transport: the progress path is templated on the transport type and passes
   // it to whichever one it has. IBRC does not need it -- `check_status()` below
   // already latches the abort on the communicator-scoped `abort_` member -- so
@@ -413,7 +413,7 @@ class P2pIbrcTransportDevice {
   __device__ __forceinline__ bool is_local_completion_ready(
       uint32_t channelId,
       const IbLocalCompletionTicket& ticket,
-      const Timeout& /*timeout*/ = Timeout()) const {
+      const AbortDevice& /*abortDevice*/ = AbortDevice()) const {
     const auto& queue = cmdQueues[queue_for_lane(
         channelId, IbDirection::Send, ticket.completionId)];
     check_status(queue);
@@ -424,14 +424,14 @@ class P2pIbrcTransportDevice {
   __device__ __forceinline__ void wait_local_completion(
       uint32_t channelId,
       const IbLocalCompletionTicket& ticket,
-      const Timeout& timeout) const {
+      const AbortDevice& abortDevice) const {
     const auto& queue = cmdQueues[queue_for_lane(
         channelId, IbDirection::Send, ticket.completionId)];
     while (static_cast<int64_t>(
                load_acquire_system_u64(queue.ci) - ticket.value) < 0) {
       check_status(queue);
       FT_ABORT_BREAK(
-          timeout,
+          abortDevice,
           "P2pIbrcTransportDevice: local completion lane=%u expected=%llu",
           ticket.completionId,
           static_cast<unsigned long long>(ticket.value));
@@ -485,16 +485,16 @@ class P2pIbrcTransportDevice {
       ThreadGroup& group,
       const IbgdaLocalBuffer& signalBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) const {
-    wait_local(group, signalBuf.ptr, expected, timeout, "signal");
+      const AbortDevice& abortDevice = AbortDevice()) const {
+    wait_local(group, signalBuf.ptr, expected, abortDevice, "signal");
   }
 
   __device__ void wait_signal(
       const IbgdaLocalBuffer& signalBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) const {
+      const AbortDevice& abortDevice = AbortDevice()) const {
     ThreadGroup solo = make_thread_solo();
-    wait_signal(solo, signalBuf, expected, timeout);
+    wait_signal(solo, signalBuf, expected, abortDevice);
   }
 
   __device__ void reset_signal(
@@ -523,16 +523,16 @@ class P2pIbrcTransportDevice {
       ThreadGroup& group,
       const IbgdaLocalBuffer& counterBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) const {
-    wait_local(group, counterBuf.ptr, expected, timeout, "counter");
+      const AbortDevice& abortDevice = AbortDevice()) const {
+    wait_local(group, counterBuf.ptr, expected, abortDevice, "counter");
   }
 
   __device__ void wait_counter(
       const IbgdaLocalBuffer& counterBuf,
       uint64_t expected,
-      const Timeout& timeout = Timeout()) const {
+      const AbortDevice& abortDevice = AbortDevice()) const {
     ThreadGroup solo = make_thread_solo();
-    wait_counter(solo, counterBuf, expected, timeout);
+    wait_counter(solo, counterBuf, expected, abortDevice);
   }
 
   __device__ uint64_t read_signal(const IbgdaLocalBuffer& signalBuf) const {
@@ -664,10 +664,10 @@ class P2pIbrcTransportDevice {
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const AbortDevice& abortDevice = AbortDevice(),
       Args... args) {
     return detail::progress_send_once<P2pIbrcTransportDevice, CopyOp, Proto>(
-        *this, group, src, nbytes, max_signal_bytes, timeout, args...);
+        *this, group, src, nbytes, max_signal_bytes, abortDevice, args...);
   }
 
   template <
@@ -679,10 +679,10 @@ class P2pIbrcTransportDevice {
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const AbortDevice& abortDevice = AbortDevice(),
       Args... args) {
     return detail::progress_recv_once<P2pIbrcTransportDevice, CopyOp, Proto>(
-        *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
+        *this, group, dst, nbytes, max_signal_bytes, abortDevice, args...);
   }
 
   // Templated for the same reason P2pIbTransportDevice templates its
@@ -698,21 +698,21 @@ class P2pIbrcTransportDevice {
       ThreadGroup& group,
       std::size_t nbytes,
       std::size_t max_signal_bytes,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       detail::RecvChunkAcquisition& out) {
     return detail::
         progress_recv_acquire_once<P2pIbrcTransportDevice, protocol::Simple>(
-            *this, group, nbytes, max_signal_bytes, timeout, out);
+            *this, group, nbytes, max_signal_bytes, abortDevice, out);
   }
 
   template <typename = void>
   __device__ __forceinline__ void progress_recv_release_once(
       ThreadGroup& group,
-      const AbortDevice& timeout,
+      const AbortDevice& abortDevice,
       const detail::RecvChunkAcquisition& view) {
     detail::
         progress_recv_release_once<P2pIbrcTransportDevice, protocol::Simple>(
-            *this, group, timeout, view);
+            *this, group, abortDevice, view);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -721,10 +721,10 @@ class P2pIbrcTransportDevice {
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const AbortDevice& abortDevice = AbortDevice(),
       Args... args) {
     detail::send<P2pIbrcTransportDevice, CopyOp>(
-        *this, group, src, nbytes, max_signal_bytes, timeout, args...);
+        *this, group, src, nbytes, max_signal_bytes, abortDevice, args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -733,10 +733,10 @@ class P2pIbrcTransportDevice {
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const AbortDevice& abortDevice = AbortDevice(),
       Args... args) {
     detail::recv<P2pIbrcTransportDevice, CopyOp>(
-        *this, group, dst, nbytes, max_signal_bytes, timeout, args...);
+        *this, group, dst, nbytes, max_signal_bytes, abortDevice, args...);
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -746,10 +746,10 @@ class P2pIbrcTransportDevice {
       P2pIbrcTransportDevice& fwd,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout(),
+      const AbortDevice& abortDevice = AbortDevice(),
       Args... args) {
     detail::forward<CopyOp>(
-        *this, group, dst, fwd, nbytes, max_signal_bytes, timeout, args...);
+        *this, group, dst, fwd, nbytes, max_signal_bytes, abortDevice, args...);
   }
 
  private:
@@ -1035,7 +1035,7 @@ class P2pIbrcTransportDevice {
       ThreadGroup& group,
       const void* ptr,
       uint64_t expected,
-      const Timeout& timeout,
+      const AbortDevice& abortDevice,
       const char* kind) const {
     if (ptr == nullptr) {
       trap("P2pIbrcTransportDevice: wait buffer is null");
@@ -1045,7 +1045,7 @@ class P2pIbrcTransportDevice {
       while (load_acquire_system_u64(ptr) < expected) {
         check_channel_status(group.group_id);
         FT_ABORT_BREAK(
-            timeout,
+            abortDevice,
             "P2pIbrcTransportDevice: wait_%s expected=%llu",
             kind,
             static_cast<unsigned long long>(expected));
@@ -1186,7 +1186,7 @@ class P2pIbrcTransportDevice {
   //
   // Held as a member rather than threaded through put()/signal()/flush()
   // because the waits that need it -- reserve() and drain_queue() -- sit behind
-  // APIs that take no timeout. Passing it per call would push an abort
+  // APIs that take no abort handle. Passing it per call would push an abort
   // parameter onto every IBRC producer, and the callers have nothing to do with
   // the answer: these waits terminate themselves. Default-constructed (no
   // handle) keeps the legacy cycle-deadline trap.

--- a/comms/prims/transport/ll/LlOps.cuh
+++ b/comms/prims/transport/ll/LlOps.cuh
@@ -74,7 +74,7 @@ namespace comms::prims {
  * @param src       Local source buffer (8-byte aligned)
  * @param nbytes    Total message size in bytes (must be a multiple of 8)
  * @param remote_ll_buf  Pointer to receiver's LL line buffer
- * @param timeout   Timeout for flag polling
+ * @param abortDevice   Timeout for flag polling
  * @param buffer_num_lines  Number of lines in the LL buffer.
  *                          0 = buffer is pre-sized to fit the entire message.
  *                          >0 and < total lines = windowed/chunked mode.
@@ -85,7 +85,7 @@ __device__ __forceinline__ void ll_send(
     const char* __restrict__ src,
     size_t nbytes,
     LlLine* __restrict__ remote_ll_buf,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     size_t buffer_num_lines = 0) {
 #ifdef __CUDA_ARCH__
   const uint32_t flag_value = 1;
@@ -130,7 +130,7 @@ __device__ __forceinline__ void ll_send(
         ll_load_line(&remote_ll_buf[buf_idx], poll);
         if (poll.flag1 != kLlReadyToWrite || poll.flag2 != kLlReadyToWrite) {
           if (FT_ABORT_CHECK(
-                  timeout,
+                  abortDevice,
                   "ll_send: waiting for READY_TO_WRITE on line %llu (buf_idx=%llu)",
                   (unsigned long long)line_idx,
                   (unsigned long long)buf_idx)) {
@@ -164,7 +164,7 @@ __device__ __forceinline__ void ll_send(
   (void)src;
   (void)nbytes;
   (void)remote_ll_buf;
-  (void)timeout;
+  (void)abortDevice;
   (void)buffer_num_lines;
 #endif
 }
@@ -184,7 +184,7 @@ __device__ __forceinline__ void ll_send(
  * @param dst       Local output buffer (8-byte aligned)
  * @param nbytes    Total message size in bytes (must be a multiple of 8)
  * @param local_ll_buf  Pointer to local LL line buffer
- * @param timeout   Timeout for flag polling
+ * @param abortDevice   Timeout for flag polling
  * @param buffer_num_lines  Number of lines in the LL buffer.
  *                          0 = buffer is pre-sized to fit the entire message.
  *                          >0 and < total lines = windowed/chunked mode.
@@ -195,7 +195,7 @@ __device__ __forceinline__ void ll_recv(
     char* __restrict__ dst,
     size_t nbytes,
     LlLine* __restrict__ local_ll_buf,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     size_t buffer_num_lines = 0) {
 #ifdef __CUDA_ARCH__
   const uint32_t flag_value = 1;
@@ -239,7 +239,7 @@ __device__ __forceinline__ void ll_recv(
         ll_load_line(&local_ll_buf[buf_idx], in);
         if (in.flag1 != pkt_flag_value || in.flag2 != pkt_flag_value) {
           if (FT_ABORT_CHECK(
-                  timeout,
+                  abortDevice,
                   "ll_recv: waiting for flag=%u on line %llu (buf_idx=%llu, got flag1=%u flag2=%u)",
                   (unsigned)pkt_flag_value,
                   (unsigned long long)line_idx,
@@ -275,7 +275,7 @@ __device__ __forceinline__ void ll_recv(
   (void)dst;
   (void)nbytes;
   (void)local_ll_buf;
-  (void)timeout;
+  (void)abortDevice;
   (void)buffer_num_lines;
 #endif
 }
@@ -297,7 +297,7 @@ __device__ __forceinline__ void ll_recv(
  * @param nbytes    Total message size in bytes (must be a multiple of 8)
  * @param local_ll_buf   Pointer to local LL buffer (predecessor wrote)
  * @param remote_ll_buf  Pointer to successor's LL buffer
- * @param timeout   Timeout for flag polling
+ * @param abortDevice   Timeout for flag polling
  * @param buffer_num_lines  Number of lines in the LL buffer.
  *                          0 = buffer is pre-sized to fit the entire message.
  *                          >0 and < total lines = windowed/chunked mode.
@@ -309,7 +309,7 @@ __device__ __forceinline__ void ll_forward(
     size_t nbytes,
     LlLine* __restrict__ local_ll_buf,
     LlLine* __restrict__ remote_ll_buf,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     size_t buffer_num_lines = 0) {
 #ifdef __CUDA_ARCH__
   const uint32_t flag_value = 1;
@@ -347,7 +347,7 @@ __device__ __forceinline__ void ll_forward(
         ll_load_line(&local_ll_buf[buf_idx], in);
         if (in.flag1 != pkt_flag_value || in.flag2 != pkt_flag_value) {
           if (FT_ABORT_CHECK(
-                  timeout,
+                  abortDevice,
                   "ll_forward: waiting for flag=%u on local line %llu (buf_idx=%llu)",
                   (unsigned)pkt_flag_value,
                   (unsigned long long)line_idx,
@@ -371,7 +371,7 @@ __device__ __forceinline__ void ll_forward(
         ll_load_line(&remote_ll_buf[buf_idx], poll);
         if (poll.flag1 != kLlReadyToWrite || poll.flag2 != kLlReadyToWrite) {
           if (FT_ABORT_CHECK(
-                  timeout,
+                  abortDevice,
                   "ll_forward: waiting for READY_TO_WRITE on remote line %llu (buf_idx=%llu)",
                   (unsigned long long)line_idx,
                   (unsigned long long)buf_idx)) {
@@ -406,7 +406,7 @@ __device__ __forceinline__ void ll_forward(
   (void)nbytes;
   (void)local_ll_buf;
   (void)remote_ll_buf;
-  (void)timeout;
+  (void)abortDevice;
   (void)buffer_num_lines;
 #endif
 }

--- a/comms/prims/transport/ll/tests/LlOpsNvlinkTest.cu
+++ b/comms/prims/transport/ll/tests/LlOpsNvlinkTest.cu
@@ -25,10 +25,10 @@ __global__ void ll_nvlink_send_kernel(
     size_t buffer_num_lines,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout timeout;
-  timeout.start();
+  Timeout abortDevice;
+  abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
-    ll_send(group, src, nbytes, remote_ll_buf, timeout, buffer_num_lines);
+    ll_send(group, src, nbytes, remote_ll_buf, abortDevice, buffer_num_lines);
   }
 }
 
@@ -39,10 +39,10 @@ __global__ void ll_nvlink_recv_kernel(
     size_t buffer_num_lines,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout timeout;
-  timeout.start();
+  Timeout abortDevice;
+  abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
-    ll_recv(group, dst, nbytes, local_ll_buf, timeout, buffer_num_lines);
+    ll_recv(group, dst, nbytes, local_ll_buf, abortDevice, buffer_num_lines);
   }
 }
 
@@ -54,8 +54,8 @@ __global__ void ll_nvlink_forward_kernel(
     size_t buffer_num_lines,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout timeout;
-  timeout.start();
+  Timeout abortDevice;
+  abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
     ll_forward(
         group,
@@ -63,7 +63,7 @@ __global__ void ll_nvlink_forward_kernel(
         nbytes,
         local_ll_buf,
         remote_ll_buf,
-        timeout,
+        abortDevice,
         buffer_num_lines);
   }
 }
@@ -86,16 +86,22 @@ __global__ void ll_nvlink_send_recv_kernel(
     int num_steps) {
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(2);
-  Timeout timeout;
-  timeout.start();
+  Timeout abortDevice;
+  abortDevice.start();
   if (partition_id == 0) {
     for (int i = 0; i < num_steps; i++) {
       ll_send(
-          subgroup, src, nbytes, remote_send_buf, timeout, buffer_num_lines);
+          subgroup,
+          src,
+          nbytes,
+          remote_send_buf,
+          abortDevice,
+          buffer_num_lines);
     }
   } else {
     for (int i = 0; i < num_steps; i++) {
-      ll_recv(subgroup, dst, nbytes, local_recv_buf, timeout, buffer_num_lines);
+      ll_recv(
+          subgroup, dst, nbytes, local_recv_buf, abortDevice, buffer_num_lines);
     }
   }
 }
@@ -357,15 +363,15 @@ __global__ void ll_nvlink_varying_send_kernel(
     size_t buffer_num_lines,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout timeout;
-  timeout.start();
+  Timeout abortDevice;
+  abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
     ll_send(
         group,
         src + i * nbytes,
         nbytes,
         remote_ll_buf,
-        timeout,
+        abortDevice,
         buffer_num_lines);
   }
 }
@@ -377,15 +383,15 @@ __global__ void ll_nvlink_varying_recv_kernel(
     size_t buffer_num_lines,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout timeout;
-  timeout.start();
+  Timeout abortDevice;
+  abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
     ll_recv(
         group,
         dst + i * nbytes,
         nbytes,
         local_ll_buf,
-        timeout,
+        abortDevice,
         buffer_num_lines);
   }
 }

--- a/comms/prims/transport/ll128/Ll128Ops.cuh
+++ b/comms/prims/transport/ll128/Ll128Ops.cuh
@@ -128,7 +128,7 @@ namespace comms::prims {
  * @param src       Local source buffer (user data, contiguous, 16-byte aligned)
  * @param nbytes    Total message size in bytes (must be a multiple of 16)
  * @param remote_ll128_buf  Pointer to receiver's LL128 packet buffer
- * @param timeout   Timeout for flag polling
+ * @param abortDevice   Timeout for flag polling
  * @param buffer_num_packets  Number of packets in the LL128 buffer.
  *                            0 = buffer is pre-sized to fit the entire message
  *                            (no chunking). >0 and < total packets =
@@ -140,7 +140,7 @@ __device__ __forceinline__ void ll128_send(
     const char* __restrict__ src,
     size_t nbytes,
     Ll128Packet* __restrict__ remote_ll128_buf,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     size_t buffer_num_packets = 0) {
 #ifdef __CUDA_ARCH__
   // Constant base flag. Multi-step works via receiver ACK (-1) reset between
@@ -222,7 +222,7 @@ __device__ __forceinline__ void ll128_send(
               : 0;
           if (!ready) {
             if (FT_ABORT_CHECK(
-                    timeout,
+                    abortDevice,
                     "ll128_send: waiting for READY_TO_WRITE on packet %llu (buf_idx=%llu, current=%lld)",
                     (unsigned long long)pkt_idx,
                     (unsigned long long)buf_idx,
@@ -303,7 +303,7 @@ __device__ __forceinline__ void ll128_send(
   (void)src;
   (void)nbytes;
   (void)remote_ll128_buf;
-  (void)timeout;
+  (void)abortDevice;
   (void)buffer_num_packets;
 #endif
 }
@@ -320,7 +320,7 @@ __device__ __forceinline__ void ll128_send(
  * @param dst       Local output buffer (contiguous user data, 16-byte aligned)
  * @param nbytes    Total message size in bytes (must be a multiple of 16)
  * @param local_ll128_buf  Pointer to local LL128 packet buffer
- * @param timeout   Timeout for flag polling
+ * @param abortDevice   Timeout for flag polling
  * @param buffer_num_packets  Number of packets in the LL128 buffer.
  *                            0 = buffer is pre-sized to fit the entire message
  *                            (no chunking). >0 and < total packets =
@@ -332,7 +332,7 @@ __device__ __forceinline__ void ll128_recv(
     char* __restrict__ dst,
     size_t nbytes,
     Ll128Packet* __restrict__ local_ll128_buf,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     size_t buffer_num_packets = 0) {
 #ifdef __CUDA_ARCH__
   // Constant base flag. Multi-step works via receiver ACK (-1) reset between
@@ -407,7 +407,7 @@ __device__ __forceinline__ void ll128_recv(
               (local_ll128_buf[buf_idx].load_flag() == pkt_flag_value) ? 1 : 0;
           if (!ready) {
             if (FT_ABORT_CHECK(
-                    timeout,
+                    abortDevice,
                     "ll128_recv: waiting for flag_value=%lld on packet %llu (buf_idx=%llu, current=%lld)",
                     (long long)pkt_flag_value,
                     (unsigned long long)pkt_idx,
@@ -498,7 +498,7 @@ __device__ __forceinline__ void ll128_recv(
   (void)dst;
   (void)nbytes;
   (void)local_ll128_buf;
-  (void)timeout;
+  (void)abortDevice;
   (void)buffer_num_packets;
 #endif
 }
@@ -517,7 +517,7 @@ __device__ __forceinline__ void ll128_recv(
  * @param nbytes    Total message size in bytes (must be a multiple of 16)
  * @param local_ll128_buf   Pointer to local LL128 buffer (predecessor wrote)
  * @param remote_ll128_buf  Pointer to successor's LL128 buffer
- * @param timeout   Timeout for flag polling
+ * @param abortDevice   Timeout for flag polling
  * @param buffer_num_packets  Number of packets in the LL128 buffer.
  *                            0 = buffer is pre-sized to fit the entire message
  *                            (no chunking). >0 and < total packets =
@@ -530,7 +530,7 @@ __device__ __forceinline__ void ll128_forward(
     size_t nbytes,
     Ll128Packet* __restrict__ local_ll128_buf,
     Ll128Packet* __restrict__ remote_ll128_buf,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     size_t buffer_num_packets = 0) {
 #ifdef __CUDA_ARCH__
   // Constant base flag. Multi-step works via receiver ACK (-1) reset between
@@ -605,7 +605,7 @@ __device__ __forceinline__ void ll128_forward(
               (local_ll128_buf[buf_idx].load_flag() == pkt_flag_value) ? 1 : 0;
           if (!ready) {
             if (FT_ABORT_CHECK(
-                    timeout,
+                    abortDevice,
                     "ll128_forward: waiting for flag_value=%lld on packet %llu (buf_idx=%llu, current=%lld)",
                     (long long)pkt_flag_value,
                     (unsigned long long)pkt_idx,
@@ -658,7 +658,7 @@ __device__ __forceinline__ void ll128_forward(
               : 0;
           if (!ready) {
             if (FT_ABORT_CHECK(
-                    timeout,
+                    abortDevice,
                     "ll128_forward: waiting for READY_TO_WRITE on remote packet %llu (buf_idx=%llu, current=%lld)",
                     (unsigned long long)pkt_idx,
                     (unsigned long long)buf_idx,
@@ -765,7 +765,7 @@ __device__ __forceinline__ void ll128_forward(
   (void)nbytes;
   (void)local_ll128_buf;
   (void)remote_ll128_buf;
-  (void)timeout;
+  (void)abortDevice;
   (void)buffer_num_packets;
 #endif
 }

--- a/comms/prims/transport/ll128/tests/Ll128OpsNvlinkTest.cu
+++ b/comms/prims/transport/ll128/tests/Ll128OpsNvlinkTest.cu
@@ -25,11 +25,11 @@ __global__ void ll128_nvlink_send_kernel(
     size_t buffer_num_packets,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout timeout;
-  timeout.start();
+  Timeout abortDevice;
+  abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
     ll128_send(
-        group, src, nbytes, remote_ll128_buf, timeout, buffer_num_packets);
+        group, src, nbytes, remote_ll128_buf, abortDevice, buffer_num_packets);
   }
 }
 
@@ -40,11 +40,11 @@ __global__ void ll128_nvlink_recv_kernel(
     size_t buffer_num_packets,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout timeout;
-  timeout.start();
+  Timeout abortDevice;
+  abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
     ll128_recv(
-        group, dst, nbytes, local_ll128_buf, timeout, buffer_num_packets);
+        group, dst, nbytes, local_ll128_buf, abortDevice, buffer_num_packets);
   }
 }
 
@@ -56,8 +56,8 @@ __global__ void ll128_nvlink_forward_kernel(
     size_t buffer_num_packets,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout timeout;
-  timeout.start();
+  Timeout abortDevice;
+  abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
     ll128_forward(
         group,
@@ -65,7 +65,7 @@ __global__ void ll128_nvlink_forward_kernel(
         nbytes,
         local_ll128_buf,
         remote_ll128_buf,
-        timeout,
+        abortDevice,
         buffer_num_packets);
   }
 }
@@ -88,17 +88,27 @@ __global__ void ll128_nvlink_send_recv_kernel(
     int num_steps) {
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(2);
-  Timeout timeout;
-  timeout.start();
+  Timeout abortDevice;
+  abortDevice.start();
   if (partition_id == 0) {
     for (int i = 0; i < num_steps; i++) {
       ll128_send(
-          subgroup, src, nbytes, remote_send_buf, timeout, buffer_num_packets);
+          subgroup,
+          src,
+          nbytes,
+          remote_send_buf,
+          abortDevice,
+          buffer_num_packets);
     }
   } else {
     for (int i = 0; i < num_steps; i++) {
       ll128_recv(
-          subgroup, dst, nbytes, local_recv_buf, timeout, buffer_num_packets);
+          subgroup,
+          dst,
+          nbytes,
+          local_recv_buf,
+          abortDevice,
+          buffer_num_packets);
     }
   }
 }
@@ -376,15 +386,15 @@ __global__ void ll128_nvlink_varying_send_kernel(
     size_t buffer_num_packets,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout timeout;
-  timeout.start();
+  Timeout abortDevice;
+  abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
     ll128_send(
         group,
         src + i * nbytes,
         nbytes,
         remote_ll128_buf,
-        timeout,
+        abortDevice,
         buffer_num_packets);
   }
 }
@@ -396,15 +406,15 @@ __global__ void ll128_nvlink_varying_recv_kernel(
     size_t buffer_num_packets,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout timeout;
-  timeout.start();
+  Timeout abortDevice;
+  abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
     ll128_recv(
         group,
         dst + i * nbytes,
         nbytes,
         local_ll128_buf,
-        timeout,
+        abortDevice,
         buffer_num_packets);
   }
 }

--- a/comms/prims/transport/llx/tests/LLIbgdaSendRecv.cu
+++ b/comms/prims/transport/llx/tests/LLIbgdaSendRecv.cu
@@ -62,16 +62,16 @@ __global__ void sendRecvKernel(
     int activeBlocks,
     std::size_t maxSignalBytes,
     bool send,
-    Timeout timeout) {
+    Timeout abortDevice) {
   (void)activeBlocks; // master's detail::send/recv has no active_blocks param
   auto group = make_block_group();
-  timeout.start();
+  abortDevice.start();
   if (send) {
     detail::send<P2pIbgdaTransportDevice, Memcpy, Proto>(
-        *transport, group, buffer, nbytes, maxSignalBytes, timeout);
+        *transport, group, buffer, nbytes, maxSignalBytes, abortDevice);
   } else {
     detail::recv<P2pIbgdaTransportDevice, Memcpy, Proto>(
-        *transport, group, buffer, nbytes, maxSignalBytes, timeout);
+        *transport, group, buffer, nbytes, maxSignalBytes, abortDevice);
   }
 }
 

--- a/comms/prims/transport/nvl/MultimemNvlSignal.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlSignal.cuh
@@ -8,7 +8,6 @@
 
 #include "comms/common/fault_tolerance/AbortMacros.cuh"
 #include "comms/prims/core/ThreadGroup.cuh"
-#include "comms/prims/core/Timeout.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
 
 namespace comms::prims {
@@ -192,10 +191,10 @@ __device__ __forceinline__ void validate_protocol() {
 __device__ __forceinline__ void wait_until_reached(
     const SignalState& signal,
     uint64_t expected,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   while (!sequence_reached(signal.load(), expected)) {
     if (FT_ABORT_CHECK(
-            timeout,
+            abortDevice,
             "NVL signal wait for sequence=%llu",
             static_cast<unsigned long long>(expected))) {
       FT_DEVICE_TRAP();
@@ -342,7 +341,7 @@ __device__ __forceinline__ void wait_per_peer_all(
     const StageRound& round,
     const NvlSignalParticipants& participants,
     ThreadGroup& group,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   const int source = static_cast<int>(group.thread_id_in_group);
   if (source < transport.nvlRanks &&
       rank_selected(participants.publisherMask, source)) {
@@ -350,7 +349,7 @@ __device__ __forceinline__ void wait_per_peer_all(
         transport.internalLocalSignals[peer_signal_id<phase>(
             transport, round, source)],
         round.value,
-        timeout);
+        abortDevice);
   }
   group.sync();
 }
@@ -361,7 +360,7 @@ __device__ __forceinline__ void wait_per_peer_serial(
     const StageRound& round,
     const NvlSignalParticipants& participants,
     ThreadGroup& group,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   if (group.is_leader()) {
     bool complete = false;
     while (!complete) {
@@ -379,7 +378,7 @@ __device__ __forceinline__ void wait_per_peer_serial(
       }
       if (!complete) {
         if (FT_ABORT_CHECK(
-                timeout,
+                abortDevice,
                 "NVL serial per-peer wait for round=%llu",
                 static_cast<unsigned long long>(round.value))) {
           FT_DEVICE_TRAP();
@@ -396,7 +395,7 @@ __device__ __forceinline__ void wait_per_peer_tree(
     const StageRound& round,
     const NvlSignalParticipants& participants,
     ThreadGroup& group,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   __shared__ uint32_t completeByThread[kMaxNvlSignalPerPeerThreads];
   const uint32_t thread = group.thread_id_in_group;
   bool complete = false;
@@ -421,7 +420,7 @@ __device__ __forceinline__ void wait_per_peer_tree(
     complete = completeByThread[0] != 0;
     if (!complete && group.is_leader()) {
       if (FT_ABORT_CHECK(
-              timeout,
+              abortDevice,
               "NVL tree per-peer wait for round=%llu",
               static_cast<unsigned long long>(round.value))) {
         FT_DEVICE_TRAP();
@@ -437,7 +436,7 @@ __device__ __forceinline__ void wait_per_peer_butterfly(
     const StageRound& round,
     const NvlSignalParticipants& participants,
     ThreadGroup& group,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   __shared__ uint32_t completeByWarp[kMaxNvlSignalPerPeerWarps];
   const uint32_t thread = group.thread_id_in_group;
   const uint32_t lane = thread % kWarpSize;
@@ -469,7 +468,7 @@ __device__ __forceinline__ void wait_per_peer_butterfly(
     }
     if (!complete && group.is_leader()) {
       if (FT_ABORT_CHECK(
-              timeout,
+              abortDevice,
               "NVL butterfly per-peer wait for round=%llu",
               static_cast<unsigned long long>(round.value))) {
         FT_DEVICE_TRAP();
@@ -637,14 +636,14 @@ __device__ __forceinline__ void signal_publish(
 /**
  * Waits for the selected publishers on every selected waiter rank.
  *
- * A caller that enables timeout checking must call `Timeout::start()` before
- * this function.
+ * A caller that enables abortDevice checking must call `Timeout::start()`
+ * before this function.
  *
  * @param transport Exchanged multimem transport device view.
  * @param round Logical channel and per-peer round value.
  * @param participants Rank masks and expected arrival count.
  * @param group Topology-specific cooperative thread group.
- * @param timeout Started timeout or the disabled default timeout.
+ * @param abortDevice Started abortDevice or the disabled default abortDevice.
  */
 namespace nvl_signal_detail {
 
@@ -658,7 +657,7 @@ __device__ __forceinline__ void signal_wait_impl(
     const StageRound& round,
     const NvlSignalParticipants& participants,
     ThreadGroup& group,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   nvl_signal_detail::validate_protocol<access, topology, phase, waitPolicy>();
   nvl_signal_detail::validate_common(transport, round, participants);
   if constexpr (topology == NvlSignalTopology::Aggregate) {
@@ -679,7 +678,7 @@ __device__ __forceinline__ void signal_wait_impl(
       const uint64_t expected =
           epoch->load() + static_cast<uint64_t>(participants.expectedArrivals);
       if (isWaiter) {
-        nvl_signal_detail::wait_until_reached(*counter, expected, timeout);
+        nvl_signal_detail::wait_until_reached(*counter, expected, abortDevice);
       }
       if constexpr (access == NvlSignalAccess::Multimem) {
         epoch->store(expected);
@@ -692,16 +691,16 @@ __device__ __forceinline__ void signal_wait_impl(
     return;
   } else if constexpr (waitPolicy == NvlPerPeerWaitPolicy::WaitAll) {
     nvl_signal_detail::wait_per_peer_all<phase>(
-        transport, round, participants, group, timeout);
+        transport, round, participants, group, abortDevice);
   } else if constexpr (waitPolicy == NvlPerPeerWaitPolicy::SerialMin) {
     nvl_signal_detail::wait_per_peer_serial<phase>(
-        transport, round, participants, group, timeout);
+        transport, round, participants, group, abortDevice);
   } else if constexpr (waitPolicy == NvlPerPeerWaitPolicy::TreeMin) {
     nvl_signal_detail::wait_per_peer_tree<phase>(
-        transport, round, participants, group, timeout);
+        transport, round, participants, group, abortDevice);
   } else {
     nvl_signal_detail::wait_per_peer_butterfly<phase>(
-        transport, round, participants, group, timeout);
+        transport, round, participants, group, abortDevice);
   }
   (void)access;
 }
@@ -719,13 +718,13 @@ __device__ __forceinline__ void signal_wait(
     const StageRound& round,
     const NvlSignalParticipants& participants,
     ThreadGroup& group,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   static_assert(
       access != NvlSignalAccess::Multimem ||
           topology != NvlSignalTopology::Aggregate,
       "aggregate multimem requires signal_publish_and_wait on every rank");
   nvl_signal_detail::signal_wait_impl<access, topology, phase, waitPolicy>(
-      transport, round, participants, group, timeout);
+      transport, round, participants, group, abortDevice);
 }
 
 /**
@@ -735,7 +734,7 @@ __device__ __forceinline__ void signal_wait(
  * @param round Logical channel and per-peer round value.
  * @param participants Rank masks and expected arrival count.
  * @param group Topology-specific cooperative thread group.
- * @param timeout Started timeout or the disabled default timeout.
+ * @param abortDevice Started abortDevice or the disabled default abortDevice.
  */
 template <
     NvlSignalAccess access,
@@ -747,11 +746,11 @@ __device__ __forceinline__ void signal_publish_and_wait(
     const StageRound& round,
     const NvlSignalParticipants& participants,
     ThreadGroup& group,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   nvl_signal_detail::signal_publish_impl<access, topology, phase, waitPolicy>(
       transport, round, participants, group);
   nvl_signal_detail::signal_wait_impl<access, topology, phase, waitPolicy>(
-      transport, round, participants, group, timeout);
+      transport, round, participants, group, abortDevice);
 }
 
 } // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -109,8 +109,9 @@ struct MultimemNvlTransportDevice {
       uint64_t signal_id,
       CmpOp op,
       uint64_t expected,
-      const AbortDevice& timeout = AbortDevice()) const {
-    user_local_signal_ptr(signal_id)->wait_until(group, op, expected, timeout);
+      const AbortDevice& abortDevice = AbortDevice()) const {
+    user_local_signal_ptr(signal_id)->wait_until(
+        group, op, expected, abortDevice);
   }
 
   __device__ __forceinline__ void signal_internal(
@@ -154,9 +155,9 @@ struct MultimemNvlTransportDevice {
       uint64_t signal_id,
       CmpOp op,
       uint64_t expected,
-      const AbortDevice& timeout = AbortDevice()) const {
+      const AbortDevice& abortDevice = AbortDevice()) const {
     internal_local_signal_ptr(signal_id)->wait_until(
-        group, op, expected, timeout);
+        group, op, expected, abortDevice);
   }
 
  private:

--- a/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
@@ -291,8 +291,9 @@ class P2pNvlTransportDevice {
       uint64_t signal_id,
       CmpOp op,
       uint64_t value,
-      const Timeout& timeout = Timeout()) {
-    localState_.signalBuffer[signal_id].wait_until(group, op, value, timeout);
+      const AbortDevice& abortDevice = AbortDevice()) {
+    localState_.signalBuffer[signal_id].wait_until(
+        group, op, value, abortDevice);
   }
 
   /**
@@ -341,7 +342,7 @@ class P2pNvlTransportDevice {
   __device__ __forceinline__ void barrier_sync(
       ThreadGroup& group,
       uint64_t barrier_id,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     // Ensure all prior memory operations are complete
     group.sync();
 
@@ -352,7 +353,7 @@ class P2pNvlTransportDevice {
       remoteState_.barrierBuffer[barrier_id].arrive();
 
       // Wait for peer - poll local barrier state until peer signals
-      localState_.barrierBuffer[barrier_id].wait(timeout);
+      localState_.barrierBuffer[barrier_id].wait(abortDevice);
     }
 
     // Ensure all threads wait for leader to complete barrier
@@ -374,13 +375,13 @@ class P2pNvlTransportDevice {
    * @param group   ThreadGroup (auto-converted to warp scope)
    * @param src     Local source buffer (16-byte aligned)
    * @param nbytes  Total bytes (must be a multiple of 16)
-   * @param timeout Timeout for flag polling
+   * @param abortDevice Timeout for flag polling
    */
   __device__ __forceinline__ void ll128_send_group(
       const ThreadGroup& group,
       const char* src,
       size_t nbytes,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
 #if PIPES_IS_DEVICE_COMPILE
     PIPES_DEVICE_CHECK(remoteState_.ll128Buffer != nullptr);
     PIPES_DEVICE_CHECK(can_use_ll128(src, nbytes));
@@ -390,7 +391,7 @@ class P2pNvlTransportDevice {
         src,
         nbytes,
         remoteState_.ll128Buffer,
-        timeout,
+        abortDevice,
         options_.ll128BufferNumPackets);
 #endif
   }
@@ -406,13 +407,13 @@ class P2pNvlTransportDevice {
    * @param group   ThreadGroup (auto-converted to warp scope)
    * @param dst     Local output buffer (16-byte aligned)
    * @param nbytes  Total bytes (must be a multiple of 16)
-   * @param timeout Timeout for flag polling
+   * @param abortDevice Timeout for flag polling
    */
   __device__ __forceinline__ void ll128_recv_group(
       const ThreadGroup& group,
       char* dst,
       size_t nbytes,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
 #if PIPES_IS_DEVICE_COMPILE
     PIPES_DEVICE_CHECK(localState_.ll128Buffer != nullptr);
     PIPES_DEVICE_CHECK(can_use_ll128(dst, nbytes));
@@ -422,7 +423,7 @@ class P2pNvlTransportDevice {
         dst,
         nbytes,
         localState_.ll128Buffer,
-        timeout,
+        abortDevice,
         options_.ll128BufferNumPackets);
 #endif
   }
@@ -440,14 +441,14 @@ class P2pNvlTransportDevice {
    * @param dst                  Local output buffer (16-byte aligned)
    * @param nbytes               Total bytes (must be a multiple of 16)
    * @param successor_transport  Transport for the successor peer
-   * @param timeout              Timeout for flag polling
+   * @param abortDevice              Timeout for flag polling
    */
   __device__ __forceinline__ void ll128_forward_group(
       const ThreadGroup& group,
       char* dst,
       size_t nbytes,
       const P2pNvlTransportDevice& successor_transport,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
 #if PIPES_IS_DEVICE_COMPILE
     PIPES_DEVICE_CHECK(localState_.ll128Buffer != nullptr);
     PIPES_DEVICE_CHECK(successor_transport.remoteState_.ll128Buffer != nullptr);
@@ -474,7 +475,7 @@ class P2pNvlTransportDevice {
         nbytes,
         localState_.ll128Buffer,
         successor_transport.remoteState_.ll128Buffer,
-        timeout,
+        abortDevice,
         effective_packets);
 #endif
   }
@@ -494,7 +495,7 @@ class P2pNvlTransportDevice {
       const void* __restrict__ src,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
 #if PIPES_IS_DEVICE_COMPILE
     if (nbytes == 0) {
       return;
@@ -536,13 +537,13 @@ class P2pNvlTransportDevice {
             group,
             CmpOp::CMP_GE,
             protocolStreamEnd - layout.pipelineBytes,
-            timeout);
+            abortDevice);
       }
       // Leave before the staging write and the DATA_READY signal below. The
       // backpressure wait gave up, so the slot may still hold data the receiver
       // has not consumed; worse, signalling DATA_READY would release a receiver
       // that is correctly blocked and prevent it reaching its own deadline.
-      if (groupAborted(group, timeout)) {
+      if (groupAborted(group, abortDevice)) {
         break;
       }
 
@@ -576,7 +577,7 @@ class P2pNvlTransportDevice {
       void* __restrict__ dst,
       std::size_t nbytes,
       std::size_t max_signal_bytes = 0,
-      [[maybe_unused]] const Timeout& timeout = Timeout(),
+      [[maybe_unused]] const AbortDevice& abortDevice = AbortDevice(),
       [[maybe_unused]] Args... args) {
 #if PIPES_IS_DEVICE_COMPILE
     if (nbytes == 0) {
@@ -614,13 +615,14 @@ class P2pNvlTransportDevice {
       const uint64_t protocolStreamEnd =
           streamEnd + (isFinalChunk ? protocolTailPadding : 0);
 
-      local_ch.data_ready.wait_until(group, CmpOp::CMP_GE, streamEnd, timeout);
+      local_ch.data_ready.wait_until(
+          group, CmpOp::CMP_GE, streamEnd, abortDevice);
       // The wait above gave up rather than being satisfied, so this chunk was
       // never written. Leave before the copy and, critically, before the
       // SLOT_FREE credit below: signalling it would tell the sender we consumed
       // a chunk it never sent, releasing a peer that is correctly blocked and
       // stopping it from ever reaching its own deadline.
-      if (groupAborted(group, timeout)) {
+      if (groupAborted(group, abortDevice)) {
         break;
       }
 
@@ -683,7 +685,7 @@ class P2pNvlTransportDevice {
       std::size_t nbytes,
       P2pNvlTransportDevice& successor,
       std::size_t max_signal_bytes = 0,
-      [[maybe_unused]] const Timeout& timeout = Timeout(),
+      [[maybe_unused]] const AbortDevice& abortDevice = AbortDevice(),
       [[maybe_unused]] Args... args) {
 #if PIPES_IS_DEVICE_COMPILE
     if (nbytes == 0) {
@@ -748,7 +750,7 @@ class P2pNvlTransportDevice {
 
       // 1. Wait for predecessor data to be ready (recv side, every step).
       recv_local_ch.data_ready.wait_until(
-          group, CmpOp::CMP_GE, recvStreamEnd, timeout);
+          group, CmpOp::CMP_GE, recvStreamEnd, abortDevice);
 
       // 2. Wait for successor's staging slot to be free once we have wrapped
       //    around the pipeline.
@@ -757,7 +759,7 @@ class P2pNvlTransportDevice {
             group,
             CmpOp::CMP_GE,
             sendProtocolStreamEnd - layout.pipelineBytes,
-            timeout);
+            abortDevice);
       }
 
       // Either wait may have given up. Leave before the copy and before both
@@ -766,7 +768,7 @@ class P2pNvlTransportDevice {
       // *and* ACK the predecessor for a chunk we never consumed, releasing two
       // correctly-blocked peers and stopping both from reaching their own
       // deadlines.
-      if (groupAborted(group, timeout)) {
+      if (groupAborted(group, abortDevice)) {
         break;
       }
 
@@ -849,14 +851,14 @@ class P2pNvlTransportDevice {
    * @param active_groups Number of groups calling concurrently.
    *   0 = default to max groups the LL buffer can support.
    *   >0 = explicit group count; buffer partitioned per group.group_id.
-   * @param timeout       Timeout for flag polling
+   * @param abortDevice       Timeout for flag polling
    */
   __device__ __forceinline__ void ll_send(
       const ThreadGroup& group,
       const char* src,
       size_t nbytes,
       int active_groups = 0,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
 #ifdef __CUDA_ARCH__ // NVIDIA-only: depends on ll_send/ll_recv/ll128_* not yet
                      // ported to AMD
     PIPES_DEVICE_CHECK(remoteState_.llBuffer != nullptr);
@@ -882,14 +884,14 @@ class P2pNvlTransportDevice {
         src,
         nbytes,
         remoteState_.llBuffer + bufferOffset,
-        timeout,
+        abortDevice,
         perGroupLines);
 #else
     (void)group;
     (void)src;
     (void)nbytes;
     (void)active_groups;
-    (void)timeout;
+    (void)abortDevice;
 #endif
   }
 
@@ -907,14 +909,14 @@ class P2pNvlTransportDevice {
    * @param active_groups Number of groups calling concurrently.
    *   0 = default to max groups the LL buffer can support.
    *   >0 = explicit group count; buffer partitioned per group.group_id.
-   * @param timeout       Timeout for flag polling
+   * @param abortDevice       Timeout for flag polling
    */
   __device__ __forceinline__ void ll_recv(
       const ThreadGroup& group,
       char* dst,
       size_t nbytes,
       int active_groups = 0,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
 #ifdef __CUDA_ARCH__ // NVIDIA-only: depends on ll_send/ll_recv/ll128_* not yet
                      // ported to AMD
     PIPES_DEVICE_CHECK(localState_.llBuffer != nullptr);
@@ -940,14 +942,14 @@ class P2pNvlTransportDevice {
         dst,
         nbytes,
         localState_.llBuffer + bufferOffset,
-        timeout,
+        abortDevice,
         perGroupLines);
 #else
     (void)group;
     (void)dst;
     (void)nbytes;
     (void)active_groups;
-    (void)timeout;
+    (void)abortDevice;
 #endif
   }
 
@@ -967,7 +969,7 @@ class P2pNvlTransportDevice {
    * @param active_groups        Number of groups calling concurrently.
    *   0 = default to max groups the LL buffer can support.
    *   >0 = explicit group count; buffer partitioned per group.group_id.
-   * @param timeout              Timeout for flag polling
+   * @param abortDevice              Timeout for flag polling
    */
   __device__ __forceinline__ void ll_forward(
       const ThreadGroup& group,
@@ -975,7 +977,7 @@ class P2pNvlTransportDevice {
       size_t nbytes,
       const P2pNvlTransportDevice& successor_transport,
       int active_groups = 0,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
 #ifdef __CUDA_ARCH__ // NVIDIA-only: depends on ll_send/ll_recv/ll128_* not yet
                      // ported to AMD
     PIPES_DEVICE_CHECK(localState_.llBuffer != nullptr);
@@ -1028,7 +1030,7 @@ class P2pNvlTransportDevice {
         nbytes,
         localState_.llBuffer + myOffset,
         successor_transport.remoteState_.llBuffer + succOffset,
-        timeout,
+        abortDevice,
         effectiveLines);
 #else
     (void)group;
@@ -1036,7 +1038,7 @@ class P2pNvlTransportDevice {
     (void)nbytes;
     (void)successor_transport;
     (void)active_groups;
-    (void)timeout;
+    (void)abortDevice;
 #endif
   }
 

--- a/comms/prims/window/DeviceWindow.cuh
+++ b/comms/prims/window/DeviceWindow.cuh
@@ -524,20 +524,20 @@ class DeviceWindow {
    *
    * Thread-level API: any single thread may call this independently.
    * The caller spins on the inbox slot until the comparison is satisfied
-   * or the timeout expires.
+   * or the abortDevice expires.
    *
    * @param source_rank  Rank to wait on (must not be self).
    * @param signal_id    Signal slot index in [0, peerSignalCount).
    * @param cmp          Comparison operator (CMP_GE, CMP_EQ, etc.).
    * @param value        Threshold value for comparison.
-   * @param timeout      Optional timeout (traps on expiry).
+   * @param abortDevice      Optional abort handle (traps on expiry).
    */
   __device__ __forceinline__ void wait_signal_from(
       int source_rank,
       int signal_id,
       CmpOp cmp,
       uint64_t value,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     DEVICE_WINDOW_CHECK_RANK(source_rank, handle_.nRanks);
     DEVICE_WINDOW_CHECK_NOT_SELF(source_rank, handle_.myRank);
     DEVICE_WINDOW_CHECK_SIGNAL_ID(signal_id, peerSignalCount_);
@@ -546,7 +546,7 @@ class DeviceWindow {
       int slot = nvlIdx * peerSignalCount_ + signal_id;
       while (!compare(nvlPeerSignalInbox_[slot].load(), cmp, value)) {
         FT_ABORT_BREAK(
-            timeout,
+            abortDevice,
             "DeviceWindow::wait_signal_from(source_rank=%d,"
             " signal_id=%d, value=%llu) rank=%d",
             source_rank,
@@ -561,7 +561,7 @@ class DeviceWindow {
       volatile uint64_t* sig = &ibgdaPeerSignalInbox_[slot];
       while (!compare(*sig, cmp, value)) {
         FT_ABORT_BREAK(
-            timeout,
+            abortDevice,
             "DeviceWindow::wait_signal_from(source_rank=%d,"
             " signal_id=%d, value=%llu) rank=%d",
             source_rank,
@@ -585,7 +585,7 @@ class DeviceWindow {
    * @param signal_id    Signal slot index in [0, peerSignalCount).
    * @param cmp          Comparison operator (CMP_GE, CMP_EQ, etc.).
    * @param value        Threshold value for comparison.
-   * @param timeout      Optional timeout (traps on expiry).
+   * @param abortDevice      Optional abort handle (traps on expiry).
    */
   __device__ __forceinline__ void wait_signal_from(
       ThreadGroup& group,
@@ -593,9 +593,9 @@ class DeviceWindow {
       int signal_id,
       CmpOp cmp,
       uint64_t value,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     if (group.is_leader()) {
-      wait_signal_from(source_rank, signal_id, cmp, value, timeout);
+      wait_signal_from(source_rank, signal_id, cmp, value, abortDevice);
     }
     group.sync();
   }
@@ -613,14 +613,14 @@ class DeviceWindow {
    * @param signal_id  Signal slot index in [0, peerSignalCount).
    * @param cmp        Comparison operator (CMP_GE, CMP_EQ, etc.).
    * @param value      Threshold value for the aggregate sum.
-   * @param timeout    Optional timeout (traps on expiry).
+   * @param abortDevice    Optional abort handle (traps on expiry).
    */
   __device__ __forceinline__ void wait_signal(
       ThreadGroup& group,
       int signal_id,
       CmpOp cmp,
       uint64_t value,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     DEVICE_WINDOW_CHECK_SIGNAL_ID(signal_id, peerSignalCount_);
     if (group.is_leader()) {
       int nPeers = num_peers();
@@ -644,7 +644,7 @@ class DeviceWindow {
           break;
         }
         FT_ABORT_BREAK(
-            timeout,
+            abortDevice,
             "DeviceWindow::wait_signal(signal_id=%d, value=%llu)"
             " rank=%d",
             signal_id,
@@ -726,14 +726,14 @@ class DeviceWindow {
    * @param counter_id  Counter slot index.
    * @param cmp         Comparison operator.
    * @param value       Threshold value for comparison.
-   * @param timeout     Optional timeout (traps on expiry).
+   * @param abortDevice     Optional abort handle (traps on expiry).
    */
   __device__ __forceinline__ void wait_counter(
       int peer_rank,
       int counter_id,
       CmpOp cmp,
       uint64_t value,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     DEVICE_WINDOW_CHECK_RANK(peer_rank, handle_.nRanks);
     DEVICE_WINDOW_CHECK_NOT_SELF(peer_rank, handle_.myRank);
     // Counter operations are IB-only; no-op for NVL peers
@@ -745,7 +745,7 @@ class DeviceWindow {
     auto ib = handle_.get_ib(peer_rank);
     while (!compare(ib.read_counter(counterSlotBuf), cmp, value)) {
       FT_ABORT_BREAK(
-          timeout,
+          abortDevice,
           "DeviceWindow::wait_counter(peer_rank=%d,"
           " counter_id=%d, value=%llu) rank=%d",
           peer_rank,
@@ -768,7 +768,7 @@ class DeviceWindow {
    * @param counter_id  Counter slot index.
    * @param cmp         Comparison operator.
    * @param value       Threshold value for comparison.
-   * @param timeout     Optional timeout (traps on expiry).
+   * @param abortDevice     Optional abort handle (traps on expiry).
    */
   __device__ __forceinline__ void wait_counter(
       ThreadGroup& group,
@@ -776,9 +776,9 @@ class DeviceWindow {
       int counter_id,
       CmpOp cmp,
       uint64_t value,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     if (group.is_leader()) {
-      wait_counter(peer_rank, counter_id, cmp, value, timeout);
+      wait_counter(peer_rank, counter_id, cmp, value, abortDevice);
     }
     group.sync();
   }
@@ -841,12 +841,12 @@ class DeviceWindow {
    *
    * @param group       ThreadGroup for group coordination.
    * @param barrier_id  Barrier slot index.
-   * @param timeout     Optional timeout (traps on expiry).
+   * @param abortDevice     Optional abort handle (traps on expiry).
    */
   __device__ __forceinline__ void barrier(
       ThreadGroup& group,
       int barrier_id,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     barrier_arrive(group, barrier_id);
     // Only one thread updates barrierExpected_ to avoid races when
     // DeviceWindow is accessed via pointer (shared mutable state).
@@ -856,7 +856,8 @@ class DeviceWindow {
     // Broadcast the updated value to all threads via group sync so
     // barrier_wait sees a consistent threshold.
     group.sync();
-    barrier_wait(group, barrier_id, CmpOp::CMP_GE, barrierExpected_, timeout);
+    barrier_wait(
+        group, barrier_id, CmpOp::CMP_GE, barrierExpected_, abortDevice);
   }
 
   /**
@@ -868,19 +869,20 @@ class DeviceWindow {
    * @param target_rank  Peer rank to barrier with (must not be self).
    * @param group        ThreadGroup for group coordination.
    * @param barrier_id   Barrier slot index.
-   * @param timeout      Optional timeout (traps on expiry).
+   * @param abortDevice      Optional abort handle (traps on expiry).
    */
   __device__ __forceinline__ void barrier_peer(
       int target_rank,
       ThreadGroup& group,
       int barrier_id,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     barrier_arrive_peer(group, target_rank, barrier_id);
     if (group.is_leader()) {
       barrierExpected_ += 1;
     }
     group.sync();
-    barrier_wait(group, barrier_id, CmpOp::CMP_GE, barrierExpected_, timeout);
+    barrier_wait(
+        group, barrier_id, CmpOp::CMP_GE, barrierExpected_, abortDevice);
   }
 
   /**
@@ -958,14 +960,14 @@ class DeviceWindow {
    * @param barrier_id  Barrier slot index.
    * @param cmp         Comparison operator.
    * @param value       Threshold value for comparison.
-   * @param timeout     Optional timeout (traps on expiry).
+   * @param abortDevice     Optional abort handle (traps on expiry).
    */
   __device__ __forceinline__ void barrier_wait(
       ThreadGroup& group,
       int barrier_id,
       CmpOp cmp,
       uint64_t value,
-      const Timeout& timeout = Timeout()) {
+      const AbortDevice& abortDevice = AbortDevice()) {
     DEVICE_WINDOW_CHECK_BARRIER_ID(barrier_id, barrierCount_);
     if (group.is_leader()) {
       while (true) {
@@ -982,7 +984,7 @@ class DeviceWindow {
           break;
         }
         FT_ABORT_BREAK(
-            timeout,
+            abortDevice,
             "DeviceWindow::barrier_wait(barrier_id=%d, value=%llu)"
             " rank=%d",
             barrier_id,


### PR DESCRIPTION
Summary:
`Timeout` has been a bare alias for `AbortDevice` since `D115656601`:

```
namespace comms::prims {
using Timeout = AbortDevice;
}
```

It was introduced as a migration shim so the fault-tolerance stack could land
without a repo-wide rename in the middle of it. That stack is done, so the shim
is now just a second name for the same type, and a misleading one -- the handle
carries an abort latch and a reason, and a deadline is only one of the ways it
trips.

This series retires it, one subtree per diff. **Type-only**: parameter names stay
`timeout`, so nothing about call sites changes except the spelling of the type.
Ben's naming comments are handled per-diff where they already live.

Because both names denote the same type until the alias is deleted, **every diff
in this series is independently correct and landable, in any order**. Files also
keep their `#include "comms/prims/core/Timeout.cuh"` until the final cleanup
diff; the alias header includes `AbortCheck.cuh`, so `AbortDevice` resolves
either way.

Two things the mechanical pass deliberately does *not* touch:
- **`#include` lines** -- repointed in the cleanup diff, with the header deletion.
- **Comment prose.** `Timeout` is renamed in comments only where it is backticked
  or plainly names the type. Lines like `param timeout Timeout for flag polling`
  read as English and are left alone. The handful of prose references that really
  did mean the type were edited by hand.

This diff: `prims/collectives` -- AllGather, AllGatherDirect, AllToAllv (and Auto/Ll128), ReduceScatterDirect (and Ib/IbV2), RingAllgather, DirectCollectiveUtils. 38 occurrences.

Reviewed By: arttianezhu

Differential Revision: D116810805
