### PR TITLE
Rename Timeout to AbortDevice in prims tests and benchmarks (#3846)

### DIFF
--- a/comms/prims/benchmarks/BenchmarkKernel.cu
+++ b/comms/prims/benchmarks/BenchmarkKernel.cu
@@ -16,8 +16,8 @@ __global__ void p2pSend(
     void* srcBuff,
     std::size_t nBytes,
     SyncScope groupScope,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
   auto group = make_thread_group(groupScope);
   TiledBuffer<char> tiles(static_cast<char*>(srcBuff), nBytes, group);
   p2p.send(
@@ -25,7 +25,7 @@ __global__ void p2pSend(
       tiles.tile_data(group.group_id),
       tiles.tile_bytes(group.group_id),
       /*max_signal_bytes=*/0,
-      timeout);
+      abortDevice);
 }
 
 __global__ void p2pRecv(
@@ -33,8 +33,8 @@ __global__ void p2pRecv(
     void* dstBuff,
     std::size_t nBytes,
     SyncScope groupScope,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
   auto group = make_thread_group(groupScope);
   TiledBuffer<char> tiles(static_cast<char*>(dstBuff), nBytes, group);
   p2p.recv(
@@ -42,7 +42,7 @@ __global__ void p2pRecv(
       tiles.tile_data(group.group_id),
       tiles.tile_bytes(group.group_id),
       /*max_signal_bytes=*/0,
-      timeout);
+      abortDevice);
 }
 
 __global__ void p2pSendTimed(
@@ -109,8 +109,8 @@ __global__ __launch_bounds__(512, 1) void p2pBidirectional(
     void* recvBuff,
     std::size_t nBytes,
     SyncScope groupScope,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
   auto group = make_thread_group(groupScope);
 
   // Partition groups into 2: half for send, half for recv
@@ -122,7 +122,7 @@ __global__ __launch_bounds__(512, 1) void p2pBidirectional(
         tiles.tile_data(subgroup.group_id),
         tiles.tile_bytes(subgroup.group_id),
         /*max_signal_bytes=*/0,
-        timeout);
+        abortDevice);
   } else {
     TiledBuffer<char> tiles(static_cast<char*>(recvBuff), nBytes, subgroup);
     p2p.recv(
@@ -130,7 +130,7 @@ __global__ __launch_bounds__(512, 1) void p2pBidirectional(
         tiles.tile_data(subgroup.group_id),
         tiles.tile_bytes(subgroup.group_id),
         /*max_signal_bytes=*/0,
-        timeout);
+        abortDevice);
   }
 }
 
@@ -158,21 +158,21 @@ __global__ void p2pLl128Send(
     P2pNvlTransportDevice p2p,
     void* srcBuff,
     std::size_t nBytes,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
   auto group = make_warp_group();
   p2p.ll128_send_group(
-      group, static_cast<const char*>(srcBuff), nBytes, timeout);
+      group, static_cast<const char*>(srcBuff), nBytes, abortDevice);
 }
 
 __global__ void p2pLl128Recv(
     P2pNvlTransportDevice p2p,
     void* dstBuff,
     std::size_t nBytes,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
   auto group = make_warp_group();
-  p2p.ll128_recv_group(group, static_cast<char*>(dstBuff), nBytes, timeout);
+  p2p.ll128_recv_group(group, static_cast<char*>(dstBuff), nBytes, abortDevice);
 }
 
 __global__ void p2pLl128Bidirectional(
@@ -180,16 +180,16 @@ __global__ void p2pLl128Bidirectional(
     void* sendBuff,
     void* recvBuff,
     std::size_t nBytes,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(2);
   if (partition_id == 0) {
     p2p.ll128_send_group(
-        subgroup, static_cast<const char*>(sendBuff), nBytes, timeout);
+        subgroup, static_cast<const char*>(sendBuff), nBytes, abortDevice);
   } else {
     p2p.ll128_recv_group(
-        subgroup, static_cast<char*>(recvBuff), nBytes, timeout);
+        subgroup, static_cast<char*>(recvBuff), nBytes, abortDevice);
   }
 }
 
@@ -197,20 +197,20 @@ __global__ void p2pLlSend(
     P2pNvlTransportDevice p2p,
     void* srcBuff,
     std::size_t nBytes,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
   auto group = make_warp_group();
-  p2p.ll_send(group, static_cast<const char*>(srcBuff), nBytes, 1, timeout);
+  p2p.ll_send(group, static_cast<const char*>(srcBuff), nBytes, 1, abortDevice);
 }
 
 __global__ void p2pLlRecv(
     P2pNvlTransportDevice p2p,
     void* dstBuff,
     std::size_t nBytes,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
   auto group = make_warp_group();
-  p2p.ll_recv(group, static_cast<char*>(dstBuff), nBytes, 1, timeout);
+  p2p.ll_recv(group, static_cast<char*>(dstBuff), nBytes, 1, abortDevice);
 }
 
 __global__ void p2pLlBidirectional(
@@ -218,15 +218,15 @@ __global__ void p2pLlBidirectional(
     void* sendBuff,
     void* recvBuff,
     std::size_t nBytes,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(2);
   if (partition_id == 0) {
     p2p.ll_send(
-        subgroup, static_cast<const char*>(sendBuff), nBytes, 1, timeout);
+        subgroup, static_cast<const char*>(sendBuff), nBytes, 1, abortDevice);
   } else {
-    p2p.ll_recv(subgroup, static_cast<char*>(recvBuff), nBytes, 1, timeout);
+    p2p.ll_recv(subgroup, static_cast<char*>(recvBuff), nBytes, 1, abortDevice);
   }
 }
 

--- a/comms/prims/benchmarks/BenchmarkKernel.cuh
+++ b/comms/prims/benchmarks/BenchmarkKernel.cuh
@@ -31,7 +31,7 @@ __global__ void p2pSend(
     void* srcBuff,
     std::size_t nBytes,
     SyncScope groupScope = SyncScope::WARP,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 // Recv kernel
 __global__ void p2pRecv(
@@ -39,7 +39,7 @@ __global__ void p2pRecv(
     void* dstBuff,
     std::size_t nBytes,
     SyncScope groupScope = SyncScope::WARP,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 // Timed versions that export GPU-side clock64() timing stats
 __global__ void p2pSendTimed(
@@ -63,7 +63,7 @@ __global__ void p2pBidirectional(
     void* recvBuff,
     std::size_t nBytes,
     SyncScope groupScope = SyncScope::WARP,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 // Signal benchmark kernel - ping-pong signaling pattern
 __global__ void p2pSignalBenchKernel(
@@ -81,14 +81,14 @@ __global__ void p2pLl128Send(
     P2pNvlTransportDevice p2p,
     void* srcBuff,
     std::size_t nBytes,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 // LL128 recv kernel
 __global__ void p2pLl128Recv(
     P2pNvlTransportDevice p2p,
     void* dstBuff,
     std::size_t nBytes,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 // LL128 bidirectional kernel - half warps send, half recv
 __global__ void p2pLl128Bidirectional(
@@ -96,7 +96,7 @@ __global__ void p2pLl128Bidirectional(
     void* sendBuff,
     void* recvBuff,
     std::size_t nBytes,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 // =============================================================================
 // LL benchmark kernels - per-thread LL protocol with inline flag signaling
@@ -107,14 +107,14 @@ __global__ void p2pLlSend(
     P2pNvlTransportDevice p2p,
     void* srcBuff,
     std::size_t nBytes,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 // LL recv kernel
 __global__ void p2pLlRecv(
     P2pNvlTransportDevice p2p,
     void* dstBuff,
     std::size_t nBytes,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 // LL bidirectional kernel - half warps send, half recv
 __global__ void p2pLlBidirectional(
@@ -122,6 +122,6 @@ __global__ void p2pLlBidirectional(
     void* sendBuff,
     void* recvBuff,
     std::size_t nBytes,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 } // namespace comms::prims::benchmark

--- a/comms/prims/benchmarks/IbgdaForward.cu
+++ b/comms/prims/benchmarks/IbgdaForward.cu
@@ -14,7 +14,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_forward_kernel(
     std::size_t totalBytes,
     int numBlocks,
     int my_rank,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
 
   const std::size_t sectionBytes = (my_rank == 1)
@@ -30,14 +30,14 @@ __global__ void __launch_bounds__(512, 1) ibgda_forward_kernel(
 
     if (my_rank == 0) {
       TiledBuffer<char> tiles(src + offset, sectionBytes, group);
-      next_transport->send(group, tiles.data(), tiles.bytes(), 0, timeout);
+      next_transport->send(group, tiles.data(), tiles.bytes(), 0, abortDevice);
     } else if (my_rank == 2) {
       TiledBuffer<char> tiles(dst + offset, sectionBytes, group);
-      prev_transport->recv(group, tiles.data(), tiles.bytes(), 0, timeout);
+      prev_transport->recv(group, tiles.data(), tiles.bytes(), 0, abortDevice);
     } else {
       TiledBuffer<char> tiles(dst + offset, sectionBytes, group);
       prev_transport->forward(
-          group, tiles.data(), *next_transport, tiles.bytes(), 0, timeout);
+          group, tiles.data(), *next_transport, tiles.bytes(), 0, abortDevice);
     }
   }
 }
@@ -50,7 +50,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_recv_send_kernel(
     std::size_t totalBytes,
     int numBlocks,
     int my_rank,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
 
   const std::size_t sectionBytes = (my_rank == 1)
@@ -66,14 +66,14 @@ __global__ void __launch_bounds__(512, 1) ibgda_recv_send_kernel(
 
     if (my_rank == 0) {
       TiledBuffer<char> tiles(src + offset, sectionBytes, group);
-      next_transport->send(group, tiles.data(), tiles.bytes(), 0, timeout);
+      next_transport->send(group, tiles.data(), tiles.bytes(), 0, abortDevice);
     } else if (my_rank == 2) {
       TiledBuffer<char> tiles(dst + offset, sectionBytes, group);
-      prev_transport->recv(group, tiles.data(), tiles.bytes(), 0, timeout);
+      prev_transport->recv(group, tiles.data(), tiles.bytes(), 0, abortDevice);
     } else {
       TiledBuffer<char> tiles(dst + offset, sectionBytes, group);
-      prev_transport->recv(group, tiles.data(), tiles.bytes(), 0, timeout);
-      next_transport->send(group, tiles.data(), tiles.bytes(), 0, timeout);
+      prev_transport->recv(group, tiles.data(), tiles.bytes(), 0, abortDevice);
+      next_transport->send(group, tiles.data(), tiles.bytes(), 0, abortDevice);
     }
   }
 }
@@ -87,7 +87,7 @@ void launch_ibgda_forward_chain(
     int numBlocks,
     int my_rank,
     cudaStream_t stream,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   ibgda_forward_kernel<<<numBlocks, 512, 0, stream>>>(
       prev_transport,
       next_transport,
@@ -96,7 +96,7 @@ void launch_ibgda_forward_chain(
       nbytes,
       numBlocks,
       my_rank,
-      timeout);
+      abortDevice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(
@@ -113,7 +113,7 @@ void launch_ibgda_recv_send_chain(
     int numBlocks,
     int my_rank,
     cudaStream_t stream,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   ibgda_recv_send_kernel<<<numBlocks, 512, 0, stream>>>(
       prev_transport,
       next_transport,
@@ -122,7 +122,7 @@ void launch_ibgda_recv_send_chain(
       nbytes,
       numBlocks,
       my_rank,
-      timeout);
+      abortDevice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(

--- a/comms/prims/benchmarks/IbgdaForward.cuh
+++ b/comms/prims/benchmarks/IbgdaForward.cuh
@@ -21,7 +21,7 @@ __global__ void ibgda_forward_kernel(
     std::size_t totalBytes,
     int numBlocks,
     int my_rank,
-    Timeout timeout);
+    AbortDevice abortDevice);
 
 /**
  * 3-rank chain kernel using recv + send on rank 1 (baseline).
@@ -35,6 +35,6 @@ __global__ void ibgda_recv_send_kernel(
     std::size_t totalBytes,
     int numBlocks,
     int my_rank,
-    Timeout timeout);
+    AbortDevice abortDevice);
 
 } // namespace comms::prims::benchmark

--- a/comms/prims/benchmarks/IbgdaForward.h
+++ b/comms/prims/benchmarks/IbgdaForward.h
@@ -22,7 +22,7 @@ void launch_ibgda_forward_chain(
     int numBlocks,
     int my_rank,
     cudaStream_t stream,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 void launch_ibgda_recv_send_chain(
     P2pIbgdaTransportDevice* prev_transport,
@@ -33,6 +33,6 @@ void launch_ibgda_recv_send_chain(
     int numBlocks,
     int my_rank,
     cudaStream_t stream,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 } // namespace comms::prims::benchmark

--- a/comms/prims/benchmarks/IbgdaSendRecv.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cu
@@ -69,7 +69,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_recv_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
 
   // Partition blocks: first half sends, second half receives.
@@ -87,11 +87,11 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_recv_kernel(
     if (isSender) {
       TiledBuffer<char> tiles(src + offset, sectionBytes, sub);
       transport->send(
-          sub, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
+          sub, tiles.data(), tiles.bytes(), maxSignalBytes, abortDevice);
     } else {
       TiledBuffer<char> tiles(dst + offset, sectionBytes, sub);
       transport->recv(
-          sub, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
+          sub, tiles.data(), tiles.bytes(), maxSignalBytes, abortDevice);
     }
   }
 }
@@ -104,9 +104,9 @@ void launch_ibgda_send_recv(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   ibgda_send_recv_kernel<<<2 * numBlocks, 512, 0, stream>>>(
-      transport, src, dst, nbytes, numBlocks, maxSignalBytes, timeout);
+      transport, src, dst, nbytes, numBlocks, maxSignalBytes, abortDevice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf("[PIPES] Kernel launch failed: %s\n", cudaGetErrorString(err));
@@ -121,7 +121,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_send_recv_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
   auto [role, sub] = group.partition(2);
   const bool isSender = (role == 0);
@@ -135,16 +135,18 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_send_recv_kernel(
     if (isSender) {
       TiledBuffer<char> tiles(src + offset, sectionBytes, sub);
       transport->init_send_progress(sub, tiles.bytes(), maxSignalBytes);
-      while (transport->progress_send_once(
-                 sub, tiles.data(), tiles.bytes(), maxSignalBytes, timeout) !=
-             IbgdaSendRecvProgressStatus::Done) {
+      while (
+          transport->progress_send_once(
+              sub, tiles.data(), tiles.bytes(), maxSignalBytes, abortDevice) !=
+          IbgdaSendRecvProgressStatus::Done) {
       }
     } else {
       TiledBuffer<char> tiles(dst + offset, sectionBytes, sub);
       transport->init_recv_progress(sub, tiles.bytes(), maxSignalBytes);
-      while (transport->progress_recv_once(
-                 sub, tiles.data(), tiles.bytes(), maxSignalBytes, timeout) !=
-             IbgdaSendRecvProgressStatus::Done) {
+      while (
+          transport->progress_recv_once(
+              sub, tiles.data(), tiles.bytes(), maxSignalBytes, abortDevice) !=
+          IbgdaSendRecvProgressStatus::Done) {
       }
     }
   }
@@ -159,7 +161,7 @@ void launch_ibgda_progress_send_recv(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
 #ifdef __HIP_PLATFORM_AMD__
   (void)transport;
   (void)src;
@@ -168,11 +170,11 @@ void launch_ibgda_progress_send_recv(
   (void)numBlocks;
   (void)stream;
   (void)maxSignalBytes;
-  (void)timeout;
+  (void)abortDevice;
   printf("[PIPES] progress send/recv benchmark is NVIDIA-only\n");
 #else
   ibgda_progress_send_recv_kernel<<<2 * numBlocks, 512, 0, stream>>>(
-      transport, src, dst, nbytes, numBlocks, maxSignalBytes, timeout);
+      transport, src, dst, nbytes, numBlocks, maxSignalBytes, abortDevice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(
@@ -191,7 +193,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_recv_two_call_kernel(
     int numBlocks,
     std::size_t firstMaxSignalBytes,
     std::size_t secondMaxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
 
   auto [role, sub] = group.partition(2);
@@ -200,17 +202,17 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_recv_two_call_kernel(
   if (isSender) {
     TiledBuffer<char> first(src, firstBytes, sub);
     transport->send(
-        sub, first.data(), first.bytes(), firstMaxSignalBytes, timeout);
+        sub, first.data(), first.bytes(), firstMaxSignalBytes, abortDevice);
     TiledBuffer<char> second(src + firstBytes, secondBytes, sub);
     transport->send(
-        sub, second.data(), second.bytes(), secondMaxSignalBytes, timeout);
+        sub, second.data(), second.bytes(), secondMaxSignalBytes, abortDevice);
   } else {
     TiledBuffer<char> first(dst, firstBytes, sub);
     transport->recv(
-        sub, first.data(), first.bytes(), firstMaxSignalBytes, timeout);
+        sub, first.data(), first.bytes(), firstMaxSignalBytes, abortDevice);
     TiledBuffer<char> second(dst + firstBytes, secondBytes, sub);
     transport->recv(
-        sub, second.data(), second.bytes(), secondMaxSignalBytes, timeout);
+        sub, second.data(), second.bytes(), secondMaxSignalBytes, abortDevice);
   }
 }
 
@@ -224,7 +226,7 @@ void launch_ibgda_send_recv_two_call(
     std::size_t firstMaxSignalBytes,
     std::size_t secondMaxSignalBytes,
     cudaStream_t stream,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   ibgda_send_recv_two_call_kernel<<<2 * numBlocks, 512, 0, stream>>>(
       transport,
       src,
@@ -234,7 +236,7 @@ void launch_ibgda_send_recv_two_call(
       numBlocks,
       firstMaxSignalBytes,
       secondMaxSignalBytes,
-      timeout);
+      abortDevice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(
@@ -248,7 +250,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
 
   const std::size_t sectionBytes = section_bytes(transport, totalBytes);
@@ -257,7 +259,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_kernel(
   for (std::size_t s = 0; s < totalSections; ++s) {
     TiledBuffer<char> tiles(src + s * sectionBytes, sectionBytes, group);
     transport->send(
-        group, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
+        group, tiles.data(), tiles.bytes(), maxSignalBytes, abortDevice);
   }
 }
 
@@ -267,7 +269,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_recv_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
 
   const std::size_t sectionBytes = section_bytes(transport, totalBytes);
@@ -276,7 +278,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_recv_kernel(
   for (std::size_t s = 0; s < totalSections; ++s) {
     TiledBuffer<char> tiles(dst + s * sectionBytes, sectionBytes, group);
     transport->recv(
-        group, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
+        group, tiles.data(), tiles.bytes(), maxSignalBytes, abortDevice);
   }
 }
 
@@ -289,15 +291,15 @@ __global__ void __launch_bounds__(kWarpProxyBlockThreads, 1)
         std::size_t totalBytes,
         std::size_t maxSignalBytes,
         uint32_t queueDepth,
-        Timeout timeout) {
-  timeout.start();
+        AbortDevice abortDevice) {
+  abortDevice.start();
   auto block = make_block_group();
   __shared__ BenchmarkWarpProxy::SharedState sharedState;
   BenchmarkWarpProxy::run(
       sharedState,
       block,
       BenchmarkWarpProxy::Config{.queueDepth = queueDepth},
-      timeout,
+      abortDevice,
       [&](auto& ops) {
         auto& workers = ops.group();
         const std::size_t sectionBytes = section_bytes(transport, totalBytes);
@@ -323,9 +325,9 @@ void launch_ibgda_send(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   ibgda_send_kernel<<<numBlocks, 512, 0, stream>>>(
-      transport, src, nbytes, numBlocks, maxSignalBytes, timeout);
+      transport, src, nbytes, numBlocks, maxSignalBytes, abortDevice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf("[PIPES] send kernel launch failed: %s\n", cudaGetErrorString(err));
@@ -339,7 +341,7 @@ void launch_ibgda_warp_proxy_send(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes,
-    Timeout timeout,
+    AbortDevice abortDevice,
     uint32_t queueDepth) {
 #ifdef __HIP_PLATFORM_AMD__
   (void)transport;
@@ -348,13 +350,13 @@ void launch_ibgda_warp_proxy_send(
   (void)numBlocks;
   (void)stream;
   (void)maxSignalBytes;
-  (void)timeout;
+  (void)abortDevice;
   (void)queueDepth;
   printf("[PIPES] warp-proxy send benchmark is NVIDIA-only\n");
 #else
   ibgda_warp_proxy_kernel<true>
       <<<numBlocks, kWarpProxyBlockThreads, 0, stream>>>(
-          transport, src, nbytes, maxSignalBytes, queueDepth, timeout);
+          transport, src, nbytes, maxSignalBytes, queueDepth, abortDevice);
   const cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(
@@ -371,9 +373,9 @@ void launch_ibgda_recv(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   ibgda_recv_kernel<<<numBlocks, 512, 0, stream>>>(
-      transport, dst, nbytes, numBlocks, maxSignalBytes, timeout);
+      transport, dst, nbytes, numBlocks, maxSignalBytes, abortDevice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf("[PIPES] recv kernel launch failed: %s\n", cudaGetErrorString(err));
@@ -394,7 +396,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_recv_ll_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
 
   auto [role, sub] = group.partition(2);
@@ -408,11 +410,11 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_recv_ll_kernel(
     if (isSender) {
       TiledBuffer<char> tiles(src + offset, sectionBytes, sub);
       transport->send<Memcpy, protocol::LL>(
-          sub, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
+          sub, tiles.data(), tiles.bytes(), maxSignalBytes, abortDevice);
     } else {
       TiledBuffer<char> tiles(dst + offset, sectionBytes, sub);
       transport->recv<Memcpy, protocol::LL>(
-          sub, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
+          sub, tiles.data(), tiles.bytes(), maxSignalBytes, abortDevice);
     }
   }
 }
@@ -425,9 +427,9 @@ void launch_ibgda_send_recv_ll(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   ibgda_send_recv_ll_kernel<<<2 * numBlocks, 512, 0, stream>>>(
-      transport, src, dst, nbytes, numBlocks, maxSignalBytes, timeout);
+      transport, src, dst, nbytes, numBlocks, maxSignalBytes, abortDevice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(
@@ -442,7 +444,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_ll_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
 
   const std::size_t sectionBytes = section_bytes(transport, totalBytes);
@@ -451,7 +453,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_ll_kernel(
   for (std::size_t s = 0; s < totalSections; ++s) {
     TiledBuffer<char> tiles(src + s * sectionBytes, sectionBytes, group);
     transport->send<Memcpy, protocol::LL>(
-        group, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
+        group, tiles.data(), tiles.bytes(), maxSignalBytes, abortDevice);
   }
 }
 
@@ -461,7 +463,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_recv_ll_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
 
   const std::size_t sectionBytes = section_bytes(transport, totalBytes);
@@ -470,7 +472,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_recv_ll_kernel(
   for (std::size_t s = 0; s < totalSections; ++s) {
     TiledBuffer<char> tiles(dst + s * sectionBytes, sectionBytes, group);
     transport->recv<Memcpy, protocol::LL>(
-        group, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
+        group, tiles.data(), tiles.bytes(), maxSignalBytes, abortDevice);
   }
 }
 
@@ -481,9 +483,9 @@ void launch_ibgda_send_ll(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   ibgda_send_ll_kernel<<<numBlocks, 512, 0, stream>>>(
-      transport, src, nbytes, numBlocks, maxSignalBytes, timeout);
+      transport, src, nbytes, numBlocks, maxSignalBytes, abortDevice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(
@@ -498,9 +500,9 @@ void launch_ibgda_recv_ll(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   ibgda_recv_ll_kernel<<<numBlocks, 512, 0, stream>>>(
-      transport, dst, nbytes, numBlocks, maxSignalBytes, timeout);
+      transport, dst, nbytes, numBlocks, maxSignalBytes, abortDevice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(
@@ -515,7 +517,7 @@ void launch_ibgda_warp_proxy_recv(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes,
-    Timeout timeout,
+    AbortDevice abortDevice,
     uint32_t queueDepth) {
 #ifdef __HIP_PLATFORM_AMD__
   (void)transport;
@@ -524,13 +526,13 @@ void launch_ibgda_warp_proxy_recv(
   (void)numBlocks;
   (void)stream;
   (void)maxSignalBytes;
-  (void)timeout;
+  (void)abortDevice;
   (void)queueDepth;
   printf("[PIPES] warp-proxy recv benchmark is NVIDIA-only\n");
 #else
   ibgda_warp_proxy_kernel<false>
       <<<numBlocks, kWarpProxyBlockThreads, 0, stream>>>(
-          transport, dst, nbytes, maxSignalBytes, queueDepth, timeout);
+          transport, dst, nbytes, maxSignalBytes, queueDepth, abortDevice);
   const cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(
@@ -545,7 +547,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_drain_send_recv_kernel(
     int numBlocks,
     std::size_t totalBytes,
     int iterations,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
   if (group.group_id >= static_cast<uint32_t>(numBlocks)) {
     return;
@@ -562,8 +564,9 @@ __global__ void __launch_bounds__(512, 1) ibgda_drain_send_recv_kernel(
   }
   auto& protoSlot = transport->local_channel_slot<protocol::Simple>(
       static_cast<uint32_t>(groupId));
-  transport->wait_counter(group, protoSlot.nicDoneWait, expectedBytes, timeout);
-  transport->wait_signal(group, protoSlot.slotFree, expectedBytes, timeout);
+  transport->wait_counter(
+      group, protoSlot.nicDoneWait, expectedBytes, abortDevice);
+  transport->wait_signal(group, protoSlot.slotFree, expectedBytes, abortDevice);
 }
 
 void launch_ibgda_drain_send_recv(
@@ -572,12 +575,12 @@ void launch_ibgda_drain_send_recv(
     std::size_t totalBytes,
     int iterations,
     cudaStream_t stream,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   if (totalBytes == 0 || iterations == 0) {
     return;
   }
   ibgda_drain_send_recv_kernel<<<numBlocks, 512, 0, stream>>>(
-      transport, numBlocks, totalBytes, iterations, timeout);
+      transport, numBlocks, totalBytes, iterations, abortDevice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf("[PIPES] Drain launch failed: %s\n", cudaGetErrorString(err));
@@ -656,7 +659,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_send_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout,
+    AbortDevice abortDevice,
     bool waitForSlotFree) {
   auto group = make_block_group();
 
@@ -666,9 +669,10 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_send_kernel(
   for (std::size_t s = 0; s < totalSections; ++s) {
     TiledBuffer<char> tiles(src + s * sectionBytes, sectionBytes, group);
     transport->init_send_progress(group, tiles.bytes(), maxSignalBytes);
-    while (transport->progress_send_once(
-               group, tiles.data(), tiles.bytes(), maxSignalBytes, timeout) !=
-           IbgdaSendRecvProgressStatus::Done) {
+    while (
+        transport->progress_send_once(
+            group, tiles.data(), tiles.bytes(), maxSignalBytes, abortDevice) !=
+        IbgdaSendRecvProgressStatus::Done) {
     }
   }
 
@@ -678,7 +682,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_send_kernel(
         group,
         protoSlot.slotFree,
         static_cast<uint64_t>(protoSlot.sendProgress.nextStep),
-        timeout);
+        abortDevice);
   }
 }
 
@@ -688,7 +692,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_registered_progress_send_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
 
   auto status = IbgdaRegisteredSendProgressStatus::Waiting;
@@ -702,11 +706,11 @@ __global__ void __launch_bounds__(512, 1) ibgda_registered_progress_send_kernel(
     while (status != IbgdaRegisteredSendProgressStatus::Posted &&
            status != IbgdaRegisteredSendProgressStatus::Drained) {
       status = transport->progress_registered_send_once(
-          group, section, sectionBytes, maxSignalBytes, timeout);
+          group, section, sectionBytes, maxSignalBytes, abortDevice);
     }
   }
   while (status != IbgdaRegisteredSendProgressStatus::Drained) {
-    status = transport->progress_registered_send_drain_once(group, timeout);
+    status = transport->progress_registered_send_drain_once(group, abortDevice);
   }
 
   auto& protoSlot = transport->local_channel_slot<protocol::Simple>(group);
@@ -714,7 +718,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_registered_progress_send_kernel(
       group,
       protoSlot.slotFree,
       static_cast<uint64_t>(protoSlot.sendProgress.nextStep),
-      timeout);
+      abortDevice);
 }
 
 __global__ void __launch_bounds__(512, 1) ibgda_progress_recv_kernel(
@@ -723,7 +727,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_recv_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
 
   const std::size_t sectionBytes = section_bytes(transport, totalBytes);
@@ -732,9 +736,10 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_recv_kernel(
   for (std::size_t s = 0; s < totalSections; ++s) {
     TiledBuffer<char> tiles(dst + s * sectionBytes, sectionBytes, group);
     transport->init_recv_progress(group, tiles.bytes(), maxSignalBytes);
-    while (transport->progress_recv_once(
-               group, tiles.data(), tiles.bytes(), maxSignalBytes, timeout) !=
-           IbgdaSendRecvProgressStatus::Done) {
+    while (
+        transport->progress_recv_once(
+            group, tiles.data(), tiles.bytes(), maxSignalBytes, abortDevice) !=
+        IbgdaSendRecvProgressStatus::Done) {
     }
   }
 }
@@ -747,7 +752,7 @@ void launch_ibgda_progress_send(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
 #ifdef __HIP_PLATFORM_AMD__
   (void)transport;
   (void)src;
@@ -755,11 +760,11 @@ void launch_ibgda_progress_send(
   (void)numBlocks;
   (void)stream;
   (void)maxSignalBytes;
-  (void)timeout;
+  (void)abortDevice;
   printf("[PIPES] progress send benchmark is NVIDIA-only\n");
 #else
   ibgda_progress_send_kernel<<<numBlocks, 512, 0, stream>>>(
-      transport, src, nbytes, numBlocks, maxSignalBytes, timeout, false);
+      transport, src, nbytes, numBlocks, maxSignalBytes, abortDevice, false);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(
@@ -776,7 +781,7 @@ void launch_ibgda_progress_send_complete(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
 #ifdef __HIP_PLATFORM_AMD__
   (void)transport;
   (void)src;
@@ -784,11 +789,11 @@ void launch_ibgda_progress_send_complete(
   (void)numBlocks;
   (void)stream;
   (void)maxSignalBytes;
-  (void)timeout;
+  (void)abortDevice;
   printf("[PIPES] progress send benchmark is NVIDIA-only\n");
 #else
   ibgda_progress_send_kernel<<<numBlocks, 512, 0, stream>>>(
-      transport, src, nbytes, numBlocks, maxSignalBytes, timeout, true);
+      transport, src, nbytes, numBlocks, maxSignalBytes, abortDevice, true);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(
@@ -805,7 +810,7 @@ void launch_ibgda_registered_progress_send(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
 #ifdef __HIP_PLATFORM_AMD__
   (void)transport;
   (void)src;
@@ -813,11 +818,11 @@ void launch_ibgda_registered_progress_send(
   (void)numBlocks;
   (void)stream;
   (void)maxSignalBytes;
-  (void)timeout;
+  (void)abortDevice;
   printf("[PIPES] registered progress send benchmark is NVIDIA-only\n");
 #else
   ibgda_registered_progress_send_kernel<<<numBlocks, 512, 0, stream>>>(
-      transport, src, nbytes, numBlocks, maxSignalBytes, timeout);
+      transport, src, nbytes, numBlocks, maxSignalBytes, abortDevice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(
@@ -834,7 +839,7 @@ void launch_ibgda_progress_recv(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
 #ifdef __HIP_PLATFORM_AMD__
   (void)transport;
   (void)dst;
@@ -842,11 +847,11 @@ void launch_ibgda_progress_recv(
   (void)numBlocks;
   (void)stream;
   (void)maxSignalBytes;
-  (void)timeout;
+  (void)abortDevice;
   printf("[PIPES] progress recv benchmark is NVIDIA-only\n");
 #else
   ibgda_progress_recv_kernel<<<numBlocks, 512, 0, stream>>>(
-      transport, dst, nbytes, numBlocks, maxSignalBytes, timeout);
+      transport, dst, nbytes, numBlocks, maxSignalBytes, abortDevice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(
@@ -870,7 +875,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_send_ll_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
 
   const std::size_t sectionBytes = section_bytes(transport, totalBytes);
@@ -880,9 +885,10 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_send_ll_kernel(
     TiledBuffer<char> tiles(src + s * sectionBytes, sectionBytes, group);
     transport->init_send_progress<protocol::LL>(
         group, tiles.bytes(), maxSignalBytes);
-    while (transport->progress_send_once<Memcpy, protocol::LL>(
-               group, tiles.data(), tiles.bytes(), maxSignalBytes, timeout) !=
-           IbgdaSendRecvProgressStatus::Done) {
+    while (
+        transport->progress_send_once<Memcpy, protocol::LL>(
+            group, tiles.data(), tiles.bytes(), maxSignalBytes, abortDevice) !=
+        IbgdaSendRecvProgressStatus::Done) {
     }
   }
 }
@@ -893,7 +899,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_recv_ll_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
 
   const std::size_t sectionBytes = section_bytes(transport, totalBytes);
@@ -903,9 +909,10 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_recv_ll_kernel(
     TiledBuffer<char> tiles(dst + s * sectionBytes, sectionBytes, group);
     transport->init_recv_progress<protocol::LL>(
         group, tiles.bytes(), maxSignalBytes);
-    while (transport->progress_recv_once<Memcpy, protocol::LL>(
-               group, tiles.data(), tiles.bytes(), maxSignalBytes, timeout) !=
-           IbgdaSendRecvProgressStatus::Done) {
+    while (
+        transport->progress_recv_once<Memcpy, protocol::LL>(
+            group, tiles.data(), tiles.bytes(), maxSignalBytes, abortDevice) !=
+        IbgdaSendRecvProgressStatus::Done) {
     }
   }
 }
@@ -918,7 +925,7 @@ void launch_ibgda_progress_send_ll(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
 #ifdef __HIP_PLATFORM_AMD__
   (void)transport;
   (void)src;
@@ -926,11 +933,11 @@ void launch_ibgda_progress_send_ll(
   (void)numBlocks;
   (void)stream;
   (void)maxSignalBytes;
-  (void)timeout;
+  (void)abortDevice;
   printf("[PIPES] progress send LL benchmark is NVIDIA-only\n");
 #else
   ibgda_progress_send_ll_kernel<<<numBlocks, 512, 0, stream>>>(
-      transport, src, nbytes, numBlocks, maxSignalBytes, timeout);
+      transport, src, nbytes, numBlocks, maxSignalBytes, abortDevice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(
@@ -947,7 +954,7 @@ void launch_ibgda_progress_recv_ll(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
 #ifdef __HIP_PLATFORM_AMD__
   (void)transport;
   (void)dst;
@@ -955,11 +962,11 @@ void launch_ibgda_progress_recv_ll(
   (void)numBlocks;
   (void)stream;
   (void)maxSignalBytes;
-  (void)timeout;
+  (void)abortDevice;
   printf("[PIPES] progress recv LL benchmark is NVIDIA-only\n");
 #else
   ibgda_progress_recv_ll_kernel<<<numBlocks, 512, 0, stream>>>(
-      transport, dst, nbytes, numBlocks, maxSignalBytes, timeout);
+      transport, dst, nbytes, numBlocks, maxSignalBytes, abortDevice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(

--- a/comms/prims/benchmarks/IbgdaSendRecv.cuh
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cuh
@@ -27,7 +27,7 @@ __global__ void ibgda_send_recv_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout);
+    AbortDevice abortDevice);
 
 #ifndef __HIP_PLATFORM_AMD__
 __global__ void ibgda_progress_send_recv_kernel(
@@ -37,7 +37,7 @@ __global__ void ibgda_progress_send_recv_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout);
+    AbortDevice abortDevice);
 #endif
 
 __global__ void ibgda_send_recv_two_call_kernel(
@@ -49,7 +49,7 @@ __global__ void ibgda_send_recv_two_call_kernel(
     int numBlocks,
     std::size_t firstMaxSignalBytes,
     std::size_t secondMaxSignalBytes,
-    Timeout timeout);
+    AbortDevice abortDevice);
 
 /**
  * Unidirectional tile send kernel. All blocks send.
@@ -61,7 +61,7 @@ __global__ void ibgda_send_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout);
+    AbortDevice abortDevice);
 
 /**
  * Unidirectional tile recv kernel. All blocks receive.
@@ -73,7 +73,7 @@ __global__ void ibgda_recv_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout);
+    AbortDevice abortDevice);
 
 #ifndef __HIP_PLATFORM_AMD__
 /**
@@ -86,7 +86,7 @@ __global__ void ibgda_progress_send_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout,
+    AbortDevice abortDevice,
     bool waitForSlotFree);
 
 /**
@@ -99,7 +99,7 @@ __global__ void ibgda_registered_progress_send_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout);
+    AbortDevice abortDevice);
 
 /**
  * Unidirectional progress recv kernel. All blocks receive.
@@ -111,7 +111,7 @@ __global__ void ibgda_progress_recv_kernel(
     std::size_t totalBytes,
     int numBlocks,
     std::size_t maxSignalBytes,
-    Timeout timeout);
+    AbortDevice abortDevice);
 #endif
 
 } // namespace comms::prims::benchmark

--- a/comms/prims/benchmarks/IbgdaSendRecv.h
+++ b/comms/prims/benchmarks/IbgdaSendRecv.h
@@ -30,7 +30,7 @@ inline constexpr uint32_t kDefaultIbgdaWarpProxyQueueDepth = 16;
  * @param numBlocks  Number of send blocks (= number of recv blocks)
  * @param stream     CUDA stream
  * @param maxSignalBytes Max bytes per signaled sub-chunk
- * @param timeout    Optional timeout for wait operations
+ * @param abortDevice    Optional abortDevice for wait operations
  */
 void launch_ibgda_send_recv(
     P2pIbgdaTransportDevice* transport,
@@ -40,7 +40,7 @@ void launch_ibgda_send_recv(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes = 0,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 /**
  * Launch bidirectional progress-send/recv kernel for IBGDA transport.
@@ -56,7 +56,7 @@ void launch_ibgda_progress_send_recv(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes = 0,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 /**
  * Launch bidirectional tile sendrecv kernel that performs two back-to-back
@@ -72,7 +72,7 @@ void launch_ibgda_send_recv_two_call(
     std::size_t firstMaxSignalBytes,
     std::size_t secondMaxSignalBytes,
     cudaStream_t stream,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 /**
  * Launch unidirectional tile send kernel. All blocks send.
@@ -84,7 +84,7 @@ void launch_ibgda_send(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes = 0,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 /**
  * Launch NVIDIA-only unidirectional send with one IB service warp per block.
@@ -96,7 +96,7 @@ void launch_ibgda_warp_proxy_send(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes = 0,
-    Timeout timeout = Timeout(),
+    AbortDevice abortDevice = AbortDevice(),
     uint32_t queueDepth = kDefaultIbgdaWarpProxyQueueDepth);
 
 /**
@@ -109,7 +109,7 @@ void launch_ibgda_recv(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes = 0,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 /**
  * Launch NVIDIA-only unidirectional receive with one IB service warp per block.
@@ -121,7 +121,7 @@ void launch_ibgda_warp_proxy_recv(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes = 0,
-    Timeout timeout = Timeout(),
+    AbortDevice abortDevice = AbortDevice(),
     uint32_t queueDepth = kDefaultIbgdaWarpProxyQueueDepth);
 
 /**
@@ -137,7 +137,7 @@ void launch_ibgda_send_recv_ll(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes = 0,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 void launch_ibgda_send_ll(
     P2pIbgdaTransportDevice* transport,
@@ -146,7 +146,7 @@ void launch_ibgda_send_ll(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes = 0,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 void launch_ibgda_recv_ll(
     P2pIbgdaTransportDevice* transport,
@@ -155,7 +155,7 @@ void launch_ibgda_recv_ll(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes = 0,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 /**
  * Drain outstanding bidirectional send/recv transport work for benchmark
@@ -167,7 +167,7 @@ void launch_ibgda_drain_send_recv(
     std::size_t totalBytes,
     int iterations,
     cudaStream_t stream,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 /**
  * Reset benchmark-owned send/recv transport state after outstanding work has
@@ -188,7 +188,7 @@ void launch_ibgda_progress_send(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes = 0,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 /**
  * Launch the staged progress sender and wait for the receiver's final credit.
@@ -200,7 +200,7 @@ void launch_ibgda_progress_send_complete(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes = 0,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 /**
  * Launch a unidirectional registered-source progress send kernel.
@@ -215,7 +215,7 @@ void launch_ibgda_registered_progress_send(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes = 0,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 /**
  * Launch unidirectional progress recv kernel. All blocks receive.
@@ -227,7 +227,7 @@ void launch_ibgda_progress_recv(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes = 0,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 /**
  * Launch unidirectional LL progress send kernel. All blocks send.
@@ -239,7 +239,7 @@ void launch_ibgda_progress_send_ll(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes = 0,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 /**
  * Launch unidirectional LL progress recv kernel. All blocks receive.
@@ -251,7 +251,7 @@ void launch_ibgda_progress_recv_ll(
     int numBlocks,
     cudaStream_t stream,
     std::size_t maxSignalBytes = 0,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 /**
  * Snapshot the transport send/recv byte cursors into device memory.

--- a/comms/prims/benchmarks/IbgdaSendRecvAns.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecvAns.cu
@@ -50,7 +50,7 @@ __global__ void __launch_bounds__(kAnsNumWarps * 32, kAnsMinBlocksPerSm)
         P2pIbgdaTransportDevice* transport,
         char* src,
         std::size_t totalBytes,
-        Timeout timeout) {
+        AbortDevice abortDevice) {
   auto group = make_block_group();
 
   const std::size_t sectionBytes = ans_section_bytes(transport, totalBytes);
@@ -68,7 +68,7 @@ __global__ void __launch_bounds__(kAnsNumWarps * 32, kAnsMinBlocksPerSm)
         tiles.data(),
         tiles.bytes(),
         /*max_signal_bytes=*/0,
-        timeout,
+        abortDevice,
         /*alignedAuxBuf=*/static_cast<char*>(nullptr));
   }
 }
@@ -78,7 +78,7 @@ __global__ void __launch_bounds__(kAnsNumWarps * 32, kAnsMinBlocksPerSm)
         P2pIbgdaTransportDevice* transport,
         char* dst,
         std::size_t totalBytes,
-        Timeout timeout) {
+        AbortDevice abortDevice) {
   auto group = make_block_group();
 
   const std::size_t sectionBytes = ans_section_bytes(transport, totalBytes);
@@ -89,7 +89,11 @@ __global__ void __launch_bounds__(kAnsNumWarps * 32, kAnsMinBlocksPerSm)
     // max_signal_bytes = 0: exercise the transport's 0-sentinel (derives the
     // trap-safe chunk size via CopyOp::max_safe_chunk_size_for_slot()).
     transport->recv<BenchAnsCompress>(
-        group, tiles.data(), tiles.bytes(), /*max_signal_bytes=*/0, timeout);
+        group,
+        tiles.data(),
+        tiles.bytes(),
+        /*max_signal_bytes=*/0,
+        abortDevice);
   }
 }
 
@@ -99,9 +103,9 @@ void launch_ibgda_send_ans(
     std::size_t nbytes,
     int numBlocks,
     cudaStream_t stream,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   ibgda_send_ans_kernel<<<numBlocks, kAnsNumWarps * 32, 0, stream>>>(
-      transport, src, nbytes, timeout);
+      transport, src, nbytes, abortDevice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(
@@ -115,9 +119,9 @@ void launch_ibgda_recv_ans(
     std::size_t nbytes,
     int numBlocks,
     cudaStream_t stream,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   ibgda_recv_ans_kernel<<<numBlocks, kAnsNumWarps * 32, 0, stream>>>(
-      transport, dst, nbytes, timeout);
+      transport, dst, nbytes, abortDevice);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(

--- a/comms/prims/benchmarks/IbgdaSendRecvAns.h
+++ b/comms/prims/benchmarks/IbgdaSendRecvAns.h
@@ -33,7 +33,7 @@ void launch_ibgda_send_ans(
     std::size_t nbytes,
     int numBlocks,
     cudaStream_t stream,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 /**
  * Launch unidirectional ANS (compressed) tile recv. All blocks receive.
@@ -45,6 +45,6 @@ void launch_ibgda_recv_ans(
     std::size_t nbytes,
     int numBlocks,
     cudaStream_t stream,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 } // namespace comms::prims::benchmark

--- a/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -809,7 +809,7 @@ class IbgdaSendRecvBenchmarkContext {
             numBlocks_,
             stream_,
             /*maxSignalBytes=*/0,
-            Timeout(),
+            AbortDevice(),
             FLAGS_ibgda_warp_proxy_queue_depth);
       } else {
         LOG(FATAL) << "unsupported send/recv API";
@@ -847,7 +847,7 @@ class IbgdaSendRecvBenchmarkContext {
           numBlocks_,
           stream_,
           /*maxSignalBytes=*/0,
-          Timeout(),
+          AbortDevice(),
           FLAGS_ibgda_warp_proxy_queue_depth);
     } else {
       LOG(FATAL) << "unsupported send/recv API";

--- a/comms/prims/benchmarks/P2pNvlLl128Benchmark.cc
+++ b/comms/prims/benchmarks/P2pNvlLl128Benchmark.cc
@@ -197,8 +197,8 @@ class P2pLl128BenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     bool isSend = (globalRank == 0);
     SyncScope groupScope = config.groupScope;
     void* devicePtr = (isSend ? sendBuff.get() : recvBuff.get());
-    Timeout timeout;
-    void* args[] = {&p2p, &devicePtr, &nBytes, &groupScope, &timeout};
+    AbortDevice abortDevice;
+    void* args[] = {&p2p, &devicePtr, &nBytes, &groupScope, &abortDevice};
     void* kernelFunc = isSend ? (void*)comms::prims::benchmark::p2pSend
                               : (void*)comms::prims::benchmark::p2pRecv;
 
@@ -257,8 +257,8 @@ class P2pLl128BenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     std::size_t nBytes = config.nBytes;
     bool isSend = (globalRank == 0);
     void* devicePtr = isSend ? sendBuff.get() : recvBuff.get();
-    Timeout timeout;
-    void* args[] = {&p2p, &devicePtr, &nBytes, &timeout};
+    AbortDevice abortDevice;
+    void* args[] = {&p2p, &devicePtr, &nBytes, &abortDevice};
     void* kernelFunc = isSend ? (void*)comms::prims::benchmark::p2pLl128Send
                               : (void*)comms::prims::benchmark::p2pLl128Recv;
 
@@ -414,8 +414,9 @@ class P2pLl128BenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     void* sendPtr = sendBuff.get();
     void* recvPtr = recvBuff.get();
     SyncScope groupScope = config.groupScope;
-    Timeout timeout;
-    void* args[] = {&p2p, &sendPtr, &recvPtr, &nBytes, &groupScope, &timeout};
+    AbortDevice abortDevice;
+    void* args[] = {
+        &p2p, &sendPtr, &recvPtr, &nBytes, &groupScope, &abortDevice};
     void* kernelFunc = (void*)comms::prims::benchmark::p2pBidirectional;
 
     bootstrap->barrierAll();
@@ -461,8 +462,8 @@ class P2pLl128BenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     std::size_t nBytes = config.nBytes;
     void* sendPtr = sendBuff.get();
     void* recvPtr = recvBuff.get();
-    Timeout timeout;
-    void* args[] = {&p2p, &sendPtr, &recvPtr, &nBytes, &timeout};
+    AbortDevice abortDevice;
+    void* args[] = {&p2p, &sendPtr, &recvPtr, &nBytes, &abortDevice};
     void* kernelFunc = (void*)comms::prims::benchmark::p2pLl128Bidirectional;
 
     bootstrap->barrierAll();

--- a/comms/prims/benchmarks/P2pNvlLlBenchmark.cc
+++ b/comms/prims/benchmarks/P2pNvlLlBenchmark.cc
@@ -183,8 +183,8 @@ class P2pLlBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     std::size_t nBytes = config.nBytes;
     bool isSend = (globalRank == 0);
     void* devicePtr = isSend ? sendBuff.get() : recvBuff.get();
-    Timeout timeout;
-    void* args[] = {&p2p, &devicePtr, &nBytes, &timeout};
+    AbortDevice abortDevice;
+    void* args[] = {&p2p, &devicePtr, &nBytes, &abortDevice};
     void* kernelFunc = isSend ? (void*)comms::prims::benchmark::p2pLl128Send
                               : (void*)comms::prims::benchmark::p2pLl128Recv;
 
@@ -244,8 +244,8 @@ class P2pLlBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     std::size_t nBytes = config.nBytes;
     bool isSend = (globalRank == 0);
     void* devicePtr = isSend ? sendBuff.get() : recvBuff.get();
-    Timeout timeout;
-    void* args[] = {&p2p, &devicePtr, &nBytes, &timeout};
+    AbortDevice abortDevice;
+    void* args[] = {&p2p, &devicePtr, &nBytes, &abortDevice};
     void* kernelFunc = isSend ? (void*)comms::prims::benchmark::p2pLlSend
                               : (void*)comms::prims::benchmark::p2pLlRecv;
 
@@ -399,8 +399,8 @@ class P2pLlBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     std::size_t nBytes = config.nBytes;
     void* sendPtr = sendBuff.get();
     void* recvPtr = recvBuff.get();
-    Timeout timeout;
-    void* args[] = {&p2p, &sendPtr, &recvPtr, &nBytes, &timeout};
+    AbortDevice abortDevice;
+    void* args[] = {&p2p, &sendPtr, &recvPtr, &nBytes, &abortDevice};
     void* kernelFunc = (void*)comms::prims::benchmark::p2pLl128Bidirectional;
 
     bootstrap->barrierAll();
@@ -446,8 +446,8 @@ class P2pLlBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     std::size_t nBytes = config.nBytes;
     void* sendPtr = sendBuff.get();
     void* recvPtr = recvBuff.get();
-    Timeout timeout;
-    void* args[] = {&p2p, &sendPtr, &recvPtr, &nBytes, &timeout};
+    AbortDevice abortDevice;
+    void* args[] = {&p2p, &sendPtr, &recvPtr, &nBytes, &abortDevice};
     void* kernelFunc = (void*)comms::prims::benchmark::p2pLlBidirectional;
 
     bootstrap->barrierAll();

--- a/comms/prims/benchmarks/P2pNvlSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/P2pNvlSendRecvBenchmark.cc
@@ -154,8 +154,9 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     SyncScope groupScope = config.groupScope;
     void* devicePtr = isSend ? sendBuff.get() : recvBuff.get();
     std::size_t nBytes = config.nBytes;
-    Timeout timeout;
-    void* args[] = {p2pDevicePtr, &devicePtr, &nBytes, &groupScope, &timeout};
+    AbortDevice abortDevice;
+    void* args[] = {
+        p2pDevicePtr, &devicePtr, &nBytes, &groupScope, &abortDevice};
 
     void* kernelFunc = isSend ? (void*)comms::prims::benchmark::p2pSend
                               : (void*)comms::prims::benchmark::p2pRecv;
@@ -224,11 +225,12 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     bool isSend = (globalRank == 0);
     SyncScope groupScope = config.groupScope;
     void* devicePtr = (isSend ? sendBuff.get() : recvBuff.get());
-    Timeout timeout; // Default timeout (disabled)
+    AbortDevice abortDevice; // Default abortDevice (disabled)
     // p2pDevicePtr points to a host-side P2pNvlTransportDevice;
     // cudaLaunchKernel reads the struct by value from host memory for the
     // kernel parameter.
-    void* args[] = {p2pDevicePtr, &devicePtr, &nBytes, &groupScope, &timeout};
+    void* args[] = {
+        p2pDevicePtr, &devicePtr, &nBytes, &groupScope, &abortDevice};
 
     void* kernelFunc = isSend ? (void*)comms::prims::benchmark::p2pSend
                               : (void*)comms::prims::benchmark::p2pRecv;
@@ -294,7 +296,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     dim3 blockDim(config.numThreads);
 
     CudaEvent start, stop;
-    Timeout timeout;
+    AbortDevice abortDevice;
 
     // Create TiledBuffer views for send and recv
     comms::prims::TiledBuffer<char> sendTiles(
@@ -311,7 +313,7 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
         ? (void*)comms::prims::benchmark::p2pTileSendRecvBidirCta
         : (void*)comms::prims::benchmark::p2pTileSendRecv;
     void* args[] = {
-        p2pDevicePtr, &sendTiles, &recvTiles, &maxSignalBytes, &timeout};
+        p2pDevicePtr, &sendTiles, &recvTiles, &maxSignalBytes, &abortDevice};
 
     dim3 defaultClusterDim(comms::common::kDefaultClusterSize, 1, 1);
     std::optional<dim3> clusterDimOpt = config.spreadClusterLaunch
@@ -498,12 +500,12 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     void* sendPtr = sendBuff.get();
     void* recvPtr = recvBuff.get();
     SyncScope groupScope = config.groupScope;
-    Timeout timeout; // Default timeout (disabled)
+    AbortDevice abortDevice; // Default abortDevice (disabled)
     // p2pDevicePtr points to a host-side P2pNvlTransportDevice;
     // cudaLaunchKernel reads the struct by value from host memory for the
     // kernel parameter.
     void* args[] = {
-        p2pDevicePtr, &sendPtr, &recvPtr, &nBytes, &groupScope, &timeout};
+        p2pDevicePtr, &sendPtr, &recvPtr, &nBytes, &groupScope, &abortDevice};
 
     void* kernelFunc = (void*)comms::prims::benchmark::p2pBidirectional;
 

--- a/comms/prims/benchmarks/TileSendRecv.cu
+++ b/comms/prims/benchmarks/TileSendRecv.cu
@@ -12,8 +12,8 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecv(
     TiledBuffer<char> sendTiles,
     TiledBuffer<char> recvTiles,
     std::size_t max_signal_bytes,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
 
   auto group = make_block_group();
   auto [role, sub] = group.partition(2);
@@ -26,14 +26,14 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecv(
         sendTiles.tile_data(blockId),
         sendTiles.tile_bytes(blockId),
         max_signal_bytes,
-        timeout);
+        abortDevice);
   } else {
     p2p.recv(
         sub,
         recvTiles.tile_data(blockId),
         recvTiles.tile_bytes(blockId),
         max_signal_bytes,
-        timeout);
+        abortDevice);
   }
 }
 
@@ -93,15 +93,15 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecvDynamic(
     TiledBuffer<char> sendTiles,
     TiledBuffer<char> recvTiles,
     bool needsBarrier,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
 
   auto group = make_block_group();
   auto [role, sub] = group.partition(2);
   const int blockId = sub.group_id;
 
   if (needsBarrier) {
-    p2p.barrier_sync(sub, blockId, timeout);
+    p2p.barrier_sync(sub, blockId, abortDevice);
   }
 
   if (role == 0) {
@@ -110,14 +110,14 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecvDynamic(
         sendTiles.tile_data(blockId),
         sendTiles.tile_bytes(blockId),
         /*max_signal_bytes=*/0,
-        timeout);
+        abortDevice);
   } else {
     p2p.recv(
         sub,
         recvTiles.tile_data(blockId),
         recvTiles.tile_bytes(blockId),
         /*max_signal_bytes=*/0,
-        timeout);
+        abortDevice);
   }
 }
 
@@ -175,8 +175,8 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecvBidirCta(
     TiledBuffer<char> sendTiles,
     TiledBuffer<char> recvTiles,
     std::size_t max_signal_bytes,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
 
   auto group = make_multiwarp_group(blockDim.x / 2);
   auto [role, sub] = group.partition_interleaved(2);
@@ -189,14 +189,14 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecvBidirCta(
         sendTiles.tile_data(blockId),
         sendTiles.tile_bytes(blockId),
         max_signal_bytes,
-        timeout);
+        abortDevice);
   } else {
     p2p.recv(
         sub,
         recvTiles.tile_data(blockId),
         recvTiles.tile_bytes(blockId),
         max_signal_bytes,
-        timeout);
+        abortDevice);
   }
 }
 
@@ -205,8 +205,8 @@ __global__ __launch_bounds__(512, 1) void p2pTileForward(
     P2pNvlTransportDevice p2p_succ,
     TiledBuffer<char> dstTiles,
     std::size_t max_signal_bytes,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
 
   auto group = make_block_group();
   const int blockId = group.group_id;
@@ -217,7 +217,7 @@ __global__ __launch_bounds__(512, 1) void p2pTileForward(
       dstTiles.tile_bytes(blockId),
       p2p_succ,
       max_signal_bytes,
-      timeout);
+      abortDevice);
 }
 
 } // namespace comms::prims::benchmark

--- a/comms/prims/benchmarks/TileSendRecv.cuh
+++ b/comms/prims/benchmarks/TileSendRecv.cuh
@@ -146,14 +146,14 @@ constexpr std::size_t kSlotSize = 16 * 1024 * 1024; // 16MB per slot
  * @param recvTiles     Tiled view of the recv buffer
  * @param stepState     Persistent step counters [2 * numSendBlocks int64s],
  *                      zeroed before first use
- * @param timeout       Optional timeout for signal waits
+ * @param abortDevice       Optional abortDevice for signal waits
  */
 __global__ void p2pTileSendRecv(
     P2pNvlTransportDevice p2p,
     TiledBuffer<char> sendTiles,
     TiledBuffer<char> recvTiles,
     std::size_t max_signal_bytes = 0,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 /**
  * p2pTileSendRecvBidirCta — Bidirectional in a single block via half-block
@@ -170,7 +170,7 @@ __global__ void p2pTileSendRecvBidirCta(
     TiledBuffer<char> sendTiles,
     TiledBuffer<char> recvTiles,
     std::size_t max_signal_bytes = 0,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 /**
  * p2pTileSendRecvDynamic — Variant using transport-internal tile state
@@ -199,7 +199,7 @@ __global__ void p2pTileSendRecvDynamic(
     TiledBuffer<char> sendTiles,
     TiledBuffer<char> recvTiles,
     bool needsBarrier,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 /**
  * p2pTileForward — Tile-style fused recv+forward kernel.
@@ -219,13 +219,13 @@ __global__ void p2pTileSendRecvDynamic(
  * @param p2p_succ   Transport to successor (write target staging)
  * @param dstTiles   Tiled view of the local output buffer
  * @param max_signal_bytes Hint for signal granularity. 0 = per-slot signal.
- * @param timeout    Optional timeout for signal waits
+ * @param abortDevice    Optional abortDevice for signal waits
  */
 __global__ void p2pTileForward(
     P2pNvlTransportDevice p2p_pred,
     P2pNvlTransportDevice p2p_succ,
     TiledBuffer<char> dstTiles,
     std::size_t max_signal_bytes = 0,
-    Timeout timeout = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 } // namespace comms::prims::benchmark

--- a/comms/prims/collectives/benchmarks/AllGatherBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/AllGatherBenchmark.cc
@@ -248,7 +248,7 @@ class AllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     void* sendBuff_d = sendBuffer.get();
 
     // Create abort handle (default = disabled)
-    Timeout abortDevice;
+    AbortDevice abortDevice;
 
     // Need non-const copy for kernel args
     std::size_t sendcount_arg = sendcount;

--- a/comms/prims/collectives/benchmarks/AllToAllvBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/AllToAllvBenchmark.cc
@@ -288,7 +288,7 @@ class AllToAllvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     void* recvBuff_d = recvBuffer.get();
     const void* sendBuff_d = sendBuffer.get();
 
-    Timeout timeout_config;
+    AbortDevice timeout_config;
 
     CudaEvent start, stop;
     const int nIter = 100;

--- a/comms/prims/collectives/benchmarks/AllToAllvLl128Benchmark.cc
+++ b/comms/prims/collectives/benchmarks/AllToAllvLl128Benchmark.cc
@@ -264,7 +264,7 @@ class AllToAllvLl128BenchmarkFixture
         ? std::optional{defaultClusterDim}
         : std::nullopt;
 
-    Timeout timeout_config;
+    AbortDevice timeout_config;
 
     CudaEvent start, stop;
     constexpr int kNIter = 100;
@@ -373,7 +373,7 @@ class AllToAllvLl128BenchmarkFixture
 
     comms::fault_tolerance::Abort abort{/*enabled=*/true};
     abort.setDefaultTimeout(std::chrono::milliseconds{5000});
-    Timeout timeout_config = abort.getDeviceHandle();
+    AbortDevice timeout_config = abort.getDeviceHandle();
 
     // Warmup: per-iteration sync to ensure each iteration completes
     bootstrap->barrierAll();

--- a/comms/prims/collectives/benchmarks/CollectiveBenchmark.cu
+++ b/comms/prims/collectives/benchmarks/CollectiveBenchmark.cu
@@ -11,7 +11,7 @@ __global__ void all_to_allv_kernel(
     DeviceSpan<Transport> transports_per_rank,
     DeviceSpan<ChunkInfo> send_chunk_infos,
     DeviceSpan<ChunkInfo> recv_chunk_infos,
-    Timeout abortDevice) {
+    AbortDevice abortDevice) {
   all_to_allv(
       recvbuff_d,
       sendbuff_d,
@@ -28,7 +28,7 @@ __global__ void all_gather_kernel(
     std::size_t sendcount,
     int my_rank_id,
     DeviceSpan<Transport> transports_per_rank,
-    Timeout abortDevice) {
+    AbortDevice abortDevice) {
   all_gather(
       recvbuff_d,
       sendbuff_d,

--- a/comms/prims/collectives/benchmarks/CollectiveBenchmark.cuh
+++ b/comms/prims/collectives/benchmarks/CollectiveBenchmark.cuh
@@ -21,7 +21,7 @@ __global__ void all_to_allv_kernel(
     DeviceSpan<Transport> transports_per_rank,
     DeviceSpan<ChunkInfo> send_chunk_infos,
     DeviceSpan<ChunkInfo> recv_chunk_infos,
-    Timeout abortDevice);
+    AbortDevice abortDevice);
 
 /**
  * AllGather benchmark kernel.
@@ -35,6 +35,6 @@ __global__ void all_gather_kernel(
     std::size_t sendcount,
     int my_rank_id,
     DeviceSpan<Transport> transports_per_rank,
-    Timeout abortDevice);
+    AbortDevice abortDevice);
 
 } // namespace comms::prims::benchmark

--- a/comms/prims/collectives/tests/AllToAllvLl128Test.cu
+++ b/comms/prims/collectives/tests/AllToAllvLl128Test.cu
@@ -17,7 +17,7 @@ __global__ void test_all_to_allv_ll128_kernel(
     DeviceSpan<Transport> transports,
     DeviceSpan<ChunkInfo> send_chunk_infos,
     DeviceSpan<ChunkInfo> recv_chunk_infos,
-    Timeout abortDevice) {
+    AbortDevice abortDevice) {
   abortDevice.start();
   all_to_allv_ll128(
       recvbuff_d,
@@ -39,7 +39,7 @@ void test_all_to_allv_ll128(
     DeviceSpan<ChunkInfo> recv_chunk_infos,
     int numBlocks,
     int blockSize,
-    Timeout abortDevice) {
+    AbortDevice abortDevice) {
   test_all_to_allv_ll128_kernel<<<numBlocks, blockSize>>>(
       recvbuff_d,
       sendbuff_d,

--- a/comms/prims/collectives/tests/AllToAllvLl128Test.cuh
+++ b/comms/prims/collectives/tests/AllToAllvLl128Test.cuh
@@ -20,6 +20,6 @@ void test_all_to_allv_ll128(
     DeviceSpan<ChunkInfo> recv_chunk_infos,
     int numBlocks,
     int blockSize,
-    Timeout abortDevice = Timeout());
+    AbortDevice abortDevice = AbortDevice());
 
 } // namespace comms::prims::test

--- a/comms/prims/tests/AllGatherTest.cu
+++ b/comms/prims/tests/AllGatherTest.cu
@@ -16,7 +16,7 @@ __global__ void testAllGatherKernel(
     DeviceSpan<Transport> transports) {
   // Call all_gather - it will perform actual data transfers
   all_gather(
-      recvbuff_d, sendbuff_d, sendcount, my_rank_id, transports, Timeout());
+      recvbuff_d, sendbuff_d, sendcount, my_rank_id, transports, AbortDevice());
 }
 
 void testAllGather(

--- a/comms/prims/tests/AllToAllvTest.cu
+++ b/comms/prims/tests/AllToAllvTest.cu
@@ -15,8 +15,8 @@ __global__ __launch_bounds__(512, 1) void testAllToAllvKernel(
     DeviceSpan<Transport> transports,
     DeviceSpan<ChunkInfo> send_chunk_infos,
     DeviceSpan<ChunkInfo> recv_chunk_infos,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
   // Call all_to_allv - it will perform actual data transfers
   all_to_allv(
       recvbuff_d,
@@ -25,7 +25,7 @@ __global__ __launch_bounds__(512, 1) void testAllToAllvKernel(
       transports,
       send_chunk_infos,
       recv_chunk_infos,
-      timeout);
+      abortDevice);
 }
 
 void testAllToAllv(
@@ -38,7 +38,7 @@ void testAllToAllv(
     DeviceSpan<ChunkInfo> recv_chunk_infos,
     int numBlocks,
     int blockSize) {
-  Timeout timeout; // Default no timeout
+  AbortDevice abortDevice; // Default: disabled
   testAllToAllvKernel<<<numBlocks, blockSize>>>(
       recvbuff_d,
       sendbuff_d,
@@ -47,7 +47,7 @@ void testAllToAllv(
       transports,
       send_chunk_infos,
       recv_chunk_infos,
-      timeout);
+      abortDevice);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/prims/tests/MultiPeerNvlTransportIntegrationTest.cu
+++ b/comms/prims/tests/MultiPeerNvlTransportIntegrationTest.cu
@@ -271,15 +271,15 @@ __global__ void signalAllAggregateDistributedKernel(
     DeviceWindow dw,
     int signalIdx,
     uint64_t* result,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_warp_group();
-  timeout.start();
+  abortDevice.start();
 
   // Every rank signals all peers with value 1
   dw.signal_all(group, signalIdx, SignalOp::SIGNAL_ADD, 1);
 
   // Wait until aggregate reaches nRanks-1 (all peers have signaled us)
-  dw.wait_signal(group, signalIdx, CmpOp::CMP_GE, dw.num_peers(), timeout);
+  dw.wait_signal(group, signalIdx, CmpOp::CMP_GE, dw.num_peers(), abortDevice);
 
   // Read aggregate (thread-level API)
   if (group.is_leader()) {

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cu
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cu
@@ -36,7 +36,7 @@ __device__ SignalState* boundaryPeerSignals[kBoundaryMaxRanks];
 
 __global__ void nvlSignalTrapKernel(
     NvlSignalTrapCase testCase,
-    Timeout waitAbort) {
+    AbortDevice waitAbort) {
   auto* trapSignals = reinterpret_cast<SignalState*>(trapSignalStorage);
   SignalState* peerSignals[4] = {
       trapSignals, trapSignals, trapSignals, trapSignals};
@@ -123,7 +123,7 @@ __global__ void nvlSignalTrapKernel(
         NvlSignalAccess::Unicast,
         NvlSignalTopology::Aggregate,
         NvlSignalPhase::Ready>(
-        transport, round, participants, group, Timeout{});
+        transport, round, participants, group, AbortDevice{});
     return;
   }
   if (testCase == NvlSignalTrapCase::AggregateDepthTooLarge ||
@@ -134,7 +134,7 @@ __global__ void nvlSignalTrapKernel(
         NvlSignalAccess::Multimem,
         NvlSignalTopology::Aggregate,
         NvlSignalPhase::Ready>(
-        transport, round, participants, group, Timeout{});
+        transport, round, participants, group, AbortDevice{});
     return;
   }
   auto group = make_block_group();
@@ -203,14 +203,14 @@ __global__ void nvlSignalRankBoundaryKernel(
           .expectedArrivals = nvl_signal_detail::mask_rank_count(publishers),
       },
       group,
-      Timeout{});
+      AbortDevice{});
   if (group.is_leader()) {
     *output = signals[selectedRank].load();
   }
 }
 
 template <NvlPerPeerWaitPolicy waitPolicy>
-__global__ void nvlSignalUpperWordWaitTimeoutKernel(Timeout waitAbort) {
+__global__ void nvlSignalUpperWordWaitTimeoutKernel(AbortDevice waitAbort) {
   auto group = make_block_group();
   auto* signals = reinterpret_cast<SignalState*>(boundarySignalStorage);
   for (int rank = static_cast<int>(threadIdx.x); rank < kBoundaryMaxRanks;

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -142,7 +142,7 @@ __global__ void aggregateSignalProtocolKernel(
       round,
       makeTestParticipants(transport, fanIn),
       group,
-      Timeout{});
+      AbortDevice{});
 
   const uint32_t lane = group.thread_id_in_group;
   if (lane < transport.pipelineDepth) {
@@ -176,7 +176,7 @@ __global__ void perPeerSignalProtocolKernel(
       round,
       makeTestParticipants(transport, fanIn),
       group,
-      Timeout{});
+      AbortDevice{});
 
   const int source = static_cast<int>(group.thread_id_in_group);
   if (source < transport.nvlRanks) {
@@ -203,7 +203,7 @@ __global__ void aggregateAckSignalProtocolKernel(
       StageRound{.channel = 0, .value = roundValue},
       makeAckParticipants(transport),
       group,
-      Timeout{});
+      AbortDevice{});
 
   const uint32_t lane = group.thread_id_in_group;
   if (lane < transport.pipelineDepth) {
@@ -232,7 +232,7 @@ __global__ void multiChannelAggregateSignalKernel(
       round,
       makeTestParticipants(transport, /*fanIn=*/false),
       group,
-      Timeout{});
+      AbortDevice{});
   const uint32_t lane = group.thread_id_in_group;
   if (lane < transport.pipelineDepth) {
     const uint64_t signalId = layout.signalBase +
@@ -258,7 +258,7 @@ __global__ void aggregateMultimemWaiterTransitionKernel(
       round,
       makeTestParticipants(transport, /*fanIn=*/true),
       group,
-      Timeout{});
+      AbortDevice{});
 
   if (transport.nvlRank == transport.nvlRanks - 1) {
     __nanosleep(100'000'000);
@@ -272,7 +272,7 @@ __global__ void aggregateMultimemWaiterTransitionKernel(
       round,
       makeTestParticipants(transport, /*fanIn=*/false),
       group,
-      Timeout{});
+      AbortDevice{});
 
   const uint32_t lane = group.thread_id_in_group;
   if (lane < transport.pipelineDepth) {
@@ -310,7 +310,7 @@ __global__ void aggregateMultimemRelaxedPayloadKernel(
       StageRound{.channel = 0, .value = 1},
       participants,
       group,
-      Timeout{});
+      AbortDevice{});
   if (transport.nvlRank == 0 && group.thread_id_in_group == kPayloadLane) {
     *observedPayload = comms::device::ld_relaxed_sys_global(localPayload);
   }
@@ -354,7 +354,7 @@ __global__ void perPeerMultimemRelaxedPayloadKernel(
       StageRound{.channel = 0, .value = 1},
       participants,
       group,
-      Timeout{});
+      AbortDevice{});
   if (transport.nvlRank == 0 && group.is_leader()) {
     *observedPayload = comms::device::ld_relaxed_sys_global(localPayload);
   }
@@ -378,7 +378,7 @@ __global__ void separatePublishAndWaitKernel(
         NvlSignalAccess::Unicast,
         NvlSignalTopology::PerPeer,
         NvlSignalPhase::Ready>(
-        transport, round, participants, group, Timeout{});
+        transport, round, participants, group, AbortDevice{});
   } else {
     signal_publish<
         NvlSignalAccess::Unicast,
@@ -418,7 +418,7 @@ __global__ void perPeerWaitOnlyKernel(
       StageRound{.channel = 0, .value = roundValue},
       participants,
       group,
-      Timeout{});
+      AbortDevice{});
   const int source = static_cast<int>(group.thread_id_in_group);
   if (source < transport.nvlRanks) {
     out[source] = transport.internalLocalSignals[source].load();

--- a/comms/prims/tests/MultipeerIbgdaTransportAnsTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportAnsTest.cu
@@ -47,10 +47,10 @@ __global__ __launch_bounds__(NumWarps * 32, 1) void sendAnsKernel(
     const void* buffer,
     std::size_t nbytes,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   using Comp = AnsCompress<NumWarps, PIPES_ANS_DEFAULT_MAX_UNCOMP_BYTES>;
   auto group = make_block_group();
-  timeout.start();
+  abortDevice.start();
 
   // maxSignalBytes == 0 exercises the transport's 0-sentinel (derives a
   // trap-safe chunk size via CopyOp::max_safe_chunk_size_for_slot()); a
@@ -63,7 +63,7 @@ __global__ __launch_bounds__(NumWarps * 32, 1) void sendAnsKernel(
       buffer,
       nbytes,
       maxSignalBytes,
-      timeout,
+      abortDevice,
       /*alignedAuxBuf=*/static_cast<char*>(nullptr));
 }
 
@@ -73,15 +73,15 @@ __global__ __launch_bounds__(NumWarps * 32, 1) void recvAnsKernel(
     void* buffer,
     std::size_t nbytes,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   using Comp = AnsCompress<NumWarps, PIPES_ANS_DEFAULT_MAX_UNCOMP_BYTES>;
   auto group = make_block_group();
-  timeout.start();
+  abortDevice.start();
 
   // maxSignalBytes == 0 exercises the transport's 0-sentinel; a non-zero value
   // drives the explicit signaled-chunk-size path. Sender and receiver must pass
   // the same value so they derive the identical chunking.
-  transport->recv<Comp>(group, buffer, nbytes, maxSignalBytes, timeout);
+  transport->recv<Comp>(group, buffer, nbytes, maxSignalBytes, abortDevice);
 }
 
 } // namespace

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -363,13 +363,13 @@ __global__ void sendRecvKernel(
     std::size_t nbytes,
     std::size_t maxSignalBytes,
     bool send,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
-  timeout.start();
+  abortDevice.start();
   if (send) {
-    transport->send(group, buffer, nbytes, maxSignalBytes, timeout);
+    transport->send(group, buffer, nbytes, maxSignalBytes, abortDevice);
   } else {
-    transport->recv(group, buffer, nbytes, maxSignalBytes, timeout);
+    transport->recv(group, buffer, nbytes, maxSignalBytes, abortDevice);
   }
 }
 
@@ -380,18 +380,18 @@ __global__ void twoCallSendThenRecvKernel(
     std::size_t firstBytes,
     std::size_t secondBytes,
     std::size_t maxSignalBytes,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
-  timeout.start();
+  abortDevice.start();
   auto* sendBytes = static_cast<const char*>(sendBuffer);
   auto* recvBytes = static_cast<char*>(recvBuffer);
 
-  transport.send(group, sendBytes, firstBytes, maxSignalBytes, timeout);
-  transport.recv(group, recvBytes, firstBytes, maxSignalBytes, timeout);
+  transport.send(group, sendBytes, firstBytes, maxSignalBytes, abortDevice);
+  transport.recv(group, recvBytes, firstBytes, maxSignalBytes, abortDevice);
   transport.send(
-      group, sendBytes + firstBytes, secondBytes, maxSignalBytes, timeout);
+      group, sendBytes + firstBytes, secondBytes, maxSignalBytes, abortDevice);
   transport.recv(
-      group, recvBytes + firstBytes, secondBytes, maxSignalBytes, timeout);
+      group, recvBytes + firstBytes, secondBytes, maxSignalBytes, abortDevice);
 }
 
 void testSendRecv(
@@ -448,8 +448,8 @@ __global__ void __launch_bounds__(WarpProxyTest::kBlockThreads, 1)
         bool send,
         uint32_t queueDepth,
         uint64_t* queueFullCount,
-        Timeout timeout) {
-  timeout.start();
+        AbortDevice abortDevice) {
+  abortDevice.start();
   auto block = make_block_group();
   __shared__ WarpProxyTest::SharedState sharedState;
   WarpProxyTest::run(
@@ -459,7 +459,7 @@ __global__ void __launch_bounds__(WarpProxyTest::kBlockThreads, 1)
           .queueDepth = queueDepth,
           .queueFullCount = queueFullCount,
       },
-      timeout,
+      abortDevice,
       [&](auto& ops) {
         if (send) {
           ops.send(*transport, buffer, nbytes, maxSignalBytes);
@@ -476,16 +476,16 @@ __global__ void progressSendRecvKernel(
     std::size_t maxSignalBytes,
     bool send,
     uint64_t* waitingCount,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
-  timeout.start();
+  abortDevice.start();
   uint64_t waits = 0;
   if (send) {
     transport->init_send_progress(group, nbytes, maxSignalBytes);
     IbgdaSendRecvProgressStatus status;
     do {
       status = transport->progress_send_once(
-          group, buffer, nbytes, maxSignalBytes, timeout);
+          group, buffer, nbytes, maxSignalBytes, abortDevice);
       waits += status == IbgdaSendRecvProgressStatus::Waiting;
     } while (status != IbgdaSendRecvProgressStatus::Done);
   } else {
@@ -493,7 +493,7 @@ __global__ void progressSendRecvKernel(
     IbgdaSendRecvProgressStatus status;
     do {
       status = transport->progress_recv_once(
-          group, buffer, nbytes, maxSignalBytes, timeout);
+          group, buffer, nbytes, maxSignalBytes, abortDevice);
       waits += status == IbgdaSendRecvProgressStatus::Waiting;
     } while (status != IbgdaSendRecvProgressStatus::Done);
   }
@@ -526,13 +526,13 @@ __device__ IbgdaRegisteredSendProgressStatus postRegisteredSend(
     const IbgdaLocalBuffer& source,
     std::size_t nbytes,
     std::size_t maxSignalBytes,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     RegisteredSendObservation* observation) {
   transport.init_registered_send_progress(group, nbytes, maxSignalBytes);
   IbgdaRegisteredSendProgressStatus status;
   do {
     status = transport.progress_registered_send_once(
-        group, source, nbytes, maxSignalBytes, timeout);
+        group, source, nbytes, maxSignalBytes, abortDevice);
     if (group.is_leader() && observation != nullptr) {
       observation->record(status);
     }
@@ -545,11 +545,11 @@ template <typename Transport>
 __device__ void drainRegisteredSends(
     Transport& transport,
     ThreadGroup& group,
-    const Timeout& timeout,
+    const AbortDevice& abortDevice,
     RegisteredSendObservation* observation) {
   IbgdaRegisteredSendProgressStatus status;
   do {
-    status = transport.progress_registered_send_drain_once(group, timeout);
+    status = transport.progress_registered_send_drain_once(group, abortDevice);
     if (group.is_leader() && observation != nullptr) {
       observation->record(status);
     }
@@ -568,12 +568,13 @@ __global__ void registeredSendRecvKernel(
     bool overwriteAfterDrain,
     uint8_t overwriteValue,
     bool zeroByteAfterPosted,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
-  timeout.start();
+  abortDevice.start();
   if (send) {
     if (blocking) {
-      transport.send_registered(group, source, nbytes, maxSignalBytes, timeout);
+      transport.send_registered(
+          group, source, nbytes, maxSignalBytes, abortDevice);
       if (group.is_leader() && observation != nullptr) {
         ++observation->drainedCount;
       }
@@ -584,18 +585,18 @@ __global__ void registeredSendRecvKernel(
           source,
           nbytes,
           maxSignalBytes,
-          timeout,
+          abortDevice,
           observation);
       if (zeroByteAfterPosted) {
         transport.init_registered_send_progress(group, 0, maxSignalBytes);
         const auto zeroByteStatus = transport.progress_registered_send_once(
-            group, IbgdaLocalBuffer{}, 0, maxSignalBytes, timeout);
+            group, IbgdaLocalBuffer{}, 0, maxSignalBytes, abortDevice);
         if (group.is_leader() && observation != nullptr) {
           observation->record(zeroByteStatus);
         }
       }
       if (status != IbgdaRegisteredSendProgressStatus::Drained) {
-        drainRegisteredSends(transport, group, timeout, observation);
+        drainRegisteredSends(transport, group, abortDevice, observation);
       }
     }
     if (overwriteAfterDrain) {
@@ -607,7 +608,7 @@ __global__ void registeredSendRecvKernel(
       group.sync();
     }
   } else {
-    transport.recv(group, recvBuffer, nbytes, maxSignalBytes, timeout);
+    transport.recv(group, recvBuffer, nbytes, maxSignalBytes, abortDevice);
   }
 }
 
@@ -620,9 +621,9 @@ __global__ void mixedRegisteredAndStagedSendRecvKernel(
     std::size_t thirdBytes,
     std::size_t maxSignalBytes,
     bool send,
-    Timeout timeout) {
+    AbortDevice abortDevice) {
   auto group = make_block_group();
-  timeout.start();
+  abortDevice.start();
   if (send) {
     (void)postRegisteredSend(
         *transport,
@@ -630,36 +631,36 @@ __global__ void mixedRegisteredAndStagedSendRecvKernel(
         sendBuffer,
         firstBytes,
         maxSignalBytes,
-        timeout,
+        abortDevice,
         nullptr);
     transport->send(
         group,
         static_cast<const char*>(sendBuffer.ptr) + firstBytes,
         secondBytes,
         maxSignalBytes,
-        timeout);
+        abortDevice);
     (void)postRegisteredSend(
         *transport,
         group,
         sendBuffer.subBuffer(firstBytes + secondBytes),
         thirdBytes,
         maxSignalBytes,
-        timeout,
+        abortDevice,
         nullptr);
-    drainRegisteredSends(*transport, group, timeout, nullptr);
+    drainRegisteredSends(*transport, group, abortDevice, nullptr);
     return;
   }
 
   auto* output = static_cast<char*>(recvBuffer);
-  transport->recv(group, output, firstBytes, maxSignalBytes, timeout);
+  transport->recv(group, output, firstBytes, maxSignalBytes, abortDevice);
   transport->recv(
-      group, output + firstBytes, secondBytes, maxSignalBytes, timeout);
+      group, output + firstBytes, secondBytes, maxSignalBytes, abortDevice);
   transport->recv(
       group,
       output + firstBytes + secondBytes,
       thirdBytes,
       maxSignalBytes,
-      timeout);
+      abortDevice);
 }
 
 __global__ void fillTransportStagingKernel(

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTest.cu
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTest.cu
@@ -143,7 +143,7 @@ __global__ void testWaitSignalUntilAbort(
       1);
 
   // Arm the deadline the way a production kernel does. Without this the
-  // handle observes explicit aborts only, and a communicator timeout never
+  // handle observes explicit aborts only, and a communicator abortDevice never
   // reaches the wait.
   abort.start();
   // Published after the handle is armed, so a host that sees it knows every
@@ -411,12 +411,14 @@ void runTestTraceIbgdaEvent(PipesTraceHandle trace) {
 }
 
 // =============================================================================
-// wait_signal timeout test kernels
+// wait_signal abortDevice test kernels
 // =============================================================================
 
-__global__ void testWaitSignalTimeout(uint64_t* d_signalBuf, Timeout timeout) {
-  // Start the timeout timer
-  timeout.start();
+__global__ void testWaitSignalTimeout(
+    uint64_t* d_signalBuf,
+    AbortDevice abortDevice) {
+  // Start the abortDevice timer
+  abortDevice.start();
 
   // Construct transport with ownedLocalSignalBuf
   IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{});
@@ -428,14 +430,16 @@ __global__ void testWaitSignalTimeout(uint64_t* d_signalBuf, Timeout timeout) {
       1);
 
   // Signal buffer is pre-set to 0 by host.
-  // Waiting for >= 999 will never succeed, so timeout should fire.
-  transport.wait_signal(0, 999, timeout);
+  // Waiting for >= 999 will never succeed, so abortDevice should fire.
+  transport.wait_signal(0, 999, abortDevice);
 }
 
-__global__ void
-testWaitSignalNoTimeout(uint64_t* d_signalBuf, Timeout timeout, bool* success) {
-  // Start the timeout timer
-  timeout.start();
+__global__ void testWaitSignalNoTimeout(
+    uint64_t* d_signalBuf,
+    AbortDevice abortDevice,
+    bool* success) {
+  // Start the abortDevice timer
+  abortDevice.start();
 
   // Construct transport with ownedLocalSignalBuf
   IbgdaLocalBuffer localSigBuf(d_signalBuf, NetworkLKeys{});
@@ -447,14 +451,14 @@ testWaitSignalNoTimeout(uint64_t* d_signalBuf, Timeout timeout, bool* success) {
       1);
 
   // Signal buffer is pre-set to 42 by host.
-  // Waiting for >= 42 will succeed immediately, no timeout.
-  transport.wait_signal(0, 42, timeout);
+  // Waiting for >= 42 will succeed immediately, no abort handle.
+  transport.wait_signal(0, 42, abortDevice);
 
   *success = true;
 }
 
 // =============================================================================
-// wait_signal timeout test wrapper functions
+// wait_signal abortDevice test wrapper functions
 // =============================================================================
 
 cudaError_t runTestWaitSignalTimeout(
@@ -468,11 +472,11 @@ cudaError_t runTestWaitSignalTimeout(
   comms::fault_tolerance::Abort abort{
       /*enabled=*/true, comms::fault_tolerance::AbortBehavior::TRAP};
   abort.setDefaultTimeout(std::chrono::milliseconds{timeout_ms});
-  Timeout timeout = abort.getDeviceHandle();
+  AbortDevice abortDevice = abort.getDeviceHandle();
 
   // Intentionally unchecked - we expect the kernel to trap
   // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
-  testWaitSignalTimeout<<<1, 1>>>(d_signalBuf, timeout);
+  testWaitSignalTimeout<<<1, 1>>>(d_signalBuf, abortDevice);
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
   return cudaDeviceSynchronize();
 }
@@ -482,9 +486,9 @@ void runTestWaitSignalNoTimeout(
     int /*device*/,
     uint32_t /*timeout_ms*/,
     bool* d_success) {
-  Timeout timeout;
+  AbortDevice abortDevice;
 
-  testWaitSignalNoTimeout<<<1, 1>>>(d_signalBuf, timeout, d_success);
+  testWaitSignalNoTimeout<<<1, 1>>>(d_signalBuf, abortDevice, d_success);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTestMain.cc
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTestMain.cc
@@ -415,8 +415,8 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, TraceIbgdaEventWritesEvent) {
 #endif // !__HIP_PLATFORM_AMD__
 
 // =============================================================================
-// wait_signal Timeout Tests
-// Verify that the Timeout parameter on wait_signal correctly traps when the
+// wait_signal AbortDevice Tests
+// Verify that the AbortDevice parameter on wait_signal correctly traps when the
 // timeout expires and does not interfere when the signal is already satisfied.
 // =============================================================================
 

--- a/comms/prims/tests/P2pNvlTransportDeviceTest.cu
+++ b/comms/prims/tests/P2pNvlTransportDeviceTest.cu
@@ -235,17 +235,17 @@ void testReadSignal(SignalState* signal_d, uint64_t* result_d) {
 __global__ void
 testLl128SendKernel(P2pNvlTransportDevice p2p, const char* src, size_t nbytes) {
   auto group = make_warp_group();
-  Timeout timeout;
-  timeout.start();
-  p2p.ll128_send_group(group, src, nbytes, timeout);
+  AbortDevice abortDevice;
+  abortDevice.start();
+  p2p.ll128_send_group(group, src, nbytes, abortDevice);
 }
 
 __global__ void
 testLl128RecvKernel(P2pNvlTransportDevice p2p, char* dst, size_t nbytes) {
   auto group = make_warp_group();
-  Timeout timeout;
-  timeout.start();
-  p2p.ll128_recv_group(group, dst, nbytes, timeout);
+  AbortDevice abortDevice;
+  abortDevice.start();
+  p2p.ll128_recv_group(group, dst, nbytes, abortDevice);
 }
 
 void testLl128SendRecv(
@@ -293,12 +293,12 @@ __global__ void testLlTiledSendKernel(
   auto group = make_warp_group();
   auto [dir, subgroup] = group.partition_interleaved(2);
   const int active = subgroup.total_groups;
-  Timeout timeout;
-  timeout.start();
+  AbortDevice abortDevice;
+  abortDevice.start();
   if (dir == 0) {
     for (int i = 0; i < num_steps; i++) {
       TiledBuffer<char> tile(const_cast<char*>(src), nbytes, subgroup);
-      p2p.ll_send(subgroup, tile.data(), tile.bytes(), active, timeout);
+      p2p.ll_send(subgroup, tile.data(), tile.bytes(), active, abortDevice);
     }
   }
 }
@@ -311,12 +311,12 @@ __global__ void testLlTiledRecvKernel(
   auto group = make_warp_group();
   auto [dir, subgroup] = group.partition_interleaved(2);
   const int active = subgroup.total_groups;
-  Timeout timeout;
-  timeout.start();
+  AbortDevice abortDevice;
+  abortDevice.start();
   if (dir == 1) {
     for (int i = 0; i < num_steps; i++) {
       TiledBuffer<char> tile(dst, nbytes, subgroup);
-      p2p.ll_recv(subgroup, tile.data(), tile.bytes(), active, timeout);
+      p2p.ll_recv(subgroup, tile.data(), tile.bytes(), active, abortDevice);
     }
   }
 }

--- a/comms/prims/tests/P2pNvlTransportTest.cc
+++ b/comms/prims/tests/P2pNvlTransportTest.cc
@@ -12,8 +12,8 @@
 
 #include "comms/common/fault_tolerance/Abort.h"
 #include "comms/prims/benchmarks/TileSendRecv.cuh"
+#include "comms/prims/core/AbortCheck.cuh"
 #include "comms/prims/core/TiledBuffer.cuh"
-#include "comms/prims/core/Timeout.cuh"
 #include "comms/prims/tests/P2pNvlTransportTest.cuh"
 #include "comms/prims/tests/Utils.cuh"
 #include "comms/prims/transport/nvl/MultiPeerNvlTransport.h"
@@ -266,7 +266,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCall) {
   dim3 grid(numSendBlocks * 2);
   dim3 block(256);
 
-  Timeout timeout;
+  AbortDevice abortDevice;
 
   for (int iter = 0; iter < nIters; iter++) {
     const int pattern = 0x10 + globalRank + iter * 0x20;
@@ -281,7 +281,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCall) {
         static_cast<char*>(recvBuf.get()), nBytes, numSendBlocks);
     std::size_t maxSignalBytes = 0;
     void* args[] = {
-        &p2pHost, &sendTiles, &recvTiles, &maxSignalBytes, &timeout};
+        &p2pHost, &sendTiles, &recvTiles, &maxSignalBytes, &abortDevice};
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
     CUDACHECK_TEST(cudaLaunchKernel(
@@ -352,7 +352,7 @@ TEST_F(
 
   comms::fault_tolerance::Abort abort{/*enabled=*/true};
   abort.setDefaultTimeout(std::chrono::milliseconds{5000});
-  Timeout timeout = abort.getDeviceHandle();
+  AbortDevice abortDevice = abort.getDeviceHandle();
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
   test::testTileTwoCallSendThenRecv(
@@ -364,7 +364,7 @@ TEST_F(
       secondCallBytes,
       maxSignalBytes,
       threadCount,
-      timeout);
+      abortDevice);
   CUDACHECK_TEST(cudaDeviceSynchronize());
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
@@ -406,9 +406,9 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvCudaGraphReplay) {
       static_cast<char*>(recvBuf.get()), nBytes, numSendBlocks);
 
   std::size_t maxSignalBytesArg = maxSignalBytes;
-  Timeout timeout;
+  AbortDevice abortDevice;
   void* args[] = {
-      &p2pHost, &sendTiles, &recvTiles, &maxSignalBytesArg, &timeout};
+      &p2pHost, &sendTiles, &recvTiles, &maxSignalBytesArg, &abortDevice};
 
   cudaStream_t stream;
   CUDACHECK_TEST(cudaStreamCreate(&stream));
@@ -488,7 +488,7 @@ static void runTileTest(
   dim3 grid(numSendBlocks * 2);
   dim3 block(threadCount);
 
-  Timeout timeout;
+  AbortDevice abortDevice;
 
   for (int iter = 0; iter < nIters; iter++) {
     const int pattern = 0x10 + globalRank + iter * 0x20;
@@ -503,7 +503,7 @@ static void runTileTest(
         static_cast<char*>(recvBuf.get()), nBytes, numSendBlocks);
     std::size_t maxSignalBytes = 0;
     void* args[] = {
-        &p2pHost, &sendTiles, &recvTiles, &maxSignalBytes, &timeout};
+        &p2pHost, &sendTiles, &recvTiles, &maxSignalBytes, &abortDevice};
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
     CUDACHECK_TEST(cudaLaunchKernel(
@@ -1390,7 +1390,7 @@ TEST_F(
 
   comms::fault_tolerance::Abort abort{/*enabled=*/true};
   abort.setDefaultTimeout(std::chrono::milliseconds{5000});
-  Timeout timeout = abort.getDeviceHandle();
+  AbortDevice abortDevice = abort.getDeviceHandle();
 
   test::testTileTwoCallVariableSignalSendRecv(
       p2pHost,
@@ -1403,7 +1403,7 @@ TEST_F(
       secondMaxSignalBytes,
       true,
       threadCount,
-      timeout);
+      abortDevice);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
   std::vector<char> hostRecv(totalBytes);
@@ -1528,7 +1528,7 @@ TEST_F(
 
   DeviceBuffer sendBuf(nBytes);
   DeviceBuffer recvBuf(nBytes);
-  Timeout timeout;
+  AbortDevice abortDevice;
 
   const std::vector<int> launchedBlocks = {2, 4, 1, 4};
   for (size_t round = 0; round < launchedBlocks.size(); ++round) {
@@ -1545,7 +1545,7 @@ TEST_F(
         static_cast<char*>(recvBuf.get()), nBytes, numSendBlocks);
     std::size_t maxSignalBytesArg = maxSignalBytes;
     void* args[] = {
-        &p2pHost, &sendTiles, &recvTiles, &maxSignalBytesArg, &timeout};
+        &p2pHost, &sendTiles, &recvTiles, &maxSignalBytesArg, &abortDevice};
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
     CUDACHECK_TEST(cudaLaunchKernel(
@@ -1837,7 +1837,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCallDifferentSizes) {
 
   dim3 grid(numSendBlocks * 2);
   dim3 block(256);
-  Timeout timeout;
+  AbortDevice abortDevice;
 
   for (size_t callIdx = 0; callIdx < sizes.size(); callIdx++) {
     size_t nBytes = sizes[callIdx];
@@ -1855,7 +1855,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCallDifferentSizes) {
         static_cast<char*>(recvBuf.get()), nBytes, numSendBlocks);
     std::size_t maxSignalBytes = 0;
     void* args[] = {
-        &p2pHost, &sendTiles, &recvTiles, &maxSignalBytes, &timeout};
+        &p2pHost, &sendTiles, &recvTiles, &maxSignalBytes, &abortDevice};
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
     CUDACHECK_TEST(cudaLaunchKernel(
@@ -2479,7 +2479,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvDynamicBlockCount) {
       {16, 64 * 1024 * 1024}, // 16 blocks, 64MB (large)
   };
 
-  Timeout timeout;
+  AbortDevice abortDevice;
   int prevBlocks = 0;
 
   for (size_t roundIdx = 0; roundIdx < rounds.size(); roundIdx++) {
@@ -2502,7 +2502,8 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvDynamicBlockCount) {
         static_cast<char*>(recvBuf.get()), nBytes, numBlocks);
 
     bool needsBarrier = (prevBlocks != 0 && prevBlocks != numBlocks);
-    void* args[] = {&p2pHost, &sendTiles, &recvTiles, &needsBarrier, &timeout};
+    void* args[] = {
+        &p2pHost, &sendTiles, &recvTiles, &needsBarrier, &abortDevice};
 
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
     CUDACHECK_TEST(cudaLaunchKernel(
@@ -2585,7 +2586,7 @@ static void runTileForwardTest(
   transport.exchange();
   auto p2pHost = transport.buildP2pTransportDevice(peerRank);
 
-  Timeout timeout;
+  AbortDevice abortDevice;
 
   for (int iter = 0; iter < nIters; iter++) {
     const int pattern = 0x10 + iter * 0x20;
@@ -2613,7 +2614,7 @@ static void runTileForwardTest(
           static_cast<char*>(recvR0Buf.get()), nBytes, numSendBlocks);
       std::size_t maxSignalBytes = 0;
       void* args[] = {
-          &p2pHost, &sendTiles, &recvTiles, &maxSignalBytes, &timeout};
+          &p2pHost, &sendTiles, &recvTiles, &maxSignalBytes, &abortDevice};
 
       CUDACHECK_TEST(cudaLaunchKernel(
           (void*)comms::prims::benchmark::p2pTileSendRecv,
@@ -2628,7 +2629,8 @@ static void runTileForwardTest(
       char* dstPtr = static_cast<char*>(fwdR1Buf.get()) + dstOffset;
       comms::prims::TiledBuffer<char> dstTiles(dstPtr, nBytes, numSendBlocks);
       std::size_t maxSignalBytes = 0;
-      void* args[] = {&p2pHost, &p2pHost, &dstTiles, &maxSignalBytes, &timeout};
+      void* args[] = {
+          &p2pHost, &p2pHost, &dstTiles, &maxSignalBytes, &abortDevice};
 
       CUDACHECK_TEST(cudaLaunchKernel(
           (void*)comms::prims::benchmark::p2pTileForward,
@@ -2884,7 +2886,7 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardDesynchronizedStepState) {
   auto p2pHost = transport.buildP2pTransportDevice(peerRank);
   comms::fault_tolerance::Abort abort{/*enabled=*/true};
   abort.setDefaultTimeout(std::chrono::milliseconds{5000});
-  Timeout timeout = abort.getDeviceHandle();
+  AbortDevice abortDevice = abort.getDeviceHandle();
 
   if (globalRank == 0) {
     CUDACHECK_TEST(cudaMemset(
@@ -2913,7 +2915,7 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardDesynchronizedStepState) {
         advanceSendBuf.get(),
         kAdvanceBytes,
         kMaxSignalBytes,
-        timeout,
+        abortDevice,
         kNumBlocks,
         kThreadCount);
   } else {
@@ -2922,7 +2924,7 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardDesynchronizedStepState) {
         advanceRecvBuf.get(),
         kAdvanceBytes,
         kMaxSignalBytes,
-        timeout,
+        abortDevice,
         kNumBlocks,
         kThreadCount);
   }
@@ -2960,14 +2962,15 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardDesynchronizedStepState) {
         srcBuf.get(),
         kForwardBytes,
         kMaxSignalBytes,
-        timeout,
+        abortDevice,
         kNumBlocks,
         kThreadCount);
   } else {
     TiledBuffer<char> dstTiles(
         static_cast<char*>(fwdR1Buf.get()), kForwardBytes, kNumBlocks);
     std::size_t maxSignalBytes = kMaxSignalBytes;
-    void* args[] = {&p2pHost, &p2pHost, &dstTiles, &maxSignalBytes, &timeout};
+    void* args[] = {
+        &p2pHost, &p2pHost, &dstTiles, &maxSignalBytes, &abortDevice};
 
     CUDACHECK_TEST(cudaLaunchKernel(
         (void*)comms::prims::benchmark::p2pTileForward,

--- a/comms/prims/tests/P2pNvlTransportTest.cu
+++ b/comms/prims/tests/P2pNvlTransportTest.cu
@@ -61,11 +61,11 @@ __global__ void testTileSendKernel(
     void* src_d,
     size_t nbytes,
     size_t maxSignalBytes,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
   auto group = make_block_group();
   TiledBuffer<char> tiles(reinterpret_cast<char*>(src_d), nbytes, group);
-  p2p.send(group, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
+  p2p.send(group, tiles.data(), tiles.bytes(), maxSignalBytes, abortDevice);
 }
 
 __global__ void testTileRecvKernel(
@@ -73,11 +73,11 @@ __global__ void testTileRecvKernel(
     void* dst_d,
     size_t nbytes,
     size_t maxSignalBytes,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
   auto group = make_block_group();
   TiledBuffer<char> tiles(reinterpret_cast<char*>(dst_d), nbytes, group);
-  p2p.recv(group, tiles.data(), tiles.bytes(), maxSignalBytes, timeout);
+  p2p.recv(group, tiles.data(), tiles.bytes(), maxSignalBytes, abortDevice);
 }
 
 __device__ void wait_for_second_call_signal(
@@ -87,7 +87,7 @@ __device__ void wait_for_second_call_signal(
     size_t bytesPerCall,
     size_t maxSignalBytes,
     bool enabled,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   if (!enabled) {
     return;
   }
@@ -101,7 +101,7 @@ __device__ void wait_for_second_call_signal(
   const uint64_t secondCallStarted = protocolBytes +
       (protocolBytes < effectiveChunk ? protocolBytes : effectiveChunk);
   p2p.local_channel_at(blockId).data_ready.wait_until(
-      group, CmpOp::CMP_GE, secondCallStarted, timeout);
+      group, CmpOp::CMP_GE, secondCallStarted, abortDevice);
 }
 
 __global__ void testTileMultiCallSendRecvKernel(
@@ -112,8 +112,8 @@ __global__ void testTileMultiCallSendRecvKernel(
     size_t bytesPerCall,
     size_t maxSignalBytes,
     bool waitForSecondCallSignal,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
 
   auto group = make_block_group();
   auto [role, sub] = group.partition(2);
@@ -127,7 +127,7 @@ __global__ void testTileMultiCallSendRecvKernel(
           sendTile + i * bytesPerCall,
           bytesPerCall,
           maxSignalBytes,
-          timeout);
+          abortDevice);
     }
   } else {
     wait_for_second_call_signal(
@@ -137,7 +137,7 @@ __global__ void testTileMultiCallSendRecvKernel(
         bytesPerCall,
         maxSignalBytes,
         waitForSecondCallSignal,
-        timeout);
+        abortDevice);
     char* recvTile = recvTiles.tile_data(blockId);
     for (int i = 0; i < numCalls; ++i) {
       p2p.recv(
@@ -145,7 +145,7 @@ __global__ void testTileMultiCallSendRecvKernel(
           recvTile + i * bytesPerCall,
           bytesPerCall,
           maxSignalBytes,
-          timeout);
+          abortDevice);
     }
   }
 }
@@ -159,8 +159,8 @@ __global__ void testTileTwoCallVariableSignalSendRecvKernel(
     size_t firstMaxSignalBytes,
     size_t secondMaxSignalBytes,
     bool waitForSecondCallSignal,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
 
   auto group = make_block_group();
   auto [role, sub] = group.partition(2);
@@ -168,13 +168,13 @@ __global__ void testTileTwoCallVariableSignalSendRecvKernel(
 
   if (role == 0) {
     char* sendTile = sendTiles.tile_data(blockId);
-    p2p.send(sub, sendTile, firstCallBytes, firstMaxSignalBytes, timeout);
+    p2p.send(sub, sendTile, firstCallBytes, firstMaxSignalBytes, abortDevice);
     p2p.send(
         sub,
         sendTile + firstCallBytes,
         secondCallBytes,
         secondMaxSignalBytes,
-        timeout);
+        abortDevice);
   } else {
     wait_for_second_call_signal(
         p2p,
@@ -183,15 +183,15 @@ __global__ void testTileTwoCallVariableSignalSendRecvKernel(
         firstCallBytes,
         secondMaxSignalBytes,
         waitForSecondCallSignal,
-        timeout);
+        abortDevice);
     char* recvTile = recvTiles.tile_data(blockId);
-    p2p.recv(sub, recvTile, firstCallBytes, firstMaxSignalBytes, timeout);
+    p2p.recv(sub, recvTile, firstCallBytes, firstMaxSignalBytes, abortDevice);
     p2p.recv(
         sub,
         recvTile + firstCallBytes,
         secondCallBytes,
         secondMaxSignalBytes,
-        timeout);
+        abortDevice);
   }
 }
 
@@ -202,28 +202,28 @@ __global__ void testTileTwoCallSendThenRecvKernel(
     size_t firstCallBytes,
     size_t secondCallBytes,
     size_t maxSignalBytes,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
 
   auto group = make_block_group();
   const int blockId = group.group_id;
   char* sendTile = sendTiles.tile_data(blockId);
   char* recvTile = recvTiles.tile_data(blockId);
 
-  p2p.send(group, sendTile, firstCallBytes, maxSignalBytes, timeout);
-  p2p.recv(group, recvTile, firstCallBytes, maxSignalBytes, timeout);
+  p2p.send(group, sendTile, firstCallBytes, maxSignalBytes, abortDevice);
+  p2p.recv(group, recvTile, firstCallBytes, maxSignalBytes, abortDevice);
   p2p.send(
       group,
       sendTile + firstCallBytes,
       secondCallBytes,
       maxSignalBytes,
-      timeout);
+      abortDevice);
   p2p.recv(
       group,
       recvTile + firstCallBytes,
       secondCallBytes,
       maxSignalBytes,
-      timeout);
+      abortDevice);
 }
 
 __global__ void testTileMultiCallSendOnlyKernel(
@@ -232,8 +232,8 @@ __global__ void testTileMultiCallSendOnlyKernel(
     int numCalls,
     size_t bytesPerCall,
     size_t maxSignalBytes,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
 
   auto group = make_block_group();
   const int blockId = group.group_id;
@@ -244,7 +244,7 @@ __global__ void testTileMultiCallSendOnlyKernel(
         sendTile + i * bytesPerCall,
         bytesPerCall,
         maxSignalBytes,
-        timeout);
+        abortDevice);
   }
 }
 
@@ -254,19 +254,19 @@ __global__ void testTileTwoCallSendOnlyKernel(
     size_t firstCallBytes,
     size_t secondCallBytes,
     size_t maxSignalBytes,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
 
   auto group = make_block_group();
   const int blockId = group.group_id;
   char* sendTile = sendTiles.tile_data(blockId);
-  p2p.send(group, sendTile, firstCallBytes, maxSignalBytes, timeout);
+  p2p.send(group, sendTile, firstCallBytes, maxSignalBytes, abortDevice);
   p2p.send(
       group,
       sendTile + firstCallBytes,
       secondCallBytes,
       maxSignalBytes,
-      timeout);
+      abortDevice);
 }
 
 __device__ void check_wrapped_substep_with_existing_signals(
@@ -275,7 +275,7 @@ __device__ void check_wrapped_substep_with_existing_signals(
     size_t maxSignalBytes,
     unsigned char sentinel,
     int* observedEarlyOverwrite,
-    const Timeout& timeout) {
+    const AbortDevice& abortDevice) {
   const size_t perChannelBuffer = p2p.options().per_channel_buffer;
   const size_t perBlockSlotSize = p2p.options().per_channel_slot;
   const size_t effectiveChunk =
@@ -306,7 +306,7 @@ __device__ void check_wrapped_substep_with_existing_signals(
   p2p.local_channel_at(0).slot_free.signal(
       group, SignalOp::SIGNAL_SET, firstAckValue);
   p2p.remote_channel_at(0).data_ready.wait_until(
-      group, CmpOp::CMP_GE, firstStreamEnd, timeout);
+      group, CmpOp::CMP_GE, firstStreamEnd, abortDevice);
 
   if (group.is_leader()) {
     const auto observed =
@@ -324,15 +324,20 @@ __global__ void testTileSendWaitsForWrappedSubstepAckKernel(
     size_t maxSignalBytes,
     unsigned char sentinel,
     int* observedEarlyOverwrite,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
 
   auto group = make_block_group();
   if (blockIdx.x == 0) {
-    p2p.send(group, sendData, nbytes, maxSignalBytes, timeout);
+    p2p.send(group, sendData, nbytes, maxSignalBytes, abortDevice);
   } else {
     check_wrapped_substep_with_existing_signals(
-        p2p, group, maxSignalBytes, sentinel, observedEarlyOverwrite, timeout);
+        p2p,
+        group,
+        maxSignalBytes,
+        sentinel,
+        observedEarlyOverwrite,
+        abortDevice);
   }
 }
 
@@ -344,15 +349,20 @@ __global__ void testTileForwardWaitsForWrappedSubstepAckKernel(
     size_t maxSignalBytes,
     unsigned char sentinel,
     int* observedEarlyOverwrite,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
 
   auto group = make_block_group();
   if (blockIdx.x == 0) {
-    pred.forward(group, dst, nbytes, succ, maxSignalBytes, timeout);
+    pred.forward(group, dst, nbytes, succ, maxSignalBytes, abortDevice);
   } else {
     check_wrapped_substep_with_existing_signals(
-        succ, group, maxSignalBytes, sentinel, observedEarlyOverwrite, timeout);
+        succ,
+        group,
+        maxSignalBytes,
+        sentinel,
+        observedEarlyOverwrite,
+        abortDevice);
   }
 }
 
@@ -362,8 +372,8 @@ __global__ void testPrepareTileStagingKernel(
     size_t bytesPerCall,
     size_t maxSignalBytes,
     int sourceRank,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
 
   auto group = make_block_group();
   const int blockId = group.group_id;
@@ -423,8 +433,8 @@ __global__ void testPrepareTileTwoCallStagingKernel(
     size_t secondCallBytes,
     size_t maxSignalBytes,
     int sourceRank,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
 
   auto group = make_block_group();
   const int blockId = group.group_id;
@@ -484,8 +494,8 @@ __global__ void testTileMultiCallRecvOnlyKernel(
     int numCalls,
     size_t bytesPerCall,
     size_t maxSignalBytes,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
 
   auto group = make_block_group();
   const int blockId = group.group_id;
@@ -496,7 +506,7 @@ __global__ void testTileMultiCallRecvOnlyKernel(
         recvTile + i * bytesPerCall,
         bytesPerCall,
         maxSignalBytes,
-        timeout);
+        abortDevice);
   }
 }
 
@@ -506,19 +516,19 @@ __global__ void testTileTwoCallRecvOnlyKernel(
     size_t firstCallBytes,
     size_t secondCallBytes,
     size_t maxSignalBytes,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
 
   auto group = make_block_group();
   const int blockId = group.group_id;
   char* recvTile = recvTiles.tile_data(blockId);
-  p2p.recv(group, recvTile, firstCallBytes, maxSignalBytes, timeout);
+  p2p.recv(group, recvTile, firstCallBytes, maxSignalBytes, abortDevice);
   p2p.recv(
       group,
       recvTile + firstCallBytes,
       secondCallBytes,
       maxSignalBytes,
-      timeout);
+      abortDevice);
 }
 
 __global__ void testTileMultiCallForwardKernel(
@@ -529,8 +539,8 @@ __global__ void testTileMultiCallForwardKernel(
     size_t bytesPerCall,
     size_t maxSignalBytes,
     bool waitForSecondCallSignal,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
 
   auto group = make_block_group();
   const int blockId = group.group_id;
@@ -541,7 +551,7 @@ __global__ void testTileMultiCallForwardKernel(
       bytesPerCall,
       maxSignalBytes,
       waitForSecondCallSignal,
-      timeout);
+      abortDevice);
 
   char* dstTile = dstTiles.tile_data(blockId);
   for (int i = 0; i < numCalls; ++i) {
@@ -551,7 +561,7 @@ __global__ void testTileMultiCallForwardKernel(
         bytesPerCall,
         succ,
         maxSignalBytes,
-        timeout);
+        abortDevice);
   }
 }
 
@@ -562,20 +572,21 @@ __global__ void testTileTwoCallForwardKernel(
     size_t firstCallBytes,
     size_t secondCallBytes,
     size_t maxSignalBytes,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
 
   auto group = make_block_group();
   const int blockId = group.group_id;
   char* dstTile = dstTiles.tile_data(blockId);
-  pred.forward(group, dstTile, firstCallBytes, succ, maxSignalBytes, timeout);
+  pred.forward(
+      group, dstTile, firstCallBytes, succ, maxSignalBytes, abortDevice);
   pred.forward(
       group,
       dstTile + firstCallBytes,
       secondCallBytes,
       succ,
       maxSignalBytes,
-      timeout);
+      abortDevice);
 }
 
 __global__ void testTileTwoCallVariableSignalForwardKernel(
@@ -586,21 +597,21 @@ __global__ void testTileTwoCallVariableSignalForwardKernel(
     size_t secondCallBytes,
     size_t firstMaxSignalBytes,
     size_t secondMaxSignalBytes,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
 
   auto group = make_block_group();
   const int blockId = group.group_id;
   char* dstTile = dstTiles.tile_data(blockId);
   pred.forward(
-      group, dstTile, firstCallBytes, succ, firstMaxSignalBytes, timeout);
+      group, dstTile, firstCallBytes, succ, firstMaxSignalBytes, abortDevice);
   pred.forward(
       group,
       dstTile + firstCallBytes,
       secondCallBytes,
       succ,
       secondMaxSignalBytes,
-      timeout);
+      abortDevice);
 }
 
 __global__ void testCopyLocalStagingKernel(
@@ -617,12 +628,12 @@ void testTileSend(
     void* src_d,
     size_t nbytes,
     size_t maxSignalBytes,
-    Timeout timeout,
+    AbortDevice abortDevice,
     int numBlocks,
     int blockSize,
     cudaStream_t stream) {
   testTileSendKernel<<<numBlocks, blockSize, 0, stream>>>(
-      p2p, src_d, nbytes, maxSignalBytes, timeout);
+      p2p, src_d, nbytes, maxSignalBytes, abortDevice);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -631,12 +642,12 @@ void testTileRecv(
     void* dst_d,
     size_t nbytes,
     size_t maxSignalBytes,
-    Timeout timeout,
+    AbortDevice abortDevice,
     int numBlocks,
     int blockSize,
     cudaStream_t stream) {
   testTileRecvKernel<<<numBlocks, blockSize, 0, stream>>>(
-      p2p, dst_d, nbytes, maxSignalBytes, timeout);
+      p2p, dst_d, nbytes, maxSignalBytes, abortDevice);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -659,7 +670,7 @@ void testTileMultiCallSendRecv(
       bytesPerCall,
       maxSignalBytes,
       waitForSecondCallSignal,
-      Timeout());
+      AbortDevice());
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -674,7 +685,7 @@ void testTileTwoCallVariableSignalSendRecv(
     size_t secondMaxSignalBytes,
     bool waitForSecondCallSignal,
     int blockSize,
-    Timeout timeout,
+    AbortDevice abortDevice,
     cudaStream_t stream) {
   testTileTwoCallVariableSignalSendRecvKernel<<<
       activeBlocks * 2,
@@ -689,7 +700,7 @@ void testTileTwoCallVariableSignalSendRecv(
       firstMaxSignalBytes,
       secondMaxSignalBytes,
       waitForSecondCallSignal,
-      timeout);
+      abortDevice);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -702,7 +713,7 @@ void testTileTwoCallSendThenRecv(
     size_t secondCallBytes,
     size_t maxSignalBytes,
     int blockSize,
-    Timeout timeout,
+    AbortDevice abortDevice,
     cudaStream_t stream) {
   testTileTwoCallSendThenRecvKernel<<<activeBlocks, blockSize, 0, stream>>>(
       p2p,
@@ -711,7 +722,7 @@ void testTileTwoCallSendThenRecv(
       firstCallBytes,
       secondCallBytes,
       maxSignalBytes,
-      timeout);
+      abortDevice);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -725,7 +736,7 @@ void testTileMultiCallSendOnly(
     int blockSize,
     cudaStream_t stream) {
   testTileMultiCallSendOnlyKernel<<<activeBlocks, blockSize, 0, stream>>>(
-      p2p, sendTiles, numCalls, bytesPerCall, maxSignalBytes, Timeout());
+      p2p, sendTiles, numCalls, bytesPerCall, maxSignalBytes, AbortDevice());
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -744,7 +755,7 @@ void testTileTwoCallSendOnly(
       firstCallBytes,
       secondCallBytes,
       maxSignalBytes,
-      Timeout());
+      AbortDevice());
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -764,7 +775,7 @@ void testTileSendWaitsForWrappedSubstepAck(
       maxSignalBytes,
       sentinel,
       observedEarlyOverwrite,
-      Timeout());
+      AbortDevice());
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -786,7 +797,7 @@ void testTileForwardWaitsForWrappedSubstepAck(
       maxSignalBytes,
       sentinel,
       observedEarlyOverwrite,
-      Timeout());
+      AbortDevice());
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -800,7 +811,7 @@ void testPrepareTileStaging(
     int blockSize,
     cudaStream_t stream) {
   testPrepareTileStagingKernel<<<activeBlocks, blockSize, 0, stream>>>(
-      p2p, numCalls, bytesPerCall, maxSignalBytes, sourceRank, Timeout());
+      p2p, numCalls, bytesPerCall, maxSignalBytes, sourceRank, AbortDevice());
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -819,7 +830,7 @@ void testPrepareTileTwoCallStaging(
       secondCallBytes,
       maxSignalBytes,
       sourceRank,
-      Timeout());
+      AbortDevice());
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -833,7 +844,7 @@ void testTileMultiCallRecvOnly(
     int blockSize,
     cudaStream_t stream) {
   testTileMultiCallRecvOnlyKernel<<<activeBlocks, blockSize, 0, stream>>>(
-      p2p, recvTiles, numCalls, bytesPerCall, maxSignalBytes, Timeout());
+      p2p, recvTiles, numCalls, bytesPerCall, maxSignalBytes, AbortDevice());
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -852,7 +863,7 @@ void testTileTwoCallRecvOnly(
       firstCallBytes,
       secondCallBytes,
       maxSignalBytes,
-      Timeout());
+      AbortDevice());
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -875,7 +886,7 @@ void testTileMultiCallForward(
       bytesPerCall,
       maxSignalBytes,
       waitForSecondCallSignal,
-      Timeout());
+      AbortDevice());
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -896,7 +907,7 @@ void testTileTwoCallForward(
       firstCallBytes,
       secondCallBytes,
       maxSignalBytes,
-      Timeout());
+      AbortDevice());
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -923,7 +934,7 @@ void testTileTwoCallVariableSignalForward(
       secondCallBytes,
       firstMaxSignalBytes,
       secondMaxSignalBytes,
-      Timeout());
+      AbortDevice());
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/prims/tests/P2pNvlTransportTest.cuh
+++ b/comms/prims/tests/P2pNvlTransportTest.cuh
@@ -24,7 +24,7 @@ void testTileSend(
     void* src_d,
     size_t nbytes,
     size_t maxSignalBytes,
-    Timeout timeout,
+    AbortDevice abortDevice,
     int numBlocks,
     int blockSize,
     cudaStream_t stream = nullptr);
@@ -34,7 +34,7 @@ void testTileRecv(
     void* dst_d,
     size_t nbytes,
     size_t maxSignalBytes,
-    Timeout timeout,
+    AbortDevice abortDevice,
     int numBlocks,
     int blockSize,
     cudaStream_t stream = nullptr);
@@ -62,7 +62,7 @@ void testTileTwoCallVariableSignalSendRecv(
     size_t secondMaxSignalBytes,
     bool waitForSecondCallSignal,
     int blockSize,
-    Timeout timeout = Timeout(),
+    AbortDevice abortDevice = AbortDevice(),
     cudaStream_t stream = nullptr);
 
 void testTileTwoCallSendThenRecv(
@@ -74,7 +74,7 @@ void testTileTwoCallSendThenRecv(
     size_t secondCallBytes,
     size_t maxSignalBytes,
     int blockSize,
-    Timeout timeout = Timeout(),
+    AbortDevice abortDevice = AbortDevice(),
     cudaStream_t stream = nullptr);
 
 void testTileMultiCallSendOnly(

--- a/comms/prims/tests/TimeoutTrapTest.cu
+++ b/comms/prims/tests/TimeoutTrapTest.cu
@@ -27,7 +27,7 @@ namespace comms::prims::test {
 
 namespace {
 
-Timeout makeTestAbortDevice(
+AbortDevice makeTestAbortDevice(
     comms::fault_tolerance::Abort& abort,
     uint32_t timeout_ms) {
   abort.setDefaultTimeout(std::chrono::milliseconds{timeout_ms});
@@ -37,28 +37,32 @@ Timeout makeTestAbortDevice(
 } // namespace
 
 // Kernel that waits on SignalState that will never be signaled
-// This should trigger a timeout and call __trap()
+// This should trigger an abort handle and call __trap()
 // Uses the single-threaded API which creates a ThreadGroup internally
-__global__ void signalStateTimeoutKernel(SignalState* state, Timeout timeout) {
-  // Start the timeout timer - captures clock64() once at kernel entry
-  timeout.start();
+__global__ void signalStateTimeoutKernel(
+    SignalState* state,
+    AbortDevice abortDevice) {
+  // Start the abortDevice timer - captures clock64() once at kernel entry
+  abortDevice.start();
 
   // State is initialized to 0, so waiting for value 1 will spin forever
-  // unless timeout triggers
-  // Uses simple API - ThreadGroup is created internally for timeout checking
-  state->wait_until(CmpOp::CMP_EQ, 1, timeout);
+  // unless abortDevice triggers
+  // Uses simple API - ThreadGroup is created internally for abortDevice
+  // checking
+  state->wait_until(CmpOp::CMP_EQ, 1, abortDevice);
 }
 
-// Kernel that starts timeout, checks once, and completes successfully
-// This is a positive test case that exercises the full timeout path
+// Kernel that starts abortDevice, checks once, and completes successfully
+// This is a positive test case that exercises the full abortDevice path
 // without actually timing out
-__global__ void noTimeoutKernel(Timeout timeout) {
-  // Start the timeout timer
-  timeout.start();
+__global__ void noTimeoutKernel(AbortDevice abortDevice) {
+  // Start the abortDevice timer
+  abortDevice.start();
 
-  // Check timeout once - should not be expired since we're well within timeout
-  if (timeout.checkExpired()) {
-    printf("CUDA TIMEOUT ERROR: Unexpected timeout in noTimeoutKernel\n");
+  // Check abortDevice once - should not be expired since we're well within
+  // abortDevice
+  if (abortDevice.checkExpired()) {
+    printf("CUDA TIMEOUT ERROR: Unexpected abortDevice in noTimeoutKernel\n");
     __trap();
   }
 }
@@ -77,12 +81,12 @@ cudaError_t launchSignalStateTimeoutKernel(int device, uint32_t timeout_ms) {
 
   comms::fault_tolerance::Abort abort{
       /*enabled=*/true, comms::fault_tolerance::AbortBehavior::TRAP};
-  Timeout timeout = makeTestAbortDevice(abort, timeout_ms);
+  AbortDevice abortDevice = makeTestAbortDevice(abort, timeout_ms);
 
-  // Launch kernel with a full warp - should trap due to timeout
+  // Launch kernel with a full warp - should trap due to abortDevice
   // Intentionally unchecked - we expect the kernel to trap
   // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
-  signalStateTimeoutKernel<<<1, 32>>>(d_state, timeout);
+  signalStateTimeoutKernel<<<1, 32>>>(d_state, abortDevice);
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
   const auto syncErr = cudaDeviceSynchronize();
 
@@ -95,23 +99,23 @@ void launchNoTimeoutKernel(int device, uint32_t timeout_ms) {
 
   comms::fault_tolerance::Abort abort{
       /*enabled=*/true, comms::fault_tolerance::AbortBehavior::TRAP};
-  Timeout timeout = makeTestAbortDevice(abort, timeout_ms);
+  AbortDevice abortDevice = makeTestAbortDevice(abort, timeout_ms);
 
   // Launch kernel - should complete normally
-  noTimeoutKernel<<<1, 1>>>(timeout);
+  noTimeoutKernel<<<1, 1>>>(abortDevice);
   CUDA_CHECK(cudaDeviceSynchronize());
 }
 
-// Kernel that uses ThreadGroup-based timeout checking for SignalState
+// Kernel that uses ThreadGroup-based abortDevice checking for SignalState
 __global__ void signalStateThreadGroupTimeoutKernel(
     SignalState* state,
-    Timeout timeout) {
-  timeout.start();
+    AbortDevice abortDevice) {
+  abortDevice.start();
   auto group = make_thread_group(SyncScope::WARP);
 
   // State is initialized to 0, so waiting for value 1 will spin forever
-  // Uses ThreadGroup-based wait which calls timeout.check(group)
-  state->wait_until(group, CmpOp::CMP_EQ, 1, timeout);
+  // Uses ThreadGroup-based wait which calls abortDevice.check(group)
+  state->wait_until(group, CmpOp::CMP_EQ, 1, abortDevice);
 }
 
 // Simple kernel that sets a flag to indicate it ran
@@ -119,12 +123,12 @@ __global__ void setFlagKernel(int* flag) {
   *flag = 1;
 }
 
-// Kernel that will timeout and trap, used to test stream behavior
-__global__ void timeoutTrapKernel(Timeout timeout) {
-  timeout.start();
-  // Spin until timeout expires, then trap
+// Kernel that will abortDevice and trap, used to test stream behavior
+__global__ void timeoutTrapKernel(AbortDevice abortDevice) {
+  abortDevice.start();
+  // Spin until abortDevice expires, then trap
   while (true) {
-    if (timeout.checkExpired()) {
+    if (abortDevice.checkExpired()) {
       printf("CUDA TIMEOUT ERROR: timeoutTrapKernel timed out\n");
       __trap();
     }
@@ -147,13 +151,13 @@ cudaError_t launchSignalStateThreadGroupTimeoutKernel(
 
   comms::fault_tolerance::Abort abort{
       /*enabled=*/true, comms::fault_tolerance::AbortBehavior::TRAP};
-  Timeout timeout = makeTestAbortDevice(abort, timeout_ms);
+  AbortDevice abortDevice = makeTestAbortDevice(abort, timeout_ms);
 
-  // Launch kernel with a full warp - should trap due to timeout
+  // Launch kernel with a full warp - should trap due to abortDevice
   // Leader-only checking means only thread 0 calls clock64()
   // Intentionally unchecked - we expect the kernel to trap
   // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
-  signalStateThreadGroupTimeoutKernel<<<1, 32>>>(d_state, timeout);
+  signalStateThreadGroupTimeoutKernel<<<1, 32>>>(d_state, abortDevice);
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
   const auto syncErr = cudaDeviceSynchronize();
 
@@ -179,12 +183,12 @@ cudaError_t launchMultipleKernelsOnStreamTest(
 
   comms::fault_tolerance::Abort abort{
       /*enabled=*/true, comms::fault_tolerance::AbortBehavior::TRAP};
-  Timeout timeout = makeTestAbortDevice(abort, timeout_ms);
+  AbortDevice abortDevice = makeTestAbortDevice(abort, timeout_ms);
 
-  // Launch first kernel that will trap due to timeout
+  // Launch first kernel that will trap due to abortDevice
   // Intentionally unchecked - we expect the kernel to trap
   // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
-  timeoutTrapKernel<<<1, 1, 0, stream>>>(timeout);
+  timeoutTrapKernel<<<1, 1, 0, stream>>>(abortDevice);
 
   // Launch second kernel on the same stream - should NOT run if first traps
   // Intentionally unchecked - previous kernel will trap

--- a/comms/prims/transport/ll/tests/LlOpsNvlinkTest.cu
+++ b/comms/prims/transport/ll/tests/LlOpsNvlinkTest.cu
@@ -25,7 +25,7 @@ __global__ void ll_nvlink_send_kernel(
     size_t buffer_num_lines,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout abortDevice;
+  AbortDevice abortDevice;
   abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
     ll_send(group, src, nbytes, remote_ll_buf, abortDevice, buffer_num_lines);
@@ -39,7 +39,7 @@ __global__ void ll_nvlink_recv_kernel(
     size_t buffer_num_lines,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout abortDevice;
+  AbortDevice abortDevice;
   abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
     ll_recv(group, dst, nbytes, local_ll_buf, abortDevice, buffer_num_lines);
@@ -54,7 +54,7 @@ __global__ void ll_nvlink_forward_kernel(
     size_t buffer_num_lines,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout abortDevice;
+  AbortDevice abortDevice;
   abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
     ll_forward(
@@ -86,7 +86,7 @@ __global__ void ll_nvlink_send_recv_kernel(
     int num_steps) {
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(2);
-  Timeout abortDevice;
+  AbortDevice abortDevice;
   abortDevice.start();
   if (partition_id == 0) {
     for (int i = 0; i < num_steps; i++) {
@@ -363,7 +363,7 @@ __global__ void ll_nvlink_varying_send_kernel(
     size_t buffer_num_lines,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout abortDevice;
+  AbortDevice abortDevice;
   abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
     ll_send(
@@ -383,7 +383,7 @@ __global__ void ll_nvlink_varying_recv_kernel(
     size_t buffer_num_lines,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout abortDevice;
+  AbortDevice abortDevice;
   abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
     ll_recv(

--- a/comms/prims/transport/ll/tests/LlOpsTest.cu
+++ b/comms/prims/transport/ll/tests/LlOpsTest.cu
@@ -26,7 +26,7 @@ __global__ void ll_forward_kernel(
     LlLine* local_ll_buf,
     LlLine* remote_ll_buf) {
   auto group = make_warp_group();
-  Timeout timeout;
+  AbortDevice timeout;
   timeout.start();
   ll_forward(group, dst, nbytes, local_ll_buf, remote_ll_buf, timeout);
 }
@@ -44,7 +44,7 @@ __global__ void ll_multi_step_combined_kernel(
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(2);
 
-  Timeout timeout;
+  AbortDevice timeout;
   timeout.start();
 
   if (partition_id == 0) {
@@ -72,7 +72,7 @@ __global__ void ll_multi_step_send_forward_recv_kernel(
     int num_steps) {
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(3);
-  Timeout timeout;
+  AbortDevice timeout;
   timeout.start();
 
   if (partition_id == 0) {
@@ -101,7 +101,7 @@ __global__ void ll_chunked_combined_kernel(
     LlLine* ll_buf,
     size_t buffer_num_lines,
     int num_steps,
-    Timeout timeout) {
+    AbortDevice timeout) {
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(2);
 
@@ -132,7 +132,7 @@ __global__ void ll_varying_data_multi_step_combined_kernel(
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(2);
 
-  Timeout timeout;
+  AbortDevice timeout;
   timeout.start();
 
   if (partition_id == 0) {
@@ -173,7 +173,7 @@ __global__ void ll_varying_data_multi_step_send_forward_recv_kernel(
     int num_steps) {
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(3);
-  Timeout timeout;
+  AbortDevice timeout;
   timeout.start();
 
   if (partition_id == 0) {

--- a/comms/prims/transport/ll128/tests/Ll128OpsNvlinkTest.cu
+++ b/comms/prims/transport/ll128/tests/Ll128OpsNvlinkTest.cu
@@ -25,7 +25,7 @@ __global__ void ll128_nvlink_send_kernel(
     size_t buffer_num_packets,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout abortDevice;
+  AbortDevice abortDevice;
   abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
     ll128_send(
@@ -40,7 +40,7 @@ __global__ void ll128_nvlink_recv_kernel(
     size_t buffer_num_packets,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout abortDevice;
+  AbortDevice abortDevice;
   abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
     ll128_recv(
@@ -56,7 +56,7 @@ __global__ void ll128_nvlink_forward_kernel(
     size_t buffer_num_packets,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout abortDevice;
+  AbortDevice abortDevice;
   abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
     ll128_forward(
@@ -88,7 +88,7 @@ __global__ void ll128_nvlink_send_recv_kernel(
     int num_steps) {
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(2);
-  Timeout abortDevice;
+  AbortDevice abortDevice;
   abortDevice.start();
   if (partition_id == 0) {
     for (int i = 0; i < num_steps; i++) {
@@ -386,7 +386,7 @@ __global__ void ll128_nvlink_varying_send_kernel(
     size_t buffer_num_packets,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout abortDevice;
+  AbortDevice abortDevice;
   abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
     ll128_send(
@@ -406,7 +406,7 @@ __global__ void ll128_nvlink_varying_recv_kernel(
     size_t buffer_num_packets,
     int num_steps) {
   auto group = make_warp_group();
-  Timeout abortDevice;
+  AbortDevice abortDevice;
   abortDevice.start();
   for (int i = 0; i < num_steps; i++) {
     ll128_recv(

--- a/comms/prims/transport/ll128/tests/Ll128OpsTest.cc
+++ b/comms/prims/transport/ll128/tests/Ll128OpsTest.cc
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include "comms/common/fault_tolerance/Abort.h"
-#include "comms/prims/core/Timeout.cuh"
+#include "comms/prims/core/AbortCheck.cuh"
 #include "comms/prims/transport/ll128/Ll128Packet.cuh"
 #include "comms/prims/transport/ll128/tests/Ll128OpsTest.cuh"
 #include "comms/testinfra/TestXPlatUtils.h"
@@ -1072,7 +1072,7 @@ TEST_F(Ll128OpsTestFixture, FlagState_AfterMultiStep_NonChunked) {
 }
 
 TEST_F(Ll128OpsTestFixture, AbortDeviceEnabledState) {
-  Timeout default_timeout;
+  AbortDevice default_timeout;
   EXPECT_FALSE(default_timeout.isEnabled());
 
   comms::fault_tolerance::Abort abort{/*enabled=*/true};

--- a/comms/prims/transport/ll128/tests/Ll128OpsTest.cu
+++ b/comms/prims/transport/ll128/tests/Ll128OpsTest.cu
@@ -26,7 +26,7 @@ __global__ void ll128_forward_kernel(
     Ll128Packet* local_ll128_buf,
     Ll128Packet* remote_ll128_buf) {
   auto group = make_warp_group();
-  Timeout timeout;
+  AbortDevice timeout;
   timeout.start();
   ll128_forward(group, dst, nbytes, local_ll128_buf, remote_ll128_buf, timeout);
 }
@@ -46,7 +46,7 @@ __global__ void ll128_forward_abort_kernel(
     Ll128Packet* remote_ll128_buf,
     comms::fault_tolerance::AbortDevice abort) {
   auto group = make_warp_group();
-  Timeout timeout = abort;
+  AbortDevice timeout = abort;
   timeout.start();
   ll128_forward(group, dst, nbytes, local_ll128_buf, remote_ll128_buf, timeout);
 }
@@ -68,7 +68,7 @@ __global__ void ll128_multi_step_combined_kernel(
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(2);
 
-  Timeout timeout;
+  AbortDevice timeout;
   timeout.start();
 
   if (partition_id == 0) {
@@ -186,7 +186,7 @@ __global__ void ll128_multi_step_send_forward_recv_kernel(
     int num_steps) {
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(3);
-  Timeout timeout;
+  AbortDevice timeout;
   timeout.start();
 
   if (partition_id == 0) {
@@ -254,7 +254,7 @@ __global__ void ll128_chunked_combined_kernel(
     Ll128Packet* ll128_buf,
     size_t buffer_num_packets,
     int num_steps,
-    Timeout timeout) {
+    AbortDevice timeout) {
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(2);
 
@@ -286,7 +286,7 @@ __global__ void ll128_chunked_send_forward_recv_kernel(
     int num_steps) {
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(3);
-  Timeout timeout;
+  AbortDevice timeout;
   timeout.start();
 
   if (partition_id == 0) {
@@ -409,7 +409,7 @@ __global__ void ll128_windowed_combined_kernel(
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(2);
 
-  Timeout timeout;
+  AbortDevice timeout;
   timeout.start();
 
   if (partition_id == 0) {
@@ -455,7 +455,7 @@ __global__ void ll128_varying_data_multi_step_combined_kernel(
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(2);
 
-  Timeout timeout;
+  AbortDevice timeout;
   timeout.start();
 
   if (partition_id == 0) {
@@ -492,7 +492,7 @@ __global__ void ll128_varying_data_multi_step_send_forward_recv_kernel(
     int num_steps) {
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(3);
-  Timeout timeout;
+  AbortDevice timeout;
   timeout.start();
 
   if (partition_id == 0) {

--- a/comms/prims/transport/ll128/tests/Ll128TimeoutTrapTest.cu
+++ b/comms/prims/transport/ll128/tests/Ll128TimeoutTrapTest.cu
@@ -18,7 +18,7 @@ __global__ void ll128_send_no_recv_kernel(
     const char* src,
     size_t nbytes,
     Ll128Packet* remote_ll128_buf,
-    Timeout timeout) {
+    AbortDevice timeout) {
   auto group = make_warp_group();
   timeout.start();
   // Send data — the sender will poll for ACK (kLl128ReadyToWrite) which
@@ -75,7 +75,7 @@ __global__ void ll128_send_recv_undersized_buffer_kernel(
     size_t buffer_num_packets) {
   auto group = make_warp_group();
   auto [partition_id, subgroup] = group.partition_interleaved(2);
-  Timeout timeout;
+  AbortDevice timeout;
   timeout.start();
 
   if (partition_id == 0) {

--- a/comms/prims/transport/llx/tests/LLIbgdaSendRecv.cu
+++ b/comms/prims/transport/llx/tests/LLIbgdaSendRecv.cu
@@ -62,7 +62,7 @@ __global__ void sendRecvKernel(
     int activeBlocks,
     std::size_t maxSignalBytes,
     bool send,
-    Timeout abortDevice) {
+    AbortDevice abortDevice) {
   (void)activeBlocks; // master's detail::send/recv has no active_blocks param
   auto group = make_block_group();
   abortDevice.start();


### PR DESCRIPTION
Summary:

`Timeout` has been a bare alias for `AbortDevice` since `D115656601`:

```
namespace comms::prims {
using Timeout = AbortDevice;
}
```

It was introduced as a migration shim so the fault-tolerance stack could land
without a repo-wide rename in the middle of it. That stack is done, so the shim
is now just a second name for the same type, and a misleading one -- the handle
carries an abort latch and a reason, and a deadline is only one of the ways it
trips.

This series retires it, one subtree per diff. **Type-only**: parameter names stay
`timeout`, so nothing about call sites changes except the spelling of the type.
Ben's naming comments are handled per-diff where they already live.

Because both names denote the same type until the alias is deleted, **every diff
in this series is independently correct and landable, in any order**. Files also
keep their `#include "comms/prims/core/Timeout.cuh"` until the final cleanup
diff; the alias header includes `AbortCheck.cuh`, so `AbortDevice` resolves
either way.

Two things the mechanical pass deliberately does *not* touch:
- **`#include` lines** -- repointed in the cleanup diff, with the header deletion.
- **Comment prose.** `Timeout` is renamed in comments only where it is backticked
  or plainly names the type. Lines like `param timeout Timeout for flag polling`
  read as English and are left alone. The handful of prose references that really
  did mean the type were edited by hand.

This diff: `prims/tests`, `prims/benchmarks`, `prims/collectives/{tests,benchmarks}` and the per-transport `tests/` leaves. 270 occurrences across 42 files -- large, but every hunk is the same substitution.

Reviewed By: arttianezhu

Differential Revision: D116810801
