### PR TITLE
Complete device-less WorkWrapper Futures exactly once

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <memory>
 
 namespace torch::comms {
 
@@ -185,6 +186,21 @@ class C10dWindowWrapper final : public c10d::Window {
 };
 #endif
 
+void completeFutureOnce(
+    const std::shared_ptr<std::atomic<bool>>& claimed,
+    const c10::intrusive_ptr<c10::ivalue::Future>& future,
+    const std::vector<at::Tensor>& tensors,
+    bool blockIfLost) {
+  if (claimed == nullptr) {
+    return;
+  }
+  if (!claimed->exchange(true) && !future->completed()) {
+    future->markCompleted(c10::IValue(tensors));
+  } else if (blockIfLost) {
+    future->wait();
+  }
+}
+
 } // namespace
 
 WorkWrapper::WorkWrapper(
@@ -218,10 +234,11 @@ WorkWrapper::WorkWrapper(
   } else {
     // For other device types (CPU) async: register end hook so
     // future completes when setStatus fires.
-    work_->registerWorkEndHook([future = future_, tensors = outputTensors_]() {
-      if (!future->completed()) {
-        future->markCompleted(c10::IValue(tensors));
-      }
+    futureCompletionClaimed_ = std::make_shared<std::atomic<bool>>(false);
+    work_->registerWorkEndHook([claimed = futureCompletionClaimed_,
+                                future = future_,
+                                tensors = outputTensors_]() {
+      completeFutureOnce(claimed, future, tensors, /*blockIfLost=*/false);
     });
   }
 }
@@ -242,9 +259,8 @@ bool WorkWrapper::wait(std::chrono::milliseconds timeout) {
     finish(std::current_exception());
     throw;
   }
-  if (!future_->completed()) {
-    future_->markCompleted(c10::IValue(outputTensors_));
-  }
+  completeFutureOnce(
+      futureCompletionClaimed_, future_, outputTensors_, /*blockIfLost=*/true);
   finish();
   return true;
 }
@@ -258,9 +274,8 @@ void WorkWrapper::synchronize() {
     finish(std::current_exception());
     throw;
   }
-  if (!future_->completed()) {
-    future_->markCompleted(c10::IValue(outputTensors_));
-  }
+  completeFutureOnce(
+      futureCompletionClaimed_, future_, outputTensors_, /*blockIfLost=*/true);
   finish();
 }
 std::vector<at::Tensor> WorkWrapper::result() {

--- a/comms/torchcomms/BackendWrapper.hpp
+++ b/comms/torchcomms/BackendWrapper.hpp
@@ -15,6 +15,7 @@
 #include "comms/torchcomms/TorchWork.hpp"
 
 #include <atomic>
+#include <memory>
 #include <optional>
 
 namespace torch::comms {
@@ -36,6 +37,7 @@ class WorkWrapper : public c10d::Work {
   friend class BackendWrapper;
   c10::intrusive_ptr<TorchWork> work_;
   c10::intrusive_ptr<c10::ivalue::Future> future_;
+  std::shared_ptr<std::atomic<bool>> futureCompletionClaimed_;
   std::vector<at::Tensor> outputTensors_;
   // When set (synchronous barrier), wait()/synchronize() also host-block via
   // work_->hostSynchronize() after the stream-ordered wait().

--- a/comms/torchcomms/tests/unit/cpp/BackendWrapperTest.cpp
+++ b/comms/torchcomms/tests/unit/cpp/BackendWrapperTest.cpp
@@ -1,0 +1,153 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <exception>
+#include <string>
+#include <thread>
+
+#include <c10/util/intrusive_ptr.h>
+
+#include "comms/torchcomms/BackendWrapper.hpp"
+#include "comms/torchcomms/TorchWork.hpp"
+
+// "Completed exactly once" is asserted by these tests NOT throwing: a second
+// markCompleted() raises. A callback counter cannot see it -- markCompleted
+// swaps the callback list out before invoking, so it can never reach two.
+
+namespace torch::comms::test {
+namespace {
+
+// Releases both threads within nanoseconds. A condvar wakeup -- or just
+// starting a thread and hoping -- is too coarse to land inside the window.
+class SpinRendezvous {
+ public:
+  void arriveAndWait() {
+    arrived_.fetch_add(1, std::memory_order_acq_rel);
+    while (arrived_.load(std::memory_order_acquire) < 2) {
+    }
+  }
+
+ private:
+  std::atomic<int> arrived_{0};
+};
+
+// wait() is stream-ordered and does not complete the work, like the real CUDA
+// backends: the terminal status only arrives when the test calls setStatus().
+class TestWork final : public TorchWork {
+ public:
+  void wait() override {
+    runWaitPreHooks();
+    if (waitRendezvous_ != nullptr) {
+      waitRendezvous_->arriveAndWait();
+    }
+    runWaitPostHooks();
+  }
+
+  // Holds wait() open so the caller enters the completion path at the same
+  // instant the end hook fires.
+  void setWaitRendezvous(SpinRendezvous* rendezvous) {
+    waitRendezvous_ = rendezvous;
+  }
+
+  using TorchWork::setStatus;
+
+ private:
+  SpinRendezvous* waitRendezvous_{nullptr};
+};
+
+} // namespace
+
+// The end hook resolved the Future first; wait() must not resolve it again.
+TEST(WorkWrapperTest, EndHookBeforeWaitCompletesFutureOnce) {
+  auto work = c10::make_intrusive<TestWork>();
+  auto wrapper = c10::make_intrusive<WorkWrapper>(work);
+
+  work->setStatus(TorchWork::WorkStatus::COMPLETED);
+  EXPECT_TRUE(wrapper->wait(kNoTimeout));
+
+  EXPECT_TRUE(wrapper->getFuture()->completed());
+}
+
+// wait() resolved it first; the late end hook must not. Pre-fix, this ordering
+// threw out of setStatus() on the watchdog thread.
+TEST(WorkWrapperTest, EndHookAfterWaitCompletesFutureOnce) {
+  auto work = c10::make_intrusive<TestWork>();
+  auto wrapper = c10::make_intrusive<WorkWrapper>(work);
+
+  EXPECT_TRUE(wrapper->wait(kNoTimeout));
+  EXPECT_NO_THROW(work->setStatus(TorchWork::WorkStatus::COMPLETED));
+
+  EXPECT_TRUE(wrapper->getFuture()->completed());
+}
+
+// Work already finished before construction (e.g. the TorchWorkCompleted
+// sentinel from an empty coalescing window) resolves the Future in the ctor.
+TEST(WorkWrapperTest, WorkCompletedBeforeConstructionCompletesFutureOnce) {
+  auto work = c10::make_intrusive<TestWork>();
+  work->setStatus(TorchWork::WorkStatus::COMPLETED);
+
+  auto wrapper = c10::make_intrusive<WorkWrapper>(work);
+  EXPECT_TRUE(wrapper->getFuture()->completed());
+
+  EXPECT_TRUE(wrapper->wait(kNoTimeout));
+}
+
+// synchronize() shares the completion path with wait().
+TEST(WorkWrapperTest, SynchronizeAfterEndHookCompletesFutureOnce) {
+  auto work = c10::make_intrusive<TestWork>();
+  auto wrapper = c10::make_intrusive<WorkWrapper>(work);
+
+  work->setStatus(TorchWork::WorkStatus::COMPLETED);
+  wrapper->synchronize();
+
+  EXPECT_TRUE(wrapper->getFuture()->completed());
+}
+
+// The production failure: the watchdog's end hook fires as the trainer comes
+// out of wait(). Both used to observe an incomplete Future and both marked it.
+TEST(WorkWrapperTest, ConcurrentEndHookAndWaitCompleteFutureOnce) {
+  constexpr int kIterations = 1000;
+
+  for (int i = 0; i < kIterations; ++i) {
+    SpinRendezvous rendezvous;
+    auto work = c10::make_intrusive<TestWork>();
+    work->setWaitRendezvous(&rendezvous);
+    auto wrapper = c10::make_intrusive<WorkWrapper>(work);
+
+    // Report rather than throw: an escaping exception would hit the
+    // still-joinable thread and abort the process instead of failing the test.
+    std::string watchdogError;
+    std::thread watchdog([&]() {
+      rendezvous.arriveAndWait();
+      try {
+        work->setStatus(TorchWork::WorkStatus::COMPLETED);
+      } catch (const std::exception& exception) {
+        watchdogError = exception.what();
+      }
+    });
+
+    // Sampled before join(), which would resolve the Future by itself and make
+    // the assertion below pass whether or not wait() honoured blockIfLost.
+    bool completedOnWaitReturn = false;
+    std::string waitError;
+    try {
+      // EXPECT_ not ASSERT_: an ASSERT_ here returns from the test body with
+      // the thread still joinable, which terminates the process.
+      EXPECT_TRUE(wrapper->wait(kNoTimeout));
+      completedOnWaitReturn = wrapper->getFuture()->completed();
+    } catch (const std::exception& exception) {
+      waitError = exception.what();
+    }
+    watchdog.join();
+
+    ASSERT_TRUE(waitError.empty()) << "iteration " << i << ": " << waitError;
+    ASSERT_TRUE(watchdogError.empty())
+        << "iteration " << i << ": " << watchdogError;
+    // wait() must not return while the end hook is still marking the Future.
+    ASSERT_TRUE(completedOnWaitReturn) << "iteration " << i;
+  }
+}
+
+} // namespace torch::comms::test


### PR DESCRIPTION
Summary:
`WorkWrapper` resolves the c10d `Future` of a device-less collective from two
places: the `TorchWork` end hook, which fires out of `setStatus()` on the
backend watchdog thread, and `wait()`/`synchronize()` on the caller thread.
Both did

```
if (!future_->completed()) {
  future_->markCompleted(...);
}
```

which is not atomic. Both threads can observe an incomplete `Future` and both
call `markCompleted()`; the loser throws `Attempting to mark a completed Future
as complete again`.

`dist.barrier()` is where this was hit, but the device-less path is wider than
barrier: it also covers `endCoalescing()` (so every `dist.batch_isend_irecv`,
i.e. every PP 1F1B step), the three window RMA ops, `gather()` on non-root
ranks (the non-root output list is normalised to one empty vector), and every
collective on a CPU/gloo process group.

The barrier case is the sharpest. The work is CUDA-backed, but `barrier()`
passes no output tensors, so `devices` is empty and the `Future` takes the
device-less path, while `TorchWorkNCCLX::checkStatus()` ->
`setStatus(COMPLETED)` runs on the watchdog thread via
`TorchWorkNCCLXQueue::garbageCollect()`. The window is tight because a
synchronous barrier's `hostSynchronize()` returns at the same moment the
watchdog's `cudaEventQuery()` on the end event starts succeeding -- the same
hardware event releases both threads. In production this surfaced as a
`RuntimeError` out of TorchMetrics `sync()` -> `gather_all_tensors()` ->
`torch.distributed.barrier()` -> `work.wait()`.

Replace the check-and-mark with a single atomic claim shared between the end
hook and the wrapper, so exactly one caller marks the `Future`. A synchronous
caller that loses the claim waits for the winner, preserving the invariant that
`future_->completed()` holds once `wait()`/`synchronize()` returns --
`Future::value()` asserts on it. The end hook never blocks, and that is a
requirement rather than a courtesy: the watchdog fires it from inside
`TorchWorkNCCLXQueue::garbageCollect()`, which holds `work_queues_mutex_` --
the same mutex `enqueueWork()` takes for every collective.

Reviewed By: pavanbalaji

Differential Revision: D117293369


