### PR TITLE
Handle BackendWrapper split non-members

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -1058,7 +1058,11 @@ c10::intrusive_ptr<c10d::Backend> BackendWrapper::split(
     commOpts.store = backendOpts->store;
     commOpts.hints = backendOpts->hints;
   }
-  auto new_comm = comm->split(ranks, opts->group_name, commOpts);
+  const auto rank = comm->getRank();
+  const auto rankIt = std::find(ranks.begin(), ranks.end(), rank);
+  const std::vector<int> emptyRanks;
+  const auto& splitRanks = rankIt == ranks.end() ? emptyRanks : ranks;
+  auto new_comm = comm->split(splitRanks, opts->group_name, commOpts);
   if (new_comm == nullptr) {
     return nullptr;
   }

--- a/comms/torchcomms/fake/TorchCommFake.cpp
+++ b/comms/torchcomms/fake/TorchCommFake.cpp
@@ -5,6 +5,8 @@
 #include <comms/torchcomms/fake/TorchCommFake.hpp>
 #include <torch/csrc/distributed/c10d/Store.hpp> // @manual=//caffe2:torch-cpp-cpu
 
+#include <algorithm>
+
 namespace torch::comms {
 
 namespace {
@@ -286,10 +288,21 @@ std::shared_ptr<TorchCommBackend> TorchCommFake::split(
     const std::vector<int>& ranks,
     const std::string& name,
     const CommOptions& options) {
-  (void)ranks;
-  (void)name;
-  (void)options;
-  return std::make_shared<TorchCommFake>();
+  if (ranks.empty()) {
+    return nullptr;
+  }
+  auto rankIt = std::find(ranks.begin(), ranks.end(), rank_);
+  TORCH_CHECK(
+      rankIt != ranks.end(),
+      "Current rank ",
+      rank_,
+      " is not included in the provided ranks list");
+
+  auto child = std::make_shared<TorchCommFake>();
+  child->init(device_, name, options);
+  child->rank_ = static_cast<int>(std::distance(ranks.begin(), rankIt));
+  child->size_ = static_cast<int>(ranks.size());
+  return child;
 }
 
 const CommOptions& TorchCommFake::getOptions() const {

--- a/comms/torchcomms/tests/unit/cpp/TorchCommOptionsTest.cpp
+++ b/comms/torchcomms/tests/unit/cpp/TorchCommOptionsTest.cpp
@@ -121,7 +121,7 @@ constexpr const char* kBackendEnvKey = "TORCHCOMMS_BACKEND_LIB_PATH_FAKE_TEST";
 // Verifies the behavior the tag field exists for: BackendWrapper::send/recv
 // must thread the c10d `tag` into SendOptions/RecvOptions and pass it down to
 // the backend. Uses the fake backend to capture the options actually received.
-class BackendWrapperTagTest : public ::testing::Test {
+class BackendWrapperTest : public ::testing::Test {
  protected:
   void SetUp() override {
     const char* lib_path = std::getenv("FAKE_TEST_BACKEND_LIB_PATH");
@@ -154,7 +154,7 @@ class BackendWrapperTagTest : public ::testing::Test {
   c10::intrusive_ptr<BackendWrapper> wrapper_;
 };
 
-TEST_F(BackendWrapperTagTest, SendThreadsTagToBackend) {
+TEST_F(BackendWrapperTest, SendThreadsTagToBackend) {
   std::vector<at::Tensor> tensors = {at::ones({4}, at::kFloat)};
   wrapper_->send(tensors, /*dstRank=*/1, /*tag=*/123);
 
@@ -165,7 +165,7 @@ TEST_F(BackendWrapperTagTest, SendThreadsTagToBackend) {
   EXPECT_EQ(fake->getLastSendDstForTest(), 1);
 }
 
-TEST_F(BackendWrapperTagTest, RecvThreadsTagToBackend) {
+TEST_F(BackendWrapperTest, RecvThreadsTagToBackend) {
   std::vector<at::Tensor> tensors = {at::empty({4}, at::kFloat)};
   wrapper_->recv(tensors, /*srcRank=*/2, /*tag=*/456);
 
@@ -176,8 +176,31 @@ TEST_F(BackendWrapperTagTest, RecvThreadsTagToBackend) {
   EXPECT_EQ(fake->getLastRecvSrcForTest(), 2);
 }
 
+TEST_F(BackendWrapperTest, SplitAcceptsRanksIncludingCurrentRank) {
+  auto opts = c10::make_intrusive<BackendWrapper::Options>();
+  opts->group_name = "member_split";
+  std::vector<int> ranks = {0};
+
+  auto splitBackend = wrapper_->split(nullptr, ranks, opts);
+
+  ASSERT_NE(splitBackend, nullptr);
+  EXPECT_EQ(splitBackend->getRank(), 0);
+  EXPECT_EQ(splitBackend->getSize(), ranks.size());
+}
+
+TEST_F(BackendWrapperTest, SplitAcceptsRanksExcludingCurrentRank) {
+  auto opts = c10::make_intrusive<BackendWrapper::Options>();
+  opts->group_name = "nonmember_split";
+  std::vector<int> ranks = {1, 2, 3};
+
+  c10::intrusive_ptr<c10d::Backend> splitBackend;
+  ASSERT_NO_THROW(splitBackend = wrapper_->split(nullptr, ranks, opts));
+
+  EXPECT_EQ(splitBackend, nullptr);
+}
+
 #ifdef C10D_BACKEND_HAS_WINDOW
-TEST_F(BackendWrapperTagTest, WindowOperationsDelegateToTorchComm) {
+TEST_F(BackendWrapperTest, WindowOperationsDelegateToTorchComm) {
   EXPECT_TRUE(wrapper_->supportsWindow());
 
   auto tensor = at::ones({4}, at::kFloat);


### PR DESCRIPTION
Summary:
TorchComms uses a per-caller split API: ranks that participate in the parent split but are omitted from the child must pass an empty rank list to request NOCOLOR. c10d split_group passes the selected child rank list to every parent rank, so BackendWrapper::split must translate c10d non-members before calling TorchComm::split.

Translate omitted BackendWrapper split members to the TorchComm empty-ranks representation. Update the fake TorchComm split behavior to model that backend contract and add BackendWrapper-local unit coverage that calls split with a rank list excluding the current rank.

Differential Revision: D117556311


