### PR TITLE
Disable AllReduceRing bi-directional AllGather by default

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3325,15 +3325,17 @@ cvars:
 
  - name        : NCCL_CTRAN_ALLREDUCE_RING_BIDIR_AG_MAX_SIZE
    type        : int64_t
-   default     : -2
+   default     : 0
    description : |-
      Maximum message size in bytes for bi-directional AllGather optimization
      in AllReduceRing. Bi-directional AG sends data in both directions
      simultaneously during the AllGather phase, reducing total steps.
-     Set to 0 to disable bi-directional AG entirely.
+     Set to 0 to disable bi-directional AG entirely (the default).
      Set to -1 to enable for all message sizes.
      Set to -2 to auto-tune per GPU architecture (GB200: 128MB, H100: 4MB).
      Set to a positive value to enable only for messages up to that size.
+     Disabled by default: at 0 CtranAlgo also skips allocating the reverse
+     ring buffers, so opting in costs both the optimization and that memory.
 
  - name        : NCCL_CTRAN_ENABLE_FAULT_TOLERANCE
    type        : bool

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3532,11 +3532,12 @@ cvars:
 
  - name        : MCCL_SCUBA_ENABLED
    type        : bool
-   default     : true
+   default     : false
    description : |-
      Enable MCCL Scuba structured logging. When enabled, MCCL will log
      events to dedicated MCCL Scuba tables for observability and debugging.
      This is separate from NCCLX logging to minimize risk.
+     Off by default; set MCCL_SCUBA_ENABLED=1 in the job environment to opt in.
 
  - name        : MCCL_COLLECTIVE_STATS_ENABLE
    type        : bool


### PR DESCRIPTION
Summary:
Flip `NCCL_CTRAN_ALLREDUCE_RING_BIDIR_AG_MAX_SIZE` from `-2` (auto-tune per GPU
architecture: GB200 128MB, H100 4MB) to `0` (disabled). Bi-directional AllGather
becomes opt-in.

This is a behaviour change for every ARv1 (`ctring`) user, not only benchmarks.
Two effects:

- `AllReduceRing.cc` selects the standard AllGather kernel instead of the
  bi-directional variant for all message sizes.
- `CtranAlgo.cc:810` stops allocating `RING_TMP_SEND_BUF_REV` and
  `RING_TMP_RECV_BUF_REV`, so the tmpbuf footprint drops by two ring buffers.

Restore the previous behaviour per job with
`NCCL_CTRAN_ALLREDUCE_RING_BIDIR_AG_MAX_SIZE=-2`, or `-1` to force it on at all
sizes.

`comms/ctran/tests/CtranDistAllReduceTest.cc` sets the var explicitly for its 0
and -1 cases, so it does not depend on the default;
`comms/mccl/collectives/allreduce/tests/benchmark_allreduce.sh:1437` already
passes 0 for one variant.

Differential Revision: D117570077


