### PR TITLE
Remove obsolete CUDA graph enablement cvar

### DIFF
--- a/comms/ctran/benchmarks/AllToAllPBench.cc
+++ b/comms/ctran/benchmarks/AllToAllPBench.cc
@@ -84,7 +84,6 @@ class CtranAllToAllPBenchTestEnv : public ctran::CtranEnvironmentBase {
     // set logging level to WARN
     setenv("NCCL_DEBUG", "WARN", 1);
     setenv("NCCL_CTRAN_ENABLE", "1", 0);
-    setenv("NCCL_CTRAN_ALLOW_CUDA_GRAPH", "1", 0);
     // Turn on colltrace to validate used algorithm
     setenv("NCCL_COLLTRACE", "algostat", 1);
   }

--- a/comms/ctran/tests/CtranDistTestUtils.cc
+++ b/comms/ctran/tests/CtranDistTestUtils.cc
@@ -38,10 +38,6 @@ void CtranDistEnvironment::SetUp() {
 #if defined(TEST_ENABLE_LOCAL_REGISTER)
   setenv("NCCL_LOCAL_REGISTER", "1", 1);
 #endif
-
-#if defined(TEST_CUDA_GRAPH_MODE)
-  setenv("NCCL_CTRAN_ALLOW_CUDA_GRAPH", "1", 1);
-#endif
 }
 
 // ============================================================================

--- a/comms/ctran/tests/DeviceAllToAllvLl128Test.cc
+++ b/comms/ctran/tests/DeviceAllToAllvLl128Test.cc
@@ -24,7 +24,6 @@ class DeviceAllToAllvLl128Environment : public ctran::CtranEnvironmentBase {
     setenv("NCCL_CTRAN_ENABLE", "1", 1);
     setenv("NCCL_CTRAN_DA2A_LL128_THRESHOLD", "262144", 1);
     setenv("NCCL_CTRAN_PIPES_DISABLE_IB", "1", 1);
-    setenv("NCCL_CTRAN_ALLOW_CUDA_GRAPH", "1", 1);
   }
 
   void TearDown() override {
@@ -32,7 +31,6 @@ class DeviceAllToAllvLl128Environment : public ctran::CtranEnvironmentBase {
     unsetenv("NCCL_CTRAN_ENABLE");
     unsetenv("NCCL_CTRAN_DA2A_LL128_THRESHOLD");
     unsetenv("NCCL_CTRAN_PIPES_DISABLE_IB");
-    unsetenv("NCCL_CTRAN_ALLOW_CUDA_GRAPH");
     ctran::CtranEnvironmentBase::TearDown();
   }
 };

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphTestBase.h
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphTestBase.h
@@ -19,7 +19,6 @@
 class CtranCudaGraphEnvironment : public ctran::CtranDistEnvironment {
  public:
   void SetUp() override {
-    setenv("NCCL_CTRAN_ALLOW_CUDA_GRAPH", "1", 1);
     setenv("NCCL_CTRAN_ENABLE", "1", 0);
     // ctranAllToAllSupport is size-gated: at 1024 int32 (4KB per peer) the
     // cudagraph cases sit below the 32KB NCCL_CTRAN_ALLTOALL_THRESHOLD

--- a/comms/ncclx/meta/tests/NcclxBaseTest.h
+++ b/comms/ncclx/meta/tests/NcclxBaseTest.h
@@ -46,9 +46,6 @@ class NcclxBaseTestFixture : public ::testing::Test,
 #ifdef TEST_ENABLE_LOCAL_REGISTER
     envs.push_back({"NCCL_LOCAL_REGISTER", "1"});
 #endif
-#ifdef TEST_CUDA_GRAPH_MODE
-    envs.push_back({"NCCL_CTRAN_ALLOW_CUDA_GRAPH", "1"});
-#endif
     SetUp(envs);
   }
 

--- a/comms/torchcomms/tests/integration/py/CudaGraphsAllGatherAwareTest.py
+++ b/comms/torchcomms/tests/integration/py/CudaGraphsAllGatherAwareTest.py
@@ -39,7 +39,6 @@ class TestAllGatherCudaGraphAware(CudaGraphTestBase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        os.environ["NCCL_CTRAN_ALLOW_CUDA_GRAPH"] = "1"
         os.environ["NCCL_ALLGATHER_ALGO"] = "ctgraph"
         os.environ.setdefault("NCCL_DEBUG", "INFO")
         os.environ.setdefault("NCCL_DEBUG_SUBSYS", "COLL")

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2999,15 +2999,6 @@ cvars:
    description : |-
      Enable network perf monitor to monitor the bandwidth of NCCL.
 
- - name        : NCCL_CTRAN_ALLOW_CUDA_GRAPH
-   type        : bool
-   default     : false
-   description : |-
-     Preallocate runtime buffers at communicator creation time,
-     allowing the communicator to be usable in CUDA graph mode
-     (runtime allocation and mapping of buffers is not CUDA graph
-     safe).
-
  - name        : NCCL_CTRAN_ENABLE_PERFTRACE
    type        : bool
    default     : false


### PR DESCRIPTION
Summary:
Remove the public `NCCL_CTRAN_ALLOW_CUDA_GRAPH` cvar and its generated C++ symbol.
This is an explicit compatibility break for external launch recipes or source consumers that still reference the cvar or generated symbol.
The cvar was behaviorally inert because the runtime had no reader.
The per-algorithm CUDA graph policy in `D114879982` is now the sole source of truth.

Remove active-source setters and the unused `TEST_CUDA_GRAPH_MODE` build path.
Delete the stale `ctran_dist_alltoall_1x8_init_none_graph` and `ctran_dist_alltoall_1x8_nolocal_init_none_graph` configurations because removal of that macro made them identical to their non-graph counterparts.
AllToAll graph coverage remains in the dedicated `alltoall_ctgraph_*` suite.
Delete `device_alltoallv_cudagraph_test` because `device_alltoallv_test` parameterizes every applicable case over both eager and CUDA graph execution.
Two frozen RCCLX snapshots intentionally retain the historical setter.

Resolve semantic rebase conflicts from newer `master` changes by removing newly added active-source references to the deleted cvar and updating stale graph-mode and test-target documentation.

Background:
CUDA graph support is declared by each collective implementation.
Only the AllReduce Fused Tree and Fused Ring algorithms opt in after the validation from `D113232313`.
Removing the obsolete global switch prevents launch configuration and test code from implying broader support.

Reviewed By: saifhhasan

Differential Revision: D116787866


