### PR TITLE
Add phased 16-byte NVL reductions (#3860)

### DIFF
--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cu
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cu
@@ -5,6 +5,7 @@
 #include "comms/common/fault_tolerance/TestAbort.h"
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlReduce.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlSignal.cuh"
 
 namespace comms::prims::test {
@@ -37,6 +38,24 @@ __device__ SignalState* boundaryPeerSignals[kBoundaryMaxRanks];
 __global__ void nvlSignalTrapKernel(
     NvlSignalTrapCase testCase,
     AbortDevice waitAbort) {
+  if (testCase == NvlSignalTrapCase::ReducedBlockRangeOutOfBounds) {
+    // A range crossing the 16-byte block boundary must trap before indexing.
+    uint4 reducedBlock{};
+    __half destination[2]{};
+    multimem::store_reduced_block16_range(
+        destination,
+        reducedBlock,
+        /*sourceFirstLane=*/7,
+        /*count=*/2);
+    return;
+  }
+  if (testCase == NvlSignalTrapCase::ReduceBlock16MisalignedSource) {
+    // Offset a 16-byte-aligned allocation by one lane to violate the contract.
+    alignas(16) __half source[9]{};
+    (void)multimem::load_reduce_block16<__half>(source + 1);
+    return;
+  }
+
   auto* trapSignals = reinterpret_cast<SignalState*>(trapSignalStorage);
   SignalState* peerSignals[4] = {
       trapSignals, trapSignals, trapSignals, trapSignals};

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cu
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cu
@@ -48,7 +48,8 @@ __global__ void nvlSignalTrapKernel(
   uint32_t signalsPerChannel =
       static_cast<uint32_t>(multimem_staging_signals_per_channel(
           static_cast<uint64_t>(nvlRanks), pipelineDepth));
-  if (testCase == NvlSignalTrapCase::SignalsPerChannelMismatch) {
+  if (testCase == NvlSignalTrapCase::SignalsPerChannelMismatch ||
+      testCase == NvlSignalTrapCase::BlockBarrierSignalsPerChannelMismatch) {
     --signalsPerChannel;
   }
   MultimemNvlTransportDevice transport{
@@ -138,6 +139,13 @@ __global__ void nvlSignalTrapKernel(
     return;
   }
   auto group = make_block_group();
+  if (testCase == NvlSignalTrapCase::BlockBarrierNon1DBlock ||
+      testCase == NvlSignalTrapCase::BlockBarrierDuplicateChannelOwner ||
+      testCase == NvlSignalTrapCase::BlockBarrierNon1DGrid ||
+      testCase == NvlSignalTrapCase::BlockBarrierSignalsPerChannelMismatch) {
+    nvl_signal_detail::validate_block_barrier(transport, /*channel=*/0, group);
+    return;
+  }
   if (testCase == NvlSignalTrapCase::PerPeerDuplicateChannelOwner ||
       testCase == NvlSignalTrapCase::PerPeerNon1DBlock) {
     signal_publish<
@@ -267,6 +275,7 @@ dim3 signal_trap_threads(NvlSignalTrapCase testCase) {
     case NvlSignalTrapCase::DuplicateChannelOwner:
       return dim3(2 * kWarpSize);
     case NvlSignalTrapCase::PerPeerNon1DBlock:
+    case NvlSignalTrapCase::BlockBarrierNon1DBlock:
       return dim3(kNvlSignalSmallPerPeerThreads, 2);
     case NvlSignalTrapCase::AggregateDepthTooLarge:
     case NvlSignalTrapCase::ArrivalCountMismatch:
@@ -282,8 +291,10 @@ dim3 signal_trap_threads(NvlSignalTrapCase testCase) {
 dim3 signal_trap_blocks(NvlSignalTrapCase testCase) {
   switch (testCase) {
     case NvlSignalTrapCase::PerPeerDuplicateChannelOwner:
+    case NvlSignalTrapCase::BlockBarrierDuplicateChannelOwner:
       return dim3(2);
     case NvlSignalTrapCase::AggregateNon1DGrid:
+    case NvlSignalTrapCase::BlockBarrierNon1DGrid:
       return dim3(1, 2);
     default:
       return dim3(1);

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
@@ -31,6 +31,8 @@ enum class NvlSignalTrapCase : uint32_t {
   BlockBarrierDuplicateChannelOwner,
   BlockBarrierNon1DGrid,
   BlockBarrierSignalsPerChannelMismatch,
+  ReducedBlockRangeOutOfBounds,
+  ReduceBlock16MisalignedSource,
 };
 
 enum class NvlSignalRankBoundaryWaitPolicy : uint32_t {

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
@@ -27,6 +27,10 @@ enum class NvlSignalTrapCase : uint32_t {
   AggregateNon1DGrid,
   PerPeerDuplicateChannelOwner,
   PerPeerNon1DBlock,
+  BlockBarrierNon1DBlock,
+  BlockBarrierDuplicateChannelOwner,
+  BlockBarrierNon1DGrid,
+  BlockBarrierSignalsPerChannelMismatch,
 };
 
 enum class NvlSignalRankBoundaryWaitPolicy : uint32_t {

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -2388,6 +2388,80 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceLoadReduceCoversPublicTypes) {
   }
 }
 
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    PhasedReduceBlockPreservesOwnedFp16AndBf16Lanes) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+
+  // 1. Create a transport shared by all participating NVL ranks.
+  auto bootstrap = makeBootstrap("mmnvl_phased_reduce_block");
+  auto transport = makeExchangedTransport(
+      bootstrap,
+      globalRank,
+      numRanks,
+      localRank,
+      /*userSignalCount=*/0,
+      /*needsInternalSignals=*/true);
+  if (!transport) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  const auto deviceTransport = transport->getDeviceTransport();
+  ASSERT_GT(deviceTransport.nvlRanks, 0);
+  ASSERT_GE(deviceTransport.nvlRank, 0);
+  ASSERT_LT(deviceTransport.nvlRank, deviceTransport.nvlRanks);
+  const std::size_t nvlRank = static_cast<std::size_t>(deviceTransport.nvlRank);
+  const std::size_t nvlRanks =
+      static_cast<std::size_t>(deviceTransport.nvlRanks);
+  constexpr std::size_t kElements = 8;
+  const float localValue = test::phasedReduceBlockRankValue(nvlRank);
+  const float expectedValue = test::phasedReduceBlockExpectedValue(nvlRanks);
+  const std::size_t ownedFirstLane = kElements * nvlRank / nvlRanks;
+  const std::size_t ownedEndLane = kElements * (nvlRank + 1) / nvlRanks;
+
+  // 2. Exercise both two-byte types and both accumulation modes.
+  for (const auto type :
+       {test::MultimemReductionTestType::Float16,
+        test::MultimemReductionTestType::Bfloat16}) {
+    for (const bool accF32 : {false, true}) {
+      test::launchPhasedReduceBlock(deviceTransport, type, accF32);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      // 3. Decode this rank's in-place multicast backing block.
+      std::vector<uint16_t> values(kElements);
+      CUDACHECK_TEST(cudaMemcpy(
+          values.data(),
+          deviceTransport.localData,
+          16,
+          cudaMemcpyDeviceToHost));
+
+      std::vector<float> actualValues(kElements);
+      for (std::size_t lane = 0; lane < kElements; ++lane) {
+        if (type == test::MultimemReductionTestType::Float16) {
+          __half raw{};
+          std::memcpy(&raw, &values[lane], sizeof(raw));
+          actualValues[lane] = __half2float(raw);
+        } else {
+          __nv_bfloat16 raw{};
+          std::memcpy(&raw, &values[lane], sizeof(raw));
+          actualValues[lane] = __bfloat162float(raw);
+        }
+      }
+
+      // 4. Compare against an independently constructed ownership layout.
+      std::vector<float> expectedValues(kElements, localValue);
+      std::fill(
+          expectedValues.begin() + ownedFirstLane,
+          expectedValues.begin() + ownedEndLane,
+          expectedValue);
+      EXPECT_EQ(actualValues, expectedValues);
+      ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+    }
+  }
+}
+
 } // namespace comms::prims::tests
 
 int main(int argc, char* argv[]) {

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -1684,6 +1684,91 @@ TEST_F(
 
 TEST_F(
     MultimemNvlTransportTestFixture,
+    BlockAggregateBarrierOrdersEveryWarpAcrossRepeatedEpochs) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  constexpr uint32_t kChannels = 2;
+  constexpr uint32_t kPipelineDepth = 4;
+  constexpr uint32_t kEpochs = 3;
+  constexpr uint32_t kThreads = 128;
+  constexpr std::size_t kElementCount = kChannels * kEpochs * kThreads;
+  auto bootstrap = makeBootstrap("mmnvl_block_aggregate_barrier");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(
+          kElementCount * sizeof(int32_t),
+          /*userSignalCount=*/0,
+          kPipelineDepth,
+          kChannels));
+  transport.exchange();
+
+  int32_t* deviceReducedValues = nullptr;
+  uint64_t* deviceSignalValues = nullptr;
+  constexpr std::size_t kSignalValueCount = 2 * kChannels * kPipelineDepth;
+  CUDACHECK_TEST(
+      cudaMalloc(&deviceReducedValues, kElementCount * sizeof(int32_t)));
+  CUDACHECK_TEST(
+      cudaMalloc(&deviceSignalValues, kSignalValueCount * sizeof(uint64_t)));
+  test::launchBlockAggregateBarrier(
+      transport.getDeviceTransport(),
+      kChannels,
+      kEpochs,
+      deviceReducedValues,
+      deviceSignalValues);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int32_t> reducedValues(kElementCount);
+  std::vector<uint64_t> signalValues(kSignalValueCount);
+  CUDACHECK_TEST(cudaMemcpy(
+      reducedValues.data(),
+      deviceReducedValues,
+      kElementCount * sizeof(int32_t),
+      cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaMemcpy(
+      signalValues.data(),
+      deviceSignalValues,
+      kSignalValueCount * sizeof(uint64_t),
+      cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaFree(deviceReducedValues));
+  CUDACHECK_TEST(cudaFree(deviceSignalValues));
+
+  const int32_t rankSum = numRanks * (numRanks + 1) / 2;
+  for (uint32_t epoch = 0; epoch < kEpochs; ++epoch) {
+    for (uint32_t channel = 0; channel < kChannels; ++channel) {
+      const int32_t expected =
+          rankSum + numRanks * static_cast<int32_t>(10 * epoch + 100 * channel);
+      const std::size_t offset =
+          (static_cast<std::size_t>(epoch) * kChannels + channel) * kThreads;
+      EXPECT_EQ(
+          std::vector<int32_t>(
+              reducedValues.begin() + offset,
+              reducedValues.begin() + offset + kThreads),
+          std::vector<int32_t>(kThreads, expected));
+    }
+  }
+  const uint64_t expectedSignalValue =
+      static_cast<uint64_t>(kEpochs * numRanks);
+  for (uint32_t channel = 0; channel < kChannels; ++channel) {
+    const std::size_t outputBase =
+        static_cast<std::size_t>(channel) * 2 * kPipelineDepth;
+    EXPECT_EQ(signalValues[outputBase], expectedSignalValue);
+    EXPECT_EQ(signalValues[outputBase + kPipelineDepth], expectedSignalValue);
+    for (uint32_t lane = 1; lane < kPipelineDepth; ++lane) {
+      EXPECT_EQ(signalValues[outputBase + lane], 0);
+      EXPECT_EQ(signalValues[outputBase + kPipelineDepth + lane], 0);
+    }
+  }
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
     UniformSignalPerPeerRoundTripUsesAggregateAck) {
   if (numRanks < 3) {
     GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -562,6 +562,40 @@ __global__ void loadReduceKernel(
       group, output, source, elems);
 }
 
+template <typename T, bool kAccF32>
+__global__ void phasedReduceBlockKernel(MultimemNvlTransportDevice transport) {
+  auto block = make_block_group();
+  constexpr std::size_t kElements = sizeof(uint4) / sizeof(T);
+  auto* local = reinterpret_cast<T*>(transport.localData);
+  if (threadIdx.x < kElements) {
+    local[threadIdx.x] =
+        reductionValue<T>(phasedReduceBlockRankValue(transport.nvlRank));
+  }
+  nvl_block_barrier(transport, /*channel=*/0, block);
+
+  uint4 reduced{};
+  if (block.is_leader()) {
+    reduced = multimem::load_reduce_block16<T, kAccF32>(
+        reinterpret_cast<const T*>(transport.multimemData));
+  }
+  nvl_block_barrier(transport, /*channel=*/0, block);
+
+  if (block.is_leader()) {
+    const std::size_t ownedFirstLane = kElements *
+        static_cast<std::size_t>(transport.nvlRank) /
+        static_cast<std::size_t>(transport.nvlRanks);
+    const std::size_t ownedEndLane = kElements *
+        static_cast<std::size_t>(transport.nvlRank + 1) /
+        static_cast<std::size_t>(transport.nvlRanks);
+    multimem::store_reduced_block16_range(
+        local + ownedFirstLane,
+        reduced,
+        ownedFirstLane,
+        ownedEndLane - ownedFirstLane);
+  }
+  nvl_block_barrier(transport, /*channel=*/0, block);
+}
+
 __global__ void stageLayoutKernel(
     MultimemNvlTransportDevice transport,
     StageLayoutResult* results) {
@@ -619,6 +653,19 @@ void launchLoadReduceTyped(
   } else {
     loadReduceKernel<T, false><<<1, 32, 0, stream>>>(
         transport, static_cast<T*>(output), elems, sourceOffsetElems);
+  }
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+template <typename T>
+void launchPhasedReduceBlockTyped(
+    MultimemNvlTransportDevice transport,
+    bool accF32,
+    cudaStream_t stream) {
+  if (accF32) {
+    phasedReduceBlockKernel<T, true><<<1, 128, 0, stream>>>(transport);
+  } else {
+    phasedReduceBlockKernel<T, false><<<1, 128, 0, stream>>>(transport);
   }
   PIPES_KERNEL_LAUNCH_CHECK();
 }
@@ -935,6 +982,23 @@ void launchLoadReduce(
     case MultimemReductionTestType::Bfloat16:
       return launchLoadReduceTyped<__nv_bfloat16>(
           transport, accF32, output, elems, sourceOffsetElems, stream);
+  }
+}
+
+void launchPhasedReduceBlock(
+    MultimemNvlTransportDevice transport,
+    MultimemReductionTestType type,
+    bool accF32,
+    cudaStream_t stream) {
+  switch (type) {
+    case MultimemReductionTestType::Float16:
+      return launchPhasedReduceBlockTyped<__half>(transport, accF32, stream);
+    case MultimemReductionTestType::Bfloat16:
+      return launchPhasedReduceBlockTyped<__nv_bfloat16>(
+          transport, accF32, stream);
+    case MultimemReductionTestType::Float:
+    case MultimemReductionTestType::Int32:
+      throw std::runtime_error("phased reduce block requires a 2-byte type");
   }
 }
 

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -404,6 +404,41 @@ __global__ void initializeAggregateSignalsKernel(
   }
 }
 
+__global__ void blockAggregateBarrierKernel(
+    MultimemNvlTransportDevice transport,
+    uint32_t epochs,
+    int32_t* reducedValues,
+    uint64_t* signalValues) {
+  auto block = make_block_group();
+  auto* local = reinterpret_cast<int32_t*>(transport.localData);
+  const auto* multicast =
+      reinterpret_cast<const int32_t*>(transport.multimemData);
+  for (uint32_t epoch = 0; epoch < epochs; ++epoch) {
+    const std::size_t offset =
+        (static_cast<std::size_t>(epoch) * gridDim.x + blockIdx.x) * blockDim.x;
+    local[offset + threadIdx.x] = transport.nvlRank + 1 +
+        static_cast<int32_t>(10 * epoch + 100 * blockIdx.x);
+    nvl_block_barrier(
+        transport, static_cast<uint32_t>(blockIdx.x), block, AbortDevice{});
+    multimem::load_reduce_at<int32_t>(
+        block, reducedValues + offset, multicast + offset, blockDim.x);
+  }
+
+  block.sync();
+  if (threadIdx.x < transport.pipelineDepth) {
+    const uint64_t signalId =
+        static_cast<uint64_t>(blockIdx.x) * transport.signalsPerChannel +
+        static_cast<uint64_t>(3 * transport.nvlRanks) +
+        static_cast<uint64_t>(4 * threadIdx.x);
+    const std::size_t outputBase =
+        static_cast<std::size_t>(blockIdx.x) * 2 * transport.pipelineDepth;
+    signalValues[outputBase + threadIdx.x] =
+        transport.internalLocalSignals[signalId].load();
+    signalValues[outputBase + transport.pipelineDepth + threadIdx.x] =
+        transport.internalLocalSignals[signalId + 1].load();
+  }
+}
+
 __global__ void perPeerWaitOnlyKernel(
     MultimemNvlTransportDevice transport,
     uint64_t roundValue,
@@ -828,6 +863,18 @@ void launchInitializeAggregateSignals(
     cudaStream_t stream) {
   initializeAggregateSignalsKernel<<<1, 32, 0, stream>>>(
       transport, counterValue, epochValue);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchBlockAggregateBarrier(
+    MultimemNvlTransportDevice transport,
+    uint32_t channels,
+    uint32_t epochs,
+    int32_t* reducedValues,
+    uint64_t* signalValues,
+    cudaStream_t stream) {
+  blockAggregateBarrierKernel<<<channels, 128, 0, stream>>>(
+      transport, epochs, reducedValues, signalValues);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -182,6 +182,14 @@ void launchInitializeAggregateSignals(
     uint64_t epochValue,
     cudaStream_t stream = nullptr);
 
+void launchBlockAggregateBarrier(
+    MultimemNvlTransportDevice transport,
+    uint32_t channels,
+    uint32_t epochs,
+    int32_t* reducedValues,
+    uint64_t* signalValues,
+    cudaStream_t stream = nullptr);
+
 void launchFillReductionInput(
     MultimemNvlTransportDevice transport,
     MultimemReductionTestType type,

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -15,6 +15,23 @@ namespace comms::prims::test {
 
 enum class MultimemReductionTestType { Float, Int32, Float16, Bfloat16 };
 
+__host__ __device__ constexpr float phasedReduceBlockRankValue(
+    std::size_t nvlRank) {
+  return static_cast<float>(nvlRank % 4 + 1);
+}
+
+constexpr float phasedReduceBlockExpectedValue(std::size_t nvlRanks) {
+  float result = 0.0f;
+  for (std::size_t rank = 0; rank < nvlRanks; ++rank) {
+    result += phasedReduceBlockRankValue(rank);
+  }
+  return result;
+}
+
+static_assert(
+    phasedReduceBlockExpectedValue(kMaxNvlSignalRanks) <= 256.0f,
+    "phased reduction test values must sum exactly in bf16");
+
 struct StageLayoutResult {
   std::size_t channelBeginBytes;
   std::size_t stagingBytes;
@@ -205,6 +222,12 @@ void launchLoadReduce(
     void* output,
     std::size_t elems,
     std::size_t sourceOffsetElems,
+    cudaStream_t stream = nullptr);
+
+void launchPhasedReduceBlock(
+    MultimemNvlTransportDevice transport,
+    MultimemReductionTestType type,
+    bool accF32,
     cudaStream_t stream = nullptr);
 
 void launchStageLayout(

--- a/comms/prims/transport/nvl/MultimemNvlReduce.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlReduce.cuh
@@ -21,6 +21,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <type_traits>
 
 #include "comms/prims/core/ThreadGroup.cuh"
@@ -229,6 +230,63 @@ namespace comms::prims::multimem {
 
 /** Reduction operator for the multimem data reduce verbs. Only Add today. */
 enum class MultimemRedOp { Add };
+
+/**
+ * Reduces one aligned 16-byte fp16 or bf16 block into registers.
+ *
+ * Keeping the reduced block separate from the eventual stores lets callers
+ * place a team barrier between the read and write phases when adjacent ranks
+ * own different lanes of the same 16-byte block.
+ */
+template <typename T, bool kAccF32 = true>
+__device__ __forceinline__ uint4 load_reduce_block16(const T* multicastBlock) {
+  static_assert(
+      std::is_same_v<T, __half> || std::is_same_v<T, __nv_bfloat16>,
+      "load_reduce_block16 supports fp16 and bf16");
+#if defined(__CUDA_ARCH__)
+  const uintptr_t sourceAddress = reinterpret_cast<uintptr_t>(multicastBlock);
+  if (sourceAddress % alignof(uint4) != 0) {
+    printf(
+        "NVL load_reduce_block16 requires a 16-byte-aligned source: "
+        "source=0x%llx\n",
+        static_cast<unsigned long long>(sourceAddress));
+    __trap();
+  }
+#endif
+  const auto* source = reinterpret_cast<const uint4*>(multicastBlock);
+  if constexpr (std::is_same_v<T, __half>) {
+    return comms::prims::detail::multimem_ld_reduce_v4_f16x2<kAccF32>(source);
+  } else {
+    return comms::prims::detail::multimem_ld_reduce_v4_bf16x2<kAccF32>(source);
+  }
+}
+
+/**
+ * Stores `count` lanes starting at `sourceFirstLane` from a previously
+ * reduced 16-byte block.
+ *
+ * `destination` must point to the first destination element and provide
+ * storage for `count` elements.
+ */
+template <typename T>
+__device__ __forceinline__ void store_reduced_block16_range(
+    T* destination,
+    const uint4& block,
+    std::size_t sourceFirstLane,
+    std::size_t count) {
+  static_assert(
+      sizeof(T) == 2, "store_reduced_block16_range requires a 2-byte type");
+#if defined(__CUDA_ARCH__)
+  constexpr std::size_t kLaneCount = sizeof(uint4) / sizeof(T);
+  if (sourceFirstLane > kLaneCount || count > kLaneCount - sourceFirstLane) {
+    __trap();
+  }
+#endif
+  const auto* lanes = reinterpret_cast<const T*>(&block);
+  for (std::size_t index = 0; index < count; ++index) {
+    destination[index] = lanes[sourceFirstLane + index];
+  }
+}
 
 /**
  * multimem.ld_reduce from an ARBITRARY multicast base pointer into `dst`.

--- a/comms/prims/transport/nvl/MultimemNvlSignal.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlSignal.cuh
@@ -529,6 +529,57 @@ __device__ __forceinline__ void validate_aggregate(
 #endif
 }
 
+__device__ __forceinline__ void validate_block_barrier(
+    const MultimemNvlTransportDevice& transport,
+    uint32_t channel,
+    const ThreadGroup& block) {
+#if defined(__CUDA_ARCH__)
+  const bool validRankCount = transport.nvlRanks > 0 &&
+      nvl_signal_rank_count_supported(
+                                  static_cast<uint32_t>(transport.nvlRanks));
+  const uint64_t expectedSignalsPerChannel = validRankCount
+      ? multimem_staging_signals_per_channel(
+            static_cast<uint64_t>(transport.nvlRanks), transport.pipelineDepth)
+      : 0;
+  const uint64_t requiredSignals =
+      static_cast<uint64_t>(transport.maxChannels) *
+      transport.signalsPerChannel;
+  if (blockDim.y != 1 || blockDim.z != 1 || gridDim.y != 1 || gridDim.z != 1 ||
+      block.scope != SyncScope::BLOCK || block.group_size != blockDim.x ||
+      block.group_size < kWarpSize || block.group_size % kWarpSize != 0 ||
+      block.group_id != channel || !validRankCount ||
+      transport.pipelineDepth == 0 || channel >= transport.maxChannels ||
+      transport.signalsPerChannel != expectedSignalsPerChannel ||
+      requiredSignals > transport.internalLocalSignals.size() ||
+      requiredSignals > transport.internalMultimemSignals.size()) {
+    printf(
+        "NVL block barrier invalid geometry: block=(%u,%u,%u) "
+        "grid=(%u,%u,%u) groupId=%u groupSize=%u ranks=%d "
+        "channel=%u maxChannels=%u pipelineDepth=%u "
+        "signalsPerChannel=%u expectedSignalsPerChannel=%llu\n",
+        static_cast<unsigned>(blockDim.x),
+        static_cast<unsigned>(blockDim.y),
+        static_cast<unsigned>(blockDim.z),
+        static_cast<unsigned>(gridDim.x),
+        static_cast<unsigned>(gridDim.y),
+        static_cast<unsigned>(gridDim.z),
+        static_cast<unsigned>(block.group_id),
+        static_cast<unsigned>(block.group_size),
+        transport.nvlRanks,
+        static_cast<unsigned>(channel),
+        static_cast<unsigned>(transport.maxChannels),
+        static_cast<unsigned>(transport.pipelineDepth),
+        static_cast<unsigned>(transport.signalsPerChannel),
+        static_cast<unsigned long long>(expectedSignalsPerChannel));
+    __trap();
+  }
+#else
+  (void)transport;
+  (void)channel;
+  (void)block;
+#endif
+}
+
 } // namespace nvl_signal_detail
 
 /**
@@ -751,6 +802,45 @@ __device__ __forceinline__ void signal_publish_and_wait(
       transport, round, participants, group);
   nvl_signal_detail::signal_wait_impl<access, topology, phase, waitPolicy>(
       transport, round, participants, group, abortDevice);
+}
+
+/**
+ * Synchronizes one CUDA block with the same channel block on every NVL rank.
+ *
+ * Every NVL rank must enter this barrier for the same channel in the same
+ * sequence. The barrier consumes the channel's aggregate Ready lane zero and
+ * must not be called from rank-local or otherwise divergent control flow.
+ *
+ * The first block synchronization makes every thread's prior writes visible
+ * to the leader. The leader publishes one release-add through lane zero of the
+ * channel's aggregate counter, waits for every NVL rank, and advances the
+ * local epoch. The final block synchronization makes the acquire wait visible
+ * to the remaining threads.
+ */
+__device__ __forceinline__ void nvl_block_barrier(
+    const MultimemNvlTransportDevice& transport,
+    uint32_t channel,
+    ThreadGroup& block,
+    const AbortDevice& abortDevice = AbortDevice{}) {
+  nvl_signal_detail::validate_block_barrier(transport, channel, block);
+
+  comms::device::fence_acq_rel_sys();
+  block.sync();
+  if (block.is_leader()) {
+    const StageRound round{.channel = channel, .value = 1};
+    const uint64_t signalId =
+        nvl_signal_detail::aggregate_counter_id<NvlSignalPhase::Ready>(
+            transport, round, /*lane=*/0);
+    auto* counter = transport.internalLocalSignals.data() + signalId;
+    auto* epoch = counter + 1;
+    const uint64_t expected =
+        epoch->load() + static_cast<uint64_t>(transport.nvlRanks);
+    transport.template signal_internal_scalar_prefenced<SignalOp::SIGNAL_ADD>(
+        signalId, 1);
+    nvl_signal_detail::wait_until_reached(*counter, expected, abortDevice);
+    epoch->store(expected);
+  }
+  block.sync();
 }
 
 } // namespace comms::prims


### PR DESCRIPTION
Summary:

## Core implementation

Add 16-byte fp16 and bf16 reduction primitives that return the existing PRIMS `uint4` register vector and retain it across a synchronization phase.
Add a separate contiguous-lane store operation so callers can complete every shared-block read before any rank writes its owned lanes.
Support both fp32 and native fp16 or bf16 accumulation through the existing multimem load-reduce instructions.

## Background

Registered in-place ReduceScatter can place adjacent rank shards inside the same 16-byte block.
Scalar two-byte reductions can race a neighboring rank's write, while one full 16-byte reduction read followed by a team barrier and selective stores is deterministic.
The synchronization policy remains outside these neutral reduction operations and is supplied by the block-scoped barrier prerequisite.

#aup

Reviewed By: dboyda

Differential Revision: D113067636


