### PR TITLE
Add registered reduce-broadcast (#3861)

### DIFF
--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cu
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cu
@@ -5,6 +5,7 @@
 #include "comms/common/fault_tolerance/TestAbort.h"
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlReduce.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlSignal.cuh"
 
 namespace comms::prims::test {
@@ -37,6 +38,24 @@ __device__ SignalState* boundaryPeerSignals[kBoundaryMaxRanks];
 __global__ void nvlSignalTrapKernel(
     NvlSignalTrapCase testCase,
     AbortDevice waitAbort) {
+  if (testCase == NvlSignalTrapCase::ReducedBlockRangeOutOfBounds) {
+    // A range crossing the 16-byte block boundary must trap before indexing.
+    uint4 reducedBlock{};
+    __half destination[2]{};
+    multimem::store_reduced_block16_range(
+        destination,
+        reducedBlock,
+        /*sourceFirstLane=*/7,
+        /*count=*/2);
+    return;
+  }
+  if (testCase == NvlSignalTrapCase::ReduceBlock16MisalignedSource) {
+    // Offset a 16-byte-aligned allocation by one lane to violate the contract.
+    alignas(16) __half source[9]{};
+    (void)multimem::load_reduce_block16<__half>(source + 1);
+    return;
+  }
+
   auto* trapSignals = reinterpret_cast<SignalState*>(trapSignalStorage);
   SignalState* peerSignals[4] = {
       trapSignals, trapSignals, trapSignals, trapSignals};

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
@@ -31,6 +31,8 @@ enum class NvlSignalTrapCase : uint32_t {
   BlockBarrierDuplicateChannelOwner,
   BlockBarrierNon1DGrid,
   BlockBarrierSignalsPerChannelMismatch,
+  ReducedBlockRangeOutOfBounds,
+  ReduceBlock16MisalignedSource,
 };
 
 enum class NvlSignalRankBoundaryWaitPolicy : uint32_t {

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -2388,6 +2388,80 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceLoadReduceCoversPublicTypes) {
   }
 }
 
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    PhasedReduceBlockPreservesOwnedFp16AndBf16Lanes) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+
+  // 1. Create a transport shared by all participating NVL ranks.
+  auto bootstrap = makeBootstrap("mmnvl_phased_reduce_block");
+  auto transport = makeExchangedTransport(
+      bootstrap,
+      globalRank,
+      numRanks,
+      localRank,
+      /*userSignalCount=*/0,
+      /*needsInternalSignals=*/true);
+  if (!transport) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  const auto deviceTransport = transport->getDeviceTransport();
+  ASSERT_GT(deviceTransport.nvlRanks, 0);
+  ASSERT_GE(deviceTransport.nvlRank, 0);
+  ASSERT_LT(deviceTransport.nvlRank, deviceTransport.nvlRanks);
+  const std::size_t nvlRank = static_cast<std::size_t>(deviceTransport.nvlRank);
+  const std::size_t nvlRanks =
+      static_cast<std::size_t>(deviceTransport.nvlRanks);
+  constexpr std::size_t kElements = 8;
+  const float localValue = test::phasedReduceBlockRankValue(nvlRank);
+  const float expectedValue = test::phasedReduceBlockExpectedValue(nvlRanks);
+  const std::size_t ownedFirstLane = kElements * nvlRank / nvlRanks;
+  const std::size_t ownedEndLane = kElements * (nvlRank + 1) / nvlRanks;
+
+  // 2. Exercise both two-byte types and both accumulation modes.
+  for (const auto type :
+       {test::MultimemReductionTestType::Float16,
+        test::MultimemReductionTestType::Bfloat16}) {
+    for (const bool accF32 : {false, true}) {
+      test::launchPhasedReduceBlock(deviceTransport, type, accF32);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      // 3. Decode this rank's in-place multicast backing block.
+      std::vector<uint16_t> values(kElements);
+      CUDACHECK_TEST(cudaMemcpy(
+          values.data(),
+          deviceTransport.localData,
+          16,
+          cudaMemcpyDeviceToHost));
+
+      std::vector<float> actualValues(kElements);
+      for (std::size_t lane = 0; lane < kElements; ++lane) {
+        if (type == test::MultimemReductionTestType::Float16) {
+          __half raw{};
+          std::memcpy(&raw, &values[lane], sizeof(raw));
+          actualValues[lane] = __half2float(raw);
+        } else {
+          __nv_bfloat16 raw{};
+          std::memcpy(&raw, &values[lane], sizeof(raw));
+          actualValues[lane] = __bfloat162float(raw);
+        }
+      }
+
+      // 4. Compare against an independently constructed ownership layout.
+      std::vector<float> expectedValues(kElements, localValue);
+      std::fill(
+          expectedValues.begin() + ownedFirstLane,
+          expectedValues.begin() + ownedEndLane,
+          expectedValue);
+      EXPECT_EQ(actualValues, expectedValues);
+      ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+    }
+  }
+}
+
 } // namespace comms::prims::tests
 
 int main(int argc, char* argv[]) {

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -26,6 +26,7 @@
 #include "comms/prims/memory/MultimemHandler.h"
 #include "comms/prims/tests/MultimemNvlTransportTest.cuh"
 #include "comms/prims/transport/nvl/MultiPeerNvlTransport.h"
+#include "comms/prims/transport/nvl/MultimemNvlStore.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlTransport.h"
 #include "comms/testinfra/DistEnvironmentBase.h"
 #include "comms/testinfra/DistTestBase.h"
@@ -1325,6 +1326,105 @@ void verifyUnicastPeerViews(
 }
 
 } // namespace
+
+TEST(MultimemNvlStoreValidationTest, ValidatesAddressAndExtent) {
+  EXPECT_TRUE(detail::is_multimem_store_valid(/*destination=*/1, /*bytes=*/0));
+  EXPECT_TRUE(detail::is_multimem_store_valid(/*destination=*/4, /*bytes=*/4));
+  EXPECT_FALSE(detail::is_multimem_store_valid(/*destination=*/2, /*bytes=*/4));
+  EXPECT_FALSE(detail::is_multimem_store_valid(/*destination=*/4, /*bytes=*/2));
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    DeviceMultimemStoreBroadcastsArbitraryRanges) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_device_store_arbitrary_ranges");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kDataBytes = 4096;
+  constexpr uint8_t kGuard = 0xA5;
+  MultimemNvlTransport transport(
+      bootstrap, globalRank, identityRankMap(numRanks), makeConfig(kDataBytes));
+  transport.exchange();
+  const auto deviceTransport = transport.getDeviceTransport();
+
+  std::vector<uint8_t> source(kDataBytes + 1);
+  for (std::size_t index = 0; index < source.size(); ++index) {
+    source[index] = static_cast<uint8_t>(index ^ 0x5A);
+  }
+  void* deviceSource = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&deviceSource, source.size()));
+  CUDACHECK_TEST(cudaMemcpy(
+      deviceSource, source.data(), source.size(), cudaMemcpyHostToDevice));
+  DeviceUint64Slot acquiredSignal;
+
+  struct StoreCase {
+    std::size_t destinationOffset;
+    std::size_t sourceOffset;
+    std::size_t bytes;
+    int unroll;
+  };
+  constexpr StoreCase kCases[] = {
+      {.destinationOffset = 1, .sourceOffset = 1, .bytes = 0, .unroll = 1},
+      {.destinationOffset = 4, .sourceOffset = 1, .bytes = 4, .unroll = 1},
+      {.destinationOffset = 8, .sourceOffset = 1, .bytes = 12, .unroll = 1},
+      {.destinationOffset = 64, .sourceOffset = 0, .bytes = 64, .unroll = 4},
+      {.destinationOffset = 128, .sourceOffset = 1, .bytes = 68, .unroll = 4},
+      {.destinationOffset = 512, .sourceOffset = 0, .bytes = 260, .unroll = 4},
+      {.destinationOffset = 1024,
+       .sourceOffset = 0,
+       .bytes = 2064,
+       .unroll = 4},
+      {.destinationOffset = 2048, .sourceOffset = 1, .bytes = 516, .unroll = 4},
+  };
+
+  uint64_t epoch = 0;
+  for (const auto& storeCase : kCases) {
+    ++epoch;
+    CUDACHECK_TEST(cudaMemset(deviceTransport.localData, kGuard, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+
+    if (globalRank == 0) {
+      test::launchMultimemStore(
+          deviceTransport,
+          storeCase.destinationOffset,
+          static_cast<const char*>(deviceSource) + storeCase.sourceOffset,
+          storeCase.bytes,
+          storeCase.unroll);
+      test::launchSetUserSignal(deviceTransport, /*signalId=*/0, epoch);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+    }
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+    test::launchWaitAndReadUserSignal(
+        deviceTransport,
+        /*signalId=*/0,
+        CmpOp::CMP_EQ,
+        epoch,
+        acquiredSignal.device_ptr());
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<uint8_t> actual(kDataBytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        actual.data(),
+        deviceTransport.localData,
+        actual.size(),
+        cudaMemcpyDeviceToHost));
+    std::vector<uint8_t> expected(kDataBytes, kGuard);
+    for (std::size_t index = 0; index < storeCase.bytes; ++index) {
+      expected[storeCase.destinationOffset + index] =
+          source[storeCase.sourceOffset + index];
+    }
+    EXPECT_EQ(actual, expected);
+  }
+
+  CUDACHECK_TEST(cudaFree(deviceSource));
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
 
 TEST_F(
     MultimemNvlTransportTestFixture,

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -26,6 +26,7 @@
 #include "comms/prims/memory/MultimemHandler.h"
 #include "comms/prims/tests/MultimemNvlTransportTest.cuh"
 #include "comms/prims/transport/nvl/MultiPeerNvlTransport.h"
+#include "comms/prims/transport/nvl/MultimemNvlRegistered.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlStore.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlTransport.h"
 #include "comms/testinfra/DistEnvironmentBase.h"
@@ -1334,6 +1335,16 @@ TEST(MultimemNvlStoreValidationTest, ValidatesAddressAndExtent) {
   EXPECT_FALSE(detail::is_multimem_store_valid(/*destination=*/4, /*bytes=*/2));
 }
 
+TEST(MultimemNvlReduceBroadcastValidationTest, ValidatesAddressAndExtent) {
+  EXPECT_TRUE(detail::is_reduce_broadcast_valid<float>(4, 8, 1));
+  EXPECT_TRUE(detail::is_reduce_broadcast_valid<__half>(16, 32, 8));
+  EXPECT_TRUE(detail::is_reduce_broadcast_valid<__nv_bfloat16>(16, 32, 8));
+  EXPECT_TRUE(detail::is_reduce_broadcast_valid<__half>(1, 1, 0));
+  EXPECT_FALSE(detail::is_reduce_broadcast_valid<float>(2, 8, 1));
+  EXPECT_FALSE(detail::is_reduce_broadcast_valid<__half>(2, 32, 8));
+  EXPECT_FALSE(detail::is_reduce_broadcast_valid<__half>(16, 32, 7));
+}
+
 TEST_F(
     MultimemNvlTransportTestFixture,
     DeviceMultimemStoreBroadcastsArbitraryRanges) {
@@ -2462,6 +2473,145 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceLoadReduceCoversPublicTypes) {
             sourceOffsetElems,
             [&, type](void* output, float expectedValue) {
               std::vector<uint16_t> values(kElems);
+              CUDACHECK_TEST(cudaMemcpy(
+                  values.data(),
+                  output,
+                  values.size() * sizeof(uint16_t),
+                  cudaMemcpyDeviceToHost));
+              for (uint16_t bits : values) {
+                float value = 0;
+                if (type == test::MultimemReductionTestType::Float16) {
+                  __half raw{};
+                  std::memcpy(&raw, &bits, sizeof(raw));
+                  value = __half2float(raw);
+                } else {
+                  __nv_bfloat16 raw{};
+                  std::memcpy(&raw, &bits, sizeof(raw));
+                  value = __bfloat162float(raw);
+                  expectedValue =
+                      __bfloat162float(__float2bfloat16(expectedValue));
+                }
+                EXPECT_EQ(value, expectedValue);
+              }
+            });
+      }
+    }
+  }
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    DeviceReduceBroadcastCoversPublicTypesAndAccModes) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_device_reduce_broadcast_types");
+  auto transport = makeExchangedTransport(
+      bootstrap,
+      globalRank,
+      numRanks,
+      localRank,
+      /*userSignalCount=*/0,
+      /*needsInternalSignals=*/true);
+  if (!transport) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kElements = 128;
+  constexpr std::size_t kDestinationOffsetBytes = 2048;
+  const float rankValue = static_cast<float>(globalRank + 1);
+  const float expected = static_cast<float>(numRanks * (numRanks + 1) / 2);
+  const auto handle = transport->getDeviceTransport();
+
+  auto run = [&](test::MultimemReductionTestType type,
+                 bool accF32,
+                 std::size_t elementSize,
+                 bool inPlace,
+                 std::size_t sourceOffsetElems,
+                 std::size_t outOfPlaceDestinationOffsetElems,
+                 auto verify) {
+    const std::size_t destinationOffsetElems =
+        inPlace ? sourceOffsetElems : outOfPlaceDestinationOffsetElems;
+    CUDACHECK_TEST(cudaMemset(handle.localData, 0, handle.dataBufferSize));
+    test::launchFillReductionInput(
+        handle, type, rankValue, kElements, sourceOffsetElems);
+    test::launchReduceBroadcast(
+        handle,
+        type,
+        accF32,
+        sourceOffsetElems,
+        destinationOffsetElems,
+        kElements);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    verify(handle.localData + destinationOffsetElems * elementSize, expected);
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+  };
+
+  for (const bool inPlace : {false, true}) {
+    run(test::MultimemReductionTestType::Float,
+        /*accF32=*/true,
+        sizeof(float),
+        inPlace,
+        /*sourceOffsetElems=*/0,
+        kDestinationOffsetBytes / sizeof(float),
+        [&](const void* output, float expectedValue) {
+          std::vector<float> values(kElements);
+          CUDACHECK_TEST(cudaMemcpy(
+              values.data(),
+              output,
+              values.size() * sizeof(float),
+              cudaMemcpyDeviceToHost));
+          for (float value : values) {
+            EXPECT_EQ(value, expectedValue);
+          }
+        });
+    run(test::MultimemReductionTestType::Float,
+        /*accF32=*/true,
+        sizeof(float),
+        inPlace,
+        /*sourceOffsetElems=*/1,
+        kDestinationOffsetBytes / sizeof(float) + 1,
+        [&](const void* output, float expectedValue) {
+          std::vector<float> values(kElements);
+          CUDACHECK_TEST(cudaMemcpy(
+              values.data(),
+              output,
+              values.size() * sizeof(float),
+              cudaMemcpyDeviceToHost));
+          for (float value : values) {
+            EXPECT_EQ(value, expectedValue);
+          }
+        });
+    run(test::MultimemReductionTestType::Int32,
+        /*accF32=*/true,
+        sizeof(int32_t),
+        inPlace,
+        /*sourceOffsetElems=*/0,
+        kDestinationOffsetBytes / sizeof(int32_t),
+        [&](const void* output, float expectedValue) {
+          std::vector<int32_t> values(kElements);
+          CUDACHECK_TEST(cudaMemcpy(
+              values.data(),
+              output,
+              values.size() * sizeof(int32_t),
+              cudaMemcpyDeviceToHost));
+          for (int32_t value : values) {
+            EXPECT_EQ(value, static_cast<int32_t>(expectedValue));
+          }
+        });
+
+    for (const auto type :
+         {test::MultimemReductionTestType::Float16,
+          test::MultimemReductionTestType::Bfloat16}) {
+      for (const bool accF32 : {false, true}) {
+        run(type,
+            accF32,
+            sizeof(uint16_t),
+            inPlace,
+            /*sourceOffsetElems=*/0,
+            kDestinationOffsetBytes / sizeof(uint16_t),
+            [&, type](const void* output, float expectedValue) {
+              std::vector<uint16_t> values(kElements);
               CUDACHECK_TEST(cudaMemcpy(
                   values.data(),
                   output,

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -8,6 +8,7 @@
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/tests/Checks.h"
 #include "comms/prims/transport/nvl/MultimemNvlReduce.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlRegistered.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlSignal.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlStageLayout.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlStore.cuh"
@@ -563,6 +564,31 @@ __global__ void loadReduceKernel(
       group, output, source, elems);
 }
 
+template <typename T, bool kAccF32>
+__global__ void reduceBroadcastKernel(
+    MultimemNvlTransportDevice transport,
+    std::size_t sourceOffsetElems,
+    std::size_t destinationOffsetElems,
+    std::size_t elems) {
+  auto block = make_block_group();
+  constexpr std::size_t kElementsPerPack = 16 / sizeof(T);
+  const std::size_t packs = elems / kElementsPerPack;
+  const std::size_t firstPack = packs * transport.nvlRank / transport.nvlRanks;
+  const std::size_t endPack =
+      packs * (transport.nvlRank + 1) / transport.nvlRanks;
+  const std::size_t first = firstPack * kElementsPerPack;
+  const std::size_t count = (endPack - firstPack) * kElementsPerPack;
+  auto* destination =
+      reinterpret_cast<T*>(transport.multimemData) + destinationOffsetElems;
+  const auto* source =
+      reinterpret_cast<const T*>(transport.multimemData) + sourceOffsetElems;
+
+  nvl_block_barrier(transport, /*channel=*/0, block);
+  multimem::reduce_broadcast_at<T, 4, kAccF32>(
+      block, destination + first, source + first, count);
+  nvl_block_barrier(transport, /*channel=*/0, block);
+}
+
 template <int kUnroll>
 __global__ void multimemStoreKernel(
     MultimemNvlTransportDevice transport,
@@ -648,6 +674,24 @@ void launchFillReductionInputTyped(
     cudaStream_t stream) {
   fillReductionInputKernel<T>
       <<<1, 32, 0, stream>>>(transport, value, elems, sourceOffsetElems);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+template <typename T>
+void launchReduceBroadcastTyped(
+    MultimemNvlTransportDevice transport,
+    bool accF32,
+    std::size_t sourceOffsetElems,
+    std::size_t destinationOffsetElems,
+    std::size_t elems,
+    cudaStream_t stream) {
+  if (accF32) {
+    reduceBroadcastKernel<T, true><<<1, 128, 0, stream>>>(
+        transport, sourceOffsetElems, destinationOffsetElems, elems);
+  } else {
+    reduceBroadcastKernel<T, false><<<1, 128, 0, stream>>>(
+        transport, sourceOffsetElems, destinationOffsetElems, elems);
+  }
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -994,6 +1038,50 @@ void launchLoadReduce(
     case MultimemReductionTestType::Bfloat16:
       return launchLoadReduceTyped<__nv_bfloat16>(
           transport, accF32, output, elems, sourceOffsetElems, stream);
+  }
+}
+
+void launchReduceBroadcast(
+    MultimemNvlTransportDevice transport,
+    MultimemReductionTestType type,
+    bool accF32,
+    std::size_t sourceOffsetElems,
+    std::size_t destinationOffsetElems,
+    std::size_t elems,
+    cudaStream_t stream) {
+  switch (type) {
+    case MultimemReductionTestType::Float:
+      return launchReduceBroadcastTyped<float>(
+          transport,
+          accF32,
+          sourceOffsetElems,
+          destinationOffsetElems,
+          elems,
+          stream);
+    case MultimemReductionTestType::Int32:
+      return launchReduceBroadcastTyped<int32_t>(
+          transport,
+          accF32,
+          sourceOffsetElems,
+          destinationOffsetElems,
+          elems,
+          stream);
+    case MultimemReductionTestType::Float16:
+      return launchReduceBroadcastTyped<__half>(
+          transport,
+          accF32,
+          sourceOffsetElems,
+          destinationOffsetElems,
+          elems,
+          stream);
+    case MultimemReductionTestType::Bfloat16:
+      return launchReduceBroadcastTyped<__nv_bfloat16>(
+          transport,
+          accF32,
+          sourceOffsetElems,
+          destinationOffsetElems,
+          elems,
+          stream);
   }
 }
 

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -562,6 +562,40 @@ __global__ void loadReduceKernel(
       group, output, source, elems);
 }
 
+template <typename T, bool kAccF32>
+__global__ void phasedReduceBlockKernel(MultimemNvlTransportDevice transport) {
+  auto block = make_block_group();
+  constexpr std::size_t kElements = sizeof(uint4) / sizeof(T);
+  auto* local = reinterpret_cast<T*>(transport.localData);
+  if (threadIdx.x < kElements) {
+    local[threadIdx.x] =
+        reductionValue<T>(phasedReduceBlockRankValue(transport.nvlRank));
+  }
+  nvl_block_barrier(transport, /*channel=*/0, block);
+
+  uint4 reduced{};
+  if (block.is_leader()) {
+    reduced = multimem::load_reduce_block16<T, kAccF32>(
+        reinterpret_cast<const T*>(transport.multimemData));
+  }
+  nvl_block_barrier(transport, /*channel=*/0, block);
+
+  if (block.is_leader()) {
+    const std::size_t ownedFirstLane = kElements *
+        static_cast<std::size_t>(transport.nvlRank) /
+        static_cast<std::size_t>(transport.nvlRanks);
+    const std::size_t ownedEndLane = kElements *
+        static_cast<std::size_t>(transport.nvlRank + 1) /
+        static_cast<std::size_t>(transport.nvlRanks);
+    multimem::store_reduced_block16_range(
+        local + ownedFirstLane,
+        reduced,
+        ownedFirstLane,
+        ownedEndLane - ownedFirstLane);
+  }
+  nvl_block_barrier(transport, /*channel=*/0, block);
+}
+
 __global__ void stageLayoutKernel(
     MultimemNvlTransportDevice transport,
     StageLayoutResult* results) {
@@ -619,6 +653,19 @@ void launchLoadReduceTyped(
   } else {
     loadReduceKernel<T, false><<<1, 32, 0, stream>>>(
         transport, static_cast<T*>(output), elems, sourceOffsetElems);
+  }
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+template <typename T>
+void launchPhasedReduceBlockTyped(
+    MultimemNvlTransportDevice transport,
+    bool accF32,
+    cudaStream_t stream) {
+  if (accF32) {
+    phasedReduceBlockKernel<T, true><<<1, 128, 0, stream>>>(transport);
+  } else {
+    phasedReduceBlockKernel<T, false><<<1, 128, 0, stream>>>(transport);
   }
   PIPES_KERNEL_LAUNCH_CHECK();
 }
@@ -935,6 +982,23 @@ void launchLoadReduce(
     case MultimemReductionTestType::Bfloat16:
       return launchLoadReduceTyped<__nv_bfloat16>(
           transport, accF32, output, elems, sourceOffsetElems, stream);
+  }
+}
+
+void launchPhasedReduceBlock(
+    MultimemNvlTransportDevice transport,
+    MultimemReductionTestType type,
+    bool accF32,
+    cudaStream_t stream) {
+  switch (type) {
+    case MultimemReductionTestType::Float16:
+      return launchPhasedReduceBlockTyped<__half>(transport, accF32, stream);
+    case MultimemReductionTestType::Bfloat16:
+      return launchPhasedReduceBlockTyped<__nv_bfloat16>(
+          transport, accF32, stream);
+    case MultimemReductionTestType::Float:
+    case MultimemReductionTestType::Int32:
+      throw std::runtime_error("phased reduce block requires a 2-byte type");
   }
 }
 

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -10,6 +10,7 @@
 #include "comms/prims/transport/nvl/MultimemNvlReduce.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlSignal.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlStageLayout.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlStore.cuh"
 
 namespace comms::prims::test {
 
@@ -562,6 +563,17 @@ __global__ void loadReduceKernel(
       group, output, source, elems);
 }
 
+template <int kUnroll>
+__global__ void multimemStoreKernel(
+    MultimemNvlTransportDevice transport,
+    std::size_t destinationOffset,
+    const void* source,
+    std::size_t bytes) {
+  auto group = make_warp_group();
+  multimem::store<kUnroll>(
+      group, transport.multimem_data_ptr(destinationOffset), source, bytes);
+}
+
 template <typename T, bool kAccF32>
 __global__ void phasedReduceBlockKernel(MultimemNvlTransportDevice transport) {
   auto block = make_block_group();
@@ -983,6 +995,25 @@ void launchLoadReduce(
       return launchLoadReduceTyped<__nv_bfloat16>(
           transport, accF32, output, elems, sourceOffsetElems, stream);
   }
+}
+
+void launchMultimemStore(
+    MultimemNvlTransportDevice transport,
+    std::size_t destinationOffset,
+    const void* source,
+    std::size_t bytes,
+    int unroll,
+    cudaStream_t stream) {
+  if (unroll == 1) {
+    multimemStoreKernel<1>
+        <<<1, 32, 0, stream>>>(transport, destinationOffset, source, bytes);
+  } else if (unroll == 4) {
+    multimemStoreKernel<4>
+        <<<1, 32, 0, stream>>>(transport, destinationOffset, source, bytes);
+  } else {
+    throw std::invalid_argument("test supports unroll 1 or 4");
+  }
+  PIPES_KERNEL_LAUNCH_CHECK();
 }
 
 void launchPhasedReduceBlock(

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -15,6 +15,23 @@ namespace comms::prims::test {
 
 enum class MultimemReductionTestType { Float, Int32, Float16, Bfloat16 };
 
+__host__ __device__ constexpr float phasedReduceBlockRankValue(
+    std::size_t nvlRank) {
+  return static_cast<float>(nvlRank % 4 + 1);
+}
+
+constexpr float phasedReduceBlockExpectedValue(std::size_t nvlRanks) {
+  float result = 0.0f;
+  for (std::size_t rank = 0; rank < nvlRanks; ++rank) {
+    result += phasedReduceBlockRankValue(rank);
+  }
+  return result;
+}
+
+static_assert(
+    phasedReduceBlockExpectedValue(kMaxNvlSignalRanks) <= 256.0f,
+    "phased reduction test values must sum exactly in bf16");
+
 struct StageLayoutResult {
   std::size_t channelBeginBytes;
   std::size_t stagingBytes;
@@ -205,6 +222,12 @@ void launchLoadReduce(
     void* output,
     std::size_t elems,
     std::size_t sourceOffsetElems,
+    cudaStream_t stream = nullptr);
+
+void launchPhasedReduceBlock(
+    MultimemNvlTransportDevice transport,
+    MultimemReductionTestType type,
+    bool accF32,
     cudaStream_t stream = nullptr);
 
 void launchStageLayout(

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -224,6 +224,14 @@ void launchLoadReduce(
     std::size_t sourceOffsetElems,
     cudaStream_t stream = nullptr);
 
+void launchMultimemStore(
+    MultimemNvlTransportDevice transport,
+    std::size_t destinationOffset,
+    const void* source,
+    std::size_t bytes,
+    int unroll,
+    cudaStream_t stream = nullptr);
+
 void launchPhasedReduceBlock(
     MultimemNvlTransportDevice transport,
     MultimemReductionTestType type,

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -224,6 +224,15 @@ void launchLoadReduce(
     std::size_t sourceOffsetElems,
     cudaStream_t stream = nullptr);
 
+void launchReduceBroadcast(
+    MultimemNvlTransportDevice transport,
+    MultimemReductionTestType type,
+    bool accF32,
+    std::size_t sourceOffsetElems,
+    std::size_t destinationOffsetElems,
+    std::size_t elems,
+    cudaStream_t stream = nullptr);
+
 void launchMultimemStore(
     MultimemNvlTransportDevice transport,
     std::size_t destinationOffset,

--- a/comms/prims/transport/nvl/MultimemNvlReduce.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlReduce.cuh
@@ -5,9 +5,8 @@
 // Holds the reduce side of the NVLS staging model: the raw `multimem.ld_reduce`
 // PTX emitters (`comms::prims::detail`) and the public entry point
 // `multimem::load_reduce_at<>` that reads the cross-rank reduction of a
-// multicast VA into a local buffer. The store side (`multimem::store()`) and
-// the staging orchestration that composes both land later in the stack
-// (`MultimemNvlStore.cuh`, `MultimemNvlStaging.cuh`).
+// multicast VA into a local buffer. The store side (`multimem::store()`) lives
+// in `MultimemNvlStore.cuh`.
 
 // clang-tidy analyzes this .cuh as a standalone main file and misflags the
 // pragma; it is a genuine include-once header. False positive, so suppress it.

--- a/comms/prims/transport/nvl/MultimemNvlReduce.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlReduce.cuh
@@ -21,6 +21,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <type_traits>
 
 #include "comms/prims/core/ThreadGroup.cuh"
@@ -229,6 +230,63 @@ namespace comms::prims::multimem {
 
 /** Reduction operator for the multimem data reduce verbs. Only Add today. */
 enum class MultimemRedOp { Add };
+
+/**
+ * Reduces one aligned 16-byte fp16 or bf16 block into registers.
+ *
+ * Keeping the reduced block separate from the eventual stores lets callers
+ * place a team barrier between the read and write phases when adjacent ranks
+ * own different lanes of the same 16-byte block.
+ */
+template <typename T, bool kAccF32 = true>
+__device__ __forceinline__ uint4 load_reduce_block16(const T* multicastBlock) {
+  static_assert(
+      std::is_same_v<T, __half> || std::is_same_v<T, __nv_bfloat16>,
+      "load_reduce_block16 supports fp16 and bf16");
+#if defined(__CUDA_ARCH__)
+  const uintptr_t sourceAddress = reinterpret_cast<uintptr_t>(multicastBlock);
+  if (sourceAddress % alignof(uint4) != 0) {
+    printf(
+        "NVL load_reduce_block16 requires a 16-byte-aligned source: "
+        "source=0x%llx\n",
+        static_cast<unsigned long long>(sourceAddress));
+    __trap();
+  }
+#endif
+  const auto* source = reinterpret_cast<const uint4*>(multicastBlock);
+  if constexpr (std::is_same_v<T, __half>) {
+    return comms::prims::detail::multimem_ld_reduce_v4_f16x2<kAccF32>(source);
+  } else {
+    return comms::prims::detail::multimem_ld_reduce_v4_bf16x2<kAccF32>(source);
+  }
+}
+
+/**
+ * Stores `count` lanes starting at `sourceFirstLane` from a previously
+ * reduced 16-byte block.
+ *
+ * `destination` must point to the first destination element and provide
+ * storage for `count` elements.
+ */
+template <typename T>
+__device__ __forceinline__ void store_reduced_block16_range(
+    T* destination,
+    const uint4& block,
+    std::size_t sourceFirstLane,
+    std::size_t count) {
+  static_assert(
+      sizeof(T) == 2, "store_reduced_block16_range requires a 2-byte type");
+#if defined(__CUDA_ARCH__)
+  constexpr std::size_t kLaneCount = sizeof(uint4) / sizeof(T);
+  if (sourceFirstLane > kLaneCount || count > kLaneCount - sourceFirstLane) {
+    __trap();
+  }
+#endif
+  const auto* lanes = reinterpret_cast<const T*>(&block);
+  for (std::size_t index = 0; index < count; ++index) {
+    destination[index] = lanes[sourceFirstLane + index];
+  }
+}
 
 /**
  * multimem.ld_reduce from an ARBITRARY multicast base pointer into `dst`.

--- a/comms/prims/transport/nvl/MultimemNvlRegistered.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlRegistered.cuh
@@ -1,0 +1,189 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace comms::prims::detail {
+
+template <typename T>
+__host__ __device__ constexpr bool is_reduce_broadcast_valid(
+    uintptr_t destination,
+    uintptr_t source,
+    std::size_t elements) {
+  if (elements == 0) {
+    return true;
+  }
+  if constexpr (std::is_same_v<T, __half> || std::is_same_v<T, __nv_bfloat16>) {
+    return ((destination | source) & 15) == 0 && (elements & 7) == 0;
+  }
+  return ((destination | source) & 3) == 0;
+}
+
+} // namespace comms::prims::detail
+
+#if defined(ENABLE_PRIMS)
+
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlReduce.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlStore.cuh"
+
+namespace comms::prims::detail {
+
+template <int kUnroll, typename Load>
+__device__ __forceinline__ void reduce_broadcast_vectors(
+    ThreadGroup& group,
+    uint4* destination,
+    const uint4* source,
+    std::size_t count,
+    Load load) {
+  static_assert(kUnroll > 0);
+  const std::size_t groupSize = group.group_size;
+  const std::size_t first = group.thread_id_in_group;
+  for (std::size_t base = first; base < count; base += groupSize * kUnroll) {
+    uint4 values[kUnroll];
+#pragma unroll
+    for (int index = 0; index < kUnroll; ++index) {
+      const std::size_t offset =
+          base + static_cast<std::size_t>(index) * groupSize;
+      if (offset < count) {
+        values[index] = load(source + offset);
+      }
+    }
+#pragma unroll
+    for (int index = 0; index < kUnroll; ++index) {
+      const std::size_t offset =
+          base + static_cast<std::size_t>(index) * groupSize;
+      if (offset < count) {
+        comms::prims::detail::multimem_store_v4_u32(
+            destination + offset, values[index]);
+      }
+    }
+  }
+}
+
+} // namespace comms::prims::detail
+
+namespace comms::prims::multimem {
+
+/**
+ * Reduce from one multicast address and broadcast to another without scratch.
+ *
+ * The reduced value remains in registers between `multimem.ld_reduce` and
+ * `multimem.st`.
+ * The primitive performs no cross-rank synchronization.
+ * In-place callers partition the range into disjoint rank-owned shards and
+ * bracket the operation with team barriers.
+ * This primitive exposes fp16 and bf16 only as complete 16-byte reduction
+ * packs, so those types require aligned source and destination ranges whose
+ * element counts are multiples of eight.
+ */
+template <typename T, int kUnroll = 1, bool kAccF32 = true>
+__device__ __forceinline__ void reduce_broadcast_at(
+    ThreadGroup& group,
+    T* destination,
+    const T* source,
+    std::size_t elements) {
+  static_assert(kUnroll > 0);
+  if (!comms::prims::detail::is_reduce_broadcast_valid<T>(
+          reinterpret_cast<uintptr_t>(destination),
+          reinterpret_cast<uintptr_t>(source),
+          elements)) {
+    __trap();
+    return;
+  }
+  if (elements == 0) {
+    return;
+  }
+
+  if constexpr (std::is_same_v<T, float>) {
+    const auto addresses = reinterpret_cast<uintptr_t>(destination) |
+        reinterpret_cast<uintptr_t>(source);
+    const std::size_t vectorCount = (addresses & 15) == 0 ? elements / 4 : 0;
+    if (vectorCount != 0) {
+      comms::prims::detail::reduce_broadcast_vectors<kUnroll>(
+          group,
+          reinterpret_cast<uint4*>(destination),
+          reinterpret_cast<const uint4*>(source),
+          vectorCount,
+          [](const uint4* address) {
+            const float4 reduced =
+                comms::prims::detail::multimem_ld_reduce_v4_f32(
+                    reinterpret_cast<const float4*>(address));
+            uint4 bits;
+            __builtin_memcpy(&bits, &reduced, sizeof(bits));
+            return bits;
+          });
+    }
+    const std::size_t stride = group.group_size;
+    for (std::size_t index = vectorCount * 4 + group.thread_id_in_group;
+         index < elements;
+         index += stride) {
+      const float reduced =
+          comms::prims::detail::multimem_ld_reduce_f32(source + index);
+      uint32_t bits;
+      __builtin_memcpy(&bits, &reduced, sizeof(bits));
+      comms::prims::detail::multimem_store_u32(
+          reinterpret_cast<uint32_t*>(destination + index), bits);
+    }
+  } else if constexpr (std::is_same_v<T, __half>) {
+    comms::prims::detail::reduce_broadcast_vectors<kUnroll>(
+        group,
+        reinterpret_cast<uint4*>(destination),
+        reinterpret_cast<const uint4*>(source),
+        elements / 8,
+        [](const uint4* address) {
+          return comms::prims::detail::multimem_ld_reduce_v4_f16x2<kAccF32>(
+              address);
+        });
+  } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    comms::prims::detail::reduce_broadcast_vectors<kUnroll>(
+        group,
+        reinterpret_cast<uint4*>(destination),
+        reinterpret_cast<const uint4*>(source),
+        elements / 8,
+        [](const uint4* address) {
+          return comms::prims::detail::multimem_ld_reduce_v4_bf16x2<kAccF32>(
+              address);
+        });
+  } else if constexpr (std::is_same_v<T, int32_t>) {
+    const std::size_t groupSize = group.group_size;
+    const std::size_t first = group.thread_id_in_group;
+    for (std::size_t base = first; base < elements;
+         base += groupSize * kUnroll) {
+      int32_t values[kUnroll];
+#pragma unroll
+      for (int index = 0; index < kUnroll; ++index) {
+        const std::size_t offset =
+            base + static_cast<std::size_t>(index) * groupSize;
+        if (offset < elements) {
+          values[index] =
+              comms::prims::detail::multimem_ld_reduce_s32(source + offset);
+        }
+      }
+#pragma unroll
+      for (int index = 0; index < kUnroll; ++index) {
+        const std::size_t offset =
+            base + static_cast<std::size_t>(index) * groupSize;
+        if (offset < elements) {
+          comms::prims::detail::multimem_store_u32(
+              reinterpret_cast<uint32_t*>(destination + offset),
+              static_cast<uint32_t>(values[index]));
+        }
+      }
+    }
+  } else {
+    static_assert(sizeof(T) == 0, "unsupported reduce-broadcast datatype");
+  }
+}
+
+} // namespace comms::prims::multimem
+
+#endif // ENABLE_PRIMS

--- a/comms/prims/transport/nvl/MultimemNvlStore.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlStore.cuh
@@ -1,0 +1,194 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#if defined(ENABLE_PRIMS)
+#include "comms/prims/core/DeviceCheck.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#endif
+
+namespace comms::prims::detail {
+
+__host__ __device__ constexpr bool is_multimem_store_valid(
+    uintptr_t destination,
+    std::size_t bytes) {
+  return bytes == 0 || ((destination & 3) == 0 && (bytes & 3) == 0);
+}
+
+} // namespace comms::prims::detail
+
+#if defined(ENABLE_PRIMS)
+
+namespace comms::prims::detail {
+
+__device__ __forceinline__ uint32_t load_u32_unaligned(const char* source) {
+  const auto* bytes = reinterpret_cast<const uint8_t*>(source);
+  return static_cast<uint32_t>(bytes[0]) |
+      (static_cast<uint32_t>(bytes[1]) << 8) |
+      (static_cast<uint32_t>(bytes[2]) << 16) |
+      (static_cast<uint32_t>(bytes[3]) << 24);
+}
+
+__device__ __forceinline__ void multimem_store_u32(
+    uint32_t* destination,
+    uint32_t value) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("multimem.st.relaxed.sys.global.b32 [%0], %1;"
+               :
+               : "l"(__cvta_generic_to_global(destination)), "r"(value)
+               : "memory");
+#elif defined(__CUDA_ARCH__)
+  __trap();
+#endif
+}
+
+__device__ __forceinline__ void multimem_store_v4_u32(
+    uint4* destination,
+    uint4 value) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("multimem.st.relaxed.sys.global.v4.f32 [%0], {%1,%2,%3,%4};"
+               :
+               : "l"(__cvta_generic_to_global(destination)),
+                 "r"(value.x),
+                 "r"(value.y),
+                 "r"(value.z),
+                 "r"(value.w)
+               : "memory");
+#elif defined(__CUDA_ARCH__)
+  __trap();
+#endif
+}
+
+template <int kUnroll>
+__device__ __forceinline__ void store_vectors(
+    ThreadGroup& group,
+    uint4* destination,
+    const uint4* source,
+    std::size_t count) {
+  static_assert(kUnroll > 0);
+  const std::size_t groupSize = group.group_size;
+  const std::size_t first = group.thread_id_in_group;
+  for (std::size_t base = first; base < count; base += groupSize * kUnroll) {
+    uint4 values[kUnroll];
+#pragma unroll
+    for (int index = 0; index < kUnroll; ++index) {
+      const std::size_t offset =
+          base + static_cast<std::size_t>(index) * groupSize;
+      if (offset < count) {
+        values[index] = source[offset];
+      }
+    }
+#pragma unroll
+    for (int index = 0; index < kUnroll; ++index) {
+      const std::size_t offset =
+          base + static_cast<std::size_t>(index) * groupSize;
+      if (offset < count) {
+        multimem_store_v4_u32(destination + offset, values[index]);
+      }
+    }
+  }
+}
+
+template <int kUnroll>
+__device__ __forceinline__ void store_words(
+    ThreadGroup& group,
+    uint32_t* destination,
+    const char* source,
+    std::size_t count) {
+  static_assert(kUnroll > 0);
+  const std::size_t groupSize = group.group_size;
+  const std::size_t first = group.thread_id_in_group;
+  for (std::size_t base = first; base < count; base += groupSize * kUnroll) {
+    uint32_t values[kUnroll];
+#pragma unroll
+    for (int index = 0; index < kUnroll; ++index) {
+      const std::size_t offset =
+          base + static_cast<std::size_t>(index) * groupSize;
+      if (offset < count) {
+        values[index] = load_u32_unaligned(source + offset * sizeof(uint32_t));
+      }
+    }
+#pragma unroll
+    for (int index = 0; index < kUnroll; ++index) {
+      const std::size_t offset =
+          base + static_cast<std::size_t>(index) * groupSize;
+      if (offset < count) {
+        multimem_store_u32(destination + offset, values[index]);
+      }
+    }
+  }
+}
+
+} // namespace comms::prims::detail
+
+namespace comms::prims::multimem {
+
+/**
+ * Broadcast bytes from a local source into an arbitrary multicast address.
+ *
+ * Every member of `group` must call with identical arguments.
+ * Source and destination may be identical. Otherwise their ranges must not
+ * overlap; like memcpy, this primitive does not provide memmove semantics.
+ * Host launchers must call `is_multimem_store_valid` before launch; the device
+ * check below is only a fail-fast backstop for contract violations.
+ * A nonempty destination must be four-byte aligned and `bytes` must be a
+ * multiple of four, matching the smallest NVLS multicast store width.
+ * The aligned path uses 16-byte vector stores, while the general path accepts
+ * any source alignment and issues four-byte stores.
+ * Stores use relaxed system ordering, so callers publish completion with an
+ * ordered signal before consumers read their local backing.
+ */
+template <int kUnroll = 1>
+__device__ __forceinline__ void store(
+    ThreadGroup& group,
+    char* destination,
+    const void* source,
+    std::size_t bytes) {
+  static_assert(kUnroll > 0);
+  if (bytes == 0) {
+    return;
+  }
+
+  const auto destinationAddress = reinterpret_cast<uintptr_t>(destination);
+  const bool valid =
+      comms::prims::detail::is_multimem_store_valid(destinationAddress, bytes);
+  PIPES_DEVICE_CHECK_MSG(
+      valid,
+      "multimem::store requires a four-byte-aligned destination and extent");
+  if (!valid) {
+    return;
+  }
+
+  const auto sourceAddress = reinterpret_cast<uintptr_t>(source);
+  if (((sourceAddress | destinationAddress) & 15) == 0) {
+    const std::size_t vectorCount = bytes / sizeof(uint4);
+    comms::prims::detail::store_vectors<kUnroll>(
+        group,
+        reinterpret_cast<uint4*>(destination),
+        static_cast<const uint4*>(source),
+        vectorCount);
+    const std::size_t vectorBytes = vectorCount * sizeof(uint4);
+    comms::prims::detail::store_words<kUnroll>(
+        group,
+        reinterpret_cast<uint32_t*>(destination + vectorBytes),
+        static_cast<const char*>(source) + vectorBytes,
+        (bytes - vectorBytes) / sizeof(uint32_t));
+    return;
+  }
+
+  comms::prims::detail::store_words<kUnroll>(
+      group,
+      reinterpret_cast<uint32_t*>(destination),
+      static_cast<const char*>(source),
+      bytes / sizeof(uint32_t));
+}
+
+} // namespace comms::prims::multimem
+
+#endif // ENABLE_PRIMS

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -63,8 +63,8 @@ __device__ __forceinline__ void multimem_red_release_sys_add_u64(
  * spans are this rank's backing memory after multicast replication. Callers
  * that want to reduce from the multicast VA should obtain
  * `multimem_data_ptr()` and pass it to `multimem::load_reduce_at()`, defined
- * in `MultimemNvlReduce.cuh`. Broadcast-store helpers are introduced by the
- * later store-primitives diff.
+ * in `MultimemNvlReduce.cuh`. Broadcast stores into arbitrary multicast
+ * addresses are defined in `MultimemNvlStore.cuh`.
  */
 struct MultimemNvlTransportDevice {
   char* localData{nullptr};


### PR DESCRIPTION
Summary:

## Core implementation

Add `reduce_broadcast_at` as a registered-address NVL primitive that reduces from one multicast range and broadcasts the result directly into another.
Keep reduced values in registers between `multimem.ld_reduce` and `multimem.st`.
Use 16-byte vector operations for aligned FP32, FP16, and BF16 ranges, scalar FP32 handling for unaligned vectors and tails, and scalar unrolled INT32 operations.
Support both FP32 and native FP16 or BF16 accumulation without adding synchronization inside the primitive.

## Background

Registered AllReduce assigns disjoint rank-owned shards and brackets this primitive with team barriers, including exact in-place operation.
Keeping synchronization and ownership outside the primitive makes the registered data movement reusable while preserving a branch-free typed kernel path.

#aup

Reviewed By: saifhhasan

Differential Revision: D110801592


