### PR TITLE
validate and initialize local NVL domains

### DIFF
--- a/comms/prims/tests/MultiPeerTransportTest.cc
+++ b/comms/prims/tests/MultiPeerTransportTest.cc
@@ -1,5 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <algorithm>
 #include <cstring>
 
 #include <unistd.h>
@@ -22,9 +23,10 @@
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
-#include "comms/utils/CudaRAII.h"
 
-using namespace meta::comms;
+using meta::comms::MpiBaseTestFixture;
+using meta::comms::MpiBootstrap;
+using meta::comms::MPIEnvironmentBase;
 
 namespace comms::prims::tests {
 
@@ -45,7 +47,8 @@ class MultiPeerTransportTestFixture : public MpiBaseTestFixture {
   }
 
   std::unique_ptr<MultiPeerTransport> createTransport(
-      std::shared_ptr<comms::fault_tolerance::Abort> abort = nullptr) {
+      std::shared_ptr<comms::fault_tolerance::Abort> abort = nullptr,
+      std::optional<std::vector<int>> logicalNvlRanks = std::nullopt) {
     MultiPeerTransportConfig config{
         .nvlConfig =
             {
@@ -58,6 +61,7 @@ class MultiPeerTransportTestFixture : public MpiBaseTestFixture {
             {
                 .cudaDevice = localRank,
             },
+        .topoConfig = {.logicalNvlRanks = std::move(logicalNvlRanks)},
     };
     return std::make_unique<MultiPeerTransport>(
         globalRank,
@@ -159,6 +163,9 @@ TEST_F(MultiPeerTransportTestFixture, TopologyDiscovery) {
   EXPECT_EQ(transport->get_transport_type(globalRank), TransportType::SELF);
   EXPECT_EQ(transport->get_transport_type(peer), TransportType::P2P_NVL);
   EXPECT_FALSE(transport->nvl_peer_ranks().empty());
+  EXPECT_EQ(
+      transport->nvl_rank_map_matches_config(),
+      transport->nvl_n_ranks() == transport->n_ranks());
   // Every remote rank must be classified either as NVL-reachable or as an
   // IB peer (no rank should be "unclassified"). On MNNVL, all peers are
   // NVL-reachable and ib_peer_ranks is empty; on non-MNNVL, IB covers what
@@ -168,6 +175,29 @@ TEST_F(MultiPeerTransportTestFixture, TopologyDiscovery) {
       static_cast<int>(transport->nvl_peer_ranks().size()) +
       static_cast<int>(transport->ib_peer_ranks().size());
   EXPECT_EQ(totalClassified, numRanks - 1);
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_F(
+    MultiPeerTransportTestFixture,
+    ConfiguredLocalRankMapSupportsMultipleNvlDomains) {
+  ASSERT_EQ(numRanks, 4);
+
+  const int domainStart = (globalRank / 2) * 2;
+  std::vector<int> logicalNvlRanks{domainStart, domainStart + 1};
+  auto transport = createTransport(nullptr, logicalNvlRanks);
+  EXPECT_TRUE(transport->nvl_rank_map_matches_config());
+  EXPECT_EQ(transport->n_ranks(), 4);
+  EXPECT_EQ(transport->nvl_n_ranks(), 2);
+  EXPECT_NE(transport->n_ranks(), transport->nvl_n_ranks());
+  EXPECT_EQ(transport->nvl_local_rank(), globalRank % 2);
+  transport.reset();
+
+  auto mismatchedRanks = logicalNvlRanks;
+  std::reverse(mismatchedRanks.begin(), mismatchedRanks.end());
+  auto mismatchedTransport = createTransport(nullptr, mismatchedRanks);
+  EXPECT_FALSE(mismatchedTransport->nvl_rank_map_matches_config());
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -420,6 +450,7 @@ TEST_F(MultiPeerTransportTestFixture, ExchangeNvlBufferFabric) {
   accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
   ASSERT_EQ(cuMemSetAccess(devPtr, allocSize, &accessDesc, 1), CUDA_SUCCESS);
 
+  // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type.
   void* localBuf = reinterpret_cast<void*>(devPtr);
   CUDACHECK_TEST(cudaMemset(localBuf, globalRank + 1, requestedSize));
   CUDACHECK_TEST(cudaDeviceSynchronize());
@@ -499,6 +530,7 @@ TEST_F(MultiPeerTransportTestFixture, ExchangeNvlBufferPosixFd) {
   accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
   ASSERT_EQ(cuMemSetAccess(devPtr, allocSize, &accessDesc, 1), CUDA_SUCCESS);
 
+  // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type.
   void* localBuf = reinterpret_cast<void*>(devPtr);
   CUDACHECK_TEST(cudaMemset(localBuf, globalRank + 1, requestedSize));
   CUDACHECK_TEST(cudaDeviceSynchronize());
@@ -578,7 +610,8 @@ TEST_F(MultiPeerTransportTestFixture, ExchangeNvlBufferPosixFd_MultipleRounds) {
     accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
     ASSERT_EQ(cuMemSetAccess(devPtr, allocSize, &accessDesc, 1), CUDA_SUCCESS);
 
-    void* localBuf = reinterpret_cast<void*>(devPtr);
+    void* localBuf =
+        reinterpret_cast<void*>(devPtr); // NOLINT(performance-no-int-to-ptr)
     CUDACHECK_TEST(cudaMemset(localBuf, iter + 1, requestedSize));
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
@@ -651,6 +684,7 @@ TEST_F(MultiPeerTransportTestFixture, ExchangeNvlBufferCuMemNone_Throws) {
   accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
   ASSERT_EQ(cuMemSetAccess(devPtr, allocSize, &accessDesc, 1), CUDA_SUCCESS);
 
+  // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type.
   void* localBuf = reinterpret_cast<void*>(devPtr);
 
   EXPECT_THROW(transport->exchangeNvlBuffer(localBuf), std::runtime_error);

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cu
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cu
@@ -138,6 +138,12 @@ __global__ void nvlSignalTrapKernel(
     return;
   }
   auto group = make_block_group();
+  if (testCase == NvlSignalTrapCase::BlockBarrierNon1DBlock ||
+      testCase == NvlSignalTrapCase::BlockBarrierDuplicateChannelOwner ||
+      testCase == NvlSignalTrapCase::BlockBarrierNon1DGrid) {
+    nvl_signal_detail::validate_block_barrier(transport, /*channel=*/0, group);
+    return;
+  }
   if (testCase == NvlSignalTrapCase::PerPeerDuplicateChannelOwner ||
       testCase == NvlSignalTrapCase::PerPeerNon1DBlock) {
     signal_publish<
@@ -267,6 +273,7 @@ dim3 signal_trap_threads(NvlSignalTrapCase testCase) {
     case NvlSignalTrapCase::DuplicateChannelOwner:
       return dim3(2 * kWarpSize);
     case NvlSignalTrapCase::PerPeerNon1DBlock:
+    case NvlSignalTrapCase::BlockBarrierNon1DBlock:
       return dim3(kNvlSignalSmallPerPeerThreads, 2);
     case NvlSignalTrapCase::AggregateDepthTooLarge:
     case NvlSignalTrapCase::ArrivalCountMismatch:
@@ -282,8 +289,10 @@ dim3 signal_trap_threads(NvlSignalTrapCase testCase) {
 dim3 signal_trap_blocks(NvlSignalTrapCase testCase) {
   switch (testCase) {
     case NvlSignalTrapCase::PerPeerDuplicateChannelOwner:
+    case NvlSignalTrapCase::BlockBarrierDuplicateChannelOwner:
       return dim3(2);
     case NvlSignalTrapCase::AggregateNon1DGrid:
+    case NvlSignalTrapCase::BlockBarrierNon1DGrid:
       return dim3(1, 2);
     default:
       return dim3(1);

--- a/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
+++ b/comms/prims/tests/MultimemNvlSignalTrapTest.cuh
@@ -27,6 +27,9 @@ enum class NvlSignalTrapCase : uint32_t {
   AggregateNon1DGrid,
   PerPeerDuplicateChannelOwner,
   PerPeerNon1DBlock,
+  BlockBarrierNon1DBlock,
+  BlockBarrierDuplicateChannelOwner,
+  BlockBarrierNon1DGrid,
 };
 
 enum class NvlSignalRankBoundaryWaitPolicy : uint32_t {

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -2388,6 +2388,64 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceLoadReduceCoversPublicTypes) {
   }
 }
 
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    PhasedReduceBlockPreservesOwnedFp16AndBf16Lanes) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_phased_reduce_block");
+  auto transport = makeExchangedTransport(
+      bootstrap,
+      globalRank,
+      numRanks,
+      localRank,
+      /*userSignalCount=*/0,
+      /*needsInternalSignals=*/true);
+  if (!transport) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kElements = 8;
+  const float expected = static_cast<float>(numRanks * (numRanks + 1) / 2);
+  const std::size_t firstLane = kElements *
+      static_cast<std::size_t>(globalRank) / static_cast<std::size_t>(numRanks);
+  const std::size_t endLane = kElements *
+      static_cast<std::size_t>(globalRank + 1) /
+      static_cast<std::size_t>(numRanks);
+  for (const auto type :
+       {test::MultimemReductionTestType::Float16,
+        test::MultimemReductionTestType::Bfloat16}) {
+    for (const bool accF32 : {false, true}) {
+      void* output = nullptr;
+      CUDACHECK_TEST(cudaMalloc(&output, 16));
+      CUDACHECK_TEST(cudaMemset(output, 0, 16));
+      test::launchPhasedReduceBlock(
+          transport->getDeviceTransport(), type, accF32, output);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      std::vector<uint16_t> values(kElements);
+      CUDACHECK_TEST(
+          cudaMemcpy(values.data(), output, 16, cudaMemcpyDeviceToHost));
+      CUDACHECK_TEST(cudaFree(output));
+      for (std::size_t lane = 0; lane < kElements; ++lane) {
+        float value = 0;
+        if (type == test::MultimemReductionTestType::Float16) {
+          __half raw{};
+          std::memcpy(&raw, &values[lane], sizeof(raw));
+          value = __half2float(raw);
+        } else {
+          __nv_bfloat16 raw{};
+          std::memcpy(&raw, &values[lane], sizeof(raw));
+          value = __bfloat162float(raw);
+        }
+        EXPECT_EQ(value, lane >= firstLane && lane < endLane ? expected : 0);
+      }
+      ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+    }
+  }
+}
+
 } // namespace comms::prims::tests
 
 int main(int argc, char* argv[]) {

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -26,6 +26,7 @@
 #include "comms/prims/memory/MultimemHandler.h"
 #include "comms/prims/tests/MultimemNvlTransportTest.cuh"
 #include "comms/prims/transport/nvl/MultiPeerNvlTransport.h"
+#include "comms/prims/transport/nvl/MultimemNvlRegistered.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlStore.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlTransport.h"
 #include "comms/testinfra/DistEnvironmentBase.h"
@@ -1334,6 +1335,16 @@ TEST(MultimemNvlStoreValidationTest, ValidatesAddressAndExtent) {
   EXPECT_FALSE(detail::is_multimem_store_valid(/*destination=*/4, /*bytes=*/2));
 }
 
+TEST(MultimemNvlReduceBroadcastValidationTest, ValidatesAddressAndExtent) {
+  EXPECT_TRUE(detail::is_reduce_broadcast_valid<float>(4, 8, 1));
+  EXPECT_TRUE(detail::is_reduce_broadcast_valid<__half>(16, 32, 8));
+  EXPECT_TRUE(detail::is_reduce_broadcast_valid<__nv_bfloat16>(16, 32, 8));
+  EXPECT_TRUE(detail::is_reduce_broadcast_valid<__half>(1, 1, 0));
+  EXPECT_FALSE(detail::is_reduce_broadcast_valid<float>(2, 8, 1));
+  EXPECT_FALSE(detail::is_reduce_broadcast_valid<__half>(2, 32, 8));
+  EXPECT_FALSE(detail::is_reduce_broadcast_valid<__half>(16, 32, 7));
+}
+
 TEST_F(
     MultimemNvlTransportTestFixture,
     DeviceMultimemStoreBroadcastsArbitraryRanges) {
@@ -2464,6 +2475,145 @@ TEST_F(MultimemNvlTransportTestFixture, DeviceLoadReduceCoversPublicTypes) {
             sourceOffsetElems,
             [&, type](void* output, float expectedValue) {
               std::vector<uint16_t> values(kElems);
+              CUDACHECK_TEST(cudaMemcpy(
+                  values.data(),
+                  output,
+                  values.size() * sizeof(uint16_t),
+                  cudaMemcpyDeviceToHost));
+              for (uint16_t bits : values) {
+                float value = 0;
+                if (type == test::MultimemReductionTestType::Float16) {
+                  __half raw{};
+                  std::memcpy(&raw, &bits, sizeof(raw));
+                  value = __half2float(raw);
+                } else {
+                  __nv_bfloat16 raw{};
+                  std::memcpy(&raw, &bits, sizeof(raw));
+                  value = __bfloat162float(raw);
+                  expectedValue =
+                      __bfloat162float(__float2bfloat16(expectedValue));
+                }
+                EXPECT_EQ(value, expectedValue);
+              }
+            });
+      }
+    }
+  }
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    DeviceReduceBroadcastCoversPublicTypesAndAccModes) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_device_reduce_broadcast_types");
+  auto transport = makeExchangedTransport(
+      bootstrap,
+      globalRank,
+      numRanks,
+      localRank,
+      /*userSignalCount=*/0,
+      /*needsInternalSignals=*/true);
+  if (!transport) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kElements = 128;
+  constexpr std::size_t kDestinationOffsetBytes = 2048;
+  const float rankValue = static_cast<float>(globalRank + 1);
+  const float expected = static_cast<float>(numRanks * (numRanks + 1) / 2);
+  const auto handle = transport->getDeviceTransport();
+
+  auto run = [&](test::MultimemReductionTestType type,
+                 bool accF32,
+                 std::size_t elementSize,
+                 bool inPlace,
+                 std::size_t sourceOffsetElems,
+                 std::size_t outOfPlaceDestinationOffsetElems,
+                 auto verify) {
+    const std::size_t destinationOffsetElems =
+        inPlace ? sourceOffsetElems : outOfPlaceDestinationOffsetElems;
+    CUDACHECK_TEST(cudaMemset(handle.localData, 0, handle.dataBufferSize));
+    test::launchFillReductionInput(
+        handle, type, rankValue, kElements, sourceOffsetElems);
+    test::launchReduceBroadcast(
+        handle,
+        type,
+        accF32,
+        sourceOffsetElems,
+        destinationOffsetElems,
+        kElements);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    verify(handle.localData + destinationOffsetElems * elementSize, expected);
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+  };
+
+  for (const bool inPlace : {false, true}) {
+    run(test::MultimemReductionTestType::Float,
+        /*accF32=*/true,
+        sizeof(float),
+        inPlace,
+        /*sourceOffsetElems=*/0,
+        kDestinationOffsetBytes / sizeof(float),
+        [&](const void* output, float expectedValue) {
+          std::vector<float> values(kElements);
+          CUDACHECK_TEST(cudaMemcpy(
+              values.data(),
+              output,
+              values.size() * sizeof(float),
+              cudaMemcpyDeviceToHost));
+          for (float value : values) {
+            EXPECT_EQ(value, expectedValue);
+          }
+        });
+    run(test::MultimemReductionTestType::Float,
+        /*accF32=*/true,
+        sizeof(float),
+        inPlace,
+        /*sourceOffsetElems=*/1,
+        kDestinationOffsetBytes / sizeof(float) + 1,
+        [&](const void* output, float expectedValue) {
+          std::vector<float> values(kElements);
+          CUDACHECK_TEST(cudaMemcpy(
+              values.data(),
+              output,
+              values.size() * sizeof(float),
+              cudaMemcpyDeviceToHost));
+          for (float value : values) {
+            EXPECT_EQ(value, expectedValue);
+          }
+        });
+    run(test::MultimemReductionTestType::Int32,
+        /*accF32=*/true,
+        sizeof(int32_t),
+        inPlace,
+        /*sourceOffsetElems=*/0,
+        kDestinationOffsetBytes / sizeof(int32_t),
+        [&](const void* output, float expectedValue) {
+          std::vector<int32_t> values(kElements);
+          CUDACHECK_TEST(cudaMemcpy(
+              values.data(),
+              output,
+              values.size() * sizeof(int32_t),
+              cudaMemcpyDeviceToHost));
+          for (int32_t value : values) {
+            EXPECT_EQ(value, static_cast<int32_t>(expectedValue));
+          }
+        });
+
+    for (const auto type :
+         {test::MultimemReductionTestType::Float16,
+          test::MultimemReductionTestType::Bfloat16}) {
+      for (const bool accF32 : {false, true}) {
+        run(type,
+            accF32,
+            sizeof(uint16_t),
+            inPlace,
+            /*sourceOffsetElems=*/0,
+            kDestinationOffsetBytes / sizeof(uint16_t),
+            [&, type](const void* output, float expectedValue) {
+              std::vector<uint16_t> values(kElements);
               CUDACHECK_TEST(cudaMemcpy(
                   values.data(),
                   output,

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -1684,6 +1684,91 @@ TEST_F(
 
 TEST_F(
     MultimemNvlTransportTestFixture,
+    BlockAggregateBarrierOrdersEveryWarpAcrossRepeatedEpochs) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  constexpr uint32_t kChannels = 2;
+  constexpr uint32_t kPipelineDepth = 4;
+  constexpr uint32_t kEpochs = 3;
+  constexpr uint32_t kThreads = 128;
+  constexpr std::size_t kElementCount = kChannels * kEpochs * kThreads;
+  auto bootstrap = makeBootstrap("mmnvl_block_aggregate_barrier");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(
+          kElementCount * sizeof(int32_t),
+          /*userSignalCount=*/0,
+          kPipelineDepth,
+          kChannels));
+  transport.exchange();
+
+  int32_t* deviceReducedValues = nullptr;
+  uint64_t* deviceSignalValues = nullptr;
+  constexpr std::size_t kSignalValueCount = 2 * kChannels * kPipelineDepth;
+  CUDACHECK_TEST(
+      cudaMalloc(&deviceReducedValues, kElementCount * sizeof(int32_t)));
+  CUDACHECK_TEST(
+      cudaMalloc(&deviceSignalValues, kSignalValueCount * sizeof(uint64_t)));
+  test::launchBlockAggregateBarrier(
+      transport.getDeviceTransport(),
+      kChannels,
+      kEpochs,
+      deviceReducedValues,
+      deviceSignalValues);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<int32_t> reducedValues(kElementCount);
+  std::vector<uint64_t> signalValues(kSignalValueCount);
+  CUDACHECK_TEST(cudaMemcpy(
+      reducedValues.data(),
+      deviceReducedValues,
+      kElementCount * sizeof(int32_t),
+      cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaMemcpy(
+      signalValues.data(),
+      deviceSignalValues,
+      kSignalValueCount * sizeof(uint64_t),
+      cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaFree(deviceReducedValues));
+  CUDACHECK_TEST(cudaFree(deviceSignalValues));
+
+  const int32_t rankSum = numRanks * (numRanks + 1) / 2;
+  for (uint32_t epoch = 0; epoch < kEpochs; ++epoch) {
+    for (uint32_t channel = 0; channel < kChannels; ++channel) {
+      const int32_t expected =
+          rankSum + numRanks * static_cast<int32_t>(10 * epoch + 100 * channel);
+      const std::size_t offset =
+          (static_cast<std::size_t>(epoch) * kChannels + channel) * kThreads;
+      EXPECT_EQ(
+          std::vector<int32_t>(
+              reducedValues.begin() + offset,
+              reducedValues.begin() + offset + kThreads),
+          std::vector<int32_t>(kThreads, expected));
+    }
+  }
+  const uint64_t expectedSignalValue =
+      static_cast<uint64_t>(kEpochs * numRanks);
+  for (uint32_t channel = 0; channel < kChannels; ++channel) {
+    const std::size_t outputBase =
+        static_cast<std::size_t>(channel) * 2 * kPipelineDepth;
+    EXPECT_EQ(signalValues[outputBase], expectedSignalValue);
+    EXPECT_EQ(signalValues[outputBase + kPipelineDepth], expectedSignalValue);
+    for (uint32_t lane = 1; lane < kPipelineDepth; ++lane) {
+      EXPECT_EQ(signalValues[outputBase + lane], 0);
+      EXPECT_EQ(signalValues[outputBase + kPipelineDepth + lane], 0);
+    }
+  }
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
     UniformSignalPerPeerRoundTripUsesAggregateAck) {
   if (numRanks < 3) {
     GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -26,6 +26,7 @@
 #include "comms/prims/memory/MultimemHandler.h"
 #include "comms/prims/tests/MultimemNvlTransportTest.cuh"
 #include "comms/prims/transport/nvl/MultiPeerNvlTransport.h"
+#include "comms/prims/transport/nvl/MultimemNvlStore.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlTransport.h"
 #include "comms/testinfra/DistEnvironmentBase.h"
 #include "comms/testinfra/DistTestBase.h"
@@ -1325,6 +1326,107 @@ void verifyUnicastPeerViews(
 }
 
 } // namespace
+
+TEST(MultimemNvlStoreValidationTest, ValidatesAddressAndExtent) {
+  EXPECT_TRUE(detail::is_multimem_store_valid(/*destination=*/1, /*bytes=*/0));
+  EXPECT_TRUE(detail::is_multimem_store_valid(/*destination=*/4, /*bytes=*/4));
+  EXPECT_FALSE(detail::is_multimem_store_valid(/*destination=*/2, /*bytes=*/4));
+  EXPECT_FALSE(detail::is_multimem_store_valid(/*destination=*/4, /*bytes=*/2));
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    DeviceMultimemStoreBroadcastsArbitraryRanges) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_device_store_arbitrary_ranges");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kDataBytes = 4096;
+  constexpr uint8_t kGuard = 0xA5;
+  MultimemNvlTransport transport(
+      bootstrap, globalRank, identityRankMap(numRanks), makeConfig(kDataBytes));
+  transport.exchange();
+  const auto deviceTransport = transport.getDeviceTransport();
+
+  std::vector<uint8_t> source(kDataBytes + 1);
+  for (std::size_t index = 0; index < source.size(); ++index) {
+    source[index] = static_cast<uint8_t>(index ^ 0x5A);
+  }
+  void* deviceSource = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&deviceSource, source.size()));
+  CUDACHECK_TEST(cudaMemcpy(
+      deviceSource, source.data(), source.size(), cudaMemcpyHostToDevice));
+  DeviceUint64Slot acquiredSignal;
+
+  struct StoreCase {
+    std::size_t destinationOffset;
+    std::size_t sourceOffset;
+    std::size_t bytes;
+    int unroll;
+  };
+  constexpr StoreCase kCases[] = {
+      {.destinationOffset = 1, .sourceOffset = 1, .bytes = 0, .unroll = 1},
+      {.destinationOffset = 4, .sourceOffset = 1, .bytes = 4, .unroll = 1},
+      {.destinationOffset = 8, .sourceOffset = 1, .bytes = 12, .unroll = 1},
+      {.destinationOffset = 64, .sourceOffset = 0, .bytes = 64, .unroll = 4},
+      {.destinationOffset = 128, .sourceOffset = 1, .bytes = 68, .unroll = 4},
+      {.destinationOffset = 512, .sourceOffset = 0, .bytes = 260, .unroll = 4},
+      {.destinationOffset = 1024,
+       .sourceOffset = 0,
+       .bytes = 2064,
+       .unroll = 4},
+      {.destinationOffset = 2048, .sourceOffset = 1, .bytes = 516, .unroll = 4},
+  };
+
+  uint64_t epoch = 0;
+  for (const auto& storeCase : kCases) {
+    ++epoch;
+    CUDACHECK_TEST(cudaMemset(deviceTransport.localData, kGuard, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+
+    if (globalRank == 0) {
+      test::launchMultimemStore(
+          deviceTransport,
+          storeCase.destinationOffset,
+          static_cast<const char*>(deviceSource) + storeCase.sourceOffset,
+          storeCase.bytes,
+          storeCase.unroll);
+      test::launchSetUserSignal(deviceTransport, /*signalId=*/0, epoch);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+    }
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+    test::launchWaitAndReadUserSignal(
+        deviceTransport,
+        /*signalId=*/0,
+        CmpOp::CMP_EQ,
+        epoch,
+        acquiredSignal.device_ptr());
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<uint8_t> actual(kDataBytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        actual.data(),
+        deviceTransport.localData,
+        actual.size(),
+        cudaMemcpyDeviceToHost));
+    for (std::size_t index = 0; index < actual.size(); ++index) {
+      const bool written = index >= storeCase.destinationOffset &&
+          index < storeCase.destinationOffset + storeCase.bytes;
+      const uint8_t expected = written
+          ? source[storeCase.sourceOffset + index - storeCase.destinationOffset]
+          : kGuard;
+      EXPECT_EQ(actual[index], expected) << "byte " << index;
+    }
+  }
+
+  CUDACHECK_TEST(cudaFree(deviceSource));
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
 
 TEST_F(
     MultimemNvlTransportTestFixture,

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -8,6 +8,7 @@
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/tests/Checks.h"
 #include "comms/prims/transport/nvl/MultimemNvlReduce.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlRegistered.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlSignal.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlStageLayout.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlStore.cuh"
@@ -563,6 +564,31 @@ __global__ void loadReduceKernel(
       group, output, source, elems);
 }
 
+template <typename T, bool kAccF32>
+__global__ void reduceBroadcastKernel(
+    MultimemNvlTransportDevice transport,
+    std::size_t sourceOffsetElems,
+    std::size_t destinationOffsetElems,
+    std::size_t elems) {
+  auto block = make_block_group();
+  constexpr std::size_t kElementsPerPack = 16 / sizeof(T);
+  const std::size_t packs = elems / kElementsPerPack;
+  const std::size_t firstPack = packs * transport.nvlRank / transport.nvlRanks;
+  const std::size_t endPack =
+      packs * (transport.nvlRank + 1) / transport.nvlRanks;
+  const std::size_t first = firstPack * kElementsPerPack;
+  const std::size_t count = (endPack - firstPack) * kElementsPerPack;
+  auto* destination =
+      reinterpret_cast<T*>(transport.multimemData) + destinationOffsetElems;
+  const auto* source =
+      reinterpret_cast<const T*>(transport.multimemData) + sourceOffsetElems;
+
+  nvl_block_barrier(transport, /*channel=*/0, block);
+  multimem::reduce_broadcast_at<T, 4, kAccF32>(
+      block, destination + first, source + first, count);
+  nvl_block_barrier(transport, /*channel=*/0, block);
+}
+
 template <int kUnroll>
 __global__ void multimemStoreKernel(
     MultimemNvlTransportDevice transport,
@@ -646,6 +672,24 @@ void launchFillReductionInputTyped(
     cudaStream_t stream) {
   fillReductionInputKernel<T>
       <<<1, 32, 0, stream>>>(transport, value, elems, sourceOffsetElems);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+template <typename T>
+void launchReduceBroadcastTyped(
+    MultimemNvlTransportDevice transport,
+    bool accF32,
+    std::size_t sourceOffsetElems,
+    std::size_t destinationOffsetElems,
+    std::size_t elems,
+    cudaStream_t stream) {
+  if (accF32) {
+    reduceBroadcastKernel<T, true><<<1, 128, 0, stream>>>(
+        transport, sourceOffsetElems, destinationOffsetElems, elems);
+  } else {
+    reduceBroadcastKernel<T, false><<<1, 128, 0, stream>>>(
+        transport, sourceOffsetElems, destinationOffsetElems, elems);
+  }
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
@@ -995,6 +1039,50 @@ void launchLoadReduce(
     case MultimemReductionTestType::Bfloat16:
       return launchLoadReduceTyped<__nv_bfloat16>(
           transport, accF32, output, elems, sourceOffsetElems, stream);
+  }
+}
+
+void launchReduceBroadcast(
+    MultimemNvlTransportDevice transport,
+    MultimemReductionTestType type,
+    bool accF32,
+    std::size_t sourceOffsetElems,
+    std::size_t destinationOffsetElems,
+    std::size_t elems,
+    cudaStream_t stream) {
+  switch (type) {
+    case MultimemReductionTestType::Float:
+      return launchReduceBroadcastTyped<float>(
+          transport,
+          accF32,
+          sourceOffsetElems,
+          destinationOffsetElems,
+          elems,
+          stream);
+    case MultimemReductionTestType::Int32:
+      return launchReduceBroadcastTyped<int32_t>(
+          transport,
+          accF32,
+          sourceOffsetElems,
+          destinationOffsetElems,
+          elems,
+          stream);
+    case MultimemReductionTestType::Float16:
+      return launchReduceBroadcastTyped<__half>(
+          transport,
+          accF32,
+          sourceOffsetElems,
+          destinationOffsetElems,
+          elems,
+          stream);
+    case MultimemReductionTestType::Bfloat16:
+      return launchReduceBroadcastTyped<__nv_bfloat16>(
+          transport,
+          accF32,
+          sourceOffsetElems,
+          destinationOffsetElems,
+          elems,
+          stream);
   }
 }
 

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -10,6 +10,7 @@
 #include "comms/prims/transport/nvl/MultimemNvlReduce.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlSignal.cuh"
 #include "comms/prims/transport/nvl/MultimemNvlStageLayout.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlStore.cuh"
 
 namespace comms::prims::test {
 
@@ -562,6 +563,17 @@ __global__ void loadReduceKernel(
       group, output, source, elems);
 }
 
+template <int kUnroll>
+__global__ void multimemStoreKernel(
+    MultimemNvlTransportDevice transport,
+    std::size_t destinationOffset,
+    const void* source,
+    std::size_t bytes) {
+  auto group = make_warp_group();
+  multimem::store<kUnroll>(
+      group, transport.multimem_data_ptr(destinationOffset), source, bytes);
+}
+
 template <typename T, bool kAccF32>
 __global__ void phasedReduceBlockKernel(
     MultimemNvlTransportDevice transport,
@@ -984,6 +996,25 @@ void launchLoadReduce(
       return launchLoadReduceTyped<__nv_bfloat16>(
           transport, accF32, output, elems, sourceOffsetElems, stream);
   }
+}
+
+void launchMultimemStore(
+    MultimemNvlTransportDevice transport,
+    std::size_t destinationOffset,
+    const void* source,
+    std::size_t bytes,
+    int unroll,
+    cudaStream_t stream) {
+  if (unroll == 1) {
+    multimemStoreKernel<1>
+        <<<1, 32, 0, stream>>>(transport, destinationOffset, source, bytes);
+  } else if (unroll == 4) {
+    multimemStoreKernel<4>
+        <<<1, 32, 0, stream>>>(transport, destinationOffset, source, bytes);
+  } else {
+    throw std::invalid_argument("test supports unroll 1 or 4");
+  }
+  PIPES_KERNEL_LAUNCH_CHECK();
 }
 
 void launchPhasedReduceBlock(

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -404,6 +404,41 @@ __global__ void initializeAggregateSignalsKernel(
   }
 }
 
+__global__ void blockAggregateBarrierKernel(
+    MultimemNvlTransportDevice transport,
+    uint32_t epochs,
+    int32_t* reducedValues,
+    uint64_t* signalValues) {
+  auto block = make_block_group();
+  auto* local = reinterpret_cast<int32_t*>(transport.localData);
+  const auto* multicast =
+      reinterpret_cast<const int32_t*>(transport.multimemData);
+  for (uint32_t epoch = 0; epoch < epochs; ++epoch) {
+    const std::size_t offset =
+        (static_cast<std::size_t>(epoch) * gridDim.x + blockIdx.x) * blockDim.x;
+    local[offset + threadIdx.x] = transport.nvlRank + 1 +
+        static_cast<int32_t>(10 * epoch + 100 * blockIdx.x);
+    nvl_block_barrier(
+        transport, static_cast<uint32_t>(blockIdx.x), block, Timeout{});
+    multimem::load_reduce_at<int32_t>(
+        block, reducedValues + offset, multicast + offset, blockDim.x);
+  }
+
+  block.sync();
+  if (threadIdx.x < transport.pipelineDepth) {
+    const uint64_t signalId =
+        static_cast<uint64_t>(blockIdx.x) * transport.signalsPerChannel +
+        static_cast<uint64_t>(3 * transport.nvlRanks) +
+        static_cast<uint64_t>(4 * threadIdx.x);
+    const std::size_t outputBase =
+        static_cast<std::size_t>(blockIdx.x) * 2 * transport.pipelineDepth;
+    signalValues[outputBase + threadIdx.x] =
+        transport.internalLocalSignals[signalId].load();
+    signalValues[outputBase + transport.pipelineDepth + threadIdx.x] =
+        transport.internalLocalSignals[signalId + 1].load();
+  }
+}
+
 __global__ void perPeerWaitOnlyKernel(
     MultimemNvlTransportDevice transport,
     uint64_t roundValue,
@@ -828,6 +863,18 @@ void launchInitializeAggregateSignals(
     cudaStream_t stream) {
   initializeAggregateSignalsKernel<<<1, 32, 0, stream>>>(
       transport, counterValue, epochValue);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchBlockAggregateBarrier(
+    MultimemNvlTransportDevice transport,
+    uint32_t channels,
+    uint32_t epochs,
+    int32_t* reducedValues,
+    uint64_t* signalValues,
+    cudaStream_t stream) {
+  blockAggregateBarrierKernel<<<channels, 128, 0, stream>>>(
+      transport, epochs, reducedValues, signalValues);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -562,6 +562,38 @@ __global__ void loadReduceKernel(
       group, output, source, elems);
 }
 
+template <typename T, bool kAccF32>
+__global__ void phasedReduceBlockKernel(
+    MultimemNvlTransportDevice transport,
+    T* output) {
+  auto block = make_block_group();
+  constexpr std::size_t kElements = sizeof(uint4) / sizeof(T);
+  auto* local = reinterpret_cast<T*>(transport.localData);
+  if (threadIdx.x < kElements) {
+    local[threadIdx.x] = reductionValue<T>(transport.nvlRank + 1);
+  }
+  nvl_block_barrier(transport, /*channel=*/0, block);
+
+  uint4 reduced{};
+  if (block.is_leader()) {
+    reduced = multimem::load_reduce_block16<T, kAccF32>(
+        reinterpret_cast<const T*>(transport.multimemData));
+  }
+  nvl_block_barrier(transport, /*channel=*/0, block);
+
+  if (block.is_leader()) {
+    const std::size_t firstLane = kElements *
+        static_cast<std::size_t>(transport.nvlRank) /
+        static_cast<std::size_t>(transport.nvlRanks);
+    const std::size_t endLane = kElements *
+        static_cast<std::size_t>(transport.nvlRank + 1) /
+        static_cast<std::size_t>(transport.nvlRanks);
+    multimem::store_reduced_block16_range(
+        output + firstLane, reduced, firstLane, endLane - firstLane);
+  }
+  nvl_block_barrier(transport, /*channel=*/0, block);
+}
+
 __global__ void stageLayoutKernel(
     MultimemNvlTransportDevice transport,
     StageLayoutResult* results) {
@@ -619,6 +651,22 @@ void launchLoadReduceTyped(
   } else {
     loadReduceKernel<T, false><<<1, 32, 0, stream>>>(
         transport, static_cast<T*>(output), elems, sourceOffsetElems);
+  }
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+template <typename T>
+void launchPhasedReduceBlockTyped(
+    MultimemNvlTransportDevice transport,
+    bool accF32,
+    void* output,
+    cudaStream_t stream) {
+  if (accF32) {
+    phasedReduceBlockKernel<T, true>
+        <<<1, 128, 0, stream>>>(transport, static_cast<T*>(output));
+  } else {
+    phasedReduceBlockKernel<T, false>
+        <<<1, 128, 0, stream>>>(transport, static_cast<T*>(output));
   }
   PIPES_KERNEL_LAUNCH_CHECK();
 }
@@ -935,6 +983,25 @@ void launchLoadReduce(
     case MultimemReductionTestType::Bfloat16:
       return launchLoadReduceTyped<__nv_bfloat16>(
           transport, accF32, output, elems, sourceOffsetElems, stream);
+  }
+}
+
+void launchPhasedReduceBlock(
+    MultimemNvlTransportDevice transport,
+    MultimemReductionTestType type,
+    bool accF32,
+    void* output,
+    cudaStream_t stream) {
+  switch (type) {
+    case MultimemReductionTestType::Float16:
+      return launchPhasedReduceBlockTyped<__half>(
+          transport, accF32, output, stream);
+    case MultimemReductionTestType::Bfloat16:
+      return launchPhasedReduceBlockTyped<__nv_bfloat16>(
+          transport, accF32, output, stream);
+    case MultimemReductionTestType::Float:
+    case MultimemReductionTestType::Int32:
+      throw std::runtime_error("phased reduce block requires a 2-byte type");
   }
 }
 

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -182,6 +182,14 @@ void launchInitializeAggregateSignals(
     uint64_t epochValue,
     cudaStream_t stream = nullptr);
 
+void launchBlockAggregateBarrier(
+    MultimemNvlTransportDevice transport,
+    uint32_t channels,
+    uint32_t epochs,
+    int32_t* reducedValues,
+    uint64_t* signalValues,
+    cudaStream_t stream = nullptr);
+
 void launchFillReductionInput(
     MultimemNvlTransportDevice transport,
     MultimemReductionTestType type,

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -207,6 +207,13 @@ void launchLoadReduce(
     std::size_t sourceOffsetElems,
     cudaStream_t stream = nullptr);
 
+void launchPhasedReduceBlock(
+    MultimemNvlTransportDevice transport,
+    MultimemReductionTestType type,
+    bool accF32,
+    void* output,
+    cudaStream_t stream = nullptr);
+
 void launchStageLayout(
     MultimemNvlTransportDevice transport,
     StageLayoutResult* results,

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -207,6 +207,15 @@ void launchLoadReduce(
     std::size_t sourceOffsetElems,
     cudaStream_t stream = nullptr);
 
+void launchReduceBroadcast(
+    MultimemNvlTransportDevice transport,
+    MultimemReductionTestType type,
+    bool accF32,
+    std::size_t sourceOffsetElems,
+    std::size_t destinationOffsetElems,
+    std::size_t elems,
+    cudaStream_t stream = nullptr);
+
 void launchMultimemStore(
     MultimemNvlTransportDevice transport,
     std::size_t destinationOffset,

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -207,6 +207,14 @@ void launchLoadReduce(
     std::size_t sourceOffsetElems,
     cudaStream_t stream = nullptr);
 
+void launchMultimemStore(
+    MultimemNvlTransportDevice transport,
+    std::size_t destinationOffset,
+    const void* source,
+    std::size_t bytes,
+    int unroll,
+    cudaStream_t stream = nullptr);
+
 void launchPhasedReduceBlock(
     MultimemNvlTransportDevice transport,
     MultimemReductionTestType type,

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -63,6 +63,30 @@ comms::fault_tolerance::AbortDevice makeAbortDeviceHandle(
   return abort->getDeviceHandle();
 }
 
+bool nvlRankMapCoversCommunicator(
+    const std::vector<int>& nvlRankToCommRank,
+    int commRanks) {
+  if (commRanks <= 0 ||
+      nvlRankToCommRank.size() != static_cast<std::size_t>(commRanks)) {
+    return false;
+  }
+  for (int rank = 0; rank < commRanks; ++rank) {
+    if (nvlRankToCommRank[static_cast<std::size_t>(rank)] != rank) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool nvlRankMapMatchesConfig(
+    const std::vector<int>& nvlRankToCommRank,
+    const std::optional<std::vector<int>>& configuredNvlRanks,
+    int commRanks) {
+  return configuredNvlRanks.has_value()
+      ? nvlRankToCommRank == *configuredNvlRanks
+      : nvlRankMapCoversCommunicator(nvlRankToCommRank, commRanks);
+}
+
 } // namespace
 
 MultiPeerTransport::MultiPeerTransport(
@@ -96,6 +120,12 @@ void MultiPeerTransport::initFromTopology(
   // Derive fields from the slim TopologyResult.
   nvlNRanks_ = static_cast<int>(nvlPeerRanks_.size()) + 1;
   nvlLocalRank_ = globalToNvlLocal_.at(myRank_);
+  std::vector<int> nvlRankToCommRank(nvlNRanks_);
+  for (const auto& [globalRank, nvlLocal] : globalToNvlLocal_) {
+    nvlRankToCommRank.at(nvlLocal) = globalRank;
+  }
+  nvlRankMapMatchesConfig_ = nvlRankMapMatchesConfig(
+      nvlRankToCommRank, config.topoConfig.logicalNvlRanks, nRanks_);
 
   typePerRank_.resize(nRanks_);
 
@@ -166,13 +196,8 @@ void MultiPeerTransport::initFromTopology(
 
   // Create NVLink sub-transport with NvlBootstrapAdapter
   if (!nvlPeerRanks_.empty()) {
-    std::vector<int> localRankToCommRank(nvlNRanks_);
-    for (const auto& [globalRank, nvlLocal] : globalToNvlLocal_) {
-      localRankToCommRank[nvlLocal] = globalRank;
-    }
-
     nvlBootstrapAdapter_ = std::make_shared<NvlBootstrapAdapter>(
-        bootstrap_, std::move(localRankToCommRank));
+        bootstrap_, std::move(nvlRankToCommRank));
 
     nvlTransport_ = std::make_unique<MultiPeerNvlTransport>(
         nvlLocalRank_,
@@ -304,6 +329,7 @@ P2pIbgdaTransportDevice* MultiPeerTransport::get_p2p_ibgda_transport_device(
   return ibgdaTransport_->getP2pTransportDevice(globalPeerRank);
 }
 
+// NOLINTNEXTLINE(facebook-hte-NullableReturn)
 Transport* /*nullable*/ MultiPeerTransport::get_nvl_transports_array() const {
   if (!nvlTransport_) {
     return nullptr;
@@ -477,6 +503,7 @@ IbgdaLocalBuffer MultiPeerTransport::allocateIbCounterBuffer(
     void* host = nullptr;
     void* device = nullptr;
     CUDA_CHECK(cudaHostAlloc(&host, size, cudaHostAllocMapped));
+    CHECK(host != nullptr);
     CUDA_CHECK(cudaHostGetDevicePointer(&device, host, 0));
     std::memset(host, 0, size);
     *hostPtr = host;
@@ -485,6 +512,7 @@ IbgdaLocalBuffer MultiPeerTransport::allocateIbCounterBuffer(
   if (ibgdaTransport_) {
     void* ptr = nullptr;
     CUDA_CHECK(cudaMalloc(&ptr, size));
+    CHECK(ptr != nullptr);
     CUDA_CHECK(cudaMemset(ptr, 0, size));
     return IbgdaLocalBuffer(ptr, NetworkLKeys{});
   }

--- a/comms/prims/transport/MultiPeerTransport.h
+++ b/comms/prims/transport/MultiPeerTransport.h
@@ -165,6 +165,14 @@ class MultiPeerTransport {
     return nvlNRanks_;
   }
 
+  /**
+   * @return Whether the discovered NVL rank map matches the configured logical
+   * map, or covers the identity-mapped communicator when no map was configured.
+   */
+  bool nvl_rank_map_matches_config() const {
+    return nvlRankMapMatchesConfig_;
+  }
+
   /** @return NVL local rank for the given global rank.
    *  @throws std::out_of_range if globalRank is not in the NVL group. */
   int global_to_nvl_local(int globalRank) const {
@@ -194,6 +202,7 @@ class MultiPeerTransport {
    * @return Pointer to the device-side Transport array from NVL transport,
    *   indexed by NVL local rank. Returns nullptr if no NVL transport.
    */
+  // NOLINTNEXTLINE(facebook-hte-NullableReturn)
   Transport* /*nullable*/ get_nvl_transports_array() const;
 
   /**
@@ -368,6 +377,7 @@ class MultiPeerTransport {
 
   // --- NVLink rank mapping ---
   std::unordered_map<int, int> globalToNvlLocal_;
+  bool nvlRankMapMatchesConfig_{false};
   int nvlLocalRank_{-1};
   int nvlNRanks_{0};
 

--- a/comms/prims/transport/nvl/MultimemNvlReduce.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlReduce.cuh
@@ -5,9 +5,8 @@
 // Holds the reduce side of the NVLS staging model: the raw `multimem.ld_reduce`
 // PTX emitters (`comms::prims::detail`) and the public entry point
 // `multimem::load_reduce_at<>` that reads the cross-rank reduction of a
-// multicast VA into a local buffer. The store side (`multimem::store()`) and
-// the staging orchestration that composes both land later in the stack
-// (`MultimemNvlStore.cuh`, `MultimemNvlStaging.cuh`).
+// multicast VA into a local buffer. The store side (`multimem::store()`) lives
+// in `MultimemNvlStore.cuh`.
 
 // clang-tidy analyzes this .cuh as a standalone main file and misflags the
 // pragma; it is a genuine include-once header. False positive, so suppress it.

--- a/comms/prims/transport/nvl/MultimemNvlReduce.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlReduce.cuh
@@ -231,6 +231,41 @@ namespace comms::prims::multimem {
 enum class MultimemRedOp { Add };
 
 /**
+ * Reduces one aligned 16-byte fp16 or bf16 block into registers.
+ *
+ * Keeping the reduced block separate from the eventual stores lets callers
+ * place a team barrier between the read and write phases when adjacent ranks
+ * own different lanes of the same 16-byte block.
+ */
+template <typename T, bool kAccF32 = true>
+__device__ __forceinline__ uint4 load_reduce_block16(const T* multicastBlock) {
+  static_assert(
+      std::is_same_v<T, __half> || std::is_same_v<T, __nv_bfloat16>,
+      "load_reduce_block16 supports fp16 and bf16");
+  const auto* source = reinterpret_cast<const uint4*>(multicastBlock);
+  if constexpr (std::is_same_v<T, __half>) {
+    return comms::prims::detail::multimem_ld_reduce_v4_f16x2<kAccF32>(source);
+  } else {
+    return comms::prims::detail::multimem_ld_reduce_v4_bf16x2<kAccF32>(source);
+  }
+}
+
+/** Stores a contiguous lane range from a previously reduced 16-byte block. */
+template <typename T>
+__device__ __forceinline__ void store_reduced_block16_range(
+    T* destination,
+    const uint4& block,
+    std::size_t firstLane,
+    std::size_t count) {
+  static_assert(
+      sizeof(T) == 2, "store_reduced_block16_range requires a 2-byte type");
+  const auto* lanes = reinterpret_cast<const T*>(&block);
+  for (std::size_t index = 0; index < count; ++index) {
+    destination[index] = lanes[firstLane + index];
+  }
+}
+
+/**
  * multimem.ld_reduce from an ARBITRARY multicast base pointer into `dst`.
  *
  * `mc` must point into a multicast VA; `dst` is local. Staging callers combine

--- a/comms/prims/transport/nvl/MultimemNvlRegistered.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlRegistered.cuh
@@ -1,0 +1,189 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace comms::prims::detail {
+
+template <typename T>
+__host__ __device__ constexpr bool is_reduce_broadcast_valid(
+    uintptr_t destination,
+    uintptr_t source,
+    std::size_t elements) {
+  if (elements == 0) {
+    return true;
+  }
+  if constexpr (std::is_same_v<T, __half> || std::is_same_v<T, __nv_bfloat16>) {
+    return ((destination | source) & 15) == 0 && (elements & 7) == 0;
+  }
+  return ((destination | source) & 3) == 0;
+}
+
+} // namespace comms::prims::detail
+
+#if defined(ENABLE_PRIMS)
+
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlReduce.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlStore.cuh"
+
+namespace comms::prims::detail {
+
+template <int kUnroll, typename Load>
+__device__ __forceinline__ void reduce_broadcast_vectors(
+    ThreadGroup& group,
+    uint4* destination,
+    const uint4* source,
+    std::size_t count,
+    Load load) {
+  static_assert(kUnroll > 0);
+  const std::size_t groupSize = group.group_size;
+  const std::size_t first = group.thread_id_in_group;
+  for (std::size_t base = first; base < count; base += groupSize * kUnroll) {
+    uint4 values[kUnroll];
+#pragma unroll
+    for (int index = 0; index < kUnroll; ++index) {
+      const std::size_t offset =
+          base + static_cast<std::size_t>(index) * groupSize;
+      if (offset < count) {
+        values[index] = load(source + offset);
+      }
+    }
+#pragma unroll
+    for (int index = 0; index < kUnroll; ++index) {
+      const std::size_t offset =
+          base + static_cast<std::size_t>(index) * groupSize;
+      if (offset < count) {
+        comms::prims::detail::multimem_store_v4_u32(
+            destination + offset, values[index]);
+      }
+    }
+  }
+}
+
+} // namespace comms::prims::detail
+
+namespace comms::prims::multimem {
+
+/**
+ * Reduce from one multicast address and broadcast to another without scratch.
+ *
+ * The reduced value remains in registers between `multimem.ld_reduce` and
+ * `multimem.st`.
+ * The primitive performs no cross-rank synchronization.
+ * In-place callers partition the range into disjoint rank-owned shards and
+ * bracket the operation with team barriers.
+ * This primitive exposes fp16 and bf16 only as complete 16-byte reduction
+ * packs, so those types require aligned source and destination ranges whose
+ * element counts are multiples of eight.
+ */
+template <typename T, int kUnroll = 1, bool kAccF32 = true>
+__device__ __forceinline__ void reduce_broadcast_at(
+    ThreadGroup& group,
+    T* destination,
+    const T* source,
+    std::size_t elements) {
+  static_assert(kUnroll > 0);
+  if (!comms::prims::detail::is_reduce_broadcast_valid<T>(
+          reinterpret_cast<uintptr_t>(destination),
+          reinterpret_cast<uintptr_t>(source),
+          elements)) {
+    __trap();
+    return;
+  }
+  if (elements == 0) {
+    return;
+  }
+
+  if constexpr (std::is_same_v<T, float>) {
+    const auto addresses = reinterpret_cast<uintptr_t>(destination) |
+        reinterpret_cast<uintptr_t>(source);
+    const std::size_t vectorCount = (addresses & 15) == 0 ? elements / 4 : 0;
+    if (vectorCount != 0) {
+      comms::prims::detail::reduce_broadcast_vectors<kUnroll>(
+          group,
+          reinterpret_cast<uint4*>(destination),
+          reinterpret_cast<const uint4*>(source),
+          vectorCount,
+          [](const uint4* address) {
+            const float4 reduced =
+                comms::prims::detail::multimem_ld_reduce_v4_f32(
+                    reinterpret_cast<const float4*>(address));
+            uint4 bits;
+            __builtin_memcpy(&bits, &reduced, sizeof(bits));
+            return bits;
+          });
+    }
+    const std::size_t stride = group.group_size;
+    for (std::size_t index = vectorCount * 4 + group.thread_id_in_group;
+         index < elements;
+         index += stride) {
+      const float reduced =
+          comms::prims::detail::multimem_ld_reduce_f32(source + index);
+      uint32_t bits;
+      __builtin_memcpy(&bits, &reduced, sizeof(bits));
+      comms::prims::detail::multimem_store_u32(
+          reinterpret_cast<uint32_t*>(destination + index), bits);
+    }
+  } else if constexpr (std::is_same_v<T, __half>) {
+    comms::prims::detail::reduce_broadcast_vectors<kUnroll>(
+        group,
+        reinterpret_cast<uint4*>(destination),
+        reinterpret_cast<const uint4*>(source),
+        elements / 8,
+        [](const uint4* address) {
+          return comms::prims::detail::multimem_ld_reduce_v4_f16x2<kAccF32>(
+              address);
+        });
+  } else if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+    comms::prims::detail::reduce_broadcast_vectors<kUnroll>(
+        group,
+        reinterpret_cast<uint4*>(destination),
+        reinterpret_cast<const uint4*>(source),
+        elements / 8,
+        [](const uint4* address) {
+          return comms::prims::detail::multimem_ld_reduce_v4_bf16x2<kAccF32>(
+              address);
+        });
+  } else if constexpr (std::is_same_v<T, int32_t>) {
+    const std::size_t groupSize = group.group_size;
+    const std::size_t first = group.thread_id_in_group;
+    for (std::size_t base = first; base < elements;
+         base += groupSize * kUnroll) {
+      int32_t values[kUnroll];
+#pragma unroll
+      for (int index = 0; index < kUnroll; ++index) {
+        const std::size_t offset =
+            base + static_cast<std::size_t>(index) * groupSize;
+        if (offset < elements) {
+          values[index] =
+              comms::prims::detail::multimem_ld_reduce_s32(source + offset);
+        }
+      }
+#pragma unroll
+      for (int index = 0; index < kUnroll; ++index) {
+        const std::size_t offset =
+            base + static_cast<std::size_t>(index) * groupSize;
+        if (offset < elements) {
+          comms::prims::detail::multimem_store_u32(
+              reinterpret_cast<uint32_t*>(destination + offset),
+              static_cast<uint32_t>(values[index]));
+        }
+      }
+    }
+  } else {
+    static_assert(sizeof(T) == 0, "unsupported reduce-broadcast datatype");
+  }
+}
+
+} // namespace comms::prims::multimem
+
+#endif // ENABLE_PRIMS

--- a/comms/prims/transport/nvl/MultimemNvlSignal.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlSignal.cuh
@@ -529,6 +529,49 @@ __device__ __forceinline__ void validate_aggregate(
 #endif
 }
 
+__device__ __forceinline__ void validate_block_barrier(
+    const MultimemNvlTransportDevice& transport,
+    uint32_t channel,
+    const ThreadGroup& block) {
+#if defined(__CUDA_ARCH__)
+  const uint64_t requiredSignals =
+      static_cast<uint64_t>(transport.maxChannels) *
+      transport.signalsPerChannel;
+  if (blockDim.y != 1 || blockDim.z != 1 || gridDim.y != 1 || gridDim.z != 1 ||
+      block.scope != SyncScope::BLOCK || block.group_size != blockDim.x ||
+      block.group_size < kWarpSize || block.group_size % kWarpSize != 0 ||
+      block.group_id != channel || transport.nvlRanks <= 0 ||
+      !nvl_signal_rank_count_supported(
+          static_cast<uint32_t>(transport.nvlRanks)) ||
+      transport.pipelineDepth == 0 || channel >= transport.maxChannels ||
+      transport.signalsPerChannel == 0 ||
+      requiredSignals > transport.internalLocalSignals.size() ||
+      requiredSignals > transport.internalMultimemSignals.size()) {
+    printf(
+        "NVL block barrier invalid geometry: block=(%u,%u,%u) "
+        "grid=(%u,%u,%u) groupId=%u groupSize=%u ranks=%d "
+        "channel=%u maxChannels=%u pipelineDepth=%u\n",
+        static_cast<unsigned>(blockDim.x),
+        static_cast<unsigned>(blockDim.y),
+        static_cast<unsigned>(blockDim.z),
+        static_cast<unsigned>(gridDim.x),
+        static_cast<unsigned>(gridDim.y),
+        static_cast<unsigned>(gridDim.z),
+        static_cast<unsigned>(block.group_id),
+        static_cast<unsigned>(block.group_size),
+        transport.nvlRanks,
+        static_cast<unsigned>(channel),
+        static_cast<unsigned>(transport.maxChannels),
+        static_cast<unsigned>(transport.pipelineDepth));
+    __trap();
+  }
+#else
+  (void)transport;
+  (void)channel;
+  (void)block;
+#endif
+}
+
 } // namespace nvl_signal_detail
 
 /**
@@ -751,6 +794,41 @@ __device__ __forceinline__ void signal_publish_and_wait(
       transport, round, participants, group);
   nvl_signal_detail::signal_wait_impl<access, topology, phase, waitPolicy>(
       transport, round, participants, group, abortDevice);
+}
+
+/**
+ * Synchronizes one CUDA block with the same channel block on every NVL rank.
+ *
+ * The first block synchronization makes every thread's prior writes visible
+ * to the leader. The leader publishes one release-add through lane zero of the
+ * channel's aggregate counter, waits for every NVL rank, and advances the
+ * local epoch. The final block synchronization makes the acquire wait visible
+ * to the remaining threads.
+ */
+__device__ __forceinline__ void nvl_block_barrier(
+    const MultimemNvlTransportDevice& transport,
+    uint32_t channel,
+    ThreadGroup& block,
+    const Timeout& timeout = Timeout{}) {
+  nvl_signal_detail::validate_block_barrier(transport, channel, block);
+
+  comms::device::fence_acq_rel_sys();
+  block.sync();
+  if (block.is_leader()) {
+    const StageRound round{.channel = channel, .value = 1};
+    const uint64_t signalId =
+        nvl_signal_detail::aggregate_counter_id<NvlSignalPhase::Ready>(
+            transport, round, /*lane=*/0);
+    auto* counter = transport.internalLocalSignals.data() + signalId;
+    auto* epoch = counter + 1;
+    const uint64_t expected =
+        epoch->load() + static_cast<uint64_t>(transport.nvlRanks);
+    transport.template signal_internal_scalar_prefenced<SignalOp::SIGNAL_ADD>(
+        signalId, 1);
+    nvl_signal_detail::wait_until_reached(*counter, expected, timeout);
+    epoch->store(expected);
+  }
+  block.sync();
 }
 
 } // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlStore.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlStore.cuh
@@ -1,0 +1,184 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace comms::prims::detail {
+
+__host__ __device__ constexpr bool is_multimem_store_valid(
+    uintptr_t destination,
+    std::size_t bytes) {
+  return bytes == 0 || ((destination & 3) == 0 && (bytes & 3) == 0);
+}
+
+} // namespace comms::prims::detail
+
+#if defined(ENABLE_PRIMS)
+
+#include "comms/prims/core/ThreadGroup.cuh"
+
+namespace comms::prims::detail {
+
+__device__ __forceinline__ uint32_t load_u32_unaligned(const char* source) {
+  const auto* bytes = reinterpret_cast<const uint8_t*>(source);
+  return static_cast<uint32_t>(bytes[0]) |
+      (static_cast<uint32_t>(bytes[1]) << 8) |
+      (static_cast<uint32_t>(bytes[2]) << 16) |
+      (static_cast<uint32_t>(bytes[3]) << 24);
+}
+
+__device__ __forceinline__ void multimem_store_u32(
+    uint32_t* destination,
+    uint32_t value) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("multimem.st.relaxed.sys.global.b32 [%0], %1;"
+               :
+               : "l"(__cvta_generic_to_global(destination)), "r"(value)
+               : "memory");
+#elif defined(__CUDA_ARCH__)
+  __trap();
+#endif
+}
+
+__device__ __forceinline__ void multimem_store_v4_u32(
+    uint4* destination,
+    uint4 value) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("multimem.st.relaxed.sys.global.v4.f32 [%0], {%1,%2,%3,%4};"
+               :
+               : "l"(__cvta_generic_to_global(destination)),
+                 "r"(value.x),
+                 "r"(value.y),
+                 "r"(value.z),
+                 "r"(value.w)
+               : "memory");
+#elif defined(__CUDA_ARCH__)
+  __trap();
+#endif
+}
+
+template <int kUnroll>
+__device__ __forceinline__ void store_vectors(
+    ThreadGroup& group,
+    uint4* destination,
+    const uint4* source,
+    std::size_t count) {
+  static_assert(kUnroll > 0);
+  const std::size_t groupSize = group.group_size;
+  const std::size_t first = group.thread_id_in_group;
+  for (std::size_t base = first; base < count; base += groupSize * kUnroll) {
+    uint4 values[kUnroll];
+#pragma unroll
+    for (int index = 0; index < kUnroll; ++index) {
+      const std::size_t offset =
+          base + static_cast<std::size_t>(index) * groupSize;
+      if (offset < count) {
+        values[index] = source[offset];
+      }
+    }
+#pragma unroll
+    for (int index = 0; index < kUnroll; ++index) {
+      const std::size_t offset =
+          base + static_cast<std::size_t>(index) * groupSize;
+      if (offset < count) {
+        multimem_store_v4_u32(destination + offset, values[index]);
+      }
+    }
+  }
+}
+
+template <int kUnroll>
+__device__ __forceinline__ void store_words(
+    ThreadGroup& group,
+    uint32_t* destination,
+    const char* source,
+    std::size_t count) {
+  static_assert(kUnroll > 0);
+  const std::size_t groupSize = group.group_size;
+  const std::size_t first = group.thread_id_in_group;
+  for (std::size_t base = first; base < count; base += groupSize * kUnroll) {
+    uint32_t values[kUnroll];
+#pragma unroll
+    for (int index = 0; index < kUnroll; ++index) {
+      const std::size_t offset =
+          base + static_cast<std::size_t>(index) * groupSize;
+      if (offset < count) {
+        values[index] = load_u32_unaligned(source + offset * sizeof(uint32_t));
+      }
+    }
+#pragma unroll
+    for (int index = 0; index < kUnroll; ++index) {
+      const std::size_t offset =
+          base + static_cast<std::size_t>(index) * groupSize;
+      if (offset < count) {
+        multimem_store_u32(destination + offset, values[index]);
+      }
+    }
+  }
+}
+
+} // namespace comms::prims::detail
+
+namespace comms::prims::multimem {
+
+/**
+ * Broadcast bytes from a local source into an arbitrary multicast address.
+ *
+ * Every member of `group` must call with identical arguments.
+ * A nonempty destination must be four-byte aligned and `bytes` must be a
+ * multiple of four, matching the smallest NVLS multicast store width.
+ * The aligned path uses 16-byte vector stores, while the general path accepts
+ * any source alignment and issues four-byte stores.
+ * Stores use relaxed system ordering, so callers publish completion with an
+ * ordered signal before consumers read their local backing.
+ */
+template <int kUnroll = 1>
+__device__ __forceinline__ void store(
+    ThreadGroup& group,
+    char* destination,
+    const void* source,
+    std::size_t bytes) {
+  static_assert(kUnroll > 0);
+  if (bytes == 0) {
+    return;
+  }
+
+  const auto destinationAddress = reinterpret_cast<uintptr_t>(destination);
+  if (!comms::prims::detail::is_multimem_store_valid(
+          destinationAddress, bytes)) {
+    __trap();
+    return;
+  }
+
+  const auto sourceAddress = reinterpret_cast<uintptr_t>(source);
+  if (((sourceAddress | destinationAddress) & 15) == 0) {
+    const std::size_t vectorCount = bytes / sizeof(uint4);
+    comms::prims::detail::store_vectors<kUnroll>(
+        group,
+        reinterpret_cast<uint4*>(destination),
+        static_cast<const uint4*>(source),
+        vectorCount);
+    const std::size_t vectorBytes = vectorCount * sizeof(uint4);
+    comms::prims::detail::store_words<kUnroll>(
+        group,
+        reinterpret_cast<uint32_t*>(destination + vectorBytes),
+        static_cast<const char*>(source) + vectorBytes,
+        (bytes - vectorBytes) / sizeof(uint32_t));
+    return;
+  }
+
+  comms::prims::detail::store_words<kUnroll>(
+      group,
+      reinterpret_cast<uint32_t*>(destination),
+      static_cast<const char*>(source),
+      bytes / sizeof(uint32_t));
+}
+
+} // namespace comms::prims::multimem
+
+#endif // ENABLE_PRIMS

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -63,8 +63,8 @@ __device__ __forceinline__ void multimem_red_release_sys_add_u64(
  * spans are this rank's backing memory after multicast replication. Callers
  * that want to reduce from the multicast VA should obtain
  * `multimem_data_ptr()` and pass it to `multimem::load_reduce_at()`, defined
- * in `MultimemNvlReduce.cuh`. Broadcast-store helpers are introduced by the
- * later store-primitives diff.
+ * in `MultimemNvlReduce.cuh`. Broadcast stores into arbitrary multicast
+ * addresses are defined in `MultimemNvlStore.cuh`.
  */
 struct MultimemNvlTransportDevice {
   char* localData{nullptr};


### PR DESCRIPTION
Summary:
Teach MultiPeerTransport to validate a local NVL collective domain independently of communicator size.
Use the transport device's `nvlRank` and `nvlRanks` as the authoritative local-domain rank information.
Keep `initializeNvlmmTransport()` as the shared validation and initialization path.
The public whole-communicator path additionally requires communicator rank and size to match local rank and size.
Remove the extra `NvlmmTeam` and `NvlmmTeamExecution` abstractions.
Add coverage for a four-rank communicator split into two logical two-rank NVL domains, including an explicit `n_ranks() != nvl_n_ranks()` assertion.

Reviewed By: saifhhasan

Differential Revision: D117015057
