### PR TITLE
Fix spdlog test temp-file collision (#3866)

### DIFF
--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -17,6 +17,7 @@
 #include <string_view>
 #include <thread>
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -31,12 +32,16 @@ void waitForAsyncThreadPoolShutdownForTesting();
 bool asyncThreadPoolLeaseAvailableForTesting();
 } // namespace meta::comms::logger::testing
 
+/*
+ * Each instance owns a private directory. Concurrent copies of this binary --
+ * how stress runs execute -- would otherwise share one path under TempDir() and
+ * unlink each other's log file while the sink still holds the old inode.
+ */
 class ScopedTestFile {
  public:
   explicit ScopedTestFile(std::string filename)
-      : path_{std::filesystem::path{testing::TempDir()} / std::move(filename)} {
-    std::filesystem::remove(path_);
-  }
+      : directory_{makeUniqueDirectory()},
+        path_{directory_ / std::move(filename)} {}
 
   ~ScopedTestFile() {
     removeNoexcept();
@@ -47,11 +52,26 @@ class ScopedTestFile {
   }
 
  private:
-  void removeNoexcept() noexcept {
-    std::error_code error;
-    std::filesystem::remove(path_, error);
+  static std::filesystem::path makeUniqueDirectory() {
+    const auto pattern =
+        (std::filesystem::path{testing::TempDir()} / "comms_spdlog_ut_XXXXXX")
+            .string();
+    std::vector<char> buffer{pattern.begin(), pattern.end()};
+    buffer.push_back('\0');
+    if (::mkdtemp(buffer.data()) == nullptr) {
+      throw std::runtime_error{
+          "Failed to create a temporary directory under " +
+          std::string{testing::TempDir()}};
+    }
+    return std::filesystem::path{buffer.data()};
   }
 
+  void removeNoexcept() noexcept {
+    std::error_code error;
+    std::filesystem::remove_all(directory_, error);
+  }
+
+  std::filesystem::path directory_;
   std::filesystem::path path_;
 };
 


### PR DESCRIPTION
Summary:

- The spdlog logger tests each wrote their log file to one fixed name in the shared system temp directory, so two copies of the test binary running at the same time collided. `AsyncInfoReachesFileViaPeriodicFlush` failed 39 of 40 concurrent runs while passing every time on its own, which is why this only surfaced under repeat-and-parallel execution and not in the normal suite.
- The root cause is that the scoped-file helper removed its path in both the constructor and the destructor. A second process starting or finishing unlinked the file a first process had already opened, leaving that process appending to an orphaned inode -- so the line it was polling for never appeared at the path it was reading, and the wait timed out.
- Each scoped file now owns a private directory created with `mkdtemp()` and removed wholesale on destruction, so concurrent copies of the binary no longer share a path. The three other tests that write log files had the same latent collision and are fixed by the same change.

___

Reviewed By: rmahidhar

Differential Revision: D117892534


