### PR TITLE
Raise CTRAN_MAX_IB_DEVICES_PER_RANK from 2 to 4

### DIFF
--- a/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
@@ -570,11 +570,11 @@ std::string createValidRemoteBusCard() {
     busCard.dataQpn[i] = 200 + i;
   }
 
-  for (int i = 0; i < NCCL_CTRAN_IB_DEVICES_PER_RANK; i++) {
+  for (int i = 0; i < CTRAN_MAX_IB_DEVICES_PER_RANK; i++) {
     busCard.ports[i] = 1; // Port 1 is typical for IB devices
   }
 
-  for (int i = 0; i < NCCL_CTRAN_IB_DEVICES_PER_RANK; i++) {
+  for (int i = 0; i < CTRAN_MAX_IB_DEVICES_PER_RANK; i++) {
     busCard.u.eth.spns[i] = 0xfe80000000000000ULL; // Link-local subnet prefix
     busCard.u.eth.iids[i] = 0x0000000000000001ULL + i; // Interface ID
   }

--- a/comms/ctran/backends/ib/tests/CtranIbCtrlMsgDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbCtrlMsgDistUT.cc
@@ -69,14 +69,32 @@ TEST_F(CtranIbCtrlMsgTest, CtrlMsg) {
     // ctrlMsg into pendingOps
     const int sendRank = 2, recvRank0 = 0, recvRank1 = 1;
 
+    // Fill every rkey slot in the message rather than the cvar's worth: the
+    // struct is sized by CTRAN_MAX_IB_DEVICES_PER_RANK and the whole
+    // sizeof(ControlMsg) goes on the wire, so this covers the full array
+    // regardless of how many NICs this host is configured with.
+    const int nKeys = CTRAN_MAX_IB_DEVICES_PER_RANK;
+    auto fillKeys = [nKeys](ControlMsg& msg, uint64_t remoteAddr, int value) {
+      msg.ibDesc.remoteAddr = remoteAddr;
+      for (int i = 0; i < nKeys; i++) {
+        msg.ibDesc.rkeys[i] = value;
+      }
+      msg.ibDesc.nKeys = nKeys;
+    };
+    auto expectKeys =
+        [nKeys](const ControlMsg& msg, uint64_t remoteAddr, int value) {
+          for (int i = 0; i < nKeys; i++) {
+            EXPECT_EQ(msg.ibDesc.rkeys[i], value) << "rkeys[" << i << "]";
+          }
+          EXPECT_EQ(msg.ibDesc.nKeys, nKeys);
+          EXPECT_EQ(msg.ibDesc.remoteAddr, remoteAddr);
+        };
+
     if (this->globalRank == sendRank) {
       reqs.resize(3, CtranIbRequest());
       smsgs.resize(3, ControlMsg(ControlMsgType::IB_EXPORT_MEM));
       // send two msgs to rank 1
-      smsgs[0].ibDesc.remoteAddr = 99;
-      smsgs[0].ibDesc.rkeys[0] = recvRank0;
-      smsgs[0].ibDesc.rkeys[1] = recvRank0;
-      smsgs[0].ibDesc.nKeys = 2;
+      fillKeys(smsgs[0], 99, recvRank0);
       COMMCHECK_TEST(ctranIb->isendCtrlMsg(
           smsgs[0].type, &smsgs[0], sizeof(smsgs[0]), recvRank0, reqs[0]));
 
@@ -85,19 +103,13 @@ TEST_F(CtranIbCtrlMsgTest, CtrlMsg) {
       // arrived in order
       sleep(2);
 
-      smsgs[1].ibDesc.remoteAddr = 100;
-      smsgs[1].ibDesc.rkeys[0] = recvRank0;
-      smsgs[1].ibDesc.rkeys[1] = recvRank0;
-      smsgs[1].ibDesc.nKeys = 2;
+      fillKeys(smsgs[1], 100, recvRank0);
 
       COMMCHECK_TEST(ctranIb->isendCtrlMsg(
           smsgs[1].type, &smsgs[1], sizeof(smsgs[1]), recvRank0, reqs[1]));
 
       // send one msg to rank 2
-      smsgs[2].ibDesc.remoteAddr = 101;
-      smsgs[2].ibDesc.rkeys[0] = recvRank1;
-      smsgs[2].ibDesc.rkeys[1] = recvRank1;
-      smsgs[2].ibDesc.nKeys = 2;
+      fillKeys(smsgs[2], 101, recvRank1);
       COMMCHECK_TEST(ctranIb->isendCtrlMsg(
           smsgs[2].type, &smsgs[2], sizeof(smsgs[2]), recvRank1, reqs[2]));
     } else if (this->globalRank == recvRank0) {
@@ -122,19 +134,10 @@ TEST_F(CtranIbCtrlMsgTest, CtrlMsg) {
     }
 
     if (this->globalRank == recvRank0) {
-      EXPECT_EQ(rmsg0.ibDesc.rkeys[0], recvRank0);
-      EXPECT_EQ(rmsg0.ibDesc.rkeys[1], recvRank0);
-      EXPECT_EQ(rmsg0.ibDesc.nKeys, 2);
-      EXPECT_EQ(rmsg0.ibDesc.remoteAddr, 99);
-      EXPECT_EQ(rmsg1.ibDesc.rkeys[0], recvRank0);
-      EXPECT_EQ(rmsg1.ibDesc.rkeys[1], recvRank0);
-      EXPECT_EQ(rmsg1.ibDesc.nKeys, 2);
-      EXPECT_EQ(rmsg1.ibDesc.remoteAddr, 100);
+      expectKeys(rmsg0, 99, recvRank0);
+      expectKeys(rmsg1, 100, recvRank0);
     } else if (this->globalRank == recvRank1) {
-      EXPECT_EQ(rmsg0.ibDesc.rkeys[0], recvRank1);
-      EXPECT_EQ(rmsg0.ibDesc.rkeys[1], recvRank1);
-      EXPECT_EQ(rmsg0.ibDesc.nKeys, 2);
-      EXPECT_EQ(rmsg0.ibDesc.remoteAddr, 101);
+      expectKeys(rmsg0, 101, recvRank1);
     }
   } catch (const std::bad_alloc& _) {
     GTEST_SKIP() << "IB backend not enabled. Skip test";

--- a/comms/ctran/backends/ib/tests/CtranIbRequestUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbRequestUT.cc
@@ -2,6 +2,11 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+#include <vector>
+
+#include <folly/String.h>
+
 #include "comms/ctran/backends/ib/CtranIbBase.h"
 
 class CtranIbRequestTest : public ::testing::Test {
@@ -81,12 +86,16 @@ TEST_F(CtranIbRequestTest, RemoteAccessKeyToString) {
   multiKey.nKeys = 2;
   EXPECT_EQ(multiKey.toString(), "111, 222");
 
-  // Test max keys (CTRAN_MAX_IB_DEVICES_PER_RANK = 2)
+  // Test max keys: a full CTRAN_MAX_IB_DEVICES_PER_RANK-wide key round-trips
+  // every entry, so the expectation is derived from the constant.
   CtranIbRemoteAccessKey maxKey;
-  maxKey.rkeys[0] = 0xFFFFFFFF;
-  maxKey.rkeys[1] = 0x12345678;
+  std::vector<std::string> expectedTokens;
+  for (int i = 0; i < CTRAN_MAX_IB_DEVICES_PER_RANK; i++) {
+    maxKey.rkeys[i] = 0xFFFFFFFF - i;
+    expectedTokens.push_back(std::to_string(maxKey.rkeys[i]));
+  }
   maxKey.nKeys = CTRAN_MAX_IB_DEVICES_PER_RANK;
-  EXPECT_EQ(maxKey.toString(), "4294967295, 305419896");
+  EXPECT_EQ(maxKey.toString(), folly::join(", ", expectedTokens));
 }
 
 TEST_F(CtranIbRequestTest, RemoteAccessKeyFromString) {
@@ -125,9 +134,14 @@ TEST_F(CtranIbRequestTest, RemoteAccessKeyFromString) {
 }
 
 TEST_F(CtranIbRequestTest, RemoteAccessKeyFromStringErrors) {
-  // Test too many keys (more than CTRAN_MAX_IB_DEVICES_PER_RANK = 2)
+  // Test too many keys (more than CTRAN_MAX_IB_DEVICES_PER_RANK)
+  std::vector<std::string> tooManyKeys;
+  for (int i = 0; i <= CTRAN_MAX_IB_DEVICES_PER_RANK; i++) {
+    tooManyKeys.push_back(std::to_string(111 + i));
+  }
   EXPECT_THROW(
-      CtranIbRemoteAccessKey::fromString("111,222,333"), std::invalid_argument);
+      CtranIbRemoteAccessKey::fromString(folly::join(",", tooManyKeys)),
+      std::invalid_argument);
 
   // Test invalid number format
   EXPECT_THROW(

--- a/comms/ctran/backends/ib/tests/VcLayoutTest.cc
+++ b/comms/ctran/backends/ib/tests/VcLayoutTest.cc
@@ -59,6 +59,24 @@ TEST(VcLayoutTest, FutureMode_1VcPer4Nics) {
   EXPECT_EQ(layout.vcToActiveDevices, expected);
 }
 
+TEST(VcLayoutTest, PinnedMode_4VcsPer4Nics) {
+  // The GB300 4-NIC deployment: one VC per NIC, so every VC is pinned to a
+  // distinct non-zero NIC for three of the four VCs.
+  const VcLayout layout(/*numNics=*/4, /*maxVcsPerPeer=*/4);
+  const Devs expected{{0}, {1}, {2}, {3}};
+  EXPECT_EQ(layout.maxVcsPerPeer, 4);
+  EXPECT_EQ(layout.maxVcsPerNic, 1);
+  EXPECT_EQ(layout.vcToActiveDevices, expected);
+}
+
+TEST(VcLayoutTest, PinnedMode_8VcsPer4Nics) {
+  const VcLayout layout(/*numNics=*/4, /*maxVcsPerPeer=*/8);
+  const Devs expected{{0}, {0}, {1}, {1}, {2}, {2}, {3}, {3}};
+  EXPECT_EQ(layout.maxVcsPerPeer, 8);
+  EXPECT_EQ(layout.maxVcsPerNic, 2);
+  EXPECT_EQ(layout.vcToActiveDevices, expected);
+}
+
 TEST(VcLayoutTest, InvalidConfig_NotDivisible_4VcsPer3Nics) {
   // 4 % 3 != 0, and 4 < 3 doesn't hold either.
   EXPECT_THROW(

--- a/comms/ctran/mapper/tests/CtranMapperUT.cc
+++ b/comms/ctran/mapper/tests/CtranMapperUT.cc
@@ -5,6 +5,11 @@
 
 #include <cstdlib>
 #include <memory>
+#include <string>
+#include <vector>
+
+#include <fmt/core.h>
+#include <folly/String.h>
 
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/mapper/CtranMapperImpl.h"
@@ -1269,14 +1274,18 @@ TEST_F(CtranMapperTest, exportMemFailsWithExtraSegments) {
 
 TEST_F(CtranMapperTest, RemoteAccessKeyToString) {
   CtranMapperRemoteAccessKey rkey1 = {.backend = CtranMapperBackend::IB};
+  std::vector<std::string> expectedKeys;
   for (auto i = 0; i < CTRAN_MAX_IB_DEVICES_PER_RANK; i++) {
     rkey1.ibKey.rkeys[i] = 291 + i;
+    expectedKeys.push_back(std::to_string(rkey1.ibKey.rkeys[i]));
   }
   rkey1.ibKey.nKeys = CTRAN_MAX_IB_DEVICES_PER_RANK;
   std::strncpy(
       rkey1.nvlKey.peerId, "host1:1234", ctran::regcache::kMaxPeerIdLen);
   rkey1.nvlKey.basePtr = (void*)0x4567890;
-  EXPECT_EQ(rkey1.toString(), "backend=IB, ibKey=[291, 292]");
+  EXPECT_EQ(
+      rkey1.toString(),
+      fmt::format("backend=IB, ibKey=[{}]", folly::join(", ", expectedKeys)));
 
   CtranMapperRemoteAccessKey rkey2 = rkey1;
   rkey2.backend = CtranMapperBackend::NVL;

--- a/comms/ctran/regcache/IpcRegCacheBase.h
+++ b/comms/ctran/regcache/IpcRegCacheBase.h
@@ -12,7 +12,12 @@
 
 // FIXME(alvinyc): move this IB constant to CtranIbBase.h once CtranIb doesn't
 // depend on CtranCtrl and CtranCtrl is removed
-constexpr int CTRAN_MAX_IB_DEVICES_PER_RANK{2};
+//
+// Sizes the per-NIC arrays in IBDesc::rkeys, CtranIbRemoteAccessKey::rkeys and
+// BusCard. BusCard is exchanged as raw bytes with a sizeof-derived length and
+// carries no version field, so changing this value changes the bootstrap wire
+// format: all CTRAN peers must run the same build.
+constexpr int CTRAN_MAX_IB_DEVICES_PER_RANK{4};
 
 namespace ctran {
 namespace regcache {


### PR DESCRIPTION
Summary:
## Context
CoreWeave GB300 hosts genuinely have 4 NICs per rank, and Chef sets
`NCCL_CTRAN_IB_DEVICES_PER_RANK=4` for `gb300_cw`
(`opsfiles/chef/cookbooks/core/fb_nvidia/recipes/nccl.rb:228`). CTRAN rejected that
outright against a compile-time cap of 2, and the failure was invisible: the
`RdmaTransport` probe (`torchcomms/transport/RdmaTransport.cpp:266-288`) constructs a
throwaway `CtranIb`, catches the exception, and caches `rdmaSupport=false` behind a
`folly::once_flag` -- one WARN for the whole process lifetime. The tensor-transfer service
then degraded to Thrift while Python kept registering CUDA tensors zero-copy, and Thrift
serialized a borrowed device pointer with a host memcpy. That is the SIGSEGV in
`__memcpy_sve` -> `FetchSliceResponse::write` that lost all trainers on
`mango_260810_gb300_20b_sftfast_hard30_tr-q02cjsfs`.

## This Diff
This raises the cap rather than pinning the cvar down to 2, which would forfeit half the
available NIC bandwidth. The cap change also *fixes* an existing mismatch: per-NIC loops
are bounded by the cvar while the arrays they index are sized by the constant
(`CtranIb.h:758`, `CtranIbImpl.h:45`), so cvar=4 against a 2-wide array was an overrun.
Raising the constant makes array size >= loop bound.

MEASURED, not assumed, by compiling both values:

- `sizeof(ControlMsg)` is **216 B at both N=2 and N=4** -- `IBDesc` grows 24 -> 32 B but
  shares a union with `IpcDesc` (200 B), which dominates. **No IB data-path wire change.**
- `sizeof(BusCard)` goes **576 B -> 608 B**.

## Test Changes
Test changes remove hardcoded 2-NIC golden values, deriving them from the constant so a
future bump does not repeat this work.


Once this lands, the `NCCL_CTRAN_IB_DEVICES_PER_RANK=2` pin in `GB300_ENVS` (D117880421)
should be removed so CoreWeave GB300 uses all four rails; `nccl.rb:228` can stay at 4. 

Next diff: turns this class of failure from a segfault into a startup error.

Reviewed By: rmahidhar

Differential Revision: D117914551


