### PR TITLE
Stop the accept loop before closing the listen socket (#3869)

### DIFF
--- a/comms/ctran/backends/ib/BootstrapInternal.cc
+++ b/comms/ctran/backends/ib/BootstrapInternal.cc
@@ -93,6 +93,12 @@ void Bootstrap::shutdown() {
     return;
   }
   if (listenSocket_) {
+    // Stop the accept loop before closing the fd, so shutdown()'s write to the
+    // fd cannot race acceptLoop()'s read of it. Sockets whose accept returns
+    // only once the fd is closed report false and need close-then-join.
+    if (listenSocket_->requestStop() && listenThread_.joinable()) {
+      listenThread_.join();
+    }
     listenSocket_->shutdown();
   }
   if (listenThread_.joinable()) {
@@ -321,8 +327,12 @@ void Bootstrap::acceptLoop(Bootstrap* self) {
     // it'll go out of scope (part of its destructor).
     auto maybeSocket = self->listenSocket_->acceptSocket();
     if (maybeSocket.hasError()) {
-      if (self->listenSocket_->hasShutDown()) {
-        break; // listen socket is closed or the CtranIb instance was aborted
+      if (self->listenSocket_->hasShutDown() ||
+          self->listenSocket_->stopRequested()) {
+        // listen socket is closed or stopping, or the CtranIb instance was
+        // aborted. A requested stop is benign, so it must not reach
+        // HANDLE_SOCKET_ERROR, which would abort the communicator.
+        break;
       }
       HANDLE_SOCKET_ERROR(maybeSocket.error(), self);
     }

--- a/comms/ctran/bootstrap/AbortableSocket.cc
+++ b/comms/ctran/bootstrap/AbortableSocket.cc
@@ -427,30 +427,6 @@ AbortableServerSocket::~AbortableServerSocket() {
   shutdown();
 }
 
-AbortableServerSocket::AbortableServerSocket(
-    AbortableServerSocket&& other) noexcept
-    : isV4_(other.isV4_),
-      acceptRetryCnt_(other.acceptRetryCnt_),
-      fd_(other.fd_),
-      abort_(std::move(other.abort_)),
-      shuttingDown_(other.shuttingDown_.load()),
-      hasShutDown_(other.hasShutDown_.load()) {
-  other.fd_ = -1;
-}
-
-AbortableServerSocket& AbortableServerSocket::operator=(
-    AbortableServerSocket&& other) noexcept {
-  if (this != &other) {
-    shutdown(); // Close the current socket if open
-    isV4_ = other.isV4_;
-    acceptRetryCnt_ = other.acceptRetryCnt_;
-    fd_ = other.fd_;
-    abort_ = std::move(other.abort_);
-    other.fd_ = -1; // Reset the file descriptor of the moved-from object
-  }
-  return *this;
-}
-
 int AbortableServerSocket::bind(
     const folly::SocketAddress& addr,
     const std::string& ifName,
@@ -643,7 +619,7 @@ AbortableServerSocket::acceptAsync() {
 
 folly::Expected<std::unique_ptr<ISocket>, int>
 AbortableServerSocket::acceptSocket() {
-  while (!abort_->isAborted()) {
+  while (!abort_->isAborted() && !stopRequested_.load()) {
     auto maybeSocket = acceptAsync();
     if (!maybeSocket.hasError() || maybeSocket.error() != EAGAIN) {
       return maybeSocket;

--- a/comms/ctran/bootstrap/AbortableSocket.h
+++ b/comms/ctran/bootstrap/AbortableSocket.h
@@ -185,17 +185,13 @@ class AbortableServerSocket : public IServerSocket {
   ~AbortableServerSocket();
 
   /**
-   * AbortableServerSocket is movable
-   */
-  AbortableServerSocket(AbortableServerSocket&& other) noexcept;
-  AbortableServerSocket& operator=(AbortableServerSocket&& other) noexcept;
-
-  /**
-   * But not copyable. This ensures 1:1 mapping from underlying
-   * socketFd_ to its owner object.
+   * Not copyable or movable. This ensures 1:1 mapping from the underlying
+   * socket fd and its shutdown state to the owner object.
    */
   AbortableServerSocket(const AbortableServerSocket& other) = delete;
   AbortableServerSocket& operator=(const AbortableServerSocket& other) = delete;
+  AbortableServerSocket(AbortableServerSocket&& other) = delete;
+  AbortableServerSocket& operator=(AbortableServerSocket&& other) = delete;
 
   /**
    * @return 0 on success, errno on error
@@ -222,6 +218,18 @@ class AbortableServerSocket : public IServerSocket {
    * this call. Primarily used for testing.
    */
   int shutdown() override;
+
+  /**
+   * @return always true; acceptSocket() returns within one poll interval.
+   */
+  bool requestStop() override {
+    stopRequested_.store(true);
+    return true;
+  }
+
+  bool stopRequested() const override {
+    return stopRequested_.load();
+  }
 
   int getFd() const override {
     return fd_;
@@ -250,6 +258,9 @@ class AbortableServerSocket : public IServerSocket {
   std::shared_ptr<Abort> abort_;
   std::atomic_bool shuttingDown_{false};
   std::atomic_bool hasShutDown_{false};
+  // Distinct from shuttingDown_, which is shutdown()'s reentrancy guard, and
+  // from hasShutDown_, whose early-return in shutdown() would skip the close.
+  std::atomic_bool stopRequested_{false};
 };
 
 class AbortableSocketFactory : public ISocketFactory {

--- a/comms/ctran/bootstrap/ISocket.h
+++ b/comms/ctran/bootstrap/ISocket.h
@@ -75,6 +75,26 @@ class IServerSocket {
    */
   virtual int shutdown() = 0;
 
+  /**
+   * Ask acceptSocket() to return promptly without closing the socket, so an
+   * accept thread can be joined before shutdown() runs.
+   *
+   * @return true if acceptSocket() is guaranteed to return promptly, allowing
+   * the caller to join before calling shutdown(). false if accept returns only
+   * once the socket is closed, requiring the shutdown()-then-join order.
+   */
+  virtual bool requestStop() {
+    return false;
+  }
+
+  /**
+   * @return true once requestStop() has been called. Lets an accept loop tell
+   * a requested stop from a genuine socket error.
+   */
+  virtual bool stopRequested() const {
+    return false;
+  }
+
   virtual int getFd() const = 0;
 
   virtual folly::Expected<folly::SocketAddress, int> getListenAddress() = 0;

--- a/comms/ctran/bootstrap/Socket.cc
+++ b/comms/ctran/bootstrap/Socket.cc
@@ -357,23 +357,6 @@ ServerSocket::~ServerSocket() {
   }
 }
 
-ServerSocket::ServerSocket(ServerSocket&& other) noexcept {
-  *this = std::move(other);
-}
-
-ServerSocket& ServerSocket::operator=(ServerSocket&& other) noexcept {
-  if (this != &other) {
-    shutdown(); // Close the current socket if open
-    if (fd_ > 0) {
-      close(fd_);
-    }
-    isV4_ = other.isV4_;
-    fd_ = other.fd_;
-    other.fd_ = -1; // Reset the file descriptor of the moved-from object
-  }
-  return *this;
-}
-
 int ServerSocket::bind(
     const folly::SocketAddress& addr,
     const std::string& ifName,
@@ -570,6 +553,19 @@ folly::Expected<std::unique_ptr<ISocket>, int> ServerSocket::acceptSocket() {
   }
 
   return std::make_unique<Socket>(std::move(maybeSocket.value()));
+}
+
+bool ServerSocket::requestStop() {
+  // Mark first so a woken accept() reports an intentional shutdown rather than
+  // an error.
+  hasShutDown_ = true;
+  stopRequested_.store(true);
+  if (fd_ >= 0) {
+    // Wakes a blocked accept() while leaving fd_ valid, so the accept thread
+    // can be joined before shutdown() invalidates it.
+    ::shutdown(fd_, SHUT_RDWR);
+  }
+  return true;
 }
 
 int ServerSocket::shutdown() {

--- a/comms/ctran/bootstrap/Socket.h
+++ b/comms/ctran/bootstrap/Socket.h
@@ -127,18 +127,14 @@ class ServerSocket : public IServerSocket {
    */
   ~ServerSocket();
 
-  /**
-   * Server socket is movable
-   */
-  ServerSocket(ServerSocket&& other) noexcept;
-  ServerSocket& operator=(ServerSocket&& other) noexcept;
-
   /*
-   * But not copyable. This ensures 1:1 maping from underlying
-   * socketFd_ to its owner object.
+   * Not copyable or movable. This ensures 1:1 mapping from the underlying
+   * socket fd and its shutdown state to the owner object.
    */
   ServerSocket(const ServerSocket& other) = delete;
   ServerSocket& operator=(const ServerSocket& other) = delete;
+  ServerSocket(ServerSocket&& other) = delete;
+  ServerSocket& operator=(ServerSocket&& other) = delete;
 
   /**
    * Bind the socket to specified address in constructor. If port in addr is
@@ -172,6 +168,16 @@ class ServerSocket : public IServerSocket {
 
   int shutdown() override;
 
+  /**
+   * @return always true; accept() is woken without invalidating the
+   * descriptor, so the caller can join before shutdown() runs.
+   */
+  bool requestStop() override;
+
+  bool stopRequested() const override {
+    return stopRequested_.load();
+  }
+
   int getFd() const override {
     return fd_;
   }
@@ -190,6 +196,7 @@ class ServerSocket : public IServerSocket {
   int acceptRetryCnt_;
   int fd_{-1};
   std::atomic_bool hasShutDown_{false};
+  std::atomic_bool stopRequested_{false};
 };
 
 class SocketFactory : public ISocketFactory {

--- a/comms/ctran/bootstrap/tests/AbortableSocketTest.cpp
+++ b/comms/ctran/bootstrap/tests/AbortableSocketTest.cpp
@@ -115,6 +115,32 @@ TEST_F(AbortableSocketTest, BasicLifecycleSendAllRecvAll) {
   EXPECT_EQ(0, std::memcmp(response.data(), rcvdResponse, response.size()));
 }
 
+TEST_F(AbortableServerSocketTest, RequestStopUnblocksAcceptWithoutClosing) {
+  // The stop must be observable by acceptSocket() while the fd is still open,
+  // so a caller can join its accept thread before shutdown() touches the fd.
+  folly::Baton<> accepting;
+  std::optional<int> acceptError;
+  std::thread acceptThread([&] {
+    accepting.post();
+    auto maybeSocket = server->acceptSocket();
+    ASSERT_TRUE(maybeSocket.hasError());
+    acceptError = maybeSocket.error();
+  });
+  accepting.wait();
+
+  EXPECT_TRUE(server->requestStop());
+  EXPECT_TRUE(server->stopRequested());
+  acceptThread.join();
+
+  EXPECT_EQ(ECONNABORTED, acceptError);
+  // Still open: the caller, not the stop, decides when the fd is closed.
+  EXPECT_NE(-1, server->getFd());
+  EXPECT_FALSE(server->hasShutDown());
+  // A stop is an ordinary teardown, so it must not look like a failure to the
+  // accept loop's error handling, which would abort the communicator.
+  EXPECT_FALSE(serverAbort->isAborted());
+}
+
 TEST_F(AbortableSocketTest, MoveSemantics) {
   ctran::bootstrap::AbortableSocket client1;
   EXPECT_EQ(0, client1.connect(serverAddr, "lo"));

--- a/comms/ctran/bootstrap/tests/SocketTest.cpp
+++ b/comms/ctran/bootstrap/tests/SocketTest.cpp
@@ -402,6 +402,31 @@ TEST(Socket, AcceptErrorOnShutdown) {
   listenThread.join();
 }
 
+TEST(Socket, RequestStopUnblocksAcceptBeforeShutdown) {
+  // FT-disabled CTRAN builds on this blocking ServerSocket, so it needs the
+  // same stop-then-join-then-close order: accept() has to be woken while fd_
+  // is still valid, or the join races shutdown()'s write to it.
+  ctran::bootstrap::ServerSocket server{1};
+  ASSERT_EQ(0, server.bindAndListen(folly::SocketAddress("::1", 0), "lo"));
+  const int fd = server.getFd();
+  ASSERT_NE(-1, fd);
+
+  std::thread listenThread([&server]() {
+    auto maybeClient = server.accept();
+    ASSERT_TRUE(maybeClient.hasError());
+  });
+
+  EXPECT_TRUE(server.requestStop());
+  EXPECT_TRUE(server.stopRequested());
+  listenThread.join();
+
+  EXPECT_TRUE(server.hasShutDown());
+  // Still valid, so nothing invalidated it while the accept thread ran.
+  EXPECT_EQ(fd, server.getFd());
+  EXPECT_EQ(0, server.shutdown());
+  EXPECT_EQ(-1, server.getFd());
+}
+
 // Tests for ISocket interface implementation
 
 TEST(Socket, ISocketInterfaceSendAll) {


### PR DESCRIPTION
Summary:

`Bootstrap::shutdown()` closed the bootstrap listen socket while its own accept loop was still reading that socket's fd. ThreadSanitizer reports the resulting data race, and the same window has previously produced a SIGSEGV (T286580299).

The fix separates stopping acceptance from closing the descriptor:

- `IServerSocket::requestStop()` asks an implementation to wake or bound `acceptSocket()` without invalidating the fd.
- `AbortableServerSocket` observes an atomic stop flag in its existing 10 ms poll loop.
- `ServerSocket` uses `::shutdown(fd, SHUT_RDWR)` to wake blocking `accept()` while leaving the descriptor valid.
- `Bootstrap::shutdown()` requests the stop, joins the listen thread, and only then closes the socket. Implementations that cannot guarantee a prompt stop retain the close-then-join fallback.
- `acceptLoop()` recognizes a requested stop as benign so normal teardown does not abort the communicator.

Both concrete server-socket implementations are explicitly non-copyable and non-movable. Their fd and shutdown state therefore remain bound to one object instead of requiring unsafe state transfer while an accept or shutdown may be active.

This fixes both FT-enabled (`AbortableSocketFactory`) and FT-disabled (`SocketFactory`) CTRAN teardown. It does not make direct concurrent calls to `shutdown()` and `acceptSocket()` safe; existing tests that deliberately exercise that separate class-level behavior remain TSAN-positive.

Differential Revision: D117930207


