### PR TITLE
Bound AbortInfo publication wait (#3870)

### DIFF
--- a/comms/common/fault_tolerance/Abort.cc
+++ b/comms/common/fault_tolerance/Abort.cc
@@ -13,8 +13,15 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <thread>
 
 namespace comms::fault_tolerance {
+
+namespace {
+
+constexpr std::chrono::milliseconds kAbortInfoPublicationTimeout{300};
+
+} // namespace
 
 Abort::Abort(bool enabled, AbortBehavior behavior) : behavior_(behavior) {
   if (!enabled) {
@@ -44,6 +51,7 @@ Abort::Abort(bool enabled, AbortBehavior behavior) : behavior_(behavior) {
   state_ = new AbortState;
 #endif
   state_->abort = encode(AbortReason::NONE);
+  state_->contextReady = 0;
   state_->timeoutMs = -1;
 }
 
@@ -86,11 +94,27 @@ std::optional<AbortInfo> Abort::getAbortInfo() {
     return std::nullopt;
   }
 
-  std::string context;
-  if (contextReady_.load(std::memory_order_acquire)) {
-    context = context_;
+  const auto publicationDeadline =
+      std::chrono::steady_clock::now() + kAbortInfoPublicationTimeout;
+  auto contextReady = isContextReady();
+  while (!contextReady &&
+         std::chrono::steady_clock::now() < publicationDeadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds{1});
+    contextReady = isContextReady();
   }
-  return AbortInfo{.reason = reason, .context = std::move(context)};
+
+  if (!contextReady) {
+    const auto reasonString = abortReasonToString(reason);
+    std::fprintf(
+        stderr,
+        "WARNING: AbortInfo publication did not complete within %lldms for "
+        "abort reason %.*s; returning empty context\n",
+        static_cast<long long>(kAbortInfoPublicationTimeout.count()),
+        static_cast<int>(reasonString.size()),
+        reasonString.data());
+    return AbortInfo{.reason = reason, .context = {}};
+  }
+  return AbortInfo{.reason = reason, .context = context_};
 }
 
 bool Abort::isAborted() {
@@ -204,6 +228,11 @@ int Abort::loadAbortReason() const {
   return std::atomic_ref<int>{state_->abort}.load(std::memory_order_acquire);
 }
 
+bool Abort::isContextReady() const {
+  return std::atomic_ref<int>{state_->contextReady}.load(
+             std::memory_order_acquire) != 0;
+}
+
 bool Abort::trySetAbort(AbortReason newReason, std::string context) {
   int expected = encode(AbortReason::NONE);
   const bool won = std::atomic_ref<int>{state_->abort}.compare_exchange_strong(
@@ -215,9 +244,12 @@ bool Abort::trySetAbort(AbortReason newReason, std::string context) {
     return false;
   }
 
-  // The reason CAS gives this call exclusive ownership of context_. Publishing
-  // happens afterwards on purpose: a racing reader may return the reason with
-  // empty context, but it never reads context_ while this swap is in progress.
+  // The reason CAS gives this call exclusive ownership of context_. Publish
+  // readiness only after the swap so getAbortInfo() cannot return a terminal
+  // reason with a transiently incomplete host context.
+  context_.swap(context);
+  std::atomic_ref<int>{state_->contextReady}.store(
+      1, std::memory_order_release);
   const auto reasonString = abortReasonToString(newReason);
   std::fprintf(
       stderr,
@@ -225,9 +257,7 @@ bool Abort::trySetAbort(AbortReason newReason, std::string context) {
       static_cast<int>(newReason),
       static_cast<int>(reasonString.size()),
       reasonString.data(),
-      context.c_str());
-  context_.swap(context);
-  contextReady_.store(true, std::memory_order_release);
+      context_.c_str());
   return true;
 }
 

--- a/comms/common/fault_tolerance/Abort.h
+++ b/comms/common/fault_tolerance/Abort.h
@@ -42,7 +42,7 @@ enum class AbortCheckResult : int {
 /**
  * Host-owned state shared with CUDA device code through mapped pinned memory.
  *
- * Both fields are read and written with system-scope atomic operations. The
+ * All fields are read and written with system-scope atomic operations. The
  * allocation is owned by `Abort`; `AbortDevice` stores only a non-owning mapped
  * pointer to this same state.
  */
@@ -57,6 +57,16 @@ struct AbortState {
   int abort;
 
   /**
+   * Whether AbortInfo context publication is complete.
+   *
+   * Host winners set this after storing their context. Device winners also set
+   * it; their host-visible context is empty because device context is not
+   * persisted in mapped host state. Readers that observe a terminal reason
+   * wait while this remains false before returning AbortInfo.
+   */
+  int contextReady;
+
+  /**
    * Shared default timeout duration in milliseconds.
    *
    * `-1` means unset. Host code may update this value, and device handles read
@@ -68,6 +78,7 @@ struct AbortState {
 // Atomic operations require naturally aligned fields. Cacheline padding is a
 // performance choice, not a correctness requirement for this shared state.
 static_assert(offsetof(AbortState, abort) % alignof(int) == 0);
+static_assert(offsetof(AbortState, contextReady) % alignof(int) == 0);
 static_assert(offsetof(AbortState, timeoutMs) % alignof(int64_t) == 0);
 
 struct AbortDevice;
@@ -88,13 +99,16 @@ struct AbortDevice;
  * singleton returned by `createAbort(false)` is intended for code paths that
  * must accept an abort object without enabling fault tolerance.
  *
- * `AbortState::abort` and `AbortState::timeoutMs` are mutable shared fields.
- * Host code and device code access them with system-scope atomic operations so
- * updates from either side become visible to the other side. The abort reason
- * is first-writer-wins: an explicit abort records `AbortReason::ABORTED`; an
- * expired timeout records `AbortReason::TIMED_OUT` only if no earlier valid
- * terminal reason has been recorded. The default timeout duration is also
- * stored in shared state for graph-mode device code; host active-deadline
+ * `AbortState` fields are mutable shared state. Host code and device code
+ * access them with system-scope atomic operations so updates from either side
+ * become visible to the other side. The abort reason is first-writer-wins: an
+ * explicit abort records `AbortReason::ABORTED`; an expired timeout records
+ * `AbortReason::TIMED_OUT` only if no earlier valid terminal reason has been
+ * recorded. The winning writer then publishes `contextReady`, preventing a
+ * reader from returning a reason before its host context is stable. Device
+ * writers publish the same ready state after winning the reason transition;
+ * their host-visible context remains empty. The default timeout duration is
+ * also stored in shared state for graph-mode device code; host active-deadline
  * tracking remains host-only.
  */
 class Abort final {
@@ -149,10 +163,9 @@ class Abort final {
    * state.
    *
    * The context is copied before attempting the transition. When this call
-   * wins, that owned string is published in host-only state and becomes
-   * available through `getAbortInfo()`. A racing reader may observe the winning
-   * reason before the context is published and receive an empty context.
-   * Device-originated aborts never publish host context.
+   * wins, that owned string is published in host-only state before AbortInfo is
+   * marked ready. `getAbortInfo()` waits for that publication to complete.
+   * Device-originated aborts publish readiness without a host context.
    *
    * Returns whether this call performed the `NONE` to terminal transition.
    */
@@ -165,7 +178,14 @@ class Abort final {
    * std::nullopt when this controller has not been aborted.
    *
    * Like `isAborted()`, this materializes an expired host timeout before
-   * reading the snapshot. Device-originated aborts have an empty context.
+   * reading the snapshot. Once a terminal reason is visible, this waits up to
+   * 300ms for the winning host or device writer to complete AbortInfo
+   * publication. Device-originated aborts have an empty context. If the winner
+   * does not publish in time, this prints a warning and returns the reason with
+   * an empty context rather than waiting indefinitely. This fallback is best
+   * effort: publication may complete later and a subsequent call may return
+   * the context. Previously returned AbortInfo snapshots are values and are not
+   * updated, so a caller that caches the fallback retains its empty context.
    */
   std::optional<AbortInfo> getAbortInfo();
 
@@ -263,6 +283,7 @@ class Abort final {
   }
 
   int loadAbortReason() const;
+  bool isContextReady() const;
   bool trySetAbort(AbortReason newReason, std::string context);
 
   AbortState* state_{nullptr};
@@ -271,9 +292,7 @@ class Abort final {
   std::atomic<std::chrono::steady_clock::time_point> deadline_{
       std::chrono::steady_clock::time_point{}};
   // Only the host reason-CAS winner writes context_. Readers copy it only after
-  // an acquire load observes contextReady_, so no mutex is needed. The flag is
-  // host-only and is never accessed by AbortDevice.
-  std::atomic<bool> contextReady_{false};
+  // an acquire load observes contextReady == 1, so no mutex is needed.
   std::string context_;
   AbortBehavior behavior_{AbortBehavior::SKIP};
 

--- a/comms/common/fault_tolerance/AbortDevice.cuh
+++ b/comms/common/fault_tolerance/AbortDevice.cuh
@@ -143,6 +143,11 @@ deviceCompareExchangeSystem(int* value, int* expected, int desired) {
 #endif
 }
 
+__device__ __forceinline__ void publishContextReady(AbortState* state) {
+  int expected = 0;
+  (void)deviceCompareExchangeSystem(&state->contextReady, &expected, 1);
+}
+
 } // namespace detail
 
 /**
@@ -411,6 +416,8 @@ struct AbortDevice final {
     const bool won = detail::deviceCompareExchangeSystem(
         &state_->abort, &expected, static_cast<int>(newReason));
     if (won) {
+      // Device context is intentionally not persisted in mapped host state.
+      detail::publishContextReady(state_);
       // NOLINTNEXTLINE(facebook-security-vulnerable-printf)
       printf(
           FT_ABORT_FIRST_WRITER_DEVICE_ "reason=%d context=%s\n",
@@ -493,6 +500,7 @@ struct AbortDevice final {
             &state_->abort,
             &expected,
             static_cast<int>(AbortReason::TIMED_OUT))) {
+      detail::publishContextReady(state_);
       if (flippedHere != nullptr) {
         *flippedHere = true;
       }
@@ -596,6 +604,8 @@ struct AbortFlag final {
    * Writing shared state is safe to do from a shared handle -- it is a
    * system-scope CAS, which is exactly what the shared state is for. Only
    * *polling* needs per-thread throttle state, and this type has none.
+   * Device context is not persisted, so a winning writer publishes
+   * `contextReady` immediately after the reason.
    */
   __device__ bool setAbort(
       AbortReason newReason = AbortReason::ABORTED,
@@ -610,8 +620,12 @@ struct AbortFlag final {
       return false;
     }
     int expected = static_cast<int>(AbortReason::NONE);
-    return detail::deviceCompareExchangeSystem(
+    const bool won = detail::deviceCompareExchangeSystem(
         &state_->abort, &expected, static_cast<int>(newReason));
+    if (won) {
+      detail::publishContextReady(state_);
+    }
+    return won;
   }
 
   /**

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
@@ -28,6 +28,33 @@ __global__ void deviceSetAbortWithContextKernel(
   }
 }
 
+__global__ void abortFlagSetAbortKernel(
+    AbortDevice abort,
+    AbortReason reason,
+    int* observedWinner,
+    int* observedContextReady) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    const AbortFlag flag{abort};
+    *observedWinner = flag.setAbort(reason) ? 1 : 0;
+    *observedContextReady =
+        detail::deviceLoadAcquireSystem(&abort.stateForFlag()->contextReady);
+  }
+}
+
+__global__ void devicePublishReasonWithoutContextKernel(
+    AbortDevice abort,
+    AbortReason reason,
+    int* observedWinner) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    int expected = static_cast<int>(AbortReason::NONE);
+    *observedWinner =
+        detail::deviceCompareExchangeSystem(
+            &abort.stateForFlag()->abort, &expected, static_cast<int>(reason))
+        ? 1
+        : 0;
+  }
+}
+
 __global__ void
 deviceReadAbortKernel(AbortDevice abort, int* observed, int* observedMode) {
   if (blockIdx.x == 0 && threadIdx.x == 0) {
@@ -193,6 +220,27 @@ cudaError_t launchDeviceSetAbortWithContext(
     cudaStream_t stream) {
   deviceSetAbortWithContextKernel<<<1, 1, 0, stream>>>(
       abort, reason, useContext, observedWinner);
+  return cudaGetLastError();
+}
+
+cudaError_t launchAbortFlagSetAbort(
+    AbortDevice abort,
+    AbortReason reason,
+    int* observedWinner,
+    int* observedContextReady,
+    cudaStream_t stream) {
+  abortFlagSetAbortKernel<<<1, 1, 0, stream>>>(
+      abort, reason, observedWinner, observedContextReady);
+  return cudaGetLastError();
+}
+
+cudaError_t launchDevicePublishReasonWithoutContext(
+    AbortDevice abort,
+    AbortReason reason,
+    int* observedWinner,
+    cudaStream_t stream) {
+  devicePublishReasonWithoutContextKernel<<<1, 1, 0, stream>>>(
+      abort, reason, observedWinner);
   return cudaGetLastError();
 }
 

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
@@ -22,6 +22,19 @@ cudaError_t launchDeviceSetAbortWithContext(
     int* observedWinner,
     cudaStream_t stream);
 
+cudaError_t launchAbortFlagSetAbort(
+    AbortDevice abort,
+    AbortReason reason,
+    int* observedWinner,
+    int* observedContextReady,
+    cudaStream_t stream);
+
+cudaError_t launchDevicePublishReasonWithoutContext(
+    AbortDevice abort,
+    AbortReason reason,
+    int* observedWinner,
+    cudaStream_t stream);
+
 cudaError_t launchDeviceReadAbort(
     AbortDevice abort,
     int* observed,

--- a/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
@@ -298,6 +298,58 @@ TEST(AbortDeviceTest, deviceNullContextCanLogForReasonCasWinner) {
       }));
 }
 
+TEST(AbortDeviceTest, abortFlagPublishesEmptyContext) {
+  Abort abort{/*enabled=*/true};
+  auto won = makeDeviceValue<int>();
+  auto contextReady = makeDeviceValue<int>();
+  ASSERT_NE(won, nullptr);
+  ASSERT_NE(contextReady, nullptr);
+
+  EXPECT_EQ(
+      launchAbortFlagSetAbort(
+          abort.getDeviceHandle(),
+          AbortReason::INTERNAL_ERROR,
+          won.get(),
+          contextReady.get(),
+          /*stream=*/nullptr),
+      cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(won), 1);
+  EXPECT_EQ(readDeviceValue(contextReady), 1);
+  EXPECT_EQ(
+      abort.getAbortInfo(),
+      (AbortInfo{
+          .reason = AbortReason::INTERNAL_ERROR,
+          .context = "",
+      }));
+}
+
+TEST(AbortDeviceTest, missingContextPublicationReturnsBestEffortSnapshot) {
+  Abort abort{/*enabled=*/true};
+  auto won = makeDeviceValue<int>();
+  ASSERT_NE(won, nullptr);
+
+  EXPECT_EQ(
+      launchDevicePublishReasonWithoutContext(
+          abort.getDeviceHandle(),
+          AbortReason::NETWORK_ERROR,
+          won.get(),
+          /*stream=*/nullptr),
+      cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  EXPECT_EQ(readDeviceValue(won), 1);
+
+  const auto start = std::chrono::steady_clock::now();
+  EXPECT_EQ(
+      abort.getAbortInfo(),
+      (AbortInfo{
+          .reason = AbortReason::NETWORK_ERROR,
+          .context = "",
+      }));
+  EXPECT_LT(std::chrono::steady_clock::now() - start, std::chrono::seconds{2});
+}
+
 TEST(AbortDeviceTest, deviceWinnerDoesNotExposeLosingHostContext) {
   Abort abort{/*enabled=*/true};
 
@@ -469,6 +521,9 @@ TEST(AbortDeviceTest, deviceTimeoutProducerHostAndDeviceConsumer) {
   EXPECT_EQ(readDeviceValue(observedIsAborted), 1);
   EXPECT_TRUE(abort.isAborted());
   EXPECT_TRUE(abort.isTimedOut());
+  EXPECT_EQ(
+      abort.getAbortInfo(),
+      (AbortInfo{.reason = AbortReason::TIMED_OUT, .context = ""}));
 }
 
 TEST(AbortDeviceTest, hostAbortWinsOverDeviceTimeout) {

--- a/comms/common/fault_tolerance/tests/AbortUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortUT.cc
@@ -6,6 +6,7 @@
 #include <optional>
 #include <stdexcept>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include <gmock/gmock.h>


### PR DESCRIPTION
Summary:

- move the existing contextReady publication flag into CUDA-mapped AbortState so both host and device abort winners can complete the same readiness protocol
- host winners publish readiness after storing context; device winners publish readiness with intentionally empty host context
- make getAbortInfo() wait at most 300ms for readiness, then warn and return the winning reason with empty context
- document the timeout as best effort: later calls may observe completed context, while previously returned or cached value snapshots remain empty
- preserve the existing reason CAS and device system-scope CAS helper without adding a separate state enum

Reviewed By: Scusemua

Differential Revision: D117597609


