### PR TITLE
Remove dead Scuba tables and stop constructing slow-rank by default (#3872)

### DIFF
--- a/comms/ncclx/meta/logger/tests/ScubaLoggerTest.cc
+++ b/comms/ncclx/meta/logger/tests/ScubaLoggerTest.cc
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <cstdlib>
 #include <filesystem>
 
 #include <folly/stop_watch.h>
@@ -11,6 +12,9 @@
 class ScubaLoggerTest : public ::testing::Test, public ScubaLoggerTestMixin {
  public:
   void SetUp() override {
+    // A table is only constructed when NCCL_COMM_EVENT_LOGGING is non-empty,
+    // and it only writes a file when its destination type is pipe.
+    setenv("NCCL_COMM_EVENT_LOGGING", "pipe:nccl_structured_logging", 1);
     ScubaLoggerTestMixin::SetUp();
   }
 };

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -119,10 +119,13 @@ cvars:
 
  - name        : NCCL_SLOW_RANK_LOGGING
    type        : string
-   default     : "scuba:nccl_profiler_slow_rank"
+   default     : ""
    description : |-
-      File location for logging communicator profiler events. By default,
-      all data is logged to scuba table nccl_profiler_slow_rank.
+      File location for logging communicator profiler events, written to the
+      nccl_profiler_slow_rank table. Disabled by default (empty): a non-empty
+      value constructs a DataTable, which costs a thread on every rank, and the
+      only producer (NetworkPerfMonitor) is itself inactive unless
+      NCCL_NETWORK_PERF_MONITOR_ENABLE is set. Opt in alongside that cvar.
       (the same format with NCCL_COMM_EVENT_LOGGING)
 
  - name        : NCCL_CTRAN_ALGO_PROFILING_LOGGING
@@ -295,20 +298,6 @@ cvars:
      Enable memory tracing for all NCCLX memory allocations, frees, and
      registrations. When enabled, memory events are logged to Scuba and
      tracked per-communicator for commDump reporting.
-
- - name        : NCCL_SLOW_COLL_LOGGING
-   type        : string
-   default     : "pipe:nccl_slow_coll"
-   description : |-
-      File location for logging slow collectives.
-      (the same format with NCCL_COMM_EVENT_LOGGING)
-
- - name        : NCCL_COLL_STATS_LOGGING
-   type        : string
-   default     : "pipe:nccl_collective_stats"
-   description : |-
-      File location for logging collective stats.
-      (the same format with NCCL_COMM_EVENT_LOGGING)
 
  - name        : NCCL_MEM_ENABLE_MC_ALIGNMENT
    type        : bool
@@ -3023,7 +3012,11 @@ cvars:
    type        : bool
    default     : False
    description : |-
-     Enable network perf monitor to report info to scuba.
+     Enable network perf monitor to report info to scuba. Also set
+     NCCL_SLOW_RANK_LOGGING to a destination (e.g.
+     "scuba:nccl_profiler_slow_rank"): it is empty by default, and without it
+     the nccl_profiler_slow_rank table is never constructed, so the samples
+     are dropped.
 
  - name        : NCCL_COMM_REGISTER_LOG_ENABLE
    type        : bool

--- a/comms/utils/logger/DataTableWrapper.cc
+++ b/comms/utils/logger/DataTableWrapper.cc
@@ -18,8 +18,6 @@ constexpr std::string_view k_nccl_profiler_algo = "nccl_profiler_algo";
 constexpr std::string_view k_nccl_profiler_gpe = "nccl_profiler_gpe";
 constexpr std::string_view k_nccl_structured_logging =
     "nccl_structured_logging";
-constexpr std::string_view k_nccl_slow_coll = "nccl_slow_coll";
-constexpr std::string_view k_nccl_collective_stats = "nccl_collective_stats";
 } // namespace
 
 namespace {
@@ -72,8 +70,6 @@ std::vector<std::pair<std::string_view, std::string_view>> getAllTableNames() {
       {k_nccl_profiler_algo, NCCL_CTRAN_ALGO_PROFILING_LOGGING},
       {k_nccl_profiler_gpe, NCCL_CTRAN_GPE_PROFILING_LOGGING},
       {k_nccl_structured_logging, NCCL_COMM_EVENT_LOGGING},
-      {k_nccl_slow_coll, NCCL_SLOW_COLL_LOGGING},
-      {k_nccl_collective_stats, NCCL_COLL_STATS_LOGGING},
   };
   return tableNames;
 }
@@ -111,42 +107,24 @@ std::shared_ptr<DataTable> DataTableWrapper::getTable() {
   return table_;
 }
 
-DEFINE_scuba_table(nccl_coll_signature);
-DEFINE_scuba_table(nccl_coll_timestamp);
-DEFINE_scuba_table(nccl_commdump);
-DEFINE_scuba_table(nccl_error_logging);
 DEFINE_scuba_table(nccl_memory_logging);
 DEFINE_scuba_table(nccl_profiler_slow_rank);
 DEFINE_scuba_table(nccl_profiler_algo);
 DEFINE_scuba_table(nccl_profiler_gpe);
 DEFINE_scuba_table(nccl_structured_logging);
-DEFINE_scuba_table(nccl_slow_coll);
-DEFINE_scuba_table(nccl_collective_stats);
 
 void DataTableWrapper::init() {
-  INIT_scuba_table(nccl_coll_signature);
-  INIT_scuba_table(nccl_coll_timestamp);
-  INIT_scuba_table(nccl_commdump);
-  INIT_scuba_table(nccl_error_logging);
   INIT_scuba_table(nccl_memory_logging);
   INIT_scuba_table(nccl_profiler_slow_rank);
   INIT_scuba_table(nccl_profiler_algo);
   INIT_scuba_table(nccl_profiler_gpe);
   INIT_scuba_table(nccl_structured_logging);
-  INIT_scuba_table(nccl_slow_coll);
-  INIT_scuba_table(nccl_collective_stats);
 }
 
 void DataTableWrapper::shutdown() {
-  SHUTDOWN_scuba_table(nccl_coll_signature);
-  SHUTDOWN_scuba_table(nccl_coll_timestamp);
-  SHUTDOWN_scuba_table(nccl_commdump);
-  SHUTDOWN_scuba_table(nccl_error_logging);
   SHUTDOWN_scuba_table(nccl_memory_logging);
   SHUTDOWN_scuba_table(nccl_profiler_slow_rank);
   SHUTDOWN_scuba_table(nccl_profiler_algo);
   SHUTDOWN_scuba_table(nccl_profiler_gpe);
   SHUTDOWN_scuba_table(nccl_structured_logging);
-  SHUTDOWN_scuba_table(nccl_slow_coll);
-  SHUTDOWN_scuba_table(nccl_collective_stats);
 }

--- a/comms/utils/logger/DataTableWrapper.h
+++ b/comms/utils/logger/DataTableWrapper.h
@@ -70,26 +70,14 @@ std::vector<std::pair<std::string_view, std::string_view>> getAllTableNames();
 //
 // Tables must exist here:
 // https://www.internalfb.com/code/configerator/[master]/source/datainfra/logarithm/transport/logarithm_conda_custom_transport.cinc
-DECLARE_scuba_table(nccl_coll_signature);
-DECLARE_scuba_table(nccl_coll_timestamp);
-DECLARE_scuba_table(nccl_commdump);
-DECLARE_scuba_table(nccl_error_logging);
 DECLARE_scuba_table(nccl_memory_logging);
 DECLARE_scuba_table(nccl_profiler_slow_rank);
 DECLARE_scuba_table(nccl_profiler_algo);
 DECLARE_scuba_table(nccl_profiler_gpe);
 DECLARE_scuba_table(nccl_structured_logging);
-DECLARE_scuba_table(nccl_slow_coll);
-DECLARE_scuba_table(nccl_collective_stats);
 
 #define SCUBA_nccl_structured_logging (*SCUBA_nccl_structured_logging_ptr)
 #define SCUBA_nccl_profiler_algo (*SCUBA_nccl_profiler_algo_ptr)
 #define SCUBA_nccl_profiler_gpe (*SCUBA_nccl_profiler_gpe_ptr)
 #define SCUBA_nccl_profiler_slow_rank (*SCUBA_nccl_profiler_slow_rank_ptr)
 #define SCUBA_nccl_memory_logging (*SCUBA_nccl_memory_logging_ptr)
-#define SCUBA_nccl_error_logging (*SCUBA_nccl_error_logging_ptr)
-#define SCUBA_nccl_coll_signature (*SCUBA_nccl_coll_signature_ptr)
-#define SCUBA_nccl_coll_timestamp (*SCUBA_nccl_coll_timestamp_ptr)
-#define SCUBA_nccl_commdump (*SCUBA_nccl_commdump_ptr)
-#define SCUBA_nccl_slow_coll (*SCUBA_nccl_slow_coll_ptr)
-#define SCUBA_nccl_collective_stats (*SCUBA_nccl_collective_stats_ptr)

--- a/comms/utils/logger/EventMgr.h
+++ b/comms/utils/logger/EventMgr.h
@@ -20,14 +20,10 @@ enum class LoggerEventType {
   CommEventType,
   MemoryEventType,
   CollEventType,
-  CollSignatureEventType,
-  CollTimestampEventType,
-  ErrorEventType,
   CtranProfilerEventType,
   CtranProfilerSlowRankModuleEventType,
   CtranProfilerAlgoEventType,
   CtranProfilerGpeEventType,
-  CommdumpEventType,
   TerminateEventType,
 };
 

--- a/comms/utils/logger/ScubaLogger.cc
+++ b/comms/utils/logger/ScubaLogger.cc
@@ -8,12 +8,6 @@
 
 DataTableWrapper* getTablePtrFromEvent(LoggerEventType event) {
   switch (event) {
-    case LoggerEventType::CollSignatureEventType:
-      return SCUBA_nccl_coll_signature_ptr.get();
-    case LoggerEventType::CollTimestampEventType:
-      return SCUBA_nccl_coll_timestamp_ptr.get();
-    case LoggerEventType::ErrorEventType:
-      return SCUBA_nccl_error_logging_ptr.get();
     case LoggerEventType::MemoryEventType:
       return SCUBA_nccl_memory_logging_ptr.get();
     case LoggerEventType::CtranProfilerSlowRankModuleEventType:

--- a/comms/utils/logger/tests/LoggerRuntimeUT.cc
+++ b/comms/utils/logger/tests/LoggerRuntimeUT.cc
@@ -35,7 +35,7 @@ TEST_F(LoggerRuntimeTest, ShutdownBeforeInitializationIsNoOp) {
   shutdownCommLoggerRuntime();
 
   EXPECT_EQ(SCUBA_nccl_structured_logging_ptr, nullptr);
-  EXPECT_EQ(SCUBA_nccl_error_logging_ptr, nullptr);
+  EXPECT_EQ(SCUBA_nccl_memory_logging_ptr, nullptr);
 }
 
 TEST_F(LoggerRuntimeTest, LegacyCloseIsSafeWhenNotInitialized) {
@@ -69,7 +69,7 @@ TEST_F(LoggerRuntimeTest, OwnsSharedStateLifecycle) {
   EXPECT_TRUE(isEnabledSubSystemBitwise(INIT));
   EXPECT_FALSE(isEnabledSubSystemBitwise(COLL));
   ASSERT_NE(SCUBA_nccl_structured_logging_ptr, nullptr);
-  ASSERT_NE(SCUBA_nccl_error_logging_ptr, nullptr);
+  ASSERT_NE(SCUBA_nccl_memory_logging_ptr, nullptr);
 
   NCCL_DEBUG_SUBSYS = "COLL";
   initCommLoggerRuntime();
@@ -81,7 +81,7 @@ TEST_F(LoggerRuntimeTest, OwnsSharedStateLifecycle) {
   EXPECT_FALSE(isEnabledSubSystemBitwise(INIT));
   EXPECT_TRUE(isEnabledSubSystemBitwise(COLL));
   ASSERT_NE(SCUBA_nccl_structured_logging_ptr, nullptr);
-  ASSERT_NE(SCUBA_nccl_error_logging_ptr, nullptr);
+  ASSERT_NE(SCUBA_nccl_memory_logging_ptr, nullptr);
 }
 
 } // namespace


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/meta-pytorch/torchcomms/pull/3872

Reviewed By: shr

Differential Revision: D117943445


