### PR TITLE
Remove stale migration references

### DIFF
--- a/comms/ctran/algos/AllReduce/Types.h
+++ b/comms/ctran/algos/AllReduce/Types.h
@@ -40,8 +40,8 @@ struct KernelArgs {
 
 } // namespace ctran::allreduce
 
-// Ring host types are only used by CPU code (AllReduceRing.cc, CtranGpe.cc).
-// Guard against nvcc which cannot compile folly XLOG in transitive includes.
+// Ring host types are only used by CPU code (AllReduceRing.cc, CtranGpe.cc),
+// so keep their host-only dependencies out of CUDA compilation.
 #if !defined(__CUDACC__)
 
 #include <memory>

--- a/comms/ctran/backends/ib/ibutils.cc
+++ b/comms/ctran/backends/ib/ibutils.cc
@@ -4,7 +4,6 @@
 #include <fmt/core.h>
 #include <folly/Singleton.h>
 #include <folly/Synchronized.h>
-#include <folly/init/Init.h>
 #include <cerrno>
 #include <chrono>
 #include <thread>


### PR DESCRIPTION
Summary:
Remove the unused `folly/init/Init.h` include and direct `//folly/init:init` dependency from the CTRAN IB library after validating its native, hipified, monolithic, and test consumers.

Update stale CTRAN/MCCL comments, MCCL review guidance, and plan-evaluator fixtures so future changes use the migrated `MCCL_LOG` interfaces rather than reintroducing Folly logging. This does not alter runtime logging behavior or hot-path execution.

Reviewed By: shr

Differential Revision: D118022510


