### PR TITLE
Add the LL blocking forward seam (#3876)

### DIFF
--- a/comms/prims/core/LLImpl.cuh
+++ b/comms/prims/core/LLImpl.cuh
@@ -480,6 +480,101 @@ struct LLImpl {
     (void)abortDevice;
 #endif
   }
+
+  /// Relay one already-ready chunk: decode `recvStaging`'s payload into `dst`
+  /// (when non-null) AND re-encode it into `fwdStaging` stamped with
+  /// `fwdFlagVal`, in a single pass. Cooperative across `group`.
+  ///
+  /// This is the LL counterpart of a fused forward, and it cannot be a
+  /// packet-to-packet copy: the two staging rings advance on independent
+  /// cursors, so the outbound packets need the DOWNSTREAM ring's generation,
+  /// not the one the upstream sender stamped. Copying the packets verbatim
+  /// would ship a stale flag and the next hop would either accept the previous
+  /// pass's data or wait forever.
+  ///
+  /// Unlike `unpack` this never spins: the caller confirms every packet's flag
+  /// before invoking it (blocking `prepareForwardBuf(LL)` polls, the resumable
+  /// path uses `progress_recv_ready(LL)`). A spin here would be unrecoverable
+  /// anyway -- a partial pass has already written `fwdStaging`.
+  template <typename Group>
+  __device__ __forceinline__ static void repack(
+      Group& group,
+      void* dst,
+      void* fwdStaging,
+      const void* recvStaging,
+      std::size_t nbytes,
+      FlagType fwdFlagVal) {
+#ifdef __CUDA_ARCH__
+    const std::size_t nPackets = P::packet_count(nbytes);
+    const auto* recvBase = reinterpret_cast<const char*>(recvStaging);
+    auto* fwdBase = reinterpret_cast<char*>(fwdStaging);
+    auto* d = reinterpret_cast<char*>(dst);
+    for (std::size_t i = group.thread_id_in_group; i < nPackets;
+         i += group.group_size) {
+      const char* recvPkt =
+          recvBase + i * static_cast<std::size_t>(P::kPacketBytes);
+      char* fwdPkt = fwdBase + i * static_cast<std::size_t>(P::kPacketBytes);
+      const std::size_t valid = P::valid_payload(i, nbytes);
+      const std::size_t off = i * static_cast<std::size_t>(P::kData);
+
+      if constexpr (P::kPacketBytes == static_cast<int>(sizeof(uint64_t))) {
+        // 8 B packet: {data:4, flag:4}. One wide load pulls both halves; one
+        // wide store re-stamps the payload with the downstream generation.
+        // Bytes past `valid` are the upstream packer's zero padding, so
+        // carrying the whole data half through preserves it.
+        const uint64_t v = comms::device::ld_volatile_global(
+            reinterpret_cast<const volatile uint64_t*>(recvPkt));
+        const auto data = static_cast<uint32_t>(v);
+        comms::device::st_volatile_global(
+            reinterpret_cast<volatile uint64_t*>(fwdPkt),
+            (static_cast<uint64_t>(fwdFlagVal) << 32) |
+                static_cast<uint64_t>(data));
+        if (d != nullptr) {
+          const auto* db = reinterpret_cast<const char*>(&data);
+#pragma unroll
+          for (int b = 0; b < P::kData; ++b) {
+            if (static_cast<std::size_t>(b) < valid) {
+              d[off + b] = db[b];
+            }
+          }
+        }
+      } else {
+        // Large packet: copy the data region word-wise, then stamp the flag
+        // last, mirroring pack()'s ordering.
+        constexpr int kDataWords =
+            P::kData / static_cast<int>(sizeof(uint64_t));
+        const auto* sp = reinterpret_cast<const volatile uint64_t*>(recvPkt);
+        auto* fp = reinterpret_cast<volatile uint64_t*>(fwdPkt);
+#pragma unroll
+        for (int w = 0; w < kDataWords; ++w) {
+          const uint64_t word = comms::device::ld_volatile_global(sp + w);
+          comms::device::st_volatile_global(fp + w, word);
+          if (d != nullptr) {
+            const auto* wb = reinterpret_cast<const char*>(&word);
+#pragma unroll
+            for (int b = 0; b < static_cast<int>(sizeof(uint64_t)); ++b) {
+              const std::size_t gb =
+                  static_cast<std::size_t>(w) * sizeof(uint64_t) +
+                  static_cast<std::size_t>(b);
+              if (gb < valid) {
+                d[off + gb] = wb[b];
+              }
+            }
+          }
+        }
+        store_flag(fwdPkt, fwdFlagVal);
+      }
+    }
+    group.sync();
+#else
+    (void)group;
+    (void)dst;
+    (void)fwdStaging;
+    (void)recvStaging;
+    (void)nbytes;
+    (void)fwdFlagVal;
+#endif
+  }
 };
 
 } // namespace comms::prims

--- a/comms/prims/core/LLImpl.cuh
+++ b/comms/prims/core/LLImpl.cuh
@@ -356,6 +356,34 @@ struct LLImpl {
 #endif
   }
 
+  /// Read a packet's data half without polling its flag, for callers that have
+  /// already confirmed readiness (the forward seams). Same wide load as
+  /// load_ready_payload, minus the spin.
+  __device__ __forceinline__ static uint32_t load_payload(const char* pkt) {
+#ifdef __CUDA_ARCH__
+    return static_cast<uint32_t>(comms::device::ld_volatile_global(
+        reinterpret_cast<const volatile uint64_t*>(pkt)));
+#else
+    (void)pkt;
+    return 0;
+#endif
+  }
+
+  /// Write payload and flag as one wide store, so a reader never observes the
+  /// new flag over the previous pass's data.
+  __device__ __forceinline__ static void
+  store_payload(char* pkt, uint32_t data, FlagType flagVal) {
+#ifdef __CUDA_ARCH__
+    comms::device::st_volatile_global(
+        reinterpret_cast<volatile uint64_t*>(pkt),
+        (static_cast<uint64_t>(flagVal) << 32) | static_cast<uint64_t>(data));
+#else
+    (void)pkt;
+    (void)data;
+    (void)flagVal;
+#endif
+  }
+
   /// Reduce the packet stream into `accum` under `Combine`: the accumulating
   /// counterpart of unpack(), which assigns. A reduce CopyOp cannot call
   /// unpack() -- that would overwrite the partial sum -- and staging into a
@@ -481,6 +509,136 @@ struct LLImpl {
 #endif
   }
 
+  /// Reduce a contiguous `local` operand into the relayed packet stream:
+  /// `fwdStaging[i] = Combine(recvStaging[i], local[i])`, stamped with the
+  /// DOWNSTREAM generation `fwdFlagVal`. The reducing counterpart of repack(),
+  /// which relays verbatim, and the forward-side counterpart of
+  /// unpack_reduce(), which accumulates into plain memory instead of
+  /// re-encoding.
+  ///
+  /// Element tilings and the scalar-granularity note are unpack_reduce()'s; the
+  /// same 8 B `{data:4, flag:4}` packet assumption applies. Like repack() this
+  /// never spins -- the caller has already confirmed every flag, and a partial
+  /// pass has already written `fwdStaging`, so a mid-pass wait is
+  /// unrecoverable.
+  ///
+  /// No `dst`: a reducing relay has nothing to land locally. The running
+  /// partial belongs to the next hop, and the local operand is an input here,
+  /// not an accumulator -- unlike the plain repack, where `dst` is the
+  /// receiving side of the same bytes being forwarded.
+  template <typename T, typename Combine, typename Group>
+  __device__ __forceinline__ static void repack_reduce(
+      Group& group,
+      void* fwdStaging,
+      const void* recvStaging,
+      const T* local,
+      std::size_t nbytes,
+      FlagType fwdFlagVal) {
+#ifdef __CUDA_ARCH__
+    // load_payload/store_payload hardcode the 8 B {data:4, flag:4} layout (one
+    // 64-bit access, flag in the high half). repack() guards them behind an
+    // `if constexpr` and falls back to a word-wise path; this codec uses them
+    // unconditionally, so a wider geometry has to fail here rather than
+    // silently read and write the wrong bytes.
+    static_assert(
+        P::kPacketBytes == static_cast<int>(sizeof(uint64_t)) && P::kData == 4,
+        "LLImpl::repack_reduce requires the 8 B {data:4, flag:4} packet");
+
+    constexpr std::size_t kData = static_cast<std::size_t>(P::kData);
+    constexpr std::size_t kPacket = static_cast<std::size_t>(P::kPacketBytes);
+    const auto* recvBase = reinterpret_cast<const char*>(recvStaging);
+    auto* fwdBase = reinterpret_cast<char*>(fwdStaging);
+
+    // Whole elements only, for both tilings. The wide branch would drop a
+    // partial trailing element out of `nElems` and then never write its
+    // packets at all, leaving the previous generation's contents in
+    // `fwdStaging` for the next hop to spin on or consume as stale data. The
+    // narrow branch reaches the same bytes through valid_payload, but a caller
+    // that bypasses the chunk sizing is a bug either way. Chunk sizing already
+    // guarantees this (calcGeometry/make_progress_geometry align chunkPayload
+    // to lcm(kData, 8)); this is the backstop.
+    PIPES_DEVICE_CHECK_MSG(
+        nbytes % sizeof(T) == 0,
+        "LL relay-reduce chunk must hold whole elements");
+
+    if constexpr (kData % sizeof(T) == 0) {
+      constexpr std::size_t kElemsPerPacket = kData / sizeof(T);
+      const std::size_t nPackets = P::packet_count(nbytes);
+      for (std::size_t i = group.thread_id_in_group; i < nPackets;
+           i += group.group_size) {
+        uint32_t data = load_payload(recvBase + i * kPacket);
+        // Reduce through a real T[] rather than a T* punned onto `data`.
+        // Writing a T into a uint32_t does not begin a T's lifetime there, so
+        // reading `data` back afterwards is undefined and TBAA is free to
+        // forward the pre-reduce value into store_payload -- which would relay
+        // the upstream payload unreduced. memcpy both ways is the defined
+        // spelling and costs nothing: nvcc folds it into the same registers.
+        T payload[kElemsPerPacket];
+        __builtin_memcpy(payload, &data, kData);
+        const std::size_t nElem = P::valid_payload(i, nbytes) / sizeof(T);
+        const std::size_t baseElem = i * kElemsPerPacket;
+#pragma unroll
+        for (std::size_t e = 0; e < kElemsPerPacket; ++e) {
+          // Past `nElem` the packet holds the upstream packer's zero padding;
+          // leaving it untouched carries it through to the next hop.
+          if (e < nElem) {
+            Combine{}(payload[e], local[baseElem + e]);
+          }
+        }
+        __builtin_memcpy(&data, payload, kData);
+        store_payload(fwdBase + i * kPacket, data, fwdFlagVal);
+      }
+    } else {
+      // Entered when kData % sizeof(T) != 0, but the reassembly below needs
+      // the stronger property: an element must be a whole number of packets.
+      // Without it kPacketsPerElem truncates and each element is silently
+      // under-filled -- at sizeof(T) == 3 it would be zero packets and `val`
+      // would be reduced wholly uninitialized. Mirrors unpack_reduce.
+      static_assert(
+          sizeof(T) % kData == 0,
+          "LL wide-element relay-reduce needs sizeof(T) to be a whole number "
+          "of packet payloads");
+      constexpr std::size_t kPacketsPerElem = sizeof(T) / kData;
+      const std::size_t nElems = nbytes / sizeof(T);
+      for (std::size_t e = group.thread_id_in_group; e < nElems;
+           e += group.group_size) {
+        T val;
+        auto* valBytes = reinterpret_cast<char*>(&val);
+#pragma unroll
+        for (std::size_t k = 0; k < kPacketsPerElem; ++k) {
+          const uint32_t word =
+              load_payload(recvBase + (e * kPacketsPerElem + k) * kPacket);
+          const auto* wordBytes = reinterpret_cast<const char*>(&word);
+#pragma unroll
+          for (std::size_t b = 0; b < kData; ++b) {
+            valBytes[k * kData + b] = wordBytes[b];
+          }
+        }
+        Combine{}(val, local[e]);
+#pragma unroll
+        for (std::size_t k = 0; k < kPacketsPerElem; ++k) {
+          uint32_t word = 0;
+          auto* wordBytes = reinterpret_cast<char*>(&word);
+#pragma unroll
+          for (std::size_t b = 0; b < kData; ++b) {
+            wordBytes[b] = valBytes[k * kData + b];
+          }
+          store_payload(
+              fwdBase + (e * kPacketsPerElem + k) * kPacket, word, fwdFlagVal);
+        }
+      }
+    }
+    group.sync();
+#else
+    (void)group;
+    (void)fwdStaging;
+    (void)recvStaging;
+    (void)local;
+    (void)nbytes;
+    (void)fwdFlagVal;
+#endif
+  }
+
   /// Relay one already-ready chunk: decode `recvStaging`'s payload into `dst`
   /// (when non-null) AND re-encode it into `fwdStaging` stamped with
   /// `fwdFlagVal`, in a single pass. Cooperative across `group`.
@@ -522,13 +680,8 @@ struct LLImpl {
         // wide store re-stamps the payload with the downstream generation.
         // Bytes past `valid` are the upstream packer's zero padding, so
         // carrying the whole data half through preserves it.
-        const uint64_t v = comms::device::ld_volatile_global(
-            reinterpret_cast<const volatile uint64_t*>(recvPkt));
-        const auto data = static_cast<uint32_t>(v);
-        comms::device::st_volatile_global(
-            reinterpret_cast<volatile uint64_t*>(fwdPkt),
-            (static_cast<uint64_t>(fwdFlagVal) << 32) |
-                static_cast<uint64_t>(data));
+        const uint32_t data = load_payload(recvPkt);
+        store_payload(fwdPkt, data, fwdFlagVal);
         if (d != nullptr) {
           const auto* db = reinterpret_cast<const char*>(&data);
 #pragma unroll

--- a/comms/prims/core/MemcpyCopyOp.cuh
+++ b/comms/prims/core/MemcpyCopyOp.cuh
@@ -100,6 +100,32 @@ struct Memcpy {
       Args...) {
     LLImpl<P>::unpack(group, dst, staging, nbytes, flagVal, abortDevice);
   }
+
+  // LL counterpart of forward(): decode the relayed chunk into `dst` and
+  // re-encode it into the next hop's staging in one pass. `recvFlagVal` is the
+  // generation the upstream sender stamped, `fwdFlagVal` the one the
+  // downstream ring expects -- they differ because the two staging rings
+  // advance on independent cursors, which is why this cannot be a
+  // packet-to-packet copy. A plain copy delegates to LLImpl<P>::repack; a
+  // reduce/convert op overrides this the way it overrides recvLL. Presence is
+  // detected by has_forwardLL_v.
+  //
+  // Takes no Timeout where recvLL() does: the caller has already confirmed
+  // every packet flag, so this hook must not spin -- a partial pass has
+  // already written fwd_staging and could not be retried.
+  template <typename P, typename... Args>
+  __device__ __forceinline__ static void forwardLL(
+      ThreadGroup& group,
+      char* dst,
+      char* fwd_staging,
+      const char* staging,
+      std::size_t nbytes,
+      std::size_t /*byte_offset*/,
+      typename P::FlagType /*recvFlagVal*/,
+      typename P::FlagType fwdFlagVal,
+      Args...) {
+    LLImpl<P>::repack(group, dst, fwd_staging, staging, nbytes, fwdFlagVal);
+  }
 };
 
 // Detection traits: does CopyOp `Op` provide packet-aware LL hooks for packet
@@ -135,5 +161,21 @@ inline constexpr bool has_recvLL_v<
         std::declval<std::size_t>(),
         std::declval<typename P::FlagType>(),
         std::declval<const AbortDevice&>()))>> = true;
+
+template <typename Op, typename P, typename = void>
+inline constexpr bool has_forwardLL_v = false;
+template <typename Op, typename P>
+inline constexpr bool has_forwardLL_v<
+    Op,
+    P,
+    std::void_t<decltype(Op::template forwardLL<P>(
+        std::declval<ThreadGroup&>(),
+        std::declval<char*>(),
+        std::declval<char*>(),
+        std::declval<const char*>(),
+        std::declval<std::size_t>(),
+        std::declval<std::size_t>(),
+        std::declval<typename P::FlagType>(),
+        std::declval<typename P::FlagType>()))>> = true;
 
 } // namespace comms::prims

--- a/comms/prims/tests/LLImplTest.cc
+++ b/comms/prims/tests/LLImplTest.cc
@@ -7,6 +7,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <vector>
 
 #include "comms/prims/core/LlxPacket.cuh"
@@ -432,6 +433,213 @@ TEST_F(LLImplTest, RepackForwardOnlyNullDst) {
       << got.flagErrors << " forwarded packet(s) still carry the upstream "
       << "generation with dst == nullptr";
   EXPECT_EQ(got.packetOut, src) << "forward-only relay payload wrong";
+}
+
+namespace {
+
+// Relay-reduce `src` (arriving as packets) against `local`, returning the
+// decoded fwd staging. `errors` receives the count of forwarded packets that
+// did not carry the downstream generation.
+template <typename T, typename Launch>
+std::vector<T> runRepackReduce(
+    const std::vector<T>& src,
+    const std::vector<T>& local,
+    Launch launch,
+    uint32_t& errors,
+    std::vector<char>& padding) {
+  const std::size_t nelems = src.size();
+  const std::size_t nbytes = nelems * sizeof(T);
+  const std::size_t wire = LlxPacketGeometry::wire_bytes(nbytes);
+  // Full data half of every packet, so the tail packet's padding comes back
+  // too. packetBytes > nbytes exactly when the payload does not fill the last
+  // packet, which is the only case where padding exists to check.
+  const std::size_t packetBytes =
+      LlxPacketGeometry::packet_count(nbytes) * LlxPacketGeometry::kData;
+
+  DeviceBuffer srcBuf(nbytes);
+  DeviceBuffer localBuf(nbytes);
+  DeviceBuffer recvStaging(wire);
+  DeviceBuffer fwdStaging(wire);
+  DeviceBuffer dstBuf(packetBytes);
+  DeviceBuffer errBuf(sizeof(uint32_t));
+  auto* err_d = static_cast<uint32_t*>(errBuf.get());
+
+  CUDACHECK_TEST(
+      cudaMemcpy(srcBuf.get(), src.data(), nbytes, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(
+      cudaMemcpy(localBuf.get(), local.data(), nbytes, cudaMemcpyHostToDevice));
+  // Poison both rings: the fwd ring must be fully rewritten, and any packet the
+  // relay skips decodes to garbage rather than to a stale zero that happens to
+  // match.
+  CUDACHECK_TEST(cudaMemset(recvStaging.get(), 0xEE, wire));
+  CUDACHECK_TEST(cudaMemset(fwdStaging.get(), 0xEE, wire));
+  // Non-zero: the padding assertion below is "still zero", so a dst pre-filled
+  // with zeros would make it pass even if the relay never wrote those bytes.
+  CUDACHECK_TEST(cudaMemset(dstBuf.get(), 0x5A, packetBytes));
+  CUDACHECK_TEST(cudaMemset(err_d, 0, sizeof(uint32_t)));
+
+  launch(
+      srcBuf.get(),
+      localBuf.get(),
+      static_cast<char*>(recvStaging.get()),
+      static_cast<char*>(fwdStaging.get()),
+      dstBuf.get(),
+      err_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  CUDACHECK_TEST(
+      cudaMemcpy(&errors, err_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+
+  std::vector<char> decoded(packetBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      decoded.data(), dstBuf.get(), packetBytes, cudaMemcpyDeviceToHost));
+
+  padding.assign(
+      decoded.begin() + static_cast<std::ptrdiff_t>(nbytes), decoded.end());
+
+  std::vector<T> out(nelems);
+  std::memcpy(out.data(), decoded.data(), nbytes);
+  return out;
+}
+
+// The packer zero-fills the tail packet's data half past the last valid byte
+// (see LLImpl::pack). Those bytes ship on the wire, so repack_reduce must
+// forward them unchanged -- a reduce that ran past nElem would write
+// Combine(0, local[...]) into them and corrupt the next hop's payload without
+// touching any byte the element comparison looks at. Empty for the tilings
+// whose payload exactly fills the last packet.
+void expectPaddingUntouched(const std::vector<char>& padding) {
+  const std::vector<char> zeros(padding.size(), char(0));
+  EXPECT_EQ(padding, zeros)
+      << "relay corrupted the tail packet's zero padding (" << padding.size()
+      << " bytes); it goes out on the wire to the next hop";
+}
+
+} // namespace
+
+// sizeof(T) == kData: one element per packet, all three reduce ops.
+TEST_F(LLImplTest, RepackReduceOneElemPerPacket) {
+  constexpr std::size_t kElems = 133;
+  std::vector<float> src(kElems), local(kElems);
+  for (std::size_t i = 0; i < kElems; ++i) {
+    src[i] = static_cast<float>(i % 17);
+    local[i] = static_cast<float>((i % 5) + 1);
+  }
+
+  const std::array<test::ReduceKind, 3> kinds{
+      test::ReduceKind::Sum, test::ReduceKind::Max, test::ReduceKind::Min};
+  for (const auto kind : kinds) {
+    std::vector<float> expected(kElems);
+    for (std::size_t i = 0; i < kElems; ++i) {
+      switch (kind) {
+        case test::ReduceKind::Sum:
+          expected[i] = src[i] + local[i];
+          break;
+        case test::ReduceKind::Max:
+          expected[i] = std::max(src[i], local[i]);
+          break;
+        case test::ReduceKind::Min:
+          expected[i] = std::min(src[i], local[i]);
+          break;
+      }
+    }
+
+    uint32_t errors = 0;
+    std::vector<char> padding;
+    const auto actual = runRepackReduce<float>(
+        src,
+        local,
+        [&](void* s, void* l, char* recv, char* fwd, void* d, uint32_t* err) {
+          test::test_ll_repack_reduce_f32(
+              static_cast<const float*>(s),
+              static_cast<const float*>(l),
+              recv,
+              fwd,
+              static_cast<float*>(d),
+              kElems,
+              kind,
+              err);
+        },
+        errors,
+        padding);
+    EXPECT_EQ(errors, 0u)
+        << "forwarded packets missing the downstream flag for kind "
+        << static_cast<int>(kind);
+    EXPECT_EQ(actual, expected)
+        << "float relay-reduce mismatch for kind " << static_cast<int>(kind);
+    expectPaddingUntouched(padding);
+  }
+}
+
+// sizeof(T) < kData: two elements per packet, odd count so the final packet
+// carries one valid element plus the packer's zero padding, which the relay
+// must forward untouched.
+TEST_F(LLImplTest, RepackReduceTwoElemsPerPacketPartialTail) {
+  constexpr std::size_t kElems = 101;
+  std::vector<__half> src(kElems), local(kElems);
+  std::vector<float> expected(kElems);
+  for (std::size_t i = 0; i < kElems; ++i) {
+    const float s = static_cast<float>(i % 7);
+    const float l = static_cast<float>(i % 3);
+    src[i] = __float2half(s);
+    local[i] = __float2half(l);
+    expected[i] = s + l;
+  }
+
+  uint32_t errors = 0;
+  std::vector<char> padding;
+  const auto actual = runRepackReduce<__half>(
+      src,
+      local,
+      [&](void* s, void* l, char* recv, char* fwd, void* d, uint32_t* err) {
+        test::test_ll_repack_reduce_f16(s, l, recv, fwd, d, kElems, err);
+      },
+      errors,
+      padding);
+  EXPECT_EQ(errors, 0u) << "forwarded packets missing the downstream flag";
+
+  std::vector<float> actualF(kElems);
+  for (std::size_t i = 0; i < kElems; ++i) {
+    actualF[i] = __half2float(actual[i]);
+  }
+  EXPECT_EQ(actualF, expected) << "fp16 two-elements-per-packet relay wrong";
+  // The only tiling here with a partial final packet: 101 halves = 202 B over
+  // 51 packets = 204 B, so 2 padding bytes must come back zero.
+  EXPECT_EQ(padding.size(), 2u) << "expected a partial final packet";
+  expectPaddingUntouched(padding);
+}
+
+// sizeof(T) > kData: one element spans two packets, so the relay has to
+// reassemble it, reduce once, and split it back out across both packets.
+TEST_F(LLImplTest, RepackReduceElementSpansPackets) {
+  constexpr std::size_t kElems = 97;
+  std::vector<int64_t> src(kElems), local(kElems), expected(kElems);
+  for (std::size_t i = 0; i < kElems; ++i) {
+    src[i] = static_cast<int64_t>((i + 1) * 0x0001'0000'0007ULL);
+    local[i] = static_cast<int64_t>(i);
+    expected[i] = src[i] + local[i];
+  }
+
+  uint32_t errors = 0;
+  std::vector<char> padding;
+  const auto actual = runRepackReduce<int64_t>(
+      src,
+      local,
+      [&](void* s, void* l, char* recv, char* fwd, void* d, uint32_t* err) {
+        test::test_ll_repack_reduce_i64(
+            static_cast<const int64_t*>(s),
+            static_cast<const int64_t*>(l),
+            recv,
+            fwd,
+            static_cast<int64_t*>(d),
+            kElems,
+            err);
+      },
+      errors,
+      padding);
+  EXPECT_EQ(errors, 0u) << "forwarded packets missing the downstream flag";
+  EXPECT_EQ(actual, expected) << "int64 spanning-packet relay-reduce wrong";
+  expectPaddingUntouched(padding);
 }
 
 TEST_F(LLImplTest, FlagRoundTrip) {

--- a/comms/prims/tests/LLImplTest.cc
+++ b/comms/prims/tests/LLImplTest.cc
@@ -24,6 +24,35 @@ namespace comms::prims {
 // dispatch report it as LL-capable.
 static_assert(has_sendLL_v<Memcpy, LlxPacketGeometry>);
 static_assert(has_recvLL_v<Memcpy, LlxPacketGeometry>);
+static_assert(has_forwardLL_v<Memcpy, LlxPacketGeometry>);
+
+namespace {
+// has_forwardLL_v probes a FIXED 8-argument list, so it silently reports false
+// for a hook whose signature drifts -- and the transport turns that false into
+// a static_assert in whichever .cu instantiated the LL forward, far from the
+// edit that caused it. Pin the negative verdicts here, next to the trait.
+//
+// Declarations only: these are never called, and the trait is an unevaluated
+// decltype.
+struct NoLlHooks {};
+
+// forwardLL present, but one argument short -- the shape a hook would have if
+// it relayed packets verbatim, with no downstream generation to re-stamp with.
+struct MissingFwdFlag {
+  template <typename P>
+  static void forwardLL(
+      ThreadGroup&,
+      char*,
+      char*,
+      const char*,
+      std::size_t,
+      std::size_t,
+      typename P::FlagType);
+};
+
+static_assert(!has_forwardLL_v<NoLlHooks, LlxPacketGeometry>);
+static_assert(!has_forwardLL_v<MissingFwdFlag, LlxPacketGeometry>);
+} // namespace
 
 namespace {
 
@@ -295,6 +324,114 @@ TEST_F(LLImplTest, AllFlagsSetFalseOnAnyMissingPacket) {
         << "packet " << p << " of " << nPackets
         << " had the wrong generation but the chunk reported ready";
   }
+}
+
+namespace {
+
+struct RepackResult {
+  uint32_t flagErrors;
+  std::vector<char> dst; // decoded by the relay itself (empty when useDst)
+  std::vector<char> packetOut; // decoded back out of the forwarded packets
+};
+
+// pack -> repack -> inspect. See test_ll_repack() for the two-pass split.
+RepackResult runRepack(const std::vector<char>& src, bool useDst) {
+  using P = LlxPacketGeometry;
+  const std::size_t nbytes = src.size();
+  const std::size_t wire = P::wire_bytes(nbytes);
+
+  DeviceBuffer srcBuf(nbytes);
+  DeviceBuffer recvStaging(wire);
+  DeviceBuffer fwdStaging(wire);
+  DeviceBuffer dstBuf(nbytes);
+  DeviceBuffer packetOut(nbytes);
+  DeviceBuffer errBuf(sizeof(uint32_t));
+
+  CUDACHECK_TEST(
+      cudaMemcpy(srcBuf.get(), src.data(), nbytes, cudaMemcpyHostToDevice));
+  // Poison both outputs: a relay that writes nothing must not look like a pass.
+  CUDACHECK_TEST(cudaMemset(dstBuf.get(), 0xA5, nbytes));
+  CUDACHECK_TEST(cudaMemset(packetOut.get(), 0xA5, nbytes));
+  // Poison the forward staging with the UPSTREAM generation, so a relay that
+  // copies packets verbatim cannot accidentally leave the right flag behind.
+  CUDACHECK_TEST(cudaMemset(fwdStaging.get(), 0x07, wire));
+  CUDACHECK_TEST(cudaMemset(errBuf.get(), 0, sizeof(uint32_t)));
+
+  test::test_ll_repack(
+      static_cast<const char*>(srcBuf.get()),
+      static_cast<char*>(recvStaging.get()),
+      static_cast<char*>(fwdStaging.get()),
+      static_cast<char*>(dstBuf.get()),
+      static_cast<char*>(packetOut.get()),
+      nbytes,
+      useDst,
+      static_cast<uint32_t*>(errBuf.get()));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  RepackResult out;
+  CUDACHECK_TEST(cudaMemcpy(
+      &out.flagErrors, errBuf.get(), sizeof(uint32_t), cudaMemcpyDeviceToHost));
+  out.packetOut.resize(nbytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      out.packetOut.data(), packetOut.get(), nbytes, cudaMemcpyDeviceToHost));
+  if (useDst) {
+    out.dst.resize(nbytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        out.dst.data(), dstBuf.get(), nbytes, cudaMemcpyDeviceToHost));
+  }
+  return out;
+}
+
+std::vector<char> pattern(std::size_t nbytes) {
+  // Position-dependent, so a relay that shifts or duplicates a packet shows up.
+  std::vector<char> v(nbytes);
+  for (std::size_t i = 0; i < nbytes; ++i) {
+    v[i] = static_cast<char>(i * 131u + 7u);
+  }
+  return v;
+}
+
+} // namespace
+
+// kData = 4, so `nbytes % 4` decides how much of the final packet is the
+// packer's zero padding. Sweep every remainder, plus sizes on either side of a
+// single packet and a few large enough to give every thread several packets.
+TEST_F(LLImplTest, RepackReStampsAndPreservesPayload) {
+  for (std::size_t n :
+       {std::size_t(1),
+        std::size_t(2),
+        std::size_t(3),
+        std::size_t(4),
+        std::size_t(5),
+        std::size_t(7),
+        std::size_t(64),
+        std::size_t(533),
+        std::size_t(1000),
+        std::size_t(4096)}) {
+    const auto src = pattern(n);
+    const auto got = runRepack(src, /*useDst=*/true);
+
+    EXPECT_EQ(got.flagErrors, 0u)
+        << "nbytes=" << n << ": " << got.flagErrors
+        << " forwarded packet(s) still carry the upstream generation";
+    EXPECT_EQ(got.dst, src)
+        << "nbytes=" << n << ": relay decode into dst wrong";
+    EXPECT_EQ(got.packetOut, src)
+        << "nbytes=" << n << ": forwarded packet payload wrong";
+  }
+}
+
+// Forward-only relay: the chain's intermediate ranks pass dst == nullptr, and
+// the packets must still be re-stamped and carry the payload.
+TEST_F(LLImplTest, RepackForwardOnlyNullDst) {
+  constexpr std::size_t kBytes = 1000;
+  const auto src = pattern(kBytes);
+  const auto got = runRepack(src, /*useDst=*/false);
+
+  EXPECT_EQ(got.flagErrors, 0u)
+      << got.flagErrors << " forwarded packet(s) still carry the upstream "
+      << "generation with dst == nullptr";
+  EXPECT_EQ(got.packetOut, src) << "forward-only relay payload wrong";
 }
 
 TEST_F(LLImplTest, FlagRoundTrip) {

--- a/comms/prims/tests/LLImplTest.cu
+++ b/comms/prims/tests/LLImplTest.cu
@@ -241,4 +241,78 @@ void test_ll_unpack_reduce_i64(
   launchByKind<int64_t>(src_d, staging_d, accum_d, nelems, ReduceKind::Sum);
 }
 
+// pack(src) under the upstream generation, relay it into a second staging
+// region under the downstream one, then check the two halves of the result
+// separately. See test_ll_repack() in the header for why the flag pass does
+// not go through unpack().
+template <typename P>
+__global__ void repack_kernel(
+    const char* src,
+    char* recvStaging,
+    char* fwdStaging,
+    char* dst,
+    char* packetOut,
+    std::size_t nbytes,
+    bool useDst,
+    uint32_t* flagErrors) {
+  ThreadGroup g{
+      threadIdx.x,
+      blockDim.x,
+      blockIdx.x,
+      blockIdx.x,
+      gridDim.x,
+      SyncScope::BLOCK};
+
+  const auto recvFlag = static_cast<typename P::FlagType>(7);
+  const auto fwdFlag = static_cast<typename P::FlagType>(9);
+
+  LLImpl<P>::pack(g, recvStaging, src, nbytes, recvFlag);
+  g.sync();
+  LLImpl<P>::repack(
+      g, useDst ? dst : nullptr, fwdStaging, recvStaging, nbytes, fwdFlag);
+  g.sync();
+
+  // (1) Flag pass. One read per packet, no spin.
+  const std::size_t nPackets = P::packet_count(nbytes);
+  for (std::size_t i = threadIdx.x; i < nPackets; i += blockDim.x) {
+    const char* pkt =
+        fwdStaging + i * static_cast<std::size_t>(P::kPacketBytes);
+    if (!LLImpl<P>::is_flag_set(pkt, fwdFlag)) {
+      atomicAdd(flagErrors, 1u);
+    }
+  }
+  g.sync();
+
+  // (2) Payload pass. Force every flag to the downstream generation first so
+  // unpack() is guaranteed to terminate even when the relay mis-stamped -- the
+  // flag verdict is already recorded above, and this isolates the data half.
+  for (std::size_t i = threadIdx.x; i < nPackets; i += blockDim.x) {
+    LLImpl<P>::store_flag(
+        fwdStaging + i * static_cast<std::size_t>(P::kPacketBytes), fwdFlag);
+  }
+  g.sync();
+  LLImpl<P>::unpack(g, packetOut, fwdStaging, nbytes, fwdFlag);
+}
+
+void test_ll_repack(
+    const char* src_d,
+    char* recvStaging_d,
+    char* fwdStaging_d,
+    char* dst_d,
+    char* packetOut_d,
+    std::size_t nbytes,
+    bool useDst,
+    uint32_t* flagErrors_d) {
+  repack_kernel<LlxPacketGeometry><<<1, 256>>>(
+      src_d,
+      recvStaging_d,
+      fwdStaging_d,
+      dst_d,
+      packetOut_d,
+      nbytes,
+      useDst,
+      flagErrors_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
 } // namespace comms::prims::test

--- a/comms/prims/tests/LLImplTest.cu
+++ b/comms/prims/tests/LLImplTest.cu
@@ -315,4 +315,151 @@ void test_ll_repack(
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
+// pack(src) with the upstream flag, relay-reduce it against `local` into a
+// second staging region under the downstream flag, then decode that region.
+//
+// The decode is written out here rather than calling unpack(): unpack() spins
+// until the flag matches, so a relay that forgot to re-stamp would hang the
+// test instead of failing it. Reading the flag once and counting the mismatch
+// keeps the failure mode a diff-able error count.
+template <typename P, typename T, typename Op>
+__global__ void repack_reduce_kernel(
+    const T* src,
+    const T* local,
+    char* recvStaging,
+    char* fwdStaging,
+    T* dst,
+    std::size_t nelems,
+    uint32_t* errorCount) {
+  ThreadGroup g{
+      threadIdx.x,
+      blockDim.x,
+      blockIdx.x,
+      blockIdx.x,
+      gridDim.x,
+      SyncScope::BLOCK};
+
+  const std::size_t nbytes = nelems * sizeof(T);
+  const auto recvFlag = static_cast<typename P::FlagType>(7);
+  const auto fwdFlag = static_cast<typename P::FlagType>(9);
+
+  LLImpl<P>::pack(
+      g, recvStaging, reinterpret_cast<const char*>(src), nbytes, recvFlag);
+  g.sync();
+  LLImpl<P>::template repack_reduce<T, TestCombine<T, Op>>(
+      g, fwdStaging, recvStaging, local, nbytes, fwdFlag);
+
+  auto* out = reinterpret_cast<char*>(dst);
+  const std::size_t nPackets = P::packet_count(nbytes);
+  for (std::size_t i = threadIdx.x; i < nPackets; i += blockDim.x) {
+    const char* pkt =
+        fwdStaging + i * static_cast<std::size_t>(P::kPacketBytes);
+    if (!LLImpl<P>::is_flag_set(pkt, fwdFlag)) {
+      atomicAdd(errorCount, 1u);
+    }
+    const uint32_t data = LLImpl<P>::load_payload(pkt);
+    const auto* db = reinterpret_cast<const char*>(&data);
+    const std::size_t off = i * static_cast<std::size_t>(P::kData);
+    // The FULL data half, not just valid_payload(i, nbytes). The tail packet's
+    // padding is shipped on the wire too, and repack_reduce must carry it
+    // through untouched; decoding only the valid bytes would let a reduce that
+    // ran past nElem corrupt the padding and still pass. `dst` is therefore
+    // sized packet_count(nbytes) * kData, not nbytes.
+    for (std::size_t b = 0; b < static_cast<std::size_t>(P::kData); ++b) {
+      out[off + b] = db[b];
+    }
+  }
+}
+
+namespace {
+
+template <typename T, typename Op>
+void launchRepackReduce(
+    const T* src,
+    const T* local,
+    char* recvStaging,
+    char* fwdStaging,
+    T* dst,
+    std::size_t nelems,
+    uint32_t* errorCount) {
+  repack_reduce_kernel<LlxPacketGeometry, T, Op><<<1, 256>>>(
+      src, local, recvStaging, fwdStaging, dst, nelems, errorCount);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace
+
+void test_ll_repack_reduce_f32(
+    const float* src_d,
+    const float* local_d,
+    char* recvStaging_d,
+    char* fwdStaging_d,
+    float* dst_d,
+    std::size_t nelems,
+    ReduceKind kind,
+    uint32_t* errorCount_d) {
+  switch (kind) {
+    case ReduceKind::Sum:
+      launchRepackReduce<float, SumOp>(
+          src_d,
+          local_d,
+          recvStaging_d,
+          fwdStaging_d,
+          dst_d,
+          nelems,
+          errorCount_d);
+      break;
+    case ReduceKind::Max:
+      launchRepackReduce<float, MaxOp>(
+          src_d,
+          local_d,
+          recvStaging_d,
+          fwdStaging_d,
+          dst_d,
+          nelems,
+          errorCount_d);
+      break;
+    case ReduceKind::Min:
+      launchRepackReduce<float, MinOp>(
+          src_d,
+          local_d,
+          recvStaging_d,
+          fwdStaging_d,
+          dst_d,
+          nelems,
+          errorCount_d);
+      break;
+  }
+}
+
+void test_ll_repack_reduce_f16(
+    const void* src_d,
+    const void* local_d,
+    char* recvStaging_d,
+    char* fwdStaging_d,
+    void* dst_d,
+    std::size_t nelems,
+    uint32_t* errorCount_d) {
+  launchRepackReduce<__half, SumOp>(
+      static_cast<const __half*>(src_d),
+      static_cast<const __half*>(local_d),
+      recvStaging_d,
+      fwdStaging_d,
+      static_cast<__half*>(dst_d),
+      nelems,
+      errorCount_d);
+}
+
+void test_ll_repack_reduce_i64(
+    const int64_t* src_d,
+    const int64_t* local_d,
+    char* recvStaging_d,
+    char* fwdStaging_d,
+    int64_t* dst_d,
+    std::size_t nelems,
+    uint32_t* errorCount_d) {
+  launchRepackReduce<int64_t, SumOp>(
+      src_d, local_d, recvStaging_d, fwdStaging_d, dst_d, nelems, errorCount_d);
+}
+
 } // namespace comms::prims::test

--- a/comms/prims/tests/LLImplTest.cuh
+++ b/comms/prims/tests/LLImplTest.cuh
@@ -69,4 +69,36 @@ void test_ll_unpack_reduce_i64(
     int64_t* accum_d,
     std::size_t nelems);
 
+/// pack(src) into `recvStaging_d` under the UPSTREAM generation, then relay it
+/// with `repack` into `fwdStaging_d` under the DOWNSTREAM generation, decoding
+/// into `dst_d` on the way.
+///
+/// The two generations are deliberately different: the relay must re-stamp
+/// every forwarded packet, and shipping the upstream flag through is the bug
+/// this pins. `repack` is byte-granular (no element type), so the axis that
+/// matters is `nbytes` -- specifically `nbytes % kData`, which decides how much
+/// of the final packet is the packer's zero padding.
+///
+/// Verification is split into two independent passes so neither failure mode
+/// can mask or hang on the other:
+///   1. flags: count packets in `fwdStaging_d` whose flag is not the
+///      downstream one, into `flagErrors_d`. Read once, never spun on -- a
+///      relay that forgot to re-stamp fails the test instead of hanging it,
+///      which is what calling `unpack()` here would do.
+///   2. payload: re-stamp every packet with the downstream flag, then `unpack`
+///      into `packetOut_d`. That cannot hang, and it checks the data half
+///      independently of the flag half.
+///
+/// `useDst == false` passes `dst == nullptr` (the forward-only relay shape the
+/// chain's intermediate ranks use); `dst_d` is then left untouched.
+void test_ll_repack(
+    const char* src_d,
+    char* recvStaging_d,
+    char* fwdStaging_d,
+    char* dst_d,
+    char* packetOut_d,
+    std::size_t nbytes,
+    bool useDst,
+    uint32_t* flagErrors_d);
+
 } // namespace comms::prims::test

--- a/comms/prims/tests/LLImplTest.cuh
+++ b/comms/prims/tests/LLImplTest.cuh
@@ -101,4 +101,49 @@ void test_ll_repack(
     bool useDst,
     uint32_t* flagErrors_d);
 
+/// pack(src) into `recvStaging_d` under the UPSTREAM generation, then
+/// repack_reduce it against `local_d` into `fwdStaging_d` under the DOWNSTREAM
+/// generation, then decode `fwdStaging_d` into `dst_d`.
+///
+/// The two flags are deliberately different: the relay must re-stamp every
+/// packet with the downstream generation, and carrying the upstream one through
+/// is the failure this pins. The decode counts flag mismatches into
+/// `errorCount_d` instead of spinning on them, so a wrong flag fails the test
+/// rather than hanging it.
+///
+/// `dst_d` receives the FULL data half of every forwarded packet, i.e.
+/// `packet_count(nbytes) * kData` bytes, not `nbytes`. The extra tail is the
+/// last packet's zero padding, which repack_reduce must relay untouched; a
+/// decode limited to valid_payload would never read it back and a reduce that
+/// ran past nElem would go unnoticed even though those bytes reach the wire.
+///
+/// Same three element/packet tilings as the unpack_reduce launchers above.
+void test_ll_repack_reduce_f32(
+    const float* src_d,
+    const float* local_d,
+    char* recvStaging_d,
+    char* fwdStaging_d,
+    float* dst_d,
+    std::size_t nelems,
+    ReduceKind kind,
+    uint32_t* errorCount_d);
+
+void test_ll_repack_reduce_f16(
+    const void* src_d,
+    const void* local_d,
+    char* recvStaging_d,
+    char* fwdStaging_d,
+    void* dst_d,
+    std::size_t nelems,
+    uint32_t* errorCount_d);
+
+void test_ll_repack_reduce_i64(
+    const int64_t* src_d,
+    const int64_t* local_d,
+    char* recvStaging_d,
+    char* fwdStaging_d,
+    int64_t* dst_d,
+    std::size_t nelems,
+    uint32_t* errorCount_d);
+
 } // namespace comms::prims::test

--- a/comms/prims/tests/RecvForwardChainTest.cc
+++ b/comms/prims/tests/RecvForwardChainTest.cc
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "comms/prims/tests/RecvForwardChainTest.h"
@@ -21,6 +22,45 @@ using meta::comms::BenchmarkTestFixture;
 using meta::comms::DeviceBuffer;
 
 namespace comms::prims::tests {
+
+namespace {
+
+struct ChainMode {
+  test::ChainProto proto;
+};
+
+// Every wire format the chain supports. Cases sweep both on ONE transport,
+// which also gives the cross-protocol coverage that matters most here: Simple
+// and LL share a channel's QPs and its recvDataReadyLaneCursor, and an LL path
+// that forgets to advance that mirror passes every all-LL and all-Simple run
+// yet deadlocks the next Simple recv.
+constexpr std::array<ChainMode, 2> kChainModes = {{
+    {test::ChainProto::Simple},
+    {test::ChainProto::LL},
+}};
+
+std::string modeName(const ChainMode& mode) {
+  return std::string(mode.proto == test::ChainProto::LL ? "ll" : "simple") +
+      "_blocking";
+}
+
+// Position-dependent so a stale-slot or stale-flag accept cannot pass. A
+// uniform fill would let LL return the previous ring pass's bytes unnoticed --
+// and it would return them EARLY, so it shows up as a better latency number
+// rather than a failure.
+uint8_t expectedByte(uint8_t base, std::size_t i) {
+  return static_cast<uint8_t>(base + (i % 251));
+}
+
+std::vector<uint8_t> makePattern(uint8_t base, std::size_t nbytes) {
+  std::vector<uint8_t> data(nbytes);
+  for (std::size_t i = 0; i < nbytes; ++i) {
+    data[i] = expectedByte(base, i);
+  }
+  return data;
+}
+
+} // namespace
 
 class RecvForwardChainTest : public BenchmarkTestFixture {
  protected:
@@ -51,6 +91,108 @@ class RecvForwardChainTest : public BenchmarkTestFixture {
     return transport;
   }
 
+  // Device-resident array of per-rank transport pointers, indexed by rank.
+  DeviceBuffer makePeerTable(MultipeerIbgdaTransport& transport) {
+    std::vector<P2pIbgdaTransportDevice*> peers(worldSize, nullptr);
+    for (int r = 0; r < worldSize; ++r) {
+      if (r != globalRank) {
+        peers[r] = transport.getP2pTransportDevice(r);
+      }
+    }
+    DeviceBuffer table(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        table.get(),
+        peers.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+    return table;
+  }
+
+  /**
+   * Run one chain pass and verify it.
+   *
+   * `use_dst` selects whether intermediates also copy into recv_buf. Ranks that
+   * are expected to hold the data are checked byte-for-byte; `expectData`
+   * decides which those are (all but rank 0 with a dst, only the last rank
+   * without one).
+   */
+  void runChainCase(
+      DeviceBuffer& peerTable,
+      DeviceBuffer& sendBuf,
+      DeviceBuffer& recvBuf,
+      std::size_t nbytes,
+      int numBlocks,
+      const ChainMode& mode,
+      bool use_dst,
+      uint8_t base) {
+    const std::vector<uint8_t> pattern = makePattern(base, nbytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        sendBuf.get(), pattern.data(), nbytes, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, nbytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    bootstrap->barrierAll();
+
+    auto* peers = static_cast<P2pIbgdaTransportDevice**>(peerTable.get());
+    auto* src = static_cast<const char*>(sendBuf.get());
+    auto* dst = static_cast<char*>(recvBuf.get());
+    if (use_dst) {
+      test::launch_recv_forward_chain(
+          peers,
+          src,
+          dst,
+          nbytes,
+          globalRank,
+          worldSize,
+          numBlocks,
+          stream_,
+          mode.proto);
+    } else {
+      test::launch_recv_forward_chain_no_dst(
+          peers,
+          src,
+          dst,
+          nbytes,
+          globalRank,
+          worldSize,
+          numBlocks,
+          stream_,
+          mode.proto);
+    }
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess)
+        << modeName(mode) << " kernel failed: " << cudaGetErrorString(err);
+    bootstrap->barrierAll();
+
+    const bool expectData =
+        use_dst ? (globalRank != 0) : (globalRank == worldSize - 1);
+    if (!expectData) {
+      return;
+    }
+    std::vector<uint8_t> hostBuf(nbytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        hostBuf.data(), recvBuf.get(), nbytes, cudaMemcpyDeviceToHost));
+
+    std::size_t errors = 0;
+    for (std::size_t i = 0; i < nbytes; ++i) {
+      if (hostBuf[i] != expectedByte(base, i)) {
+        if (errors < 10) {
+          COMMS_LOG(
+              ERR,
+              "[{}] rank {}: byte {} expected 0x{:02X} got 0x{:02X}",
+              modeName(mode),
+              globalRank,
+              i,
+              expectedByte(base, i),
+              hostBuf[i]);
+        }
+        ++errors;
+      }
+    }
+    EXPECT_EQ(errors, 0u) << modeName(mode) << ": rank " << globalRank
+                          << " saw " << errors << " byte mismatches";
+  }
+
   cudaStream_t stream_{};
 };
 
@@ -68,69 +210,21 @@ TEST_F(RecvForwardChainTest, ForwardWithCopy) {
 
   try {
     auto transport = create_transport(kDataBytes, kNumBlocks);
-
     DeviceBuffer sendBuf(kDataBytes);
     DeviceBuffer recvBuf(kDataBytes);
+    DeviceBuffer peerTable = makePeerTable(*transport);
 
-    const uint8_t fillPattern = 0xCA;
-    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
-    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
-    CUDACHECK_TEST(cudaDeviceSynchronize());
-
-    // Build per-rank transport pointer array
-    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
-    for (int r = 0; r < worldSize; ++r) {
-      if (r != globalRank) {
-        peer_transports[r] = transport->getP2pTransportDevice(r);
-      }
-    }
-    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
-    CUDACHECK_TEST(cudaMemcpy(
-        d_transports.get(),
-        peer_transports.data(),
-        worldSize * sizeof(P2pIbgdaTransportDevice*),
-        cudaMemcpyHostToDevice));
-
-    bootstrap->barrierAll();
-
-    test::launch_recv_forward_chain(
-        static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
-        static_cast<const char*>(sendBuf.get()),
-        static_cast<char*>(recvBuf.get()),
-        kDataBytes,
-        globalRank,
-        worldSize,
-        kNumBlocks,
-        stream_);
-
-    cudaError_t err = cudaStreamSynchronize(stream_);
-    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
-
-    bootstrap->barrierAll();
-
-    // All ranks except rank 0 should have received the data
-    if (globalRank != 0) {
-      std::vector<uint8_t> hostBuf(kDataBytes);
-      CUDACHECK_TEST(cudaMemcpy(
-          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
-
-      int errors = 0;
-      for (std::size_t i = 0; i < kDataBytes; ++i) {
-        if (hostBuf[i] != fillPattern) {
-          if (errors < 10) {
-            COMMS_LOG(
-                ERR,
-                "Rank {}: byte {} expected 0x{:02X} got 0x{:02X}",
-                globalRank,
-                i,
-                fillPattern,
-                hostBuf[i]);
-          }
-          ++errors;
-        }
-      }
-      EXPECT_EQ(errors, 0) << "Rank " << globalRank << ": " << errors
-                           << " byte mismatches";
+    uint8_t base = 0xCA;
+    for (const auto& mode : kChainModes) {
+      runChainCase(
+          peerTable,
+          sendBuf,
+          recvBuf,
+          kDataBytes,
+          kNumBlocks,
+          mode,
+          /*use_dst=*/true,
+          base++);
     }
   } catch (const std::exception& e) {
     GTEST_SKIP() << "IBGDA transport not available: " << e.what();
@@ -150,58 +244,21 @@ TEST_F(RecvForwardChainTest, ForwardOnly) {
 
   try {
     auto transport = create_transport(kDataBytes, kNumBlocks);
-
     DeviceBuffer sendBuf(kDataBytes);
     DeviceBuffer recvBuf(kDataBytes);
+    DeviceBuffer peerTable = makePeerTable(*transport);
 
-    const uint8_t fillPattern = 0xBE;
-    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
-    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
-    CUDACHECK_TEST(cudaDeviceSynchronize());
-
-    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
-    for (int r = 0; r < worldSize; ++r) {
-      if (r != globalRank) {
-        peer_transports[r] = transport->getP2pTransportDevice(r);
-      }
-    }
-    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
-    CUDACHECK_TEST(cudaMemcpy(
-        d_transports.get(),
-        peer_transports.data(),
-        worldSize * sizeof(P2pIbgdaTransportDevice*),
-        cudaMemcpyHostToDevice));
-
-    bootstrap->barrierAll();
-
-    test::launch_recv_forward_chain_no_dst(
-        static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
-        static_cast<const char*>(sendBuf.get()),
-        static_cast<char*>(recvBuf.get()),
-        kDataBytes,
-        globalRank,
-        worldSize,
-        kNumBlocks,
-        stream_);
-
-    cudaError_t err = cudaStreamSynchronize(stream_);
-    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
-
-    bootstrap->barrierAll();
-
-    // Only the last rank gets data
-    if (globalRank == worldSize - 1) {
-      std::vector<uint8_t> hostBuf(kDataBytes);
-      CUDACHECK_TEST(cudaMemcpy(
-          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
-
-      int errors = 0;
-      for (std::size_t i = 0; i < kDataBytes; ++i) {
-        if (hostBuf[i] != fillPattern) {
-          ++errors;
-        }
-      }
-      EXPECT_EQ(errors, 0) << "Last rank: " << errors << " byte mismatches";
+    uint8_t base = 0xBE;
+    for (const auto& mode : kChainModes) {
+      runChainCase(
+          peerTable,
+          sendBuf,
+          recvBuf,
+          kDataBytes,
+          kNumBlocks,
+          mode,
+          /*use_dst=*/false,
+          base++);
     }
   } catch (const std::exception& e) {
     GTEST_SKIP() << "IBGDA transport not available: " << e.what();
@@ -221,65 +278,31 @@ TEST_F(RecvForwardChainTest, SendRecvDirect) {
 
   try {
     auto transport = create_transport(kDataBytes, kNumBlocks);
-
     DeviceBuffer sendBuf(kDataBytes);
     DeviceBuffer recvBuf(kDataBytes);
+    DeviceBuffer peerTable = makePeerTable(*transport);
 
-    const uint8_t fillPattern = 0x55;
-    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
-    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
-    CUDACHECK_TEST(cudaDeviceSynchronize());
-
-    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
-    for (int r = 0; r < worldSize; ++r) {
-      if (r != globalRank) {
-        peer_transports[r] = transport->getP2pTransportDevice(r);
-      }
-    }
-    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
-    CUDACHECK_TEST(cudaMemcpy(
-        d_transports.get(),
-        peer_transports.data(),
-        worldSize * sizeof(P2pIbgdaTransportDevice*),
-        cudaMemcpyHostToDevice));
-
-    bootstrap->barrierAll();
-
-    // Chain with worldSize=2: rank 0 sends, rank 1 receives — no recv_forward
-    test::launch_recv_forward_chain(
-        static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
-        static_cast<const char*>(sendBuf.get()),
-        static_cast<char*>(recvBuf.get()),
-        kDataBytes,
-        globalRank,
-        worldSize,
-        kNumBlocks,
-        stream_);
-
-    cudaError_t err = cudaStreamSynchronize(stream_);
-    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
-
-    bootstrap->barrierAll();
-
-    if (globalRank == 1) {
-      std::vector<uint8_t> hostBuf(kDataBytes);
-      CUDACHECK_TEST(cudaMemcpy(
-          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
-
-      int errors = 0;
-      for (std::size_t i = 0; i < kDataBytes; ++i) {
-        if (hostBuf[i] != fillPattern) {
-          ++errors;
-        }
-      }
-      EXPECT_EQ(errors, 0) << "Rank 1: " << errors << " byte mismatches";
+    uint8_t base = 0x55;
+    for (const auto& mode : kChainModes) {
+      runChainCase(
+          peerTable,
+          sendBuf,
+          recvBuf,
+          kDataBytes,
+          kNumBlocks,
+          mode,
+          /*use_dst=*/true,
+          base++);
     }
   } catch (const std::exception& e) {
     GTEST_SKIP() << "IBGDA transport not available: " << e.what();
   }
 }
 
-// Multi-section test: transfer more data than one slot to exercise pipelining.
+// Multi-section test: transfer more data than one slot to exercise pipelining,
+// slot reuse, and the generation advance that slot reuse implies. Without a
+// transfer long enough to wrap the staging ring, every packet in an LL run
+// carries generation 1 and a missing re-stamp cannot show up.
 TEST_F(RecvForwardChainTest, MultiSection) {
   if (worldSize < 2) {
     COMMS_LOG(INFO, "Skipping: requires >= 2 ranks, got {}", worldSize);
@@ -292,58 +315,115 @@ TEST_F(RecvForwardChainTest, MultiSection) {
 
   try {
     auto transport = create_transport(kSlotSize, kNumBlocks);
-
     DeviceBuffer sendBuf(kDataBytes);
     DeviceBuffer recvBuf(kDataBytes);
+    DeviceBuffer peerTable = makePeerTable(*transport);
 
-    const uint8_t fillPattern = 0xDD;
-    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
-    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
-    CUDACHECK_TEST(cudaDeviceSynchronize());
-
-    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
-    for (int r = 0; r < worldSize; ++r) {
-      if (r != globalRank) {
-        peer_transports[r] = transport->getP2pTransportDevice(r);
-      }
+    uint8_t base = 0xDD;
+    for (const auto& mode : kChainModes) {
+      runChainCase(
+          peerTable,
+          sendBuf,
+          recvBuf,
+          kDataBytes,
+          kNumBlocks,
+          mode,
+          /*use_dst=*/true,
+          base++);
     }
-    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
-    CUDACHECK_TEST(cudaMemcpy(
-        d_transports.get(),
-        peer_transports.data(),
-        worldSize * sizeof(P2pIbgdaTransportDevice*),
-        cudaMemcpyHostToDevice));
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
 
-    bootstrap->barrierAll();
+// A transfer whose per-block size is not a multiple of the LL packet payload
+// (kData = 4), so the final packet of each stream carries fewer than kData
+// valid bytes alongside the packer's zero padding. Every size above is a clean
+// multiple, which never exercises the valid_payload mask on the relay hop.
+TEST_F(RecvForwardChainTest, PartialFinalPacket) {
+  if (worldSize < 2) {
+    COMMS_LOG(INFO, "Skipping: requires >= 2 ranks, got {}", worldSize);
+    return;
+  }
 
-    test::launch_recv_forward_chain(
-        static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
-        static_cast<const char*>(sendBuf.get()),
-        static_cast<char*>(recvBuf.get()),
-        kDataBytes,
-        globalRank,
-        worldSize,
-        kNumBlocks,
-        stream_);
+  // The slot size stays 16 B-aligned (the transport requires it of
+  // perChannelSize); only the payload is odd. Block 0 takes a 16 B-aligned
+  // share and the last block takes the remainder, so its stream ends
+  // mid-packet: 131083 % 4 == 3.
+  constexpr std::size_t kSlotSize = 256 * 1024;
+  constexpr std::size_t kDataBytes = kSlotSize - 5;
+  constexpr int kNumBlocks = 2;
 
-    cudaError_t err = cudaStreamSynchronize(stream_);
-    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+  try {
+    auto transport = create_transport(kSlotSize, kNumBlocks);
+    DeviceBuffer sendBuf(kDataBytes);
+    DeviceBuffer recvBuf(kDataBytes);
+    DeviceBuffer peerTable = makePeerTable(*transport);
 
-    bootstrap->barrierAll();
+    uint8_t base = 0x33;
+    for (const auto& mode : kChainModes) {
+      runChainCase(
+          peerTable,
+          sendBuf,
+          recvBuf,
+          kDataBytes,
+          kNumBlocks,
+          mode,
+          /*use_dst=*/true,
+          base++);
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
 
-    if (globalRank != 0) {
-      std::vector<uint8_t> hostBuf(kDataBytes);
-      CUDACHECK_TEST(cudaMemcpy(
-          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
+/**
+ * Alternate Simple and LL forwards repeatedly on one channel.
+ *
+ * The two protocols own separate progress cursors and staging banks but SHARE
+ * the channel's QPs and its recvDataReadyLaneCursor. select_put_lane_ordinal()
+ * bumps the sender's cursor on every put regardless of protocol, so every LL
+ * recv-side path has to bump the receiver's mirror to match. Skipping it
+ * leaves the two one chunk apart per LL transfer, and the NEXT Simple receive
+ * resolves to a lane the sender never wrote and blocks forever.
+ *
+ * All-Simple and all-LL runs cannot catch that -- the first keeps both
+ * counters in step, the second never consults the lane mapping. Only an
+ * interleaving does, which is why this case exists separately from the sweeps
+ * above and alternates several times rather than once.
+ */
+TEST_F(RecvForwardChainTest, MixedProtocolAlternating) {
+  if (worldSize < 2) {
+    COMMS_LOG(INFO, "Skipping: requires >= 2 ranks, got {}", worldSize);
+    return;
+  }
 
-      int errors = 0;
-      for (std::size_t i = 0; i < kDataBytes; ++i) {
-        if (hostBuf[i] != fillPattern) {
-          ++errors;
-        }
+  constexpr std::size_t kDataBytes = 256 * 1024;
+  constexpr int kNumBlocks = 2;
+  constexpr int kRounds = 3;
+
+  try {
+    auto transport = create_transport(kDataBytes, kNumBlocks);
+    DeviceBuffer sendBuf(kDataBytes);
+    DeviceBuffer recvBuf(kDataBytes);
+    DeviceBuffer peerTable = makePeerTable(*transport);
+
+    uint8_t base = 0x10;
+    for (int round = 0; round < kRounds; ++round) {
+      for (const auto proto :
+           {test::ChainProto::Simple,
+            test::ChainProto::LL,
+            test::ChainProto::Simple}) {
+        runChainCase(
+            peerTable,
+            sendBuf,
+            recvBuf,
+            kDataBytes,
+            kNumBlocks,
+            ChainMode{proto},
+            /*use_dst=*/true,
+            base++);
       }
-      EXPECT_EQ(errors, 0) << "Rank " << globalRank << ": " << errors
-                           << " byte mismatches in multi-section transfer";
     }
   } catch (const std::exception& e) {
     GTEST_SKIP() << "IBGDA transport not available: " << e.what();

--- a/comms/prims/tests/RecvForwardChainTest.cu
+++ b/comms/prims/tests/RecvForwardChainTest.cu
@@ -1,5 +1,7 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include "comms/prims/tests/RecvForwardChainTest.h"
+
 #include <cuda_runtime.h>
 
 #include <cstdint>
@@ -11,6 +13,8 @@
 namespace comms::prims::test {
 
 // Chain kernel: rank 0 sends, intermediates recv_forward, last rank receives.
+// `Proto` selects the wire format; every rank must instantiate the same one.
+template <typename Proto>
 __global__ void recv_forward_chain_kernel(
     P2pIbgdaTransportDevice** transports,
     const char* send_buf,
@@ -33,18 +37,80 @@ __global__ void recv_forward_chain_kernel(
   if (my_rank == 0) {
     // First rank: send to next
     P2pIbgdaTransportDevice& next = *transports[next_rank];
-    next.send(group, send_buf + my_off, my_bytes);
+    next.send<Memcpy, Proto>(group, send_buf + my_off, my_bytes);
   } else if (my_rank == world_size - 1) {
     // Last rank: receive from prev
     P2pIbgdaTransportDevice& prev = *transports[prev_rank];
-    prev.recv(group, recv_buf + my_off, my_bytes);
+    prev.recv<Memcpy, Proto>(group, recv_buf + my_off, my_bytes);
   } else {
     P2pIbgdaTransportDevice& prev = *transports[prev_rank];
     P2pIbgdaTransportDevice& next = *transports[next_rank];
     char* dst = use_dst ? (recv_buf + my_off) : nullptr;
-    prev.forward(group, dst, next, my_bytes);
+    prev.forward<Memcpy, Proto>(group, dst, next, my_bytes);
   }
 }
+
+namespace {
+
+template <typename Proto>
+void launch_typed(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream,
+    bool use_dst) {
+  recv_forward_chain_kernel<Proto><<<num_blocks, 128, 0, stream>>>(
+      transports, send_buf, recv_buf, nbytes, my_rank, world_size, use_dst);
+}
+
+// Runtime enum -> compile-time tag. The protocol is a template parameter all
+// the way down to the transport seam, so the choice has to be resolved here.
+void launch_chain(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream,
+    ChainProto proto,
+    bool use_dst,
+    const char* what) {
+  if (proto == ChainProto::LL) {
+    launch_typed<protocol::LL>(
+        transports,
+        send_buf,
+        recv_buf,
+        nbytes,
+        my_rank,
+        world_size,
+        num_blocks,
+        stream,
+        use_dst);
+  } else {
+    launch_typed<protocol::Simple>(
+        transports,
+        send_buf,
+        recv_buf,
+        nbytes,
+        my_rank,
+        world_size,
+        num_blocks,
+        stream,
+        use_dst);
+  }
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf("%s kernel launch failed: %s\n", what, cudaGetErrorString(err));
+  }
+}
+
+} // namespace
 
 void launch_recv_forward_chain(
     P2pIbgdaTransportDevice** transports,
@@ -54,21 +120,20 @@ void launch_recv_forward_chain(
     int my_rank,
     int world_size,
     int num_blocks,
-    cudaStream_t stream) {
-  recv_forward_chain_kernel<<<num_blocks, 128, 0, stream>>>(
+    cudaStream_t stream,
+    ChainProto proto) {
+  launch_chain(
       transports,
       send_buf,
       recv_buf,
       nbytes,
       my_rank,
       world_size,
-      /*use_dst=*/true);
-  cudaError_t err = cudaGetLastError();
-  if (err != cudaSuccess) {
-    printf(
-        "recv_forward_chain kernel launch failed: %s\n",
-        cudaGetErrorString(err));
-  }
+      num_blocks,
+      stream,
+      proto,
+      /*use_dst=*/true,
+      "recv_forward_chain");
 }
 
 void launch_recv_forward_chain_no_dst(
@@ -79,21 +144,20 @@ void launch_recv_forward_chain_no_dst(
     int my_rank,
     int world_size,
     int num_blocks,
-    cudaStream_t stream) {
-  recv_forward_chain_kernel<<<num_blocks, 128, 0, stream>>>(
+    cudaStream_t stream,
+    ChainProto proto) {
+  launch_chain(
       transports,
       send_buf,
       recv_buf,
       nbytes,
       my_rank,
       world_size,
-      /*use_dst=*/false);
-  cudaError_t err = cudaGetLastError();
-  if (err != cudaSuccess) {
-    printf(
-        "recv_forward_chain_no_dst kernel launch failed: %s\n",
-        cudaGetErrorString(err));
-  }
+      num_blocks,
+      stream,
+      proto,
+      /*use_dst=*/false,
+      "recv_forward_chain_no_dst");
 }
 
 } // namespace comms::prims::test

--- a/comms/prims/tests/RecvForwardChainTest.h
+++ b/comms/prims/tests/RecvForwardChainTest.h
@@ -2,14 +2,19 @@
 
 #pragma once
 
+#include <cuda_runtime.h>
 #include <cstddef>
-#include <cstdint>
 
 namespace comms::prims {
 class P2pIbgdaTransportDevice;
 } // namespace comms::prims
 
 namespace comms::prims::test {
+
+/// Wire format the chain runs on. Maps to protocol::Simple / protocol::LL.
+/// Every rank must pick the same one: the two formats disagree on packet
+/// layout and land on different per-protocol channel slots.
+enum class ChainProto { Simple, LL };
 
 /**
  * Launch a chain test kernel: rank 0 sends, intermediates recv_forward,
@@ -25,6 +30,7 @@ namespace comms::prims::test {
  * @param world_size     Total number of ranks.
  * @param num_blocks     CUDA grid dimension.
  * @param stream         CUDA stream.
+ * @param proto          Wire format; every rank in the chain must agree.
  */
 void launch_recv_forward_chain(
     P2pIbgdaTransportDevice** transports,
@@ -34,7 +40,8 @@ void launch_recv_forward_chain(
     int my_rank,
     int world_size,
     int num_blocks,
-    cudaStream_t stream);
+    cudaStream_t stream,
+    ChainProto proto = ChainProto::Simple);
 
 /**
  * Same as above but with dst=nullptr for intermediates (forward-only mode).
@@ -48,6 +55,7 @@ void launch_recv_forward_chain_no_dst(
     int my_rank,
     int world_size,
     int num_blocks,
-    cudaStream_t stream);
+    cudaStream_t stream,
+    ChainProto proto = ChainProto::Simple);
 
 } // namespace comms::prims::test

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -571,7 +571,7 @@ __device__ __forceinline__ void P2pIbTransportDevice::recv(
   }
 }
 
-template <typename CopyOp, typename... Args>
+template <typename CopyOp, typename Proto, typename... Args>
 __device__ __forceinline__ void P2pIbTransportDevice::forward(
     ThreadGroup& group,
     void* __restrict__ dst,
@@ -581,12 +581,12 @@ __device__ __forceinline__ void P2pIbTransportDevice::forward(
     const AbortDevice& abortDevice,
     Args... args) {
   if (type == P2pIbBackendType::IBRC && fwd.type == P2pIbBackendType::IBRC) {
-    ibrc->forward<CopyOp>(
+    ibrc->forward<CopyOp, Proto>(
         group, dst, *fwd.ibrc, nbytes, max_signal_bytes, abortDevice, args...);
     return;
   }
   if (type == P2pIbBackendType::IBGDA && fwd.type == P2pIbBackendType::IBGDA) {
-    ibgda->forward<CopyOp>(
+    ibgda->forward<CopyOp, Proto>(
         group, dst, *fwd.ibgda, nbytes, max_signal_bytes, abortDevice, args...);
     return;
   }

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -349,7 +349,10 @@ struct P2pIbTransportDevice {
       const AbortDevice& abortDevice = AbortDevice(),
       Args... args);
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename Proto = protocol::Simple,
+      typename... Args>
   __device__ __forceinline__ void forward(
       ThreadGroup& group,
       void* __restrict__ dst,
@@ -464,10 +467,16 @@ struct P2pIbTransportDevice {
 static_assert(std::is_standard_layout_v<P2pIbTransportDevice>);
 static_assert(std::is_trivially_copyable_v<P2pIbTransportDevice>);
 
-template <uint32_t WorkerThreads>
+// `Proto` is the wire format every op on this policy uses. It lives on the
+// policy rather than on each call so a collective picks the format once, at the
+// point it builds its ops object, and cannot end up with a mixed-protocol
+// sequence on one channel. The warp-proxy policy has no LL counterpart, so LL
+// is only reachable through this blocking one.
+template <uint32_t WorkerThreads, typename Proto = protocol::Simple>
 class BlockingIbOps {
  public:
   static constexpr uint32_t kWorkerThreads = WorkerThreads;
+  using WireProto = Proto;
 
   __device__ BlockingIbOps(ThreadGroup workers, const AbortDevice& abortDevice)
       : workers_(workers), timeout_(abortDevice) {}
@@ -489,7 +498,7 @@ class BlockingIbOps {
       std::size_t nbytes,
       std::size_t maxSignalBytes,
       Args... args) {
-    transport.template send<CopyOp>(
+    transport.template send<CopyOp, Proto>(
         workers_, src, nbytes, maxSignalBytes, timeout_, args...);
   }
 
@@ -500,7 +509,7 @@ class BlockingIbOps {
       std::size_t nbytes,
       std::size_t maxSignalBytes,
       Args... args) {
-    transport.template recv<CopyOp>(
+    transport.template recv<CopyOp, Proto>(
         workers_, dst, nbytes, maxSignalBytes, timeout_, args...);
   }
 
@@ -512,7 +521,7 @@ class BlockingIbOps {
       std::size_t nbytes,
       std::size_t maxSignalBytes,
       Args... args) {
-    prev.template forward<CopyOp>(
+    prev.template forward<CopyOp, Proto>(
         workers_, dst, next, nbytes, maxSignalBytes, timeout_, args...);
   }
 

--- a/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
@@ -643,6 +643,10 @@ __device__ __forceinline__ void consumeRecvBuf(
 // analog of consumeRecvBuf (recv-side readiness) fused with prepareSendBuf
 // (relay signal); LL later overrides it to poll inline flags, repack the fwd
 // staging, and return an empty signal.
+//
+// `recvFlagVal` / `fwdFlagVal` are the two ring generations, unused by Simple
+// (which has no inline flag) but part of the shared seam so forward_impl keeps
+// a single tag-dispatched call site.
 template <
     typename CopyOp = Memcpy,
     typename Transport,
@@ -662,6 +666,8 @@ __device__ __forceinline__ SendSignal prepareForwardBuf(
     std::size_t nbytes,
     std::size_t dataOff,
     uint64_t recvWaitCredit,
+    uint64_t recvFlagVal,
+    uint64_t fwdFlagVal,
     const IbRemoteChannel& fwdRemoteChannel,
     uint64_t fwdSignalVal,
     uint32_t fwdSlot,
@@ -670,6 +676,8 @@ __device__ __forceinline__ SendSignal prepareForwardBuf(
     const PipesTraceAllReduceContext* recvTraceContext,
     const PipesTraceAllReduceContext* sendTraceContext,
     Args... args) {
+  (void)recvFlagVal;
+  (void)fwdFlagVal;
 #if PIPES_IS_DEVICE_COMPILE
   // Both waits must clear before CopyOp::forward, which reads recvStaging and
   // writes fwdStaging; they are independent, so the order is a latency choice,
@@ -711,6 +719,9 @@ __device__ __forceinline__ SendSignal prepareForwardBuf(
         static_cast<uint8_t>(kPipesTraceQpLaneMask),
         fwdSignalVal);
   }
+  // Each protocol owns its own resource slot (Simple kProtoSlot 0, LL 1), so
+  // the slot template argument must be THIS overload's tag, not a fixed
+  // protocol -- an LL overload that copies this body must swap it for LL.
   if (prepare_send_slot<protocol::Simple>(
           fwdTransport, group, fwdSlot, fwdPipelineCycle, abortDevice)) {
     // Slot not retired: a lane's completion was never observed, so the NIC may
@@ -1974,6 +1985,12 @@ __device__ __forceinline__ void forward_impl(
   static_assert(
       std::is_void_v<IbOps> || std::is_same_v<Proto, protocol::Simple>,
       "IB operation policies support protocol::Simple only");
+  static_assert(
+      !detail::copyop_variable_size_v<CopyOp> ||
+          std::is_same_v<Proto, protocol::Simple>,
+      "variable-size CopyOps (e.g. AnsCompress) are supported on "
+      "protocol::Simple only; the compressed loop is not behind the "
+      "prepareForwardBuf seam.");
 #if PIPES_IS_DEVICE_COMPILE
 #ifdef __HIP_PLATFORM_AMD__
   static_assert(
@@ -2100,6 +2117,15 @@ __device__ __forceinline__ void forward_impl(
         ? fwdProtocolStreamEnd - fwdGeo.pipelineBytesWire
         : 0;
     if constexpr (std::is_void_v<IbOps>) {
+      // Per-ring-pass packet generations, one per side. They are NOT the same
+      // value: the two cursors advance independently and the two channels can
+      // have different pipeline windows, so the relayed packets must be
+      // re-stamped from recvFlagVal to fwdFlagVal. Same expression the blocking
+      // send/recv paths and next_chunk() use. Ignored by Simple.
+      const uint64_t recvFlagVal =
+          recvStreamPayload / recvGeo.pipelineBytesPayload + 1;
+      const uint64_t fwdFlagVal = fwdPipelineCycle + 1;
+
       // (1) prepareForwardBuf: fwd slot-reuse backpressure + recv-side
       // readiness
       //     + fused transform recvStaging -> dst + fwdStaging, returning the
@@ -2118,6 +2144,8 @@ __device__ __forceinline__ void forward_impl(
           nbytes,
           dataOff,
           recvProtocolBytesThis,
+          recvFlagVal,
+          fwdFlagVal,
           fwdRemoteChannel,
           fwdProtocolBytesThis,
           static_cast<uint32_t>(fwdSlot),

--- a/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
@@ -5,6 +5,8 @@
 #include <type_traits>
 #include <utility>
 
+#include "comms/common/fault_tolerance/AbortMacros.cuh"
+#include "comms/prims/core/LLImpl.cuh"
 #include "comms/prims/core/LlxPacket.cuh"
 #include "comms/prims/core/MemcpyCopyOp.cuh"
 #include "comms/prims/trace/PipesTraceTypes.h"
@@ -124,7 +126,7 @@ struct Simple {
 // (8 B packet = 4 B data + 4 B flag), so wire == 2x payload; readiness is the
 // inline flag (no DATA_READY -- see consumeRecvBuf(LL)). LL reuses the same
 // channel/state as Simple (shared IbChannelLayout, staging, and progress
-// cursor); forward is not implemented for LL yet.
+// cursor).
 namespace protocol {
 struct LL {
   // Slot 1: LL owns its own per-channel resource slot. The two protocols must
@@ -791,6 +793,202 @@ __device__ __forceinline__ SendSignal prepareForwardBuf(
   return SendSignal{};
 #endif
 }
+
+// LL forward: poll the upstream chunk's inline packet flags, then a single
+// fused CopyOp::forwardLL re-stamps recvStaging -> dst + fwdStaging with the
+// DOWNSTREAM ring's generation, and the relay put carries no DATA_READY. The
+// LL analog of consumeRecvBuf(LL) fused with prepareSendBuf(LL).
+//
+// Both this and consumeRecvBuf(LL) poll the whole chunk before decoding, but
+// only here is the poll load-bearing. On the recv side a codec that spins per
+// packet would also be correct, and the seam's poll is there so correctness
+// does not depend on which CopyOp turns up. The fused hook has no such
+// fallback: it writes fwdStaging as it reads recvStaging, so a spin partway
+// through would already have emitted packets built from not-yet-arrived data,
+// with nothing to roll back. Confirm the whole chunk first, then transform in
+// one non-spinning pass -- which is why CopyOp::forwardLL takes no AbortDevice.
+template <
+    typename CopyOp = Memcpy,
+    typename Transport,
+    typename FwdTransport,
+    typename... Args>
+__device__ __forceinline__ SendSignal prepareForwardBuf(
+    protocol::LL,
+    Transport& transport,
+    FwdTransport& fwdTransport,
+    ThreadGroup& group,
+    IbLocalChannel& recvLocalChannel,
+    const IbgdaLocalBuffer& recvDataReady,
+    char* dst,
+    char* fwdStaging,
+    const char* recvStaging,
+    std::size_t payloadBytes,
+    std::size_t nbytes,
+    std::size_t dataOff,
+    uint64_t recvWaitCredit,
+    uint64_t recvFlagVal,
+    uint64_t fwdFlagVal,
+    const IbRemoteChannel& fwdRemoteChannel,
+    uint64_t fwdSignalVal,
+    uint32_t fwdSlot,
+    uint64_t fwdPipelineCycle,
+    const AbortDevice& abortDevice,
+    const PipesTraceAllReduceContext* recvTraceContext,
+    const PipesTraceAllReduceContext* sendTraceContext,
+    Args... args) {
+  using P = LlxPacket<4, 4>;
+  static_assert(
+      has_forwardLL_v<CopyOp, P>,
+      "LL forward path requires a CopyOp with a packet-aware forwardLL<P>(); "
+      "Memcpy provides one. A reduce/convert CopyOp must supply its own -- "
+      "neither a contiguous copy nor a verbatim packet copy works, because the "
+      "relayed packets must carry the downstream ring's generation");
+#if PIPES_IS_DEVICE_COMPILE
+  // LL carries no DATA_READY and no slot-free credit on the recv side, so the
+  // signal-driven parameters Simple uses are inert here.
+  (void)recvDataReady;
+  (void)recvWaitCredit;
+  (void)fwdRemoteChannel;
+  (void)fwdSignalVal;
+  (void)recvTraceContext;
+
+  // Readiness first, for the same latency reason as the Simple overload: the
+  // upstream wait is the remote-dependent one, so by the time it clears the
+  // local NIC has usually already released this fwdStaging slot.
+  const auto recvFlag = static_cast<typename P::FlagType>(recvFlagVal);
+  while (
+      !LLImpl<P>::all_flags_set(group, recvStaging, payloadBytes, recvFlag)) {
+    // The loop condition itself is a group barrier (all_flags_set ends in
+    // group.all()), so the exit has to be group-uniform: a bare FT_ABORT_BREAK
+    // would let the threads that saw the abort leave while the rest block
+    // forever in that barrier. Check, then agree, then leave together.
+    const bool stop = FT_ABORT_CHECK(
+        abortDevice,
+        "forward(LL) waiting for packet flags flagVal=%llu, payloadBytes=%llu",
+        static_cast<unsigned long long>(recvFlagVal),
+        static_cast<unsigned long long>(payloadBytes));
+    if (group.all(stop)) {
+      break;
+    }
+  }
+  if (group.is_leader()) {
+    // LL carries no DATA_READY, but the upstream put still advanced the
+    // sender's IbQpState::cursor -- select_put_lane_ordinal() increments it on
+    // every put regardless of protocol, and it is channel-scoped, not
+    // slot-scoped. recvDataReadyLaneCursor mirrors it, so consuming an LL chunk
+    // here without the matching bump leaves the two one chunk apart per
+    // transfer and Simple's next receive on this channel waits on a lane the
+    // sender never wrote. Matches progress_recv_ready(LL) and
+    // consumeRecvBuf(LL).
+    ++recvLocalChannel.recvDataReadyLaneCursor;
+    trace_allreduce_event(
+        sendTraceContext,
+        PipesTraceEventType::kAllReduceLocalCompletionWaitBegin,
+        static_cast<uint8_t>(kPipesTraceQpLaneMask),
+        fwdFlagVal);
+  }
+  // LL owns kProtoSlot 1: the slot template argument must be this overload's
+  // tag, not Simple's.
+  if (prepare_send_slot<protocol::LL>(
+          fwdTransport, group, fwdSlot, fwdPipelineCycle, abortDevice)) {
+    // Slot not retired -- same memory hazard the Simple overload guards
+    // against: the NIC may still be reading this staging, so stop before
+    // CopyOp::forwardLL writes over it.
+    //
+    // KNOWN GAP, deferred to a follow-up: this abandonment is not reported
+    // precisely to the caller. Simple marks it with an empty SendSignal, but
+    // LL's success path returns an empty signal too (the inline flag IS the
+    // readiness mark), so forward_impl's `if constexpr (Simple)` test cannot
+    // cover us. That leaves only its `groupAborted()` break, which is amortized
+    // behind `nextPollCycles_` and so can answer false on the very iteration
+    // this guard fired -- exactly the staleness the Simple empty-signal test
+    // exists to close.
+    //
+    // The consequence is worse than a stall and is FAULT_TOLERANCE.md
+    // principle 4: continuing would ACK the predecessor for a chunk we never
+    // consumed and hand the successor a fused DATA_READY for data we never
+    // wrote, releasing two correctly-blocked peers and stopping them reaching
+    // their own deadlines -- one rank's abort silently suppressing fault
+    // detection on the rest.
+    //
+    // The guard still belongs here: dropping it would stage over live NIC
+    // reads, which is silent data corruption rather than a detection gap. The
+    // fix is a precise out-param (the `bool& abandoned` idiom LLImpl already
+    // uses in load_ready_payload) plus an LL arm in forward_impl's test.
+    return SendSignal{};
+  }
+  if (group.is_leader()) {
+    trace_allreduce_event(
+        sendTraceContext,
+        PipesTraceEventType::kAllReduceLocalCompletionWaitEnd,
+        static_cast<uint8_t>(kPipesTraceQpLaneMask),
+        fwdFlagVal);
+  }
+
+  // Clamp to the REAL payload before the codec, exactly as prepareSendBuf(LL)
+  // does: payloadBytes is rounded up to kData for the wire/credit stream, and
+  // both hops derive validBytes from values they already agree on, so
+  // packet_count() matches on each side.
+  const std::size_t validBytes =
+      valid_payload_bytes(dataOff, payloadBytes, nbytes);
+  if (validBytes > 0) {
+    if (group.is_leader()) {
+      trace_allreduce_event(
+          sendTraceContext,
+          PipesTraceEventType::kAllReduceStageCopyBegin,
+          static_cast<uint8_t>(kPipesTraceQpLaneMask),
+          validBytes);
+    }
+    CopyOp::template forwardLL<P>(
+        group,
+        dst,
+        fwdStaging,
+        recvStaging,
+        validBytes,
+        dataOff,
+        recvFlag,
+        static_cast<typename P::FlagType>(fwdFlagVal),
+        args...);
+    if (group.is_leader()) {
+      trace_allreduce_event(
+          sendTraceContext,
+          PipesTraceEventType::kAllReduceStageCopyEnd,
+          static_cast<uint8_t>(kPipesTraceQpLaneMask),
+          validBytes);
+    }
+  }
+  group.sync();
+  // No DATA_READY: the inline flag the transform just stamped is the readiness
+  // mark. An empty IbgdaRemoteBuffer makes the put carry data only, exactly as
+  // prepareSendBuf(LL) / progress_send_signal(LL) do.
+  return SendSignal{IbgdaRemoteBuffer{}, /*val=*/0};
+#else
+  (void)transport;
+  (void)fwdTransport;
+  (void)group;
+  (void)recvLocalChannel;
+  (void)recvDataReady;
+  (void)dst;
+  (void)fwdStaging;
+  (void)recvStaging;
+  (void)payloadBytes;
+  (void)nbytes;
+  (void)dataOff;
+  (void)recvWaitCredit;
+  (void)recvFlagVal;
+  (void)fwdFlagVal;
+  (void)fwdRemoteChannel;
+  (void)fwdSignalVal;
+  (void)fwdSlot;
+  (void)fwdPipelineCycle;
+  (void)abortDevice;
+  (void)recvTraceContext;
+  (void)sendTraceContext;
+  ((void)args, ...);
+  return SendSignal{};
+#endif
+}
+
 // LL encode: pack payload + trailing flag=flagVal into staging via
 // LLImpl::pack; the put carries NO DATA_READY (empty signal) -- the inline
 // flag is the readiness mark. Ignores the remote signal slot/value that

--- a/comms/prims/transport/ibgda/IbgdaWarpProxy.cuh
+++ b/comms/prims/transport/ibgda/IbgdaWarpProxy.cuh
@@ -135,6 +135,10 @@ class IbgdaWarpProxy {
   class Ops {
    public:
     static constexpr uint32_t kWorkerThreads = WorkerThreads;
+    // Every ops policy names its wire format so callers can size transfers by
+    // it (see BlockingIbOps). The proxy stages through its own queues and has
+    // no LL counterpart, so this one is fixed.
+    using WireProto = protocol::Simple;
 
     __device__ __forceinline__ ThreadGroup& group() {
       return workers_;

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -2702,7 +2702,10 @@ class P2pIbgdaTransportDevice {
    * @param abortDevice         Optional abortDevice for wait operations.
    * @param args            Extra args forwarded to CopyOp::forward.
    */
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename Proto = protocol::Simple,
+      typename... Args>
   __device__ __forceinline__ void forward(
       ThreadGroup& group,
       void* __restrict__ dst,
@@ -2711,11 +2714,14 @@ class P2pIbgdaTransportDevice {
       std::size_t max_signal_bytes = 0,
       const AbortDevice& abortDevice = AbortDevice(),
       Args... args) {
-    forwardWithTrace<CopyOp>(
+    forwardWithTrace<CopyOp, Proto>(
         group, dst, fwd, nbytes, max_signal_bytes, abortDevice, {}, 0, args...);
   }
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename Proto = protocol::Simple,
+      typename... Args>
   __device__ __forceinline__ void forwardWithTrace(
       ThreadGroup& group,
       void* __restrict__ dst,
@@ -2738,7 +2744,7 @@ class P2pIbgdaTransportDevice {
           /*step=*/0,
           static_cast<uint16_t>(group.group_id));
     }
-    detail::forward<CopyOp>(
+    detail::forward<CopyOp, P2pIbgdaTransportDevice, Proto>(
         *this, group, dst, fwd, nbytes, max_signal_bytes, abortDevice, args...);
     if (group.is_leader()) {
       trace_ibgda_event(
@@ -2751,7 +2757,10 @@ class P2pIbgdaTransportDevice {
 #endif
   }
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename Proto = protocol::Simple,
+      typename... Args>
   __device__ __forceinline__ void forwardWithFineTrace(
       ThreadGroup& group,
       void* __restrict__ dst,
@@ -2762,7 +2771,7 @@ class P2pIbgdaTransportDevice {
       const PipesTraceAllReduceContext& recvTraceContext,
       const PipesTraceAllReduceContext& sendTraceContext,
       Args... args) {
-    detail::forward_with_fine_trace<CopyOp>(
+    detail::forward_with_fine_trace<CopyOp, P2pIbgdaTransportDevice, Proto>(
         *this,
         group,
         dst,

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -739,7 +739,10 @@ class P2pIbrcTransportDevice {
         *this, group, dst, nbytes, max_signal_bytes, abortDevice, args...);
   }
 
-  template <typename CopyOp = Memcpy, typename... Args>
+  template <
+      typename CopyOp = Memcpy,
+      typename Proto = protocol::Simple,
+      typename... Args>
   __device__ __forceinline__ void forward(
       ThreadGroup& group,
       void* __restrict__ dst,
@@ -748,7 +751,7 @@ class P2pIbrcTransportDevice {
       std::size_t max_signal_bytes = 0,
       const AbortDevice& abortDevice = AbortDevice(),
       Args... args) {
-    detail::forward<CopyOp>(
+    detail::forward<CopyOp, P2pIbrcTransportDevice, Proto>(
         *this, group, dst, fwd, nbytes, max_signal_bytes, abortDevice, args...);
   }
 


### PR DESCRIPTION
Summary:

`forward` was the last IB seam that could not run the LL wire format. This adds
it. The resumable (progress-style) forward is a separate concern and lands in
the diff above, with the benchmark that is its only consumer.

**`prepareForwardBuf(protocol::LL, ...)`**

The LL sibling of the Simple forward seam, and the first thing that selects a
non-Simple `Proto` on `forward`. It:

- Confirms the whole upstream chunk with `LLImpl<P>::all_flags_set` BEFORE
  transforming. Unlike the recv side this is load-bearing rather than
  defensive: the fused hook writes `fwdStaging` as it reads `recvStaging`, so
  a codec that waited partway through would already have emitted packets built
  from not-yet-arrived data, with nothing to roll back. That is also why
  `CopyOp::forwardLL` takes no `Timeout` -- it must not wait.
- Advances `recvDataReadyLaneCursor`. LL carries no DATA_READY, but the
  upstream put still bumped the sender's channel-scoped `IbQpState::cursor`;
  the receiver's mirror has to follow or the next Simple recv on this channel
  waits on a lane the sender never wrote.
- Takes `kProtoSlot` 1 via `prepare_send_slot<protocol::LL>`, not Simple's 0.
- Returns an empty `SendSignal`: the inline flag the transform stamped IS the
  readiness mark, so the relay put carries data only.

Its readiness loop uses `FT_ABORT_CHECK` plus a group-wide agreement rather
than a bare `FT_ABORT_BREAK`. The loop condition is itself a group barrier
(`all_flags_set` ends in `group.all()`), so an exit that is not group-uniform
strands the threads that did not see the abort inside that barrier.

Reviewed By: Scusemua

Differential Revision: D116866199


