### PR TITLE
Fix PYRE call error in the sharded-relay injection example

### DIFF
--- a/comms/torchcomms/rcclx/examples/ShardedRelayCollectives.py
+++ b/comms/torchcomms/rcclx/examples/ShardedRelayCollectives.py
@@ -100,6 +100,7 @@ import socket
 import sys
 import time
 import unittest
+from collections.abc import Callable
 from dataclasses import dataclass, replace
 
 import torch
@@ -599,7 +600,7 @@ def _inject_overflow(rcclx, rank: int, is_active: bool) -> None:
     raise AssertionError(f"Rank {rank}: over-capacity plan was accepted")
 
 
-def _injectors() -> dict[str, object]:
+def _injectors() -> dict[str, Callable[..., None]]:
     """Explicit mapping rather than a registry decorator, which would need an
     import side effect to populate."""
     return {


### PR DESCRIPTION
Summary:
`_injectors()` in the sharded-relay example returned `dict[str, object]`, so
`run_injection` failed the PYRE linter when it called the looked-up value:

  Call error [29]: `object` is not a function.

Type the mapping values as callables instead. The values were already the
`_inject_*` functions, so this is an annotation-only change -- the explicit
mapping (rather than a registry decorator) is kept as-is.

Differential Revision: D118137886


