### PR TITLE
Fix broken conda build: CLOGF -> CTRAN_LOG in PersistentCollectives

### DIFF
--- a/comms/rcclx/develop/meta/ctran/PersistentCollectives.cc
+++ b/comms/rcclx/develop/meta/ctran/PersistentCollectives.cc
@@ -41,30 +41,32 @@ __attribute__((visibility("default"))) ncclResult_t allGatherInit(
 
 #define CHECK_VALID_CTRAN(comm)                                             \
   if (!ctranInitialized(comm)) {                                            \
-    CLOGF(                                                                  \
+    CTRAN_LOG(                                                              \
         ERR,                                                                \
         "CTRAN must be enabled and initialized for persistent collective"); \
     return ncclInvalidUsage;                                                \
   }
 
-#define CHECK_PREQ_TYPE(pReq, type)                                \
-  if (pReq->type != type) {                                        \
-    CLOGF(                                                         \
+/* The parameter must not be named `type`: the preprocessor would also rewrite
+ * the `->type` member accesses below, turning the check into a tautology. */
+#define CHECK_PREQ_TYPE(pReq, expectedType)                        \
+  if ((pReq)->type != (expectedType)) {                            \
+    CTRAN_LOG(                                                     \
         ERR,                                                       \
-        "%s requires persistent request type %d, but received %d", \
+        "{} requires persistent request type {}, but received {}", \
         __func__,                                                  \
-        type,                                                      \
-        pReq->type);                                               \
+        (expectedType),                                            \
+        (pReq)->type);                                             \
     return ncclInvalidArgument;                                    \
   }
 
-#define GET_VALID_PREQ_OR_ERRRETURN(req, pReq)                     \
-  do {                                                             \
-    if (request == nullptr) {                                      \
-      CLOGF(ERR, "%s received invalid nullptr request", __func__); \
-      return ncclInvalidArgument;                                  \
-    }                                                              \
-    *(pReq) = reinterpret_cast<CtranPersistentRequest*>(request);  \
+#define GET_VALID_PREQ_OR_ERRRETURN(req, pReq)                         \
+  do {                                                                 \
+    if ((req) == nullptr) {                                            \
+      CTRAN_LOG(ERR, "{} received invalid nullptr request", __func__); \
+      return ncclInvalidArgument;                                      \
+    }                                                                  \
+    *(pReq) = reinterpret_cast<CtranPersistentRequest*>(req);          \
   } while (0)
 
 __attribute__((visibility("default"))) ncclResult_t allGatherExec(
@@ -84,25 +86,25 @@ __attribute__((visibility("default"))) ncclResult_t allGatherExec(
 __attribute__((visibility("default"))) ncclResult_t pExec(void* request) {
   CtranPersistentRequest* pReq = nullptr;
   GET_VALID_PREQ_OR_ERRRETURN(request, &pReq);
-  CLOGF(
+  CTRAN_LOG(
       INFO,
       "Executing persistent request {} comm {}",
       (void*)pReq,
       (void*)pReq->comm_);
 
   if (!ctranInitialized(pReq->comm_)) {
-    CLOGF(
+    CTRAN_LOG(
         ERR, "CTRAN must be enabled and initialized for persistent collective");
     return ncclInvalidUsage;
   }
 
   switch (pReq->type) {
     default:
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "Persistent request {} has unknown op type {}",
           (void*)pReq,
-          (void*)pReq->type);
+          pReq->type);
       return ncclInvalidArgument;
   }
 }
@@ -116,7 +118,7 @@ __attribute__((visibility("default"))) ncclResult_t pFree(void* request) {
       NCCLCHECK(metaCommToNccl(ctran::allGatherPDestroy(pReq)));
       break;
     default:
-      CLOGF(
+      CTRAN_LOG(
           ERR,
           "Persistent request {} has unknown op type {}",
           (void*)pReq,


### PR DESCRIPTION
Summary:
The `xlformers_llama4_amd_conda-rcclx-oci` conveyor build is broken on trunk. The `rccl` CMake target fails to compile `comms/rcclx/develop/meta/ctran/PersistentCollectives.cc` with 27 errors, all of the form:

```
PersistentCollectives.cc:76:3: error: use of undeclared identifier 'ERR'
   76 |   GET_VALID_PREQ_OR_ERRRETURN(request, &pReq);
PersistentCollectives.cc:64:13: note: expanded from macro 'GET_VALID_PREQ_OR_ERRRETURN'
   64 |       CLOGF(ERR, "%s received invalid nullptr request", __func__); \
```

`CLOGF` needs `comms/utils/logger/LogUtils.h` (folly `XLOGF`) in scope. CTRAN has since migrated its logging to spdlog, so `Checks.h` -> `CtranLogUtils.h` -> `CtranLogger.h` now provides `CTRAN_LOG` and no longer pulls in `CLOGF` or the folly `LogLevel` enumerators. `PersistentCollectives.cc` was the last `CLOGF` caller under `comms/rcclx/develop/` and it has no BUCK target -- it is built only from `projects/rccl/CMakeLists.txt` -- so Buck CI never compiled it and only the conda/CMake build catches this.

Convert the 7 call sites to `CTRAN_LOG`, matching the rest of CTRAN. No new include is needed: `Checks.h` already reaches `CtranLogger.h`, and `CtranAlgo.h` provides `fmt::formatter<CtranPersistentRequest::Type>`, so `{}` formats the enum directly.

Two latent bugs fixed along the way, both required for the converted log lines to be correct:

- `CHECK_PREQ_TYPE`'s parameter was named `type`, so the preprocessor also rewrote the `pReq->type` member accesses in the body. `if (pReq->type != type)` expanded to `if (pReq->ALLGATHER_P != ALLGATHER_P)` -- legal C++, since an enumerator is a class member reachable via `->`, but an always-false tautology. The type check has been dead since it was written and is now live. Renamed the parameter to `expectedType`.
- `GET_VALID_PREQ_OR_ERRRETURN`'s `req` parameter was unused; the body hardcoded `request`. All four call sites pass `request`, so this is a no-op today, but the macro is now honest.

Also converted the two printf-style format strings (`%s`/`%d`) to fmt `{}` style, and dropped a bogus `(void*)` cast on `pReq->type`.

Broken build: https://www.internalfb.com/sandcastle/workflow/243194379898203285

Reviewed By: srinathb-meta

Differential Revision: D118118596


