### PR TITLE
Opt-in out-of-order data placement (dp_ordering) for IBGDA QPs

### DIFF
--- a/comms/prims/benchmarks/IbgdaBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cc
@@ -56,6 +56,52 @@ inline std::string benchIbHca() {
   return hca ? std::string(hca) : std::string();
 }
 
+// enableDataDirect is never read from the environment by the transport -- the
+// caller is expected to tunnel NCCL_IB_DATA_DIRECT into it, and NCCL does, but
+// the benchmarks never did. On a host that advertises Data-Direct but cannot
+// register a DMA-BUF MR, the transport activates DD and then fails at
+// registration with ENOTSUPP, so every IBGDA test SKIPs. Observed on GB300
+// burn-in hosts at every allocation size. NCCL_IB_DATA_DIRECT=0 works around
+// it; unset preserves the previous default of Only.
+inline DataDirectMode benchDataDirect() {
+  const char* dd = std::getenv("NCCL_IB_DATA_DIRECT");
+  if (dd == nullptr) {
+    return DataDirectMode::Only;
+  }
+  switch (std::atoi(dd)) {
+    case 0:
+      return DataDirectMode::Disabled;
+    case 2:
+      return DataDirectMode::Both;
+    default:
+      return DataDirectMode::Only;
+  }
+}
+
+// dp_ordering policy for the benchmark's QPs. Production resolves
+// MCCL_IBGDA_QP_ORDERING_SEMANTIC as a cvar, but that needs ncclCvarInit(),
+// which benchmarks never call -- so the cvar sits at its default and the
+// transport falls back to the config field. Reading the same spelling here is
+// what makes a command-line A/B possible.
+//
+// Unset must map to Auto, i.e. the same default production runs. Returning
+// anything else would put every benchmark on a different policy from the code
+// it is meant to measure. Unparseable values throw rather than defaulting: an
+// A/B that silently runs the control twice is worse than one that fails.
+inline IbQpOrderingPolicy benchQpOrderingPolicy() {
+  const char* v = std::getenv("MCCL_IBGDA_QP_ORDERING_SEMANTIC");
+  if (v == nullptr || *v == '\0') {
+    return IbQpOrderingPolicy::Auto;
+  }
+  const auto parsed = parseIbQpOrderingPolicy(std::string(v));
+  if (!parsed.has_value()) {
+    throw std::invalid_argument(
+        std::string("MCCL_IBGDA_QP_ORDERING_SEMANTIC=") + v +
+        " is not one of auto|ibta|ibta_forced|ooo_rw|ooo_all");
+  }
+  return *parsed;
+}
+
 enum class BenchIbBackend {
   IBGDA,
   IBRC,
@@ -437,6 +483,8 @@ TEST_P(IbgdaBenchmarkFixture, PutFlush) {
         .cudaDevice = localRank,
     };
     transportConfig.ibHca = benchIbHca();
+    transportConfig.enableDataDirect = benchDataDirect();
+    transportConfig.qpOrderingPolicy = benchQpOrderingPolicy();
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     BenchIbTransport transport(
@@ -518,6 +566,124 @@ TEST_P(IbgdaBenchmarkFixture, PutFlush) {
   printResultsTable(backendTitle("Put+Flush (RDMA Write)"), results);
 }
 
+TEST_P(IbgdaBenchmarkFixture, PutSignalFlush) {
+  // Measures RDMA Write plus a trailing atomic signal, completed as
+  // put + signal + flush. Identical to PutFlush other than the signal, so the
+  // per-size delta between the two is the marginal cost of the signal. No
+  // counter is used, keeping the companion QP out of the measurement.
+  if (numRanks != 2) {
+    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  constexpr int kSignalId = 0;
+  auto configs = getFullConfigs();
+
+  std::size_t maxBufferSize = 0;
+  for (const auto& config : configs) {
+    maxBufferSize = std::max(maxBufferSize, config.nBytes);
+  }
+
+  std::vector<IbgdaBenchmarkResult> results;
+
+  try {
+    MultipeerIbgdaTransportConfig transportConfig{
+        .cudaDevice = localRank,
+    };
+    transportConfig.ibHca = benchIbHca();
+    transportConfig.enableDataDirect = benchDataDirect();
+    transportConfig.qpOrderingPolicy = benchQpOrderingPolicy();
+
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    BenchIbTransport transport(
+        backend(), globalRank, numRanks, bootstrap, transportConfig);
+    transport.exchange();
+
+    DeviceBuffer dataBuffer(maxBufferSize);
+    auto localDataBuf =
+        transport.registerBuffer(dataBuffer.get(), maxBufferSize);
+
+    auto remoteDataBufs = transport.exchangeBuffer(localDataBuf);
+    const int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
+    if (peerIndex < 0 ||
+        static_cast<std::size_t>(peerIndex) >= remoteDataBufs.size()) {
+      throw std::runtime_error(
+          "Peer index out of range for exchanged remote buffers");
+    }
+    auto remoteDataBuf = remoteDataBufs[peerIndex];
+
+    DeviceBuffer signalBuffer(sizeof(uint64_t));
+    CUDA_CHECK_VOID(cudaMemset(signalBuffer.get(), 0, sizeof(uint64_t)));
+    auto localSignalBuf =
+        transport.registerBuffer(signalBuffer.get(), sizeof(uint64_t));
+    auto remoteSignalBufs = transport.exchangeBuffer(localSignalBuf);
+    auto remoteSignalBuf = remoteSignalBufs[peerIndex];
+
+    P2pIbTransportDevice deviceTransport =
+        transport.getP2pTransportDevice(peerRank);
+
+    unsigned long long* d_totalCycles;
+    CUDA_CHECK_VOID(cudaMalloc(&d_totalCycles, sizeof(unsigned long long)));
+
+    XLOGF(
+        INFO,
+        "Rank {}: GPU clock rate = {:.2f} GHz",
+        globalRank,
+        clockRateGHz_);
+
+    for (const auto& config : configs) {
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      if (globalRank == 0) {
+        launchIbgdaPutSignalFlushBatch(
+            deviceTransport,
+            localDataBuf,
+            remoteDataBuf,
+            remoteSignalBuf,
+            config.nBytes,
+            kSignalId,
+            kIbgdaBatchIters,
+            d_totalCycles,
+            stream_);
+        CUDA_CHECK_VOID(cudaStreamSynchronize(stream_));
+
+        unsigned long long totalCycles;
+        CUDA_CHECK_VOID(cudaMemcpy(
+            &totalCycles,
+            d_totalCycles,
+            sizeof(unsigned long long),
+            cudaMemcpyDeviceToHost));
+
+        IbgdaBenchmarkResult result;
+        result.testName = config.name;
+        result.messageSize = config.nBytes;
+        result.latency = cyclesToUs(totalCycles) / kIbgdaBatchIters;
+        result.bandwidth = (config.nBytes / 1e9f) / (result.latency / 1e6f);
+
+        results.push_back(result);
+
+        XLOGF(
+            INFO,
+            "Rank {}: {} - Latency: {:.2f} us, BW: {:.2f} GB/s",
+            globalRank,
+            config.name,
+            result.latency,
+            result.bandwidth);
+      }
+
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    }
+
+    CUDA_CHECK_VOID(cudaFree(d_totalCycles));
+
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IB transport not available: " << e.what();
+  }
+
+  printResultsTable(backendTitle("Put+Signal+Flush (RDMA Write)"), results);
+}
+
 TEST_P(IbgdaBenchmarkFixture, ThreadScopeMultiBlockPutFlush) {
   // One thread per block uses the no-ThreadGroup put()+flush() API on a
   // block-private slice. This checks that thread-scope wrappers inherit the
@@ -550,6 +716,8 @@ TEST_P(IbgdaBenchmarkFixture, ThreadScopeMultiBlockPutFlush) {
         .maxGroups = kNumBlocks,
     };
     transportConfig.ibHca = benchIbHca();
+    transportConfig.enableDataDirect = benchDataDirect();
+    transportConfig.qpOrderingPolicy = benchQpOrderingPolicy();
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     MultipeerIbgdaTransport transport(
@@ -671,6 +839,8 @@ TEST_P(IbgdaBenchmarkFixture, PutCompletionComparison) {
         .cudaDevice = localRank,
     };
     transportConfig.ibHca = benchIbHca();
+    transportConfig.enableDataDirect = benchDataDirect();
+    transportConfig.qpOrderingPolicy = benchQpOrderingPolicy();
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     BenchIbTransport transport(
@@ -815,6 +985,8 @@ TEST_P(IbgdaBenchmarkFixture, PutSignalWaitCounter) {
         .cudaDevice = localRank,
     };
     transportConfig.ibHca = benchIbHca();
+    transportConfig.enableDataDirect = benchDataDirect();
+    transportConfig.qpOrderingPolicy = benchQpOrderingPolicy();
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     BenchIbTransport transport(
@@ -918,6 +1090,8 @@ TEST_P(IbgdaBenchmarkFixture, SignalOnly) {
         .cudaDevice = localRank,
     };
     transportConfig.ibHca = benchIbHca();
+    transportConfig.enableDataDirect = benchDataDirect();
+    transportConfig.qpOrderingPolicy = benchQpOrderingPolicy();
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     BenchIbTransport transport(
@@ -1032,6 +1206,8 @@ TEST_P(IbgdaBenchmarkFixture, PutSignalComparison) {
         .cudaDevice = localRank,
     };
     transportConfig.ibHca = benchIbHca();
+    transportConfig.enableDataDirect = benchDataDirect();
+    transportConfig.qpOrderingPolicy = benchQpOrderingPolicy();
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     BenchIbTransport transport(
@@ -1162,6 +1338,8 @@ TEST_P(IbgdaBenchmarkFixture, MultiPeerCounterFanOut) {
         .cudaDevice = localRank,
     };
     transportConfig.ibHca = benchIbHca();
+    transportConfig.enableDataDirect = benchDataDirect();
+    transportConfig.qpOrderingPolicy = benchQpOrderingPolicy();
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     BenchIbTransport transport(

--- a/comms/prims/benchmarks/IbgdaBenchmark.cu
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cu
@@ -110,6 +110,41 @@ __global__ void ibgdaPutWaitLocalBatchKernel(
   }
 }
 
+__global__ void ibgdaPutSignalFlushBatchKernel(
+    P2pIbTransportDevice transport,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    std::size_t nbytes,
+    int signalId,
+    int numIters,
+    unsigned long long* totalCycles) {
+  auto group = make_block_group();
+  if (group.is_global_leader()) {
+    // Write + signal on the same QP (no counter, hence no companion QP),
+    // completion observed via flush(). Pairs with ibgdaPutFlushBatchKernel,
+    // which is identical except that it issues no signal, so the latency
+    // delta isolates the marginal cost of the trailing ATOMIC_FA.
+    const auto resolvedSignalBuf =
+        remoteSignalBuf.subBuffer(signalId * sizeof(uint64_t));
+
+    for (int i = 0; i < 10; i++) {
+      transport.put(localBuf, remoteBuf, nbytes, resolvedSignalBuf, 1);
+      transport.flush();
+    }
+
+    const unsigned long long startCycle = BENCHMARK_CLOCK64();
+
+    for (int i = 0; i < numIters; i++) {
+      transport.put(localBuf, remoteBuf, nbytes, resolvedSignalBuf, 1);
+      transport.flush();
+    }
+
+    const unsigned long long endCycle = BENCHMARK_CLOCK64();
+    *totalCycles = endCycle - startCycle;
+  }
+}
+
 __global__ void ibgdaPutFlushBatchKernel(
     P2pIbTransportDevice transport,
     IbgdaLocalBuffer localBuf,
@@ -419,6 +454,32 @@ void launchIbgdaPutWaitLocalBatch(
   ibgdaPutWaitLocalBatchKernel<<<1, 32, 0, stream>>>(
       transport, localBuf, remoteBuf, nbytes, numIters, totalCycles);
   cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
+void launchIbgdaPutSignalFlushBatch(
+    P2pIbTransportDevice transport,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    const IbgdaRemoteBuffer& remoteSignalBuf,
+    std::size_t nbytes,
+    int signalId,
+    int numIters,
+    unsigned long long* totalCycles,
+    cudaStream_t stream) {
+  ibgdaPutSignalFlushBatchKernel<<<1, 32, 0, stream>>>(
+      transport,
+      localBuf,
+      remoteBuf,
+      remoteSignalBuf,
+      nbytes,
+      signalId,
+      numIters,
+      totalCycles);
+  const cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(
         std::string("Kernel launch failed: ") + cudaGetErrorString(err));

--- a/comms/prims/benchmarks/IbgdaBenchmark.h
+++ b/comms/prims/benchmarks/IbgdaBenchmark.h
@@ -82,6 +82,27 @@ void launchIbgdaPutFlushBatch(
     cudaStream_t stream);
 
 /**
+ * Launch batched kernel: Multiple put + signal + flush iterations
+ *
+ * Identical to launchIbgdaPutFlushBatch except that each put carries a
+ * trailing ATOMIC_FA signal on the same QP. No counter is used, so the
+ * companion QP stays out of the measurement. Differencing the two isolates
+ * the marginal cost of the signal.
+ *
+ * @param totalCycles Output: total GPU cycles for numIters operations
+ */
+void launchIbgdaPutSignalFlushBatch(
+    P2pIbTransportDevice transport,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    const IbgdaRemoteBuffer& remoteSignalBuf,
+    std::size_t nbytes,
+    int signalId,
+    int numIters,
+    unsigned long long* totalCycles,
+    cudaStream_t stream);
+
+/**
  * Launch batched kernel: one thread per block uses the thread-scope put +
  * flush API on a block-private buffer slice.
  *

--- a/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
+++ b/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
@@ -342,5 +342,185 @@ TEST(MultiPeerIbTransportConfigTest, SymmetricRequestGraphsNeverStall) {
   }
 }
 
+// -----------------------------------------------------------------------------
+// dp_ordering (MCCL_IBGDA_QP_ORDERING_SEMANTIC / config.qpOrderingPolicy)
+// -----------------------------------------------------------------------------
+
+// The default is a policy, not a tier: it walks ooo_all -> ooo_rw -> ibta and
+// settles on whatever the NIC reports. Which rung it lands on is decided in the
+// transport, against real capabilities.
+TEST(MultiPeerIbTransportConfigTest, QpOrderingDefaultPolicyIsAuto) {
+  const MultipeerIbTransportConfig config;
+  EXPECT_EQ(config.qpOrderingPolicy, IbQpOrderingPolicy::Auto);
+  EXPECT_TRUE(ibQpOrderingPolicyIsAuto(config.qpOrderingPolicy));
+}
+
+// The auto ladder is ordered strongest-first, and the tiers it walks are
+// strictly decreasing. resolveQpOrderingSemanticForNic() picks the first rung
+// whose tier fits under the NIC's reported cap, so if this ordering were ever
+// reversed a capable NIC would silently settle for the weaker tier.
+TEST(MultiPeerIbTransportConfigTest, QpOrderingAutoLadderIsStrongestFirst) {
+  const std::vector<int> ladderTiers = {
+      ibQpOrderingTier(IbQpOrderingSemantic::OooAll),
+      ibQpOrderingTier(IbQpOrderingSemantic::OooRw),
+      ibQpOrderingTier(IbQpOrderingSemantic::Ibta),
+  };
+  const std::vector<int> expected = {2, 1, 0};
+  EXPECT_EQ(ladderTiers, expected);
+}
+
+// Every rung above ibta needs the QPC dp_ordering_force bit, so a NIC without
+// cmd_hca_cap_2.dp_ordering_force drops straight to ibta regardless of which
+// tier it advertises -- the tier bits are ignored without force.
+TEST(MultiPeerIbTransportConfigTest, QpOrderingLadderRungsAboveIbtaNeedForce) {
+  EXPECT_TRUE(ibQpOrderingForce(IbQpOrderingSemantic::OooAll));
+  EXPECT_TRUE(ibQpOrderingForce(IbQpOrderingSemantic::OooRw));
+  EXPECT_FALSE(ibQpOrderingForce(IbQpOrderingSemantic::Ibta));
+}
+
+// Only auto is allowed to fall back. Every other policy names a tier and must
+// fail closed instead, or an A/B silently measures the control twice.
+TEST(MultiPeerIbTransportConfigTest, QpOrderingOnlyAutoIsAFallbackPolicy) {
+  const std::vector<IbQpOrderingPolicy> explicitPolicies = {
+      IbQpOrderingPolicy::Ibta,
+      IbQpOrderingPolicy::IbtaForced,
+      IbQpOrderingPolicy::OooRw,
+      IbQpOrderingPolicy::OooAll,
+  };
+  for (const auto policy : explicitPolicies) {
+    EXPECT_FALSE(ibQpOrderingPolicyIsAuto(policy))
+        << ibQpOrderingPolicyName(policy);
+  }
+}
+
+// Each explicit policy names exactly one resolved tier. Auto has no fixed
+// answer, so it maps to the safe end rather than silently claiming a tier.
+TEST(MultiPeerIbTransportConfigTest, QpOrderingExplicitPolicyMapsToSemantic) {
+  const std::vector<IbQpOrderingSemantic> expected = {
+      IbQpOrderingSemantic::Ibta, // Auto: undecided until a NIC is consulted
+      IbQpOrderingSemantic::Ibta,
+      IbQpOrderingSemantic::IbtaForced,
+      IbQpOrderingSemantic::OooRw,
+      IbQpOrderingSemantic::OooAll,
+  };
+  const std::vector<IbQpOrderingPolicy> policies = {
+      IbQpOrderingPolicy::Auto,
+      IbQpOrderingPolicy::Ibta,
+      IbQpOrderingPolicy::IbtaForced,
+      IbQpOrderingPolicy::OooRw,
+      IbQpOrderingPolicy::OooAll,
+  };
+  std::vector<IbQpOrderingSemantic> actual;
+  actual.reserve(policies.size());
+  for (const auto policy : policies) {
+    actual.push_back(ibQpOrderingPolicyToSemantic(policy));
+  }
+  EXPECT_EQ(actual, expected);
+}
+
+// resolveQpOrderingPolicy() treats a cvar equal to _DEFAULTCVARVALUE as "not
+// set" and falls through to the config field. That only reproduces production
+// if a zero-initialized cvar -- what every binary that skips ncclCvarInit()
+// sees -- also lands on auto, which requires auto to be choice 0 in the yaml.
+TEST(MultiPeerIbTransportConfigTest, QpOrderingAutoIsTheZeroValuedPolicy) {
+  EXPECT_EQ(static_cast<int>(IbQpOrderingPolicy::Auto), 0);
+}
+
+// The (tier, force) pair each mode expands to is what actually lands in the
+// QPC dp_ordering_0 / dp_ordering_1 / dp_ordering_force bits.
+TEST(MultiPeerIbTransportConfigTest, QpOrderingModesMapToTierAndForce) {
+  const std::vector<std::pair<int, bool>> expected = {
+      {0, false}, // Ibta
+      {0, true}, // IbtaForced: strict ordering, but override the NIC default
+      {1, true}, // OooRw
+      {2, true}, // OooAll
+  };
+  const std::vector<IbQpOrderingSemantic> modes = {
+      IbQpOrderingSemantic::Ibta,
+      IbQpOrderingSemantic::IbtaForced,
+      IbQpOrderingSemantic::OooRw,
+      IbQpOrderingSemantic::OooAll,
+  };
+  std::vector<std::pair<int, bool>> actual;
+  actual.reserve(modes.size());
+  for (const auto mode : modes) {
+    actual.emplace_back(ibQpOrderingTier(mode), ibQpOrderingForce(mode));
+  }
+  EXPECT_EQ(actual, expected);
+}
+
+// The MCCL_IBGDA_QP_ORDERING_SEMANTIC spelling is the experiment's only
+// interface; a typo must not fall back to the default arm.
+TEST(MultiPeerIbTransportConfigTest, QpOrderingParsesTheFourSpellings) {
+  EXPECT_EQ(parseIbQpOrderingSemantic("ibta"), IbQpOrderingSemantic::Ibta);
+  EXPECT_EQ(
+      parseIbQpOrderingSemantic("ibta_forced"),
+      IbQpOrderingSemantic::IbtaForced);
+  EXPECT_EQ(parseIbQpOrderingSemantic("ooo_rw"), IbQpOrderingSemantic::OooRw);
+  EXPECT_EQ(parseIbQpOrderingSemantic("ooo_all"), IbQpOrderingSemantic::OooAll);
+  EXPECT_FALSE(parseIbQpOrderingSemantic("OOO_ALL").has_value());
+  EXPECT_FALSE(parseIbQpOrderingSemantic("ooo").has_value());
+  EXPECT_FALSE(parseIbQpOrderingSemantic("").has_value());
+}
+
+// Same for the policy spelling, which is what the cvar and the benchmark env
+// tunnel actually parse. "auto" is the extra one, and it is the default, so a
+// typo landing on it silently would be the worst outcome of the three.
+TEST(MultiPeerIbTransportConfigTest, QpOrderingPolicyParsesTheFiveSpellings) {
+  EXPECT_EQ(parseIbQpOrderingPolicy("auto"), IbQpOrderingPolicy::Auto);
+  EXPECT_EQ(parseIbQpOrderingPolicy("ibta"), IbQpOrderingPolicy::Ibta);
+  EXPECT_EQ(
+      parseIbQpOrderingPolicy("ibta_forced"), IbQpOrderingPolicy::IbtaForced);
+  EXPECT_EQ(parseIbQpOrderingPolicy("ooo_rw"), IbQpOrderingPolicy::OooRw);
+  EXPECT_EQ(parseIbQpOrderingPolicy("ooo_all"), IbQpOrderingPolicy::OooAll);
+  EXPECT_FALSE(parseIbQpOrderingPolicy("AUTO").has_value());
+  EXPECT_FALSE(parseIbQpOrderingPolicy("default").has_value());
+  EXPECT_FALSE(parseIbQpOrderingPolicy("").has_value());
+}
+
+// Names round-trip so log lines and the cvar value are the same vocabulary.
+TEST(MultiPeerIbTransportConfigTest, QpOrderingNamesRoundTrip) {
+  for (const auto mode :
+       {IbQpOrderingSemantic::Ibta,
+        IbQpOrderingSemantic::IbtaForced,
+        IbQpOrderingSemantic::OooRw,
+        IbQpOrderingSemantic::OooAll}) {
+    EXPECT_EQ(parseIbQpOrderingSemantic(ibQpOrderingSemanticName(mode)), mode);
+  }
+  for (const auto policy :
+       {IbQpOrderingPolicy::Auto,
+        IbQpOrderingPolicy::Ibta,
+        IbQpOrderingPolicy::IbtaForced,
+        IbQpOrderingPolicy::OooRw,
+        IbQpOrderingPolicy::OooAll}) {
+    EXPECT_EQ(parseIbQpOrderingPolicy(ibQpOrderingPolicyName(policy)), policy);
+  }
+}
+
+// The mismatch error names the peer's value, which arrives over the wire from
+// a binary that may not share this enum. An unknown code must report itself as
+// unknown rather than be aliased onto a real mode.
+TEST(MultiPeerIbTransportConfigTest, QpOrderingNamesWireValuesDefensively) {
+  EXPECT_STREQ(
+      ibQpOrderingSemanticNameFromWire(
+          static_cast<int>(IbQpOrderingSemantic::OooAll)),
+      "ooo_all");
+  EXPECT_STREQ(ibQpOrderingSemanticNameFromWire(-1), "unknown");
+  EXPECT_STREQ(ibQpOrderingSemanticNameFromWire(99), "unknown");
+}
+
+// doMaterializePeer() rejects a peer whose tier differs from ours by comparing
+// the exchanged int against static_cast<int>(the local enum), so the wire
+// encoding of the opted-out state has to agree with the enum.
+//
+// This is also what AMD sends. The dp_ordering path is compiled out there, so
+// qpOrderingSemantic_ keeps its Ibta member initializer and never resolves --
+// the payload default and the AMD value have to stay the same number.
+TEST(MultiPeerIbTransportConfigTest, QpOrderingWireDefaultMatchesIbta) {
+  const PeerQpPayload payload;
+  EXPECT_EQ(
+      payload.qpOrderingSemantic, static_cast<int>(IbQpOrderingSemantic::Ibta));
+}
+
 } // namespace
 } // namespace comms::prims

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -38,6 +38,216 @@ enum class AddressFamily {
 };
 
 /**
+ * The *resolved* NIC data-placement ordering mode for an IB QP (mlx5 QPC
+ * dp_ordering) -- what actually gets written to the QPC, after the requested
+ * IbQpOrderingPolicy below has been checked against the NIC.
+ *
+ * The NIC encodes this as a 2-bit tier plus a "force" bit that overrides the
+ * HCA's mlxreg adaptive-routing admin default:
+ *   tier 0 IBTA    - strict IBTA ordering
+ *   tier 1 OOO_RW  - out-of-order placement for RDMA Read/Write
+ *   tier 2 OOO_ALL - out-of-order placement for all supported opcodes
+ * This enum flattens the (tier, force) pair into the four combinations worth
+ * selecting; ibQpOrderingTier()/ibQpOrderingForce() below split it back out.
+ *
+ * Ibta leaves both QPC bits and the force bit at zero, which is the pre-patch
+ * wire behaviour. IbtaForced is deliberately distinct: it pins the QP to strict
+ * ordering even when the NIC's admin default enables adaptive routing, which is
+ * how you find out whether a QP is being sprayed today.
+ *
+ * Note that Ibta does NOT mean "the QP runs strict IBTA". It means "we wrote
+ * nothing and the firmware chose". On a ConnectX-8 rail with adaptive routing
+ * enabled the firmware chooses OOO_RW on its own, so Ibta and OooRw describe
+ * the same QP there; on ConnectX-7 (AR off) Ibta really is tier 0.
+ */
+enum class IbQpOrderingSemantic {
+  Ibta, // tier IBTA, force off (default; no QPC write at all)
+  IbtaForced, // tier IBTA, force on
+  OooRw, // tier OOO_RW, force on
+  OooAll, // tier OOO_ALL, force on
+};
+
+// The 2-bit dp_ordering tier the NIC expects (matches DOCA's
+// doca_verbs_qp_ordering_semantic and UCX's uct_ib_mlx5_dp_ordering_t).
+constexpr int ibQpOrderingTier(IbQpOrderingSemantic mode) {
+  switch (mode) {
+    case IbQpOrderingSemantic::OooRw:
+      return 1;
+    case IbQpOrderingSemantic::OooAll:
+      return 2;
+    case IbQpOrderingSemantic::Ibta:
+    case IbQpOrderingSemantic::IbtaForced:
+      break;
+  }
+  return 0;
+}
+
+// Whether the QPC dp_ordering_force bit is set (requires HCA
+// cmd_hca_cap_2.dp_ordering_force).
+constexpr bool ibQpOrderingForce(IbQpOrderingSemantic mode) {
+  return mode != IbQpOrderingSemantic::Ibta;
+}
+
+// True when the mode writes nothing to the QPC, i.e. is a wire-level no-op and
+// the QP keeps whatever tier the firmware picked for it.
+constexpr bool ibQpOrderingIsWireNoOp(IbQpOrderingSemantic mode) {
+  return mode == IbQpOrderingSemantic::Ibta;
+}
+
+constexpr const char* ibQpOrderingSemanticName(IbQpOrderingSemantic mode) {
+  switch (mode) {
+    case IbQpOrderingSemantic::IbtaForced:
+      return "ibta_forced";
+    case IbQpOrderingSemantic::OooRw:
+      return "ooo_rw";
+    case IbQpOrderingSemantic::OooAll:
+      return "ooo_all";
+    case IbQpOrderingSemantic::Ibta:
+      break;
+  }
+  return "ibta";
+}
+
+// Name for an ordering mode that arrived over the wire from a peer, which may
+// be out of range if that peer is running a different build. Never casts the
+// value to the enum, so an unknown value is reported rather than aliased onto a
+// real mode.
+constexpr const char* ibQpOrderingSemanticNameFromWire(int value) {
+  switch (value) {
+    case static_cast<int>(IbQpOrderingSemantic::Ibta):
+      return ibQpOrderingSemanticName(IbQpOrderingSemantic::Ibta);
+    case static_cast<int>(IbQpOrderingSemantic::IbtaForced):
+      return ibQpOrderingSemanticName(IbQpOrderingSemantic::IbtaForced);
+    case static_cast<int>(IbQpOrderingSemantic::OooRw):
+      return ibQpOrderingSemanticName(IbQpOrderingSemantic::OooRw);
+    case static_cast<int>(IbQpOrderingSemantic::OooAll):
+      return ibQpOrderingSemanticName(IbQpOrderingSemantic::OooAll);
+    default:
+      break;
+  }
+  return "unknown";
+}
+
+// Parse the MCCL_IBGDA_QP_ORDERING_SEMANTIC spelling. Returns nullopt on an
+// unrecognized value so the caller can fail loudly instead of silently running
+// the default arm of an A/B.
+inline std::optional<IbQpOrderingSemantic> parseIbQpOrderingSemantic(
+    const std::string& value) {
+  if (value == "ibta") {
+    return IbQpOrderingSemantic::Ibta;
+  }
+  if (value == "ibta_forced") {
+    return IbQpOrderingSemantic::IbtaForced;
+  }
+  if (value == "ooo_rw") {
+    return IbQpOrderingSemantic::OooRw;
+  }
+  if (value == "ooo_all") {
+    return IbQpOrderingSemantic::OooAll;
+  }
+  return std::nullopt;
+}
+
+/**
+ * What the *caller* asks for, before the NIC gets a say. Resolved into an
+ * IbQpOrderingSemantic at transport init by consulting the HCA capabilities.
+ *
+ * The distinction exists because the two kinds of request want opposite
+ * failure behaviour:
+ *
+ *   Auto      - a fleet default. Walks OooAll -> OooRw -> Ibta and takes the
+ *               strongest tier the NIC reports, silently, falling all the way
+ *               to Ibta when the capability query fails outright (a non-mlx5
+ *               NIC has no such query). A default must never be the reason a
+ *               job refuses to start.
+ *   explicit  - somebody is running an experiment and named a tier. Fail
+ *               closed if the NIC cannot deliver it, because a silent
+ *               downgrade turns an A/B into a no-op that reads as "OOO does
+ *               not help". NVIDIA's GDAKI refuses here for the same reason.
+ *
+ * Auto aims at OooAll because that is the rung that pays: it is the only tier
+ * that lifts the ordering fence in front of an atomic, and every prims signal
+ * is an ATOMIC_FETCH_AND_ADD. OooRw relaxes Read/Write placement only, leaves
+ * that fence standing, and on a ConnectX-8 rail is close to a no-op anyway --
+ * the firmware already programs OOO_RW at INIT2RTR under adaptive routing with
+ * nothing in userspace asking for it.
+ *
+ * The ladder is not decoration. ConnectX-8 reports OooAll; ConnectX-7 reports
+ * OooRw but not OooAll (measured: cmd_hca_cap.dp_ordering_ooo_all_rc = 0), so a
+ * flat "ask for OooAll" would fail closed on every CX7 NIC. Ranks that resolve
+ * different tiers are rejected at peer connect, so a job spanning both NIC
+ * generations has to pin ooo_rw explicitly.
+ */
+enum class IbQpOrderingPolicy {
+  Auto, // strongest tier the NIC supports: OooAll, else OooRw, else Ibta
+  Ibta, // explicit: write nothing, keep the firmware default
+  IbtaForced, // explicit: pin to strict IBTA even under adaptive routing
+  OooRw, // explicit: out-of-order placement for RDMA Read/Write
+  OooAll, // explicit: also covers atomics
+};
+
+constexpr bool ibQpOrderingPolicyIsAuto(IbQpOrderingPolicy policy) {
+  return policy == IbQpOrderingPolicy::Auto;
+}
+
+// The tier an explicit policy names. Auto has no fixed answer -- it depends on
+// the NIC -- so it is not accepted here; callers must go through the resolver.
+constexpr IbQpOrderingSemantic ibQpOrderingPolicyToSemantic(
+    IbQpOrderingPolicy policy) {
+  switch (policy) {
+    case IbQpOrderingPolicy::IbtaForced:
+      return IbQpOrderingSemantic::IbtaForced;
+    case IbQpOrderingPolicy::OooRw:
+      return IbQpOrderingSemantic::OooRw;
+    case IbQpOrderingPolicy::OooAll:
+      return IbQpOrderingSemantic::OooAll;
+    case IbQpOrderingPolicy::Auto:
+    case IbQpOrderingPolicy::Ibta:
+      break;
+  }
+  return IbQpOrderingSemantic::Ibta;
+}
+
+constexpr const char* ibQpOrderingPolicyName(IbQpOrderingPolicy policy) {
+  switch (policy) {
+    case IbQpOrderingPolicy::Auto:
+      return "auto";
+    case IbQpOrderingPolicy::IbtaForced:
+      return "ibta_forced";
+    case IbQpOrderingPolicy::OooRw:
+      return "ooo_rw";
+    case IbQpOrderingPolicy::OooAll:
+      return "ooo_all";
+    case IbQpOrderingPolicy::Ibta:
+      break;
+  }
+  return "ibta";
+}
+
+// Parse the MCCL_IBGDA_QP_ORDERING_SEMANTIC spelling into a policy. Returns
+// nullopt on an unrecognized value so a typo cannot silently select the
+// default.
+inline std::optional<IbQpOrderingPolicy> parseIbQpOrderingPolicy(
+    const std::string& value) {
+  if (value == "auto") {
+    return IbQpOrderingPolicy::Auto;
+  }
+  if (value == "ibta") {
+    return IbQpOrderingPolicy::Ibta;
+  }
+  if (value == "ibta_forced") {
+    return IbQpOrderingPolicy::IbtaForced;
+  }
+  if (value == "ooo_rw") {
+    return IbQpOrderingPolicy::OooRw;
+  }
+  if (value == "ooo_all") {
+    return IbQpOrderingPolicy::OooAll;
+  }
+  return std::nullopt;
+}
+
+/**
  * Shared configuration for the multi-peer IB transports (IBGDA, IBRC). Every
  * field is backend-agnostic IB transport config. IMPORTANT: all ranks must use
  * identical configuration values.
@@ -216,6 +426,17 @@ struct MultipeerIbTransportConfig {
   };
   PciRelaxedOrderingMode enablePciRelaxedOrdering{PciRelaxedOrderingMode::Auto};
 
+  // NIC data-placement ordering for IB QPs (mlx5 dp_ordering, a.k.a. DDP /
+  // out-of-order data placement). The PCIe knob above reorders the NIC's writes
+  // across the PCIe bus; this one decides whether the NIC may place inbound
+  // fabric payload out of order, which is what lets adaptive routing spray a
+  // QP's packets across paths without a reassembly stall.
+  //
+  // Auto is the default: take the strongest tier the NIC reports, walking
+  // OooAll -> OooRw -> Ibta. See IbQpOrderingPolicy for why the ladder has
+  // three rungs and what each one costs.
+  IbQpOrderingPolicy qpOrderingPolicy{IbQpOrderingPolicy::Auto};
+
   // InfiniBand Verbs Timeout for QP ACK timeout (4.096us * 2^timeout). Valid
   // 1-31; 0 or >=32 is infinite. Default 20 (similar to NCCL_IB_TIMEOUT).
   uint8_t timeout{20};
@@ -235,6 +456,24 @@ struct MultipeerIbTransportConfig {
 
   // RNR retry count (ibv_qp_attr.rnr_retry); 7 means infinite.
   uint8_t rnrRetry{7};
+
+  // Depth of the RDMA-Read/Atomic pipeline on one QP, applied to BOTH
+  // directions: max_dest_rd_atomic (responder, QPC log_rra_max, written on
+  // INIT->RTR) and max_rd_atomic (initiator, QPC log_sra_max, written on
+  // RTR->RTS). Must be a power of two in [1, 128] because the NIC stores
+  // log2 of it.
+  //
+  // 1 is the historical IBGDA behaviour, NOT a considered default: the DOCA
+  // modify masks never carried MAX_QP_RD_ATOMIC / MAX_DEST_RD_ATOMIC, so both
+  // QPC fields stayed at their zeroed value (log2(1) == 0), i.e. exactly one
+  // outstanding read/atomic per QP per direction. Every prims signal is an
+  // ATOMIC_FA, so this serializes signalling on an RTT. Keeping 1 as the
+  // default makes wiring the masks up a provable no-op; raise it (16 matches
+  // the AMD sibling's kMaxRdAtomic in
+  // comms/prims/transport/amd/pipes_gda/PipesGdaHost.cc) to pipeline.
+  //
+  // Clamped down to the NIC's max_qp_rd_atom / max_qp_init_rd_atom.
+  uint8_t maxRdAtomic{1};
 
   // Deprecated compatibility setting. Per-peer state is always materialized
   // on demand; false no longer enables eager all-peer allocation.
@@ -328,6 +567,16 @@ inline bool reliableDoorbellActiveForNic(
 inline bool reliableDoorbellNeedsCapabilityQuery(
     const MultipeerIbTransportConfig& config) {
   return config.enableReliableDoorbell.value_or(true);
+}
+
+// Whether MultipeerIbTransportConfig::maxRdAtomic is programmable as-is.
+// max_rd_atomic / max_dest_rd_atomic are stored by the NIC as log2, so only
+// powers of two round-trip. DOCA's own setters only reject 0 (they call
+// doca_internal_utils_next_power_of_two() where they meant
+// doca_internal_utils_is_power_of_two()), so a non-power-of-two would silently
+// be rounded DOWN by log2 -- e.g. 15 would become 8. Reject it here instead.
+constexpr bool isIbMaxRdAtomicValid(unsigned value) {
+  return value >= 1 && value <= 128 && (value & (value - 1)) == 0;
 }
 
 // Order in which connectPeers() walks a rank's pending peers.
@@ -449,6 +698,13 @@ constexpr int kIbPeerBufferExchangeTag = 1;
 
 // Wire formats for bilateral peer materialization. Split into two phases: QP
 // info first (to connect), then buffer info (acts as QP-ready barrier).
+//
+// WIRE FORMAT: PeerQpPayload is exchanged between peer ranks as raw bytes by
+// exchangeWithPeer(), which sends and expects exactly sizeof(PeerQpPayload).
+// Its layout is therefore an ABI both ends must agree on. Only APPEND new
+// fields: inserting or reordering one shifts every field after it, so two
+// ranks built from different revisions would decode each other's gids, qpns
+// and MTU as garbage instead of failing on the size.
 struct PeerQpPayload {
   struct NicQpInfo {
     uint8_t gid[16]{};
@@ -462,6 +718,11 @@ struct PeerQpPayload {
   int numQpsPerPeerPerNic{0};
   int maxGroups{0};
   int qpsPerBlockPerNic{0};
+  // dp_ordering mode, exchanged so a mismatch is a loud connect-time error
+  // rather than a silent one-sided reassembly change. NVIDIA's GDAKI refuses to
+  // connect on an ordering_semantic mismatch for the same reason.
+  // static_cast<int>(IbQpOrderingSemantic); 0 == Ibta == opted out.
+  int qpOrderingSemantic{0};
 };
 
 struct PeerBufferPayload {

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -33,6 +33,8 @@
 #ifndef __HIP_PLATFORM_AMD__
 #include "comms/prims/platform/CudaDriverLazy.h"
 #include "comms/prims/platform/DocaHostUtils.h"
+// MCCL_IBGDA_MAX_RD_ATOMIC / MCCL_IBGDA_QP_ORDERING_SEMANTIC. Generated header.
+#include "comms/utils/cvars/nccl_cvars.h" // @manual
 #endif
 #include "comms/prims/transport/ibgda/MultipeerIbgdaDeviceTransport.cuh"
 #include "comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cuh"
@@ -148,6 +150,200 @@ bool nicSupportsReliableDoorbell(
   }
   return supported;
 }
+
+// ---------------------------------------------------------------------------
+// dp_ordering (QPC dp_ordering_0 / dp_ordering_1 / dp_ordering_force)
+// ---------------------------------------------------------------------------
+
+// MCCL_IBGDA_QP_ORDERING_SEMANTIC wins over
+// MultipeerIbTransportConfig::qpOrderingPolicy only when it holds something
+// other than its registered default. Comparing against the generated
+// _DEFAULTCVARVALUE rather than a literal also covers the case where
+// ncclCvarInit() was never called: prims is driven from benchmarks and unit
+// tests that do not run it, and both globals are then still zero-initialized
+// and therefore equal.
+//
+// This is why "auto" is the FIRST choice in the cvar's yaml, and so the one
+// that gets enum value 0. A binary that never calls ncclCvarInit() reads the
+// cvar as zero; with auto at 0 that lands on the same policy as the registered
+// default, by construction rather than by coincidence. Were the default any
+// other choice, every benchmark would silently run a different policy from
+// production -- which is exactly the failure this A/B hit once already.
+IbQpOrderingPolicy resolveQpOrderingPolicy(
+    const MultipeerIbgdaTransportConfig& config) {
+  if (MCCL_IBGDA_QP_ORDERING_SEMANTIC ==
+      MCCL_IBGDA_QP_ORDERING_SEMANTIC_DEFAULTCVARVALUE) {
+    return config.qpOrderingPolicy;
+  }
+  using OrderingCvar = decltype(MCCL_IBGDA_QP_ORDERING_SEMANTIC);
+  switch (MCCL_IBGDA_QP_ORDERING_SEMANTIC) {
+    case OrderingCvar::ibta:
+      return IbQpOrderingPolicy::Ibta;
+    case OrderingCvar::ibta_forced:
+      return IbQpOrderingPolicy::IbtaForced;
+    case OrderingCvar::ooo_rw:
+      return IbQpOrderingPolicy::OooRw;
+    case OrderingCvar::ooo_all:
+      return IbQpOrderingPolicy::OooAll;
+    case OrderingCvar::auto_:
+      break;
+  }
+  return IbQpOrderingPolicy::Auto;
+}
+
+doca_verbs_qp_ordering_semantic toDocaOrderingSemantic(
+    IbQpOrderingSemantic mode) {
+  switch (ibQpOrderingTier(mode)) {
+    case 1:
+      return DOCA_VERBS_QP_ORDERING_SEMANTIC_OOO_RW;
+    case 2:
+      return DOCA_VERBS_QP_ORDERING_SEMANTIC_OOO_ALL;
+    default:
+      return DOCA_VERBS_QP_ORDERING_SEMANTIC_IBTA;
+  }
+}
+
+// What one NIC will let us do with dp_ordering.
+struct NicDpOrderingCap {
+  int capTier{0};
+  bool forceSupported{false};
+};
+
+// A DEVX QUERY_HCA_CAP round trip. Returns nullopt when the NIC cannot be
+// asked at all -- the query is mlx5-specific, so a non-mlx5 NIC fails here
+// rather than reporting "not capable". `failureReason` receives a
+// human-readable explanation in that case.
+std::optional<NicDpOrderingCap> queryNicDpOrderingCap(
+    ::ibv_context* ibvContext,
+    const std::string& deviceName,
+    std::string& failureReason) {
+  doca_verbs_device_attr* deviceAttr = nullptr;
+  const doca_error_t queryErr =
+      doca_verbs_query_device(ibvContext, &deviceAttr);
+  if (queryErr != DOCA_SUCCESS) {
+    failureReason = fmt::format(
+        "the DOCA capability query for NIC {} failed: {}",
+        deviceName,
+        docaErrorToString(queryErr));
+    return std::nullopt;
+  }
+  const NicDpOrderingCap cap{
+      static_cast<int>(
+          doca_verbs_device_attr_get_dp_ordering_cap_rc(deviceAttr)),
+      doca_verbs_device_attr_get_dp_ordering_force_supported(deviceAttr) != 0};
+  const doca_error_t freeErr = doca_verbs_device_attr_free(deviceAttr);
+  if (freeErr != DOCA_SUCCESS) {
+    LOG(WARNING) << "MultipeerIbgdaTransport: failed to free DOCA device "
+                    "attributes for NIC "
+                 << deviceName << ": " << docaErrorToString(freeErr);
+  }
+  return cap;
+}
+
+// Resolve a requested policy against one NIC's capabilities.
+//
+// The two request kinds fail in opposite directions on purpose:
+//
+//   Auto     - never throws. It is the fleet default, so it must not be the
+//              reason a job refuses to start, and the capability query itself
+//              is mlx5-only. Anything it cannot get, it demotes to Ibta and
+//              logs why.
+//   explicit - fails closed, exactly as before. Somebody named a tier because
+//              they are measuring it; a silent downgrade would turn their A/B
+//              into a no-op that reads as "OOO does not help". NVIDIA's GDAKI
+//              refuses here for the same reason.
+IbQpOrderingSemantic resolveQpOrderingSemanticForNic(
+    IbQpOrderingPolicy policy,
+    ::ibv_context* ibvContext,
+    const std::string& deviceName) {
+  // Ibta writes nothing to the QPC, so there is nothing to check and no reason
+  // to spend a DEVX round trip finding that out.
+  if (policy == IbQpOrderingPolicy::Ibta) {
+    return IbQpOrderingSemantic::Ibta;
+  }
+
+  std::string queryFailure;
+  const std::optional<NicDpOrderingCap> cap =
+      queryNicDpOrderingCap(ibvContext, deviceName, queryFailure);
+
+  if (ibQpOrderingPolicyIsAuto(policy)) {
+    if (!cap.has_value()) {
+      LOG(INFO) << "MultipeerIbgdaTransport: qp_ordering_semantic=auto falling "
+                   "back to ibta on NIC "
+                << deviceName << " because " << queryFailure;
+      return IbQpOrderingSemantic::Ibta;
+    }
+    if (!cap->forceSupported) {
+      LOG(INFO) << "MultipeerIbgdaTransport: qp_ordering_semantic=auto falling "
+                   "back to ibta on NIC "
+                << deviceName
+                << ": the NIC does not report cmd_hca_cap_2.dp_ordering_force, "
+                   "without which the QPC tier is ignored";
+      return IbQpOrderingSemantic::Ibta;
+    }
+    // Ladder: take the strongest tier this NIC reports, ooo_all first.
+    //
+    //   ooo_all -> ooo_rw -> ibta
+    //
+    // ooo_all is the rung worth having: it is the only tier that lifts the
+    // ordering fence in front of an atomic, and every prims signal is an
+    // ATOMIC_FETCH_AND_ADD. ooo_rw relaxes Read/Write placement only and leaves
+    // that fence in place.
+    //
+    // ConnectX-8 rails report ooo_all; ConnectX-7 reports ooo_rw but not
+    // ooo_all (measured: cmd_hca_cap.dp_ordering_ooo_all_rc = 0), which is why
+    // the ladder exists rather than a flat "ask for ooo_all". Note the caller
+    // then narrows across a rank's NICs, so a rank holding both generations
+    // settles on ooo_rw for all of them rather than letting its own NICs
+    // disagree.
+    //
+    // A job spanning ranks with different NIC generations will resolve
+    // different tiers and be rejected at peer connect; those jobs must pin
+    // MCCL_IBGDA_QP_ORDERING_SEMANTIC=ooo_rw explicitly. That is deliberate --
+    // see the mismatch check in doMaterializePeer().
+    for (const auto candidate :
+         {IbQpOrderingSemantic::OooAll, IbQpOrderingSemantic::OooRw}) {
+      if (ibQpOrderingTier(candidate) <= cap->capTier) {
+        return candidate;
+      }
+    }
+    LOG(INFO) << "MultipeerIbgdaTransport: qp_ordering_semantic=auto falling "
+                 "back to ibta on NIC "
+              << deviceName
+              << ": the NIC reports no out-of-order placement tier "
+                 "(cmd_hca_cap.dp_ordering_ooo_{rw,all}_rc both clear)";
+    return IbQpOrderingSemantic::Ibta;
+  }
+
+  const IbQpOrderingSemantic mode = ibQpOrderingPolicyToSemantic(policy);
+  if (!cap.has_value()) {
+    throw std::runtime_error(
+        fmt::format(
+            "qp_ordering_semantic={} requested but {}",
+            ibQpOrderingSemanticName(mode),
+            queryFailure));
+  }
+  if (ibQpOrderingTier(mode) > cap->capTier) {
+    throw std::runtime_error(
+        fmt::format(
+            "qp_ordering_semantic={} needs dp_ordering tier {} but NIC {} "
+            "supports at most tier {} (cmd_hca_cap.dp_ordering_ooo_rw_rc / "
+            "dp_ordering_ooo_all_rc)",
+            ibQpOrderingSemanticName(mode),
+            ibQpOrderingTier(mode),
+            deviceName,
+            cap->capTier));
+  }
+  if (ibQpOrderingForce(mode) && !cap->forceSupported) {
+    throw std::runtime_error(
+        fmt::format(
+            "qp_ordering_semantic={} needs the QPC dp_ordering_force bit but "
+            "NIC {} does not report cmd_hca_cap_2.dp_ordering_force",
+            ibQpOrderingSemanticName(mode),
+            deviceName));
+  }
+  return mode;
+}
 #endif
 
 // Check DOCA error and throw on failure
@@ -214,6 +410,44 @@ void MultipeerIbgdaTransport::openIbDevice() {
               << reliableDoorbellModeName(config_.enableReliableDoorbell)
               << " send_dbr_mode="
               << (nicDoca_[n].useReliableDoorbell ? "NO_DBR_HW" : "VALID_DBR");
+
+    // Resolve the dp_ordering tier against this NIC before any QP exists. An
+    // explicit policy throws here; auto demotes to Ibta and logs why.
+    //
+    // Narrow to the least capable NIC: a single qpOrderingSemantic_ drives
+    // every NIC on the rank and is what goes on the wire to peers, so under
+    // auto one NIC that cannot do OooRw demotes the whole rank rather than
+    // leaving the rank's NICs disagreeing with each other. Same in-loop clamp
+    // as maxRdAtomic_ above, and monotone for the same reason: auto only ever
+    // yields Ibta or OooRw, so taking the weaker of the two is well defined.
+    const IbQpOrderingSemantic nicOrdering = resolveQpOrderingSemanticForNic(
+        qpOrderingPolicy_,
+        reinterpret_cast<::ibv_context*>(nics_[n].ibvCtx),
+        nics_[n].deviceName);
+    // The first NIC seeds; later NICs can only demote. Seeding rather than
+    // clamping from the member's initial value matters because that value is
+    // Ibta (tier 0), which nothing can clamp below.
+    if (n == 0 ||
+        ibQpOrderingTier(nicOrdering) < ibQpOrderingTier(qpOrderingSemantic_)) {
+      qpOrderingSemantic_ = nicOrdering;
+    }
+    // Say "written", not "effective". When we write nothing the firmware
+    // supplies its own tier -- on a ConnectX-8 rail with adaptive routing
+    // enabled that is OOO_RW, not IBTA. Logging "tier=0" as though it were the
+    // QP's state would be actively misleading: it reads as strict ordering when
+    // the QP is in fact relaxed for reads and writes.
+    LOG(INFO) << "MultipeerIbgdaTransport: NIC " << nics_[n].deviceName
+              << " qp_ordering_policy="
+              << ibQpOrderingPolicyName(qpOrderingPolicy_)
+              << " qp_ordering_semantic="
+              << ibQpOrderingSemanticName(qpOrderingSemantic_)
+              << " (dp_ordering written tier="
+              << ibQpOrderingTier(qpOrderingSemantic_)
+              << " force=" << ibQpOrderingForce(qpOrderingSemantic_)
+              << (ibQpOrderingIsWireNoOp(qpOrderingSemantic_)
+                      ? "; nothing written, QP keeps the firmware default"
+                      : "")
+              << ")";
 #endif
 
     doca_error_t err = doca_verbs_ah_attr_create(
@@ -579,6 +813,13 @@ void MultipeerIbgdaTransport::createPeerQps(int peerIndex) {
     mainAttr.send_dbr_mode_ext = nicDoca_[nic].useReliableDoorbell
         ? DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_HW
         : DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR;
+    // dp_ordering tier is carried on the init attr and applied to the QPC when
+    // DOCA moves the QP INIT->RTR. At the Ibta default both fields stay zero
+    // (the struct is value-initialized above) and DOCA executes no DEVX_SET
+    // for them, so the emitted command is unchanged.
+    mainAttr.ordering_semantic = toDocaOrderingSemantic(qpOrderingSemantic_);
+    mainAttr.ordering_semantic_force =
+        ibQpOrderingForce(qpOrderingSemantic_) ? 1 : 0;
 #endif
 
     doca_gpu_verbs_qp_init_attr_hl loopbackAttr = mainAttr;
@@ -586,6 +827,13 @@ void MultipeerIbgdaTransport::createPeerQps(int peerIndex) {
 #ifndef __HIP_PLATFORM_AMD__
     loopbackAttr.send_dbr_mode_ext =
         DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR;
+    // Host side of a pure loopback pair: never traverses the fabric, so it
+    // cannot see the reordering that OOO exists to absorb. Note the WAIT and
+    // counter ATOMIC_FA ride the *device-visible companion* built inside
+    // create_qp_group_hl(), not this QP; that companion is pinned to IBTA in
+    // DOCA. This is the responder half of the same pair, so it must match.
+    loopbackAttr.ordering_semantic = DOCA_VERBS_QP_ORDERING_SEMANTIC_IBTA;
+    loopbackAttr.ordering_semantic_force = 0;
 #endif
 
     auto& nicQps = nicDoca_[nic].blockQpGroups;
@@ -745,6 +993,13 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
 
     // Initialize DOCA GPU context
     initDocaGpu();
+
+#ifndef __HIP_PLATFORM_AMD__
+    // Take the requested dp_ordering policy (config value, optionally
+    // overridden by MCCL_IBGDA_QP_ORDERING_SEMANTIC). openIbDevice() resolves
+    // it against each NIC's capability into qpOrderingSemantic_.
+    qpOrderingPolicy_ = resolveQpOrderingPolicy(config_);
+#endif
 
     // Open IB device and create PD
     openIbDevice();
@@ -990,6 +1245,7 @@ PeerQpPayload MultipeerIbgdaTransport::buildLocalQpPayload(
   payload.numQpsPerPeerPerNic = mainQpsPerPeerPerNic;
   payload.maxGroups = config_.max_num_channels;
   payload.qpsPerBlockPerNic = config_.qpsPerConnection;
+  payload.qpOrderingSemantic = static_cast<int>(qpOrderingSemantic_);
 
   auto& symbols = ibverbx::ibvSymbols;
   for (int n = 0; n < numNics_; ++n) {
@@ -1092,6 +1348,39 @@ void MultipeerIbgdaTransport::doMaterializePeer(int peerRank) {
             remoteQp.qpsPerBlockPerNic,
             config_.max_num_channels,
             config_.qpsPerConnection));
+  }
+  // dp_ordering has to match on both ends of a connection: fail closed and name
+  // both sides rather than silently let one end reassemble in order while the
+  // other lets the fabric spray it.
+  //
+  // Measured on GB300 (ConnectX-8, mlx5_0, two hosts): a matched pair passes --
+  // tier1<->tier1 and tier2<->tier2 both verified clean over 2100 iterations of
+  // 64 KiB x 8 writes. BOTH mismatched orientations failed outright with
+  // "transport retry counter exceeded". That measurement used
+  // MLX5DV_QP_CREATE_OOO_DP, which also enables out-of-order receive-WR
+  // handling, so it is not proof that a QPC-bit-only mismatch fails -- but it
+  // is the only direct evidence, and it says mismatch is not safe.
+  //
+  // Hence: fail fast here even under the auto policy, where a mismatch is
+  // reachable without anyone misconfiguring anything (a rank whose NIC lacks
+  // the capability falls back to ibta while its peers resolve ooo_rw). If
+  // mismatch is in fact broken, this error beats an opaque RDMA retry failure
+  // later; if it is in fact safe, this is merely conservative and the operator
+  // has a documented way out. Both are better than an asymmetry we cannot
+  // vouch for.
+  if (remoteQp.qpOrderingSemantic != static_cast<int>(qpOrderingSemantic_)) {
+    throw std::runtime_error(
+        fmt::format(
+            "materializePeer: peer {} qpOrderingSemantic={} ({}) vs local "
+            "qpOrderingSemantic={} ({}). Ranks resolved different dp_ordering "
+            "tiers, which happens when they do not all have the same NIC "
+            "capability. Set MCCL_IBGDA_QP_ORDERING_SEMANTIC=ibta on every "
+            "rank to pin them all to the firmware default.",
+            peerRank,
+            remoteQp.qpOrderingSemantic,
+            ibQpOrderingSemanticNameFromWire(remoteQp.qpOrderingSemantic),
+            static_cast<int>(qpOrderingSemantic_),
+            ibQpOrderingSemanticName(qpOrderingSemantic_)));
   }
 
   connectPeerMainQps(peerIndex, remoteQp);

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
@@ -275,6 +275,20 @@ class MultipeerIbgdaTransport
   };
   std::vector<NicDocaResources> nicDoca_;
 
+  // What was asked for: config value, or MCCL_IBGDA_QP_ORDERING_SEMANTIC when
+  // that cvar is set to something other than its registered default. Taken in
+  // the ctor, before openIbDevice() consults the NICs.
+  IbQpOrderingPolicy qpOrderingPolicy_{IbQpOrderingPolicy::Auto};
+
+  // What we actually got: the policy above resolved against every NIC's
+  // capability in openIbDevice(), narrowed to the least capable one. This is
+  // the value written to the QPC and exchanged with peers.
+  //
+  // Stays Ibta on AMD, where the whole dp_ordering path is compiled out and
+  // openIbDevice() never resolves anything -- so AMD keeps sending the same
+  // zero it always did.
+  IbQpOrderingSemantic qpOrderingSemantic_{IbQpOrderingSemantic::Ibta};
+
   // Sink buffer for RDMA atomic return values (discarded).
   // DOCA's OPCODE_ATOMIC_FA requires a local address for the fetch-add
   // return value. We don't need it, so we use a small "sink" buffer.

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3461,6 +3461,44 @@ cvars:
    description : |-
      Enable the dedicated IBGDA warp-proxy send, receive, and forward path for
      fused Ring AllReduce. Disabled by default while the path is evaluated.
+ - name        : MCCL_IBGDA_QP_ORDERING_SEMANTIC
+   type        : enum
+   default     : auto
+   choices     : auto, ibta, ibta_forced, ooo_rw, ooo_all
+   description : |-
+     Select the NIC data-placement ordering (mlx5 dp_ordering, a.k.a. DDP or
+     out-of-order placement) for the Prims IBGDA transport. Out-of-order
+     placement is what lets adaptive routing spray a QP's packets across fabric
+     paths without stalling reassembly.
+     auto is the default: take the strongest tier the NIC reports, walking
+     ooo_all -> ooo_rw -> ibta, falling all the way to ibta on a NIC whose
+     capability query fails outright. On a ConnectX-8 rail that resolves to
+     ooo_all, which is the tier that actually pays -- it is the only one that
+     lifts the ordering fence in front of an atomic, and every prims signal is
+     an ATOMIC_FETCH_AND_ADD. ConnectX-7 reports ooo_rw but not ooo_all, so it
+     resolves one rung lower. Set ibta to get the pre-change behaviour back.
+     Because ranks resolve independently, a job spanning both NIC generations
+     will resolve different tiers and be rejected at peer connect; pin every
+     rank to ooo_rw in that case.
+     ibta leaves the QPC dp_ordering bits untouched, so it is a wire-level
+     no-op and the QP keeps whatever the NIC's mlxreg admin default gives it.
+     Note this does NOT mean the QP runs strict IBTA: on a ConnectX-8 rail with
+     adaptive routing on, the firmware supplies OOO_RW on its own.
+     ibta_forced pins the QP to strict IBTA ordering even when that admin
+     default enables adaptive routing. ooo_rw allows out-of-order placement for
+     RDMA Read and Write only. ooo_all also covers atomics, which is what
+     removes the ordering fence in front of a put+signal.
+     ibta_forced requires only cmd_hca_cap_2.dp_ordering_force; ooo_rw and
+     ooo_all additionally require the matching
+     cmd_hca_cap.dp_ordering_ooo_{rw,all}_rc capability. An explicitly named
+     tier fails transport initialization when the NIC lacks it; there is no
+     silent downgrade, because that would turn an A/B into a no-op. Only auto
+     falls back.
+     All ranks must end up on the same tier or peer connection fails. Under
+     auto that is reachable without anyone misconfiguring anything, if the job
+     spans NICs of differing capability; pin every rank to ibta in that case.
+     Host-only loopback QPs always use ibta.
+     This policy is NVIDIA-only and ignored on AMD.
 
  - name        : MCCL_IB_QP_DEPTH
    type        : uint64_t

--- a/comms/utils/cvars/tests/CvarInitUT.cc
+++ b/comms/utils/cvars/tests/CvarInitUT.cc
@@ -51,6 +51,7 @@ class CvarInitTest : public ::testing::Test {
     unsetenv("NCCL_MIN_CTAS");
     unsetenv("MCCL_BOOTSTRAP_TCP_KEEPALIVE_ENABLED");
     unsetenv("MCCL_IBGDA_RELIABLE_DOORBELL_MODE");
+    unsetenv("MCCL_IBGDA_QP_ORDERING_SEMANTIC");
   }
 };
 
@@ -81,6 +82,49 @@ TEST_F(CvarInitTest, McclIbgdaReliableDoorbellModeParsesAllModes) {
     setenv("MCCL_IBGDA_RELIABLE_DOORBELL_MODE", value, 1);
     ncclCvarInit();
     EXPECT_EQ(MCCL_IBGDA_RELIABLE_DOORBELL_MODE, expected);
+  }
+}
+
+// auto is the dp_ordering default: request ooo_rw, fall back to ibta on a NIC
+// that cannot do it.
+TEST_F(CvarInitTest, McclIbgdaQpOrderingSemanticDefaultsToAuto) {
+  MCCL_IBGDA_QP_ORDERING_SEMANTIC = MCCL_IBGDA_QP_ORDERING_SEMANTIC::ooo_all;
+  ncclCvarInit();
+  EXPECT_EQ(
+      MCCL_IBGDA_QP_ORDERING_SEMANTIC, MCCL_IBGDA_QP_ORDERING_SEMANTIC::auto_);
+}
+
+// The transport reads "cvar == _DEFAULTCVARVALUE" as "nobody set this" and
+// falls through to the config field. Binaries that skip ncclCvarInit() -- the
+// benchmarks, most unit tests -- see a zero-initialized cvar instead. Those two
+// agree only if the default choice is also the zero-valued one, which is why
+// auto is listed first in the yaml. A failure here means someone reordered
+// `choices` and every benchmark is now silently on a different policy from
+// production.
+TEST_F(CvarInitTest, McclIbgdaQpOrderingSemanticDefaultIsTheZeroValue) {
+  ncclCvarInit();
+  EXPECT_EQ(
+      static_cast<int>(MCCL_IBGDA_QP_ORDERING_SEMANTIC_DEFAULTCVARVALUE), 0);
+  EXPECT_EQ(
+      MCCL_IBGDA_QP_ORDERING_SEMANTIC_DEFAULTCVARVALUE,
+      MCCL_IBGDA_QP_ORDERING_SEMANTIC::auto_);
+}
+
+TEST_F(CvarInitTest, McclIbgdaQpOrderingSemanticParsesAllModes) {
+  using Mode = decltype(MCCL_IBGDA_QP_ORDERING_SEMANTIC);
+  const std::vector<std::pair<const char*, Mode>> modes{
+      {"auto", Mode::auto_},
+      {"ibta", Mode::ibta},
+      {"ibta_forced", Mode::ibta_forced},
+      {"ooo_rw", Mode::ooo_rw},
+      {"ooo_all", Mode::ooo_all},
+  };
+  for (const auto& [value, expected] : modes) {
+    MCCL_IBGDA_QP_ORDERING_SEMANTIC =
+        expected == Mode::ibta ? Mode::ooo_all : Mode::ibta;
+    setenv("MCCL_IBGDA_QP_ORDERING_SEMANTIC", value, 1);
+    ncclCvarInit();
+    EXPECT_EQ(MCCL_IBGDA_QP_ORDERING_SEMANTIC, expected);
   }
 }
 


### PR DESCRIPTION
Summary:
Adds an opt-in `dp_ordering` (out-of-order data placement) tier to the prims
IBGDA transport. On a GB300 ConnectX-8 rail this removes a full network round
trip from every `put + signal`.

The DOCA GPUNetIO plumbing this depends on is the parent diff; this one is the
consumer: capability probe, cvar, peer negotiation, benchmark and tests.

Default is `ibta`, which is a provable no-op: no DEVX_SET is executed and the
emitted INIT2RTR command is byte-identical to before this diff.

# Why

prims' fused `put + signal` posts N RDMA_WRITEs and then one ATOMIC_FETCH_AND_ADD
on the *same* QP. On a fabric with adaptive routing enabled -- which is the fleet
state on CX8 rails (`ROCE_ACCL.adaptive_routing_forced_en=1`) -- the requester
will not put that trailing atomic on the wire until the writes have been ACKed.
The signal therefore costs one full RTT that it does not need to.

Three things were measured on GB300 hardware to establish this, each with the
control that makes it interpretable:

1. The NIC firmware programs each QP at tier `OOO_RW` *by itself* when adaptive
   routing is on. Nothing in DOCA or prims writes that field today -- confirmed
   by reading the QPC back after connect. `OOO_RW` covers RDMA Read and Write
   only, so writes flow freely and atomics do not.

2. The cost is specific to the trailing *opcode*, not to the extra WQE. With an
   identical WQE count and only the trailing operation changed, cross-host on a
   CX8 rail:

       trailing write   0.992 us     <- negative control
       trailing atomic 12.256 us
       trailing imm    13.249 us
       trailing send   13.504 us

3. It is a fixed round trip, not a data-dependent cost. The atomic delta is
   12.0-12.2 us across payloads from 8 B to 64 KiB and write counts from 1 to
   16, while the measured RTT moves underneath it; cross-rack it grows to
   17.312 us, tracking RTT one-for-one.

Promoting the QP to tier `OOO_ALL` removes the fence: the trailing atomic drops
to 0.384 us, and stays there regardless of size, write count or distance.

# What this changes

## prims

- `MultiPeerIbTransport.h` -- `IbQpOrderingSemantic` config field, a
  tier/force accessor pair, and the resolved tier appended to `PeerQpPayload`.
- `MultipeerIbgdaTransport.{cc,h}` -- per-NIC capability probe, fail-closed
  resolution, applies the tier to the main data QP, and rejects a peer whose
  tier differs. `dp_ordering` must match on both ends of a connection; since
  this is opt-in, a mismatch means a misconfigured job and is a loud error
  rather than a silent downgrade to the stricter tier.
- The device-visible companion QP is pinned to IBTA. It carries the inter-QP
  WAIT and the counter ATOMIC_FA, only ever connects to a local loopback
  partner, and gains nothing from relaxation since loopback traffic never
  leaves the NIC. Without this the loopback pair would come up with mismatched
  tiers.
- `nccl_cvars.yaml` -- `MCCL_IBGDA_QP_ORDERING_SEMANTIC`
  (`ibta` | `ibta_forced` | `ooo_rw` | `ooo_all`, default `ibta`), following the
  `MCCL_IBGDA_RELIABLE_DOORBELL_MODE` precedent. `ibta_forced` pins the QP to
  strict ordering and overrides the firmware's automatic choice, which is the
  only way to ask "is this QP being sprayed right now?" without touching a
  device-wide register.

## Benchmark

- `PutSignalFlush` -- put + signal + flush, no counter, so it pairs exactly with
  the existing `PutFlush` and the delta isolates the signal.
- `benchDataDirect()` / `benchQpOrderingSemantic()` -- env tunnels into the
  transport config. Neither setting is read from the environment by the
  transport itself, and benchmarks do not call `ncclCvarInit()`, so without
  these an A/B silently runs the control twice.

Reviewed By: saifhhasan

Differential Revision: D117918163


