### PR TITLE
Remove NCCLX test XLOG (#3885)

### DIFF
--- a/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <exception>
 #include <filesystem>
+#include <optional>
 
 #include <folly/ScopeGuard.h>
 #include <folly/Synchronized.h>
@@ -21,6 +22,7 @@
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/testinfra/TestUtils.h"
+#include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/utils/colltrace/CollTrace.h"
 #include "comms/utils/colltrace/tests/nvidia-only/CPUControlledKernel.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -113,6 +115,8 @@ class CollTraceTest : public NcclxBaseTestFixture {
         NCCL_DEBUG_SUBSYS.empty() ? "INIT,BOOTSTRAP,ENV" : NCCL_DEBUG_SUBSYS;
     NCCL_DEBUG = "INFO";
     NCCL_DEBUG_SUBSYS = "INIT,COLL";
+    debugEnvGuard.emplace("NCCL_DEBUG", "INFO");
+    debugSubsysEnvGuard.emplace("NCCL_DEBUG_SUBSYS", "INIT,COLL");
     reconfigureLogging();
   }
 
@@ -121,6 +125,8 @@ class CollTraceTest : public NcclxBaseTestFixture {
     flushLogging();
     NCCL_DEBUG = prevDebug;
     NCCL_DEBUG_SUBSYS = prevDebugSubsys;
+    debugSubsysEnvGuard.reset();
+    debugEnvGuard.reset();
     reconfigureLogging();
   }
 
@@ -148,6 +154,8 @@ class CollTraceTest : public NcclxBaseTestFixture {
   cudaStream_t stream;
   std::string prevDebug;
   std::string prevDebugSubsys;
+  std::optional<SysEnvRAII> debugEnvGuard;
+  std::optional<SysEnvRAII> debugSubsysEnvGuard;
 };
 
 TEST_F(CollTraceTest, NewCollTraceAllReduce) {

--- a/comms/ncclx/meta/logger/tests/DebugExtentionUT.cc
+++ b/comms/ncclx/meta/logger/tests/DebugExtentionUT.cc
@@ -6,6 +6,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 #include "meta/NcclxLogger.h"
@@ -52,6 +53,8 @@ TEST_F(DebugExtTest, TestWarnLogToLimit) {
   initEnv();
   NCCL_DEBUG = "WARN";
   NCCL_DEBUG_FILE = NCCL_DEBUG_FILE_DEFAULTCVARVALUE;
+  SysEnvRAII debugEnv{"NCCL_DEBUG", "WARN"};
+  SysEnvRAII debugFileEnv{"NCCL_DEBUG_FILE", ""};
   initLogging();
   constexpr int logCount = 3;
   constexpr int iterCount = 10;
@@ -79,6 +82,8 @@ TEST_F(DebugExtTest, TestWarnLogBelowLimit) {
   initEnv();
   NCCL_DEBUG = "WARN";
   NCCL_DEBUG_FILE = NCCL_DEBUG_FILE_DEFAULTCVARVALUE;
+  SysEnvRAII debugEnv{"NCCL_DEBUG", "WARN"};
+  SysEnvRAII debugFileEnv{"NCCL_DEBUG_FILE", ""};
   initLogging();
   constexpr int logCount = 20;
   constexpr int iterCount = 10;
@@ -100,6 +105,8 @@ TEST_F(DebugExtTest, TestThreeSeperateWarnLog) {
   initEnv();
   NCCL_DEBUG = "WARN";
   NCCL_DEBUG_FILE = NCCL_DEBUG_FILE_DEFAULTCVARVALUE;
+  SysEnvRAII debugEnv{"NCCL_DEBUG", "WARN"};
+  SysEnvRAII debugFileEnv{"NCCL_DEBUG_FILE", ""};
   initLogging();
   constexpr int logCount = 3;
   constexpr int iterCount = 10;

--- a/comms/ncclx/meta/logger/tests/LoggerUTBench.cc
+++ b/comms/ncclx/meta/logger/tests/LoggerUTBench.cc
@@ -11,6 +11,7 @@
 #include "debug.h" // @manual
 
 #include "comms/testinfra/TestUtils.h"
+#include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/EventMgr.h"
@@ -186,6 +187,7 @@ TEST_F(NcclLoggerBenchTest, CommBenchDebugLog) {
   folly::test::TemporaryFile tmpFile;
   setLogType(LogType::FILE);
   EnvRAII env(NCCL_DEBUG_FILE, getTmpLogFile());
+  SysEnvRAII sysEnv{"NCCL_DEBUG_FILE", getTmpLogFile()};
   // Reset ncclDebugLevel to force debug sub-system to be re-initialized
   ncclDebugLevel = -1;
   initNcclLogger();

--- a/comms/ncclx/meta/logger/tests/LoggingUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggingUT.cc
@@ -85,6 +85,7 @@ TEST_F(NcclLoggerTest, LogDisplay) {
 
 TEST_F(NcclLoggerTest, NcclxChecksPreserveResultsAndSingleEvaluation) {
   auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"INFO"});
+  SysEnvRAII sysDebugGuard("NCCL_DEBUG", "INFO");
   ncclResetDebugInitInternal();
   initLogging();
   auto loggingGuard = folly::makeGuard([&] { finishLogging(); });
@@ -220,6 +221,7 @@ TEST_F(NcclLoggerTest, GetLastCommsErrorLongMessageTest) {
 
 TEST_F(NcclLoggerTest, GetLastCommsErrorLongStreamMessageTest) {
   auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"INFO"});
+  SysEnvRAII sysDebugGuard("NCCL_DEBUG", "INFO");
   ncclResetDebugInit();
 
   initLogging();
@@ -438,6 +440,8 @@ TEST_F(NcclLoggerTest, MetaDebugBridgePreservesTraceAndSourceMetadata) {
 TEST_F(NcclLoggerTest, SpdlogDebugUsesVerboseLevel) {
   auto debugGuard = EnvRAII(NCCL_DEBUG, std::string{"TRACE"});
   auto asyncGuard = EnvRAII(NCCL_DEBUG_LOGGING_ASYNC, false);
+  SysEnvRAII sysDebugGuard("NCCL_DEBUG", "TRACE");
+  SysEnvRAII sysAsyncGuard("NCCL_DEBUG_LOGGING_ASYNC", "0");
 
   initLogging();
   auto& logger =

--- a/comms/ncclx/meta/tests/LoggerConfigTest.cc
+++ b/comms/ncclx/meta/tests/LoggerConfigTest.cc
@@ -1,0 +1,507 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include <folly/testing/TestUtil.h>
+#include <gtest/gtest.h>
+
+#include "comms/utils/logger/LogTypes.h"
+#include "comms/utils/logger/SpdlogLogger.h"
+#include "debug.h"
+#include "env.h"
+#include "meta/NcclxLogger.h"
+#include "param.h"
+
+namespace {
+
+static_assert(noexcept(initNcclLogger()));
+static_assert(noexcept(ncclRefreshDebugInitInternal()));
+
+class ScopedEnvironmentVariable {
+ public:
+  ScopedEnvironmentVariable(std::string name, std::optional<std::string> value)
+      : name_{std::move(name)} {
+    if (const char* previousValue = std::getenv(name_.c_str())) {
+      previousValue_ = previousValue;
+    }
+
+    const int result = value.has_value()
+        ? ::setenv(name_.c_str(), value->c_str(), 1)
+        : ::unsetenv(name_.c_str());
+    if (result != 0) {
+      throw std::runtime_error{"failed to update test environment variable"};
+    }
+  }
+
+  ScopedEnvironmentVariable(const ScopedEnvironmentVariable&) = delete;
+  ScopedEnvironmentVariable& operator=(const ScopedEnvironmentVariable&) =
+      delete;
+  ScopedEnvironmentVariable(ScopedEnvironmentVariable&&) = delete;
+  ScopedEnvironmentVariable& operator=(ScopedEnvironmentVariable&&) = delete;
+
+  ~ScopedEnvironmentVariable() {
+    if (previousValue_.has_value()) {
+      ::setenv(name_.c_str(), previousValue_->c_str(), 1);
+    } else {
+      ::unsetenv(name_.c_str());
+    }
+  }
+
+ private:
+  std::string name_;
+  std::optional<std::string> previousValue_;
+};
+
+std::string readFile(const std::string& path) {
+  std::ifstream file{path};
+  return {
+      std::istreambuf_iterator<char>{file}, std::istreambuf_iterator<char>{}};
+}
+
+} // namespace
+
+TEST(LoggerConfigTest, PreservesLazyNativeConfigurationBeforePluginInit) {
+  folly::test::TemporaryDirectory directory{"nccl_logger_pre_plugin_config"};
+  const auto configPath = directory.path() / "nccl.conf";
+  const auto logPath = directory.path() / "nccl.log";
+  {
+    std::ofstream config{configPath};
+    ASSERT_TRUE(config.is_open());
+    config << "NCCL_DEBUG=info\n"
+           << "NCCL_DEBUG_SUBSYS=COLL\n"
+           << "NCCL_DEBUG_FILE=" << logPath.string() << "\n"
+           << "NCCL_DEBUG_LOGGING_ASYNC=0\n";
+  }
+
+  const ScopedEnvironmentVariable debug{"NCCL_DEBUG", std::nullopt};
+  const ScopedEnvironmentVariable debugSubsys{
+      "NCCL_DEBUG_SUBSYS", std::nullopt};
+  const ScopedEnvironmentVariable debugFile{"NCCL_DEBUG_FILE", std::nullopt};
+  const ScopedEnvironmentVariable asyncLogging{
+      "NCCL_DEBUG_LOGGING_ASYNC", std::nullopt};
+  const ScopedEnvironmentVariable configFile{
+      "NCCL_CONF_FILE", configPath.string()};
+
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_EXIT(
+      ([&]() {
+        ncclResetDebugInitInternal();
+        initEnv();
+        INFO(NCCL_COLL, "%s", "native record before plugin initialization");
+
+        auto& logger = meta::comms::logger::getSpdlogLogger(
+            ncclx::logging::kNcclxLoggerName);
+        logger.flush();
+        const auto output = readFile(logPath.string());
+        EXPECT_NE(
+            output.find("native record before plugin initialization"),
+            std::string::npos);
+        EXPECT_TRUE(
+            meta::comms::logger::isEnabledSubSystemBitwise(
+                meta::comms::logger::COLL));
+        EXPECT_FALSE(
+            meta::comms::logger::isEnabledSubSystemBitwise(
+                meta::comms::logger::INIT));
+        std::_Exit(::testing::Test::HasFailure() ? 3 : 0);
+      }()),
+      ::testing::ExitedWithCode(0),
+      "");
+}
+
+TEST(LoggerConfigTest, ResetBeforePluginRefreshesNativeAndSpdlogLoggers) {
+  folly::test::TemporaryDirectory directory{"nccl_logger_pre_plugin_reset"};
+  const auto initialLogPath = directory.path() / "initial.log";
+  const auto resetLogPath = directory.path() / "reset.log";
+
+  const ScopedEnvironmentVariable debug{"NCCL_DEBUG", "INFO"};
+  const ScopedEnvironmentVariable debugSubsys{"NCCL_DEBUG_SUBSYS", "COLL"};
+  const ScopedEnvironmentVariable debugFile{
+      "NCCL_DEBUG_FILE", initialLogPath.string()};
+  const ScopedEnvironmentVariable asyncLogging{"NCCL_DEBUG_LOGGING_ASYNC", "0"};
+  const ScopedEnvironmentVariable configFile{"NCCL_CONF_FILE", std::nullopt};
+
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_EXIT(
+      ([&]() {
+        initEnv();
+        INFO(NCCL_COLL, "%s", "native record before pre-plugin reset");
+        NCCLX_LOG_INFO("direct record before pre-plugin reset");
+        auto& logger = meta::comms::logger::getSpdlogLogger(
+            ncclx::logging::kNcclxLoggerName);
+        logger.flush();
+
+        if (setenv("NCCL_DEBUG_FILE", resetLogPath.c_str(), 1) != 0) {
+          std::_Exit(2);
+        }
+        ncclResetDebugInitInternal();
+
+        NCCLX_LOG_INFO("direct record after pre-plugin reset");
+        INFO(NCCL_COLL, "%s", "native record after pre-plugin reset");
+        logger.flush();
+
+        const auto initialOutput = readFile(initialLogPath.string());
+        const auto resetOutput = readFile(resetLogPath.string());
+        EXPECT_NE(
+            initialOutput.find("native record before pre-plugin reset"),
+            std::string::npos);
+        EXPECT_NE(
+            initialOutput.find("direct record before pre-plugin reset"),
+            std::string::npos);
+        EXPECT_EQ(
+            initialOutput.find("direct record after pre-plugin reset"),
+            std::string::npos);
+        EXPECT_NE(
+            resetOutput.find("direct record after pre-plugin reset"),
+            std::string::npos);
+        EXPECT_NE(
+            resetOutput.find("native record after pre-plugin reset"),
+            std::string::npos);
+        std::_Exit(::testing::Test::HasFailure() ? 3 : 0);
+      }()),
+      ::testing::ExitedWithCode(0),
+      "");
+}
+
+TEST(LoggerConfigTest, UsesNativeNcclConfigurationSources) {
+  folly::test::TemporaryDirectory directory{"nccl_logger_config"};
+  const auto configPath = directory.path() / "nccl.conf";
+  const auto logPath = directory.path() / "nccl.log";
+  const auto resetLogPath = directory.path() / "nccl-reset.log";
+  const auto sharedLogPath = directory.path() / "shared.log";
+  {
+    std::ofstream config{configPath};
+    ASSERT_TRUE(config.is_open());
+    config << "NCCL_DEBUG=info\n"
+           << "NCCL_DEBUG_SUBSYS=COLL\n"
+           << "NCCL_DEBUG_FILE=" << logPath.string() << "\n"
+           << "NCCL_DEBUG_LOGGING_ASYNC=0\n";
+  }
+
+  const ScopedEnvironmentVariable debug{"NCCL_DEBUG", std::nullopt};
+  const ScopedEnvironmentVariable debugSubsys{
+      "NCCL_DEBUG_SUBSYS", std::nullopt};
+  const ScopedEnvironmentVariable debugFile{"NCCL_DEBUG_FILE", std::nullopt};
+  const ScopedEnvironmentVariable asyncLogging{
+      "NCCL_DEBUG_LOGGING_ASYNC", std::nullopt};
+  const ScopedEnvironmentVariable configFile{
+      "NCCL_CONF_FILE", configPath.string()};
+
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_EXIT(
+      ([&]() {
+        ncclResetDebugInitInternal();
+        initEnv();
+
+        auto& logger = meta::comms::logger::getSpdlogLogger(
+            ncclx::logging::kNcclxLoggerName);
+        auto& sharedLogger = meta::comms::logger::getSpdlogLogger();
+        EXPECT_TRUE(logger.should_log(spdlog::level::info));
+        EXPECT_FALSE(logger.should_log(spdlog::level::debug));
+        EXPECT_FALSE(logger.usesAsyncLogging());
+        EXPECT_TRUE(sharedLogger.should_log(spdlog::level::info));
+        EXPECT_FALSE(sharedLogger.should_log(spdlog::level::debug));
+        EXPECT_FALSE(sharedLogger.usesAsyncLogging());
+        EXPECT_TRUE(
+            meta::comms::logger::isEnabledSubSystemBitwise(
+                meta::comms::logger::COLL));
+        EXPECT_FALSE(
+            meta::comms::logger::isEnabledSubSystemBitwise(
+                meta::comms::logger::INIT));
+
+        INFO(
+            NCCL_COLL,
+            "%s",
+            "native logger configuration came from NCCL_CONF_FILE");
+        NCCLX_LOG_INFO("logger configuration came from NCCL_CONF_FILE");
+        COMMS_LOG_INFO("shared logger configuration came from NCCL_CONF_FILE");
+        logger.flush();
+        sharedLogger.flush();
+        std::ifstream logFile{logPath};
+        const std::string output{
+            std::istreambuf_iterator<char>{logFile},
+            std::istreambuf_iterator<char>{}};
+        EXPECT_NE(
+            output.find("logger configuration came from NCCL_CONF_FILE"),
+            std::string::npos);
+        EXPECT_NE(
+            output.find("shared logger configuration came from NCCL_CONF_FILE"),
+            std::string::npos);
+        EXPECT_NE(
+            output.find("native logger configuration came from NCCL_CONF_FILE"),
+            std::string::npos);
+
+        sharedLogger.reconfigure(
+            "SHARED",
+            sharedLogPath.string(),
+            []() { return 0; },
+            {},
+            false,
+            spdlog::level::info);
+
+        if (setenv("NCCL_DEBUG", "WARN", 1) != 0 ||
+            setenv("NCCL_DEBUG_SUBSYS", "INIT", 1) != 0 ||
+            ncclEnvPluginInit() != ncclSuccess) {
+          std::_Exit(2);
+        }
+
+        NCCLX_LOG_WARN("direct record after plugin reset");
+        logger.flush();
+        WARN("native record after plugin reset");
+        logger.flush();
+        const auto postPluginOutput = readFile(logPath.string());
+        EXPECT_NE(
+            postPluginOutput.find("direct record after plugin reset"),
+            std::string::npos);
+        EXPECT_NE(
+            postPluginOutput.find("native record after plugin reset"),
+            std::string::npos);
+        EXPECT_NE(
+            postPluginOutput.find(
+                "logger configuration came from NCCL_CONF_FILE"),
+            std::string::npos);
+        EXPECT_NE(
+            postPluginOutput.find(
+                "shared logger configuration came from NCCL_CONF_FILE"),
+            std::string::npos);
+        EXPECT_NE(
+            postPluginOutput.find(
+                "native logger configuration came from NCCL_CONF_FILE"),
+            std::string::npos);
+
+        EXPECT_TRUE(logger.should_log(spdlog::level::warn));
+        EXPECT_FALSE(logger.should_log(spdlog::level::info));
+        EXPECT_TRUE(sharedLogger.should_log(spdlog::level::warn));
+        EXPECT_TRUE(sharedLogger.should_log(spdlog::level::info));
+        EXPECT_TRUE(
+            meta::comms::logger::isEnabledSubSystemBitwise(
+                meta::comms::logger::INIT));
+        EXPECT_FALSE(
+            meta::comms::logger::isEnabledSubSystemBitwise(
+                meta::comms::logger::COLL));
+
+        COMMS_LOG_INFO("shared logger retained its owner configuration");
+        std::ifstream sharedLogFile{sharedLogPath};
+        const std::string sharedOutput{
+            std::istreambuf_iterator<char>{sharedLogFile},
+            std::istreambuf_iterator<char>{}};
+        EXPECT_NE(
+            sharedOutput.find("shared logger retained its owner configuration"),
+            std::string::npos);
+
+        {
+          std::ofstream resetLog{resetLogPath};
+          resetLog << "previous generation must be truncated\n";
+        }
+        if (setenv("NCCL_DEBUG_FILE", resetLogPath.c_str(), 1) != 0) {
+          std::_Exit(4);
+        }
+        ncclResetDebugInitInternal();
+        NCCLX_LOG_WARN("direct record after file reset");
+        logger.flush();
+        WARN("native record after file reset");
+        logger.flush();
+        const auto postFileResetOutput = readFile(resetLogPath.string());
+        EXPECT_EQ(
+            postFileResetOutput.find("previous generation must be truncated"),
+            std::string::npos);
+        EXPECT_NE(
+            postFileResetOutput.find("direct record after file reset"),
+            std::string::npos);
+        EXPECT_NE(
+            postFileResetOutput.find("native record after file reset"),
+            std::string::npos);
+
+        if (setenv("NCCL_DEBUG", "INFO", 1) != 0 ||
+            setenv("NCCL_DEBUG_SUBSYS", "COLL", 1) != 0) {
+          std::_Exit(4);
+        }
+        ncclResetDebugInitInternal();
+
+        EXPECT_TRUE(logger.should_log(spdlog::level::info));
+        EXPECT_TRUE(sharedLogger.should_log(spdlog::level::info));
+        EXPECT_TRUE(
+            meta::comms::logger::isEnabledSubSystemBitwise(
+                meta::comms::logger::COLL));
+        EXPECT_FALSE(
+            meta::comms::logger::isEnabledSubSystemBitwise(
+                meta::comms::logger::INIT));
+
+        std::atomic<bool> start{false};
+        std::thread loggingThread{[&] {
+          while (!start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+          }
+          for (int iteration = 0; iteration < 64; ++iteration) {
+            NCCLX_LOG_INFO("concurrent logger reset {}", iteration);
+            INFO(
+                NCCL_COLL,
+                "%s %d",
+                "concurrent native logger reset",
+                iteration);
+          }
+        }};
+        start.store(true, std::memory_order_release);
+        for (int iteration = 0; iteration < 64; ++iteration) {
+          ncclResetDebugInitInternal();
+        }
+        loggingThread.join();
+
+        EXPECT_TRUE(logger.should_log(spdlog::level::info));
+        EXPECT_TRUE(
+            meta::comms::logger::isEnabledSubSystemBitwise(
+                meta::comms::logger::COLL));
+        std::_Exit(::testing::Test::HasFailure() ? 3 : 0);
+      }()),
+      ::testing::ExitedWithCode(0),
+      "");
+}
+
+TEST(LoggerConfigTest, PluginRefreshTruncatesNewDebugFile) {
+  folly::test::TemporaryDirectory directory{"nccl_logger_plugin_file"};
+  const auto initialLogPath = directory.path() / "initial.log";
+  const auto pluginLogPath = directory.path() / "plugin.log";
+  {
+    std::ofstream pluginLog{pluginLogPath};
+    ASSERT_TRUE(pluginLog.is_open());
+    pluginLog << "previous destination content must be truncated\n";
+  }
+
+  const ScopedEnvironmentVariable debug{"NCCL_DEBUG", "INFO"};
+  const ScopedEnvironmentVariable debugSubsys{"NCCL_DEBUG_SUBSYS", "COLL"};
+  const ScopedEnvironmentVariable debugFile{
+      "NCCL_DEBUG_FILE", initialLogPath.string()};
+  const ScopedEnvironmentVariable asyncLogging{"NCCL_DEBUG_LOGGING_ASYNC", "0"};
+  const ScopedEnvironmentVariable configFile{"NCCL_CONF_FILE", std::nullopt};
+
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_EXIT(
+      ([&]() {
+        initEnv();
+        INFO(NCCL_COLL, "%s", "native record before plugin path refresh");
+        NCCLX_LOG_INFO("direct record before plugin path refresh");
+        auto& logger = meta::comms::logger::getSpdlogLogger(
+            ncclx::logging::kNcclxLoggerName);
+        logger.flush();
+
+        if (setenv("NCCL_DEBUG_FILE", pluginLogPath.c_str(), 1) != 0 ||
+            ncclEnvPluginInit() != ncclSuccess) {
+          std::_Exit(2);
+        }
+        NCCLX_LOG_INFO("direct record after plugin path refresh");
+        INFO(NCCL_COLL, "%s", "native record after plugin path refresh");
+        logger.flush();
+
+        const auto initialOutput = readFile(initialLogPath.string());
+        const auto pluginOutput = readFile(pluginLogPath.string());
+        EXPECT_NE(
+            initialOutput.find("native record before plugin path refresh"),
+            std::string::npos);
+        EXPECT_NE(
+            initialOutput.find("direct record before plugin path refresh"),
+            std::string::npos);
+        EXPECT_EQ(
+            pluginOutput.find("previous destination content must be truncated"),
+            std::string::npos);
+        EXPECT_NE(
+            pluginOutput.find("direct record after plugin path refresh"),
+            std::string::npos);
+        EXPECT_NE(
+            pluginOutput.find("native record after plugin path refresh"),
+            std::string::npos);
+        std::_Exit(::testing::Test::HasFailure() ? 3 : 0);
+      }()),
+      ::testing::ExitedWithCode(0),
+      "");
+}
+
+TEST(LoggerConfigTest, PluginInitializationRefreshesNativeAndSpdlogGates) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  folly::test::TemporaryDirectory directory{"nccl_plugin_logger_config"};
+  const auto capturedStdoutPath = directory.path() / "stdout.log";
+  EXPECT_EXIT(
+      {
+        if (std::freopen(capturedStdoutPath.c_str(), "w", stdout) == nullptr) {
+          std::_Exit(2);
+        }
+        if (setenv("NCCL_DEBUG", "WARN", 1) != 0 ||
+            setenv("NCCL_DEBUG_SUBSYS", "INIT", 1) != 0 ||
+            setenv("NCCL_DEBUG_LOGGING_ASYNC", "0", 1) != 0 ||
+            unsetenv("NCCL_DEBUG_FILE") != 0 ||
+            unsetenv("NCCL_CONF_FILE") != 0) {
+          std::_Exit(2);
+        }
+        initEnv();
+
+        INFO(NCCL_COLL, "suppressed before plugin initialization");
+        if (setenv("NCCL_DEBUG", "INFO", 1) != 0 ||
+            setenv("NCCL_DEBUG_SUBSYS", "COLL", 1) != 0 ||
+            ncclEnvPluginInit() != ncclSuccess) {
+          std::_Exit(3);
+        }
+
+        INFO(NCCL_COLL, "native and spdlog gates refreshed together");
+        std::fflush(stdout);
+        const auto output = readFile(capturedStdoutPath.string());
+        EXPECT_NE(
+            output.find("native and spdlog gates refreshed together"),
+            std::string::npos);
+        EXPECT_EQ(
+            output.find("suppressed before plugin initialization"),
+            std::string::npos);
+        std::_Exit(::testing::Test::HasFailure() ? 4 : 0);
+      },
+      ::testing::ExitedWithCode(0),
+      "");
+}
+
+TEST(LoggerConfigTest, InvalidDebugFileFallsBackToStdout) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  folly::test::TemporaryDirectory directory{"nccl_invalid_log_path"};
+  const auto parentFile = directory.path() / "not_a_directory";
+  const auto capturedStdoutPath = directory.path() / "stdout.log";
+  ASSERT_TRUE(std::ofstream{parentFile}.is_open());
+  const auto invalidLogPath = parentFile / "nccl.log";
+  const ScopedEnvironmentVariable debug{"NCCL_DEBUG", "WARN"};
+  const ScopedEnvironmentVariable debugSubsys{"NCCL_DEBUG_SUBSYS", "INIT"};
+  const ScopedEnvironmentVariable debugFile{
+      "NCCL_DEBUG_FILE", invalidLogPath.string()};
+  const ScopedEnvironmentVariable asyncLogging{"NCCL_DEBUG_LOGGING_ASYNC", "0"};
+  const ScopedEnvironmentVariable configFile{"NCCL_CONF_FILE", std::nullopt};
+
+  EXPECT_EXIT(
+      {
+        if (std::freopen(capturedStdoutPath.c_str(), "w", stdout) == nullptr) {
+          std::_Exit(2);
+        }
+        initEnv();
+        EXPECT_TRUE(
+            meta::comms::logger::isEnabledSubSystemBitwise(
+                meta::comms::logger::INIT));
+        EXPECT_FALSE(
+            meta::comms::logger::isEnabledSubSystemBitwise(
+                meta::comms::logger::COLL));
+        NCCLX_LOG_WARN("invalid debug file fell back to stdout");
+        COMMS_LOG_WARN("shared logger also fell back to stdout");
+        std::fflush(stdout);
+        const auto output = readFile(capturedStdoutPath.string());
+        std::_Exit(
+            output.find("invalid debug file fell back to stdout") !=
+                        std::string::npos &&
+                    output.find("shared logger also fell back to stdout") !=
+                        std::string::npos
+                ? 0
+                : 3);
+      },
+      ::testing::ExitedWithCode(0),
+      "");
+}

--- a/comms/ncclx/v2_29/src/debug.cc
+++ b/comms/ncclx/v2_29/src/debug.cc
@@ -69,7 +69,9 @@ static ncclResult_t getHostNameForLog(char* hostname, int maxlen, const char del
 }
 
 // This function must be called with ncclDebugLock locked!
-static void ncclDebugInit() {
+static void ncclDebugInit(
+    bool configureCommsSubSystemMask = true,
+    std::string_view preserveLogFilePath = {}) {
   // FIXME[max7255]: upstream has decent code there
   bool envPluginInitialized = ncclEnvPluginInitialized();
   const char* nccl_debug;
@@ -316,7 +318,7 @@ static void ncclDebugInit() {
     }
     *dfn = '\0';
     if (debugFn[0] != '\0') {
-      FILE *file = fopen(debugFn, "w");
+      FILE *file = fopen(debugFn, preserveLogFilePath == debugFn ? "a" : "w");
       if (file != nullptr) {
         setlinebuf(file); // disable block buffering
         ncclDebugFile = file;
@@ -325,10 +327,13 @@ static void ncclDebugInit() {
   }
 
   ncclEpoch = std::chrono::steady_clock::now();
-  ncclDebugMask = tempNcclDebugMask;
+  COMPILER_ATOMIC_STORE(
+      &ncclDebugMask, tempNcclDebugMask, std::memory_order_relaxed);
 
   // NCCLX -> Enable CTRAN subsystems logging as per NCCL_DEBUG_SUBSYS
-  meta::comms::logger::setSubSystemMask(ncclDebugMask);
+  if (configureCommsSubSystemMask) {
+    meta::comms::logger::setSubSystemMask(tempNcclDebugMask);
+  }
 
   COMPILER_ATOMIC_STORE(&ncclDebugLevel, tempNcclDebugLevel, std::memory_order_release);
 }
@@ -351,7 +356,8 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
     va_end(vargs);
   }
 
-  if (gotLevel >= 0 && (gotLevel < level || (flags & ncclDebugMask) == 0)) {
+  if (gotLevel >= 0 &&
+      (gotLevel < level || (flags & ncclDebugMaskLoad()) == 0)) {
     return;
   }
 
@@ -360,7 +366,7 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
     if (ncclDebugLevel < 0) {
       ncclDebugInit();
     }
-    if (ncclDebugLevel < level || ((flags & ncclDebugMask) == 0)) {
+    if (ncclDebugLevel < level || ((flags & ncclDebugMaskLoad()) == 0)) {
       return;
     }
   }
@@ -383,15 +389,38 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
   ncclx::logging::writeNcclLog(level, filefunc, "", line, logStr);
 }
 
+static void reconfigureDebugInit(std::string_view preserveLogFilePath) {
+  std::lock_guard<std::mutex> lock(ncclDebugMutex);
+  COMPILER_ATOMIC_STORE(&ncclDebugLevel, NCCL_DEBUG_RESET_TRIGGERED, std::memory_order_release);
+  if (ncclEnvPluginInitialized() || ncclLoggerInitialized()) {
+    ncclDebugInit(false, preserveLogFilePath);
+    initNcclLogger(false);
+  }
+}
+
+void ncclRefreshDebugInitInternal() noexcept {
+  /*
+   * Plugin discovery can log before publishing the plugin. Reopen in append
+   * mode only when refreshing the active destination; a newly selected file
+   * retains native NCCL's overwrite behavior.
+   */
+  try {
+    reconfigureDebugInit(
+        meta::comms::logger::getSpdlogLogger(
+            ncclx::logging::kNcclxLoggerName)
+            .outputPath());
+  } catch (...) {
+    meta::comms::logger::reportCommsLoggingFailureToStderr("ERROR");
+  }
+}
+
 // Non-deprecated version for internal use.
 extern "C"
 __attribute__ ((visibility("default")))
 void ncclResetDebugInitInternal() {
   // Cleans up from a previous ncclDebugInit() and reruns.
   // Use this after changing NCCL_DEBUG and related parameters in the environment.
-  std::lock_guard<std::mutex> lock(ncclDebugMutex);
-  // Let ncclDebugInit() know to complete the reset.
-  COMPILER_ATOMIC_STORE(&ncclDebugLevel, NCCL_DEBUG_RESET_TRIGGERED, std::memory_order_release);
+  reconfigureDebugInit({});
 }
 
 // In place of: NCCL_API(void, ncclResetDebugInit);
@@ -474,7 +503,8 @@ void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *
     va_end(vargs);
   }
 
-  if (gotLevel >= 0 && (gotLevel < level || (flags & ncclDebugMask) == 0)) {
+  if (gotLevel >= 0 &&
+      (gotLevel < level || (flags & ncclDebugMaskLoad()) == 0)) {
     return;
   }
 
@@ -483,7 +513,7 @@ void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *
     if (ncclDebugLevel < 0) {
       ncclDebugInit();
     }
-    if (ncclDebugLevel < level || ((flags & ncclDebugMask) == 0)) {
+    if (ncclDebugLevel < level || ((flags & ncclDebugMaskLoad()) == 0)) {
       return;
     }
   }

--- a/comms/ncclx/v2_29/src/include/debug.h
+++ b/comms/ncclx/v2_29/src/include/debug.h
@@ -21,6 +21,10 @@ extern int ncclDebugLevel;
 extern uint64_t ncclDebugMask;
 extern FILE *ncclDebugFile;
 
+static inline uint64_t ncclDebugMaskLoad() {
+  return COMPILER_ATOMIC_LOAD(&ncclDebugMask, std::memory_order_relaxed);
+}
+
 void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *filefunc, int line, const char *fmt, ...) __attribute__ ((format (printf, 5, 6)));
 
 void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file, const char *func, int line, const char *fmt, ...) __attribute__ ((format (printf, 6, 7)));
@@ -50,14 +54,14 @@ extern char ncclLastError[];
 #define INFO(FLAGS, ...) \
     do{ \
         int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
-        if((level >= NCCL_LOG_INFO && ((unsigned long)(FLAGS) & ncclDebugMask)) || (level < 0)) \
+        if((level >= NCCL_LOG_INFO && ((unsigned long)(FLAGS) & ncclDebugMaskLoad())) || (level < 0)) \
             ncclMetaDebugLog(NCCL_LOG_INFO, (unsigned long)(FLAGS), __FILE__, __func__, __LINE__, __VA_ARGS__); \
     } while(0)
 
 #define TRACE_CALL(...) \
     do { \
         int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
-        if((level >= NCCL_LOG_TRACE && (NCCL_CALL & ncclDebugMask)) || (level < 0)) { \
+        if((level >= NCCL_LOG_TRACE && (NCCL_CALL & ncclDebugMaskLoad())) || (level < 0)) { \
             ncclMetaDebugLog(NCCL_LOG_TRACE, NCCL_CALL, __FILE__, __func__, __LINE__, __VA_ARGS__); \
         } \
     } while (0)
@@ -66,7 +70,7 @@ extern char ncclLastError[];
 #define TRACE(FLAGS, ...) \
     do { \
         int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
-        if ((level >= NCCL_LOG_TRACE && ((unsigned long)(FLAGS) & ncclDebugMask)) || (level < 0)) { \
+        if ((level >= NCCL_LOG_TRACE && ((unsigned long)(FLAGS) & ncclDebugMaskLoad())) || (level < 0)) { \
             ncclMetaDebugLog(NCCL_LOG_TRACE, (unsigned long)(FLAGS), __FILE__, __func__, __LINE__, __VA_ARGS__); \
         } \
     } while (0)
@@ -77,6 +81,8 @@ extern char ncclLastError[];
 void ncclSetThreadName(std::thread& thread, const char *fmt, ...);
 
 void ncclResetDebugInit();
+extern "C" void ncclResetDebugInitInternal();
+void ncclRefreshDebugInitInternal() noexcept;
 
 void ncclSetMyThreadLoggingName(std::string_view name);
 

--- a/comms/ncclx/v2_29/src/include/param.h
+++ b/comms/ncclx/v2_29/src/include/param.h
@@ -31,6 +31,7 @@ int64_t ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, i
     return cache; \
   }
 
-void initNcclLogger();
+void initNcclLogger(bool configureCommsLogger = true) noexcept;
+bool ncclLoggerInitialized() noexcept;
 
 #endif

--- a/comms/ncclx/v2_29/src/misc/param.cc
+++ b/comms/ncclx/v2_29/src/misc/param.cc
@@ -10,6 +10,7 @@
 #include "env.h"
 
 #include <algorithm>
+#include <atomic>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -154,31 +155,76 @@ int64_t ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, i
 }
 
 const char* ncclGetEnv(const char* name) {
-  ncclInitEnv();
+  /*
+   * The plugin is published only after its initialization callback succeeds.
+   * Query it directly once published so logger reset during ncclInitEnv() does
+   * not recursively enter the active call_once.
+   */
+  if (!ncclEnvPluginInitialized()) {
+    ncclInitEnv();
+  }
   return ncclEnvPluginGetEnv(name);
 }
 
-void initNcclLogger() {
-  meta::comms::logger::initCommLoggerRuntime();
-  const auto logFilePath =
-      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str());
-  const auto threadContextFn = []() {
-    int cudaDev = -1;
-    (void)cudaGetDevice(&cudaDev);
-    return cudaDev;
-  };
-  const auto errorCallback = [](std::string_view message) {
-    meta::comms::logger::setLastError(std::string{message}, {});
-  };
-  const auto logLevel = meta::comms::logger::loggerLevelToSpdlogLevel(
-      meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG));
+static const char* getNcclLoggerEnv(const char* name) {
+  return ncclEnvPluginInitialized() ? ncclEnvPluginGetEnv(name)
+                                    : std::getenv(name);
+}
 
-  meta::comms::logger::configureCommsAndNamedSpdlogLoggers(
-      ncclx::logging::kNcclxLoggerName,
-      "NCCL",
-      logFilePath,
-      threadContextFn,
-      errorCallback,
-      NCCL_DEBUG_LOGGING_ASYNC,
-      logLevel);
+static std::atomic<bool> ncclLoggerIsInitialized{false};
+
+bool ncclLoggerInitialized() noexcept {
+  return ncclLoggerIsInitialized.load(std::memory_order_acquire);
+}
+
+void initNcclLogger(bool configureCommsLogger) noexcept {
+  try {
+    meta::comms::logger::initCommLoggerRuntime();
+    const auto subSystemMask = meta::comms::logger::parseDebugSubsysMask(
+        getNcclLoggerEnv("NCCL_DEBUG_SUBSYS"));
+    const auto logFilePath = meta::comms::logger::parseDebugFile(
+        getNcclLoggerEnv("NCCL_DEBUG_FILE"));
+    const auto threadContextFn = []() {
+      int cudaDev = -1;
+      (void)cudaGetDevice(&cudaDev);
+      return cudaDev;
+    };
+    const auto errorCallback = [](std::string_view message) {
+      meta::comms::logger::setLastError(std::string{message}, {});
+    };
+    const auto* debugLevelValue = getNcclLoggerEnv("NCCL_DEBUG");
+    const auto logLevel = meta::comms::logger::loggerLevelToSpdlogLevel(
+        meta::comms::logger::getNcclLoggerDebugLevel(
+            debugLevelValue == nullptr ? std::string_view{}
+                                       : std::string_view{debugLevelValue}));
+    const auto asyncLogging = meta::comms::logger::parseDebugLoggingAsync(
+        getNcclLoggerEnv("NCCL_DEBUG_LOGGING_ASYNC"),
+        NCCL_DEBUG_LOGGING_ASYNC);
+
+    const auto configureLoggers = [&](std::string_view outputPath) {
+      meta::comms::logger::configureCommsAndNamedSpdlogLoggers(
+          ncclx::logging::kNcclxLoggerName,
+          "NCCL",
+          outputPath,
+          threadContextFn,
+          errorCallback,
+          asyncLogging,
+          logLevel,
+          configureCommsLogger);
+    };
+    try {
+      configureLoggers(logFilePath);
+    } catch (const spdlog::spdlog_ex&) {
+      /*
+       * Keep the shared and NCCLX loggers on one destination. If either file
+       * backend cannot be created, retry both on stdout rather than leaving a
+       * partially configured split route.
+       */
+      configureLoggers({});
+    }
+    meta::comms::logger::setSubSystemMask(subSystemMask);
+    ncclLoggerIsInitialized.store(true, std::memory_order_release);
+  } catch (...) {
+    meta::comms::logger::reportCommsLoggingFailureToStderr("ERROR");
+  }
 }

--- a/comms/ncclx/v2_29/src/plugin/env.cc
+++ b/comms/ncclx/v2_29/src/plugin/env.cc
@@ -93,6 +93,7 @@ ncclResult_t ncclEnvPluginInit(void) {
   NCCLCHECK(ncclEnvPlugin->init(NCCL_MAJOR, NCCL_MINOR, NCCL_PATCH, NCCL_SUFFIX));
   atexit(ncclEnvPluginFinalize);
   COMPILER_ATOMIC_STORE(&initialized, true, std::memory_order_release);
+  ncclRefreshDebugInitInternal();
   return ncclSuccess;
 }
 

--- a/comms/ncclx/v2_30/src/debug.cc
+++ b/comms/ncclx/v2_30/src/debug.cc
@@ -66,7 +66,9 @@ static ncclResult_t getHostNameForLog(char* hostname, int maxlen, const char del
 }
 
 // This function must be called with ncclDebugLock locked!
-static void ncclDebugInit() {
+static void ncclDebugInit(
+    bool configureCommsSubSystemMask = true,
+    std::string_view preserveLogFilePath = {}) {
   // FIXME[max7255]: upstream has decent code there
   bool envPluginInitialized = ncclEnvPluginInitialized();
   const char* nccl_debug;
@@ -315,7 +317,7 @@ static void ncclDebugInit() {
     }
     *dfn = '\0';
     if (debugFn[0] != '\0') {
-      FILE *file = fopen(debugFn, "w");
+      FILE *file = fopen(debugFn, preserveLogFilePath == debugFn ? "a" : "w");
       if (file != nullptr) {
 #if defined(NCCL_OS_LINUX)
         setlinebuf(file); // disable block buffering
@@ -328,10 +330,13 @@ static void ncclDebugInit() {
   }
 
   ncclEpoch = std::chrono::steady_clock::now();
-  ncclDebugMask = tempNcclDebugMask;
+  COMPILER_ATOMIC_STORE(
+      &ncclDebugMask, tempNcclDebugMask, std::memory_order_relaxed);
 
   // NCCLX -> Enable CTRAN subsystems logging as per NCCL_DEBUG_SUBSYS
-  meta::comms::logger::setSubSystemMask(ncclDebugMask);
+  if (configureCommsSubSystemMask) {
+    meta::comms::logger::setSubSystemMask(tempNcclDebugMask);
+  }
 
   COMPILER_ATOMIC_STORE(&ncclDebugLevel, tempNcclDebugLevel, std::memory_order_release);
 }
@@ -354,7 +359,8 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
     va_end(vargs);
   }
 
-  if (gotLevel >= 0 && (gotLevel < level || (flags & ncclDebugMask) == 0)) {
+  if (gotLevel >= 0 &&
+      (gotLevel < level || (flags & ncclDebugMaskLoad()) == 0)) {
     return;
   }
 
@@ -363,7 +369,7 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
     if (ncclDebugLevel < 0) {
       ncclDebugInit();
     }
-    if (ncclDebugLevel < level || ((flags & ncclDebugMask) == 0)) {
+    if (ncclDebugLevel < level || ((flags & ncclDebugMaskLoad()) == 0)) {
       return;
     }
   }
@@ -386,6 +392,31 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
   ncclx::logging::writeNcclLog(level, filefunc, "", line, logStr);
 }
 
+static void reconfigureDebugInit(std::string_view preserveLogFilePath) {
+  std::lock_guard<std::mutex> lock(ncclDebugMutex);
+  COMPILER_ATOMIC_STORE(&ncclDebugLevel, static_cast<int>(NCCL_DEBUG_RESET_TRIGGERED), std::memory_order_release);
+  if (ncclEnvPluginInitialized() || ncclLoggerInitialized()) {
+    ncclDebugInit(false, preserveLogFilePath);
+    initNcclLogger(false);
+  }
+}
+
+void ncclRefreshDebugInitInternal() noexcept {
+  /*
+   * Plugin discovery can log before publishing the plugin. Reopen in append
+   * mode only when refreshing the active destination; a newly selected file
+   * retains native NCCL's overwrite behavior.
+   */
+  try {
+    reconfigureDebugInit(
+        meta::comms::logger::getSpdlogLogger(
+            ncclx::logging::kNcclxLoggerName)
+            .outputPath());
+  } catch (...) {
+    meta::comms::logger::reportCommsLoggingFailureToStderr("ERROR");
+  }
+}
+
 // Non-deprecated version for internal use.
 extern "C"
 #if !defined(NCCL_OS_WINDOWS)
@@ -394,9 +425,7 @@ __attribute__ ((visibility("default")))
 void ncclResetDebugInitInternal() {
   // Cleans up from a previous ncclDebugInit() and reruns.
   // Use this after changing NCCL_DEBUG and related parameters in the environment.
-  std::lock_guard<std::mutex> lock(ncclDebugMutex);
-  // Let ncclDebugInit() know to complete the reset.
-  COMPILER_ATOMIC_STORE(&ncclDebugLevel, static_cast<int>(NCCL_DEBUG_RESET_TRIGGERED), std::memory_order_release);
+  reconfigureDebugInit({});
 }
 
 // In place of: NCCL_API(void, ncclResetDebugInit);
@@ -463,7 +492,8 @@ void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *
     va_end(vargs);
   }
 
-  if (gotLevel >= 0 && (gotLevel < level || (flags & ncclDebugMask) == 0)) {
+  if (gotLevel >= 0 &&
+      (gotLevel < level || (flags & ncclDebugMaskLoad()) == 0)) {
     return;
   }
 
@@ -472,7 +502,7 @@ void ncclMetaDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *
     if (ncclDebugLevel < 0) {
       ncclDebugInit();
     }
-    if (ncclDebugLevel < level || ((flags & ncclDebugMask) == 0)) {
+    if (ncclDebugLevel < level || ((flags & ncclDebugMaskLoad()) == 0)) {
       return;
     }
   }

--- a/comms/ncclx/v2_30/src/include/debug.h
+++ b/comms/ncclx/v2_30/src/include/debug.h
@@ -21,6 +21,10 @@ extern int ncclDebugLevel;
 extern uint64_t ncclDebugMask;
 extern FILE *ncclDebugFile;
 
+static inline uint64_t ncclDebugMaskLoad() {
+  return COMPILER_ATOMIC_LOAD(&ncclDebugMask, std::memory_order_relaxed);
+}
+
 #ifdef NCCL_OS_LINUX
 void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *filefunc, int line, const char *fmt, ...) __attribute__ ((format (printf, 5, 6)));
 #elif defined(NCCL_OS_WINDOWS)
@@ -53,14 +57,14 @@ extern char ncclLastError[];
 #define INFO(FLAGS, ...) \
     do{ \
         int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
-        if((level >= NCCL_LOG_INFO && ((unsigned long)(FLAGS) & ncclDebugMask)) || (level < 0)) \
+        if((level >= NCCL_LOG_INFO && ((unsigned long)(FLAGS) & ncclDebugMaskLoad())) || (level < 0)) \
             ncclMetaDebugLog(NCCL_LOG_INFO, (unsigned long)(FLAGS), __FILE__, __func__, __LINE__, __VA_ARGS__); \
     } while(0)
 
 #define TRACE_CALL(...) \
     do { \
         int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
-        if((level >= NCCL_LOG_TRACE && (NCCL_CALL & ncclDebugMask)) || (level < 0)) { \
+        if((level >= NCCL_LOG_TRACE && (NCCL_CALL & ncclDebugMaskLoad())) || (level < 0)) { \
             ncclMetaDebugLog(NCCL_LOG_TRACE, NCCL_CALL, __FILE__, __func__, __LINE__, __VA_ARGS__); \
         } \
     } while (0)
@@ -69,7 +73,7 @@ extern char ncclLastError[];
 #define TRACE(FLAGS, ...) \
     do { \
         int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
-        if ((level >= NCCL_LOG_TRACE && ((unsigned long)(FLAGS) & ncclDebugMask)) || (level < 0)) { \
+        if ((level >= NCCL_LOG_TRACE && ((unsigned long)(FLAGS) & ncclDebugMaskLoad())) || (level < 0)) { \
             ncclMetaDebugLog(NCCL_LOG_TRACE, (unsigned long)(FLAGS), __FILE__, __func__, __LINE__, __VA_ARGS__); \
         } \
     } while (0)
@@ -85,9 +89,11 @@ extern "C" {
 #undef ncclResetDebugInit
 #endif
 void ncclResetDebugInit();
+void ncclResetDebugInitInternal();
 #ifdef __cplusplus
 }
 #endif
+void ncclRefreshDebugInitInternal() noexcept;
 
 void ncclSetMyThreadLoggingName(std::string_view name);
 

--- a/comms/ncclx/v2_30/src/include/param.h
+++ b/comms/ncclx/v2_30/src/include/param.h
@@ -31,6 +31,7 @@ int64_t ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, i
     return cache; \
   }
 
-void initNcclLogger();
+void initNcclLogger(bool configureCommsLogger = true) noexcept;
+bool ncclLoggerInitialized() noexcept;
 
 #endif

--- a/comms/ncclx/v2_30/src/misc/param.cc
+++ b/comms/ncclx/v2_30/src/misc/param.cc
@@ -11,6 +11,7 @@
 #include "env.h"
 
 #include <algorithm>
+#include <atomic>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -117,31 +118,76 @@ int64_t ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, i
 }
 
 const char* ncclGetEnv(const char* name) {
-  ncclInitEnv();
+  /*
+   * The plugin is published only after its initialization callback succeeds.
+   * Query it directly once published so logger reset during ncclInitEnv() does
+   * not recursively enter the active call_once.
+   */
+  if (!ncclEnvPluginInitialized()) {
+    ncclInitEnv();
+  }
   return ncclEnvPluginGetEnv(name);
 }
 
-void initNcclLogger() {
-  meta::comms::logger::initCommLoggerRuntime();
-  const auto logFilePath =
-      meta::comms::logger::parseDebugFile(NCCL_DEBUG_FILE.c_str());
-  const auto threadContextFn = []() {
-    int cudaDev = -1;
-    (void)cudaGetDevice(&cudaDev);
-    return cudaDev;
-  };
-  const auto errorCallback = [](std::string_view message) {
-    meta::comms::logger::setLastError(std::string{message}, {});
-  };
-  const auto logLevel = meta::comms::logger::loggerLevelToSpdlogLevel(
-      meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG));
+static const char* getNcclLoggerEnv(const char* name) {
+  return ncclEnvPluginInitialized() ? ncclEnvPluginGetEnv(name)
+                                    : std::getenv(name);
+}
 
-  meta::comms::logger::configureCommsAndNamedSpdlogLoggers(
-      ncclx::logging::kNcclxLoggerName,
-      "NCCL",
-      logFilePath,
-      threadContextFn,
-      errorCallback,
-      NCCL_DEBUG_LOGGING_ASYNC,
-      logLevel);
+static std::atomic<bool> ncclLoggerIsInitialized{false};
+
+bool ncclLoggerInitialized() noexcept {
+  return ncclLoggerIsInitialized.load(std::memory_order_acquire);
+}
+
+void initNcclLogger(bool configureCommsLogger) noexcept {
+  try {
+    meta::comms::logger::initCommLoggerRuntime();
+    const auto subSystemMask = meta::comms::logger::parseDebugSubsysMask(
+        getNcclLoggerEnv("NCCL_DEBUG_SUBSYS"));
+    const auto logFilePath = meta::comms::logger::parseDebugFile(
+        getNcclLoggerEnv("NCCL_DEBUG_FILE"));
+    const auto threadContextFn = []() {
+      int cudaDev = -1;
+      (void)cudaGetDevice(&cudaDev);
+      return cudaDev;
+    };
+    const auto errorCallback = [](std::string_view message) {
+      meta::comms::logger::setLastError(std::string{message}, {});
+    };
+    const auto* debugLevelValue = getNcclLoggerEnv("NCCL_DEBUG");
+    const auto logLevel = meta::comms::logger::loggerLevelToSpdlogLevel(
+        meta::comms::logger::getNcclLoggerDebugLevel(
+            debugLevelValue == nullptr ? std::string_view{}
+                                       : std::string_view{debugLevelValue}));
+    const auto asyncLogging = meta::comms::logger::parseDebugLoggingAsync(
+        getNcclLoggerEnv("NCCL_DEBUG_LOGGING_ASYNC"),
+        NCCL_DEBUG_LOGGING_ASYNC);
+
+    const auto configureLoggers = [&](std::string_view outputPath) {
+      meta::comms::logger::configureCommsAndNamedSpdlogLoggers(
+          ncclx::logging::kNcclxLoggerName,
+          "NCCL",
+          outputPath,
+          threadContextFn,
+          errorCallback,
+          asyncLogging,
+          logLevel,
+          configureCommsLogger);
+    };
+    try {
+      configureLoggers(logFilePath);
+    } catch (const spdlog::spdlog_ex&) {
+      /*
+       * Keep the shared and NCCLX loggers on one destination. If either file
+       * backend cannot be created, retry both on stdout rather than leaving a
+       * partially configured split route.
+       */
+      configureLoggers({});
+    }
+    meta::comms::logger::setSubSystemMask(subSystemMask);
+    ncclLoggerIsInitialized.store(true, std::memory_order_release);
+  } catch (...) {
+    meta::comms::logger::reportCommsLoggingFailureToStderr("ERROR");
+  }
 }

--- a/comms/ncclx/v2_30/src/plugin/env.cc
+++ b/comms/ncclx/v2_30/src/plugin/env.cc
@@ -93,6 +93,7 @@ ncclResult_t ncclEnvPluginInit(void) {
   NCCLCHECK(ncclEnvPlugin->init(NCCL_MAJOR, NCCL_MINOR, NCCL_PATCH, NCCL_SUFFIX));
   atexit(ncclEnvPluginFinalize);
   COMPILER_ATOMIC_STORE(&initialized, true, std::memory_order_release);
+  ncclRefreshDebugInitInternal();
   return ncclSuccess;
 }
 

--- a/comms/torchcomms/ncclx/tests/integration/cpp/CommDumpTest.cpp
+++ b/comms/torchcomms/ncclx/tests/integration/cpp/CommDumpTest.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "CommDumpTest.hpp"
-#include <folly/logging/xlog.h>
 
 void CommDumpTest::SetUp() {
   wrapper_ = std::make_unique<TorchCommTestWrapper>();

--- a/comms/torchcomms/ncclx/tests/integration/cpp/CommDumpTestMain.cpp
+++ b/comms/torchcomms/ncclx/tests/integration/cpp/CommDumpTestMain.cpp
@@ -1,13 +1,29 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <iostream>
+#include <utility>
+
+#include <fmt/format.h>
 #include <folly/json/dynamic.h>
 #include <folly/json/json.h>
-#include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
 #include "comms/torchcomms/ncclx/NcclxGlobalApi.hpp"
 #include "comms/torchcomms/ncclx/tests/integration/cpp/CommDumpTest.hpp"
 
-#define LOG_TEST(msg) XLOG(INFO) << "[Rank " << rank_ << "] " << msg
+namespace {
+
+template <typename... Args>
+void logTest(int rank, fmt::format_string<Args...> format, Args&&... args) {
+  std::cout << fmt::format(
+                   "[Rank {}] {}\n",
+                   rank,
+                   fmt::format(format, std::forward<Args>(args)...))
+            << std::flush;
+}
+
+} // namespace
+
+#define LOG_TEST(...) logTest(rank_, __VA_ARGS__)
 
 TEST_F(CommDumpTest, BasicCommDump) {
   LOG_TEST("Starting BasicCommDump test");
@@ -33,9 +49,9 @@ TEST_F(CommDumpTest, BasicCommDump) {
   }
 
   if (rank_ == 0) {
-    LOG_TEST("comm_dump() returned " << dump.size() << " entries");
+    LOG_TEST("comm_dump() returned {} entries", dump.size());
     for (const auto& [key, val] : dump) {
-      LOG_TEST("  " << key << ": " << val);
+      LOG_TEST("  {}: {}", key, val);
     }
   }
 
@@ -62,7 +78,7 @@ TEST_F(CommDumpTest, CommDumpAfterCollective) {
     auto pastColls = folly::parseJson(dump["CT_pastColls"]);
     EXPECT_GT(pastColls.size(), 0)
         << "CT_pastColls should be non-empty after all_reduce";
-    LOG_TEST("CT_pastColls has " << pastColls.size() << " entries");
+    LOG_TEST("CT_pastColls has {} entries", pastColls.size());
   }
 
   LOG_TEST("CommDumpAfterCollective test passed");
@@ -92,10 +108,9 @@ TEST_F(CommDumpTest, CommDumpAll) {
   }
 
   if (rank_ == 0) {
-    LOG_TEST(
-        "comm_dump_all() returned " << all_dumps.size() << " communicators");
+    LOG_TEST("comm_dump_all() returned {} communicators", all_dumps.size());
     for (const auto& [comm_key, dump] : all_dumps) {
-      LOG_TEST("  Comm " << comm_key << ": " << dump.size() << " entries");
+      LOG_TEST("  Comm {}: {} entries", comm_key, dump.size());
     }
   }
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3013,7 +3013,7 @@ cvars:
    type        : bool
    default     : true
    description : |-
-     Controls if the folly logging should be async or not.
+     Controls whether comms logging uses asynchronous delivery.
 
  - name        : NCCL_NETWORK_PERF_MONITOR_SCUBA_LOGGING_ENABLE
    type        : bool

--- a/comms/utils/logger/LogTypes.h
+++ b/comms/utils/logger/LogTypes.h
@@ -37,6 +37,7 @@ enum SubSystem {
   REG = 0x2000,
   PROFILE = 0x4000,
   RAS = 0x8000,
+  DESTROY = 0x10000,
   ALL = ~0
 };
 #pragma pop_macro("INIT")

--- a/comms/utils/logger/LoggingFormat.cc
+++ b/comms/utils/logger/LoggingFormat.cc
@@ -95,7 +95,7 @@ uint64_t getSubSystemMaskForName(std::string_view name) {
     std::string_view name;
     uint64_t mask;
   };
-  static constexpr std::array<NamedMask, 17> kNamedMasks{{
+  static constexpr std::array<NamedMask, 18> kNamedMasks{{
       {"INIT", meta::comms::logger::INIT},
       {"COLL", meta::comms::logger::COLL},
       {"P2P", meta::comms::logger::P2P},
@@ -112,6 +112,7 @@ uint64_t getSubSystemMaskForName(std::string_view name) {
       {"REG", meta::comms::logger::REG},
       {"PROFILE", meta::comms::logger::PROFILE},
       {"RAS", meta::comms::logger::RAS},
+      {"DESTROY", meta::comms::logger::DESTROY},
       {"ALL", static_cast<uint64_t>(meta::comms::logger::ALL)},
   }};
   for (const auto& namedMask : kNamedMasks) {
@@ -171,6 +172,9 @@ folly::StringPiece getCategoryNthParent(folly::StringPiece category, int n) {
  * or ^INIT,COLL etc
  */
 uint64_t parseDebugSubsysMask(const char* ncclDebugSubsysEnv) {
+  if (ncclDebugSubsysEnv == nullptr) {
+    return INIT | BOOTSTRAP | ENV;
+  }
   std::string_view input{ncclDebugSubsysEnv};
   const bool invert = !input.empty() && input.front() == '^';
   if (invert) {
@@ -197,6 +201,9 @@ uint64_t parseDebugSubsysMask(const char* ncclDebugSubsysEnv) {
 }
 
 std::string parseDebugFile(const char* ncclDebugFileEnv) {
+  if (ncclDebugFileEnv == nullptr) {
+    return {};
+  }
   initProcMetaData();
 
   int c = 0;
@@ -262,6 +269,45 @@ LogLevel getLoggerDebugLevel(std::string_view level) {
   }
   // TODO: Add a warning here
   return LogLevel::NONE;
+}
+
+LogLevel getNcclLoggerDebugLevel(std::string_view level) {
+  if (asciiCaseInsensitiveEqual(level, "VERSION")) {
+    return LogLevel::VERSION;
+  } else if (asciiCaseInsensitiveEqual(level, "ERROR")) {
+    return LogLevel::ERROR;
+  } else if (asciiCaseInsensitiveEqual(level, "WARN")) {
+    return LogLevel::WARN;
+  } else if (asciiCaseInsensitiveEqual(level, "INFO")) {
+    return LogLevel::INFO;
+  } else if (asciiCaseInsensitiveEqual(level, "ABORT")) {
+    return LogLevel::ABORT;
+  } else if (asciiCaseInsensitiveEqual(level, "TRACE")) {
+    return LogLevel::TRACE;
+  }
+  return LogLevel::NONE;
+}
+
+bool parseDebugLoggingAsync(const char* value, bool valueWhenUnset) {
+  if (value == nullptr) {
+    return valueWhenUnset;
+  }
+  const std::string_view input{value};
+  if (asciiCaseInsensitiveEqual(input, "1") ||
+      asciiCaseInsensitiveEqual(input, "Y") ||
+      asciiCaseInsensitiveEqual(input, "YES") ||
+      asciiCaseInsensitiveEqual(input, "T") ||
+      asciiCaseInsensitiveEqual(input, "TRUE")) {
+    return true;
+  }
+  if (asciiCaseInsensitiveEqual(input, "0") ||
+      asciiCaseInsensitiveEqual(input, "N") ||
+      asciiCaseInsensitiveEqual(input, "NO") ||
+      asciiCaseInsensitiveEqual(input, "F") ||
+      asciiCaseInsensitiveEqual(input, "FALSE")) {
+    return false;
+  }
+  return true;
 }
 
 void initProcMetaData() {

--- a/comms/utils/logger/LoggingFormat.h
+++ b/comms/utils/logger/LoggingFormat.h
@@ -28,6 +28,13 @@ uint64_t parseDebugSubsysMask(const char* ncclDebugSubsysEnv);
 std::string parseDebugFile(const char* ncclDebugFileEnv);
 
 LogLevel getLoggerDebugLevel(std::string_view levelStr);
+LogLevel getNcclLoggerDebugLevel(std::string_view levelStr);
+
+/*
+ * The fallback applies only when value is absent. Any present value other
+ * than a recognized false token enables logging, matching NCCL cvar parsing.
+ */
+bool parseDebugLoggingAsync(const char* value, bool valueWhenUnset);
 
 void initProcMetaData();
 

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -367,22 +367,35 @@ std::mutex& getCommsLoggingShutdownMutex() {
   return *mutex;
 }
 
-std::shared_ptr<spdlog::logger> createLogger(std::string name) {
-  auto threadPoolLease = getCommsThreadPoolState().acquire();
-  auto sink = std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
-  std::shared_ptr<spdlog::logger> logger;
-  if (threadPoolLease) {
-    logger = std::make_shared<spdlog::async_logger>(
-        std::move(name),
-        std::move(sink),
-        threadPoolLease.threadPool(),
-        spdlog::async_overflow_policy::overrun_oldest);
+std::shared_ptr<spdlog::sinks::dist_sink_mt> createOutputSink(
+    std::string_view logFilePath) {
+  std::vector<std::shared_ptr<spdlog::sinks::sink>> sinks;
+  if (logFilePath.empty()) {
+    sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
   } else {
-    // A logger first referenced during exit cannot use the stopped async pool.
-    logger = std::make_shared<spdlog::logger>(std::move(name), std::move(sink));
+    const auto path = std::string{logFilePath};
+    std::shared_ptr<spdlog::sinks::sink> fileSink;
+    try {
+      fileSink =
+          std::make_shared<spdlog::sinks::basic_file_sink_mt>(path, false);
+    } catch (const spdlog::spdlog_ex& error) {
+      throw spdlog::spdlog_ex(
+          "Failed to open comms log file '" + path + "': " + error.what());
+    }
+    sinks.push_back(std::move(fileSink));
+    sinks.push_back(std::make_shared<StderrRoutingSink>());
   }
-  logger->set_formatter(makeFormatter());
-  return logger;
+  for (auto& sink : sinks) {
+    sink->set_formatter(makeFormatter());
+  }
+  return std::make_shared<spdlog::sinks::dist_sink_mt>(std::move(sinks));
+}
+
+std::shared_ptr<spdlog::sinks::dist_sink_mt> createInitialOutputSink() {
+  auto sink = std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
+  sink->set_formatter(makeFormatter());
+  return std::make_shared<spdlog::sinks::dist_sink_mt>(
+      std::vector<std::shared_ptr<spdlog::sinks::sink>>{std::move(sink)});
 }
 
 } // namespace
@@ -494,13 +507,13 @@ CommsSpdlogLogger::CommsSpdlogLogger()
     : CommsSpdlogLogger(std::string{kCommsLoggerName}) {}
 
 CommsSpdlogLogger::CommsSpdlogLogger(std::string name)
-    : logger_(createLogger(std::move(name))) {
-  outputSink_ = std::make_shared<spdlog::sinks::dist_sink_mt>(logger_->sinks());
-  logger_->sinks() = {outputSink_};
-  synchronousLogger_ =
-      std::make_shared<spdlog::logger>(logger_->name(), outputSink_);
-  synchronousLogger_->set_level(spdlog::level::trace);
-  storeConfiguration(std::make_shared<const Configuration>());
+    : name_{std::move(name)} {
+  auto configuration = std::make_shared<const Configuration>();
+  auto backend =
+      createBackend(createInitialOutputSink(), {}, configuration->asyncLogging);
+  storeState(
+      std::make_shared<const State>(
+          State{std::move(configuration), std::move(backend)}));
 }
 
 CommsLogStreamBase::CommsLogStreamBase(
@@ -557,38 +570,39 @@ std::string_view CommsSpdlogLogger::getLevelName(
 }
 
 bool CommsSpdlogLogger::should_log(spdlog::level::level_enum level) const {
-  return logger_->should_log(level);
+  return level >= logLevel_.load(std::memory_order_relaxed);
 }
 
 const std::string& CommsSpdlogLogger::name() const {
-  return logger_->name();
+  return name_;
+}
+
+std::string CommsSpdlogLogger::outputPath() const {
+  return loadState()->backend->outputPath;
 }
 
 void CommsSpdlogLogger::set_level(spdlog::level::level_enum level) {
-  logger_->set_level(level);
-  /*
-   * logger_ applies the runtime gate before either delivery path. The
-   * synchronous logger stays at trace so it accepts enabled synchronous
-   * messages while logFatal can bypass the primary gate.
-   */
+  std::lock_guard lock{reconfigurationMutex_};
+  logLevel_.store(level, std::memory_order_release);
 }
 
 bool CommsSpdlogLogger::usesAsyncLogging() const {
-  return loadConfiguration()->asyncLogging;
+  return loadState()->configuration->asyncLogging;
 }
 
 void CommsSpdlogLogger::flush() {
+  const auto state = loadState();
   // Once the async pool is gone, spdlog reports the failed post through its
   // error handler and drops the flush, so use the synchronous path instead.
   // The lease is released before that fallback for the reason logFormatted()
   // documents: synchronous delivery must not hold a pool lease.
   bool asyncFlushed = false;
   if (const auto threadPoolLease = getCommsThreadPoolState().acquire()) {
-    logger_->flush();
+    state->backend->logger->flush();
     asyncFlushed = true;
   }
-  if (!usesAsyncLogging() || !asyncFlushed) {
-    synchronousLogger_->flush();
+  if (!state->configuration->asyncLogging || !asyncFlushed) {
+    state->backend->synchronousLogger->flush();
   }
 }
 
@@ -624,76 +638,163 @@ void CommsSpdlogLogger::configure(
   if (!threadContextFn) {
     threadContextFn = []() { return 0; };
   }
-  std::shared_ptr<const Configuration> configuration =
-      std::make_shared<const Configuration>(Configuration{
-          std::move(prefix),
-          std::move(threadContextFn),
-          std::move(errorCallback),
-          asyncLogging});
-  storeConfiguration(std::move(configuration));
+  auto configuration = std::make_shared<const Configuration>(Configuration{
+      std::move(prefix),
+      std::move(threadContextFn),
+      std::move(errorCallback),
+      asyncLogging});
 
-  /*
-   * The file sink buffers in user space and spdlog does not flush by default,
-   * so errors would otherwise reach the log file only once the buffer filled.
-   * Set unconditionally: configure() is public and may switch a logger back to
-   * synchronous, which must not inherit the previous flush level.
-   */
-  logger_->flush_on(asyncLogging ? spdlog::level::err : spdlog::level::off);
-  if (asyncLogging) {
-    if (const auto threadPoolLease = getCommsThreadPoolState().acquire()) {
-      getPeriodicSinkFlusher().registerSink(outputSink_);
-    }
-  }
+  std::lock_guard lock{reconfigurationMutex_};
+  const auto current = loadState();
+  auto backend = createBackend(
+      current->backend->outputSink, current->backend->outputPath, asyncLogging);
+  storeState(
+      std::make_shared<const State>(
+          State{std::move(configuration), std::move(backend)}));
 }
 
-std::shared_ptr<const CommsSpdlogLogger::Configuration>
-CommsSpdlogLogger::loadConfiguration() const {
+std::shared_ptr<const CommsSpdlogLogger::State> CommsSpdlogLogger::loadState()
+    const {
 #if defined(__cpp_lib_atomic_shared_ptr) && \
     __cpp_lib_atomic_shared_ptr >= 201711L
-  return configuration_.load(std::memory_order_acquire);
+  return state_.load(std::memory_order_acquire);
 #else
-  return std::atomic_load_explicit(&configuration_, std::memory_order_acquire);
+  return std::atomic_load_explicit(&state_, std::memory_order_acquire);
 #endif
 }
 
-void CommsSpdlogLogger::storeConfiguration(
-    std::shared_ptr<const Configuration> configuration) {
+void CommsSpdlogLogger::storeState(std::shared_ptr<const State> state) {
 #if defined(__cpp_lib_atomic_shared_ptr) && \
     __cpp_lib_atomic_shared_ptr >= 201711L
-  configuration_.store(std::move(configuration), std::memory_order_release);
+  state_.store(std::move(state), std::memory_order_release);
 #else
   std::atomic_store_explicit(
-      &configuration_, std::move(configuration), std::memory_order_release);
+      &state_, std::move(state), std::memory_order_release);
 #endif
+}
+
+std::shared_ptr<CommsSpdlogLogger::Backend> CommsSpdlogLogger::createBackend(
+    std::shared_ptr<spdlog::sinks::dist_sink_mt> outputSink,
+    std::string outputPath,
+    bool asyncLogging) const {
+  auto threadPoolLease = getCommsThreadPoolState().acquire();
+  std::shared_ptr<spdlog::logger> logger;
+  if (threadPoolLease) {
+    logger = std::make_shared<spdlog::async_logger>(
+        name_,
+        outputSink,
+        threadPoolLease.threadPool(),
+        spdlog::async_overflow_policy::overrun_oldest);
+  } else {
+    logger = std::make_shared<spdlog::logger>(name_, outputSink);
+  }
+  logger->set_level(spdlog::level::trace);
+  logger->flush_on(asyncLogging ? spdlog::level::err : spdlog::level::off);
+
+  auto synchronousLogger = std::make_shared<spdlog::logger>(name_, outputSink);
+  synchronousLogger->set_level(spdlog::level::trace);
+
+  if (asyncLogging && threadPoolLease) {
+    getPeriodicSinkFlusher().registerSink(outputSink);
+  }
+
+  return std::make_shared<Backend>(Backend{
+      std::move(outputPath),
+      std::move(logger),
+      std::move(outputSink),
+      std::move(synchronousLogger)});
 }
 
 void CommsSpdlogLogger::configureOutput(std::string_view logFilePath) {
-  std::vector<std::shared_ptr<spdlog::sinks::sink>> sinks;
-  if (logFilePath.empty()) {
-    sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
-  } else {
-    const auto path = std::string{logFilePath};
-    std::shared_ptr<spdlog::sinks::sink> fileSink;
-    try {
-      fileSink =
-          std::make_shared<spdlog::sinks::basic_file_sink_mt>(path, false);
-    } catch (const spdlog::spdlog_ex& error) {
-      throw spdlog::spdlog_ex(
-          "Failed to open comms log file '" + path + "': " + error.what());
-    }
-    sinks.push_back(std::move(fileSink));
-    sinks.push_back(std::make_shared<StderrRoutingSink>());
+  auto outputSink = createOutputSink(logFilePath);
+  std::lock_guard lock{reconfigurationMutex_};
+  const auto current = loadState();
+  auto backend = createBackend(
+      std::move(outputSink),
+      std::string{logFilePath},
+      current->configuration->asyncLogging);
+  storeState(
+      std::make_shared<const State>(
+          State{current->configuration, std::move(backend)}));
+}
+
+void CommsSpdlogLogger::reconfigure(
+    std::string prefix,
+    std::string_view logFilePath,
+    std::function<int(void)> threadContextFn,
+    std::function<void(std::string_view)> errorCallback,
+    bool asyncLogging) {
+  reconfigureImpl(
+      std::move(prefix),
+      logFilePath,
+      std::move(threadContextFn),
+      std::move(errorCallback),
+      asyncLogging,
+      std::nullopt);
+}
+
+void CommsSpdlogLogger::reconfigure(
+    std::string prefix,
+    std::string_view logFilePath,
+    std::function<int(void)> threadContextFn,
+    std::function<void(std::string_view)> errorCallback,
+    bool asyncLogging,
+    spdlog::level::level_enum logLevel) {
+  reconfigureImpl(
+      std::move(prefix),
+      logFilePath,
+      std::move(threadContextFn),
+      std::move(errorCallback),
+      asyncLogging,
+      logLevel);
+}
+
+void CommsSpdlogLogger::reconfigureImpl(
+    std::string prefix,
+    std::string_view logFilePath,
+    std::function<int(void)> threadContextFn,
+    std::function<void(std::string_view)> errorCallback,
+    bool asyncLogging,
+    std::optional<spdlog::level::level_enum> logLevel) {
+  if (!threadContextFn) {
+    threadContextFn = []() { return 0; };
   }
-  for (auto& sink : sinks) {
-    sink->set_formatter(makeFormatter());
+  auto configuration = std::make_shared<const Configuration>(Configuration{
+      std::move(prefix),
+      std::move(threadContextFn),
+      std::move(errorCallback),
+      asyncLogging});
+  auto outputSink = createOutputSink(logFilePath);
+  auto backend = createBackend(
+      std::move(outputSink), std::string{logFilePath}, asyncLogging);
+  auto state = std::make_shared<const State>(
+      State{std::move(configuration), std::move(backend)});
+
+  std::lock_guard lock{reconfigurationMutex_};
+  const auto previousLevel = logLevel_.load(std::memory_order_relaxed);
+  /*
+   * Keep the level separate from State so a disabled log pays only one scalar
+   * atomic load. When enabling levels, publish the new backend first so newly
+   * admitted records cannot use the old backend. When disabling levels,
+   * publish the threshold first so newly rejected records cannot reach the new
+   * backend. Release publication of an enabling threshold pairs with the
+   * acquire fence on the enabled path. A call already past should_log() may
+   * finish on either generation.
+   */
+  if (logLevel.has_value() && *logLevel > previousLevel) {
+    logLevel_.store(*logLevel, std::memory_order_relaxed);
   }
-  outputSink_->set_sinks(std::move(sinks));
+  storeState(std::move(state));
+  if (logLevel.has_value() && *logLevel < previousLevel) {
+    logLevel_.store(*logLevel, std::memory_order_release);
+  }
 }
 
 void CommsSpdlogLogger::addSinkForTesting(
     std::shared_ptr<spdlog::sinks::sink> sink) {
   sink->set_formatter(makeFormatter());
-  outputSink_->add_sink(std::move(sink));
+  std::lock_guard lock{reconfigurationMutex_};
+  loadState()->backend->outputSink->add_sink(std::move(sink));
 }
 
 void CommsSpdlogLogger::logFormatted(
@@ -706,7 +807,13 @@ void CommsSpdlogLogger::logFormatted(
   // exit-time destruction still format messages through here.
   static const auto* hostname = new std::string{getHostName()};
   static const auto processId = getpid();
-  const auto configuration = loadConfiguration();
+  /*
+   * If should_log() observed a newly enabled release-store, acquire that
+   * publication before loading State. Rejected logs never reach this fence.
+   */
+  std::atomic_thread_fence(std::memory_order_acquire);
+  const auto state = loadState();
+  const auto& configuration = state->configuration;
   if (level >= spdlog::level::err && configuration->errorCallback &&
       !errorCallbackInProgress) {
     ErrorCallbackGuard guard;
@@ -737,12 +844,12 @@ void CommsSpdlogLogger::logFormatted(
    */
   if (!bypassLevelGate && configuration->asyncLogging) {
     if (const auto threadPoolLease = getCommsThreadPoolState().acquire()) {
-      logger_->log(location, level, formatted);
+      state->backend->logger->log(location, level, formatted);
       return;
     }
   }
-  synchronousLogger_->log(location, level, formatted);
-  synchronousLogger_->flush();
+  state->backend->synchronousLogger->log(location, level, formatted);
+  state->backend->synchronousLogger->flush();
 }
 
 CommsSpdlogLogger& getSpdlogLogger() {
@@ -804,12 +911,12 @@ void configureSpdlogLogger(
     std::function<void(std::string_view)> errorCallback,
     bool asyncLogging) {
   auto& logger = getSpdlogLogger(loggerName);
-  logger.configure(
+  logger.reconfigure(
       std::move(prefix),
+      logFilePath,
       std::move(threadContextFn),
       std::move(errorCallback),
       asyncLogging);
-  logger.configureOutput(logFilePath);
 }
 
 void configureCommsAndNamedSpdlogLoggers(
@@ -822,25 +929,24 @@ void configureCommsAndNamedSpdlogLoggers(
     spdlog::level::level_enum logLevel,
     bool configureCommsLogger) {
   if (configureCommsLogger || loggerName == kCommsLoggerName) {
-    configureSpdlogLogger(
-        kCommsLoggerName,
+    getSpdlogLogger().reconfigure(
         "COMM",
         logFilePath,
         threadContextFn,
         errorCallback,
-        asyncLogging);
-    getSpdlogLogger().set_level(logLevel);
+        asyncLogging,
+        logLevel);
   }
 
   if (loggerName != kCommsLoggerName) {
-    configureSpdlogLogger(
-        loggerName,
-        std::move(logPrefix),
-        logFilePath,
-        std::move(threadContextFn),
-        std::move(errorCallback),
-        asyncLogging);
-    getSpdlogLogger(loggerName).set_level(logLevel);
+    getSpdlogLogger(loggerName)
+        .reconfigure(
+            std::move(logPrefix),
+            logFilePath,
+            std::move(threadContextFn),
+            std::move(errorCallback),
+            asyncLogging,
+            logLevel);
   }
 }
 

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -7,6 +7,8 @@
 #include <cstdlib>
 #include <functional>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -97,6 +99,7 @@ class CommsSpdlogLogger {
 
   bool should_log(spdlog::level::level_enum level) const;
   const std::string& name() const;
+  std::string outputPath() const;
   void set_level(spdlog::level::level_enum level);
   bool usesAsyncLogging() const;
   void flush();
@@ -107,6 +110,19 @@ class CommsSpdlogLogger {
       std::function<void(std::string_view)> errorCallback = {},
       bool asyncLogging = true);
   void configureOutput(std::string_view logFilePath);
+  void reconfigure(
+      std::string prefix,
+      std::string_view logFilePath,
+      std::function<int(void)> threadContextFn,
+      std::function<void(std::string_view)> errorCallback,
+      bool asyncLogging);
+  void reconfigure(
+      std::string prefix,
+      std::string_view logFilePath,
+      std::function<int(void)> threadContextFn,
+      std::function<void(std::string_view)> errorCallback,
+      bool asyncLogging,
+      spdlog::level::level_enum logLevel);
 
   // Test-only: appends to the dist sink so a test can observe delivery from
   // inside the sink call, which is the only point where the lease scoping in
@@ -121,19 +137,41 @@ class CommsSpdlogLogger {
     bool asyncLogging{true};
   };
 
+  struct Backend {
+    std::string outputPath;
+    std::shared_ptr<spdlog::logger> logger;
+    std::shared_ptr<spdlog::sinks::dist_sink_mt> outputSink;
+    std::shared_ptr<spdlog::logger> synchronousLogger;
+  };
+
+  struct State {
+    std::shared_ptr<const Configuration> configuration;
+    std::shared_ptr<Backend> backend;
+  };
+
 #if defined(__cpp_lib_atomic_shared_ptr) && \
     __cpp_lib_atomic_shared_ptr >= 201711L
-  using ConfigurationStorage =
-      std::atomic<std::shared_ptr<const Configuration>>;
+  using StateStorage = std::atomic<std::shared_ptr<const State>>;
 #else
   // NCCLX also builds this target as C++17, before atomic<shared_ptr> exists.
-  using ConfigurationStorage = std::shared_ptr<const Configuration>;
+  using StateStorage = std::shared_ptr<const State>;
 #endif
 
   static std::string_view getLevelName(spdlog::level::level_enum level);
 
-  std::shared_ptr<const Configuration> loadConfiguration() const;
-  void storeConfiguration(std::shared_ptr<const Configuration> configuration);
+  std::shared_ptr<const State> loadState() const;
+  void storeState(std::shared_ptr<const State> state);
+  std::shared_ptr<Backend> createBackend(
+      std::shared_ptr<spdlog::sinks::dist_sink_mt> outputSink,
+      std::string outputPath,
+      bool asyncLogging) const;
+  void reconfigureImpl(
+      std::string prefix,
+      std::string_view logFilePath,
+      std::function<int(void)> threadContextFn,
+      std::function<void(std::string_view)> errorCallback,
+      bool asyncLogging,
+      std::optional<spdlog::level::level_enum> logLevel);
 
   void logFormatted(
       spdlog::source_loc location,
@@ -142,10 +180,10 @@ class CommsSpdlogLogger {
       std::string_view message,
       bool bypassLevelGate);
 
-  std::shared_ptr<spdlog::logger> logger_;
-  std::shared_ptr<spdlog::sinks::dist_sink_mt> outputSink_;
-  std::shared_ptr<spdlog::logger> synchronousLogger_;
-  ConfigurationStorage configuration_;
+  std::string name_;
+  std::atomic<spdlog::level::level_enum> logLevel_{spdlog::level::info};
+  mutable std::mutex reconfigurationMutex_;
+  StateStorage state_;
 };
 
 class CommsLogStreamBase {

--- a/comms/utils/logger/tests/FormatterUT.cc
+++ b/comms/utils/logger/tests/FormatterUT.cc
@@ -157,7 +157,10 @@ TEST(CommsLogFormatter, emptyLevelUsesPlaceholder) {
 
 TEST(LoggingFormat, ParseDebugSubsysMaskPreservesLegacyBehavior) {
   using meta::comms::logger::ALL;
+  using meta::comms::logger::BOOTSTRAP;
   using meta::comms::logger::COLL;
+  using meta::comms::logger::DESTROY;
+  using meta::comms::logger::ENV;
   using meta::comms::logger::INIT;
   using meta::comms::logger::P2P;
   using meta::comms::logger::parseDebugSubsysMask;
@@ -166,7 +169,7 @@ TEST(LoggingFormat, ParseDebugSubsysMaskPreservesLegacyBehavior) {
     const char* input;
     uint64_t expected;
   };
-  constexpr std::array<TestCase, 14> kCases{{
+  constexpr std::array<TestCase, 16> kCases{{
       {"", 0},
       {",", 0},
       {"^", ~0ULL},
@@ -181,12 +184,48 @@ TEST(LoggingFormat, ParseDebugSubsysMaskPreservesLegacyBehavior) {
       {"^UNKNOWN", ~0ULL},
       {"INIT,,COLL,", INIT | COLL},
       {" INIT", 0},
+      {"DESTROY", DESTROY},
+      {"destroy,init", DESTROY | INIT},
   }};
+
+  EXPECT_EQ(
+      parseDebugSubsysMask(nullptr),
+      static_cast<uint64_t>(INIT | BOOTSTRAP | ENV));
 
   for (const auto& testCase : kCases) {
     EXPECT_EQ(parseDebugSubsysMask(testCase.input), testCase.expected)
         << "input: " << testCase.input;
   }
+}
+
+TEST(LoggingFormat, SharedDebugLevelParsingRemainsCaseSensitive) {
+  using meta::comms::logger::getLoggerDebugLevel;
+  using meta::comms::logger::LogLevel;
+
+  EXPECT_EQ(getLoggerDebugLevel("INFO"), LogLevel::INFO);
+  EXPECT_EQ(getLoggerDebugLevel("info"), LogLevel::NONE);
+}
+
+TEST(LoggingFormat, NcclDebugLevelParsingIsCaseInsensitive) {
+  using meta::comms::logger::getNcclLoggerDebugLevel;
+  using meta::comms::logger::LogLevel;
+
+  EXPECT_EQ(getNcclLoggerDebugLevel("info"), LogLevel::INFO);
+  EXPECT_EQ(getNcclLoggerDebugLevel("WaRn"), LogLevel::WARN);
+  EXPECT_EQ(getNcclLoggerDebugLevel("trace"), LogLevel::TRACE);
+  EXPECT_EQ(getNcclLoggerDebugLevel("invalid"), LogLevel::NONE);
+}
+
+TEST(LoggingFormat, ParsesAsyncDeliveryLikeGeneratedNcclCvar) {
+  using meta::comms::logger::parseDebugLoggingAsync;
+
+  EXPECT_TRUE(parseDebugLoggingAsync(nullptr, true));
+  EXPECT_FALSE(parseDebugLoggingAsync(nullptr, false));
+  EXPECT_TRUE(parseDebugLoggingAsync("", false));
+  EXPECT_FALSE(parseDebugLoggingAsync("No", true));
+  EXPECT_TRUE(parseDebugLoggingAsync("YES", false));
+  EXPECT_TRUE(parseDebugLoggingAsync("invalid", true));
+  EXPECT_TRUE(parseDebugLoggingAsync("invalid", false));
 }
 
 TEST(LoggingFormat, ParseDebugSubsysMaskSupportsConcurrentCalls) {

--- a/comms/utils/logger/tests/LegacyLoggingContractTest.bxl
+++ b/comms/utils/logger/tests/LegacyLoggingContractTest.bxl
@@ -1,11 +1,23 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-_SCOPES = (
-    "fbcode//comms/ctran/...",
-    "fbcode//comms/mccl/...",
-    "fbcode//comms/ncclx/...",
-    "fbcode//comms/prims/...",
+_SCOPE_CONFIGS = (
+    ("fbcode//comms/ctran/...", "//comms/ctran/"),
+    ("fbcode//comms/mccl/...", "//comms/mccl/"),
+    ("fbcode//comms/ncclx/...", "//comms/ncclx/"),
+    ("fbcode//comms/prims/...", "//comms/prims/"),
+    ("fbcode//comms/torchcomms/ncclx/...", "//comms/torchcomms/ncclx/"),
 )
+_SCOPE_LABEL_PREFIX = "fbcode//"
+_SCOPE_LABEL_SUFFIX = "/..."
+
+def _scope_source_fragment(scope: str) -> str:
+    if not scope.startswith(_SCOPE_LABEL_PREFIX) or not scope.endswith(_SCOPE_LABEL_SUFFIX):
+        fail("Invalid migrated logging scope: {}".format(scope))
+    relative_path = scope[len(_SCOPE_LABEL_PREFIX) : -len(_SCOPE_LABEL_SUFFIX)]
+    return "//{}/".format(relative_path)
+
+_SCOPES = [scope for scope, _ in _SCOPE_CONFIGS]
+_SCOPE_SOURCE_FRAGMENTS = [fragment for _, fragment in _SCOPE_CONFIGS]
 
 _SOURCE_EXTENSIONS = (
     ".c",
@@ -207,7 +219,10 @@ def _is_scoped_source(path: str) -> bool:
             break
     if not has_source_extension:
         return False
-    return "//comms/ctran/" in path or "//comms/mccl/" in path or "//comms/ncclx/" in path or "//comms/prims/" in path
+    for source_fragment in _SCOPE_SOURCE_FRAGMENTS:
+        if source_fragment in path:
+            return True
+    return False
 
 def _check_direct_dependencies(ctx: bxl.Context) -> None:
     violations = {}
@@ -306,6 +321,27 @@ def _check_source_content(ctx: bxl.Context) -> None:
     ctx.output.ensure(result)
 
 def _validate_detector() -> None:
+    for scope, expected_fragment in _SCOPE_CONFIGS:
+        actual_fragment = _scope_source_fragment(scope)
+        if actual_fragment != expected_fragment:
+            fail(
+                "Migrated scope {} produced {}, expected {}".format(
+                    scope,
+                    actual_fragment,
+                    expected_fragment,
+                ),
+            )
+        source_path = "{}source.cc".format(expected_fragment)
+        if not _is_scoped_source(source_path):
+            fail("Migrated scope detector missed: {}".format(source_path))
+    for source_path in (
+        "//comms/utils/logger/Source.cc",
+        "//comms/ctran/README.md",
+        "//comms/torchcomms/source.cc",
+    ):
+        if _is_scoped_source(source_path):
+            fail("Migrated scope detector accepted: {}".format(source_path))
+
     for source in (
         "XLOG(ERR)",
         'XLOGF_IF(INFO, enabled, "message")',

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -23,7 +23,6 @@
 #include <vector>
 
 #include <gtest/gtest.h>
-#include <spdlog/async.h>
 #include <spdlog/sinks/sink.h>
 
 #include "comms/utils/logger/CommsLogFormatter.h"
@@ -236,6 +235,18 @@ TEST_F(LogLevelRestoringTest, ConfiguresOnlyNamedLoggerWhenRequested) {
   EXPECT_EQ(namedErrors, (std::vector<std::string>{"named error"}));
 }
 
+TEST(SpdlogLoggerTest, NamedConfigurationPreservesExistingLevel) {
+  constexpr std::string_view kContext{"comms.preserve_level_test"};
+  auto& logger = getSpdlogLogger(kContext);
+  logger.set_level(spdlog::level::err);
+
+  meta::comms::logger::configureSpdlogLogger(
+      kContext, "TEST", "", []() { return 0; }, {}, false);
+
+  EXPECT_FALSE(logger.should_log(spdlog::level::info));
+  EXPECT_TRUE(logger.should_log(spdlog::level::err));
+}
+
 TEST(SpdlogLoggerTest, MatchesLegacyStderrRouting) {
   EXPECT_TRUE(meta::comms::logger::shouldWriteCommsLogToStderr("WARN message"));
   EXPECT_TRUE(
@@ -285,6 +296,86 @@ TEST(SpdlogLoggerTest, AsyncInfoReachesFileViaPeriodicFlush) {
 
   EXPECT_TRUE(waitForFileToContain(
       scopedLogFile.path(), "asynchronous periodic flush"));
+}
+
+TEST(SpdlogLoggerTest, AsyncReconfigurationPreservesQueuedDestination) {
+  struct BlockingSinkState {
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool workerBlocked{false};
+    bool releaseWorker{false};
+  };
+
+  constexpr std::string_view kBlockingContext{
+      "comms.reconfiguration_blocker_test"};
+  constexpr std::string_view kTargetContext{
+      "comms.reconfiguration_target_test"};
+  const ScopedTestFile oldLogFile{"comms_spdlog_reconfiguration_old.log"};
+  const ScopedTestFile newLogFile{"comms_spdlog_reconfiguration_new.log"};
+
+  auto& blockingLogger = getSpdlogLogger(kBlockingContext);
+  blockingLogger.configure("BLOCKER", []() { return 0; }, {}, true);
+  blockingLogger.set_level(spdlog::level::info);
+
+  const auto blockingSinkState = std::make_shared<BlockingSinkState>();
+  meta::comms::logger::testing::addSinkForTesting(
+      blockingLogger, std::make_shared<CallbackSink>([blockingSinkState]() {
+        std::unique_lock lock{blockingSinkState->mutex};
+        blockingSinkState->workerBlocked = true;
+        blockingSinkState->condition.notify_all();
+        blockingSinkState->condition.wait(
+            lock, [&]() { return blockingSinkState->releaseWorker; });
+      }));
+  COMMS_LOG_NAMED(kBlockingContext, INFO, "block async worker");
+
+  {
+    std::unique_lock lock{blockingSinkState->mutex};
+    if (!blockingSinkState->condition.wait_for(
+            lock, std::chrono::seconds{5}, [&]() {
+              return blockingSinkState->workerBlocked;
+            })) {
+      blockingSinkState->releaseWorker = true;
+      blockingSinkState->condition.notify_all();
+      FAIL() << "async worker did not enter the blocking sink";
+    }
+  }
+
+  meta::comms::logger::configureSpdlogLogger(
+      kTargetContext,
+      "OLD",
+      oldLogFile.path().string(),
+      []() { return 0; },
+      {},
+      true);
+  auto& targetLogger = getSpdlogLogger(kTargetContext);
+  targetLogger.set_level(spdlog::level::info);
+  COMMS_LOG_NAMED(kTargetContext, ERR, "record accepted before reset");
+
+  meta::comms::logger::configureSpdlogLogger(
+      kTargetContext,
+      "NEW",
+      newLogFile.path().string(),
+      []() { return 0; },
+      {},
+      true);
+  COMMS_LOG_NAMED(kTargetContext, ERR, "record accepted after reset");
+
+  {
+    std::lock_guard lock{blockingSinkState->mutex};
+    blockingSinkState->releaseWorker = true;
+  }
+  blockingSinkState->condition.notify_all();
+
+  ASSERT_TRUE(
+      waitForFileToContain(oldLogFile.path(), "record accepted before reset"));
+  ASSERT_TRUE(
+      waitForFileToContain(newLogFile.path(), "record accepted after reset"));
+  EXPECT_EQ(
+      readFile(oldLogFile.path()).find("record accepted after reset"),
+      std::string::npos);
+  EXPECT_EQ(
+      readFile(newLogFile.path()).find("record accepted before reset"),
+      std::string::npos);
 }
 
 TEST(SpdlogLoggerTest, AbortWritesErrorBeforeTermination) {


### PR DESCRIPTION
Summary:

The `torchcomms/ncclx` integration tests were outside the legacy-logging drift guard and retained one direct `XLOG` call plus two direct Folly logging dependencies.

Preserve the test progress messages as unconditional stdout diagnostics so they remain visible even when NCCLX initializes with the default `NCCL_DEBUG=NONE`. Extend the drift guard to cover `torchcomms/ncclx`, preventing these callsites and dependencies from returning.

This changes test-only diagnostics and CI coverage; it does not alter production or hot-path code.

Reviewed By: shr

Differential Revision: D118093986


