### PR TITLE
Post IBGDA WQEs with EXCLUSIVE sharing when a QP has one poster

### DIFF
--- a/comms/prims/docs/Channels.md
+++ b/comms/prims/docs/Channels.md
@@ -129,3 +129,42 @@ Public raw put/signal APIs default to the Send direction. Send/recv/forward
 internals use explicit directions: data puts and `DATA_READY` use Send, while
 recv-side `SLOT_FREE` uses Recv. Raw put/signal transports allocate only Send
 QPs; send/recv transports allocate Send and Recv QPs.
+
+### QP posting ownership
+
+**A QP has exactly one poster, and the transport relies on that.**
+
+The slot index is
+
+```text
+((channel_id * directions + direction) * qpsPerConnection) + qp_index
+```
+
+per NIC, with no modulo, so a QP belongs to exactly one
+`(channel_id, direction)`. Combined with the ownership unit above — concurrent
+duplicate use of a `(peer, channel_id, direction)` is caller error — and with
+every posting site being leader-only, at most one thread ever posts on a given
+QP.
+
+This is a structural property of the channel model, not a tuning option. The
+transport already depends on it outside the posting path:
+`select_put_lane_ordinal` advances `IbQpState::cursor` with a plain
+non-atomic increment, so a caller that drove one `(channel, direction)` from two
+groups would already be racing that counter.
+
+Consequences for IBGDA:
+
+- WQ-slot reservation and ready-index publication use
+  `DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE`. The shared-QP mode
+  spends device-scope atomics and `atomicCAS` spins arbitrating between posters
+  that cannot exist; under `EXCLUSIVE` those become plain loads and stores.
+- Because `EXCLUSIVE` makes `mark_wqes_ready` a bare store with no fence, the
+  release that orders WQE payload stores before the MMIO doorbell moves into the
+  submit step, at GPU scope. Something must provide that release or the NIC can
+  fetch a WQE it has not been shown.
+- On AMD the sharing mode is an inert placeholder in
+  `transport/amd/DocaCompat.h`, so this changes nothing there.
+
+Adding a second poster to a QP is therefore not a configuration change; it would
+require revisiting the slot geometry, the cursor increment, and the fence
+placement together.

--- a/comms/prims/transport/amd/DocaCompat.h
+++ b/comms/prims/transport/amd/DocaCompat.h
@@ -62,6 +62,11 @@ using doca_gpu_dev_verbs_wqe_ctrl_flags = uint8_t;
 // equivalents (same bit values).
 
 constexpr int DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU = 0;
+// Same inert placeholder as the GPU mode above: the `prims_amd_gda_*` overloads
+// ignore the sharing mode, so selecting EXCLUSIVE on the NVIDIA side leaves AMD
+// behaviour unchanged. It has to be spelled here regardless, because the
+// posting helpers that name it are compiled on both platforms.
+constexpr int DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE = 0;
 constexpr int DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO = 0;
 constexpr int DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU = 0;
 constexpr int DOCA_GPUNETIO_VERBS_SYNC_SCOPE_THREAD = 0;

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -1485,6 +1485,47 @@ class P2pIbgdaTransportDevice {
     return ticket;
   }
 
+  // --- WQ slot lifecycle ---
+  //
+  // Every posting site funnels through these three, so the sharing mode and the
+  // fence rule are stated once instead of at each call.
+  //
+  // A QP has exactly one poster; see "QP posting ownership" in
+  // comms/prims/docs/Channels.md for why that is structural and what depends
+  // on it.
+
+  static constexpr auto kQpSharingMode =
+      DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE;
+
+  __device__ __forceinline__ uint64_t
+  reserve_wqes(doca_gpu_dev_verbs_qp* qp, uint32_t count) const {
+    return doca_gpu_dev_verbs_reserve_wq_slots<kQpSharingMode>(qp, count);
+  }
+
+  __device__ __forceinline__ void mark_wqes_ready_mode(
+      doca_gpu_dev_verbs_qp* qp,
+      uint64_t fromWqe,
+      uint64_t toWqe) const {
+    doca_gpu_dev_verbs_mark_wqes_ready<kQpSharingMode>(qp, fromWqe, toWqe);
+  }
+
+  /**
+   * Ring the doorbell for everything up to and including `toWqe`.
+   *
+   * The GPU sync scope is load-bearing, not a default: under EXCLUSIVE
+   * `mark_wqes_ready` is a bare store, so this is the only release ordering the
+   * WQE payload before the MMIO doorbell. THREAD here would let the NIC fetch a
+   * WQE it has not been shown.
+   */
+  __device__ __forceinline__ void submit_wqes(
+      doca_gpu_dev_verbs_qp* qp,
+      uint64_t toWqe) const {
+    doca_gpu_dev_verbs_submit<
+        kQpSharingMode,
+        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp, toWqe + 1);
+  }
+
   __device__ IbgdaPutSignalTickets put_signal_single_impl(
       const IbgdaLane& lane,
       const IbgdaLocalBuffer& localBuf,
@@ -1523,8 +1564,7 @@ class P2pIbgdaTransportDevice {
     uint64_t numChunks = doca_gpu_dev_verbs_div_ceil_aligned_pow2(
         nbytes, DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE_SHIFT);
     numChunks = numChunks > 1 ? numChunks : 1;
-    uint64_t baseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(lane.qp, numChunks + 1);
+    uint64_t baseWqeIdx = reserve_wqes(lane.qp, numChunks + 1);
     uint64_t wqeIdx = baseWqeIdx;
     std::size_t remainingSize = nbytes;
 
@@ -1569,13 +1609,8 @@ class P2pIbgdaTransportDevice {
         sizeof(uint64_t),
         signalVal,
         0);
-    doca_gpu_dev_verbs_mark_wqes_ready<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
-        lane.qp, baseWqeIdx, wqeIdx);
-    doca_gpu_dev_verbs_submit<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
-        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_THREAD,
-        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(lane.qp, wqeIdx + 1);
+    mark_wqes_ready_mode(lane.qp, baseWqeIdx, wqeIdx);
+    submit_wqes(lane.qp, wqeIdx);
     return IbgdaPutSignalTickets{lastPutWqeIdx, wqeIdx};
 #endif
   }
@@ -1928,8 +1963,7 @@ class P2pIbgdaTransportDevice {
         .key = signalBuf.rkey_per_device[lane.nic_id].value};
     doca_gpu_dev_verbs_addr sinkAddr = {.addr = 0, .key = nic.sink_lkey.value};
 
-    uint64_t wqe_idx = doca_gpu_dev_verbs_reserve_wq_slots<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(qp, 1);
+    uint64_t wqe_idx = reserve_wqes(qp, 1);
 
     doca_gpu_dev_verbs_wqe* wqe_ptr =
         doca_gpu_dev_verbs_get_wqe_ptr(qp, wqe_idx);
@@ -1950,13 +1984,8 @@ class P2pIbgdaTransportDevice {
         signalVal,
         0);
 
-    doca_gpu_dev_verbs_mark_wqes_ready<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(qp, wqe_idx, wqe_idx);
-
-    doca_gpu_dev_verbs_submit<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
-        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_THREAD,
-        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp, wqe_idx + 1);
+    mark_wqes_ready_mode(qp, wqe_idx, wqe_idx);
+    submit_wqes(qp, wqe_idx);
     return wqe_idx;
   }
 


### PR DESCRIPTION
Summary:
The WQ slot lifecycle -- `reserve_wq_slots`, `mark_wqes_ready`, `submit` -- ran
under `DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU`, paying a device-scope
`atomicAdd`, two `atomicCAS` spin locks and three GPU-scope fences per post to
arbitrate between posters that do not exist.

A QP slot is `((channel * qpDirectionCount + directionIndex) * qpsPerConnection)
+ qpIndex` with no modulo, so a QP belongs to exactly one (channel, direction),
and a channel is driven by a single group through leader-only operations. One
poster per QP is a structural property, not a configuration --
`select_put_lane_ordinal` already relies on it by advancing
`qp_state(channelId, direction).cursor` non-atomically. Under `EXCLUSIVE` all of
those atomics degenerate to plain loads and stores.

Changes:
- Three helpers -- `reserve_wqes`, `mark_wqes_ready_mode`, `submit_wqes` -- so
  the sharing mode and the fence rule are stated once rather than at each
  posting site.
- `put_signal_single_impl` and `signal_fenced` post through them.

The fence rule is the load-bearing part. Something must release the WQE payload
stores before the MMIO doorbell or the NIC can fetch a WQE it has not been shown.
Under GPU sharing that release came from `mark_wqes_ready`, which is why the
previous call passed `SYNC_SCOPE_THREAD` and relied on it. Under EXCLUSIVE,
`mark_wqes_ready` is a bare store with no fence, so `submit_wqes` moves the
release to `SYNC_SCOPE_GPU` -- matching the visibility the shared path already
depended on. Passing THREAD in both cases would silently drop the only ordering
on the path.

AMD: the helpers are compiled on both platforms and resolve to the shims in
`transport/amd/DocaCompat.h`, where the sharing mode is an inert placeholder, so
AMD behaviour is unchanged. `DocaCompat.h` gains the `EXCLUSIVE` constant next
to the existing `GPU` one because the helpers name it unconditionally. That
omission is what broke the AMD build on the first version: the helpers sat
inside `#ifndef __HIP_PLATFORM_AMD__` while `signal_fenced` called them
unguarded.

The sharing semantics now live in `comms/prims/docs/Channels.md` under "QP
posting ownership", next to the existing QP slot-geometry description, rather
than in a header comment block.

## Measured: put/signal issue cost, GB300 / ConnectX-8

This is the metric the work was aimed at -- GPU cycles from the warp proxy
picking a send command off its queue to the doorbell store retiring, not
collective wall time. Report: https://www.internalfb.com/intern/paste/P2481775944/

BEFORE and AFTER share base `36dedf09974b` and differ only by this diff;
interleaved paired trials on rtptest1631.mwg2, 4 KiB warp-proxy send, 1 SM.

| site | master p50 | +C1 p50 | change |
|---|---|---|---|
| `issue_put_signal` | 4.86 us | 3.29 us | **-32%** |
| `peer_issue_slot_free_signal` | 2.68 us | 3.09 us | -15% |

Sub-step breakdown (separate run; the sub-step atomics inflate the total, so
read the steps only):

| step | master p50 | +C1 p50 | change |
|---|---|---|---|
| `reserve` | 1.14 us | 0.98 us | -14% |
| `prepare` | 0.38 us | 0.56 us | +46% |
| `mark_ready` | **1.35 us** | **0.09 us** | **-93%** |
| `submit` | 1.38 us | 1.00 us | -28% |

`mark_ready` collapsing 93% is precisely the mechanism: under GPU sharing it is
a release fence plus an `atomicCAS` spin plus an acquire fence; under EXCLUSIVE
it is a bare store. `prepare` rising is the counter-move -- the release moves to
GPU scope in `submit` -- and `submit` still drops on net.

Known cost: the reverse credit path is ~11-15% slower, because `signal_fenced`
posts a single WQE and so pays the fence relocation without a `mark_ready`
saving to offset it. Small in absolute terms and a candidate for follow-up
(inline write instead of a NIC atomic), but it is a real regression on that
path and not hidden here.

## Measured: collective latency, GB300 / ConnectX-8, 4 rank, IB_ONLY, nblocks=1

Full report: https://www.internalfb.com/intern/paste/P2481608347/

rtptest1631.mwg2, cross-built `--arch gb300`, `-n 20 -w 5`, 1 B - 2 GiB.
All three binaries are staged on the host up front and trials are
**interleaved** -- master, +C1 and +C1+C2 run back to back within a trial -- so
host drift is shared and samples are paired. Deltas use an exact paired
sign-flip test; **bold** = p<0.05. (An earlier time-blocked design overstated
C1 by roughly 2x; these are the numbers to quote.)

Median across sizes, this diff against master:

| workload | n | C1 vs master (latency) |
|---|---|---|
| ARv2 Ring, warp proxy ON | 9 | **+2.8%** |
| ARv2 Ring, proxy off (shipping default) | 11 | **+2.4%** |
| ARv2 Tree | 9 | +0.4% |
| Send/Recv, np=2 | 7 | **+3.7%** |

Per-size latency and busBw follow. The `C2 vs C1` and `C1+C2` columns are the
next diff in the stack and are shown only for continuity.

### Send/Recv, np=2, IB_ONLY

Paired interleaved trials, n=7 (trials 1,2,3,4,5,6,7). **bold** = paired sign-flip p<0.05. Latency lower is better, busBw higher is better; positive % = improvement.

| size | master us | master busBw GB/s | +C1 us | +C1 busBw | C1 vs master (lat / bw) | +C1+C2 us | +C1+C2 busBw | C2 vs C1 (lat / bw) | C1+C2 vs master (lat / bw) |
|---|---|---|---|---|---|---|---|---|---|
| 1 | 35.0 | 0 | 33.7 | 0 | **+3.8%** / n/a | 33.7 | 0 | +0.0% / n/a | **+3.8%** / n/a |
| 2 | 35.1 | 0 | 33.7 | 0 | **+4.0%** / n/a | 33.8 | 0 | -0.4% / n/a | +3.6% / n/a |
| 4 | 35.4 | 0 | 33.9 | 0 | +4.0% / n/a | 33.6 | 0 | +1.0% / n/a | **+5.0%** / n/a |
| 8 | 35.5 | 0 | 34.2 | 0 | +3.7% / n/a | 33.9 | 0 | +0.6% / n/a | **+4.3%** / n/a |
| 16 | 34.9 | 0 | 33.4 | 0 | **+4.4%** / n/a | 33.2 | 0 | +0.6% / n/a | **+5.0%** / n/a |
| 32 | 35.1 | 0 | 33.5 | 0 | +4.6% / n/a | 33.4 | 0 | +0.4% / n/a | **+4.9%** / n/a |
| 64 | 35.3 | 0 | 33.6 | 0 | +4.8% / n/a | 33.3 | 0 | +0.8% / n/a | **+5.5%** / n/a |
| 128 | 35.3 | 0 | 33.7 | 0 | +4.4% / n/a | 33.4 | 0 | +1.0% / n/a | **+5.4%** / n/a |
| 256 | 35.4 | 0.01 | 33.6 | 0.01 | **+5.0%** / n/a | 33.4 | 0.01 | +0.5% / n/a | **+5.5%** / n/a |
| 512 | 35.1 | 0.01 | 33.6 | 0.02 | **+4.4%** / n/a | 33.6 | 0.02 | -0.0% / n/a | **+4.3%** / n/a |
| 1K | 35.2 | 0.03 | 33.6 | 0.03 | **+4.4%** / n/a | 33.2 | 0.03 | +1.2% / n/a | **+5.6%** / n/a |
| 2K | 35.5 | 0.06 | 33.8 | 0.06 | +4.6% / +0.0% | 33.7 | 0.06 | +0.4% / +0.0% | **+5.0%** / +0.0% |
| 4K | 35.5 | 0.12 | 34.2 | 0.12 | +3.7% / +0.0% | 34.0 | 0.12 | +0.4% / +0.0% | **+4.1%** / +0.0% |
| 8K | 36.8 | 0.22 | 35.3 | 0.23 | +4.0% / +4.5% | 35.0 | 0.23 | +0.9% / +0.0% | +4.9% / +4.5% |
| 16K | 37.7 | 0.44 | 36.2 | 0.45 | **+3.9%** / +2.3% | 36.1 | 0.45 | +0.3% / +0.0% | **+4.1%** / **+2.3%** |
| 32K | 39.3 | 0.83 | 38.1 | 0.86 | **+3.1%** / +3.6% | 37.7 | 0.87 | +1.0% / +1.2% | **+4.0%** / **+4.8%** |
| 64K | 42.6 | 1.54 | 40.8 | 1.61 | +4.1% / +4.5% | 40.8 | 1.61 | +0.0% / +0.0% | **+4.1%** / +4.5% |
| 128K | 46.3 | 2.83 | 44.5 | 2.94 | **+3.7%** / **+3.9%** | 44.3 | 2.96 | +0.4% / +0.7% | **+4.2%** / **+4.6%** |
| 256K | 47.9 | 5.47 | 46.4 | 5.65 | **+3.2%** / **+3.3%** | 46.5 | 5.64 | -0.2% / -0.2% | **+3.1%** / **+3.1%** |
| 512K | 58.4 | 8.97 | 56.2 | 9.33 | **+3.9%** / **+4.0%** | 56.3 | 9.32 | -0.2% / -0.1% | **+3.7%** / **+3.9%** |
| 1M | 80.3 | 13.1 | 78.1 | 13.4 | **+2.7%** / **+2.8%** | 78.5 | 13.4 | -0.4% / -0.4% | **+2.3%** / **+2.3%** |
| 2M | 105.3 | 19.9 | 102.5 | 20.5 | **+2.7%** / **+2.7%** | 102.0 | 20.6 | +0.5% / +0.5% | **+3.1%** / **+3.3%** |
| 4M | 108.7 | 38.6 | 105.7 | 39.7 | **+2.8%** / **+2.9%** | 105.8 | 39.6 | -0.1% / -0.1% | **+2.7%** / **+2.8%** |
| 8M | 160.5 | 52.3 | 156.0 | 53.8 | **+2.8%** / **+2.9%** | 155.6 | 53.9 | +0.3% / +0.2% | **+3.1%** / **+3.2%** |
| 16M | 265.6 | 63.2 | 257.5 | 65.2 | **+3.0%** / **+3.1%** | 257.2 | 65.2 | +0.1% / +0.1% | **+3.2%** / **+3.3%** |
| 32M | 480.9 | 69.8 | 466.2 | 72 | **+3.1%** / **+3.2%** | 466.5 | 71.9 | -0.1% / -0.1% | **+3.0%** / **+3.1%** |
| 64M | 912.0 | 73.6 | 886.4 | 75.7 | **+2.8%** / **+2.9%** | 886.1 | 75.7 | +0.0% / +0.0% | **+2.8%** / **+2.9%** |
| 128M | 1779.1 | 75.4 | 1728.1 | 77.7 | **+2.9%** / **+3.0%** | 1722.0 | 77.9 | +0.4% / +0.3% | **+3.2%** / **+3.3%** |
| 256M | 3521.4 | 76.2 | 3410.9 | 78.7 | **+3.1%** / **+3.2%** | 3400.5 | 78.9 | +0.3% / +0.3% | **+3.4%** / **+3.6%** |
| 512M | 6988.1 | 76.8 | 6770.0 | 79.3 | **+3.1%** / **+3.2%** | 6773.4 | 79.3 | -0.1% / -0.1% | **+3.1%** / **+3.2%** |
| 1G | 13979.0 | 76.8 | 13524.0 | 79.4 | **+3.3%** / **+3.4%** | 13489.0 | 79.6 | +0.3% / +0.3% | **+3.5%** / **+3.6%** |
| 2G | 27957.0 | 76.8 | 27070.0 | 79.3 | **+3.2%** / **+3.3%** | 26971.0 | 79.6 | +0.4% / +0.4% | **+3.5%** / **+3.7%** |

### ARv2 Ring, 4 ranks, IB_ONLY, warp proxy ON

Paired interleaved trials, n=9 (trials 1,2,4,7,8,9,10,12,13). **bold** = paired sign-flip p<0.05. Latency lower is better, busBw higher is better; positive % = improvement.

| size | master us | master busBw GB/s | +C1 us | +C1 busBw | C1 vs master (lat / bw) | +C1+C2 us | +C1+C2 busBw | C2 vs C1 (lat / bw) | C1+C2 vs master (lat / bw) |
|---|---|---|---|---|---|---|---|---|---|
| 0 | 47.3 | 0 | 47.1 | 0 | +0.3% / n/a | 46.7 | 0 | +1.0% / n/a | +1.3% / n/a |
| 4 | 137.6 | 0 | 135.0 | 0 | **+1.9%** / n/a | 133.6 | 0 | +1.0% / n/a | **+2.9%** / n/a |
| 8 | 137.7 | 0 | 134.9 | 0 | **+2.0%** / n/a | 133.9 | 0 | +0.7% / n/a | **+2.8%** / n/a |
| 16 | 137.6 | 0 | 134.0 | 0 | **+2.6%** / n/a | 133.4 | 0 | +0.4% / n/a | **+3.1%** / n/a |
| 32 | 151.9 | 0 | 147.5 | 0 | **+2.9%** / n/a | 146.6 | 0 | +0.6% / n/a | **+3.5%** / n/a |
| 64 | 167.6 | 0 | 160.6 | 0 | **+4.2%** / n/a | 160.4 | 0 | +0.1% / n/a | **+4.3%** / n/a |
| 128 | 167.3 | 0 | 160.2 | 0 | **+4.2%** / n/a | 159.5 | 0 | +0.4% / n/a | **+4.7%** / n/a |
| 256 | 166.5 | 0 | 160.8 | 0 | **+3.4%** / n/a | 159.2 | 0 | +1.0% / n/a | **+4.4%** / n/a |
| 512 | 166.2 | 0 | 160.3 | 0 | **+3.5%** / n/a | 159.1 | 0 | +0.7% / n/a | **+4.3%** / n/a |
| 1K | 167.4 | 0.01 | 160.9 | 0.01 | **+3.9%** / n/a | 161.1 | 0.01 | -0.1% / n/a | **+3.8%** / n/a |
| 2K | 167.4 | 0.02 | 161.1 | 0.02 | **+3.8%** / n/a | 160.2 | 0.02 | +0.6% / n/a | **+4.3%** / n/a |
| 4K | 167.5 | 0.04 | 162.5 | 0.04 | **+3.0%** / n/a | 160.1 | 0.04 | +1.5% / n/a | **+4.4%** / n/a |
| 8K | 168.3 | 0.07 | 161.1 | 0.08 | **+4.3%** / **+14.3%** | 161.2 | 0.08 | -0.1% / +0.0% | **+4.2%** / **+14.3%** |
| 16K | 169.9 | 0.14 | 164.2 | 0.15 | **+3.4%** / **+7.1%** | 162.4 | 0.15 | +1.1% / +0.0% | **+4.4%** / **+7.1%** |
| 32K | 177.9 | 0.28 | 170.8 | 0.29 | **+4.0%** / **+3.6%** | 170.1 | 0.29 | +0.4% / +0.0% | **+4.4%** / **+3.6%** |
| 64K | 184.1 | 0.53 | 178.2 | 0.55 | **+3.2%** / **+3.8%** | 177.1 | 0.56 | +0.6% / +1.8% | **+3.8%** / **+5.7%** |
| 128K | 196.2 | 1 | 190.3 | 1.03 | **+3.0%** / **+3.0%** | 189.1 | 1.04 | +0.6% / +1.0% | **+3.6%** / **+4.0%** |
| 256K | 202.2 | 1.94 | 195.0 | 2.02 | **+3.6%** / **+4.1%** | 194.0 | 2.03 | +0.5% / +0.5% | **+4.1%** / **+4.6%** |
| 512K | 225.0 | 3.5 | 218.7 | 3.6 | **+2.8%** / **+2.9%** | 217.2 | 3.62 | +0.7% / +0.6% | **+3.5%** / **+3.4%** |
| 1M | 271.1 | 5.8 | 266.6 | 5.9 | **+1.7%** / **+1.7%** | 265.4 | 5.93 | +0.5% / +0.5% | **+2.1%** / **+2.2%** |
| 2M | 365.0 | 8.62 | 360.2 | 8.73 | **+1.3%** / **+1.3%** | 359.7 | 8.75 | +0.1% / +0.2% | **+1.5%** / **+1.5%** |
| 4M | 494.0 | 12.7 | 485.9 | 12.9 | **+1.6%** / **+1.6%** | 482.7 | 13 | +0.7% / +0.6% | **+2.3%** / **+2.3%** |
| 8M | 932.0 | 13.5 | 906.2 | 13.9 | **+2.8%** / **+2.9%** | 904.8 | 13.9 | +0.2% / +0.1% | **+2.9%** / **+3.0%** |
| 16M | 1817.2 | 13.8 | 1764.6 | 14.3 | **+2.9%** / **+3.0%** | 1758.0 | 14.3 | +0.4% / +0.4% | **+3.3%** / **+3.4%** |
| 32M | 3628.1 | 13.9 | 3527.7 | 14.3 | **+2.8%** / **+2.9%** | 3516.8 | 14.3 | +0.3% / +0.3% | **+3.1%** / **+3.2%** |
| 64M | 7261.2 | 13.9 | 7063.6 | 14.2 | **+2.7%** / **+2.8%** | 7036.5 | 14.3 | +0.4% / +0.4% | **+3.1%** / **+3.2%** |
| 128M | 14523.0 | 13.9 | 14123.0 | 14.2 | **+2.8%** / **+2.8%** | 14076.0 | 14.3 | +0.3% / +0.4% | **+3.1%** / **+3.2%** |
| 256M | 29047.0 | 13.9 | 28254.0 | 14.2 | **+2.7%** / **+2.8%** | 28141.0 | 14.3 | +0.4% / +0.4% | **+3.1%** / **+3.2%** |
| 512M | 58068.0 | 13.9 | 56490.0 | 14.3 | **+2.7%** / **+2.8%** | 56216.0 | 14.3 | +0.5% / +0.5% | **+3.2%** / **+3.3%** |
| 1G | 116155.0 | 13.9 | 112935.0 | 14.3 | **+2.8%** / **+2.8%** | 112406.0 | 14.3 | +0.5% / +0.5% | **+3.2%** / **+3.3%** |
| 2G | 232285.0 | 13.9 | 225811.0 | 14.3 | **+2.8%** / **+2.9%** | 225009.0 | 14.3 | +0.4% / +0.4% | **+3.1%** / **+3.2%** |

### ARv2 Ring, 4 ranks, IB_ONLY (proxy off, as shipped)

Paired interleaved trials, n=11 (trials 1,2,4,5,6,7,16,17,18,19,20). **bold** = paired sign-flip p<0.05. Latency lower is better, busBw higher is better; positive % = improvement.

| size | master us | master busBw GB/s | +C1 us | +C1 busBw | C1 vs master (lat / bw) | +C1+C2 us | +C1+C2 busBw | C2 vs C1 (lat / bw) | C1+C2 vs master (lat / bw) |
|---|---|---|---|---|---|---|---|---|---|
| 0 | 47.4 | 0 | 47.6 | 0 | -0.3% / n/a | 47.6 | 0 | -0.2% / n/a | -0.4% / n/a |
| 4 | 148.0 | 0 | 143.5 | 0 | **+3.0%** / n/a | 144.2 | 0 | -0.5% / n/a | **+2.6%** / n/a |
| 8 | 148.2 | 0 | 143.9 | 0 | **+2.9%** / n/a | 144.4 | 0 | -0.3% / n/a | **+2.6%** / n/a |
| 16 | 147.4 | 0 | 143.5 | 0 | **+2.6%** / n/a | 143.9 | 0 | -0.3% / n/a | **+2.4%** / n/a |
| 32 | 166.4 | 0 | 162.5 | 0 | **+2.3%** / n/a | 164.4 | 0 | -1.2% / n/a | **+1.2%** / n/a |
| 64 | 204.2 | 0 | 198.1 | 0 | +3.0% / n/a | 202.5 | 0 | -2.2% / n/a | +0.8% / n/a |
| 128 | 204.8 | 0 | 198.1 | 0 | +3.3% / n/a | 203.8 | 0 | -2.9% / n/a | +0.5% / n/a |
| 256 | 204.0 | 0 | 197.3 | 0 | +3.3% / n/a | 203.4 | 0 | -3.1% / n/a | +0.3% / n/a |
| 512 | 203.8 | 0 | 198.4 | 0 | +2.6% / n/a | 203.7 | 0 | -2.7% / n/a | +0.0% / n/a |
| 1K | 204.5 | 0.01 | 199.3 | 0.01 | +2.5% / n/a | 202.6 | 0.01 | -1.7% / n/a | +0.9% / n/a |
| 2K | 204.2 | 0.02 | 198.8 | 0.02 | +2.6% / n/a | 203.7 | 0.02 | -2.5% / n/a | +0.2% / n/a |
| 4K | 204.7 | 0.03 | 198.0 | 0.03 | +3.3% / n/a | 204.0 | 0.03 | -3.0% / n/a | +0.3% / n/a |
| 8K | 205.2 | 0.06 | 199.4 | 0.06 | +2.8% / +0.0% | 204.1 | 0.06 | -2.4% / +0.0% | +0.5% / +0.0% |
| 16K | 206.7 | 0.12 | 201.9 | 0.12 | +2.3% / +0.0% | 204.7 | 0.12 | -1.4% / +0.0% | +1.0% / +0.0% |
| 32K | 209.1 | 0.24 | 204.0 | 0.24 | +2.4% / +0.0% | 208.5 | 0.24 | -2.2% / +0.0% | +0.3% / +0.0% |
| 64K | 216.9 | 0.45 | 210.2 | 0.47 | +3.1% / +4.4% | 216.3 | 0.45 | -2.9% / -4.3% | +0.3% / +0.0% |
| 128K | 229.2 | 0.86 | 223.1 | 0.88 | +2.7% / +2.3% | 227.7 | 0.86 | -2.1% / -2.3% | +0.7% / +0.0% |
| 256K | 234.9 | 1.67 | 230.1 | 1.71 | +2.0% / +2.4% | 234.0 | 1.68 | -1.7% / -1.8% | +0.4% / +0.6% |
| 512K | 250.4 | 3.14 | 244.7 | 3.21 | +2.3% / +2.2% | 248.4 | 3.17 | -1.5% / -1.2% | +0.8% / +1.0% |
| 1M | 288.0 | 5.46 | 281.2 | 5.59 | **+2.4%** / **+2.4%** | 284.5 | 5.53 | -1.2% / -1.1% | **+1.2%** / **+1.3%** |
| 2M | 379.8 | 8.28 | 372.4 | 8.45 | **+1.9%** / **+2.1%** | 375.4 | 8.38 | -0.8% / -0.8% | **+1.2%** / **+1.2%** |
| 4M | 637.5 | 9.87 | 622.8 | 10.1 | **+2.3%** / **+2.3%** | 630.2 | 9.98 | -1.2% / -1.2% | +1.1% / +1.1% |
| 8M | 1219.7 | 10.3 | 1186.5 | 10.6 | **+2.7%** / **+2.8%** | 1201.6 | 10.5 | -1.3% / -1.3% | **+1.5%** / **+1.5%** |
| 16M | 2458.7 | 10.2 | 2412.4 | 10.4 | **+1.9%** / **+1.9%** | 2425.2 | 10.4 | -0.5% / -0.5% | **+1.4%** / **+1.4%** |
| 32M | 4924.3 | 10.2 | 4837.8 | 10.4 | **+1.8%** / **+1.8%** | 4859.7 | 10.4 | -0.5% / -0.4% | **+1.3%** / **+1.4%** |
| 64M | 9866.6 | 10.2 | 9686.0 | 10.4 | **+1.8%** / **+1.9%** | 9739.4 | 10.3 | -0.6% / -0.5% | **+1.3%** / **+1.4%** |
| 128M | 19742.0 | 10.2 | 19373.0 | 10.4 | **+1.9%** / **+1.9%** | 19474.0 | 10.3 | -0.5% / -0.5% | **+1.4%** / **+1.4%** |
| 256M | 39457.0 | 10.2 | 38687.0 | 10.4 | **+2.0%** / **+2.1%** | 38926.0 | 10.3 | -0.6% / -0.7% | **+1.3%** / **+1.4%** |
| 512M | 78848.0 | 10.2 | 77406.0 | 10.4 | **+1.8%** / **+1.9%** | 77791.0 | 10.3 | -0.5% / -0.5% | **+1.3%** / **+1.4%** |
| 1G | 157626.0 | 10.2 | 154726.0 | 10.4 | **+1.8%** / **+1.9%** | 155507.0 | 10.4 | -0.5% / -0.5% | **+1.3%** / **+1.4%** |
| 2G | 315230.0 | 10.2 | 309382.0 | 10.4 | **+1.9%** / **+1.9%** | 310866.0 | 10.4 | -0.5% / -0.5% | **+1.4%** / **+1.4%** |

### ARv2 Tree, 4 ranks, IB_ONLY

Paired interleaved trials, n=9 (trials 1,3,4,5,6,8,9,10,12). **bold** = paired sign-flip p<0.05. Latency lower is better, busBw higher is better; positive % = improvement.

| size | master us | master busBw GB/s | +C1 us | +C1 busBw | C1 vs master (lat / bw) | +C1+C2 us | +C1+C2 busBw | C2 vs C1 (lat / bw) | C1+C2 vs master (lat / bw) |
|---|---|---|---|---|---|---|---|---|---|
| 0 | 48.0 | 0 | 47.2 | 0 | +1.6% / n/a | 48.5 | 0 | -2.7% / n/a | -1.1% / n/a |
| 4 | 156.2 | 0 | 153.1 | 0 | **+2.0%** / n/a | 152.4 | 0 | +0.5% / n/a | **+2.4%** / n/a |
| 8 | 156.7 | 0 | 151.9 | 0 | **+3.1%** / n/a | 152.7 | 0 | -0.5% / n/a | **+2.6%** / n/a |
| 16 | 156.8 | 0 | 151.8 | 0 | **+3.2%** / n/a | 151.0 | 0 | +0.5% / n/a | **+3.7%** / n/a |
| 32 | 193.4 | 0 | 191.2 | 0 | +1.1% / n/a | 191.5 | 0 | -0.2% / n/a | +1.0% / n/a |
| 64 | 194.3 | 0 | 193.0 | 0 | +0.7% / n/a | 192.5 | 0 | +0.3% / n/a | +0.9% / n/a |
| 128 | 192.3 | 0 | 191.6 | 0 | +0.4% / n/a | 191.1 | 0 | +0.3% / n/a | +0.6% / n/a |
| 256 | 194.4 | 0 | 191.5 | 0 | **+1.5%** / n/a | 190.9 | 0 | +0.3% / n/a | **+1.8%** / n/a |
| 512 | 193.5 | 0 | 191.3 | 0 | +1.1% / n/a | 191.1 | 0 | +0.1% / n/a | +1.2% / n/a |
| 1K | 193.5 | 0.01 | 192.5 | 0.01 | +0.5% / n/a | 192.6 | 0.01 | -0.1% / n/a | +0.5% / n/a |
| 2K | 191.8 | 0.02 | 192.7 | 0.02 | -0.5% / n/a | 192.0 | 0.02 | +0.4% / n/a | -0.1% / n/a |
| 4K | 193.3 | 0.03 | 191.4 | 0.03 | +1.0% / n/a | 192.6 | 0.03 | -0.6% / n/a | +0.4% / n/a |
| 8K | 196.9 | 0.06 | 193.8 | 0.06 | +1.6% / +0.0% | 195.7 | 0.06 | -1.0% / +0.0% | +0.6% / +0.0% |
| 16K | 203.9 | 0.12 | 202.0 | 0.12 | +0.9% / +0.0% | 200.0 | 0.12 | +1.0% / +0.0% | +1.9% / +0.0% |
| 32K | 210.2 | 0.23 | 208.5 | 0.24 | +0.8% / +4.3% | 209.1 | 0.24 | -0.3% / +0.0% | +0.5% / +4.3% |
| 64K | 222.9 | 0.44 | 216.2 | 0.45 | +3.0% / +2.3% | 218.5 | 0.45 | -1.1% / +0.0% | +2.0% / +2.3% |
| 128K | 236.0 | 0.83 | 229.9 | 0.86 | +2.6% / +3.6% | 231.3 | 0.85 | -0.6% / -1.2% | +2.0% / +2.4% |
| 256K | 246.2 | 1.6 | 250.7 | 1.57 | -1.8% / -1.9% | 250.1 | 1.57 | +0.2% / +0.0% | -1.6% / -1.9% |
| 512K | 296.8 | 2.65 | 296.9 | 2.65 | -0.0% / +0.0% | 293.7 | 2.68 | +1.1% / +1.1% | +1.0% / +1.1% |
| 1M | 390.4 | 4.03 | 389.0 | 4.04 | +0.4% / +0.2% | 389.2 | 4.04 | -0.1% / +0.0% | +0.3% / +0.2% |
| 2M | 559.8 | 5.62 | 557.4 | 5.64 | +0.4% / +0.4% | 555.9 | 5.66 | +0.3% / +0.4% | +0.7% / +0.7% |
| 4M | 968.9 | 6.49 | 965.9 | 6.51 | +0.3% / +0.3% | 961.4 | 6.54 | +0.5% / +0.5% | +0.8% / +0.8% |
| 8M | 1803.7 | 6.98 | 1802.6 | 6.98 | +0.1% / +0.0% | 1794.7 | 7.01 | +0.4% / +0.4% | +0.5% / +0.4% |
| 16M | 3486.1 | 7.22 | 3485.1 | 7.22 | +0.0% / +0.0% | 3495.1 | 7.2 | -0.3% / -0.3% | -0.3% / -0.3% |
| 32M | 6873.9 | 7.32 | 6877.8 | 7.32 | -0.1% / +0.0% | 6880.4 | 7.32 | -0.0% / +0.0% | -0.1% / +0.0% |
| 64M | 13699.0 | 7.35 | 13679.0 | 7.36 | +0.1% / +0.1% | 13698.0 | 7.35 | -0.1% / -0.1% | +0.0% / +0.0% |
| 128M | 27395.0 | 7.35 | 27397.0 | 7.35 | -0.0% / +0.0% | 27402.0 | 7.35 | -0.0% / +0.0% | -0.0% / +0.0% |
| 256M | 54649.0 | 7.37 | 54633.0 | 7.37 | +0.0% / +0.0% | 54620.0 | 7.37 | +0.0% / +0.0% | +0.1% / +0.0% |
| 512M | 109057.0 | 7.38 | 108934.0 | 7.39 | +0.1% / +0.1% | 109020.0 | 7.39 | -0.1% / +0.0% | +0.0% / +0.1% |
| 1G | 217919.0 | 7.39 | 217678.0 | 7.4 | +0.1% / +0.1% | 217808.0 | 7.39 | -0.1% / -0.1% | +0.1% / +0.0% |
| 2G | 435624.0 | 7.39 | 436565.0 | 7.38 | -0.2% / -0.1% | 435489.0 | 7.4 | +0.2% / +0.3% | +0.0% / +0.1% |

Reviewed By: zhiyongww, goelayu

Differential Revision: D117934231


