### PR TITLE
Fix Pyre error in ShardedRelayCollectives injector map

### DIFF
--- a/comms/torchcomms/rcclx/examples/ShardedRelayCollectives.py
+++ b/comms/torchcomms/rcclx/examples/ShardedRelayCollectives.py
@@ -100,6 +100,7 @@ import socket
 import sys
 import time
 import unittest
+from collections.abc import Callable
 from dataclasses import dataclass, replace
 
 import torch
@@ -599,7 +600,7 @@ def _inject_overflow(rcclx, rank: int, is_active: bool) -> None:
     raise AssertionError(f"Rank {rank}: over-capacity plan was accepted")
 
 
-def _injectors() -> dict[str, object]:
+def _injectors() -> dict[str, Callable[[object, int, bool], None]]:
     """Explicit mapping rather than a registry decorator, which would need an
     import side effect to populate."""
     return {


### PR DESCRIPTION
Summary:
`_injectors()` was annotated as returning `dict[str, object]`, so Pyre rejects
the call at line 625:

  fbcode/comms/torchcomms/rcclx/examples/ShardedRelayCollectives.py:625:5
  Expected a callable, got `object`

All five injectors share the signature `(rcclx, rank: int, is_active: bool)
-> None`, so annotate the map values as that Callable instead. No behavior
change -- the file is `# pyre-unsafe` and this is annotation-only.

This is currently LAND_BLOCKING on every diff exported to the torchcomms
GitHub repo: the `meta-pytorch/torchcomms: Lint / lintrunner` job runs PYRE
over the tree, so the error fails CI for changes that do not touch this file
(hit while landing D116398864, which only touches ncclx net_ib).

Differential Revision: D118159293


