### PR TITLE
Enable automatic MCCL zero-copy registration (#3889)

### DIFF
--- a/comms/prims/platform/DocaHostUtils.h
+++ b/comms/prims/platform/DocaHostUtils.h
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <optional>
 
 #include "comms/prims/platform/CudaDriverLazy.h"
@@ -143,6 +144,58 @@ inline std::optional<DmaBufExport> export_gpu_dmabuf_aligned(
     return std::nullopt;
   }
 
+  return DmaBufExport{fd, alignment};
+}
+
+// Export only the page-rounded virtual-address range containing [ptr,
+// ptr+size). Unlike export_gpu_dmabuf_aligned(), this deliberately does not
+// resolve or widen to the allocator's backing allocation.
+inline std::optional<DmaBufExport> export_gpu_dmabuf_va_range_aligned(
+    void* ptr,
+    size_t size,
+    DmaBufExportKind kind = DmaBufExportKind::Default) {
+  if (ptr == nullptr || size == 0) {
+    return std::nullopt;
+  }
+  const auto address = reinterpret_cast<uintptr_t>(ptr);
+  if (address > std::numeric_limits<uintptr_t>::max() - size) {
+    return std::nullopt;
+  }
+
+  unsigned long long handleFlags = 0;
+  if (kind == DmaBufExportKind::Pcie) {
+#if CUDA_VERSION >= 12080
+    handleFlags = CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE;
+#else
+    return std::nullopt;
+#endif
+  }
+
+  if (cuda_driver_lazy_init() != 0 ||
+      pfn_cuMemGetHandleForAddressRange == nullptr) {
+    LOG(WARNING)
+        << "export_gpu_dmabuf_va_range_aligned: CUDA driver API is not available";
+    return std::nullopt;
+  }
+
+  static const size_t pageSize = sysconf(_SC_PAGESIZE);
+  const auto alignment = compute_dmabuf_alignment(address, size, ptr, pageSize);
+  int fd = -1;
+  const CUresult result = pfn_cuMemGetHandleForAddressRange(
+      &fd,
+      reinterpret_cast<CUdeviceptr>(alignment.alignedBase),
+      alignment.alignedSize,
+      CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+      handleFlags);
+  if (result != CUDA_SUCCESS || fd < 0) {
+    LOG(WARNING)
+        << "export_gpu_dmabuf_va_range_aligned: cuMemGetHandleForAddressRange"
+        << " failed err=" << result << " ptr=" << ptr << " size=" << size
+        << " kind=" << (kind == DmaBufExportKind::Pcie ? "pcie" : "default")
+        << " alignedBase=" << alignment.alignedBase
+        << " alignedSize=" << alignment.alignedSize;
+    return std::nullopt;
+  }
   return DmaBufExport{fd, alignment};
 }
 

--- a/comms/prims/tests/MultiSegmentRegistrationTest.cc
+++ b/comms/prims/tests/MultiSegmentRegistrationTest.cc
@@ -140,9 +140,10 @@ struct TransportHandle {
   std::unique_ptr<MultipeerIbgdaTransport> ibgda;
   std::unique_ptr<MultipeerIbrcTransport> ibrc;
 
-  IbgdaLocalBuffer registerBuffer(void* ptr, std::size_t size) {
-    return ibgda ? ibgda->registerBuffer(ptr, size)
-                 : ibrc->registerBuffer(ptr, size);
+  IbgdaLocalBuffer
+  registerBuffer(void* ptr, std::size_t size, bool relaxedOrdering = false) {
+    return ibgda ? ibgda->registerBuffer(ptr, size, relaxedOrdering)
+                 : ibrc->registerBuffer(ptr, size, relaxedOrdering);
   }
 
   void deregisterBuffer(void* ptr) {
@@ -153,30 +154,17 @@ struct TransportHandle {
     }
   }
 
-  IbBufferRegistrationLease registerIbBulkBuffer(void* ptr, std::size_t size) {
-    return ibgda ? ibgda->registerIbBulkBuffer(ptr, size)
-                 : ibrc->registerIbBulkBuffer(ptr, size);
+  IbBufferRegistration registerIbBufferRange(void* ptr, std::size_t size) {
+    return ibgda ? ibgda->registerIbBufferRange(ptr, size)
+                 : ibrc->registerIbBufferRange(ptr, size);
   }
 
-  std::optional<IbBufferRegistrationView> lookupIbBulkBuffer(
-      const IbBufferRegistrationLease& lease,
-      void* ptr,
-      std::size_t size) const {
-    return ibgda ? ibgda->lookupIbBulkBuffer(lease, ptr, size)
-                 : ibrc->lookupIbBulkBuffer(lease, ptr, size);
-  }
-
-  void deregisterIbBulkBuffer(IbBufferRegistrationLease& lease) {
+  void deregisterIbBufferRange(IbBufferRegistration& registration) {
     if (ibgda) {
-      ibgda->deregisterIbBulkBuffer(lease);
+      ibgda->deregisterIbBufferRange(registration);
     } else {
-      ibrc->deregisterIbBulkBuffer(lease);
+      ibrc->deregisterIbBufferRange(registration);
     }
-  }
-
-  bool isIbBulkBufferViewActive(const IbBufferRegistrationView& view) const {
-    return ibgda ? ibgda->isIbBulkBufferViewActive(view)
-                 : ibrc->isIbBulkBufferViewActive(view);
   }
 };
 
@@ -283,7 +271,37 @@ TEST_P(MultiSegmentRegistrationTest, ContiguousBufferRegistration) {
   CUDACHECK_TEST(cudaFree(devPtr));
 }
 
-TEST_P(MultiSegmentRegistrationTest, BulkLeaseBoundsContainedViews) {
+TEST_P(MultiSegmentRegistrationTest, ExactRangeSpansDisjointSegments) {
+  CUDACHECK_TEST(cudaSetDevice(0));
+
+  TransportHandle transport;
+  try {
+    transport = createTransport(GetParam());
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << backendName(GetParam())
+                 << " transport not available: " << e.what();
+  }
+
+  constexpr std::size_t kTotalSize = 8 * 1024 * 1024;
+  constexpr int kNumSegments = 4;
+  DisjointBuffer disjointBuffer;
+  try {
+    disjointBuffer = DisjointBuffer::allocate(kTotalSize, kNumSegments, 0);
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "cuMem VMM allocation failed: " << e.what();
+  }
+
+  auto registration =
+      transport.registerIbBufferRange(disjointBuffer.ptr(), kTotalSize);
+  EXPECT_TRUE(registration.valid());
+  EXPECT_EQ(registration.localBuffer.ptr, disjointBuffer.ptr());
+  EXPECT_EQ(registration.size, kTotalSize);
+
+  transport.deregisterIbBufferRange(registration);
+  disjointBuffer.free();
+}
+
+TEST_P(MultiSegmentRegistrationTest, ExactRangeRegistrationUsesRequestedVa) {
   CUDACHECK_TEST(cudaSetDevice(0));
 
   TransportHandle transport;
@@ -295,52 +313,32 @@ TEST_P(MultiSegmentRegistrationTest, BulkLeaseBoundsContainedViews) {
   }
 
   constexpr std::size_t kAllocationSize = 4 * 1024 * 1024;
-  constexpr std::size_t kLeaseOffset = 512 * 1024;
-  constexpr std::size_t kLeaseSize = 2 * 1024 * 1024;
-  constexpr std::size_t kViewOffset = 128 * 1024;
-  constexpr std::size_t kViewSize = 256 * 1024;
+  constexpr std::size_t kRangeOffset = 512 * 1024;
+  constexpr std::size_t kRangeSize = 2 * 1024 * 1024;
   void* allocation = nullptr;
   CUDACHECK_TEST(cudaMalloc(&allocation, kAllocationSize));
-  auto* const leasePtr = static_cast<char*>(allocation) + kLeaseOffset;
+  auto* const rangePtr = static_cast<char*>(allocation) + kRangeOffset;
 
   EXPECT_THROW(
-      transport.registerIbBulkBuffer(leasePtr, 0), std::invalid_argument);
-  auto lease = transport.registerIbBulkBuffer(leasePtr, kLeaseSize);
+      transport.registerIbBufferRange(rangePtr, 0), std::invalid_argument);
   EXPECT_THROW(
-      transport.lookupIbBulkBuffer(lease, leasePtr, 0), std::invalid_argument);
-  EXPECT_THROW(
-      transport.lookupIbBulkBuffer(
-          lease, leasePtr, std::numeric_limits<std::size_t>::max()),
+      transport.registerIbBufferRange(
+          rangePtr, std::numeric_limits<std::size_t>::max()),
       std::invalid_argument);
-  auto exact = transport.lookupIbBulkBuffer(lease, leasePtr, kLeaseSize);
-  auto contained =
-      transport.lookupIbBulkBuffer(lease, leasePtr + kViewOffset, kViewSize);
-  auto tail = transport.lookupIbBulkBuffer(lease, leasePtr + kLeaseSize - 1, 1);
-  auto before = transport.lookupIbBulkBuffer(lease, leasePtr - 1, kViewSize);
-  auto after = transport.lookupIbBulkBuffer(
-      lease, leasePtr + kLeaseSize - kViewSize + 1, kViewSize);
 
-  ASSERT_TRUE(exact.has_value());
-  ASSERT_TRUE(contained.has_value());
-  ASSERT_TRUE(tail.has_value());
-  EXPECT_EQ(exact->localBuffer.ptr, leasePtr);
-  EXPECT_EQ(contained->localBuffer.ptr, leasePtr + kViewOffset);
-  EXPECT_EQ(contained->size, kViewSize);
-  EXPECT_EQ(contained->leaseGeneration, lease.generation());
-  EXPECT_FALSE(before.has_value());
-  EXPECT_FALSE(after.has_value());
-  EXPECT_TRUE(transport.isIbBulkBufferViewActive(*contained));
+  auto registration = transport.registerIbBufferRange(rangePtr, kRangeSize);
+  EXPECT_TRUE(registration.valid());
+  EXPECT_EQ(registration.localBuffer.ptr, rangePtr);
+  EXPECT_EQ(registration.size, kRangeSize);
 
-  transport.deregisterIbBulkBuffer(lease);
-  EXPECT_FALSE(lease.valid());
-  EXPECT_FALSE(
-      transport.lookupIbBulkBuffer(lease, leasePtr, kViewSize).has_value());
-  EXPECT_FALSE(transport.isIbBulkBufferViewActive(*contained));
-  EXPECT_THROW(transport.deregisterIbBulkBuffer(lease), std::invalid_argument);
+  transport.deregisterIbBufferRange(registration);
+  EXPECT_FALSE(registration.valid());
+  EXPECT_THROW(
+      transport.deregisterIbBufferRange(registration), std::invalid_argument);
   CUDACHECK_TEST(cudaFree(allocation));
 }
 
-TEST_P(MultiSegmentRegistrationTest, BulkLeaseReportsEffectiveStrictOrdering) {
+TEST_P(MultiSegmentRegistrationTest, ExactRangeReportsEffectiveStrictOrdering) {
   CUDACHECK_TEST(cudaSetDevice(0));
 
   auto config = makeConfig();
@@ -358,16 +356,53 @@ TEST_P(MultiSegmentRegistrationTest, BulkLeaseReportsEffectiveStrictOrdering) {
   void* allocation = nullptr;
   CUDACHECK_TEST(cudaMalloc(&allocation, kSize));
 
-  auto lease = transport.registerIbBulkBuffer(allocation, kSize);
-  auto view = transport.lookupIbBulkBuffer(lease, allocation, kSize);
-  ASSERT_TRUE(view.has_value());
-  EXPECT_FALSE(view->relaxedOrdering);
+  auto registration = transport.registerIbBufferRange(allocation, kSize);
+  EXPECT_FALSE(registration.relaxedOrdering);
 
-  transport.deregisterIbBulkBuffer(lease);
+  transport.deregisterIbBufferRange(registration);
   CUDACHECK_TEST(cudaFree(allocation));
 }
 
-TEST_P(MultiSegmentRegistrationTest, OverlappingBulkLeasesRemainDistinct) {
+TEST_P(MultiSegmentRegistrationTest, ExactRangeDoesNotReuseCachedRegistration) {
+  CUDACHECK_TEST(cudaSetDevice(0));
+
+  auto config = makeConfig();
+  config.enablePciRelaxedOrdering =
+      MultipeerIbTransportConfig::PciRelaxedOrderingMode::Enabled;
+  TransportHandle transport;
+  try {
+    transport = createTransport(GetParam(), config);
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << backendName(GetParam())
+                 << " transport not available: " << e.what();
+  }
+
+  constexpr std::size_t kSize = 2 * 1024 * 1024;
+  void* allocation = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&allocation, kSize));
+
+  const auto cached =
+      transport.registerBuffer(allocation, kSize, /*relaxedOrdering=*/false);
+  constexpr std::size_t kRangeOffset = 17;
+  constexpr std::size_t kRangeSize = kSize - 4099;
+  auto* const range = static_cast<char*>(allocation) + kRangeOffset;
+  auto exact = transport.registerIbBufferRange(range, kRangeSize);
+  EXPECT_TRUE(exact.valid());
+  EXPECT_EQ(exact.localBuffer.ptr, range);
+  EXPECT_EQ(exact.size, kRangeSize);
+  ASSERT_EQ(
+      cached.lkey_per_device.size, exact.localBuffer.lkey_per_device.size);
+  for (int nic = 0; nic < cached.lkey_per_device.size; ++nic) {
+    EXPECT_NE(
+        cached.lkey_per_device[nic], exact.localBuffer.lkey_per_device[nic]);
+  }
+
+  transport.deregisterIbBufferRange(exact);
+  transport.deregisterBuffer(allocation);
+  CUDACHECK_TEST(cudaFree(allocation));
+}
+
+TEST_P(MultiSegmentRegistrationTest, OverlappingExactRangesRemainIndependent) {
   CUDACHECK_TEST(cudaSetDevice(0));
 
   TransportHandle transport;
@@ -386,55 +421,17 @@ TEST_P(MultiSegmentRegistrationTest, OverlappingBulkLeasesRemainDistinct) {
   CUDACHECK_TEST(cudaMalloc(&allocation, kAllocationSize));
   auto* const base = static_cast<char*>(allocation);
 
-  auto outer = transport.registerIbBulkBuffer(base, kOuterSize);
-  auto inner = transport.registerIbBulkBuffer(base + kInnerOffset, kInnerSize);
-  auto outerView =
-      transport.lookupIbBulkBuffer(outer, base + kInnerOffset, kInnerSize);
-  auto innerView =
-      transport.lookupIbBulkBuffer(inner, base + kInnerOffset, kInnerSize);
+  auto outer = transport.registerIbBufferRange(base, kOuterSize);
+  auto inner = transport.registerIbBufferRange(base + kInnerOffset, kInnerSize);
+  EXPECT_TRUE(outer.valid());
+  EXPECT_TRUE(inner.valid());
+  EXPECT_EQ(outer.localBuffer.ptr, base);
+  EXPECT_EQ(inner.localBuffer.ptr, base + kInnerOffset);
 
-  ASSERT_TRUE(outerView.has_value());
-  ASSERT_TRUE(innerView.has_value());
-  EXPECT_NE(outer.generation(), inner.generation());
-  EXPECT_EQ(outerView->leaseGeneration, outer.generation());
-  EXPECT_EQ(innerView->leaseGeneration, inner.generation());
-
-  transport.deregisterIbBulkBuffer(inner);
-  EXPECT_FALSE(transport.isIbBulkBufferViewActive(*innerView));
-  EXPECT_TRUE(transport.isIbBulkBufferViewActive(*outerView));
-  transport.deregisterIbBulkBuffer(outer);
-  CUDACHECK_TEST(cudaFree(allocation));
-}
-
-TEST_P(MultiSegmentRegistrationTest, ReregistrationChangesLeaseGeneration) {
-  CUDACHECK_TEST(cudaSetDevice(0));
-
-  TransportHandle transport;
-  try {
-    transport = createTransport(GetParam());
-  } catch (const std::exception& e) {
-    GTEST_SKIP() << backendName(GetParam())
-                 << " transport not available: " << e.what();
-  }
-
-  constexpr std::size_t kSize = 2 * 1024 * 1024;
-  void* allocation = nullptr;
-  CUDACHECK_TEST(cudaMalloc(&allocation, kSize));
-
-  auto first = transport.registerIbBulkBuffer(allocation, kSize);
-  auto firstView = transport.lookupIbBulkBuffer(first, allocation, kSize);
-  ASSERT_TRUE(firstView.has_value());
-  const uint64_t firstGeneration = first.generation();
-  transport.deregisterIbBulkBuffer(first);
-
-  auto second = transport.registerIbBulkBuffer(allocation, kSize);
-  auto secondView = transport.lookupIbBulkBuffer(second, allocation, kSize);
-  ASSERT_TRUE(secondView.has_value());
-  EXPECT_NE(firstGeneration, second.generation());
-  EXPECT_FALSE(transport.isIbBulkBufferViewActive(*firstView));
-  EXPECT_TRUE(transport.isIbBulkBufferViewActive(*secondView));
-
-  transport.deregisterIbBulkBuffer(second);
+  transport.deregisterIbBufferRange(inner);
+  EXPECT_FALSE(inner.valid());
+  EXPECT_TRUE(outer.valid());
+  transport.deregisterIbBufferRange(outer);
   CUDACHECK_TEST(cudaFree(allocation));
 }
 

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -35,8 +35,6 @@
 #include "comms/prims/transport/amd/nic/ionic/IonicGidDiscovery.h"
 #endif
 #else
-#include <cuda_runtime.h>
-
 #include "comms/prims/platform/CudaDriverLazy.h"
 #include "comms/prims/platform/DocaHostUtils.h"
 // meta::comms::DeviceBuffer (CUDA RAII) for the send/recv staging bulks.
@@ -44,6 +42,11 @@
 #endif
 
 namespace comms::prims {
+
+IbBufferRegistration::~IbBufferRegistration() {
+  LOG_IF(DFATAL, valid())
+      << "IbBufferRegistration destroyed without deregisterIbBufferRange()";
+}
 
 namespace {
 constexpr int kDefaultGidIndex = 3; // Default RoCE GID index
@@ -1100,6 +1103,15 @@ IbgdaLocalBuffer MultiPeerIbTransportBase::registerBuffer(
     void* ptr,
     std::size_t size,
     bool relaxedOrdering) {
+  auto registrations = registrationState_.wlock();
+  return registerBufferLocked(ptr, size, relaxedOrdering, *registrations);
+}
+
+IbgdaLocalBuffer MultiPeerIbTransportBase::registerBufferLocked(
+    void* ptr,
+    std::size_t size,
+    bool relaxedOrdering,
+    RegistrationState& registrations) {
   if (ptr == nullptr || size == 0) {
     throw std::invalid_argument("Invalid buffer pointer or size");
   }
@@ -1121,8 +1133,8 @@ IbgdaLocalBuffer MultiPeerIbTransportBase::registerBuffer(
   // Fast path: containment lookup — if [ptr, ptr+size) falls entirely within an
   // existing registration with the same effective ordering, return the cached
   // per-NIC lkeys with no driver call.
-  auto it = registeredBuffers_.upper_bound(addr);
-  if (it != registeredBuffers_.begin()) {
+  auto it = registrations.registeredBuffers.upper_bound(addr);
+  if (it != registrations.registeredBuffers.begin()) {
     --it;
     if (rangeContains(it->first, it->second.allocSize, addr, size)) {
       // The cache holds one MR set per allocation; its access flags (including
@@ -1335,7 +1347,8 @@ IbgdaLocalBuffer MultiPeerIbTransportBase::registerBuffer(
     cached.mrs[n] = mr;
   }
 
-  registeredBuffers_.emplace(static_cast<uintptr_t>(allocBase), cached);
+  registrations.registeredBuffers.emplace(
+      static_cast<uintptr_t>(allocBase), cached);
 
   NetworkLKeys keys(numNics_);
   for (int n = 0; n < numNics_; ++n) {
@@ -1344,119 +1357,184 @@ IbgdaLocalBuffer MultiPeerIbTransportBase::registerBuffer(
   return IbgdaLocalBuffer(ptr, keys);
 }
 
-IbBufferRegistrationLease MultiPeerIbTransportBase::registerIbBulkBuffer(
+IbBufferRegistration MultiPeerIbTransportBase::registerIbBufferRange(
     void* ptr,
     std::size_t size) {
-  checkedRangeEnd(ptr, size, "registerIbBulkBuffer");
-  const auto localBuffer = registerBuffer(ptr, size, /*relaxedOrdering=*/true);
-
-  try {
-    const auto addr = reinterpret_cast<uintptr_t>(ptr);
-    auto mrIt = registeredBuffers_.upper_bound(addr);
-    if (mrIt == registeredBuffers_.begin()) {
-      throw std::logic_error(
-          "registerIbBulkBuffer: MR missing after registration");
-    }
-    --mrIt;
-    if (!rangeContains(mrIt->first, mrIt->second.allocSize, addr, size)) {
-      throw std::logic_error(
-          "registerIbBulkBuffer: MR does not contain registered range");
-    }
-    if (nextBulkBufferGeneration_ == std::numeric_limits<uint64_t>::max()) {
-      throw std::overflow_error(
-          "registerIbBulkBuffer: lease generation exhausted");
-    }
-
-    const uint64_t generation = nextBulkBufferGeneration_++;
-    bulkBufferRegistrations_.emplace(
-        generation,
-        BulkBufferRegistration{
-            .ptr = ptr,
-            .size = size,
-            .localBuffer = localBuffer,
-            .relaxedOrdering = mrIt->second.relaxedOrdering,
-        });
-    return IbBufferRegistrationLease(generation);
-  } catch (...) {
-    deregisterBuffer(ptr);
-    throw;
-  }
-}
-
-std::optional<IbBufferRegistrationView>
-MultiPeerIbTransportBase::lookupIbBulkBuffer(
-    const IbBufferRegistrationLease& lease,
-    void* ptr,
-    std::size_t size) const {
-  checkedRangeEnd(ptr, size, "lookupIbBulkBuffer");
-  if (!lease.valid()) {
-    return std::nullopt;
+  checkedRangeEnd(ptr, size, "registerIbBufferRange");
+  const bool useRelaxedOrdering =
+      relaxedOrderingActiveForNic(config_, relaxedOrderingCapable_);
+  // Exact-range registrations are local send sources: callers receive only
+  // lkeys and never exchange rkeys. Keep remote access disabled so the
+  // provider-level page widening required by Data-Direct does not grant peers
+  // access outside the caller-visible range.
+  int accessFlags = ibverbx::IBV_ACCESS_LOCAL_WRITE;
+  if (useRelaxedOrdering) {
+    accessFlags |= ibverbx::IBV_ACCESS_RELAXED_ORDERING;
   }
 
-  const auto registration = bulkBufferRegistrations_.find(lease.generation());
-  if (registration == bulkBufferRegistrations_.end()) {
-    return std::nullopt;
-  }
-
-  const auto& active = registration->second;
-  const auto requestedBegin = reinterpret_cast<uintptr_t>(ptr);
-  const auto registeredBegin = reinterpret_cast<uintptr_t>(active.ptr);
-  if (!rangeContains(registeredBegin, active.size, requestedBegin, size)) {
-    return std::nullopt;
-  }
-
-  return IbBufferRegistrationView{
-      .leaseGeneration = lease.generation(),
-      .localBuffer =
-          active.localBuffer.subBuffer(requestedBegin - registeredBegin),
-      .size = size,
-      .relaxedOrdering = active.relaxedOrdering,
-  };
-}
-
-void MultiPeerIbTransportBase::deregisterIbBulkBuffer(
-    IbBufferRegistrationLease& lease) {
-  if (!lease.valid()) {
-    throw std::invalid_argument(
-        "deregisterIbBulkBuffer: invalid registration lease");
-  }
-
-  const auto registration = bulkBufferRegistrations_.find(lease.generation());
-  if (registration == bulkBufferRegistrations_.end()) {
+  bool mayUsePlainMr = true;
+#ifndef __HIP_PLATFORM_AMD__
+  if (cuda_driver_lazy_init() != 0 || pfn_cuMemGetAddressRange == nullptr) {
     throw std::runtime_error(
-        "deregisterIbBulkBuffer: stale registration lease");
+        "registerIbBufferRange: failed to initialize CUDA driver API");
+  }
+  CUdeviceptr allocationBase = 0;
+  std::size_t allocationSize = 0;
+  const CUresult addressRangeResult = pfn_cuMemGetAddressRange(
+      &allocationBase, &allocationSize, reinterpret_cast<CUdeviceptr>(ptr));
+  if (addressRangeResult != CUDA_SUCCESS || allocationBase == 0) {
+    throw std::runtime_error(
+        "registerIbBufferRange: cuMemGetAddressRange failed for ptr");
+  }
+  const auto requestedEnd = checkedRangeEnd(ptr, size, "registerIbBufferRange");
+  const auto allocationEnd =
+      static_cast<uintptr_t>(allocationBase) + allocationSize;
+  mayUsePlainMr = requestedEnd <= allocationEnd;
+#endif
+
+  auto& symbols = ibverbx::ibvSymbols;
+  std::array<ibverbx::ibv_mr*, kMaxNicsPerGpu> mrs{};
+  const auto cleanup = [&](int end) {
+    for (int n = 0; n < end; ++n) {
+      if (mrs[n] != nullptr) {
+        symbols.ibv_internal_dereg_mr(mrs[n]);
+        mrs[n] = nullptr;
+      }
+    }
+  };
+
+  for (int n = 0; n < numNics_; ++n) {
+    ibverbx::ibv_mr* mr = nullptr;
+    if (dataDirectActiveForNic(config_, nics_[n].isDataDirect)) {
+      if (symbols.mlx5dv_internal_reg_dmabuf_mr == nullptr) {
+        cleanup(n);
+        throw std::runtime_error(
+            fmt::format(
+                "Data-Direct selected for NIC {} but DMA-BUF registration is unavailable",
+                n));
+      }
+      auto dmabuf =
+          export_gpu_dmabuf_va_range_aligned(ptr, size, DmaBufExportKind::Pcie);
+      if (!dmabuf) {
+        cleanup(n);
+        throw std::runtime_error(
+            fmt::format(
+                "Data-Direct selected for NIC {} but exact VA DMA-BUF export "
+                "failed (ptr={} size={})",
+                n,
+                ptr,
+                size));
+      }
+      errno = 0;
+      // mlx5 Data-Direct requires the MR to cover the complete exported
+      // mapping. Registering only the logical subrange can succeed on GB300
+      // but fault when the NIC first reads it. The returned registration still
+      // exposes exactly ptr/size; the aligned extent is provider bookkeeping.
+      mr = symbols.mlx5dv_internal_reg_dmabuf_mr(
+          nics_[n].ibvPd,
+          /*offset=*/0,
+          dmabuf->alignment.alignedSize,
+          reinterpret_cast<uint64_t>(dmabuf->alignment.alignedBase),
+          dmabuf->fd,
+          accessFlags,
+          ibverbx::MLX5DV_REG_DMABUF_ACCESS_DATA_DIRECT);
+      const int regErrno = errno;
+      close(dmabuf->fd);
+      if (!mr) {
+        cleanup(n);
+        throw std::runtime_error(
+            fmt::format(
+                "Data-Direct exact VA registration failed for NIC {} "
+                "(ptr={} size={} errno={} ({}))",
+                n,
+                ptr,
+                size,
+                regErrno,
+                folly::errnoStr(regErrno)));
+      }
+    } else {
+      auto dmabuf = export_gpu_dmabuf_va_range_aligned(ptr, size);
+      int dmabufErrno = 0;
+      if (dmabuf && symbols.ibv_internal_reg_dmabuf_mr != nullptr) {
+        errno = 0;
+        mr = symbols.ibv_internal_reg_dmabuf_mr(
+            nics_[n].ibvPd,
+            dmabuf->alignment.dmabufOffset,
+            size,
+            reinterpret_cast<uint64_t>(ptr),
+            dmabuf->fd,
+            accessFlags);
+        dmabufErrno = errno;
+      }
+      if (dmabuf) {
+        close(dmabuf->fd);
+      }
+      if (!mr && symbols.ibv_internal_reg_mr != nullptr && mayUsePlainMr) {
+        errno = 0;
+        mr =
+            symbols.ibv_internal_reg_mr(nics_[n].ibvPd, ptr, size, accessFlags);
+      }
+      if (!mr) {
+        const int regErrno = errno;
+        cleanup(n);
+        throw std::runtime_error(
+            fmt::format(
+                "Exact VA registration failed for NIC {} "
+                "(ptr={} size={} dmabuf_errno={} ({}) errno={} ({}) "
+                "plain_mr_safe={})",
+                n,
+                ptr,
+                size,
+                dmabufErrno,
+                folly::errnoStr(dmabufErrno),
+                regErrno,
+                folly::errnoStr(regErrno),
+                mayUsePlainMr));
+      }
+    }
+    mrs[n] = mr;
   }
 
-  void* const ptr = registration->second.ptr;
-  bulkBufferRegistrations_.erase(registration);
-  deregisterBuffer(ptr);
-  lease.reset();
+  NetworkLKeys keys(numNics_);
+  for (int n = 0; n < numNics_; ++n) {
+    keys[n] = NetworkLKey(HostLKey(mrs[n]->lkey));
+  }
+  return IbBufferRegistration(
+      IbgdaLocalBuffer(ptr, keys), size, useRelaxedOrdering, mrs, numNics_);
 }
 
-bool MultiPeerIbTransportBase::isIbBulkBufferViewActive(
-    const IbBufferRegistrationView& view) const {
-  if (!view.valid()) {
-    return false;
+void MultiPeerIbTransportBase::deregisterIbBufferRange(
+    IbBufferRegistration& registration) {
+  if (!registration.valid()) {
+    throw std::invalid_argument(
+        "deregisterIbBufferRange: invalid registration");
   }
-  const auto registration = bulkBufferRegistrations_.find(view.leaseGeneration);
-  if (registration == bulkBufferRegistrations_.end()) {
-    return false;
+  for (int n = 0; n < registration.numNics_; ++n) {
+    if (registration.mrs_[n] != nullptr) {
+      const int rc =
+          ibverbx::ibvSymbols.ibv_internal_dereg_mr(registration.mrs_[n]);
+      if (rc != 0) {
+        LOG(WARNING) << "Failed to deregister exact VA MR on NIC " << n
+                     << ": rc=" << rc;
+      }
+    }
   }
-
-  const auto& active = registration->second;
-  return rangeContains(
-      reinterpret_cast<uintptr_t>(active.ptr),
-      active.size,
-      reinterpret_cast<uintptr_t>(view.localBuffer.ptr),
-      view.size);
+  registration.reset();
 }
 
 void MultiPeerIbTransportBase::deregisterBuffer(void* ptr) {
+  auto registrations = registrationState_.wlock();
+  deregisterBufferLocked(ptr, *registrations);
+}
+
+void MultiPeerIbTransportBase::deregisterBufferLocked(
+    void* ptr,
+    RegistrationState& registrations) {
   // Containment lookup on the ordered map avoids resolving the allocation range
   // again (which fails once the underlying memory is freed).
   const auto addr = reinterpret_cast<uintptr_t>(ptr);
-  auto it = registeredBuffers_.upper_bound(addr);
-  if (it != registeredBuffers_.begin()) {
+  auto it = registrations.registeredBuffers.upper_bound(addr);
+  if (it != registrations.registeredBuffers.begin()) {
     --it;
     if (addr < it->first + it->second.allocSize) {
       it->second.refs--;
@@ -1468,7 +1546,7 @@ void MultiPeerIbTransportBase::deregisterBuffer(void* ptr) {
         for (int n = 0; n < numNics_; ++n) {
           ibverbx::ibvSymbols.ibv_internal_dereg_mr(it->second.mrs[n]);
         }
-        registeredBuffers_.erase(it);
+        registrations.registeredBuffers.erase(it);
       }
       return;
     }
@@ -1484,23 +1562,25 @@ std::vector<IbgdaRemoteBuffer> MultiPeerIbTransportBase::exchangeBuffer(
   // allocation covering localBuf.ptr. Avoids re-resolving the allocation base;
   // sub-buffers resolve correctly via the ordered map.
   const auto addr = reinterpret_cast<uintptr_t>(localBuf.ptr);
-  auto it = registeredBuffers_.upper_bound(addr);
-  if (it == registeredBuffers_.begin()) {
-    throw std::runtime_error(
-        "Buffer not registered - call registerBuffer() first");
-  }
-  --it;
-  if (addr >= it->first + it->second.allocSize) {
-    throw std::runtime_error(
-        "Buffer not registered - call registerBuffer() first");
-  }
-
   // allGather addr + per-NIC rkeys; one entry per rank.
   std::vector<IbgdaBufferExchInfo> allInfo(nRanks_);
   allInfo[myRank_].addr = reinterpret_cast<uint64_t>(localBuf.ptr);
   allInfo[myRank_].numNics = numNics_;
-  for (int n = 0; n < numNics_; ++n) {
-    allInfo[myRank_].rkey_per_device[n] = HostRKey(it->second.mrs[n]->rkey);
+  {
+    auto registrations = registrationState_.rlock();
+    auto it = registrations->registeredBuffers.upper_bound(addr);
+    if (it == registrations->registeredBuffers.begin()) {
+      throw std::runtime_error(
+          "Buffer not registered - call registerBuffer() first");
+    }
+    --it;
+    if (addr >= it->first + it->second.allocSize) {
+      throw std::runtime_error(
+          "Buffer not registered - call registerBuffer() first");
+    }
+    for (int n = 0; n < numNics_; ++n) {
+      allInfo[myRank_].rkey_per_device[n] = HostRKey(it->second.mrs[n]->rkey);
+    }
   }
 
   auto result =
@@ -1624,8 +1704,9 @@ IbgdaLocalBuffer MultiPeerIbTransportBase::registerSlotMemory(
 
   NetworkLKeys keys(numNics_);
   const auto addr = reinterpret_cast<uintptr_t>(registrationPtr);
-  auto it = registeredBuffers_.upper_bound(addr);
-  CHECK(it != registeredBuffers_.begin())
+  auto registrations = registrationState_.rlock();
+  auto it = registrations->registeredBuffers.upper_bound(addr);
+  CHECK(it != registrations->registeredBuffers.begin())
       << "slot allocation MR not found after registration";
   --it;
   CHECK(addr < it->first + it->second.allocSize)
@@ -1643,8 +1724,9 @@ IbgdaBufferExchInfo MultiPeerIbTransportBase::registeredSlotMemoryExchInfo(
         "MultiPeerIbTransport: invalid slot memory exchange info");
   }
   const auto addr = reinterpret_cast<uintptr_t>(registrationPtr);
-  auto it = registeredBuffers_.upper_bound(addr);
-  CHECK(it != registeredBuffers_.begin())
+  auto registrations = registrationState_.rlock();
+  auto it = registrations->registeredBuffers.upper_bound(addr);
+  CHECK(it != registrations->registeredBuffers.begin())
       << "slot allocation MR not found after registration";
   --it;
   CHECK(addr < it->first + it->second.allocSize)

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -17,6 +17,8 @@
 #include <utility>
 #include <vector>
 
+#include <folly/Synchronized.h>
+
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/ctran/ibverbx/Ibvcore.h"
 #include "comms/prims/memory/DeviceSpan.cuh"
@@ -522,52 +524,62 @@ inline bool relaxedOrderingActiveForNic(
       nicRelaxedOrderingCapable;
 }
 
-// Explicit-release token for one transport-owned registration. Callers must
-// pass every valid lease to deregisterIbBulkBuffer() before destroying it; the
-// lease does not own the transport and therefore cannot release itself safely.
-class IbBufferRegistrationLease {
+// Exact caller-visible user-VA registration owned by its caller. A provider MR
+// may cover its page-aligned DMA-BUF mapping, but only local lkeys and the
+// requested ptr/size are exposed. The registration does not own the transport
+// and must be passed to deregisterIbBufferRange() while the transport is alive.
+class IbBufferRegistration {
  public:
-  IbBufferRegistrationLease() = default;
-  ~IbBufferRegistrationLease() = default;
-  IbBufferRegistrationLease(const IbBufferRegistrationLease&) = delete;
-  IbBufferRegistrationLease& operator=(const IbBufferRegistrationLease&) =
-      delete;
-  IbBufferRegistrationLease(IbBufferRegistrationLease&& other) noexcept
-      : generation_(std::exchange(other.generation_, 0)) {}
-  // Assignment could silently discard a registration that still requires an
-  // explicit release.
-  IbBufferRegistrationLease& operator=(IbBufferRegistrationLease&&) = delete;
+  IbBufferRegistration() = default;
+  ~IbBufferRegistration();
+  IbBufferRegistration(const IbBufferRegistration&) = delete;
+  IbBufferRegistration& operator=(const IbBufferRegistration&) = delete;
+  IbBufferRegistration(IbBufferRegistration&& other) noexcept
+      : localBuffer(std::exchange(other.localBuffer, IbgdaLocalBuffer{})),
+        size(std::exchange(other.size, 0)),
+        relaxedOrdering(std::exchange(other.relaxedOrdering, false)),
+        mrs_(
+            std::exchange(
+                other.mrs_,
+                std::array<ibverbx::ibv_mr*, kMaxNicsPerGpu>{})),
+        numNics_(std::exchange(other.numNics_, 0)) {}
+  // Assignment could silently discard MRs that still require an explicit
+  // release.
+  IbBufferRegistration& operator=(IbBufferRegistration&&) = delete;
 
   bool valid() const {
-    return generation_ != 0;
+    return localBuffer.ptr != nullptr && size != 0 && numNics_ != 0;
   }
 
-  uint64_t generation() const {
-    return generation_;
-  }
-
- private:
-  friend class MultiPeerIbTransportBase;
-
-  explicit IbBufferRegistrationLease(uint64_t generation)
-      : generation_(generation) {}
-
-  void reset() {
-    generation_ = 0;
-  }
-
-  uint64_t generation_{0};
-};
-
-struct IbBufferRegistrationView {
-  uint64_t leaseGeneration{0};
   IbgdaLocalBuffer localBuffer;
   std::size_t size{0};
   bool relaxedOrdering{false};
 
-  bool valid() const {
-    return leaseGeneration != 0 && localBuffer.ptr != nullptr && size != 0;
+ private:
+  friend class MultiPeerIbTransportBase;
+
+  IbBufferRegistration(
+      IbgdaLocalBuffer buffer,
+      std::size_t registrationSize,
+      bool registrationRelaxedOrdering,
+      std::array<ibverbx::ibv_mr*, kMaxNicsPerGpu> mrs,
+      int numNics)
+      : localBuffer(buffer),
+        size(registrationSize),
+        relaxedOrdering(registrationRelaxedOrdering),
+        mrs_(mrs),
+        numNics_(numNics) {}
+
+  void reset() {
+    localBuffer = {};
+    size = 0;
+    relaxedOrdering = false;
+    mrs_ = {};
+    numNics_ = 0;
   }
+
+  std::array<ibverbx::ibv_mr*, kMaxNicsPerGpu> mrs_{};
+  int numNics_{0};
 };
 
 inline bool reliableDoorbellActiveForNic(
@@ -853,27 +865,16 @@ class MultiPeerIbTransportBase {
   void deregisterBuffer(void* ptr);
 
   /**
-   * Register a logical bulk-data range and return its move-only ownership
-   * token. The underlying allocation MR is shared with other registrations,
-   * while the lease preserves the exact caller-visible range.
+   * Register a local send source and expose exactly [ptr, ptr + size) without
+   * allocation discovery or caching. A provider MR may be page-aligned. The
+   * result exposes local keys only and is invisible to exchangeBuffer() and
+   * registeredSlotMemoryExchInfo(); use registerBuffer() for memory that peers
+   * write into.
    */
-  IbBufferRegistrationLease registerIbBulkBuffer(void* ptr, std::size_t size);
+  IbBufferRegistration registerIbBufferRange(void* ptr, std::size_t size);
 
-  /**
-   * Return a non-owning RDMA view when the requested range is fully contained
-   * in the active lease. The view remains valid only while its lease is active.
-   */
-  std::optional<IbBufferRegistrationView> lookupIbBulkBuffer(
-      const IbBufferRegistrationLease& lease,
-      void* ptr,
-      std::size_t size) const;
-
-  /** Release one logical bulk registration and invalidate its ownership token.
-   */
-  void deregisterIbBulkBuffer(IbBufferRegistrationLease& lease);
-
-  /** Return whether a previously resolved view still names its active lease. */
-  bool isIbBulkBufferViewActive(const IbBufferRegistrationView& view) const;
+  /** Release an exact-range registration and invalidate it. */
+  void deregisterIbBufferRange(IbBufferRegistration& registration);
 
   /**
    * exchangeBuffer - COLLECTIVE. allGather a registered buffer's addr + per-NIC
@@ -1048,13 +1049,6 @@ class MultiPeerIbTransportBase {
     bool relaxedOrdering{false};
   };
 
-  struct BulkBufferRegistration {
-    void* ptr{nullptr};
-    std::size_t size{0};
-    IbgdaLocalBuffer localBuffer;
-    bool relaxedOrdering{false};
-  };
-
   const int myRank_{-1};
   const int nRanks_{0};
   std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
@@ -1096,14 +1090,19 @@ class MultiPeerIbTransportBase {
   // Ordering must be uniform across NICs; gating on this aggregate keeps it so.
   bool relaxedOrderingCapable_{false};
 
-  // Maps allocation base address -> cached MR covering the full allocation.
-  // Ordered map enables O(log n) containment lookup via upper_bound.
-  std::map<uintptr_t, CachedMr> registeredBuffers_;
+  struct RegistrationState {
+    // Maps allocation base address -> cached MR covering the full allocation.
+    // Ordered map enables O(log n) containment lookup via upper_bound.
+    std::map<uintptr_t, CachedMr> registeredBuffers;
+  };
+  folly::Synchronized<RegistrationState> registrationState_;
 
-  // Logical bulk-data registrations are keyed by a monotonically increasing
-  // generation. Their underlying MRs remain owned by registeredBuffers_.
-  std::map<uint64_t, BulkBufferRegistration> bulkBufferRegistrations_;
-  uint64_t nextBulkBufferGeneration_{1};
+  IbgdaLocalBuffer registerBufferLocked(
+      void* ptr,
+      std::size_t size,
+      bool relaxedOrdering,
+      RegistrationState& registrations);
+  void deregisterBufferLocked(void* ptr, RegistrationState& registrations);
 
   // Shared send/recv staging-ring state (eager mode). Owns the bulk
   // allocations; sendRecvPeerBuffers_ slices them per peer.

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -407,54 +407,30 @@ IbgdaLocalBuffer MultiPeerTransport::localRegisterIbgdaBuffer(
       "localRegisterIbgdaBuffer: IB transport not available");
 }
 
-IbBufferRegistrationLease MultiPeerTransport::registerIbBulkBuffer(
+IbBufferRegistration MultiPeerTransport::registerIbBufferRange(
     void* ptr,
     std::size_t size) {
   if (ibgdaTransport_) {
-    return ibgdaTransport_->registerIbBulkBuffer(ptr, size);
+    return ibgdaTransport_->registerIbBufferRange(ptr, size);
   }
   if (ibrcTransport_) {
-    return ibrcTransport_->registerIbBulkBuffer(ptr, size);
+    return ibrcTransport_->registerIbBufferRange(ptr, size);
   }
-  throw std::runtime_error("registerIbBulkBuffer: IB transport not available");
+  throw std::runtime_error("registerIbBufferRange: IB transport not available");
 }
 
-std::optional<IbBufferRegistrationView> MultiPeerTransport::lookupIbBulkBuffer(
-    const IbBufferRegistrationLease& lease,
-    void* ptr,
-    std::size_t size) const {
+void MultiPeerTransport::deregisterIbBufferRange(
+    IbBufferRegistration& registration) {
   if (ibgdaTransport_) {
-    return ibgdaTransport_->lookupIbBulkBuffer(lease, ptr, size);
-  }
-  if (ibrcTransport_) {
-    return ibrcTransport_->lookupIbBulkBuffer(lease, ptr, size);
-  }
-  return std::nullopt;
-}
-
-void MultiPeerTransport::deregisterIbBulkBuffer(
-    IbBufferRegistrationLease& lease) {
-  if (ibgdaTransport_) {
-    ibgdaTransport_->deregisterIbBulkBuffer(lease);
+    ibgdaTransport_->deregisterIbBufferRange(registration);
     return;
   }
   if (ibrcTransport_) {
-    ibrcTransport_->deregisterIbBulkBuffer(lease);
+    ibrcTransport_->deregisterIbBufferRange(registration);
     return;
   }
   throw std::runtime_error(
-      "deregisterIbBulkBuffer: IB transport not available");
-}
-
-bool MultiPeerTransport::isIbBulkBufferViewActive(
-    const IbBufferRegistrationView& view) const {
-  if (ibgdaTransport_) {
-    return ibgdaTransport_->isIbBulkBufferViewActive(view);
-  }
-  if (ibrcTransport_) {
-    return ibrcTransport_->isIbBulkBufferViewActive(view);
-  }
-  return false;
+      "deregisterIbBufferRange: IB transport not available");
 }
 
 void MultiPeerTransport::localDeregisterIbgdaBuffer(void* ptr) {

--- a/comms/prims/transport/MultiPeerTransport.h
+++ b/comms/prims/transport/MultiPeerTransport.h
@@ -298,16 +298,9 @@ class MultiPeerTransport {
    */
   IbgdaLocalBuffer localRegisterIbgdaBuffer(void* ptr, size_t size);
 
-  IbBufferRegistrationLease registerIbBulkBuffer(void* ptr, std::size_t size);
+  IbBufferRegistration registerIbBufferRange(void* ptr, std::size_t size);
 
-  std::optional<IbBufferRegistrationView> lookupIbBulkBuffer(
-      const IbBufferRegistrationLease& lease,
-      void* ptr,
-      std::size_t size) const;
-
-  void deregisterIbBulkBuffer(IbBufferRegistrationLease& lease);
-
-  bool isIbBulkBufferViewActive(const IbBufferRegistrationView& view) const;
+  void deregisterIbBufferRange(IbBufferRegistration& registration);
 
   /**
    * Deregister a previously registered IBGDA buffer.

--- a/comms/prims/transport/amd/prims_amd_gda/PrimsAmdGdaDmaBuf.cc
+++ b/comms/prims/transport/amd/prims_amd_gda/PrimsAmdGdaDmaBuf.cc
@@ -74,6 +74,13 @@ export_gpu_dmabuf_aligned(void* ptr, std::size_t size, DmaBufExportKind kind) {
   return ex;
 }
 
+std::optional<DmaBufExport> export_gpu_dmabuf_va_range_aligned(
+    [[maybe_unused]] void* ptr,
+    [[maybe_unused]] std::size_t size,
+    [[maybe_unused]] DmaBufExportKind kind) {
+  return std::nullopt;
+}
+
 } // namespace comms::prims
 
 #endif // __HIP_PLATFORM_AMD__

--- a/comms/prims/transport/amd/prims_amd_gda/PrimsAmdGdaDmaBuf.h
+++ b/comms/prims/transport/amd/prims_amd_gda/PrimsAmdGdaDmaBuf.h
@@ -43,6 +43,11 @@ std::optional<DmaBufExport> export_gpu_dmabuf_aligned(
     std::size_t size,
     DmaBufExportKind kind = DmaBufExportKind::Default);
 
+std::optional<DmaBufExport> export_gpu_dmabuf_va_range_aligned(
+    void* ptr,
+    std::size_t size,
+    DmaBufExportKind kind = DmaBufExportKind::Default);
+
 } // namespace comms::prims
 
 #endif // __HIP_PLATFORM_AMD__

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -1220,17 +1220,20 @@ void MultipeerIbgdaTransport::cleanup() {
   cleanupSignalCounterResources();
 
   // Destroy user buffer MRs
-  for (auto& [_, cached] : registeredBuffers_) {
-    // numNics_=1 today; loop is the multi-NIC-ready shape (P2.x fills the
-    // rest of mrs[]).
-    for (int n = 0; n < numNics_; ++n) {
-      if (cached.mrs[n] != nullptr &&
-          symbols.ibv_internal_dereg_mr != nullptr) {
-        symbols.ibv_internal_dereg_mr(cached.mrs[n]);
+  {
+    auto registrations = registrationState_.wlock();
+    for (auto& [_, cached] : registrations->registeredBuffers) {
+      // numNics_=1 today; loop is the multi-NIC-ready shape (P2.x fills the
+      // rest of mrs[]).
+      for (int n = 0; n < numNics_; ++n) {
+        if (cached.mrs[n] != nullptr &&
+            symbols.ibv_internal_dereg_mr != nullptr) {
+          symbols.ibv_internal_dereg_mr(cached.mrs[n]);
+        }
       }
     }
+    registrations->registeredBuffers.clear();
   }
-  registeredBuffers_.clear();
 
   // Destroy per-NIC sink MRs. Iterate over actual nicDoca_ entries
   // (vector is empty if cleanup runs before openIbDevice; partial init leaves

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
@@ -249,7 +249,7 @@ class MultipeerIbgdaTransport
   // backend's doMaterializePeer()/cleanupPeerOnFailure() hooks.
   friend class MultiPeerIbTransport<MultipeerIbgdaTransport>;
 
-  // myRank_/nRanks_/bootstrap_/config_/registeredBuffers_/nics_/lazy-state are
+  // myRank_/nRanks_/bootstrap_/config_/registrationState_/nics_/lazy-state are
   // inherited (protected) from MultiPeerIbTransport.
 
   // DOCA GPU context (shared across NICs).
@@ -304,7 +304,7 @@ class MultipeerIbgdaTransport
   std::size_t sinkBufferAllocSize_{0};
   std::uint64_t sinkBufferHandle_{0};
 
-  // The refcounted MR cache (CachedMr + registeredBuffers_) lives in
+  // The refcounted MR cache (CachedMr + registrationState_) lives in
   // MultiPeerIbTransport.
 
   // GPU PCIe bus ID.

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -25,7 +25,6 @@
 #ifdef __HIP_PLATFORM_AMD__
 #include <hip/hip_runtime.h>
 #else
-#include <cuda_runtime.h>
 #endif
 
 #include <fmt/core.h>
@@ -355,21 +354,24 @@ void MultipeerIbrcTransport::cleanup() {
   cleanupSignalCounterResources();
 
   auto& symbols = ibverbx::ibvSymbols;
-  if (symbols.ibv_internal_dereg_mr != nullptr) {
-    for (auto& [_, cached] : registeredBuffers_) {
-      for (int n = 0; n < numNics_; ++n) {
-        if (cached.mrs[n] != nullptr) {
-          int rc = symbols.ibv_internal_dereg_mr(cached.mrs[n]);
-          if (rc != 0) {
-            LOG(WARNING) << "Failed to deregister IBRC MR on NIC " << n
-                         << ": rc=" << rc;
+  {
+    auto registrations = registrationState_.wlock();
+    if (symbols.ibv_internal_dereg_mr != nullptr) {
+      for (auto& [_, cached] : registrations->registeredBuffers) {
+        for (int n = 0; n < numNics_; ++n) {
+          if (cached.mrs[n] != nullptr) {
+            int rc = symbols.ibv_internal_dereg_mr(cached.mrs[n]);
+            if (rc != 0) {
+              LOG(WARNING) << "Failed to deregister IBRC MR on NIC " << n
+                           << ": rc=" << rc;
+            }
+            cached.mrs[n] = nullptr;
           }
-          cached.mrs[n] = nullptr;
         }
       }
     }
+    registrations->registeredBuffers.clear();
   }
-  registeredBuffers_.clear();
 
   statusHostByNic_.clear();
   statusDeviceByNic_.clear();

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2058,10 +2058,12 @@ cvars:
    default     : "off"
    choices     : off, force
    description : |-
-     Select send-side zero-copy for MCCL-native AllReduce.
+     Select zero-copy for MCCL-native AllReduce.
      off - Preserve the existing copy-based registration and collective paths.
-     force - Require every rank and the exact Phase-2 source range to be
-             eligible for IBGDA zero-copy; never fall back to the copy path.
+     force - Use zero-copy when every rank is eligible during CUDA graph
+             capture. Eager calls and graph captures where any rank is
+             ineligible or registration fails collectively use the copy path.
+             Invalid or rank-mismatched requests return an error.
 
  - name        : MCCL_ALLREDUCE_RING_BIDIRECTIONAL_ENABLE
    type        : bool


### PR DESCRIPTION
Summary:

Route forced MCCL AllReduce Tree and Ring calls through the existing zero-copy preparation path and automatically create PRIMS-only buffer registrations when no explicit registration covers the operation. Eager registrations live through stream completion, while CUDA graph registrations are retained by graph user objects and released with the graph. Preserve rank agreement, abort quarantine, and reconfigure safety without requiring PAFT or TorchComm changes.

Reviewed By: saifhhasan

Differential Revision: D118163249


