### PR TITLE
Default NCCL_CTRAN_IB_VC_MODE to spray (#3891)

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1872,7 +1872,7 @@ cvars:
 
  - name        : NCCL_CTRAN_IB_VC_MODE
    type        : enum
-   default     : dqplb
+   default     : spray
    choices     : spray, dqplb
    description : |-
      Configure IBVCs to support either spray mode (uses extra QP for


### PR DESCRIPTION
Summary:

`NCCL_CTRAN_IB_VC_MODE` defaulted to `dqplb`, which left a gap: CTRAN did
not spray on the first hop.

The `NCCL_CTRAN_IB_QP_CONFIG_{XRACK,XZONE,XDC}` configList overrides already
carry `spray` in their `<QP_SCALING_THRESHOLD>,<MAX_QPS>,<VC_MODE>,<QP_MAX_MSGS>`
tuples, so only the VCs that have no configList entry -- same-zone / first-hop
VCs -- fell through to the cvar default and stayed on `dqplb`.

This flips the default to `spray` so unconfigured VCs spray too. `dqplb`
remains a valid choice and can still be requested explicitly.

Companion diffs flip the launcher-side `NCCL_CTRAN_IB_VC_MODE` env overrides
that pin `dqplb` and would otherwise mask this new default.

Reviewed By: goelayu

Differential Revision: D118059703


