### PR TITLE
Default NCCL_CTRAN_AGP_SKIP_MC_INTRA_BARRIER to true (#3892)

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2320,12 +2320,12 @@ cvars:
 
  - name        : NCCL_CTRAN_AGP_SKIP_MC_INTRA_BARRIER
    type        : bool
-   default     : false
+   default     : true
    description : |-
      Perf A/B knob for the per-step intra-node NVL broadcast barrier in the
      AllGatherP pipeline / streamed-recursive-doubling algorithms, scoped to the
-     CE-multicast path only. When false (default) the per-step barrier is
-     emitted; when true it is skipped, but only where the multicast write is
+     CE-multicast path only. When false the per-step barrier is emitted;
+     when true (default) it is skipped, but only where the multicast write is
      engaged (pArgs.mcWrite). The barrier exists to pace the N-1 per-peer unicast
      writes so they do not all-to-one incast a single peer, so it is always kept
      on the unicast path regardless of this setting — including on ctwin runs


### PR DESCRIPTION
Summary:

Flips `NCCL_CTRAN_AGP_SKIP_MC_INTRA_BARRIER` from `default: false` to
`default: true` and swaps the "(default)" marker in its description.

The knob skips the per-step intra-node NVL broadcast barrier in the AllGatherP
pipeline / streamed-RD algorithms, and only where the CE-multicast write is
engaged (`pArgs.mcWrite`). The barrier exists to pace N-1 per-peer unicast writes
so they do not incast one peer; a multicast broadcast is a single switch-fanned
store with nothing to pace, which is what makes dropping it safe there. The
unicast path keeps the barrier regardless of this setting, and the step-0 WAR
guard and PipeEnd barrier are untouched.

Sweep data across GB200/GB300, two NVL widths and 8-256 ranks shows the skip is a
consistent win at nNodes >= 2 (median +15% eager / +20% graph at <=128 MiB, +7% /
+3% above that) and exactly inert at nNodes=1, where the gated work is bounded by
`nNodes-1` and does not exist. Measured -0.0% across every nNodes=1 cell in both
modes, so default-on costs nothing in the single-node case.

Also adds the full sweep writeup under
comms/ctran/algos/AllGather/fb/docs/ctwin_multicast_barrier_sweep.md: per-config
busbw and latency tables, the recommended knob matrix, and the mechanism behind
the multicast/unicast split under graph capture.

Two caveats recorded in the doc: eager arms ran with `-z 1` and graph arms with
`-z 0`, so eager-vs-graph carries that confound; and all runs used
`NCCL_CTRAN_GRAPH_MIXING_SUPPORT=1`, which makes
`NCCL_CTRAN_GPE_HOST_NODE_SIDE_STREAM` inert, so the graph numbers are pessimistic
by a near-constant 52-85 us per replay.

Reviewed By: minsii

Differential Revision: D118171012
