### PR TITLE
Scope IBGDA SQ and CQ synchronization to ownership

### DIFF
--- a/comms/prims/docs/Channels.md
+++ b/comms/prims/docs/Channels.md
@@ -154,10 +154,13 @@ groups would already be racing that counter.
 
 Consequences for IBGDA:
 
-- WQ-slot reservation and ready-index publication use
+- SQ reservation, ready-index publication, and submission use
   `DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE`. The shared-QP mode
   spends device-scope atomics and `atomicCAS` spins arbitrating between posters
   that cannot exist; under `EXCLUSIVE` those become plain loads and stores.
+- CQ ownership is separate. The normal path's group leader owns the Send CQ, so
+  it uses `EXCLUSIVE`. The warp proxy's worker and service leaders share that CQ
+  within one CTA, so its completion waits and SQ-slot check use `CTA`.
 - Because `EXCLUSIVE` makes `mark_wqes_ready` a bare store with no fence, the
   release that orders WQE payload stores before the MMIO doorbell moves into the
   submit step, at GPU scope. Something must provide that release or the NIC can

--- a/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
@@ -217,7 +217,7 @@ __device__ __forceinline__ void assert_progress_slot_idle(
     const IbChannelProgress& slot,
     const char* opName);
 
-template <typename P, typename Transport>
+template <typename P, bool IsWarpProxy = false, typename Transport>
 [[nodiscard]] __device__ __forceinline__ bool prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
@@ -1476,7 +1476,7 @@ __device__ __forceinline__ void send_impl(
           return prepare_send_slot<Proto>(
               transport, group, slot, pipelineCycle, abortDevice);
         } else {
-          return ibOps->prepare_send_slot(
+          return ibOps->template prepare_send_slot<Proto>(
               transport, group, slot, pipelineCycle, abortDevice);
         }
       }();
@@ -2469,7 +2469,7 @@ __device__ __forceinline__ void forward_impl(
     } else {
       const uint64_t recvToken = ibOps->wait_recv(
           transport, group, recvProtocolBytesThis, abortDevice);
-      if (ibOps->prepare_send_slot(
+      if (ibOps->template prepare_send_slot<Proto>(
               fwdTransport,
               group,
               static_cast<uint32_t>(fwdSlot),
@@ -2824,7 +2824,7 @@ __device__ __forceinline__ void assert_progress_slot_idle(
  * The verdict leaves through the `group.sync()` that already terminated this
  * function, now a broadcast, so making it group-uniform costs no extra barrier.
  */
-template <typename P, typename Transport>
+template <typename P, bool IsWarpProxy, typename Transport>
 [[nodiscard]] __device__ __forceinline__ bool prepare_send_slot(
     Transport& transport,
     ThreadGroup& group,
@@ -2847,11 +2847,19 @@ template <typename P, typename Transport>
             .completionId = laneId,
             .value = slot.values[laneId],
         };
-        transport.wait_local_completion(group.group_id, ticket, abortDevice);
-        // Confirm rather than assume: the wait above cannot report that it gave
-        // up, and a lane earlier in this loop may already have latched the
-        // abort, so later lanes can fall straight through it.
-        if (transport.is_local_completion_ready(group.group_id, ticket)) {
+        // A void wait may stop on abort, so confirm the completion afterward.
+        bool completed;
+        if constexpr (IsWarpProxy) {
+          transport.template wait_local_completion<true>(
+              group.group_id, ticket, abortDevice);
+          completed = transport.template is_local_completion_ready<true>(
+              group.group_id, ticket, abortDevice);
+        } else {
+          transport.wait_local_completion(group.group_id, ticket, abortDevice);
+          completed = transport.is_local_completion_ready(
+              group.group_id, ticket, abortDevice);
+        }
+        if (completed) {
           pending &= ~laneBit;
         }
       }

--- a/comms/prims/transport/amd/DocaCompat.h
+++ b/comms/prims/transport/amd/DocaCompat.h
@@ -62,6 +62,7 @@ using doca_gpu_dev_verbs_wqe_ctrl_flags = uint8_t;
 // equivalents (same bit values).
 
 constexpr int DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU = 0;
+constexpr int DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_CTA = 0;
 // Same inert placeholder as the GPU mode above: the `prims_amd_gda_*` overloads
 // ignore the sharing mode, so selecting EXCLUSIVE on the NVIDIA side leaves AMD
 // behaviour unchanged. It has to be spelled here regardless, because the

--- a/comms/prims/transport/ibgda/IbgdaWarpProxy.cuh
+++ b/comms/prims/transport/ibgda/IbgdaWarpProxy.cuh
@@ -233,6 +233,7 @@ class IbgdaWarpProxy {
     // Returns true when the slot could not be retired -- see
     // detail::prepare_send_slot. The caller must not stage or put on a slot the
     // NIC may still be reading.
+    template <typename Proto>
     [[nodiscard]] __device__ __forceinline__ bool prepare_send_slot(
         P2pIbgdaTransportDevice& transport,
         ThreadGroup& workers,
@@ -241,7 +242,7 @@ class IbgdaWarpProxy {
         const AbortDevice& abortDevice) {
       IbgdaWarpProxy::wait_prior_send_posted(
           storage_, workers, slot, abortDevice);
-      return detail::prepare_send_slot(
+      return detail::prepare_send_slot<Proto, true>(
           transport, workers, slot, generation, abortDevice);
     }
 
@@ -778,16 +779,17 @@ class IbgdaWarpProxy {
     const IbRemoteChannel remote = makeIbRemoteChannel(
         command.transport->channel_layout(), static_cast<int>(command.channel));
     ThreadGroup solo = make_solo_group(command.channel, fullBlock);
-    const IbLocalCompletionTicket ticket = command.transport->put(
-        solo,
-        command.source,
-        remote.recvStaging.subBuffer(command.remoteOffset),
-        command.bytes,
-        remote.dataReady,
-        command.protocolBytes,
-        /*counterBuf=*/{},
-        /*counterVal=*/0,
-        /*signalPerLane=*/true);
+    const IbLocalCompletionTicket ticket =
+        command.transport->template put<true>(
+            solo,
+            command.source,
+            remote.recvStaging.subBuffer(command.remoteOffset),
+            command.bytes,
+            remote.dataReady,
+            command.protocolBytes,
+            /*counterBuf=*/{},
+            /*counterVal=*/0,
+            /*signalPerLane=*/true);
     detail::record_send_completion(
         *command.transport,
         command.channel,

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -505,6 +505,7 @@ class P2pIbgdaTransportDevice {
    *                   WQE through the companion QP.
    * @param counterVal Value added to *counterBuf.
    */
+  template <bool IsWarpProxy = false>
   __device__ IbLocalCompletionTicket
   put(ThreadGroup& group,
       const IbgdaLocalBuffer& localBuf,
@@ -515,7 +516,7 @@ class P2pIbgdaTransportDevice {
       const IbgdaLocalBuffer& counterBuf = {},
       uint64_t counterVal = 1,
       bool signalPerLane = false) {
-    return put_impl(
+    return put_impl<IsWarpProxy>(
         group,
         localBuf,
         remoteBuf,
@@ -684,14 +685,17 @@ class P2pIbgdaTransportDevice {
     group.sync();
   }
 
+  template <bool IsWarpProxy = false>
   __device__ __forceinline__ bool is_local_completion_ready(
       uint32_t channelId,
       const IbLocalCompletionTicket& ticket,
       const AbortDevice& abortDevice = AbortDevice()) {
     IbgdaLane lane =
         lane_from_ordinal(channelId, IbDirection::Send, ticket.completionId);
-    const int status = doca_gpu_dev_verbs_poll_one_cq_at<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+    constexpr auto kCqSharingMode = IsWarpProxy
+        ? DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_CTA
+        : DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE;
+    const int status = doca_gpu_dev_verbs_poll_one_cq_at<kCqSharingMode>(
         doca_gpu_dev_verbs_qp_get_cq_sq(lane.qp), ticket.value);
     if (status == 0) {
       return true;
@@ -735,13 +739,14 @@ class P2pIbgdaTransportDevice {
     return false;
   }
 
+  template <bool IsWarpProxy = false>
   __device__ __forceinline__ void wait_local_completion(
       uint32_t channelId,
       const IbLocalCompletionTicket& ticket,
       const AbortDevice& abortDevice) {
     IbgdaLane lane =
         lane_from_ordinal(channelId, IbDirection::Send, ticket.completionId);
-    wait_local_on_qp(lane.qp, ticket.value, abortDevice);
+    wait_local_on_qp<IsWarpProxy>(lane.qp, ticket.value, abortDevice);
   }
 
   __device__ __forceinline__ uint32_t send_completion_lane_count() const {
@@ -1100,19 +1105,22 @@ class P2pIbgdaTransportDevice {
     record_flush_wqe(lane, ticket);
   }
 
+  template <bool IsWarpProxy = false>
   __device__ void wait_local_on_qp(
       doca_gpu_dev_verbs_qp* qp,
       doca_gpu_dev_verbs_ticket_t ticket,
       AbortDevice abortDevice = AbortDevice()) {
+    constexpr auto kCqSharingMode = IsWarpProxy
+        ? DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_CTA
+        : DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE;
     if (!abortDevice.isEnabled()) {
       doca_gpu_dev_verbs_wait<
-          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+          kCqSharingMode,
           DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp, ticket);
     } else {
       int status;
       do {
-        status = doca_gpu_dev_verbs_poll_one_cq_at<
-            DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+        status = doca_gpu_dev_verbs_poll_one_cq_at<kCqSharingMode>(
             doca_gpu_dev_verbs_qp_get_cq_sq(qp), ticket);
         if (status == EBUSY) {
           FT_ABORT_BREAK(
@@ -1183,6 +1191,7 @@ class P2pIbgdaTransportDevice {
         group.group_id, direction, mask, state.lastFlushWqe, abortDevice);
   }
 
+  template <bool IsWarpProxy>
   __device__ IbLocalCompletionTicket put_impl(
       ThreadGroup& group,
       const IbgdaLocalBuffer& localBuf,
@@ -1235,7 +1244,7 @@ class P2pIbgdaTransportDevice {
         record_put_wqe(lane, tickets.put_wqe);
         record_signal_wqe(lane, tickets.signal_wqe);
       } else if (hasSignal) {
-        const auto tickets = put_signal_single_impl(
+        const auto tickets = put_signal_single_impl<IsWarpProxy>(
             lane, localBuf, remoteBuf, nbytes, effectiveSignalBuf, signalVal);
         dataTicket = tickets.put_wqe;
         record_put_wqe(lane, tickets.put_wqe);
@@ -1413,7 +1422,8 @@ class P2pIbgdaTransportDevice {
     uint64_t base_wqe_idx = 0;
     if (group.is_leader()) {
       base_wqe_idx = doca_gpu_dev_verbs_reserve_wq_slots<
-          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(qp, group.group_size);
+          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE>(
+          qp, group.group_size);
     }
     base_wqe_idx = group.broadcast<uint64_t>(base_wqe_idx);
 
@@ -1447,14 +1457,14 @@ class P2pIbgdaTransportDevice {
 
     // Leader marks ready and rings doorbell
     if (group.is_leader()) {
+      const uint64_t lastWqeIdx = base_wqe_idx + group.group_size - 1;
       doca_gpu_dev_verbs_mark_wqes_ready<
-          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
-          qp, base_wqe_idx, base_wqe_idx + group.group_size - 1);
+          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE>(
+          qp, base_wqe_idx, lastWqeIdx);
       doca_gpu_dev_verbs_submit<
-          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE,
           DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU,
-          DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(
-          qp, base_wqe_idx + group.group_size);
+          DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp, lastWqeIdx + 1);
     }
 
     group.sync();
@@ -1478,54 +1488,14 @@ class P2pIbgdaTransportDevice {
         .key = remoteBuf.rkey_per_device[lane.nic_id].value};
 
     doca_gpu_dev_verbs_put<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE,
         DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO,
         DOCA_GPUNETIO_VERBS_EXEC_SCOPE_THREAD>(
         lane.qp, remoteAddr, localAddr, nbytes, &ticket);
     return ticket;
   }
 
-  // --- WQ slot lifecycle ---
-  //
-  // Every posting site funnels through these three, so the sharing mode and the
-  // fence rule are stated once instead of at each call.
-  //
-  // A QP has exactly one poster; see "QP posting ownership" in
-  // comms/prims/docs/Channels.md for why that is structural and what depends
-  // on it.
-
-  static constexpr auto kQpSharingMode =
-      DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE;
-
-  __device__ __forceinline__ uint64_t
-  reserve_wqes(doca_gpu_dev_verbs_qp* qp, uint32_t count) const {
-    return doca_gpu_dev_verbs_reserve_wq_slots<kQpSharingMode>(qp, count);
-  }
-
-  __device__ __forceinline__ void mark_wqes_ready_mode(
-      doca_gpu_dev_verbs_qp* qp,
-      uint64_t fromWqe,
-      uint64_t toWqe) const {
-    doca_gpu_dev_verbs_mark_wqes_ready<kQpSharingMode>(qp, fromWqe, toWqe);
-  }
-
-  /**
-   * Ring the doorbell for everything up to and including `toWqe`.
-   *
-   * The GPU sync scope is load-bearing, not a default: under EXCLUSIVE
-   * `mark_wqes_ready` is a bare store, so this is the only release ordering the
-   * WQE payload before the MMIO doorbell. THREAD here would let the NIC fetch a
-   * WQE it has not been shown.
-   */
-  __device__ __forceinline__ void submit_wqes(
-      doca_gpu_dev_verbs_qp* qp,
-      uint64_t toWqe) const {
-    doca_gpu_dev_verbs_submit<
-        kQpSharingMode,
-        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU,
-        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp, toWqe + 1);
-  }
-
+  template <bool IsWarpProxy = false>
   __device__ IbgdaPutSignalTickets put_signal_single_impl(
       const IbgdaLane& lane,
       const IbgdaLocalBuffer& localBuf,
@@ -1564,7 +1534,22 @@ class P2pIbgdaTransportDevice {
     uint64_t numChunks = doca_gpu_dev_verbs_div_ceil_aligned_pow2(
         nbytes, DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE_SHIFT);
     numChunks = numChunks > 1 ? numChunks : 1;
-    uint64_t baseWqeIdx = reserve_wqes(lane.qp, numChunks + 1);
+    uint64_t baseWqeIdx;
+    if constexpr (!IsWarpProxy) {
+      baseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
+          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE>(
+          lane.qp, numChunks + 1);
+    } else {
+      // The service warp owns the SQ; service and worker warps share its CQ.
+      baseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
+          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE>(
+          lane.qp,
+          numChunks + 1,
+          DOCA_GPUNETIO_VERBS_GPU_CODE_OPT_SKIP_AVAILABILITY_CHECK);
+      doca_gpu_dev_verbs_wait_until_slot_available<
+          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_CTA>(
+          lane.qp, baseWqeIdx + numChunks);
+    }
     uint64_t wqeIdx = baseWqeIdx;
     std::size_t remainingSize = nbytes;
 
@@ -1609,8 +1594,13 @@ class P2pIbgdaTransportDevice {
         sizeof(uint64_t),
         signalVal,
         0);
-    mark_wqes_ready_mode(lane.qp, baseWqeIdx, wqeIdx);
-    submit_wqes(lane.qp, wqeIdx);
+    doca_gpu_dev_verbs_mark_wqes_ready<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE>(
+        lane.qp, baseWqeIdx, wqeIdx);
+    doca_gpu_dev_verbs_submit<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE,
+        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(lane.qp, wqeIdx + 1);
     return IbgdaPutSignalTickets{lastPutWqeIdx, wqeIdx};
 #endif
   }
@@ -1666,7 +1656,7 @@ class P2pIbgdaTransportDevice {
         nbytes, DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE_SHIFT);
     numChunks = numChunks > 1 ? numChunks : 1;
     uint64_t baseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(qp, numChunks);
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE>(qp, numChunks);
     uint64_t wqeIdx = baseWqeIdx;
     std::size_t remainingSize = nbytes;
 
@@ -1696,11 +1686,11 @@ class P2pIbgdaTransportDevice {
     const uint64_t lastPutWqeIdx = wqeIdx;
 
     doca_gpu_dev_verbs_mark_wqes_ready<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE>(
         qp, baseWqeIdx, lastPutWqeIdx);
 
     uint64_t companionBaseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(companionQp, 2);
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE>(companionQp, 2);
     uint64_t companionWqeIdx = companionBaseWqeIdx;
     doca_gpu_dev_verbs_wqe* wqePtr =
         doca_gpu_dev_verbs_get_wqe_ptr(companionQp, companionWqeIdx);
@@ -1728,15 +1718,15 @@ class P2pIbgdaTransportDevice {
         counterVal,
         0);
     doca_gpu_dev_verbs_mark_wqes_ready<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE>(
         companionQp, companionBaseWqeIdx, companionWqeIdx);
 
     doca_gpu_dev_verbs_qp* qps[kNumQps] = {qp, companionQp};
     uint64_t prodIndices[kNumQps] = {lastPutWqeIdx + 1, companionWqeIdx + 1};
     doca_gpu_dev_verbs_submit_multi_qps<
         kNumQps,
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
-        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_THREAD,
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE,
+        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU,
         DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qps, prodIndices);
     return lastPutWqeIdx;
 #endif
@@ -1783,7 +1773,7 @@ class P2pIbgdaTransportDevice {
         nbytes, DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE_SHIFT);
     numChunks = numChunks > 1 ? numChunks : 1;
     uint64_t baseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(qp, numChunks + 1);
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE>(qp, numChunks + 1);
     uint64_t wqeIdx = baseWqeIdx;
     std::size_t remainingSize = nbytes;
 
@@ -1829,11 +1819,11 @@ class P2pIbgdaTransportDevice {
         0);
     const uint64_t signalWqeIdx = wqeIdx;
     doca_gpu_dev_verbs_mark_wqes_ready<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE>(
         qp, baseWqeIdx, signalWqeIdx);
 
     uint64_t companionBaseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(companionQp, 2);
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE>(companionQp, 2);
     uint64_t companionWqeIdx = companionBaseWqeIdx;
     wqePtr = doca_gpu_dev_verbs_get_wqe_ptr(companionQp, companionWqeIdx);
     doca_gpu_dev_verbs_wqe_prepare_wait(
@@ -1860,15 +1850,15 @@ class P2pIbgdaTransportDevice {
         counterVal,
         0);
     doca_gpu_dev_verbs_mark_wqes_ready<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE>(
         companionQp, companionBaseWqeIdx, companionWqeIdx);
 
     doca_gpu_dev_verbs_qp* qps[kNumQps] = {qp, companionQp};
     uint64_t prodIndices[kNumQps] = {signalWqeIdx + 1, companionWqeIdx + 1};
     doca_gpu_dev_verbs_submit_multi_qps<
         kNumQps,
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
-        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_THREAD,
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE,
+        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU,
         DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qps, prodIndices);
     return IbgdaPutSignalTickets{lastPutWqeIdx, signalWqeIdx};
 #endif
@@ -1913,7 +1903,7 @@ class P2pIbgdaTransportDevice {
         counterVal);
 #else
     uint64_t baseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(companionQp, 2);
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE>(companionQp, 2);
     uint64_t wqeIdx = baseWqeIdx;
     doca_gpu_dev_verbs_wqe* wqePtr =
         doca_gpu_dev_verbs_get_wqe_ptr(companionQp, wqeIdx);
@@ -1941,11 +1931,11 @@ class P2pIbgdaTransportDevice {
         counterVal,
         0);
     doca_gpu_dev_verbs_mark_wqes_ready<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE>(
         companionQp, baseWqeIdx, wqeIdx);
     doca_gpu_dev_verbs_submit<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
-        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_THREAD,
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE,
+        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU,
         DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(companionQp, wqeIdx + 1);
 #endif
   }
@@ -1963,7 +1953,8 @@ class P2pIbgdaTransportDevice {
         .key = signalBuf.rkey_per_device[lane.nic_id].value};
     doca_gpu_dev_verbs_addr sinkAddr = {.addr = 0, .key = nic.sink_lkey.value};
 
-    uint64_t wqe_idx = reserve_wqes(qp, 1);
+    uint64_t wqe_idx = doca_gpu_dev_verbs_reserve_wq_slots<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE>(qp, 1);
 
     doca_gpu_dev_verbs_wqe* wqe_ptr =
         doca_gpu_dev_verbs_get_wqe_ptr(qp, wqe_idx);
@@ -1984,8 +1975,13 @@ class P2pIbgdaTransportDevice {
         signalVal,
         0);
 
-    mark_wqes_ready_mode(qp, wqe_idx, wqe_idx);
-    submit_wqes(qp, wqe_idx);
+    doca_gpu_dev_verbs_mark_wqes_ready<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE>(
+        qp, wqe_idx, wqe_idx);
+    doca_gpu_dev_verbs_submit<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE,
+        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp, wqe_idx + 1);
     return wqe_idx;
   }
 


### PR DESCRIPTION
Summary:
D117934231 moved the IBGDA WQ-slot lifecycle to `EXCLUSIVE` because each QP has one poster. That ownership argument is correct for the SQ, but `reserve_wq_slots` also performs a Send-CQ availability check. In warp-proxy mode, the service warp posts while worker warps retire prior sends through the same CQ, so using `EXCLUSIVE` for that implicit CQ access violates its single-consumer contract.

Keep SQ reservation, ready publication, and submission `EXCLUSIVE`. For warp proxy, skip the CQ check during SQ reservation, then perform slot-availability waits and send-completion polling with `CTA`; normal-path CQ polling remains `EXCLUSIVE`. Retain GPU-scope submission to order WQE writes before the doorbell, and keep protocol selection independent of warp-proxy mode.

Add the inert `CTA` selector to the AMD DOCA compatibility shim so the shared code compiles under HIP; AMD behavior is unchanged because the shim ignores sharing-mode selectors.

Differential Revision: D118187938


