### PR TITLE
Migrate the NVL transport suite off raw MPI (#3894)

### DIFF
--- a/comms/common/fault_tolerance/FAULT_TOLERANCE.md
+++ b/comms/common/fault_tolerance/FAULT_TOLERANCE.md
@@ -425,9 +425,9 @@ unlikely case of a `commSuccess`, the comm result data should still be ignored."
    handles outlive individual operations and are shared across blocks. Copy the
    handle per block and call `startTimeout()` on the copy.
 6. **Returning a status is welcome, not required.** Several waits return `bool`
-   and the IB progress path returns `Aborted`; that lets callers stop sooner and
-   more precisely. Callers are not *obliged* to consume it, so never rely on
-   propagation for liveness.
+   and the IB and NVL progress paths return `Aborted`; that lets callers stop
+   sooner and more precisely. Callers are not *obliged* to consume it, so never
+   rely on propagation for liveness.
 7. **Leave the channel state releasable.** A wait that unwinds must not strand
    the resource it was waiting on. In the IB progress path this is
    `abandon_progress_state()` (`P2pIbTransportProgressImpl.cuh`): every abort
@@ -441,6 +441,18 @@ unlikely case of a `commSuccess`, the comm result data should still be ignored."
    channel is fit to reuse. If a new wait acquires state of its own, releasing
    it on abort is part of adding the wait — pushing that onto the collective
    violates the containment principle.
+
+   The NVL progress path holds the same guarantee by the same shape:
+   `abandon_progress_state()` in `P2pNvlTransportDevice.cuh` drives the slot to
+   `Idle` — NVL's terminal stage — so the aborting call returns `Aborted` and a
+   later progress call short-circuits to `Done`, and the next
+   `init_*_progress()` passes `assert_progress_slot_idle()`. The channel cursor
+   stays advanced there too, because the peer may still write into the reserved
+   range over NVLink. `NvlSendRecvProgressStatus::Aborted` mirrors the IB enum,
+   so a transport-agnostic driver loop keeps one abort branch across both
+   transports: treat `Done` and `Aborted` alike as "stop polling this
+   operation", and take `Aborted` as the signal to consult the host `Abort` for
+   the reason rather than to record a completed transfer.
 
 ### Collective Enablement — onboarding a collective
 

--- a/comms/prims/benchmarks/P2pNvlBenchmarkUtils.h
+++ b/comms/prims/benchmarks/P2pNvlBenchmarkUtils.h
@@ -24,6 +24,15 @@ struct BenchmarkConfig {
   bool useTiled = false; // Use tiled protocol (Triton-style head/tail)
   bool useBidirCta = false; // One block does both send+recv via half-block
                             // multiwarp groups. Requires useTiled = true.
+  bool useProgress = false; // Drive both directions from one block through the
+                            // resumable progress API instead of blocking
+                            // send()/recv(). Requires useTiled = true.
+  bool useProgressDrain = false; // Serial alternation, but each direction
+                                 // advances until it would block before
+                                 // yielding. Requires useProgress = true.
+  bool useProgressBidirCta = false; // Progress API with the two directions in
+                                    // concurrent half-block groups rather than
+                                    // alternating. Requires useProgress = true.
   int chunksPerSlot = 1; // Sub-chunks per pipeline slot for finer signaling
   std::string name;
 };

--- a/comms/prims/benchmarks/P2pNvlSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/P2pNvlSendRecvBenchmark.cc
@@ -288,8 +288,12 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
     int numSendBlocks = config.numBlocks;
     // BidirCta packs send + recv into ONE block via half-block multiwarp
-    // groups, so the grid is half the size of the 2-role partition() kernel.
-    int totalBlocks = config.useBidirCta ? numSendBlocks : numSendBlocks * 2;
+    // groups, and the progress kernel drives both directions from one block by
+    // polling, so both use half the grid of the 2-role partition() kernel.
+    int totalBlocks = (config.useBidirCta || config.useProgress ||
+                       config.useProgressBidirCta || config.useProgressDrain)
+        ? numSendBlocks
+        : numSendBlocks * 2;
     dim3 gridDim(totalBlocks);
     dim3 blockDim(config.numThreads);
 
@@ -307,9 +311,19 @@ class P2pSendRecvBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
               config.nBytes / config.numBlocks / config.chunksPerSlot) &
             ~15ULL
         : 0;
-    void* kernelFunc = config.useBidirCta
-        ? (void*)comms::prims::benchmark::p2pTileSendRecvBidirCta
-        : (void*)comms::prims::benchmark::p2pTileSendRecv;
+    void* kernelFunc = nullptr;
+    if (config.useProgressDrain) {
+      kernelFunc = (void*)comms::prims::benchmark::p2pTileProgressDrainSendRecv;
+    } else if (config.useProgressBidirCta) {
+      kernelFunc =
+          (void*)comms::prims::benchmark::p2pTileProgressSendRecvBidirCta;
+    } else if (config.useProgress) {
+      kernelFunc = (void*)comms::prims::benchmark::p2pTileProgressSendRecv;
+    } else if (config.useBidirCta) {
+      kernelFunc = (void*)comms::prims::benchmark::p2pTileSendRecvBidirCta;
+    } else {
+      kernelFunc = (void*)comms::prims::benchmark::p2pTileSendRecv;
+    }
     void* args[] = {
         p2pDevicePtr, &sendTiles, &recvTiles, &maxSignalBytes, &abortDevice};
 
@@ -834,6 +848,89 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
         .useTiled = true,
         .useBidirCta = true,
         .name = "BidirCta_" + nm,
+    });
+  }
+
+  // === PROGRESS (ASYNC) TILE CONFIGS — one block drives both directions
+  //     through init_*_progress / progress_*_once instead of blocking in
+  //     send()/recv(). Geometry is identical to the Tile_ configs above so the
+  //     two rows are directly comparable; like BidirCta the grid is halved,
+  //     since no role partition is needed.
+  for (const auto& [sz, nm] : tileSizes) {
+    constexpr std::size_t kSlot = 8 * 1024 * 1024;
+    configs.push_back({
+        .nBytes = sz,
+        .stagedBufferSize = kSlot,
+        .numBlocks = 16,
+        .numThreads = 512,
+        .pipelineDepth = 2,
+        .chunkSize = kSlot,
+        .groupScope = SyncScope::BLOCK,
+        .useTiled = true,
+        .useProgress = true,
+        .name = "Progress_" + nm,
+    });
+  }
+
+  // === BIDIR-CTA, CLUSTER OFF — the matched blocking counterpart to ProgCta_.
+  //     Same kernel as BidirCta_ but without spread-cluster launch, so it
+  //     differs from ProgCta_ in exactly one variable: blocking send()/recv()
+  //     versus the progress API. This is the only pair that isolates API cost.
+  for (const auto& [sz, nm] : tileSizes) {
+    constexpr std::size_t kSlot = 8 * 1024 * 1024;
+    configs.push_back({
+        .nBytes = sz,
+        .stagedBufferSize = kSlot,
+        .numBlocks = 16,
+        .numThreads = 512,
+        .pipelineDepth = 2,
+        .chunkSize = kSlot,
+        .groupScope = SyncScope::BLOCK,
+        .useTiled = true,
+        .useBidirCta = true,
+        .name = "BidirCtaNC_" + nm,
+    });
+  }
+
+  // === PROGRESS DRAIN CONFIGS — matched against Progress_ in every respect
+  //     except the loop: same single 512-thread block group, same grid, same
+  //     cluster setting. Isolates "yield after one chunk" from "yield when
+  //     blocked".
+  for (const auto& [sz, nm] : tileSizes) {
+    constexpr std::size_t kSlot = 8 * 1024 * 1024;
+    configs.push_back({
+        .nBytes = sz,
+        .stagedBufferSize = kSlot,
+        .numBlocks = 16,
+        .numThreads = 512,
+        .pipelineDepth = 2,
+        .chunkSize = kSlot,
+        .groupScope = SyncScope::BLOCK,
+        .useTiled = true,
+        .useProgress = true,
+        .useProgressDrain = true,
+        .name = "ProgDrain_" + nm,
+    });
+  }
+
+  // === PROGRESS BIDIR-CTA CONFIGS — progress API, but the two directions run
+  //     in concurrent half-block groups instead of alternating in one group.
+  //     Isolates the API cost from the loop-shape cost: identical transport
+  //     calls to Progress_, identical grid to BidirCta_.
+  for (const auto& [sz, nm] : tileSizes) {
+    constexpr std::size_t kSlot = 8 * 1024 * 1024;
+    configs.push_back({
+        .nBytes = sz,
+        .stagedBufferSize = kSlot,
+        .numBlocks = 16,
+        .numThreads = 512,
+        .pipelineDepth = 2,
+        .chunkSize = kSlot,
+        .groupScope = SyncScope::BLOCK,
+        .useTiled = true,
+        .useProgress = true,
+        .useProgressBidirCta = true,
+        .name = "ProgCta_" + nm,
     });
   }
 

--- a/comms/prims/benchmarks/TileSendRecv.cu
+++ b/comms/prims/benchmarks/TileSendRecv.cu
@@ -7,6 +7,19 @@
 
 namespace comms::prims::benchmark {
 
+namespace {
+/*
+ * Both terminal statuses stop the driver loop. These kernels never set an abort
+ * handle, so `Aborted` is unreachable here; testing for it keeps the loops from
+ * spinning if one is ever driven under a live abort.
+ */
+__device__ __forceinline__ bool progressFinished(
+    NvlSendRecvProgressStatus status) {
+  return status == NvlSendRecvProgressStatus::Done ||
+      status == NvlSendRecvProgressStatus::Aborted;
+}
+} // namespace
+
 __global__ __launch_bounds__(512, 1) void p2pTileSendRecv(
     P2pNvlTransportDevice p2p,
     TiledBuffer<char> sendTiles,
@@ -34,6 +47,46 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecv(
         recvTiles.tile_bytes(blockId),
         max_signal_bytes,
         abortDevice);
+  }
+}
+
+/*
+ * `sendDone` / `recvDone` are per-thread but derive only from the group-uniform
+ * status each progress call returns, so every thread in the block agrees on
+ * them. That matters: progress_*_once syncs the group internally, so a diverged
+ * skip would strand part of the block at the next barrier.
+ */
+__global__ __launch_bounds__(512, 1) void p2pTileProgressSendRecv(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    std::size_t max_signal_bytes,
+    AbortDevice timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  const int blockId = group.group_id;
+
+  char* src = sendTiles.tile_data(blockId);
+  const std::size_t sendBytes = sendTiles.tile_bytes(blockId);
+  char* dst = recvTiles.tile_data(blockId);
+  const std::size_t recvBytes = recvTiles.tile_bytes(blockId);
+
+  p2p.init_send_progress(group, sendBytes, max_signal_bytes);
+  p2p.init_recv_progress(group, recvBytes, max_signal_bytes);
+
+  bool sendDone = sendBytes == 0;
+  bool recvDone = recvBytes == 0;
+
+  while (!sendDone || !recvDone) {
+    if (!sendDone) {
+      sendDone = progressFinished(p2p.progress_send_once(
+          group, src, sendBytes, max_signal_bytes, timeout));
+    }
+    if (!recvDone) {
+      recvDone = progressFinished(p2p.progress_recv_once(
+          group, dst, recvBytes, max_signal_bytes, timeout));
+    }
   }
 }
 
@@ -197,6 +250,91 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecvBidirCta(
         recvTiles.tile_bytes(blockId),
         max_signal_bytes,
         abortDevice);
+  }
+}
+
+__global__ __launch_bounds__(512, 1) void p2pTileProgressDrainSendRecv(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    std::size_t max_signal_bytes,
+    AbortDevice timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  const int blockId = group.group_id;
+
+  char* src = sendTiles.tile_data(blockId);
+  const std::size_t sendBytes = sendTiles.tile_bytes(blockId);
+  char* dst = recvTiles.tile_data(blockId);
+  const std::size_t recvBytes = recvTiles.tile_bytes(blockId);
+
+  p2p.init_send_progress(group, sendBytes, max_signal_bytes);
+  p2p.init_recv_progress(group, recvBytes, max_signal_bytes);
+
+  bool sendDone = sendBytes == 0;
+  bool recvDone = recvBytes == 0;
+
+  while (!sendDone || !recvDone) {
+    // Drain each direction to its blocking point rather than surrendering the
+    // block after a single chunk. The status is group-uniform, so every thread
+    // leaves the inner loop together.
+    while (!sendDone) {
+      const auto status = p2p.progress_send_once(
+          group, src, sendBytes, max_signal_bytes, timeout);
+      sendDone = progressFinished(status);
+      if (status != NvlSendRecvProgressStatus::Progressed) {
+        break;
+      }
+    }
+    while (!recvDone) {
+      const auto status = p2p.progress_recv_once(
+          group, dst, recvBytes, max_signal_bytes, timeout);
+      recvDone = progressFinished(status);
+      if (status != NvlSendRecvProgressStatus::Progressed) {
+        break;
+      }
+    }
+  }
+}
+
+/*
+ * Same progress API as p2pTileProgressSendRecv, but each direction gets its own
+ * half-block group so the two run concurrently rather than alternating. This is
+ * the progress-API analogue of p2pTileSendRecvBidirCta, and exists to separate
+ * the cost of the API itself from the cost of the alternating loop shape.
+ */
+__global__ __launch_bounds__(512, 1) void p2pTileProgressSendRecvBidirCta(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    std::size_t max_signal_bytes,
+    AbortDevice timeout) {
+  timeout.start();
+
+  auto group = make_multiwarp_group(blockDim.x / 2);
+  auto [role, sub] = group.partition_interleaved(2);
+
+  const int blockId = sub.group_id;
+
+  if (role == 0) {
+    char* src = sendTiles.tile_data(blockId);
+    const std::size_t sendBytes = sendTiles.tile_bytes(blockId);
+    p2p.init_send_progress(sub, sendBytes, max_signal_bytes);
+    bool done = sendBytes == 0;
+    while (!done) {
+      done = progressFinished(p2p.progress_send_once(
+          sub, src, sendBytes, max_signal_bytes, timeout));
+    }
+  } else {
+    char* dst = recvTiles.tile_data(blockId);
+    const std::size_t recvBytes = recvTiles.tile_bytes(blockId);
+    p2p.init_recv_progress(sub, recvBytes, max_signal_bytes);
+    bool done = recvBytes == 0;
+    while (!done) {
+      done = progressFinished(p2p.progress_recv_once(
+          sub, dst, recvBytes, max_signal_bytes, timeout));
+    }
   }
 }
 

--- a/comms/prims/benchmarks/TileSendRecv.cuh
+++ b/comms/prims/benchmarks/TileSendRecv.cuh
@@ -173,6 +173,67 @@ __global__ void p2pTileSendRecvBidirCta(
     AbortDevice abortDevice = AbortDevice());
 
 /**
+ * p2pTileProgressSendRecv — Bidirectional exchange over the resumable progress
+ * API, the async counterpart of p2pTileSendRecv.
+ *
+ * Where the blocking kernel dedicates one block to each direction and blocks
+ * inside send()/recv(), this drives both directions from a single block: it
+ * initializes both, then polls each in turn until both report Done. A direction
+ * that cannot advance reports Waiting instead of stalling the block, so the
+ * other direction keeps moving.
+ *
+ * Launches with `numSendBlocks` total blocks -- half of what p2pTileSendRecv
+ * needs for the same channel count, since no role partition is required.
+ *
+ * @param p2p              Transport device (passed by value from host memory)
+ * @param sendTiles        Tiled view of the send buffer
+ * @param recvTiles        Tiled view of the recv buffer
+ * @param max_signal_bytes Hint for signal granularity. 0 = per-slot signal.
+ * @param timeout          Abort handle for the polling loop
+ */
+__global__ void p2pTileProgressSendRecv(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    std::size_t max_signal_bytes = 0,
+    AbortDevice timeout = AbortDevice());
+
+/**
+ * p2pTileProgressDrainSendRecv — serial alternation, but each direction
+ * advances until it would block before yielding to the other.
+ *
+ * Matched against p2pTileProgressSendRecv in every respect except the loop:
+ * same single 512-thread block group, same grid, same transport calls. It
+ * isolates "yield after one chunk" from "yield when blocked". It does not
+ * overlap the two directions -- only two concurrent groups do that -- so the
+ * gain should be bounded by how much work a direction can queue before
+ * blocking, i.e. by pipelineDepth.
+ */
+__global__ void p2pTileProgressDrainSendRecv(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    std::size_t max_signal_bytes = 0,
+    AbortDevice timeout = AbortDevice());
+
+/**
+ * p2pTileProgressSendRecvBidirCta — Progress API with the two directions in
+ * concurrent half-block groups instead of alternating in one group.
+ *
+ * The progress-API analogue of p2pTileSendRecvBidirCta. Separates the cost of
+ * the API from the cost of the alternating loop shape: identical transport
+ * calls to p2pTileProgressSendRecv, different group structure.
+ *
+ * Launches with `numSendBlocks` total blocks.
+ */
+__global__ void p2pTileProgressSendRecvBidirCta(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    std::size_t max_signal_bytes = 0,
+    AbortDevice timeout = AbortDevice());
+
+/**
  * p2pTileSendRecvDynamic — Variant using transport-internal tile state
  * with support for dynamic block count changes.
  *

--- a/comms/prims/tests/NvlProgressMultiPeerTest.cc
+++ b/comms/prims/tests/NvlProgressMultiPeerTest.cc
@@ -1,0 +1,182 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/*
+ * Multi-peer NVL progress coverage, in its own binary because it needs more
+ * ranks than the rest of the suite.
+ *
+ * `p2p_nvl_transport_test` is configured for exactly 2 ranks, and at two ranks
+ * a rank's local peer index is always zero -- so `progressDirectionStride_` and
+ * the per-peer slicing in MultiPeerNvlTransport are never exercised there. This
+ * target runs at 4 ranks so that arithmetic has a nonzero offset under test in
+ * CI, rather than only under a manual launch.
+ */
+
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/prims/core/AbortCheck.cuh"
+#include "comms/prims/tests/NvlProgressPayload.h"
+#include "comms/prims/tests/P2pNvlTransportTest.cuh"
+#include "comms/prims/transport/nvl/MultiPeerNvlTransport.h"
+#include "comms/prims/transport/nvl/P2pNvlTransportDevice.cuh"
+#include "comms/testinfra/DistEnvironmentBase.h"
+#include "comms/testinfra/DistTestBase.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using namespace meta::comms;
+
+namespace comms::prims::tests {
+
+namespace {
+
+int g_bootstrapSeq = 0;
+
+/*
+ * Per-test out-of-band bootstrap. The prefix must be identical on every rank or
+ * they rendezvous on different stores and hang, and distinct between bootstraps
+ * or a later one picks up an earlier one's keys. Deriving it from the running
+ * test name gives both, since every rank runs the same test.
+ */
+std::shared_ptr<meta::comms::IBootstrap> makeTestBootstrap() {
+  const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+  const std::string prefix = std::string(info->test_suite_name()) + "." +
+      info->name() + "#" + std::to_string(g_bootstrapSeq++);
+  return std::shared_ptr<meta::comms::IBootstrap>(
+      meta::comms::createBootstrap(prefix));
+}
+
+MultiPeerNvlTransportConfig makeNvlConfig(
+    std::size_t dataBufferSize,
+    std::size_t pipelineDepth,
+    int maxNumChannels = 1) {
+  const auto channels = static_cast<std::size_t>(maxNumChannels);
+  const std::size_t chunkAlign = 16 * std::max<std::size_t>(pipelineDepth, 1);
+  const std::size_t perChannelSize =
+      std::max<std::size_t>(16, ((dataBufferSize + channels - 1) / channels));
+  return MultiPeerNvlTransportConfig{
+      .pipelineDepth = pipelineDepth,
+      .maxNumChannels = maxNumChannels,
+      .perChannelSize =
+          ((perChannelSize + chunkAlign - 1) / chunkAlign) * chunkAlign,
+  };
+}
+
+} // namespace
+
+class NvlProgressMultiPeerTestFixture : public ::testing::Test,
+                                        public meta::comms::DistBaseTest {
+ protected:
+  void SetUp() override {
+    distSetUp();
+    g_bootstrapSeq = 0;
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    distTearDown();
+  }
+};
+
+TEST_F(NvlProgressMultiPeerTestFixture, ProgressTwoPeersConcurrently) {
+  // This target is configured for exactly 4 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip -- a skip
+  // here would restore exactly the silent no-coverage this target exists to
+  // remove. The ring only needs 3 ranks to give the per-peer progress slice a
+  // nonzero offset, but the guard matches the target so a miscount cannot pass.
+  ASSERT_EQ(numRanks, 4) << "target is configured for 4 ranks, got "
+                         << numRanks;
+
+  // Ring topology: every rank exchanges with both its predecessor and its
+  // successor concurrently, which keeps each rank's launch symmetric and
+  // guarantees both peers are reciprocating rather than waiting on a rank that
+  // never engages.
+  const int predRank = (globalRank + numRanks - 1) % numRanks;
+  const int succRank = (globalRank + 1) % numRanks;
+  const size_t nbytes = 256 * 1024;
+
+  auto config = makeNvlConfig(
+      /*dataBufferSize=*/1024 * 1024,
+      /*pipelineDepth=*/2,
+      /*maxNumChannels=*/1);
+  auto bootstrap = makeTestBootstrap();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  auto p2pPred = transport.buildP2pTransportDevice(predRank);
+  auto p2pSucc = transport.buildP2pTransportDevice(succRank);
+
+  DeviceBuffer predSrc(nbytes);
+  DeviceBuffer predDst(nbytes);
+  DeviceBuffer succSrc(nbytes);
+  DeviceBuffer succDst(nbytes);
+
+  // Keyed on the destination peer, so a chunk delivered to or from the wrong
+  // peer mismatches even at the right offset -- which is exactly what a wrong
+  // per-peer slice offset would produce.
+  const std::vector<char> predHost =
+      comms::prims::test::makeProgressPayload(globalRank, predRank, nbytes);
+  const std::vector<char> succHost =
+      comms::prims::test::makeProgressPayload(globalRank, succRank, nbytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      predSrc.get(), predHost.data(), nbytes, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemcpy(
+      succSrc.get(), succHost.data(), nbytes, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(predDst.get(), 0, nbytes));
+  CUDACHECK_TEST(cudaMemset(succDst.get(), 0, nbytes));
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+  comms::prims::test::testProgressTwoPeerSendRecv(
+      p2pPred,
+      p2pSucc,
+      predSrc.get(),
+      predDst.get(),
+      succSrc.get(),
+      succDst.get(),
+      nbytes,
+      /*maxSignalBytes=*/0,
+      AbortDevice(),
+      /*blockSize=*/256);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+
+  // This rank is its predecessor's successor and vice versa, so each peer
+  // filled its payload keyed on this rank as the destination.
+  std::vector<char> hostBuf(nbytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostBuf.data(), predDst.get(), nbytes, cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < nbytes; i++) {
+    ASSERT_EQ(
+        static_cast<unsigned char>(hostBuf[i]),
+        comms::prims::test::progressPayloadByte(predRank, globalRank, i))
+        << "predecessor payload mismatch at byte " << i;
+  }
+  CUDACHECK_TEST(cudaMemcpy(
+      hostBuf.data(), succDst.get(), nbytes, cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < nbytes; i++) {
+    ASSERT_EQ(
+        static_cast<unsigned char>(hostBuf[i]),
+        comms::prims::test::progressPayloadByte(succRank, globalRank, i))
+        << "successor payload mismatch at byte " << i;
+  }
+}
+
+} // namespace comms::prims::tests
+
+int main(int argc, char* argv[]) {
+  // InitGoogleTest first: it strips the --gtest_* flags from argv. gflags,
+  // which folly::Init sets up, hard-errors on flags it does not recognise, so
+  // the reverse order breaks every filtered invocation, including running this
+  // suite under compute-sanitizer with a --gtest_filter.
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::DistEnvironmentBase());
+  return RUN_ALL_TESTS();
+}

--- a/comms/prims/tests/NvlProgressPayload.h
+++ b/comms/prims/tests/NvlProgressPayload.h
@@ -1,0 +1,58 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace comms::prims::test {
+
+/*
+ * Position- and key-dependent payload byte for the NVL progress oracles.
+ *
+ * Shared rather than duplicated per test file on purpose: this is the oracle
+ * itself, and two copies that drifted apart would silently weaken whichever
+ * side stopped matching its producer.
+ *
+ * A constant fill cannot tell a correct chunk from one that was replayed,
+ * reordered, or written at the wrong offset, and a pattern with a short period
+ * cannot tell apart offsets one period apart. This is a splitmix64 finalizer
+ * over (rank, peer, index): it avoids the short structured periods a simple
+ * arithmetic pattern has, and it is keyed so a chunk from the wrong peer
+ * differs from the expected bytes even at the right offset.
+ *
+ * The output is one byte, so this does not make individual offsets unique --
+ * any two unrelated offsets still agree about 1 time in 256. The strength is in
+ * checking the whole buffer: a misplaced chunk has to collide at every one of
+ * its bytes to pass. A rotated-chunk negative control is what demonstrates
+ * that, rather than the per-byte properties of the hash.
+ *
+ * Channel is deliberately not a key. Channels partition the buffer into
+ * disjoint tiles, so a channel swap relocates bytes and the index term already
+ * catches it; keying on channel too would mean threading tile geometry through
+ * every caller for no added detection.
+ */
+inline unsigned char
+progressPayloadByte(int rank, int peer, std::size_t index) {
+  uint64_t h = (static_cast<uint64_t>(rank) << 56) ^
+      (static_cast<uint64_t>(peer) << 48) ^ static_cast<uint64_t>(index);
+  h ^= h >> 30;
+  h *= 0xbf58476d1ce4e5b9ULL;
+  h ^= h >> 27;
+  h *= 0x94d049bb133111ebULL;
+  h ^= h >> 31;
+  return static_cast<unsigned char>(h & 0xFFULL);
+}
+
+// Fills a host buffer with `rank`'s payload for `peer`, ready to upload.
+inline std::vector<char>
+makeProgressPayload(int rank, int peer, std::size_t nbytes) {
+  std::vector<char> host(nbytes);
+  for (std::size_t i = 0; i < nbytes; ++i) {
+    host[i] = static_cast<char>(progressPayloadByte(rank, peer, i));
+  }
+  return host;
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/NvlProgressSlotReleaseTest.cc
+++ b/comms/prims/tests/NvlProgressSlotReleaseTest.cc
@@ -1,0 +1,51 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include "comms/prims/tests/NvlProgressSlotReleaseTest.cuh"
+
+namespace comms::prims {
+namespace {
+
+using test::NvlSlotProbe;
+
+// NVL has one non-terminal stage, so unlike the IB suite there is no stage
+// sweep here: `Active` is the only state a transfer can unwind from.
+
+// Control. If staging did not actually produce a non-idle slot, the test below
+// would pass without proving anything.
+TEST(NvlProgressSlotReleaseTest, StagedSlotIsNotIdle) {
+  const NvlSlotProbe probe = test::stageNvlSlot();
+  EXPECT_EQ(probe.stage, test::kNvlStageActive);
+  EXPECT_NE(probe.stage, test::kNvlStageIdle);
+  EXPECT_GT(probe.nextByte, 0u) << "slot should be mid-transfer";
+}
+
+// The containment property: an aborted transfer leaves the slot reusable, so
+// the next kernel on the channel re-initializes instead of trapping. The
+// assert_progress_slot_idle() call inside the second kernel launch is itself
+// half the assertion -- it traps the whole context if the slot is not
+// released, which surfaces here as a CUDA error from the readback.
+TEST(NvlProgressSlotReleaseTest, AbandonedSlotIsIdleForTheNextKernel) {
+  const NvlSlotProbe probe = test::abandonNvlSlotThenReinit();
+  EXPECT_EQ(probe.stage, test::kNvlStageIdle);
+  EXPECT_EQ(probe.baseByte, 0u);
+  EXPECT_EQ(probe.nextByte, 0u);
+  EXPECT_EQ(probe.payloadBytes, 0u);
+  EXPECT_EQ(probe.tailPadding, 0u);
+  EXPECT_EQ(probe.userBytes, 0u);
+  EXPECT_EQ(probe.maxSignalBytes, 0u);
+}
+
+// The reserved range is abandoned, not recycled. The peer may still write into
+// it over NVLink, so rewinding the channel cursor would hand those bytes to the
+// next operation.
+TEST(NvlProgressSlotReleaseTest, AbandonKeepsTheChannelCursorAdvanced) {
+  const NvlSlotProbe staged = test::stageNvlSlot();
+  const NvlSlotProbe abandoned = test::abandonNvlSlotThenReinit();
+  EXPECT_GT(staged.sendCursor, 0);
+  EXPECT_EQ(abandoned.sendCursor, staged.sendCursor);
+}
+
+} // namespace
+} // namespace comms::prims

--- a/comms/prims/tests/NvlProgressSlotReleaseTest.cu
+++ b/comms/prims/tests/NvlProgressSlotReleaseTest.cu
@@ -1,0 +1,147 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <cstddef>
+
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/tests/Checks.h"
+#include "comms/prims/tests/NvlProgressSlotReleaseTest.cuh"
+#include "comms/prims/transport/nvl/P2pNvlTransportDevice.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+static_assert(static_cast<int>(NvlProgressStage::Idle) == kNvlStageIdle);
+static_assert(static_cast<int>(NvlProgressStage::Active) == kNvlStageActive);
+
+// Arbitrary non-zero geometry. It exists only so the probe can tell an
+// abandoned slot from an untouched one.
+constexpr std::size_t kBaseByte = 4096;
+constexpr std::size_t kNextByte = 8192; // Half a chunk in: unambiguously
+                                        // mid-transfer.
+constexpr std::size_t kPayloadBytes = 16384;
+constexpr std::size_t kTailPadding = 64;
+constexpr std::size_t kUserBytes = 16000;
+constexpr std::size_t kMaxSignalBytes = 512;
+constexpr int64_t kSendCursor = 1ll << 20;
+
+__device__ ThreadGroup make_group() {
+  return ThreadGroup{
+      threadIdx.x,
+      blockDim.x,
+      blockIdx.x,
+      blockIdx.x,
+      gridDim.x,
+      SyncScope::BLOCK};
+}
+
+// Reproduces the state a transfer leaves behind when it unwinds part-way
+// through: the byte range is reserved (send_cursor advanced) and the slot is
+// Active.
+__global__ void stage_slot_kernel(
+    NvlChannelProgress* slot,
+    NvlChannelState* channel) {
+  if (threadIdx.x != 0 || blockIdx.x != 0) {
+    return;
+  }
+  channel->send_cursor = kSendCursor;
+  slot->activeBaseByte = kBaseByte;
+  slot->activeNextByte = kNextByte;
+  slot->activePayloadBytes = kPayloadBytes;
+  slot->activeTailPadding = kTailPadding;
+  slot->activeUserBytes = kUserBytes;
+  slot->activeMaxSignalBytes = kMaxSignalBytes;
+  slot->stage = NvlProgressStage::Active;
+}
+
+__global__ void abandon_kernel(NvlChannelProgress* slot) {
+  ThreadGroup g = make_group();
+  abandon_progress_state(g, *slot);
+}
+
+// Stands in for the next collective queued on this channel. Traps unless the
+// preceding abort left the slot idle.
+__global__ void reinit_kernel(NvlChannelProgress* slot) {
+  ThreadGroup g = make_group();
+  assert_progress_slot_idle(g, *slot, /*channel=*/0, "send");
+}
+
+__global__ void read_slot_kernel(
+    const NvlChannelProgress* slot,
+    const NvlChannelState* channel,
+    NvlSlotProbe* out) {
+  if (threadIdx.x != 0 || blockIdx.x != 0) {
+    return;
+  }
+  out->stage = static_cast<int>(slot->stage);
+  out->baseByte = static_cast<unsigned long long>(slot->activeBaseByte);
+  out->nextByte = static_cast<unsigned long long>(slot->activeNextByte);
+  out->payloadBytes = static_cast<unsigned long long>(slot->activePayloadBytes);
+  out->tailPadding = static_cast<unsigned long long>(slot->activeTailPadding);
+  out->userBytes = static_cast<unsigned long long>(slot->activeUserBytes);
+  out->maxSignalBytes =
+      static_cast<unsigned long long>(slot->activeMaxSignalBytes);
+  out->sendCursor = static_cast<long long>(channel->send_cursor);
+}
+
+// The slot lives in device global memory, not shared or local, because the
+// property under test is that it survives the aborted kernel in a reusable
+// state for the next one.
+class NvlSlotFixture {
+ public:
+  NvlSlotFixture() {
+    PIPES_CUDA_CHECK(cudaMalloc(&slot_, sizeof(NvlChannelProgress)));
+    PIPES_CUDA_CHECK(cudaMalloc(&channel_, sizeof(NvlChannelState)));
+    PIPES_CUDA_CHECK(cudaMemset(slot_, 0, sizeof(NvlChannelProgress)));
+    PIPES_CUDA_CHECK(cudaMemset(channel_, 0, sizeof(NvlChannelState)));
+    PIPES_CUDA_CHECK(cudaMalloc(&probe_, sizeof(NvlSlotProbe)));
+    stage_slot_kernel<<<1, 1>>>(slot_, channel_);
+    PIPES_KERNEL_LAUNCH_CHECK();
+  }
+
+  ~NvlSlotFixture() {
+    (void)cudaFree(slot_);
+    (void)cudaFree(channel_);
+    (void)cudaFree(probe_);
+  }
+
+  NvlSlotFixture(const NvlSlotFixture&) = delete;
+  NvlSlotFixture& operator=(const NvlSlotFixture&) = delete;
+
+  NvlChannelProgress* slot() {
+    return slot_;
+  }
+
+  NvlSlotProbe read() {
+    read_slot_kernel<<<1, 1>>>(slot_, channel_, probe_);
+    PIPES_KERNEL_LAUNCH_CHECK();
+    PIPES_CUDA_CHECK(cudaDeviceSynchronize());
+    NvlSlotProbe host{};
+    PIPES_CUDA_CHECK(
+        cudaMemcpy(&host, probe_, sizeof(host), cudaMemcpyDeviceToHost));
+    return host;
+  }
+
+ private:
+  NvlChannelProgress* slot_{nullptr};
+  NvlChannelState* channel_{nullptr};
+  NvlSlotProbe* probe_{nullptr};
+};
+
+} // namespace
+
+NvlSlotProbe stageNvlSlot() {
+  NvlSlotFixture fixture;
+  return fixture.read();
+}
+
+NvlSlotProbe abandonNvlSlotThenReinit() {
+  NvlSlotFixture fixture;
+  abandon_kernel<<<1, 32>>>(fixture.slot());
+  PIPES_KERNEL_LAUNCH_CHECK();
+  reinit_kernel<<<1, 32>>>(fixture.slot());
+  PIPES_KERNEL_LAUNCH_CHECK();
+  return fixture.read();
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/NvlProgressSlotReleaseTest.cuh
+++ b/comms/prims/tests/NvlProgressSlotReleaseTest.cuh
@@ -1,0 +1,44 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+namespace comms::prims::test {
+
+/// Host-visible copy of one `NvlChannelProgress` slot plus the channel cursor
+/// it reserved from, so the .cc can assert without including any transport
+/// header.
+struct NvlSlotProbe {
+  int stage;
+  unsigned long long baseByte;
+  unsigned long long nextByte;
+  unsigned long long payloadBytes;
+  unsigned long long tailPadding;
+  unsigned long long userBytes;
+  unsigned long long maxSignalBytes;
+  long long sendCursor;
+};
+
+/// `NvlProgressStage` mirrored as plain ints, same reason. Static-asserted
+/// against the enum in the .cu.
+constexpr int kNvlStageIdle = 0;
+constexpr int kNvlStageActive = 1;
+
+/// Writes a mid-transfer progress slot into device memory and reads it back
+/// untouched, so a test can show the staged state is one that
+/// `assert_progress_slot_idle()` would reject.
+NvlSlotProbe stageNvlSlot();
+
+/// Stages the same mid-transfer slot, runs `abandon_progress_state()` over it,
+/// then -- from a SECOND kernel launch -- runs the real
+/// `assert_progress_slot_idle()` and reads the slot back.
+///
+/// The second launch is the point. The trap this containment property exists
+/// to remove does not fire in the kernel that aborted; it fires in the next
+/// kernel queued on the same channel, when its `init_send_progress()` finds the
+/// slot still mid-transfer. Running the check in the same kernel would not
+/// exercise that.
+NvlSlotProbe abandonNvlSlotThenReinit();
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/P2pNvlProgressTrapTest.cc
+++ b/comms/prims/tests/P2pNvlProgressTrapTest.cc
@@ -1,0 +1,70 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <string>
+
+#include "comms/prims/tests/P2pNvlProgressTrapTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+#ifndef NVL_PROGRESS_TRAP_CASE
+#error "NVL_PROGRESS_TRAP_CASE must select one isolated trap case"
+#endif
+
+namespace comms::prims::tests {
+namespace {
+
+/*
+ * The device-side diagnostic this case must emit. Asserting on it is what makes
+ * the target prove *why* the process trapped: the CUDA status alone is generic,
+ * so any unrelated kernel fault would satisfy it and the target would pass for
+ * the wrong reason.
+ *
+ * The runtime flushes device printf on synchronize, including on the trap path,
+ * so the message reaches stdout before launchNvlProgressTrap() returns.
+ */
+constexpr const char* kExpectedDiagnostic =
+#if NVL_PROGRESS_TRAP_CASE == 0
+    "progress_send_once observed abort";
+#elif NVL_PROGRESS_TRAP_CASE == 1
+    "init_send_progress: channel 0 already has an in-flight send";
+#elif NVL_PROGRESS_TRAP_CASE == 2
+    "init_send_progress: progress storage not configured";
+#else
+#error "No expected diagnostic for this NVL_PROGRESS_TRAP_CASE"
+#endif
+
+} // namespace
+
+TEST(P2pNvlProgressTrapTest, ProgressMisuseTraps) {
+  int deviceCount = 0;
+  CUDACHECK_TEST(cudaGetDeviceCount(&deviceCount));
+  if (deviceCount == 0) {
+    GTEST_SKIP() << "No CUDA devices available";
+  }
+  CUDACHECK_TEST(cudaSetDevice(0));
+
+  // The helper synchronizes internally: the `Abort` backing the kernel's device
+  // handle is owned there, so waiting out here would read freed state. Capture
+  // spans the launch and that synchronize, which is when the runtime flushes
+  // the device printf.
+  ::testing::internal::CaptureStdout();
+  const auto error = test::launchNvlProgressTrap(
+      static_cast<test::NvlProgressTrapCase>(NVL_PROGRESS_TRAP_CASE));
+  const std::string deviceOutput = ::testing::internal::GetCapturedStdout();
+  // Re-emit so the diagnostic still appears in the test log on success.
+  std::cerr << deviceOutput;
+
+  EXPECT_NE(deviceOutput.find(kExpectedDiagnostic), std::string::npos)
+      << "trapped without the expected diagnostic \"" << kExpectedDiagnostic
+      << "\"; this case may be trapping for an unintended reason";
+  EXPECT_TRUE(
+      error == cudaErrorIllegalInstruction || error == cudaErrorAssert ||
+      error == cudaErrorLaunchFailure)
+      << cudaGetErrorString(error);
+  EXPECT_EQ(cudaDeviceReset(), cudaSuccess);
+}
+
+} // namespace comms::prims::tests

--- a/comms/prims/tests/P2pNvlProgressTrapTest.cu
+++ b/comms/prims/tests/P2pNvlProgressTrapTest.cu
@@ -1,0 +1,145 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/tests/P2pNvlProgressTrapTest.cuh"
+
+#include <chrono>
+
+#include "comms/common/fault_tolerance/Abort.h"
+#include "comms/prims/core/SignalState.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/transport/nvl/NvlChannelProgress.cuh"
+#include "comms/prims/transport/nvl/NvlChannelState.cuh"
+#include "comms/prims/transport/nvl/P2pNvlTransportDevice.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+constexpr int kMaxChannels = 1;
+constexpr std::size_t kPipelineDepth = 2;
+constexpr std::size_t kPerChannelBuffer = 128 * 1024;
+constexpr std::size_t kPerChannelSlot = kPerChannelBuffer / kPipelineDepth;
+// Larger than the pipeline window, so the send necessarily reaches the
+// backpressure branch where the abort check lives.
+constexpr std::size_t kPayloadBytes = 4 * kPerChannelBuffer;
+// Bounded so a non-trapping implementation fails the test instead of hanging.
+constexpr int kMaxIterations = 256;
+
+__global__ void nvlProgressTrapKernel(
+    P2pNvlTransportDevice p2p,
+    NvlProgressTrapCase testCase,
+    char* src,
+    AbortDevice abort) {
+  abort.start();
+  auto group = make_block_group();
+
+  switch (testCase) {
+    case NvlProgressTrapCase::NullProgressStorage:
+      p2p.init_send_progress(group, kPayloadBytes, 0);
+      break;
+    case NvlProgressTrapCase::ReinitWhileActive:
+      p2p.init_send_progress(group, kPayloadBytes, 0);
+      p2p.init_send_progress(group, kPayloadBytes, 0);
+      break;
+    case NvlProgressTrapCase::AbortTrapBehavior:
+      p2p.init_send_progress(group, kPayloadBytes, 0);
+      for (int i = 0; i < kMaxIterations; ++i) {
+        const auto status =
+            p2p.progress_send_once(group, src, kPayloadBytes, 0, abort);
+        if (status == NvlSendRecvProgressStatus::Done ||
+            status == NvlSendRecvProgressStatus::Aborted) {
+          break;
+        }
+      }
+      break;
+  }
+}
+
+} // namespace
+
+cudaError_t launchNvlProgressTrap(NvlProgressTrapCase testCase) {
+  const std::size_t stagingBytes = kMaxChannels * kPerChannelBuffer;
+
+  char* staging = nullptr;
+  char* src = nullptr;
+  NvlChannelState* channels = nullptr;
+  NvlChannelProgress* sendProgress = nullptr;
+  NvlChannelProgress* recvProgress = nullptr;
+  SignalState* signals = nullptr;
+
+  // NOLINTBEGIN(facebook-cuda-safe-api-call-check)
+  cudaMalloc(reinterpret_cast<void**>(&staging), stagingBytes);
+  cudaMalloc(reinterpret_cast<void**>(&src), kPayloadBytes);
+  cudaMalloc(
+      reinterpret_cast<void**>(&channels),
+      kMaxChannels * sizeof(NvlChannelState));
+  cudaMalloc(reinterpret_cast<void**>(&signals), sizeof(SignalState));
+  cudaMemset(staging, 0, stagingBytes);
+  cudaMemset(src, 0xA5, kPayloadBytes);
+  cudaMemset(channels, 0, kMaxChannels * sizeof(NvlChannelState));
+  cudaMemset(signals, 0, sizeof(SignalState));
+
+  // The null-storage case is the one that must NOT have progress arrays.
+  if (testCase != NvlProgressTrapCase::NullProgressStorage) {
+    cudaMalloc(
+        reinterpret_cast<void**>(&sendProgress),
+        kMaxChannels * sizeof(NvlChannelProgress));
+    cudaMalloc(
+        reinterpret_cast<void**>(&recvProgress),
+        kMaxChannels * sizeof(NvlChannelProgress));
+    cudaMemset(sendProgress, 0, kMaxChannels * sizeof(NvlChannelProgress));
+    cudaMemset(recvProgress, 0, kMaxChannels * sizeof(NvlChannelProgress));
+  }
+  // NOLINTEND(facebook-cuda-safe-api-call-check)
+
+  const P2pNvlTransportOptions options{
+      .dataBufferSize = stagingBytes,
+      .pipelineDepth = kPipelineDepth,
+      .per_channel_buffer = kPerChannelBuffer,
+      .per_channel_slot = kPerChannelSlot,
+      .max_num_channels = kMaxChannels,
+  };
+
+  // Self-loopback: local and remote staging are the same allocation. Nothing
+  // returns SLOT_FREE credit, which is exactly the stall these cases need.
+  const LocalState localState{
+      .dataBuffer = staging,
+      .signalBuffer = DeviceSpan<SignalState>(signals, 1),
+      .barrierBuffer = DeviceSpan<BarrierState>(nullptr, 0),
+  };
+  const RemoteState remoteState{
+      .dataBuffer = staging,
+      .signalBuffer = DeviceSpan<SignalState>(signals, 1),
+      .barrierBuffer = DeviceSpan<BarrierState>(nullptr, 0),
+  };
+
+  P2pNvlTransportDevice p2p(
+      /*myRank=*/0,
+      /*peerRank=*/1,
+      options,
+      localState,
+      remoteState,
+      channels,
+      channels,
+      sendProgress,
+      recvProgress);
+
+  // TRAP behavior with the abort already recorded on the host, so the first
+  // device-side check observes it and the test does not race a deadline.
+  comms::fault_tolerance::Abort abort{
+      /*enabled=*/true, comms::fault_tolerance::AbortBehavior::TRAP};
+  abort.startTimeout(std::chrono::milliseconds{0});
+  static_cast<void>(abort.isAborted());
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
+  nvlProgressTrapKernel<<<1, 256>>>(
+      p2p, testCase, src, abort.getDeviceHandle());
+
+  // Synchronize here, not in the caller. `abort` is destroyed on return and its
+  // destructor frees the CUDA-mapped state the kernel reads through the
+  // non-owning device handle. The device buffers above are deliberately left
+  // allocated: a trap leaves the context unusable, and the caller resets it.
+  return cudaDeviceSynchronize();
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/P2pNvlProgressTrapTest.cuh
+++ b/comms/prims/tests/P2pNvlProgressTrapTest.cuh
@@ -1,0 +1,37 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace comms::prims::test {
+
+/*
+ * Failure modes of the NVL progress API that end in a device trap. Each runs in
+ * its own binary: a trap aborts the process, so it cannot share one with cases
+ * that must survive.
+ */
+enum class NvlProgressTrapCase : int {
+  // Stalled send with an AbortBehavior::TRAP handle. The poll must trap rather
+  // than unwinding, which is what distinguishes TRAP from SKIP.
+  AbortTrapBehavior = 0,
+  // Second init_send_progress while the channel is still Active.
+  ReinitWhileActive = 1,
+  // Progress entry point on a transport built without progress storage.
+  NullProgressStorage = 2,
+};
+
+/*
+ * Builds a single-GPU P2pNvlTransportDevice with hand-made state and drives it
+ * into `testCase`. Self-loopback: the staging buffers are local, so nothing
+ * ever returns credit and a stalled send stays stalled.
+ *
+ * Synchronizes internally and returns the resulting CUDA status. The wait must
+ * happen here rather than in the caller: the `Abort` backing the device handle
+ * is owned by this function, and `AbortDevice` is a non-owning view that must
+ * not outlive it.
+ */
+cudaError_t launchNvlProgressTrap(NvlProgressTrapCase testCase);
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/P2pNvlTransportTest.cc
+++ b/comms/prims/tests/P2pNvlTransportTest.cc
@@ -7,36 +7,69 @@
 
 #include <algorithm>
 #include <chrono>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/common/fault_tolerance/Abort.h"
 #include "comms/prims/benchmarks/TileSendRecv.cuh"
 #include "comms/prims/core/AbortCheck.cuh"
 #include "comms/prims/core/TiledBuffer.cuh"
+#include "comms/prims/tests/NvlProgressPayload.h"
 #include "comms/prims/tests/P2pNvlTransportTest.cuh"
 #include "comms/prims/tests/Utils.cuh"
 #include "comms/prims/transport/nvl/MultiPeerNvlTransport.h"
 #include "comms/prims/transport/nvl/P2pNvlTransportDevice.cuh"
+#include "comms/testinfra/DistEnvironmentBase.h"
+#include "comms/testinfra/DistTestBase.h"
 #include "comms/testinfra/TestXPlatUtils.h"
-#include "comms/testinfra/mpi/MpiBootstrap.h"
-#include "comms/testinfra/mpi/MpiTestUtils.h"
 #include "comms/utils/CudaRAII.h"
 
 using namespace meta::comms;
 
 namespace comms::prims::tests {
 
-class P2pNvlTransportTestFixture : public MpiBaseTestFixture {
+namespace {
+
+// Reset per test by the fixture. Rank-symmetric: every rank runs the same test
+// and therefore executes the same sequence of makeTestBootstrap() calls.
+int g_bootstrapSeq = 0;
+
+/*
+ * Per-test out-of-band bootstrap.
+ *
+ * The prefix must be identical on every rank or they rendezvous on different
+ * stores and hang, and distinct between bootstraps or a later one picks up an
+ * earlier one's keys. Deriving it from the running test name gives both: every
+ * rank runs the same test, and the sequence counter disambiguates tests that
+ * build more than one bootstrap.
+ *
+ * Free rather than a fixture member so the helper functions below, which build
+ * their own transports, can use it too.
+ */
+std::shared_ptr<meta::comms::IBootstrap> makeTestBootstrap() {
+  const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+  const std::string prefix = std::string(info->test_suite_name()) + "." +
+      info->name() + "#" + std::to_string(g_bootstrapSeq++);
+  return std::shared_ptr<meta::comms::IBootstrap>(
+      meta::comms::createBootstrap(prefix));
+}
+
+} // namespace
+
+class P2pNvlTransportTestFixture : public ::testing::Test,
+                                   public meta::comms::DistBaseTest {
  protected:
   void SetUp() override {
-    MpiBaseTestFixture::SetUp();
+    distSetUp();
+    g_bootstrapSeq = 0;
     CUDACHECK_TEST(cudaSetDevice(localRank));
   }
 
   void TearDown() override {
-    MpiBaseTestFixture::TearDown();
+    distTearDown();
   }
 };
 
@@ -71,9 +104,11 @@ static void expectTwoCallPattern(
     const std::string& label);
 
 TEST_F(P2pNvlTransportTestFixture, PipelineGeometry) {
-  if (numRanks != 2) {
-    GTEST_SKIP() << "Requires exactly 2 ranks, got " << numRanks;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
 
   constexpr std::size_t perChannelBufferSize = 64 * 1024;
   constexpr std::size_t pipelineDepth = 4;
@@ -87,7 +122,7 @@ TEST_F(P2pNvlTransportTestFixture, PipelineGeometry) {
       .perChannelSize = perChannelBufferSize,
   };
 
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
   auto p2p = transport.buildP2pTransportDevice(peerRank);
@@ -99,18 +134,18 @@ TEST_F(P2pNvlTransportTestFixture, PipelineGeometry) {
 
 TEST_F(P2pNvlTransportTestFixture, IpcMemAccess) {
   // Only test with 2 ranks
-  if (numRanks != 2) {
-    COMMS_LOG(
-        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
-    return;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
   const size_t numElements = 256;
   auto config = makeNvlConfig(sizeof(int) * numElements, 4);
 
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
   COMMS_LOG(INFO, "Rank {} created transport and exchanged IPC", globalRank);
@@ -138,7 +173,7 @@ TEST_F(P2pNvlTransportTestFixture, IpcMemAccess) {
       INFO, "Rank {} filled local buffer with {}", globalRank, writeValue);
 
   // Barrier to ensure both ranks have written their data
-  MPI_Barrier(MPI_COMM_WORLD);
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
   COMMS_LOG(INFO, "Rank {} passed barrier", globalRank);
 
   // Now each rank reads from peer buffer and verifies
@@ -185,7 +220,7 @@ class TransportTestHelper {
       : globalRank_(globalRank),
         numRanks_(numRanks),
         peerRank_((globalRank == 0) ? 1 : 0),
-        bootstrap_(std::make_shared<meta::comms::MpiBootstrap>()),
+        bootstrap_(makeTestBootstrap()),
         transport_(
             std::make_unique<MultiPeerNvlTransport>(
                 globalRank,
@@ -233,7 +268,7 @@ class TransportTestHelper {
   int globalRank_;
   int numRanks_;
   int peerRank_;
-  std::shared_ptr<meta::comms::MpiBootstrap> bootstrap_;
+  std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
   std::unique_ptr<MultiPeerNvlTransport> transport_;
   std::unique_ptr<P2pNvlTransportDevice> p2pHost_;
   std::unique_ptr<DeviceBuffer> p2pDevice_;
@@ -244,10 +279,11 @@ class TransportTestHelper {
 // =============================================================================
 
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCall) {
-  if (numRanks != 2) {
-    COMMS_LOG(WARN, "Skipping: requires 2 ranks, got {}", numRanks);
-    return;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
 
   int peerRank = (globalRank == 0) ? 1 : 0;
   const size_t nBytes = 8 * 1024 * 1024; // 8MB
@@ -256,7 +292,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCall) {
 
   auto config = makeNvlConfig(2 * 1024 * 1024, 2, numSendBlocks);
 
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
   auto p2pHost = transport.buildP2pTransportDevice(peerRank);
@@ -284,7 +320,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCall) {
     void* args[] = {
         &p2pHost, &sendTiles, &recvTiles, &maxSignalBytes, &abortDevice};
 
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
     CUDACHECK_TEST(cudaLaunchKernel(
         (void*)comms::prims::benchmark::p2pTileSendRecv,
         grid,
@@ -293,7 +329,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCall) {
         0,
         nullptr));
     CUDACHECK_TEST(cudaDeviceSynchronize());
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 
     // Verify received data
     std::vector<char> hostBuf(nBytes);
@@ -316,9 +352,11 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCall) {
 TEST_F(
     P2pNvlTransportTestFixture,
     TileTwoCallSendThenRecvPaddingCreditNoDeadlock) {
-  if (numRanks != 2) {
-    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
 
   const int peerRank = (globalRank == 0) ? 1 : 0;
   const int numBlocks = 1;
@@ -328,7 +366,7 @@ TEST_F(
   const size_t maxSignalBytes = 0;
 
   auto config = makeNvlConfig(perChannelSize, pipelineDepth, numBlocks);
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
   auto p2pHost = transport.buildP2pTransportDevice(peerRank);
@@ -355,7 +393,7 @@ TEST_F(
   abort.setDefaultTimeout(std::chrono::milliseconds{5000});
   AbortDevice abortDevice = abort.getDeviceHandle();
 
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
   test::testTileTwoCallSendThenRecv(
       p2pHost,
       sendTiles,
@@ -367,7 +405,7 @@ TEST_F(
       threadCount,
       abortDevice);
   CUDACHECK_TEST(cudaDeviceSynchronize());
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 
   std::vector<char> hostRecv(totalBytes);
   CUDACHECK_TEST(cudaMemcpy(
@@ -382,10 +420,11 @@ TEST_F(
 }
 
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvCudaGraphReplay) {
-  if (numRanks != 2) {
-    COMMS_LOG(WARN, "Skipping: requires 2 ranks, got {}", numRanks);
-    return;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
 
   const int peerRank = (globalRank == 0) ? 1 : 0;
   const size_t nBytes = 2 * 1024 * 1024;
@@ -394,7 +433,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvCudaGraphReplay) {
 
   auto config = makeNvlConfig(128 * 1024, 2, numSendBlocks);
 
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
   auto p2pHost = transport.buildP2pTransportDevice(peerRank);
@@ -434,10 +473,10 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvCudaGraphReplay) {
     CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, nBytes));
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
     CUDACHECK_TEST(cudaGraphLaunch(graphExec, stream));
     CUDACHECK_TEST(cudaStreamSynchronize(stream));
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 
     std::vector<char> hostBuf(nBytes);
     CUDACHECK_TEST(cudaMemcpy(
@@ -467,7 +506,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvCudaGraphReplay) {
 static void runTileTest(
     int globalRank,
     int numRanks,
-    std::shared_ptr<meta::comms::MpiBootstrap> bootstrap,
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
     size_t nBytes,
     size_t perChannelSize,
     size_t chunkSize,
@@ -506,7 +545,7 @@ static void runTileTest(
     void* args[] = {
         &p2pHost, &sendTiles, &recvTiles, &maxSignalBytes, &abortDevice};
 
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
     CUDACHECK_TEST(cudaLaunchKernel(
         (void*)comms::prims::benchmark::p2pTileSendRecv,
         grid,
@@ -515,7 +554,7 @@ static void runTileTest(
         0,
         nullptr));
     CUDACHECK_TEST(cudaDeviceSynchronize());
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 
     std::vector<char> hostBuf(nBytes);
     CUDACHECK_TEST(cudaMemcpy(
@@ -786,10 +825,12 @@ class LocalTileHarness {
 
 // Test various message sizes with default config
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvMessageSizes) {
-  if (numRanks != 2) {
-    return;
-  }
-  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
+  auto bs = makeTestBootstrap();
 
   // Small sizes
   runTileTest(
@@ -870,10 +911,12 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMessageSizes) {
 
 // Test signal granularity (chunkSize < slotSize)
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvSignalGranularity) {
-  if (numRanks != 2) {
-    return;
-  }
-  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
+  auto bs = makeTestBootstrap();
   const size_t nBytes = 32 * 1024 * 1024; // 32MB
 
   // Per-slot signaling (chunkSize == slotSize)
@@ -903,10 +946,12 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvSignalGranularity) {
 
 // Test different block counts
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvBlockCounts) {
-  if (numRanks != 2) {
-    return;
-  }
-  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
+  auto bs = makeTestBootstrap();
   const size_t nBytes = 16 * 1024 * 1024; // 16MB
 
   runTileTest(
@@ -973,10 +1018,12 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvBlockCounts) {
 
 // Test pipeline depth variations
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvPipelineDepth) {
-  if (numRanks != 2) {
-    return;
-  }
-  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
+  auto bs = makeTestBootstrap();
   const size_t nBytes = 32 * 1024 * 1024;
 
   runTileTest(
@@ -987,10 +1034,12 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvPipelineDepth) {
 
 // Test multi-call with persistent step state
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCallPersistentStep) {
-  if (numRanks != 2) {
-    return;
-  }
-  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
+  auto bs = makeTestBootstrap();
 
   // 5 iterations with same size — tests step counter persistence
   runTileTest(
@@ -1504,10 +1553,11 @@ TEST_F(
 TEST_F(
     P2pNvlTransportTestFixture,
     TileSendRecvChangingLaunchedBlocksWithSameActiveBlocks) {
-  if (numRanks != 2) {
-    COMMS_LOG(WARN, "Skipping: requires 2 ranks, got {}", numRanks);
-    return;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
 
   const int peerRank = (globalRank == 0) ? 1 : 0;
   const int activeBlocks = 4;
@@ -1522,7 +1572,7 @@ TEST_F(
       .perChannelSize = perBlockSlotSize,
   };
 
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
   auto p2pHost = transport.buildP2pTransportDevice(peerRank);
@@ -1548,7 +1598,7 @@ TEST_F(
     void* args[] = {
         &p2pHost, &sendTiles, &recvTiles, &maxSignalBytesArg, &abortDevice};
 
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
     CUDACHECK_TEST(cudaLaunchKernel(
         (void*)comms::prims::benchmark::p2pTileSendRecv,
         dim3(numSendBlocks * 2),
@@ -1557,7 +1607,7 @@ TEST_F(
         0,
         nullptr));
     CUDACHECK_TEST(cudaDeviceSynchronize());
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 
     std::vector<char> hostRecv(nBytes);
     CUDACHECK_TEST(cudaMemcpy(
@@ -1815,15 +1865,17 @@ TEST_F(P2pNvlTransportTestFixture, TileSendAndForwardWaitForWrappedSubstepAck) {
 
 // Test multi-call with different message sizes per call
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCallDifferentSizes) {
-  if (numRanks != 2) {
-    return;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
   int peerRank = (globalRank == 0) ? 1 : 0;
 
   const int numSendBlocks = 4;
   auto config = makeNvlConfig(2 * 1024 * 1024, 2, numSendBlocks);
 
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
   auto p2pHost = transport.buildP2pTransportDevice(peerRank);
@@ -1858,7 +1910,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCallDifferentSizes) {
     void* args[] = {
         &p2pHost, &sendTiles, &recvTiles, &maxSignalBytes, &abortDevice};
 
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
     CUDACHECK_TEST(cudaLaunchKernel(
         (void*)comms::prims::benchmark::p2pTileSendRecv,
         grid,
@@ -1867,7 +1919,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCallDifferentSizes) {
         0,
         nullptr));
     CUDACHECK_TEST(cudaDeviceSynchronize());
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 
     std::vector<char> hostBuf(nBytes);
     CUDACHECK_TEST(cudaMemcpy(
@@ -1889,10 +1941,12 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCallDifferentSizes) {
 
 // Test partial tiles (nbytes not evenly divisible by numBlocks)
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvPartialTiles) {
-  if (numRanks != 2) {
-    return;
-  }
-  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
+  auto bs = makeTestBootstrap();
 
   // nBytes not divisible by numBlocks — last block gets fewer bytes
   runTileTest(
@@ -1931,10 +1985,12 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvPartialTiles) {
 
 // Test with different staging buffer sizes
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvStagingSizes) {
-  if (numRanks != 2) {
-    return;
-  }
-  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
+  auto bs = makeTestBootstrap();
   const size_t nBytes = 16 * 1024 * 1024;
 
   // 4MB staging
@@ -1983,6 +2039,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvStagingSizes) {
 // Helper to run a write() test with verification
 void runPutTest(
     int globalRank,
+    const std::function<void()>& barrier,
     P2pNvlTransportDevice* p2p,
     char* localSrc,
     char* remoteDst,
@@ -1998,7 +2055,7 @@ void runPutTest(
     CUDACHECK_TEST(cudaMemset(localSrc, testValue, nbytes));
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    barrier();
 
     // Write data to peer's buffer
     test::testPutWithSignal(
@@ -2009,7 +2066,7 @@ void runPutTest(
     // Rank 1: Clear destination buffer and verify after write()
     CUDACHECK_TEST(cudaMemset(localSrc, 0, nbytes));
 
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    barrier();
 
     test::testWait(p2p, CmpOp::CMP_GE, signal_id, nbytes, numBlocks, blockSize);
 
@@ -2043,11 +2100,11 @@ void runPutTest(
 
 // Basic write() test with aligned pointers
 TEST_F(P2pNvlTransportTestFixture, PutBasic) {
-  if (numRanks != 2) {
-    COMMS_LOG(
-        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
-    return;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
 
   const size_t nbytes = 1024 * 1024; // 1MB
   auto config = makeNvlConfig(nbytes, 1);
@@ -2060,7 +2117,16 @@ TEST_F(P2pNvlTransportTestFixture, PutBasic) {
   char* localSrc = p2pHost.getLocalState().dataBuffer;
   char* remoteDst = p2pHost.getRemoteState().dataBuffer;
 
-  runPutTest(globalRank, p2p, localSrc, remoteDst, nbytes, 4, 128, "PutBasic");
+  runPutTest(
+      globalRank,
+      [this] { oobBarrier(); },
+      p2p,
+      localSrc,
+      remoteDst,
+      nbytes,
+      4,
+      128,
+      "PutBasic");
 
   COMMS_LOG(INFO, "Rank {}: PutBasic test completed", globalRank);
 }
@@ -2072,21 +2138,26 @@ struct PutTransferSizeParams {
 };
 
 class PutTransferSizeTestFixture
-    : public MpiBaseTestFixture,
+    : public ::testing::Test,
+      public meta::comms::DistBaseTest,
       public ::testing::WithParamInterface<PutTransferSizeParams> {
  protected:
   void SetUp() override {
-    MpiBaseTestFixture::SetUp();
+    distSetUp();
     CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    distTearDown();
   }
 };
 
 TEST_P(PutTransferSizeTestFixture, Put) {
-  if (numRanks != 2) {
-    COMMS_LOG(
-        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
-    return;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
 
   const auto& params = GetParam();
   COMMS_LOG(
@@ -2105,7 +2176,15 @@ TEST_P(PutTransferSizeTestFixture, Put) {
   char* remoteDst = p2pHost.getRemoteState().dataBuffer;
 
   runPutTest(
-      globalRank, p2p, localSrc, remoteDst, params.nbytes, 4, 128, params.name);
+      globalRank,
+      [this] { oobBarrier(); },
+      p2p,
+      localSrc,
+      remoteDst,
+      params.nbytes,
+      4,
+      128,
+      params.name);
 
   COMMS_LOG(
       INFO,
@@ -2155,21 +2234,26 @@ struct PutUnalignedParams {
 };
 
 class PutUnalignedTestFixture
-    : public MpiBaseTestFixture,
+    : public ::testing::Test,
+      public meta::comms::DistBaseTest,
       public ::testing::WithParamInterface<PutUnalignedParams> {
  protected:
   void SetUp() override {
-    MpiBaseTestFixture::SetUp();
+    distSetUp();
     CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    distTearDown();
   }
 };
 
 TEST_P(PutUnalignedTestFixture, Put) {
-  if (numRanks != 2) {
-    COMMS_LOG(
-        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
-    return;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
 
   const auto& params = GetParam();
   COMMS_LOG(
@@ -2201,7 +2285,15 @@ TEST_P(PutUnalignedTestFixture, Put) {
   }
 
   runPutTest(
-      globalRank, p2p, localSrc, remoteDst, params.nbytes, 4, 128, params.name);
+      globalRank,
+      [this] { oobBarrier(); },
+      p2p,
+      localSrc,
+      remoteDst,
+      params.nbytes,
+      4,
+      128,
+      params.name);
 
   COMMS_LOG(
       INFO,
@@ -2295,11 +2387,11 @@ INSTANTIATE_TEST_SUITE_P(
 // The bug caused chunkBytes to accumulate across iterations, leading to
 // buffer overflows and data corruption.
 TEST_F(P2pNvlTransportTestFixture, PutMultiChunkAccumulationRegression) {
-  if (numRanks != 2) {
-    COMMS_LOG(
-        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
-    return;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
 
   // Parameters chosen to trigger multi-chunk per group:
   // numBlocks=4, blockSize=128 -> total_groups=16
@@ -2329,7 +2421,7 @@ TEST_F(P2pNvlTransportTestFixture, PutMultiChunkAccumulationRegression) {
         localSrc, pattern.data(), paddedSize, cudaMemcpyHostToDevice));
     CUDACHECK_TEST(cudaDeviceSynchronize());
 
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    oobBarrier();
 
     test::testPutWithSignal(
         p2p, remoteDst, localSrc, signal_id, nbytes, 4, 128);
@@ -2338,7 +2430,7 @@ TEST_F(P2pNvlTransportTestFixture, PutMultiChunkAccumulationRegression) {
     // Fill destination with sentinel to detect any writes
     CUDACHECK_TEST(cudaMemset(localSrc, sentinelValue, paddedSize));
 
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    oobBarrier();
 
     test::testWait(p2p, CmpOp::CMP_GE, signal_id, nbytes, 4, 128);
     CUDACHECK_TEST(cudaDeviceSynchronize());
@@ -2373,18 +2465,18 @@ TEST_F(P2pNvlTransportTestFixture, PutMultiChunkAccumulationRegression) {
 // =============================================================================
 
 TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Enabled) {
-  if (numRanks != 2) {
-    COMMS_LOG(
-        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
-    return;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
   auto config = makeNvlConfig(4096, 2);
   config.ll128BufferSize = ll128_buffer_size(4096);
 
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
 
@@ -2405,17 +2497,17 @@ TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Enabled) {
 }
 
 TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Disabled) {
-  if (numRanks != 2) {
-    COMMS_LOG(
-        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
-    return;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
   auto config = makeNvlConfig(4096, 2);
 
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
 
@@ -2445,10 +2537,11 @@ TEST_F(P2pNvlTransportTestFixture, Ll128BufferWiring_Disabled) {
 // correctly with the maxBlocks layout and host-side barrier.
 
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvDynamicBlockCount) {
-  if (numRanks != 2) {
-    COMMS_LOG(WARN, "Skipping: requires 2 ranks, got {}", numRanks);
-    return;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
 
   int peerRank = (globalRank == 0) ? 1 : 0;
   constexpr int maxBlocks = 32;
@@ -2460,7 +2553,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvDynamicBlockCount) {
       .perChannelSize = 256 * 1024,
   };
 
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
   auto p2pHost = transport.buildP2pTransportDevice(peerRank);
@@ -2506,7 +2599,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvDynamicBlockCount) {
     void* args[] = {
         &p2pHost, &sendTiles, &recvTiles, &needsBarrier, &abortDevice};
 
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
     CUDACHECK_TEST(cudaLaunchKernel(
         (void*)comms::prims::benchmark::p2pTileSendRecvDynamic,
         dim3(totalBlocks),
@@ -2515,7 +2608,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvDynamicBlockCount) {
         0,
         nullptr));
     CUDACHECK_TEST(cudaDeviceSynchronize());
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 
     // Verify received data
     std::vector<char> hostBuf(nBytes);
@@ -2566,7 +2659,7 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvDynamicBlockCount) {
 static void runTileForwardTest(
     int globalRank,
     int numRanks,
-    const std::shared_ptr<meta::comms::MpiBootstrap>& bootstrap,
+    const std::shared_ptr<meta::comms::IBootstrap>& bootstrap,
     size_t nBytes,
     size_t perChannelSize,
     size_t chunkSize,
@@ -2575,9 +2668,11 @@ static void runTileForwardTest(
     int nIters = 1,
     int threadCount = 256,
     size_t dstOffset = 0) {
-  if (numRanks != 2) {
-    return;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
@@ -2604,7 +2699,7 @@ static void runTileForwardTest(
       CUDACHECK_TEST(cudaMemset(fwdR1Buf.get(), 0, nBytes + dstOffset));
     }
 
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 
     if (globalRank == 0) {
       // Rank 0: tile send src + tile recv into recvR0 (single kernel,
@@ -2643,7 +2738,7 @@ static void runTileForwardTest(
     }
 
     CUDACHECK_TEST(cudaDeviceSynchronize());
-    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 
     // Verify rank 0's recv data matches the original send pattern.
     if (globalRank == 0) {
@@ -2701,11 +2796,12 @@ static void runTileForwardTest(
 
 // Basic single-call test
 TEST_F(P2pNvlTransportTestFixture, TileForwardBasic) {
-  if (numRanks != 2) {
-    COMMS_LOG(WARN, "Skipping: requires 2 ranks, got {}", numRanks);
-    return;
-  }
-  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
+  auto bs = makeTestBootstrap();
 
   // 8MB transfer, 8MB slot (single-step), 4 blocks
   runTileForwardTest(
@@ -2722,10 +2818,12 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardBasic) {
 
 // Various message sizes
 TEST_F(P2pNvlTransportTestFixture, TileForwardMessageSizes) {
-  if (numRanks != 2) {
-    return;
-  }
-  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
+  auto bs = makeTestBootstrap();
 
   // Small
   runTileForwardTest(
@@ -2774,10 +2872,12 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardMessageSizes) {
 
 // Signal granularity (chunkSize < slotSize → multiple sub-step signals)
 TEST_F(P2pNvlTransportTestFixture, TileForwardSignalGranularity) {
-  if (numRanks != 2) {
-    return;
-  }
-  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
+  auto bs = makeTestBootstrap();
   const size_t nBytes = 32 * 1024 * 1024;
 
   // Per-slot signaling
@@ -2800,10 +2900,12 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardSignalGranularity) {
 
 // Different block counts
 TEST_F(P2pNvlTransportTestFixture, TileForwardBlockCounts) {
-  if (numRanks != 2) {
-    return;
-  }
-  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
+  auto bs = makeTestBootstrap();
   const size_t nBytes = 16 * 1024 * 1024;
 
   for (int blocks : {1, 2, 4, 8, 16, 32}) {
@@ -2822,10 +2924,12 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardBlockCounts) {
 
 // Pipeline depth variations
 TEST_F(P2pNvlTransportTestFixture, TileForwardPipelineDepth) {
-  if (numRanks != 2) {
-    return;
-  }
-  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
+  auto bs = makeTestBootstrap();
   const size_t nBytes = 32 * 1024 * 1024;
 
   runTileForwardTest(
@@ -2836,10 +2940,12 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardPipelineDepth) {
 
 // Multi-call: persistent step state across iterations
 TEST_F(P2pNvlTransportTestFixture, TileForwardMultiCallPersistentStep) {
-  if (numRanks != 2) {
-    return;
-  }
-  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
+  auto bs = makeTestBootstrap();
 
   runTileForwardTest(
       globalRank,
@@ -2865,9 +2971,11 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardMultiCallPersistentStep) {
 }
 
 TEST_F(P2pNvlTransportTestFixture, TileForwardDesynchronizedStepState) {
-  if (numRanks != 2) {
-    return;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
 
   constexpr int kNumBlocks = 4;
   constexpr size_t kDataBufferSize = 1024 * 1024;
@@ -2879,9 +2987,12 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardDesynchronizedStepState) {
   constexpr unsigned char kAdvancePattern = 0x33;
   constexpr unsigned char kForwardPattern = 0x7a;
 
-  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bs = makeTestBootstrap();
   const int peerRank = globalRank == 0 ? 1 : 0;
-  auto config = makeNvlConfig(kPerBlockSlotSize, 2, kNumBlocks);
+  // makeNvlConfig's first argument is the total staging size across channels,
+  // not the per-channel slot: passing kPerBlockSlotSize divided it by
+  // kNumBlocks a second time and left every offset below out of range.
+  auto config = makeNvlConfig(kDataBufferSize, 2, kNumBlocks);
   MultiPeerNvlTransport transport(globalRank, numRanks, bs, config);
   transport.exchange();
   auto p2pHost = transport.buildP2pTransportDevice(peerRank);
@@ -2909,7 +3020,7 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardDesynchronizedStepState) {
 
   // Advance only the rank1->rank0 tile send/recv state by 5 sub-steps. The
   // following forward call then has recvStep == 0 and sendStep == 5 on rank 1.
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  oobBarrier();
   if (globalRank == 1) {
     test::testTileSend(
         p2pHost,
@@ -2930,7 +3041,7 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardDesynchronizedStepState) {
         kThreadCount);
   }
   CUDACHECK_TEST(cudaDeviceSynchronize());
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  oobBarrier();
 
   if (globalRank == 0) {
     std::vector<char> hostBuf(kAdvanceBytes);
@@ -2956,7 +3067,7 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardDesynchronizedStepState) {
     CUDACHECK_TEST(cudaMemset(fwdR1Buf.get(), 0, kForwardBytes));
   }
 
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  oobBarrier();
   if (globalRank == 0) {
     test::testTileSend(
         p2pHost,
@@ -2982,14 +3093,16 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardDesynchronizedStepState) {
         nullptr));
   }
   CUDACHECK_TEST(cudaDeviceSynchronize());
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  oobBarrier();
 
   if (globalRank == 0) {
+    // Channel-major staging is a single region of maxNumChannels *
+    // perChannelSize starting at dataBuffer; the second directional region this
+    // offset used to skip past no longer exists.
     std::vector<char> stagingSlot(kDataBufferSize);
     CUDACHECK_TEST(cudaMemcpy(
         stagingSlot.data(),
-        static_cast<char*>(p2pHost.getLocalState().dataBuffer) +
-            kDataBufferSize,
+        static_cast<char*>(p2pHost.getLocalState().dataBuffer),
         kDataBufferSize,
         cudaMemcpyDeviceToHost));
     for (int block = 0; block < kNumBlocks; ++block) {
@@ -3126,10 +3239,12 @@ TEST_F(
 
 // Partial tiles (nbytes not evenly divisible by numBlocks)
 TEST_F(P2pNvlTransportTestFixture, TileForwardPartialTiles) {
-  if (numRanks != 2) {
-    return;
-  }
-  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
+  auto bs = makeTestBootstrap();
 
   runTileForwardTest(
       globalRank,
@@ -3179,21 +3294,26 @@ std::string forwardUnalignedParamName(
 
 // Tile forward unaligned: reuse runTileForwardTest's dstOffset parameter.
 class TileForwardUnalignedTestFixture
-    : public MpiBaseTestFixture,
+    : public ::testing::Test,
+      public meta::comms::DistBaseTest,
       public ::testing::WithParamInterface<ForwardUnalignedParams> {
  protected:
   void SetUp() override {
-    MpiBaseTestFixture::SetUp();
+    distSetUp();
     CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    distTearDown();
   }
 };
 
 TEST_P(TileForwardUnalignedTestFixture, TileForward) {
-  if (numRanks != 2) {
-    COMMS_LOG(
-        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
-    return;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
 
   const auto& params = GetParam();
   COMMS_LOG(
@@ -3203,7 +3323,7 @@ TEST_P(TileForwardUnalignedTestFixture, TileForward) {
       params.nbytes,
       params.dstOffset);
 
-  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bs = makeTestBootstrap();
   // Use a multi-step config so the
   // unaligned dst is exercised across many steps and chunks.
   runTileForwardTest(
@@ -3265,18 +3385,18 @@ INSTANTIATE_TEST_SUITE_P(
 // =============================================================================
 
 TEST_F(P2pNvlTransportTestFixture, LlBufferWiring_Enabled) {
-  if (numRanks != 2) {
-    COMMS_LOG(
-        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
-    return;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
   auto config = makeNvlConfig(4096, 2);
   config.llBufferSize = ll_buffer_size(4096);
 
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
 
@@ -3296,17 +3416,17 @@ TEST_F(P2pNvlTransportTestFixture, LlBufferWiring_Enabled) {
 }
 
 TEST_F(P2pNvlTransportTestFixture, LlBufferWiring_Disabled) {
-  if (numRanks != 2) {
-    COMMS_LOG(
-        WARN, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
-    return;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
 
   int peerRank = (globalRank == 0) ? 1 : 0;
 
   auto config = makeNvlConfig(4096, 2);
 
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
 
@@ -3334,40 +3454,6 @@ TEST_F(P2pNvlTransportTestFixture, LlBufferWiring_Disabled) {
 
 namespace {
 
-/*
- * Position- and key-dependent payload byte.
- *
- * A constant fill cannot tell a correct chunk from one that was replayed,
- * reordered, or written at the wrong offset, and a pattern with a short period
- * cannot tell apart offsets one period apart. This is a splitmix64 finalizer
- * over (rank, peer, index), so it has no period at any test-sized buffer and a
- * chunk that arrived from the wrong peer mismatches even at the right offset.
- *
- * Channel is deliberately not a key. Channels partition the buffer into
- * disjoint tiles, so a channel swap relocates bytes and the index term already
- * catches it; keying on channel too would mean threading tile geometry through
- * every caller for no added detection.
- */
-unsigned char progressPayloadByte(int rank, int peer, size_t index) {
-  uint64_t h = (static_cast<uint64_t>(rank) << 56) ^
-      (static_cast<uint64_t>(peer) << 48) ^ static_cast<uint64_t>(index);
-  h ^= h >> 30;
-  h *= 0xbf58476d1ce4e5b9ULL;
-  h ^= h >> 27;
-  h *= 0x94d049bb133111ebULL;
-  h ^= h >> 31;
-  return static_cast<unsigned char>(h & 0xFFULL);
-}
-
-// Fills `host` with this rank's payload for `peer`, ready to upload.
-std::vector<char> makeProgressPayload(int rank, int peer, size_t nbytes) {
-  std::vector<char> host(nbytes);
-  for (size_t i = 0; i < nbytes; ++i) {
-    host[i] = static_cast<char>(progressPayloadByte(rank, peer, i));
-  }
-  return host;
-}
-
 // Symmetric exchange: each rank fills its send buffer with a rank/peer/position
 // keyed pattern and must observe the peer's pattern in its recv buffer.
 void runProgressExchange(
@@ -3382,7 +3468,7 @@ void runProgressExchange(
   const int peerRank = (globalRank == 0) ? 1 : 0;
   auto config = makeNvlConfig(dataBufferSize, pipelineDepth, numBlocks);
 
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
   auto p2pHost = transport.buildP2pTransportDevice(peerRank);
@@ -3390,7 +3476,7 @@ void runProgressExchange(
   DeviceBuffer sendBuf(nbytes);
   DeviceBuffer recvBuf(nbytes);
   const std::vector<char> sendHost =
-      makeProgressPayload(globalRank, peerRank, nbytes);
+      test::makeProgressPayload(globalRank, peerRank, nbytes);
   CUDACHECK_TEST(cudaMemcpy(
       sendBuf.get(), sendHost.data(), nbytes, cudaMemcpyHostToDevice));
   CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, nbytes));
@@ -3399,7 +3485,7 @@ void runProgressExchange(
   CUDACHECK_TEST(cudaMemset(
       counters.get(), 0, sizeof(comms::prims::test::ProgressCounters)));
 
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
   comms::prims::test::testProgressSendRecv(
       p2pHost,
       sendBuf.get(),
@@ -3411,7 +3497,7 @@ void runProgressExchange(
       numBlocks,
       /*blockSize=*/256);
   CUDACHECK_TEST(cudaDeviceSynchronize());
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 
   std::vector<char> hostBuf(nbytes);
   CUDACHECK_TEST(cudaMemcpy(
@@ -3419,7 +3505,7 @@ void runProgressExchange(
   for (size_t i = 0; i < nbytes; i++) {
     ASSERT_EQ(
         static_cast<unsigned char>(hostBuf[i]),
-        progressPayloadByte(peerRank, globalRank, i))
+        test::progressPayloadByte(peerRank, globalRank, i))
         << "mismatch at byte " << i << " of " << nbytes;
   }
 
@@ -3435,9 +3521,11 @@ void runProgressExchange(
 } // namespace
 
 TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvDeliversBytes) {
-  if (numRanks != 2) {
-    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
   // Fits inside one pipeline window, so the transfer completes without ever
   // hitting backpressure -- the simplest path through the state machine.
   ASSERT_NO_FATAL_FAILURE(runProgressExchange(
@@ -3452,9 +3540,11 @@ TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvDeliversBytes) {
 }
 
 TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvNonAlignedSize) {
-  if (numRanks != 2) {
-    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
   // Not a multiple of 16, so align_tile_protocol_bytes pads and the final chunk
   // carries tail padding that must be credited but not copied.
   ASSERT_NO_FATAL_FAILURE(runProgressExchange(
@@ -3469,9 +3559,11 @@ TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvNonAlignedSize) {
 }
 
 TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvWrapsPipelineAndWaits) {
-  if (numRanks != 2) {
-    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
   // Payload many times the pipeline window, so the transfer can only complete
   // by wrapping and reusing slots repeatedly. Whether Waiting is observed
   // depends on how fast the peer drains, so it is not asserted here;
@@ -3495,9 +3587,11 @@ TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvWrapsPipelineAndWaits) {
 }
 
 TEST_F(P2pNvlTransportTestFixture, ProgressSendBlocksWhenPeerDoesNotDrain) {
-  if (numRanks != 2) {
-    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
   // Rank 0 sends a payload far larger than the pipeline window while rank 1
   // never posts a matching recv. With no credit returned the sender must fill
   // the window and then report Waiting indefinitely rather than completing or
@@ -3509,7 +3603,7 @@ TEST_F(P2pNvlTransportTestFixture, ProgressSendBlocksWhenPeerDoesNotDrain) {
 
   auto config = makeNvlConfig(
       /*dataBufferSize=*/256 * 1024, /*pipelineDepth=*/4, /*maxNumChannels=*/1);
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
   auto p2pHost = transport.buildP2pTransportDevice(peerRank);
@@ -3551,13 +3645,15 @@ TEST_F(P2pNvlTransportTestFixture, ProgressSendBlocksWhenPeerDoesNotDrain) {
 
   // Rank 1 must outlive rank 0's kernel: the sender writes into rank 1's
   // staging buffer, which the transport owns.
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 }
 
 TEST_F(P2pNvlTransportTestFixture, ProgressSendUnwindsOnAbortWithSkipBehavior) {
-  if (numRanks != 2) {
-    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
   // The same one-sided stall as ProgressSendBlocksWhenPeerDoesNotDrain, but
   // with an abort already recorded. Completion is impossible here -- no credit
   // is ever returned -- so a terminal status can only mean the poll observed
@@ -3570,7 +3666,7 @@ TEST_F(P2pNvlTransportTestFixture, ProgressSendUnwindsOnAbortWithSkipBehavior) {
 
   auto config = makeNvlConfig(
       /*dataBufferSize=*/256 * 1024, /*pipelineDepth=*/4, /*maxNumChannels=*/1);
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
   auto p2pHost = transport.buildP2pTransportDevice(peerRank);
@@ -3615,13 +3711,15 @@ TEST_F(P2pNvlTransportTestFixture, ProgressSendUnwindsOnAbortWithSkipBehavior) {
         << "abort must not be reported as completion -- the bytes never moved";
   }
 
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 }
 
 TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvMultipleChannels) {
-  if (numRanks != 2) {
-    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
   // One channel per block, each with its own progress slot: a shared array
   // would have blocks trampling each other's cursors. Covers channel indexing
   // only -- a two-rank run has a single remote peer, so the per-peer slice
@@ -3637,91 +3735,12 @@ TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvMultipleChannels) {
       /*countersOut=*/nullptr));
 }
 
-TEST_F(P2pNvlTransportTestFixture, ProgressTwoPeersConcurrently) {
-  if (numRanks < 3) {
-    GTEST_SKIP() << "Skipping: requires >= 3 ranks to give the per-peer "
-                    "progress slice a nonzero offset, got "
-                 << numRanks;
-  }
-  // At two ranks the local peer index is always zero, so
-  // `progressDirectionStride_` and the per-peer slicing in
-  // MultiPeerNvlTransport are never exercised by any other case. Ring topology:
-  // every rank exchanges with both its predecessor and its successor
-  // concurrently, which keeps each rank's launch symmetric and guarantees both
-  // peers are reciprocating rather than waiting on a rank that never engages.
-  const int predRank = (globalRank + numRanks - 1) % numRanks;
-  const int succRank = (globalRank + 1) % numRanks;
-  const size_t nbytes = 256 * 1024;
-
-  auto config = makeNvlConfig(
-      /*dataBufferSize=*/1024 * 1024,
-      /*pipelineDepth=*/2,
-      /*maxNumChannels=*/1);
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
-  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
-  transport.exchange();
-  auto p2pPred = transport.buildP2pTransportDevice(predRank);
-  auto p2pSucc = transport.buildP2pTransportDevice(succRank);
-
-  DeviceBuffer predSrc(nbytes);
-  DeviceBuffer predDst(nbytes);
-  DeviceBuffer succSrc(nbytes);
-  DeviceBuffer succDst(nbytes);
-
-  // Keyed on the destination peer, so a chunk delivered to or from the wrong
-  // peer mismatches even at the right offset -- which is exactly what a wrong
-  // per-peer slice offset would produce.
-  const std::vector<char> predHost =
-      makeProgressPayload(globalRank, predRank, nbytes);
-  const std::vector<char> succHost =
-      makeProgressPayload(globalRank, succRank, nbytes);
-  CUDACHECK_TEST(cudaMemcpy(
-      predSrc.get(), predHost.data(), nbytes, cudaMemcpyHostToDevice));
-  CUDACHECK_TEST(cudaMemcpy(
-      succSrc.get(), succHost.data(), nbytes, cudaMemcpyHostToDevice));
-  CUDACHECK_TEST(cudaMemset(predDst.get(), 0, nbytes));
-  CUDACHECK_TEST(cudaMemset(succDst.get(), 0, nbytes));
-
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
-  comms::prims::test::testProgressTwoPeerSendRecv(
-      p2pPred,
-      p2pSucc,
-      predSrc.get(),
-      predDst.get(),
-      succSrc.get(),
-      succDst.get(),
-      nbytes,
-      /*maxSignalBytes=*/0,
-      AbortDevice(),
-      /*blockSize=*/256);
-  CUDACHECK_TEST(cudaDeviceSynchronize());
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
-
-  // This rank is its predecessor's successor and vice versa, so each peer
-  // filled its payload keyed on this rank as the destination.
-  std::vector<char> hostBuf(nbytes);
-  CUDACHECK_TEST(cudaMemcpy(
-      hostBuf.data(), predDst.get(), nbytes, cudaMemcpyDeviceToHost));
-  for (size_t i = 0; i < nbytes; i++) {
-    ASSERT_EQ(
-        static_cast<unsigned char>(hostBuf[i]),
-        progressPayloadByte(predRank, globalRank, i))
-        << "predecessor payload mismatch at byte " << i;
-  }
-  CUDACHECK_TEST(cudaMemcpy(
-      hostBuf.data(), succDst.get(), nbytes, cudaMemcpyDeviceToHost));
-  for (size_t i = 0; i < nbytes; i++) {
-    ASSERT_EQ(
-        static_cast<unsigned char>(hostBuf[i]),
-        progressPayloadByte(succRank, globalRank, i))
-        << "successor payload mismatch at byte " << i;
-  }
-}
-
 TEST_F(P2pNvlTransportTestFixture, ProgressZeroBytesIsNoOp) {
-  if (numRanks != 2) {
-    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
   // init_*_progress returns without reserving, so both directions start Done
   // and the loop exits immediately. Nothing to verify beyond not hanging.
   ASSERT_NO_FATAL_FAILURE(runProgressExchange(
@@ -3736,9 +3755,11 @@ TEST_F(P2pNvlTransportTestFixture, ProgressZeroBytesIsNoOp) {
 }
 
 TEST_F(P2pNvlTransportTestFixture, ProgressTwoSequentialOpsOnSameChannel) {
-  if (numRanks != 2) {
-    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
   // Covers cursor reservation and the Active -> Idle reset: the second
   // operation must resume from where the first left the channel cursor. If the
   // reset were missing the second init would trap; if the reservation were
@@ -3751,7 +3772,7 @@ TEST_F(P2pNvlTransportTestFixture, ProgressTwoSequentialOpsOnSameChannel) {
   const int numBlocks = 1;
 
   auto config = makeNvlConfig(1024 * 1024, 2, numBlocks);
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
   auto p2pHost = transport.buildP2pTransportDevice(peerRank);
@@ -3763,12 +3784,12 @@ TEST_F(P2pNvlTransportTestFixture, ProgressTwoSequentialOpsOnSameChannel) {
   // catches one that resumed at the wrong offset within the right half, which
   // is the failure the cursor reservation actually risks.
   const std::vector<char> sendHost =
-      makeProgressPayload(globalRank, peerRank, totalBytes);
+      test::makeProgressPayload(globalRank, peerRank, totalBytes);
   CUDACHECK_TEST(cudaMemcpy(
       sendBuf.get(), sendHost.data(), totalBytes, cudaMemcpyHostToDevice));
   CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, totalBytes));
 
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
   comms::prims::test::testProgressTwoCallSendRecv(
       p2pHost,
       sendBuf.get(),
@@ -3781,7 +3802,7 @@ TEST_F(P2pNvlTransportTestFixture, ProgressTwoSequentialOpsOnSameChannel) {
       numBlocks,
       /*blockSize=*/256);
   CUDACHECK_TEST(cudaDeviceSynchronize());
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 
   std::vector<char> hostBuf(totalBytes);
   CUDACHECK_TEST(cudaMemcpy(
@@ -3789,7 +3810,7 @@ TEST_F(P2pNvlTransportTestFixture, ProgressTwoSequentialOpsOnSameChannel) {
   for (size_t i = 0; i < totalBytes; i++) {
     ASSERT_EQ(
         static_cast<unsigned char>(hostBuf[i]),
-        progressPayloadByte(peerRank, globalRank, i))
+        test::progressPayloadByte(peerRank, globalRank, i))
         << (i < firstBytes ? "first" : "second")
         << " operation mismatch at byte " << i;
   }
@@ -3804,9 +3825,11 @@ TEST_F(P2pNvlTransportTestFixture, ProgressTwoSequentialOpsOnSameChannel) {
  * progress call.
  */
 TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvPartialSignalGranularity) {
-  if (numRanks != 2) {
-    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
   ASSERT_NO_FATAL_FAILURE(runProgressExchange(
       globalRank,
       numRanks,
@@ -3819,9 +3842,11 @@ TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvPartialSignalGranularity) {
 }
 
 TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvUnalignedSignalGranularity) {
-  if (numRanks != 2) {
-    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
   // Neither 16-byte aligned nor a divisor of the slot: the transport rounds it
   // down with `& ~15`, so the last sub-chunk of each slot is short and the
   // payload itself is not a multiple of the granularity.
@@ -3839,9 +3864,11 @@ TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvUnalignedSignalGranularity) {
 TEST_F(
     P2pNvlTransportTestFixture,
     ProgressSequentialOpsChangingSignalGranularity) {
-  if (numRanks != 2) {
-    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
   // Two operations on one channel with different legal granularities. The
   // cursor is in protocol bytes and tail padding is computed from the base
   // byte, so a granularity change between operations must still land the second
@@ -3852,7 +3879,7 @@ TEST_F(
   const size_t totalBytes = firstBytes + secondBytes;
 
   auto config = makeNvlConfig(1024 * 1024, 2, 1);
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
   auto p2pHost = transport.buildP2pTransportDevice(peerRank);
@@ -3868,7 +3895,7 @@ TEST_F(
       secondBytes));
   CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, totalBytes));
 
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
   comms::prims::test::testProgressTwoCallSendRecv(
       p2pHost,
       sendBuf.get(),
@@ -3881,7 +3908,7 @@ TEST_F(
       /*numBlocks=*/1,
       /*blockSize=*/256);
   CUDACHECK_TEST(cudaDeviceSynchronize());
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 
   std::vector<char> hostBuf(totalBytes);
   CUDACHECK_TEST(cudaMemcpy(
@@ -3914,7 +3941,7 @@ void runRecvStallCase(
   const size_t nbytes = 1024 * 1024;
 
   auto config = makeNvlConfig(256 * 1024, 4, 1);
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
   auto p2pHost = transport.buildP2pTransportDevice(peerRank);
@@ -3954,7 +3981,7 @@ void runRecvStallCase(
         cudaMemcpyDeviceToHost));
   }
 
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 
   // Rank 0's recv writes SLOT_FREE into rank 1's channel state, so rank 1 is
   // where a wrongly-issued credit would show up.
@@ -3974,13 +4001,15 @@ void runRecvStallCase(
         << "receiver credited SLOT_FREE for a chunk that was never sent";
   }
 
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 }
 
 TEST_F(P2pNvlTransportTestFixture, ProgressAbortThenReinitSameKernel) {
-  if (numRanks != 2) {
-    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
   // The abort path clears `stage` so the channel can be reused. No other case
   // exercises abort and re-init together in one kernel, which is
   // exactly the ordering that cleanup exists to make safe: the trap target
@@ -3991,7 +4020,7 @@ TEST_F(P2pNvlTransportTestFixture, ProgressAbortThenReinitSameKernel) {
 
   auto config = makeNvlConfig(
       /*dataBufferSize=*/256 * 1024, /*pipelineDepth=*/4, /*maxNumChannels=*/1);
-  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  auto bootstrap = makeTestBootstrap();
   MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
   transport.exchange();
   auto p2pHost = transport.buildP2pTransportDevice(peerRank);
@@ -4032,13 +4061,15 @@ TEST_F(P2pNvlTransportTestFixture, ProgressAbortThenReinitSameKernel) {
   }
 
   // Rank 1 holds its transport open for rank 0's staging writes.
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
 }
 
 TEST_F(P2pNvlTransportTestFixture, ProgressRecvBlocksWhenPeerDoesNotSend) {
-  if (numRanks != 2) {
-    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
   comms::prims::test::ProgressCounters counters{};
   ASSERT_NO_FATAL_FAILURE(runRecvStallCase(
       globalRank, numRanks, /*abortMidFlight=*/false, &counters));
@@ -4053,9 +4084,11 @@ TEST_F(P2pNvlTransportTestFixture, ProgressRecvBlocksWhenPeerDoesNotSend) {
 }
 
 TEST_F(P2pNvlTransportTestFixture, ProgressRecvUnwindsOnAbortWithSkipBehavior) {
-  if (numRanks != 2) {
-    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
-  }
+  // This target is configured for exactly 2 ranks. Anything else means the
+  // launcher misconfigured the job, which must fail rather than skip: a skip
+  // here is what let the whole suite report green while executing nothing.
+  ASSERT_EQ(numRanks, 2) << "target is configured for 2 ranks, got "
+                         << numRanks;
   comms::prims::test::ProgressCounters counters{};
   ASSERT_NO_FATAL_FAILURE(runRecvStallCase(
       globalRank, numRanks, /*abortMidFlight=*/true, &counters));
@@ -4071,9 +4104,12 @@ TEST_F(P2pNvlTransportTestFixture, ProgressRecvUnwindsOnAbortWithSkipBehavior) {
 } // namespace comms::prims::tests
 
 int main(int argc, char* argv[]) {
+  // InitGoogleTest first: it strips the --gtest_* flags from argv. gflags,
+  // which folly::Init sets up, hard-errors on flags it does not recognise, so
+  // the reverse order breaks every filtered invocation, including running this
+  // suite under compute-sanitizer with a --gtest_filter.
   ::testing::InitGoogleTest(&argc, argv);
-  auto mpi_env = std::make_unique<MPIEnvironmentBase>();
-  ::testing::AddGlobalTestEnvironment(mpi_env.get());
   folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::DistEnvironmentBase());
   return RUN_ALL_TESTS();
 }

--- a/comms/prims/tests/P2pNvlTransportTest.cc
+++ b/comms/prims/tests/P2pNvlTransportTest.cc
@@ -3334,8 +3334,42 @@ TEST_F(P2pNvlTransportTestFixture, LlBufferWiring_Disabled) {
 
 namespace {
 
-// Symmetric exchange: each rank fills its send buffer with a rank-derived
-// pattern and must observe the peer's pattern in its recv buffer.
+/*
+ * Position- and key-dependent payload byte.
+ *
+ * A constant fill cannot tell a correct chunk from one that was replayed,
+ * reordered, or written at the wrong offset, and a pattern with a short period
+ * cannot tell apart offsets one period apart. This is a splitmix64 finalizer
+ * over (rank, peer, index), so it has no period at any test-sized buffer and a
+ * chunk that arrived from the wrong peer mismatches even at the right offset.
+ *
+ * Channel is deliberately not a key. Channels partition the buffer into
+ * disjoint tiles, so a channel swap relocates bytes and the index term already
+ * catches it; keying on channel too would mean threading tile geometry through
+ * every caller for no added detection.
+ */
+unsigned char progressPayloadByte(int rank, int peer, size_t index) {
+  uint64_t h = (static_cast<uint64_t>(rank) << 56) ^
+      (static_cast<uint64_t>(peer) << 48) ^ static_cast<uint64_t>(index);
+  h ^= h >> 30;
+  h *= 0xbf58476d1ce4e5b9ULL;
+  h ^= h >> 27;
+  h *= 0x94d049bb133111ebULL;
+  h ^= h >> 31;
+  return static_cast<unsigned char>(h & 0xFFULL);
+}
+
+// Fills `host` with this rank's payload for `peer`, ready to upload.
+std::vector<char> makeProgressPayload(int rank, int peer, size_t nbytes) {
+  std::vector<char> host(nbytes);
+  for (size_t i = 0; i < nbytes; ++i) {
+    host[i] = static_cast<char>(progressPayloadByte(rank, peer, i));
+  }
+  return host;
+}
+
+// Symmetric exchange: each rank fills its send buffer with a rank/peer/position
+// keyed pattern and must observe the peer's pattern in its recv buffer.
 void runProgressExchange(
     int globalRank,
     int numRanks,
@@ -3355,9 +3389,10 @@ void runProgressExchange(
 
   DeviceBuffer sendBuf(nbytes);
   DeviceBuffer recvBuf(nbytes);
-  const int pattern = 0x40 + globalRank;
-  const int peerPattern = 0x40 + peerRank;
-  CUDACHECK_TEST(cudaMemset(sendBuf.get(), pattern, nbytes));
+  const std::vector<char> sendHost =
+      makeProgressPayload(globalRank, peerRank, nbytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf.get(), sendHost.data(), nbytes, cudaMemcpyHostToDevice));
   CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, nbytes));
 
   DeviceBuffer counters(sizeof(comms::prims::test::ProgressCounters));
@@ -3384,7 +3419,7 @@ void runProgressExchange(
   for (size_t i = 0; i < nbytes; i++) {
     ASSERT_EQ(
         static_cast<unsigned char>(hostBuf[i]),
-        static_cast<unsigned char>(peerPattern))
+        progressPayloadByte(peerRank, globalRank, i))
         << "mismatch at byte " << i << " of " << nbytes;
   }
 
@@ -3602,6 +3637,87 @@ TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvMultipleChannels) {
       /*countersOut=*/nullptr));
 }
 
+TEST_F(P2pNvlTransportTestFixture, ProgressTwoPeersConcurrently) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "Skipping: requires >= 3 ranks to give the per-peer "
+                    "progress slice a nonzero offset, got "
+                 << numRanks;
+  }
+  // At two ranks the local peer index is always zero, so
+  // `progressDirectionStride_` and the per-peer slicing in
+  // MultiPeerNvlTransport are never exercised by any other case. Ring topology:
+  // every rank exchanges with both its predecessor and its successor
+  // concurrently, which keeps each rank's launch symmetric and guarantees both
+  // peers are reciprocating rather than waiting on a rank that never engages.
+  const int predRank = (globalRank + numRanks - 1) % numRanks;
+  const int succRank = (globalRank + 1) % numRanks;
+  const size_t nbytes = 256 * 1024;
+
+  auto config = makeNvlConfig(
+      /*dataBufferSize=*/1024 * 1024,
+      /*pipelineDepth=*/2,
+      /*maxNumChannels=*/1);
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  auto p2pPred = transport.buildP2pTransportDevice(predRank);
+  auto p2pSucc = transport.buildP2pTransportDevice(succRank);
+
+  DeviceBuffer predSrc(nbytes);
+  DeviceBuffer predDst(nbytes);
+  DeviceBuffer succSrc(nbytes);
+  DeviceBuffer succDst(nbytes);
+
+  // Keyed on the destination peer, so a chunk delivered to or from the wrong
+  // peer mismatches even at the right offset -- which is exactly what a wrong
+  // per-peer slice offset would produce.
+  const std::vector<char> predHost =
+      makeProgressPayload(globalRank, predRank, nbytes);
+  const std::vector<char> succHost =
+      makeProgressPayload(globalRank, succRank, nbytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      predSrc.get(), predHost.data(), nbytes, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemcpy(
+      succSrc.get(), succHost.data(), nbytes, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(predDst.get(), 0, nbytes));
+  CUDACHECK_TEST(cudaMemset(succDst.get(), 0, nbytes));
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  comms::prims::test::testProgressTwoPeerSendRecv(
+      p2pPred,
+      p2pSucc,
+      predSrc.get(),
+      predDst.get(),
+      succSrc.get(),
+      succDst.get(),
+      nbytes,
+      /*maxSignalBytes=*/0,
+      AbortDevice(),
+      /*blockSize=*/256);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // This rank is its predecessor's successor and vice versa, so each peer
+  // filled its payload keyed on this rank as the destination.
+  std::vector<char> hostBuf(nbytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostBuf.data(), predDst.get(), nbytes, cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < nbytes; i++) {
+    ASSERT_EQ(
+        static_cast<unsigned char>(hostBuf[i]),
+        progressPayloadByte(predRank, globalRank, i))
+        << "predecessor payload mismatch at byte " << i;
+  }
+  CUDACHECK_TEST(cudaMemcpy(
+      hostBuf.data(), succDst.get(), nbytes, cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < nbytes; i++) {
+    ASSERT_EQ(
+        static_cast<unsigned char>(hostBuf[i]),
+        progressPayloadByte(succRank, globalRank, i))
+        << "successor payload mismatch at byte " << i;
+  }
+}
+
 TEST_F(P2pNvlTransportTestFixture, ProgressZeroBytesIsNoOp) {
   if (numRanks != 2) {
     GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
@@ -3642,15 +3758,14 @@ TEST_F(P2pNvlTransportTestFixture, ProgressTwoSequentialOpsOnSameChannel) {
 
   DeviceBuffer sendBuf(totalBytes);
   DeviceBuffer recvBuf(totalBytes);
-  // Distinct patterns per half, so a second operation that resumed from the
-  // wrong offset shows up as the wrong pattern rather than passing by accident.
-  const int firstPattern = 0x50 + globalRank;
-  const int secondPattern = 0x60 + globalRank;
-  CUDACHECK_TEST(cudaMemset(sendBuf.get(), firstPattern, firstBytes));
-  CUDACHECK_TEST(cudaMemset(
-      static_cast<char*>(sendBuf.get()) + firstBytes,
-      secondPattern,
-      secondBytes));
+  // Keyed per byte position across the whole buffer. A per-half pattern would
+  // only catch a second operation that resumed in the wrong half; this also
+  // catches one that resumed at the wrong offset within the right half, which
+  // is the failure the cursor reservation actually risks.
+  const std::vector<char> sendHost =
+      makeProgressPayload(globalRank, peerRank, totalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf.get(), sendHost.data(), totalBytes, cudaMemcpyHostToDevice));
   CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, totalBytes));
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
@@ -3671,17 +3786,12 @@ TEST_F(P2pNvlTransportTestFixture, ProgressTwoSequentialOpsOnSameChannel) {
   std::vector<char> hostBuf(totalBytes);
   CUDACHECK_TEST(cudaMemcpy(
       hostBuf.data(), recvBuf.get(), totalBytes, cudaMemcpyDeviceToHost));
-  for (size_t i = 0; i < firstBytes; i++) {
+  for (size_t i = 0; i < totalBytes; i++) {
     ASSERT_EQ(
         static_cast<unsigned char>(hostBuf[i]),
-        static_cast<unsigned char>(0x50 + peerRank))
-        << "first operation mismatch at byte " << i;
-  }
-  for (size_t i = firstBytes; i < totalBytes; i++) {
-    ASSERT_EQ(
-        static_cast<unsigned char>(hostBuf[i]),
-        static_cast<unsigned char>(0x60 + peerRank))
-        << "second operation mismatch at byte " << i;
+        progressPayloadByte(peerRank, globalRank, i))
+        << (i < firstBytes ? "first" : "second")
+        << " operation mismatch at byte " << i;
   }
 }
 

--- a/comms/prims/tests/P2pNvlTransportTest.cc
+++ b/comms/prims/tests/P2pNvlTransportTest.cc
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -3320,6 +3321,641 @@ TEST_F(P2pNvlTransportTestFixture, LlBufferWiring_Disabled) {
 
   COMMS_LOG(
       INFO, "Rank {}: LlBufferWiring_Disabled test completed", globalRank);
+}
+
+/*
+ * Resumable progress API (init_*_progress + progress_*_once).
+ *
+ * These drive the same loop shape the batched MCCL send/recv kernel uses: hold
+ * both directions in flight and cycle between them until each reports Done. A
+ * progress operation must deliver exactly what the blocking path would, so the
+ * oracle throughout is the peer's byte pattern.
+ */
+
+namespace {
+
+// Symmetric exchange: each rank fills its send buffer with a rank-derived
+// pattern and must observe the peer's pattern in its recv buffer.
+void runProgressExchange(
+    int globalRank,
+    int numRanks,
+    size_t nbytes,
+    int numBlocks,
+    std::size_t pipelineDepth,
+    std::size_t dataBufferSize,
+    std::size_t maxSignalBytes,
+    comms::prims::test::ProgressCounters* countersOut) {
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  auto config = makeNvlConfig(dataBufferSize, pipelineDepth, numBlocks);
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  auto p2pHost = transport.buildP2pTransportDevice(peerRank);
+
+  DeviceBuffer sendBuf(nbytes);
+  DeviceBuffer recvBuf(nbytes);
+  const int pattern = 0x40 + globalRank;
+  const int peerPattern = 0x40 + peerRank;
+  CUDACHECK_TEST(cudaMemset(sendBuf.get(), pattern, nbytes));
+  CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, nbytes));
+
+  DeviceBuffer counters(sizeof(comms::prims::test::ProgressCounters));
+  CUDACHECK_TEST(cudaMemset(
+      counters.get(), 0, sizeof(comms::prims::test::ProgressCounters)));
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  comms::prims::test::testProgressSendRecv(
+      p2pHost,
+      sendBuf.get(),
+      recvBuf.get(),
+      nbytes,
+      maxSignalBytes,
+      AbortDevice(),
+      static_cast<comms::prims::test::ProgressCounters*>(counters.get()),
+      numBlocks,
+      /*blockSize=*/256);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  std::vector<char> hostBuf(nbytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostBuf.data(), recvBuf.get(), nbytes, cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < nbytes; i++) {
+    ASSERT_EQ(
+        static_cast<unsigned char>(hostBuf[i]),
+        static_cast<unsigned char>(peerPattern))
+        << "mismatch at byte " << i << " of " << nbytes;
+  }
+
+  if (countersOut != nullptr) {
+    CUDACHECK_TEST(cudaMemcpy(
+        countersOut,
+        counters.get(),
+        sizeof(comms::prims::test::ProgressCounters),
+        cudaMemcpyDeviceToHost));
+  }
+}
+
+} // namespace
+
+TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvDeliversBytes) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
+  }
+  // Fits inside one pipeline window, so the transfer completes without ever
+  // hitting backpressure -- the simplest path through the state machine.
+  ASSERT_NO_FATAL_FAILURE(runProgressExchange(
+      globalRank,
+      numRanks,
+      /*nbytes=*/64 * 1024,
+      /*numBlocks=*/1,
+      /*pipelineDepth=*/2,
+      /*dataBufferSize=*/1024 * 1024,
+      /*maxSignalBytes=*/0,
+      /*countersOut=*/nullptr));
+}
+
+TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvNonAlignedSize) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
+  }
+  // Not a multiple of 16, so align_tile_protocol_bytes pads and the final chunk
+  // carries tail padding that must be credited but not copied.
+  ASSERT_NO_FATAL_FAILURE(runProgressExchange(
+      globalRank,
+      numRanks,
+      /*nbytes=*/(64 * 1024) + 13,
+      /*numBlocks=*/1,
+      /*pipelineDepth=*/2,
+      /*dataBufferSize=*/1024 * 1024,
+      /*maxSignalBytes=*/0,
+      /*countersOut=*/nullptr));
+}
+
+TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvWrapsPipelineAndWaits) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
+  }
+  // Payload many times the pipeline window, so the transfer can only complete
+  // by wrapping and reusing slots repeatedly. Whether Waiting is observed
+  // depends on how fast the peer drains, so it is not asserted here;
+  // ProgressSendBlocksWhenPeerDoesNotDrain covers backpressure
+  // deterministically.
+  comms::prims::test::ProgressCounters counters{};
+  ASSERT_NO_FATAL_FAILURE(runProgressExchange(
+      globalRank,
+      numRanks,
+      /*nbytes=*/4 * 1024 * 1024,
+      /*numBlocks=*/1,
+      /*pipelineDepth=*/4,
+      /*dataBufferSize=*/256 * 1024,
+      /*maxSignalBytes=*/0,
+      &counters));
+
+  EXPECT_GT(counters.sendProgressed, 1)
+      << "expected the payload to take several chunks";
+  EXPECT_GT(counters.recvProgressed, 1)
+      << "expected the payload to take several chunks";
+}
+
+TEST_F(P2pNvlTransportTestFixture, ProgressSendBlocksWhenPeerDoesNotDrain) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
+  }
+  // Rank 0 sends a payload far larger than the pipeline window while rank 1
+  // never posts a matching recv. With no credit returned the sender must fill
+  // the window and then report Waiting indefinitely rather than completing or
+  // overwriting unacknowledged slots. Bounded iterations, so a broken
+  // implementation that ignores SLOT_FREE fails the assertions instead of
+  // hanging the suite.
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  const size_t nbytes = 4 * 1024 * 1024;
+
+  auto config = makeNvlConfig(
+      /*dataBufferSize=*/256 * 1024, /*pipelineDepth=*/4, /*maxNumChannels=*/1);
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  auto p2pHost = transport.buildP2pTransportDevice(peerRank);
+
+  comms::prims::test::ProgressCounters counters{};
+  if (globalRank == 0) {
+    DeviceBuffer sendBuf(nbytes);
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), 0x7A, nbytes));
+    DeviceBuffer countersBuf(sizeof(comms::prims::test::ProgressCounters));
+    CUDACHECK_TEST(cudaMemset(
+        countersBuf.get(), 0, sizeof(comms::prims::test::ProgressCounters)));
+
+    comms::prims::test::testProgressSendBackpressure(
+        p2pHost,
+        sendBuf.get(),
+        nbytes,
+        /*maxSignalBytes=*/0,
+        /*maxIterations=*/4096,
+        AbortDevice(),
+        static_cast<comms::prims::test::ProgressCounters*>(countersBuf.get()),
+        /*numBlocks=*/1,
+        /*blockSize=*/256);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    CUDACHECK_TEST(cudaMemcpy(
+        &counters,
+        countersBuf.get(),
+        sizeof(counters),
+        cudaMemcpyDeviceToHost));
+
+    EXPECT_EQ(counters.sendCompleted, 0)
+        << "sender completed without the receiver ever returning credit";
+    EXPECT_EQ(counters.sendAborted, 0)
+        << "sender reported Aborted with no abort recorded";
+    EXPECT_GT(counters.sendProgressed, 0)
+        << "sender should fill the pipeline window before blocking";
+    EXPECT_GT(counters.sendWaiting, 0)
+        << "sender should report Waiting once the window is full";
+  }
+
+  // Rank 1 must outlive rank 0's kernel: the sender writes into rank 1's
+  // staging buffer, which the transport owns.
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+TEST_F(P2pNvlTransportTestFixture, ProgressSendUnwindsOnAbortWithSkipBehavior) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
+  }
+  // The same one-sided stall as ProgressSendBlocksWhenPeerDoesNotDrain, but
+  // with an abort already recorded. Completion is impossible here -- no credit
+  // is ever returned -- so a terminal status can only mean the poll observed
+  // the abort and unwound, which is what the fault-tolerance contract requires
+  // of a wait. Reporting it as Aborted rather than Done is what keeps that
+  // distinguishable from a real completion. Without abort the same kernel
+  // reports neither, so the two tests bracket the behavior.
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  const size_t nbytes = 4 * 1024 * 1024;
+
+  auto config = makeNvlConfig(
+      /*dataBufferSize=*/256 * 1024, /*pipelineDepth=*/4, /*maxNumChannels=*/1);
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  auto p2pHost = transport.buildP2pTransportDevice(peerRank);
+
+  if (globalRank == 0) {
+    DeviceBuffer sendBuf(nbytes);
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), 0x7B, nbytes));
+    DeviceBuffer countersBuf(sizeof(comms::prims::test::ProgressCounters));
+    CUDACHECK_TEST(cudaMemset(
+        countersBuf.get(), 0, sizeof(comms::prims::test::ProgressCounters)));
+
+    // SKIP behavior: the poll should unwind rather than trap. Recording the
+    // timeout on the host makes the first device-side check observe it, so the
+    // test does not race a deadline.
+    comms::fault_tolerance::Abort abort{
+        /*enabled=*/true, comms::fault_tolerance::AbortBehavior::SKIP};
+    abort.startTimeout(std::chrono::milliseconds{0});
+    ASSERT_TRUE(abort.isAborted());
+
+    comms::prims::test::ProgressCounters counters{};
+    comms::prims::test::testProgressSendBackpressure(
+        p2pHost,
+        sendBuf.get(),
+        nbytes,
+        /*maxSignalBytes=*/0,
+        /*maxIterations=*/4096,
+        abort.getDeviceHandle(),
+        static_cast<comms::prims::test::ProgressCounters*>(countersBuf.get()),
+        /*numBlocks=*/1,
+        /*blockSize=*/256);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    CUDACHECK_TEST(cudaMemcpy(
+        &counters,
+        countersBuf.get(),
+        sizeof(counters),
+        cudaMemcpyDeviceToHost));
+
+    EXPECT_EQ(counters.sendAborted, 1)
+        << "aborted send should report Aborted rather than spinning on credit "
+           "that will never arrive";
+    EXPECT_EQ(counters.sendCompleted, 0)
+        << "abort must not be reported as completion -- the bytes never moved";
+  }
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvMultipleChannels) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
+  }
+  // One channel per block, each with its own progress slot: a shared array
+  // would have blocks trampling each other's cursors. Covers channel indexing
+  // only -- a two-rank run has a single remote peer, so the per-peer slice
+  // offset is always zero and is not exercised here.
+  ASSERT_NO_FATAL_FAILURE(runProgressExchange(
+      globalRank,
+      numRanks,
+      /*nbytes=*/1024 * 1024,
+      /*numBlocks=*/4,
+      /*pipelineDepth=*/2,
+      /*dataBufferSize=*/2 * 1024 * 1024,
+      /*maxSignalBytes=*/0,
+      /*countersOut=*/nullptr));
+}
+
+TEST_F(P2pNvlTransportTestFixture, ProgressZeroBytesIsNoOp) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
+  }
+  // init_*_progress returns without reserving, so both directions start Done
+  // and the loop exits immediately. Nothing to verify beyond not hanging.
+  ASSERT_NO_FATAL_FAILURE(runProgressExchange(
+      globalRank,
+      numRanks,
+      /*nbytes=*/0,
+      /*numBlocks=*/1,
+      /*pipelineDepth=*/2,
+      /*dataBufferSize=*/1024 * 1024,
+      /*maxSignalBytes=*/0,
+      /*countersOut=*/nullptr));
+}
+
+TEST_F(P2pNvlTransportTestFixture, ProgressTwoSequentialOpsOnSameChannel) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
+  }
+  // Covers cursor reservation and the Active -> Idle reset: the second
+  // operation must resume from where the first left the channel cursor. If the
+  // reset were missing the second init would trap; if the reservation were
+  // wrong the second payload would land at the wrong stream offset and the
+  // second half of the buffer would not verify.
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  const size_t firstBytes = 32 * 1024;
+  const size_t secondBytes = 48 * 1024;
+  const size_t totalBytes = firstBytes + secondBytes;
+  const int numBlocks = 1;
+
+  auto config = makeNvlConfig(1024 * 1024, 2, numBlocks);
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  auto p2pHost = transport.buildP2pTransportDevice(peerRank);
+
+  DeviceBuffer sendBuf(totalBytes);
+  DeviceBuffer recvBuf(totalBytes);
+  // Distinct patterns per half, so a second operation that resumed from the
+  // wrong offset shows up as the wrong pattern rather than passing by accident.
+  const int firstPattern = 0x50 + globalRank;
+  const int secondPattern = 0x60 + globalRank;
+  CUDACHECK_TEST(cudaMemset(sendBuf.get(), firstPattern, firstBytes));
+  CUDACHECK_TEST(cudaMemset(
+      static_cast<char*>(sendBuf.get()) + firstBytes,
+      secondPattern,
+      secondBytes));
+  CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, totalBytes));
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  comms::prims::test::testProgressTwoCallSendRecv(
+      p2pHost,
+      sendBuf.get(),
+      recvBuf.get(),
+      firstBytes,
+      secondBytes,
+      /*firstMaxSignalBytes=*/0,
+      /*secondMaxSignalBytes=*/0,
+      AbortDevice(),
+      numBlocks,
+      /*blockSize=*/256);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  std::vector<char> hostBuf(totalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostBuf.data(), recvBuf.get(), totalBytes, cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < firstBytes; i++) {
+    ASSERT_EQ(
+        static_cast<unsigned char>(hostBuf[i]),
+        static_cast<unsigned char>(0x50 + peerRank))
+        << "first operation mismatch at byte " << i;
+  }
+  for (size_t i = firstBytes; i < totalBytes; i++) {
+    ASSERT_EQ(
+        static_cast<unsigned char>(hostBuf[i]),
+        static_cast<unsigned char>(0x60 + peerRank))
+        << "second operation mismatch at byte " << i;
+  }
+}
+
+/*
+ * Signal granularity. makeNvlConfig(dataBufferSize, depth, channels) gives a
+ * per-channel slot of dataBufferSize/channels/depth; with 1 MiB / 1 / 2 that is
+ * 512 KiB. A max_signal_bytes below the slot makes the transport signal
+ * per sub-chunk instead of per slot, which changes chunk sizing, pipeline
+ * position and tail padding -- and it is stored at init and validated on every
+ * progress call.
+ */
+TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvPartialSignalGranularity) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
+  }
+  ASSERT_NO_FATAL_FAILURE(runProgressExchange(
+      globalRank,
+      numRanks,
+      /*nbytes=*/1024 * 1024,
+      /*numBlocks=*/1,
+      /*pipelineDepth=*/2,
+      /*dataBufferSize=*/1024 * 1024,
+      /*maxSignalBytes=*/128 * 1024,
+      /*countersOut=*/nullptr));
+}
+
+TEST_F(P2pNvlTransportTestFixture, ProgressSendRecvUnalignedSignalGranularity) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
+  }
+  // Neither 16-byte aligned nor a divisor of the slot: the transport rounds it
+  // down with `& ~15`, so the last sub-chunk of each slot is short and the
+  // payload itself is not a multiple of the granularity.
+  ASSERT_NO_FATAL_FAILURE(runProgressExchange(
+      globalRank,
+      numRanks,
+      /*nbytes=*/(768 * 1024) + 37,
+      /*numBlocks=*/1,
+      /*pipelineDepth=*/2,
+      /*dataBufferSize=*/1024 * 1024,
+      /*maxSignalBytes=*/3000,
+      /*countersOut=*/nullptr));
+}
+
+TEST_F(
+    P2pNvlTransportTestFixture,
+    ProgressSequentialOpsChangingSignalGranularity) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
+  }
+  // Two operations on one channel with different legal granularities. The
+  // cursor is in protocol bytes and tail padding is computed from the base
+  // byte, so a granularity change between operations must still land the second
+  // payload at the offset the receiver expects.
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  const size_t firstBytes = 96 * 1024;
+  const size_t secondBytes = 160 * 1024;
+  const size_t totalBytes = firstBytes + secondBytes;
+
+  auto config = makeNvlConfig(1024 * 1024, 2, 1);
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  auto p2pHost = transport.buildP2pTransportDevice(peerRank);
+
+  DeviceBuffer sendBuf(totalBytes);
+  DeviceBuffer recvBuf(totalBytes);
+  const int firstPattern = 0x70 + globalRank;
+  const int secondPattern = 0x80 + globalRank;
+  CUDACHECK_TEST(cudaMemset(sendBuf.get(), firstPattern, firstBytes));
+  CUDACHECK_TEST(cudaMemset(
+      static_cast<char*>(sendBuf.get()) + firstBytes,
+      secondPattern,
+      secondBytes));
+  CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, totalBytes));
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  comms::prims::test::testProgressTwoCallSendRecv(
+      p2pHost,
+      sendBuf.get(),
+      recvBuf.get(),
+      firstBytes,
+      secondBytes,
+      /*firstMaxSignalBytes=*/64 * 1024,
+      /*secondMaxSignalBytes=*/16 * 1024,
+      AbortDevice(),
+      /*numBlocks=*/1,
+      /*blockSize=*/256);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  std::vector<char> hostBuf(totalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostBuf.data(), recvBuf.get(), totalBytes, cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < firstBytes; i++) {
+    ASSERT_EQ(
+        static_cast<unsigned char>(hostBuf[i]),
+        static_cast<unsigned char>(0x70 + peerRank))
+        << "first operation mismatch at byte " << i;
+  }
+  for (size_t i = firstBytes; i < totalBytes; i++) {
+    ASSERT_EQ(
+        static_cast<unsigned char>(hostBuf[i]),
+        static_cast<unsigned char>(0x80 + peerRank))
+        << "second operation mismatch at byte " << i;
+  }
+}
+
+/*
+ * Receiver-side backpressure and abort, the mirror of the two send-side cases.
+ * Rank 0 posts a recv that no one will satisfy; rank 1 only holds its transport
+ * open and then checks that rank 0 never credited a chunk it did not receive.
+ */
+void runRecvStallCase(
+    int globalRank,
+    int numRanks,
+    bool abortMidFlight,
+    comms::prims::test::ProgressCounters* countersOut) {
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  const size_t nbytes = 1024 * 1024;
+
+  auto config = makeNvlConfig(256 * 1024, 4, 1);
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  auto p2pHost = transport.buildP2pTransportDevice(peerRank);
+
+  if (globalRank == 0) {
+    DeviceBuffer recvBuf(nbytes);
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, nbytes));
+    DeviceBuffer countersBuf(sizeof(comms::prims::test::ProgressCounters));
+    CUDACHECK_TEST(cudaMemset(
+        countersBuf.get(), 0, sizeof(comms::prims::test::ProgressCounters)));
+
+    AbortDevice handle;
+    std::unique_ptr<comms::fault_tolerance::Abort> abort;
+    if (abortMidFlight) {
+      abort = std::make_unique<comms::fault_tolerance::Abort>(
+          /*enabled=*/true, comms::fault_tolerance::AbortBehavior::SKIP);
+      abort->startTimeout(std::chrono::milliseconds{0});
+      ASSERT_TRUE(abort->isAborted());
+      handle = abort->getDeviceHandle();
+    }
+
+    comms::prims::test::testProgressRecvBackpressure(
+        p2pHost,
+        recvBuf.get(),
+        nbytes,
+        /*maxSignalBytes=*/0,
+        /*maxIterations=*/4096,
+        handle,
+        static_cast<comms::prims::test::ProgressCounters*>(countersBuf.get()),
+        /*numBlocks=*/1,
+        /*blockSize=*/256);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    CUDACHECK_TEST(cudaMemcpy(
+        countersOut,
+        countersBuf.get(),
+        sizeof(comms::prims::test::ProgressCounters),
+        cudaMemcpyDeviceToHost));
+  }
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  // Rank 0's recv writes SLOT_FREE into rank 1's channel state, so rank 1 is
+  // where a wrongly-issued credit would show up.
+  if (globalRank == 1) {
+    DeviceBuffer slotFree(sizeof(unsigned long long));
+    CUDACHECK_TEST(
+        cudaMemset(slotFree.get(), 0xFF, sizeof(unsigned long long)));
+    comms::prims::test::testReadSlotFreeCounter(
+        p2pHost,
+        /*channel=*/0,
+        static_cast<unsigned long long*>(slotFree.get()));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    unsigned long long observed = 0;
+    CUDACHECK_TEST(cudaMemcpy(
+        &observed, slotFree.get(), sizeof(observed), cudaMemcpyDeviceToHost));
+    EXPECT_EQ(observed, 0ULL)
+        << "receiver credited SLOT_FREE for a chunk that was never sent";
+  }
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+TEST_F(P2pNvlTransportTestFixture, ProgressAbortThenReinitSameKernel) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
+  }
+  // The abort path clears `stage` so the channel can be reused. No other case
+  // exercises abort and re-init together in one kernel, which is
+  // exactly the ordering that cleanup exists to make safe: the trap target
+  // covers re-init while *active*, and the sequential-ops test covers re-init
+  // after normal completion. Neither would catch an unpublished abort cleanup.
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  const size_t nbytes = 4 * 1024 * 1024;
+
+  auto config = makeNvlConfig(
+      /*dataBufferSize=*/256 * 1024, /*pipelineDepth=*/4, /*maxNumChannels=*/1);
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  auto p2pHost = transport.buildP2pTransportDevice(peerRank);
+
+  if (globalRank == 0) {
+    DeviceBuffer sendBuf(nbytes);
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), 0x5C, nbytes));
+    DeviceBuffer countersBuf(sizeof(comms::prims::test::ProgressCounters));
+    CUDACHECK_TEST(cudaMemset(
+        countersBuf.get(), 0, sizeof(comms::prims::test::ProgressCounters)));
+
+    comms::fault_tolerance::Abort abort{
+        /*enabled=*/true, comms::fault_tolerance::AbortBehavior::SKIP};
+    abort.startTimeout(std::chrono::milliseconds{0});
+    ASSERT_TRUE(abort.isAborted());
+
+    comms::prims::test::ProgressCounters counters{};
+    comms::prims::test::testProgressAbortThenReinit(
+        p2pHost,
+        sendBuf.get(),
+        nbytes,
+        /*maxIterations=*/4096,
+        abort.getDeviceHandle(),
+        static_cast<comms::prims::test::ProgressCounters*>(countersBuf.get()),
+        /*numBlocks=*/1,
+        /*blockSize=*/256);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    CUDACHECK_TEST(cudaMemcpy(
+        &counters,
+        countersBuf.get(),
+        sizeof(counters),
+        cudaMemcpyDeviceToHost));
+
+    EXPECT_EQ(counters.sendAborted, 1)
+        << "abort should have concluded the stalled send";
+    EXPECT_EQ(counters.sendCompleted, 0)
+        << "abort must not be reported as completion -- the bytes never moved";
+  }
+
+  // Rank 1 holds its transport open for rank 0's staging writes.
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+TEST_F(P2pNvlTransportTestFixture, ProgressRecvBlocksWhenPeerDoesNotSend) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
+  }
+  comms::prims::test::ProgressCounters counters{};
+  ASSERT_NO_FATAL_FAILURE(runRecvStallCase(
+      globalRank, numRanks, /*abortMidFlight=*/false, &counters));
+  if (globalRank == 0) {
+    EXPECT_EQ(counters.recvCompleted, 0) << "recv completed with no sender";
+    EXPECT_EQ(counters.recvAborted, 0)
+        << "recv reported Aborted with no abort recorded";
+    EXPECT_EQ(counters.recvProgressed, 0)
+        << "recv consumed a chunk that was never sent";
+    EXPECT_GT(counters.recvWaiting, 0) << "recv should report Waiting";
+  }
+}
+
+TEST_F(P2pNvlTransportTestFixture, ProgressRecvUnwindsOnAbortWithSkipBehavior) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping: requires 2 ranks, got " << numRanks;
+  }
+  comms::prims::test::ProgressCounters counters{};
+  ASSERT_NO_FATAL_FAILURE(runRecvStallCase(
+      globalRank, numRanks, /*abortMidFlight=*/true, &counters));
+  if (globalRank == 0) {
+    EXPECT_EQ(counters.recvAborted, 1)
+        << "aborted recv should report Aborted rather than spinning";
+    EXPECT_EQ(counters.recvCompleted, 0)
+        << "abort must not be reported as completion -- the bytes never "
+           "arrived";
+  }
 }
 
 } // namespace comms::prims::tests

--- a/comms/prims/tests/P2pNvlTransportTest.cu
+++ b/comms/prims/tests/P2pNvlTransportTest.cu
@@ -1095,6 +1095,85 @@ void testProgressSendRecv(
 }
 
 /*
+ * Two peers driven concurrently from one block.
+ *
+ * Group construction matters here. `make_block_group().partition(2)` does not
+ * work on a single-block launch: partition() splits *groups*, and one block
+ * group means total_groups == 1, so it rejects num_partitions == 2. Instead
+ * make two half-block multiwarp groups and interleave them, the same shape
+ * p2pTileSendRecvBidirCta uses. partition_interleaved(2) renumbers both
+ * subgroups to group_id 0, so each drives channel 0 of its own transport --
+ * and channel indices are per-transport, so that is not a collision.
+ *
+ * Each subgroup runs the same alternating send/recv loop as the single-peer
+ * case. The status is group-uniform within a subgroup, so every thread of a
+ * subgroup leaves the loop together.
+ */
+__global__ void testProgressTwoPeerSendRecvKernel(
+    P2pNvlTransportDevice p2pPred,
+    P2pNvlTransportDevice p2pSucc,
+    void* predSrc,
+    void* predDst,
+    void* succSrc,
+    void* succDst,
+    size_t nbytes,
+    size_t maxSignalBytes,
+    AbortDevice abort) {
+  abort.start();
+  auto group = make_multiwarp_group(blockDim.x / 2);
+  auto [role, sub] = group.partition_interleaved(2);
+
+  P2pNvlTransportDevice& p2p = (role == 0) ? p2pPred : p2pSucc;
+  char* src = static_cast<char*>((role == 0) ? predSrc : succSrc);
+  char* dst = static_cast<char*>((role == 0) ? predDst : succDst);
+
+  p2p.init_send_progress(sub, nbytes, maxSignalBytes);
+  p2p.init_recv_progress(sub, nbytes, maxSignalBytes);
+
+  bool sendDone = nbytes == 0;
+  bool recvDone = nbytes == 0;
+  while (!sendDone || !recvDone) {
+    if (!sendDone) {
+      const auto status =
+          p2p.progress_send_once(sub, src, nbytes, maxSignalBytes, abort);
+      sendDone = status == NvlSendRecvProgressStatus::Done ||
+          status == NvlSendRecvProgressStatus::Aborted;
+    }
+    if (!recvDone) {
+      const auto status =
+          p2p.progress_recv_once(sub, dst, nbytes, maxSignalBytes, abort);
+      recvDone = status == NvlSendRecvProgressStatus::Done ||
+          status == NvlSendRecvProgressStatus::Aborted;
+    }
+  }
+}
+
+void testProgressTwoPeerSendRecv(
+    P2pNvlTransportDevice p2pPred,
+    P2pNvlTransportDevice p2pSucc,
+    void* predSrc,
+    void* predDst,
+    void* succSrc,
+    void* succDst,
+    size_t nbytes,
+    size_t maxSignalBytes,
+    AbortDevice abort,
+    int blockSize,
+    cudaStream_t stream) {
+  testProgressTwoPeerSendRecvKernel<<<1, blockSize, 0, stream>>>(
+      p2pPred,
+      p2pSucc,
+      predSrc,
+      predDst,
+      succSrc,
+      succDst,
+      nbytes,
+      maxSignalBytes,
+      abort);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+/*
  * Sender with nobody draining the far end, so the pipeline necessarily fills
  * and stays full. Bounded iteration count: the point is to observe Waiting and
  * non-completion, not to finish. In a symmetric exchange whether Waiting is

--- a/comms/prims/tests/P2pNvlTransportTest.cu
+++ b/comms/prims/tests/P2pNvlTransportTest.cu
@@ -1005,4 +1005,388 @@ void testWait(
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
+/*
+ * `sendDone` / `recvDone` are per-thread but derive only from the group-uniform
+ * status each progress call returns, so every thread in the block agrees on
+ * them. That matters: progress_*_once syncs the group internally, so a diverged
+ * skip would strand part of the block at the next barrier.
+ */
+__global__ void testProgressSendRecvKernel(
+    P2pNvlTransportDevice p2p,
+    void* src_d,
+    void* dst_d,
+    size_t nbytes,
+    size_t maxSignalBytes,
+    AbortDevice abort,
+    ProgressCounters* counters) {
+  abort.start();
+  auto group = make_block_group();
+
+  TiledBuffer<char> sendTiles(static_cast<char*>(src_d), nbytes, group);
+  TiledBuffer<char> recvTiles(static_cast<char*>(dst_d), nbytes, group);
+
+  p2p.init_send_progress(group, sendTiles.bytes(), maxSignalBytes);
+  p2p.init_recv_progress(group, recvTiles.bytes(), maxSignalBytes);
+
+  bool sendDone = sendTiles.bytes() == 0;
+  bool recvDone = recvTiles.bytes() == 0;
+  int sendWaiting = 0;
+  int sendProgressed = 0;
+  int sendAborted = 0;
+  int recvWaiting = 0;
+  int recvProgressed = 0;
+  int recvAborted = 0;
+
+  while (!sendDone || !recvDone) {
+    if (!sendDone) {
+      const auto status = p2p.progress_send_once(
+          group, sendTiles.data(), sendTiles.bytes(), maxSignalBytes, abort);
+      if (status == NvlSendRecvProgressStatus::Done) {
+        sendDone = true;
+      } else if (status == NvlSendRecvProgressStatus::Aborted) {
+        sendDone = true;
+        ++sendAborted;
+      } else if (status == NvlSendRecvProgressStatus::Waiting) {
+        ++sendWaiting;
+      } else {
+        ++sendProgressed;
+      }
+    }
+    if (!recvDone) {
+      const auto status = p2p.progress_recv_once(
+          group, recvTiles.data(), recvTiles.bytes(), maxSignalBytes, abort);
+      if (status == NvlSendRecvProgressStatus::Done) {
+        recvDone = true;
+      } else if (status == NvlSendRecvProgressStatus::Aborted) {
+        recvDone = true;
+        ++recvAborted;
+      } else if (status == NvlSendRecvProgressStatus::Waiting) {
+        ++recvWaiting;
+      } else {
+        ++recvProgressed;
+      }
+    }
+  }
+
+  if (counters != nullptr && blockIdx.x == 0 && group.is_leader()) {
+    counters->sendWaiting = sendWaiting;
+    counters->sendProgressed = sendProgressed;
+    counters->recvWaiting = recvWaiting;
+    counters->recvProgressed = recvProgressed;
+    counters->sendAborted = sendAborted;
+    counters->recvAborted = recvAborted;
+  }
+}
+
+void testProgressSendRecv(
+    P2pNvlTransportDevice p2p,
+    void* src_d,
+    void* dst_d,
+    size_t nbytes,
+    size_t maxSignalBytes,
+    AbortDevice abort,
+    ProgressCounters* counters,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream) {
+  testProgressSendRecvKernel<<<numBlocks, blockSize, 0, stream>>>(
+      p2p, src_d, dst_d, nbytes, maxSignalBytes, abort, counters);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+/*
+ * Sender with nobody draining the far end, so the pipeline necessarily fills
+ * and stays full. Bounded iteration count: the point is to observe Waiting and
+ * non-completion, not to finish. In a symmetric exchange whether Waiting is
+ * ever observed depends on how fast the peer drains, so this one-sided shape is
+ * the only way to make backpressure deterministic.
+ */
+__global__ void testProgressSendBackpressureKernel(
+    P2pNvlTransportDevice p2p,
+    void* src_d,
+    size_t nbytes,
+    size_t maxSignalBytes,
+    int maxIterations,
+    AbortDevice abort,
+    ProgressCounters* counters) {
+  abort.start();
+  auto group = make_block_group();
+
+  TiledBuffer<char> sendTiles(static_cast<char*>(src_d), nbytes, group);
+  p2p.init_send_progress(group, sendTiles.bytes(), maxSignalBytes);
+
+  bool done = false;
+  bool aborted = false;
+  int waiting = 0;
+  int progressed = 0;
+
+  for (int i = 0; i < maxIterations && !done && !aborted; ++i) {
+    const auto status = p2p.progress_send_once(
+        group, sendTiles.data(), sendTiles.bytes(), maxSignalBytes, abort);
+    if (status == NvlSendRecvProgressStatus::Done) {
+      done = true;
+    } else if (status == NvlSendRecvProgressStatus::Aborted) {
+      aborted = true;
+    } else if (status == NvlSendRecvProgressStatus::Waiting) {
+      ++waiting;
+    } else {
+      ++progressed;
+    }
+  }
+
+  if (counters != nullptr && blockIdx.x == 0 && group.is_leader()) {
+    counters->sendWaiting = waiting;
+    counters->sendProgressed = progressed;
+    counters->sendCompleted = done ? 1 : 0;
+    counters->sendAborted = aborted ? 1 : 0;
+    counters->recvWaiting = 0;
+    counters->recvProgressed = 0;
+  }
+}
+
+void testProgressSendBackpressure(
+    P2pNvlTransportDevice p2p,
+    void* src_d,
+    size_t nbytes,
+    size_t maxSignalBytes,
+    int maxIterations,
+    AbortDevice abort,
+    ProgressCounters* counters,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream) {
+  testProgressSendBackpressureKernel<<<numBlocks, blockSize, 0, stream>>>(
+      p2p, src_d, nbytes, maxSignalBytes, maxIterations, abort, counters);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// Drives one progress operation to completion on this block's channel.
+__device__ inline void drainProgressPair(
+    P2pNvlTransportDevice& p2p,
+    ThreadGroup& group,
+    char* src,
+    char* dst,
+    size_t bytes,
+    size_t maxSignalBytes,
+    const AbortDevice& abort) {
+  p2p.init_send_progress(group, bytes, maxSignalBytes);
+  p2p.init_recv_progress(group, bytes, maxSignalBytes);
+
+  bool sendDone = bytes == 0;
+  bool recvDone = bytes == 0;
+  while (!sendDone || !recvDone) {
+    if (!sendDone) {
+      const auto status =
+          p2p.progress_send_once(group, src, bytes, maxSignalBytes, abort);
+      sendDone = status == NvlSendRecvProgressStatus::Done ||
+          status == NvlSendRecvProgressStatus::Aborted;
+    }
+    if (!recvDone) {
+      const auto status =
+          p2p.progress_recv_once(group, dst, bytes, maxSignalBytes, abort);
+      recvDone = status == NvlSendRecvProgressStatus::Done ||
+          status == NvlSendRecvProgressStatus::Aborted;
+    }
+  }
+}
+
+__global__ void testProgressTwoCallSendRecvKernel(
+    P2pNvlTransportDevice p2p,
+    void* src_d,
+    void* dst_d,
+    size_t firstBytes,
+    size_t secondBytes,
+    size_t firstMaxSignalBytes,
+    size_t secondMaxSignalBytes,
+    AbortDevice abort) {
+  abort.start();
+  auto group = make_block_group();
+
+  TiledBuffer<char> firstSend(static_cast<char*>(src_d), firstBytes, group);
+  TiledBuffer<char> firstRecv(static_cast<char*>(dst_d), firstBytes, group);
+  drainProgressPair(
+      p2p,
+      group,
+      firstSend.data(),
+      firstRecv.data(),
+      firstSend.bytes(),
+      firstMaxSignalBytes,
+      abort);
+
+  // Second operation starts where the first left the cursor. Offsetting the
+  // user buffers keeps the two payloads distinguishable at verification time.
+  TiledBuffer<char> secondSend(
+      static_cast<char*>(src_d) + firstBytes, secondBytes, group);
+  TiledBuffer<char> secondRecv(
+      static_cast<char*>(dst_d) + firstBytes, secondBytes, group);
+  drainProgressPair(
+      p2p,
+      group,
+      secondSend.data(),
+      secondRecv.data(),
+      secondSend.bytes(),
+      secondMaxSignalBytes,
+      abort);
+}
+
+void testProgressTwoCallSendRecv(
+    P2pNvlTransportDevice p2p,
+    void* src_d,
+    void* dst_d,
+    size_t firstBytes,
+    size_t secondBytes,
+    size_t firstMaxSignalBytes,
+    size_t secondMaxSignalBytes,
+    AbortDevice abort,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream) {
+  testProgressTwoCallSendRecvKernel<<<numBlocks, blockSize, 0, stream>>>(
+      p2p,
+      src_d,
+      dst_d,
+      firstBytes,
+      secondBytes,
+      firstMaxSignalBytes,
+      secondMaxSignalBytes,
+      abort);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+__global__ void testProgressAbortThenReinitKernel(
+    P2pNvlTransportDevice p2p,
+    void* src_d,
+    size_t nbytes,
+    int maxIterations,
+    AbortDevice abort,
+    ProgressCounters* counters) {
+  abort.start();
+  auto group = make_block_group();
+
+  TiledBuffer<char> sendTiles(static_cast<char*>(src_d), nbytes, group);
+
+  // Phase 1: stall with no receiver, until the abort concludes the operation.
+  // Completion is impossible here, so Aborted is the only terminal status the
+  // loop can reach; `done` is tracked separately to keep that assertable.
+  p2p.init_send_progress(group, sendTiles.bytes(), 0);
+  bool done = false;
+  bool aborted = false;
+  for (int i = 0; i < maxIterations && !done && !aborted; ++i) {
+    const auto status = p2p.progress_send_once(
+        group, sendTiles.data(), sendTiles.bytes(), 0, abort);
+    done = status == NvlSendRecvProgressStatus::Done;
+    aborted = status == NvlSendRecvProgressStatus::Aborted;
+  }
+
+  if (counters != nullptr && blockIdx.x == 0 && group.is_leader()) {
+    counters->sendCompleted = done ? 1 : 0;
+    counters->sendAborted = aborted ? 1 : 0;
+  }
+
+  // Phase 2: re-init the same channel with no kernel boundary. If the abort
+  // cleanup were not published to every thread, this traps ("already has an
+  // in-flight send") or strands part of the group at a barrier.
+  p2p.init_send_progress(group, sendTiles.bytes(), 0);
+  group.sync();
+}
+
+void testProgressAbortThenReinit(
+    P2pNvlTransportDevice p2p,
+    void* src_d,
+    size_t nbytes,
+    int maxIterations,
+    AbortDevice abort,
+    ProgressCounters* counters,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream) {
+  testProgressAbortThenReinitKernel<<<numBlocks, blockSize, 0, stream>>>(
+      p2p, src_d, nbytes, maxIterations, abort, counters);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+/*
+ * Receiver-side mirror of testProgressSendBackpressureKernel. With no sender,
+ * DATA_READY never advances and every poll must report Waiting.
+ */
+__global__ void testProgressRecvBackpressureKernel(
+    P2pNvlTransportDevice p2p,
+    void* dst_d,
+    size_t nbytes,
+    size_t maxSignalBytes,
+    int maxIterations,
+    AbortDevice abort,
+    ProgressCounters* counters) {
+  abort.start();
+  auto group = make_block_group();
+
+  TiledBuffer<char> recvTiles(static_cast<char*>(dst_d), nbytes, group);
+  p2p.init_recv_progress(group, recvTiles.bytes(), maxSignalBytes);
+
+  bool done = false;
+  bool aborted = false;
+  int waiting = 0;
+  int progressed = 0;
+
+  for (int i = 0; i < maxIterations && !done && !aborted; ++i) {
+    const auto status = p2p.progress_recv_once(
+        group, recvTiles.data(), recvTiles.bytes(), maxSignalBytes, abort);
+    if (status == NvlSendRecvProgressStatus::Done) {
+      done = true;
+    } else if (status == NvlSendRecvProgressStatus::Aborted) {
+      aborted = true;
+    } else if (status == NvlSendRecvProgressStatus::Waiting) {
+      ++waiting;
+    } else {
+      ++progressed;
+    }
+  }
+
+  if (counters != nullptr && blockIdx.x == 0 && group.is_leader()) {
+    counters->recvWaiting = waiting;
+    counters->recvProgressed = progressed;
+    counters->recvCompleted = done ? 1 : 0;
+    counters->recvAborted = aborted ? 1 : 0;
+    counters->sendWaiting = 0;
+    counters->sendProgressed = 0;
+    counters->sendCompleted = 0;
+    counters->sendAborted = 0;
+  }
+}
+
+void testProgressRecvBackpressure(
+    P2pNvlTransportDevice p2p,
+    void* dst_d,
+    size_t nbytes,
+    size_t maxSignalBytes,
+    int maxIterations,
+    AbortDevice abort,
+    ProgressCounters* counters,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream) {
+  testProgressRecvBackpressureKernel<<<numBlocks, blockSize, 0, stream>>>(
+      p2p, dst_d, nbytes, maxSignalBytes, maxIterations, abort, counters);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+__global__ void testReadSlotFreeCounterKernel(
+    P2pNvlTransportDevice p2p,
+    int channel,
+    unsigned long long* out) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    *out = static_cast<unsigned long long>(
+        p2p.local_channel_at(channel).slot_free.load());
+  }
+}
+
+void testReadSlotFreeCounter(
+    P2pNvlTransportDevice p2p,
+    int channel,
+    unsigned long long* out,
+    cudaStream_t stream) {
+  testReadSlotFreeCounterKernel<<<1, 32, 0, stream>>>(p2p, channel, out);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
 } // namespace comms::prims::test

--- a/comms/prims/tests/P2pNvlTransportTest.cuh
+++ b/comms/prims/tests/P2pNvlTransportTest.cuh
@@ -263,6 +263,30 @@ void testProgressSendRecv(
     cudaStream_t stream = nullptr);
 
 /*
+ * Drives two peers concurrently from one block: subgroup 0 owns the
+ * predecessor transport, subgroup 1 the successor, each cycling send and recv
+ * on its own transport's channel 0.
+ *
+ * This is the only shape that gives the per-peer progress slice a nonzero
+ * offset. At two ranks the local peer index is always zero, so
+ * `progressDirectionStride_` and the per-peer slicing in
+ * `MultiPeerNvlTransport` are never exercised by the other cases. Channel
+ * indices are per-transport, so both subgroups using channel 0 cannot collide.
+ */
+void testProgressTwoPeerSendRecv(
+    P2pNvlTransportDevice p2pPred,
+    P2pNvlTransportDevice p2pSucc,
+    void* predSrc,
+    void* predDst,
+    void* succSrc,
+    void* succDst,
+    size_t nbytes,
+    size_t maxSignalBytes,
+    AbortDevice abort,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+/*
  * One-sided send with no peer draining, so the pipeline fills and the sender is
  * forced into Waiting. Runs at most `maxIterations` progress calls and is
  * expected NOT to complete; `counters` reports what was observed.

--- a/comms/prims/tests/P2pNvlTransportTest.cuh
+++ b/comms/prims/tests/P2pNvlTransportTest.cuh
@@ -222,4 +222,126 @@ void testWait(
     int blockSize,
     GroupType groupType = GroupType::WARP);
 
+/*
+ * Transition tallies for the resumable progress loop, written by the leader of
+ * block 0. Lets a test assert on the state machine itself, not just on the
+ * bytes that arrive.
+ */
+struct ProgressCounters {
+  int sendWaiting;
+  int sendProgressed;
+  int recvWaiting;
+  int recvProgressed;
+  // `Completed` counts only a Done terminal status; `Aborted` counts only the
+  // Aborted one. Keeping them apart is what lets an abort case assert that the
+  // poll unwound rather than that it merely stopped.
+  int sendCompleted;
+  int recvCompleted;
+  int sendAborted;
+  int recvAborted;
+};
+
+/*
+ * Drives one send and one recv through init_*_progress + progress_*_once,
+ * cycling between them until both reach a terminal status. This is the shape
+ * the batched
+ * MCCL send/recv kernel uses, so it exercises the API the way its real caller
+ * does rather than in isolation.
+ *
+ * `counters` may be null; when set it receives block 0's transition tallies.
+ */
+void testProgressSendRecv(
+    P2pNvlTransportDevice p2p,
+    void* src_d,
+    void* dst_d,
+    size_t nbytes,
+    size_t maxSignalBytes,
+    AbortDevice abort,
+    ProgressCounters* counters,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+/*
+ * One-sided send with no peer draining, so the pipeline fills and the sender is
+ * forced into Waiting. Runs at most `maxIterations` progress calls and is
+ * expected NOT to complete; `counters` reports what was observed.
+ */
+void testProgressSendBackpressure(
+    P2pNvlTransportDevice p2p,
+    void* src_d,
+    size_t nbytes,
+    size_t maxSignalBytes,
+    int maxIterations,
+    AbortDevice abort,
+    ProgressCounters* counters,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+/*
+ * Aborts a stalled send, then immediately re-inits the same channel in the same
+ * kernel. Pins the invariant that justifies clearing `stage` on the abort path:
+ * the cleanup must be visible to every thread in the group before the next
+ * init reads it, with no kernel boundary in between. `counters->sendAborted`
+ * reports whether the abort concluded; reaching the end without trapping or
+ * hanging is the rest of the assertion.
+ */
+void testProgressAbortThenReinit(
+    P2pNvlTransportDevice p2p,
+    void* src_d,
+    size_t nbytes,
+    int maxIterations,
+    AbortDevice abort,
+    ProgressCounters* counters,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+/*
+ * Two sequential progress operations on the same channel, to cover the cursor
+ * reservation and the Active -> Idle reset between them. The second call must
+ * resume from where the first left the cursor, not from zero.
+ */
+void testProgressTwoCallSendRecv(
+    P2pNvlTransportDevice p2p,
+    void* src_d,
+    void* dst_d,
+    size_t firstBytes,
+    size_t secondBytes,
+    size_t firstMaxSignalBytes,
+    size_t secondMaxSignalBytes,
+    AbortDevice abort,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+/*
+ * Receiver-side counterpart of testProgressSendBackpressure: a recv with no
+ * sender. DATA_READY never advances, so the poll must keep reporting Waiting
+ * and must not signal SLOT_FREE credit for a chunk it never received.
+ */
+void testProgressRecvBackpressure(
+    P2pNvlTransportDevice p2p,
+    void* dst_d,
+    size_t nbytes,
+    size_t maxSignalBytes,
+    int maxIterations,
+    AbortDevice abort,
+    ProgressCounters* counters,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+/*
+ * Reads this rank's SLOT_FREE counter for `channel` into `out`. Lets a test
+ * assert the peer never credited a chunk it did not consume, which is the
+ * invariant the recv abort path protects.
+ */
+void testReadSlotFreeCounter(
+    P2pNvlTransportDevice p2p,
+    int channel,
+    unsigned long long* out,
+    cudaStream_t stream = nullptr);
+
 } // namespace comms::prims::test

--- a/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
@@ -12,6 +12,7 @@
 #include "comms/prims/transport/Transport.cuh"
 #include "comms/prims/transport/ll/LlPacket.cuh"
 #include "comms/prims/transport/ll128/Ll128Packet.cuh"
+#include "comms/prims/transport/nvl/NvlChannelProgress.cuh"
 #include "comms/prims/transport/nvl/NvlChannelState.cuh"
 #include "comms/prims/transport/self/P2pSelfTransportDevice.cuh"
 #ifdef __HIP_PLATFORM_AMD__
@@ -166,6 +167,27 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
         bootstrap_, myRank_, nRanks_, totalChannelStateSize, memSharingMode_);
     auto* channelStatePtr = channelStateHandler_->getLocalDeviceMemPtr();
     CUDA_CHECK(cudaMemset(channelStatePtr, 0, totalChannelStateSize));
+
+    // Same per-peer shape as the channel state above, but local rather than
+    // IPC-shared. One allocation holds both directions back to back, send
+    // first; progressDirectionStride_ is the offset to the recv half. Zeroed so
+    // every channel starts NvlProgressStage::Idle.
+    perPeerChannelProgressSize_ =
+        config_.maxNumChannels * sizeof(NvlChannelProgress);
+    progressDirectionStride_ = perPeerChannelProgressSize_ * (nRanks_ - 1);
+    // A single-rank transport has no peers and so no progress slices. Skip the
+    // allocation rather than calling cudaMalloc with size 0, which succeeds
+    // while leaving the pointer null. buildP2pTransportDevice leaves the device
+    // progress pointers null, and the progress entry points trap on them.
+    if (progressDirectionStride_ > 0) {
+      void* progressPtr = nullptr;
+      CUDA_CHECK(cudaMalloc(&progressPtr, progressDirectionStride_ * 2));
+      if (progressPtr == nullptr) {
+        throw std::runtime_error("failed to allocate NVL progress state");
+      }
+      progressBase_.reset(progressPtr);
+      CUDA_CHECK(cudaMemset(progressPtr, 0, progressDirectionStride_ * 2));
+    }
   }
 
   // Conditionally allocate barrier buffer
@@ -370,6 +392,19 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
         remoteChBase + remotePeerIndex * perPeerChannelStateSize_);
   }
 
+  // Both directions slice by localPeerIndex; unlike the channel state there is
+  // no remote endpoint, since this storage is local. The recv half sits one
+  // direction stride into the same allocation.
+  NvlChannelProgress* sendProgress = nullptr;
+  NvlChannelProgress* recvProgress = nullptr;
+  if (progressBase_) {
+    auto* progressPtr = static_cast<char*>(progressBase_.get()) +
+        localPeerIndex * perPeerChannelProgressSize_;
+    sendProgress = reinterpret_cast<NvlChannelProgress*>(progressPtr);
+    recvProgress = reinterpret_cast<NvlChannelProgress*>(
+        progressPtr + progressDirectionStride_);
+  }
+
   auto* localSignalPtr =
       static_cast<char*>(signalBufferHandler_->getLocalDeviceMemPtr());
   auto* remoteSignalPtr =
@@ -477,7 +512,9 @@ P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
       localState,
       remoteState,
       localChannels,
-      remoteChannels);
+      remoteChannels,
+      sendProgress,
+      recvProgress);
 }
 
 DeviceSpan<Transport> MultiPeerNvlTransport::getDeviceTransports() {

--- a/comms/prims/transport/nvl/MultiPeerNvlTransport.h
+++ b/comms/prims/transport/nvl/MultiPeerNvlTransport.h
@@ -316,6 +316,14 @@ class MultiPeerNvlTransport {
   }
 
   /**
+   * @return Logical NVL channels per peer; device code requires
+   * group_id < this.
+   */
+  int maxNumChannels() const {
+    return config_.maxNumChannels;
+  }
+
+  /**
    * buildP2pTransportDevice - Build host-side P2pNvlTransportDevice
    *
    * Constructs a P2pNvlTransportDevice on the host for the specified peer.
@@ -470,6 +478,22 @@ class MultiPeerNvlTransport {
   // Allocated when maxNumChannels > 0.
   std::unique_ptr<GpuMemHandler> channelStateHandler_;
   std::size_t perPeerChannelStateSize_{0};
+
+  // Per-peer NvlChannelProgress arrays (length = maxNumChannels per peer,
+  // sliced by localPeerIndex). One allocation holds both directions, send
+  // first, recv at progressDirectionStride_. Plain device memory rather than a
+  // GpuMemHandler because, unlike the channel state, this is never
+  // IPC-exchanged.
+  struct CudaFreeDeleter {
+    void operator()(void* ptr) const noexcept {
+      if (ptr != nullptr) {
+        static_cast<void>(cudaFree(ptr));
+      }
+    }
+  };
+  std::unique_ptr<void, CudaFreeDeleter> progressBase_;
+  std::size_t perPeerChannelProgressSize_{0};
+  std::size_t progressDirectionStride_{0};
   std::size_t perPeerLlBufferSize_{0};
 
   // Flag to track if multi-peer device arrays have been initialized

--- a/comms/prims/transport/nvl/NvlChannelProgress.cuh
+++ b/comms/prims/transport/nvl/NvlChannelProgress.cuh
@@ -1,0 +1,66 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace comms::prims {
+
+enum class NvlProgressStage : uint8_t {
+  Idle,
+  Active,
+};
+
+/*
+ * Resumable state for one in-flight NVL send or recv, held per
+ * (peer, channel, direction). Device-local: never IPC-exchanged, because a
+ * rank's progress through its own operation is not read by the peer.
+ *
+ * Concurrency: one operation per (peer, channel, direction) at a time, the same
+ * contract the blocking send()/recv() rely on. A second progress init traps,
+ * but the blocking paths do not inspect `stage`, so interleaving a blocking op
+ * with an in-flight progress op on one channel is caller error and goes
+ * undetected.
+ */
+struct NvlChannelProgress {
+  // Stream offset reserved at init.
+  uint64_t activeBaseByte{0};
+  // How far this operation has advanced. Protocol bytes, so a resumed step
+  // lands on the chunk boundary the blocking loop would have used.
+  std::size_t activeNextByte{0};
+  std::size_t activePayloadBytes{0};
+  std::size_t activeTailPadding{0};
+  std::size_t activeUserBytes{0};
+  std::size_t activeMaxSignalBytes{0};
+  NvlProgressStage stage{NvlProgressStage::Idle};
+};
+
+/*
+ * Mirrors IbgdaSendRecvProgressStatus so one loop can drive both transports.
+ *
+ * `Aborted` is terminal and distinct from `Done`, matching the IB enum: the
+ * operation stopped because the communicator aborted, so the remaining bytes
+ * never moved. Reporting `Done` would let a driver claim success on data that
+ * was never transferred, and would leave a transport-agnostic loop -- which
+ * already has an abort branch for IB -- needing a transport-specific one here.
+ * A driver that only needs to stop polling treats both as terminal.
+ */
+enum class NvlSendRecvProgressStatus : uint8_t {
+  Waiting,
+  Progressed,
+  Done,
+  Aborted,
+};
+
+/*
+ * Leader verdict for a readiness poll, broadcast as one value. Folding abort
+ * into the same verdict keeps an unsuccessful poll to a single broadcast; two
+ * broadcasts would cost four group barriers on the path a resumable caller
+ * re-enters most often.
+ */
+inline constexpr uint32_t kNvlProgressWaiting = 0U;
+inline constexpr uint32_t kNvlProgressReady = 1U;
+inline constexpr uint32_t kNvlProgressAborted = 2U;
+
+} // namespace comms::prims

--- a/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
@@ -18,6 +18,7 @@
 #include "comms/prims/transport/amd/HipHostCompat.h"
 #include "comms/prims/transport/ll/LlOps.cuh"
 #include "comms/prims/transport/ll128/Ll128Ops.cuh"
+#include "comms/prims/transport/nvl/NvlChannelProgress.cuh"
 #include "comms/prims/transport/nvl/NvlChannelState.cuh"
 
 namespace comms::prims {
@@ -95,6 +96,87 @@ struct P2pNvlTransportOptions {
 };
 
 /**
+ * Trap if a caller starts a second operation on a channel before the first
+ * ends. NVL counterpart of assert_progress_slot_idle() in
+ * P2pIbTransportProgressImpl.cuh, and group-uniform for the same reason: the
+ * broadcast is the ordering point for init callers. A non-leader that read
+ * `stage` itself could observe the leader's own Active store from the same
+ * call, take a different branch, skip the init barrier, and spend the rest of
+ * the operation one barrier generation ahead of its group.
+ */
+__device__ __forceinline__ void assert_progress_slot_idle(
+    ThreadGroup& group,
+    const NvlChannelProgress& prog,
+    uint32_t channel,
+    const char* direction) {
+#if PIPES_IS_DEVICE_COMPILE
+  uint32_t idle = 1U;
+  if (group.is_leader()) {
+    idle = prog.stage == NvlProgressStage::Idle ? 1U : 0U;
+    if (idle == 0U) {
+      printf(
+          "init_%s_progress: channel %u already has an in-flight %s\n",
+          direction,
+          channel,
+          direction);
+    }
+  }
+  idle = group.broadcast<uint32_t>(idle);
+  if (idle == 0U) {
+    PIPES_DEVICE_TRAP();
+  }
+#else
+  (void)group;
+  (void)prog;
+  (void)channel;
+  (void)direction;
+#endif
+}
+
+/**
+ * Drive an aborted NVL progress slot to its terminal stage. Counterpart of the
+ * IB path's abandon_progress_state() in P2pIbTransportProgressImpl.cuh.
+ *
+ * A transfer that unwinds on abort would otherwise leave the slot Active, so
+ * the next operation on the channel trips the in-flight check in
+ * init_*_progress() and traps -- turning a clean abort into a device fault one
+ * kernel later. Marking the slot Idle makes that a clean exit instead: the
+ * aborting call reports Aborted and every later one short-circuits to Done --
+ * as the IB path does -- so a driver loop drains and the kernel exits on its
+ * existing loop condition.
+ *
+ * This buys liveness, not a usable channel. After an abort the DATA_READY /
+ * SLOT_FREE counters are skewed against the peer's, so later traffic on this
+ * channel is not meaningful; recovery is still a reconfigure().
+ *
+ * The reserved byte range is deliberately NOT returned to the channel cursor.
+ * The peer may still write into it, so the cursor stays advanced and the range
+ * is abandoned rather than recycled.
+ *
+ * The caller must have rendezvoused the group first: this writes state every
+ * thread reads, and the trailing sync publishes it.
+ */
+__device__ __forceinline__ void abandon_progress_state(
+    ThreadGroup& group,
+    NvlChannelProgress& prog) {
+#if PIPES_IS_DEVICE_COMPILE
+  if (group.is_leader()) {
+    prog.stage = NvlProgressStage::Idle;
+    prog.activeBaseByte = 0;
+    prog.activeNextByte = 0;
+    prog.activePayloadBytes = 0;
+    prog.activeTailPadding = 0;
+    prog.activeUserBytes = 0;
+    prog.activeMaxSignalBytes = 0;
+  }
+  group.sync();
+#else
+  (void)group;
+  (void)prog;
+#endif
+}
+
+/**
  * P2pNvlTransportDevice - High-Performance GPU-to-GPU Data Transfer over NVLink
  *
  * Provides per-channel pipelined data transfer between GPUs using NVLink.
@@ -113,14 +195,18 @@ class P2pNvlTransportDevice {
       const LocalState& localState,
       const RemoteState& remoteState,
       NvlChannelState* localChannels = nullptr,
-      NvlChannelState* remoteChannels = nullptr)
+      NvlChannelState* remoteChannels = nullptr,
+      NvlChannelProgress* sendProgress = nullptr,
+      NvlChannelProgress* recvProgress = nullptr)
       : myRank_(myRank),
         peerRank_(peerRank),
         options_(options),
         localState_(localState),
         remoteState_(remoteState),
         local_channels_(localChannels),
-        remote_channels_(remoteChannels) {}
+        remote_channels_(remoteChannels),
+        send_progress_(sendProgress),
+        recv_progress_(recvProgress) {}
 
   __host__ __device__ ~P2pNvlTransportDevice() = default;
 
@@ -652,6 +738,410 @@ class P2pNvlTransportDevice {
       local_ch.recv_cursor = static_cast<int64_t>(baseByte + protocolBytes);
     }
     group.sync();
+#endif
+  }
+
+  /**
+   * init_send_progress - begin a resumable send on this group's channel.
+   *
+   * Reserves the sender-side byte stream for `group.group_id` and records the
+   * geometry. The source pointer is not captured; it is passed to each
+   * progress_send_once() instead.
+   *
+   * Reserving here, rather than at completion as blocking send() does, is what
+   * lets init and every later progress call agree on the byte range. It is also
+   * why a channel cannot interleave a blocking send() with an in-flight
+   * progress send: both would claim from the same cursor.
+   *
+   * The send progress slot for this group must be idle; re-initializing while
+   * an operation is outstanding traps rather than silently overwriting it.
+   *
+   * @param group Thread group that will execute all later progress calls.
+   * @param nbytes User-buffer bytes to send for this group.
+   * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
+   */
+  __device__ __forceinline__ void init_send_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0) {
+#if PIPES_IS_DEVICE_COMPILE
+    if (nbytes == 0) {
+      return;
+    }
+
+    // Validate geometry before indexing progress storage, so a bad
+    // configuration produces make_channel_layout's diagnostic rather than an
+    // out-of-bounds access.
+    const NvlChannelLayout layout =
+        make_channel_layout(group, max_signal_bytes, "init_send_progress");
+    if (send_progress_ == nullptr) {
+      if (group.is_leader()) {
+        printf("init_send_progress: progress storage not configured\n");
+        PIPES_DEVICE_TRAP();
+      }
+      return;
+    }
+
+    const uint32_t channel = group.group_id;
+    NvlChannelProgress& prog = send_progress_[channel];
+
+    // Slot inspection is group-uniform; mutation is leader-only. See
+    // assert_progress_slot_idle().
+    assert_progress_slot_idle(group, prog, channel, "send");
+    if (group.is_leader()) {
+      NvlChannelState& local_ch = local_channels_[channel];
+      const uint64_t baseByte = static_cast<uint64_t>(local_ch.send_cursor);
+      const std::size_t payloadProtocolBytes =
+          align_tile_protocol_bytes(nbytes);
+      const std::size_t protocolTailPadding =
+          tail_padding_for_signal_granularity(
+              baseByte, max_signal_bytes, layout.perChannelSlot, nbytes);
+      local_ch.send_cursor = static_cast<int64_t>(
+          baseByte + payloadProtocolBytes + protocolTailPadding);
+      prog.activeBaseByte = baseByte;
+      prog.activeNextByte = 0;
+      prog.activePayloadBytes = payloadProtocolBytes;
+      prog.activeTailPadding = protocolTailPadding;
+      prog.activeUserBytes = nbytes;
+      prog.activeMaxSignalBytes = max_signal_bytes;
+      prog.stage = NvlProgressStage::Active;
+    }
+    group.sync();
+#else
+    (void)group;
+    (void)nbytes;
+    (void)max_signal_bytes;
+    (void)send_progress_;
+#endif
+  }
+
+  /**
+   * progress_send_once - advance a resumable send by at most one chunk.
+   *
+   * Non-blocking counterpart of the blocking send() loop body: instead of
+   * waiting on SLOT_FREE it polls once and reports Waiting, so a caller holding
+   * several operations in flight is never stuck on one peer.
+   *
+   * @return Done when the operation has completed, Aborted when it was cut
+   *         short by the abort handle, Progressed when a chunk was published,
+   *         Waiting when backpressure blocked this call.
+   */
+  __device__ __forceinline__ NvlSendRecvProgressStatus progress_send_once(
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0,
+      const AbortDevice& timeout = AbortDevice()) {
+#if PIPES_IS_DEVICE_COMPILE
+    const NvlChannelLayout layout =
+        make_channel_layout(group, max_signal_bytes, "progress_send_once");
+    if (send_progress_ == nullptr) {
+      if (group.is_leader()) {
+        printf("progress_send_once: progress storage not configured\n");
+        PIPES_DEVICE_TRAP();
+      }
+      return NvlSendRecvProgressStatus::Done;
+    }
+
+    const uint32_t channel = group.group_id;
+    NvlChannelProgress& prog = send_progress_[channel];
+    if (prog.stage == NvlProgressStage::Idle) {
+      return NvlSendRecvProgressStatus::Done;
+    }
+    // The geometry recorded at init is authoritative; these parameters only
+    // mirror it. Changing them mid-operation would silently corrupt the byte
+    // stream, so trap instead.
+    if (prog.activeUserBytes != nbytes ||
+        prog.activeMaxSignalBytes != max_signal_bytes) {
+      if (group.is_leader()) {
+        printf(
+            "progress_send_once: geometry changed mid-operation on channel %u\n",
+            channel);
+        PIPES_DEVICE_TRAP();
+      }
+      return NvlSendRecvProgressStatus::Done;
+    }
+
+    NvlChannelState& local_ch = local_channels_[channel];
+    NvlChannelState& remote_ch = remote_channels_[channel];
+
+    const char* __restrict__ srcPtr = reinterpret_cast<const char*>(src);
+    char* __restrict__ stagBuf = remoteState_.dataBuffer;
+
+    const std::size_t dataOff = prog.activeNextByte;
+    const uint64_t streamStart = prog.activeBaseByte + dataOff;
+    const NvlPipelinePosition position = layout.position(streamStart);
+    const std::size_t dataRemaining = prog.activePayloadBytes - dataOff;
+    std::size_t copyBytes = layout.effectiveChunk < dataRemaining
+        ? layout.effectiveChunk
+        : dataRemaining;
+    copyBytes =
+        copyBytes < position.slotRemaining ? copyBytes : position.slotRemaining;
+    const bool isFinalChunk = dataOff + copyBytes >= prog.activePayloadBytes;
+    const uint64_t streamEnd = streamStart + copyBytes;
+    const uint64_t protocolStreamEnd =
+        streamEnd + (isFinalChunk ? prog.activeTailPadding : 0);
+
+    // Non-blocking form of blocking send()'s slot_free.wait_until(). The leader
+    // resolves ready / waiting / aborted in one step and broadcasts a single
+    // verdict, as the IB progress path does. The broadcast comes first: only
+    // once every thread agrees on the verdict does the group clear the slot,
+    // uniformly, through abandon_progress_state(). Mutating shared progress
+    // state before that agreement splits the group across barrier generations.
+    if (protocolStreamEnd > layout.pipelineBytes) {
+      const uint64_t needed = protocolStreamEnd - layout.pipelineBytes;
+      uint32_t verdict = kNvlProgressReady;
+      if (group.is_leader() && local_ch.slot_free.load() < needed) {
+        // Same invariant blocking send() protects: leave before the staging
+        // write and the DATA_READY signal. Publishing either without credit
+        // would release a receiver that is correctly blocked.
+        verdict = FT_ABORT_CHECK(timeout, "progress_send_once observed abort")
+            ? kNvlProgressAborted
+            : kNvlProgressWaiting;
+      }
+      verdict = group.template broadcast<uint32_t>(verdict);
+      if (verdict == kNvlProgressAborted) {
+        // Release only after the broadcast has rendezvoused the group, so no
+        // thread can still be reading the slot for this call. Abort-only, so
+        // the barrier inside costs one per aborted operation, not per chunk.
+        abandon_progress_state(group, prog);
+        return NvlSendRecvProgressStatus::Aborted;
+      }
+      if (verdict == kNvlProgressWaiting) {
+        return NvlSendRecvProgressStatus::Waiting;
+      }
+    }
+
+    const std::size_t validBytes =
+        valid_payload_bytes(dataOff, copyBytes, prog.activeUserBytes);
+    if (validBytes > 0) {
+      memcpy_vectorized(
+          layout.staging_ptr(stagBuf, position),
+          srcPtr + dataOff,
+          validBytes,
+          group);
+    }
+
+    /*
+     * Two barriers, and both are load-bearing. The first joins every thread's
+     * staging write before the peer-visible signal, and also guarantees every
+     * thread has finished reading `activeNextByte` for this call -- on the
+     * in-window path nothing else rendezvouses the group, so a fast leader
+     * could otherwise overwrite the cursor while a slow warp was still reading
+     * it. The second publishes the leader's cursor/stage update for the next
+     * call to read.
+     */
+    group.sync();
+    if (group.is_leader()) {
+      remote_ch.data_ready.signal(SignalOp::SIGNAL_SET, protocolStreamEnd);
+      prog.activeNextByte = dataOff + copyBytes;
+      if (prog.activeNextByte >= prog.activePayloadBytes) {
+        prog.stage = NvlProgressStage::Idle;
+      }
+    }
+    group.sync();
+
+    // No reload: `prog.stage` becomes Idle exactly when this was the final
+    // chunk, which every thread already holds in a register.
+    return isFinalChunk ? NvlSendRecvProgressStatus::Done
+                        : NvlSendRecvProgressStatus::Progressed;
+#else
+    (void)group;
+    (void)src;
+    (void)nbytes;
+    (void)max_signal_bytes;
+    (void)timeout;
+    return NvlSendRecvProgressStatus::Done;
+#endif
+  }
+
+  /**
+   * init_recv_progress - begin a resumable receive on this group's channel.
+   *
+   * Receiver-side counterpart of init_send_progress(); see it for the
+   * cursor-reservation contract and the concurrency restriction.
+   */
+  __device__ __forceinline__ void init_recv_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0) {
+#if PIPES_IS_DEVICE_COMPILE
+    if (nbytes == 0) {
+      return;
+    }
+
+    const NvlChannelLayout layout =
+        make_channel_layout(group, max_signal_bytes, "init_recv_progress");
+    if (recv_progress_ == nullptr) {
+      if (group.is_leader()) {
+        printf("init_recv_progress: progress storage not configured\n");
+        PIPES_DEVICE_TRAP();
+      }
+      return;
+    }
+
+    const uint32_t channel = group.group_id;
+    NvlChannelProgress& prog = recv_progress_[channel];
+
+    // Group-uniform check, leader-only mutation: see init_send_progress().
+    assert_progress_slot_idle(group, prog, channel, "recv");
+    if (group.is_leader()) {
+      NvlChannelState& local_ch = local_channels_[channel];
+      const uint64_t baseByte = static_cast<uint64_t>(local_ch.recv_cursor);
+      const std::size_t payloadProtocolBytes =
+          align_tile_protocol_bytes(nbytes);
+      const std::size_t protocolTailPadding =
+          tail_padding_for_signal_granularity(
+              baseByte, max_signal_bytes, layout.perChannelSlot, nbytes);
+      local_ch.recv_cursor = static_cast<int64_t>(
+          baseByte + payloadProtocolBytes + protocolTailPadding);
+      prog.activeBaseByte = baseByte;
+      prog.activeNextByte = 0;
+      prog.activePayloadBytes = payloadProtocolBytes;
+      prog.activeTailPadding = protocolTailPadding;
+      prog.activeUserBytes = nbytes;
+      prog.activeMaxSignalBytes = max_signal_bytes;
+      prog.stage = NvlProgressStage::Active;
+    }
+    group.sync();
+#else
+    (void)group;
+    (void)nbytes;
+    (void)max_signal_bytes;
+    (void)recv_progress_;
+#endif
+  }
+
+  /**
+   * progress_recv_once - advance a resumable receive by at most one chunk.
+   *
+   * Non-blocking counterpart of the blocking recv() loop body: polls DATA_READY
+   * once and reports Waiting rather than spinning on it.
+   *
+   * @return Done when the operation has completed, Aborted when it was cut
+   *         short by the abort handle, Progressed when a chunk was consumed,
+   *         Waiting when the chunk had not arrived.
+   */
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ NvlSendRecvProgressStatus progress_recv_once(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      std::size_t max_signal_bytes = 0,
+      const AbortDevice& timeout = AbortDevice(),
+      Args... args) {
+#if PIPES_IS_DEVICE_COMPILE
+    const NvlChannelLayout layout =
+        make_channel_layout(group, max_signal_bytes, "progress_recv_once");
+    if (recv_progress_ == nullptr) {
+      if (group.is_leader()) {
+        printf("progress_recv_once: progress storage not configured\n");
+        PIPES_DEVICE_TRAP();
+      }
+      return NvlSendRecvProgressStatus::Done;
+    }
+
+    const uint32_t channel = group.group_id;
+    NvlChannelProgress& prog = recv_progress_[channel];
+    if (prog.stage == NvlProgressStage::Idle) {
+      return NvlSendRecvProgressStatus::Done;
+    }
+    if (prog.activeUserBytes != nbytes ||
+        prog.activeMaxSignalBytes != max_signal_bytes) {
+      if (group.is_leader()) {
+        printf(
+            "progress_recv_once: geometry changed mid-operation on channel %u\n",
+            channel);
+        PIPES_DEVICE_TRAP();
+      }
+      return NvlSendRecvProgressStatus::Done;
+    }
+
+    NvlChannelState& local_ch = local_channels_[channel];
+    NvlChannelState& remote_ch = remote_channels_[channel];
+
+    char* __restrict__ dstPtr = reinterpret_cast<char*>(dst);
+    char* __restrict__ stagBuf = localState_.dataBuffer;
+
+    const std::size_t dataOff = prog.activeNextByte;
+    const uint64_t streamStart = prog.activeBaseByte + dataOff;
+    const NvlPipelinePosition position = layout.position(streamStart);
+    const std::size_t dataRemaining = prog.activePayloadBytes - dataOff;
+    std::size_t copyBytes = layout.effectiveChunk < dataRemaining
+        ? layout.effectiveChunk
+        : dataRemaining;
+    copyBytes =
+        copyBytes < position.slotRemaining ? copyBytes : position.slotRemaining;
+    const bool isFinalChunk = dataOff + copyBytes >= prog.activePayloadBytes;
+    const uint64_t streamEnd = streamStart + copyBytes;
+    const uint64_t protocolStreamEnd =
+        streamEnd + (isFinalChunk ? prog.activeTailPadding : 0);
+
+    // Non-blocking form of blocking recv()'s data_ready.wait_until(). Note the
+    // wait target is streamEnd, not protocolStreamEnd: tail padding is credited
+    // in the SLOT_FREE signal below but never transferred.
+    // One leader-computed verdict, one broadcast -- see progress_send_once().
+    {
+      uint32_t verdict = kNvlProgressReady;
+      if (group.is_leader() && local_ch.data_ready.load() < streamEnd) {
+        // Same invariant blocking recv() protects: leave before the copy and,
+        // critically, before the SLOT_FREE credit. Signalling it would tell the
+        // sender we consumed a chunk it never sent, releasing a peer that is
+        // correctly blocked.
+        verdict = FT_ABORT_CHECK(timeout, "progress_recv_once observed abort")
+            ? kNvlProgressAborted
+            : kNvlProgressWaiting;
+      }
+      verdict = group.template broadcast<uint32_t>(verdict);
+      if (verdict == kNvlProgressAborted) {
+        // Release only after the broadcast has rendezvoused the group -- see
+        // progress_send_once().
+        abandon_progress_state(group, prog);
+        return NvlSendRecvProgressStatus::Aborted;
+      }
+      if (verdict == kNvlProgressWaiting) {
+        return NvlSendRecvProgressStatus::Waiting;
+      }
+    }
+
+    const std::size_t validBytes =
+        valid_payload_bytes(dataOff, copyBytes, prog.activeUserBytes);
+    if (validBytes > 0) {
+      CopyOp::recv(
+          dstPtr + dataOff,
+          layout.staging_ptr(stagBuf, position),
+          validBytes,
+          group,
+          dataOff,
+          args...);
+    }
+
+    // Two barriers, both load-bearing -- see progress_send_once(). The first
+    // joins every thread's read of staging before the credit is returned and
+    // before the cursor moves; the second publishes the cursor/stage update.
+    group.sync();
+    if (group.is_leader()) {
+      if (position.chunkOff + copyBytes == layout.perChannelSlot ||
+          isFinalChunk) {
+        remote_ch.slot_free.signal(SignalOp::SIGNAL_SET, protocolStreamEnd);
+      }
+      prog.activeNextByte = dataOff + copyBytes;
+      if (prog.activeNextByte >= prog.activePayloadBytes) {
+        prog.stage = NvlProgressStage::Idle;
+      }
+    }
+    group.sync();
+
+    return isFinalChunk ? NvlSendRecvProgressStatus::Done
+                        : NvlSendRecvProgressStatus::Progressed;
+#else
+    (void)group;
+    (void)dst;
+    (void)nbytes;
+    (void)max_signal_bytes;
+    (void)timeout;
+    ((void)args, ...);
+    return NvlSendRecvProgressStatus::Done;
 #endif
   }
 
@@ -1189,6 +1679,12 @@ class P2pNvlTransportDevice {
   //   array; this rank's send / recv write into it to signal the remote rank.
   NvlChannelState* local_channels_{nullptr};
   NvlChannelState* remote_channels_{nullptr};
+
+  // Per-channel resumable state, sliced per peer by the transport. Null when
+  // the transport was built without progress storage, which the progress entry
+  // points trap on.
+  NvlChannelProgress* send_progress_{nullptr};
+  NvlChannelProgress* recv_progress_{nullptr};
 };
 
 } // namespace comms::prims


### PR DESCRIPTION
Summary:

A plain `buck2 test` of `p2p_nvl_transport_test` reported green while executing
almost nothing. The BUCK rule asks for `nnodes=1, ppn=2`, but the default
`comms_launch_distributed_binary` RE path goes through `re_launcher`, which
starts two ordinary child processes and injects rank-like environment variables
without forming a PMIx world. The fixture took its rank count from
`MPI_Comm_size(MPI_COMM_WORLD)`, so each process was an MPI singleton, every
two-rank case hit `GTEST_SKIP`, and the target passed having exercised no data
movement at all.

Migrates the suite to `DistBaseTest`, which selects a TCPStore or MPI bootstrap
from the detected dist environment, so the cases run under the standard
invocation.

This is a full migration rather than a base-class swap, because native TCPStore
mode does not initialize MPI at all -- any leftover raw MPI call would fail or
hang under RE instead of skipping cleanly. Covered:

- 4 fixtures rebased from `MpiBaseTestFixture` onto
  `::testing::Test` + `DistBaseTest`, each with both `distSetUp()` and
  `distTearDown()`. The teardown is not optional cleanup: it is a join-dispatch
  rendezvous that stops rank 0 destroying the TCPStore while another rank still
  has requests in flight (`DistTestBase.cc`). The three parameterized fixtures
  are the ones that would have shown it, and they had only `SetUp` at first.
- 40 `MpiBootstrap` construction sites and type declarations moved to
  `createBootstrap()` / `IBootstrap`
- 37 `MPI_Barrier(MPI_COMM_WORLD)` calls replaced with an OOB barrier, plus one
  bare unchecked `MPI_Barrier` that the sweep for `MPI_CHECK` would have missed
- `MPIEnvironmentBase` swapped for `DistEnvironmentBase` in `main()`.
  `InitGoogleTest` stays **ahead** of `folly::Init`: it strips the `--gtest_*`
  flags, and gflags hard-errors on flags it does not recognise, so the reverse
  order breaks every filtered invocation -- including the compute-sanitizer
  synccheck run D116816500's test plan documents.
- MPI includes and BUCK deps dropped for `//comms/testinfra:dist_test_base`

**All 47 exact-two-rank guards are now hard failures**, not skips. Migrating the
launcher is only half the fix: 31 of those guards silently `return` (reporting
OK) and 16 called `GTEST_SKIP()`, so a future regression to a singleton launcher
would have quietly restored the same no-coverage state this diff exists to
remove. The rule is now uniform: a target that receives a rank count other than
the one it is configured for fails. That includes the 3+-rank case, which is no
longer conditional at all -- it moved to its own target and carries an exact
`ASSERT_EQ(numRanks, 4)` matching that target's `ppn`, so a launcher that
produced 3 ranks would fail rather than silently run weaker coverage.

**`ProgressTwoPeersConcurrently` gets its own `ppn=4` target**
(`nvl_progress_multi_peer_test`). It was added in the diff below this one but
always skipped at `ppn=2`, so it protected nothing. The suite target cannot host
it, since the two rank counts are mutually exclusive. Its payload oracle moves
to a shared `NvlProgressPayload.h` rather than being copied: two copies of an
oracle that drifted apart would silently weaken whichever side stopped matching
its producer. The main suite now has **zero** skips.

Bootstrap prefixes are derived from the running test name plus a per-test
sequence counter. Both properties are load-bearing: the prefix must be identical
on every rank or they rendezvous on different stores and hang, and distinct
between bootstraps or a later one picks up an earlier one's keys. Deriving from
the test name gives symmetry for free since every rank runs the same test, and
the counter is rank-symmetric for the same reason.

`runPutTest` takes a barrier callable rather than a bootstrap: the Put tests
build their transport through `TransportTestHelper`, which owns its bootstrap
privately, so the fixture's OOB barrier is what is actually in scope at those
call sites.

This addresses the CI-coverage finding from the multi-agent review of
D116816500. It is not specific to that diff -- all 47 two-rank guards in the
file were affected equally.

Reviewed By: saifhhasan

Differential Revision: D117287720


