### PR TITLE
comms/uniflow/tcp: pinned staging slabs, and frames that can live in one (#3895)

### DIFF
--- a/comms/uniflow/transport/tcp/TcpPinnedSlabPool.cpp
+++ b/comms/uniflow/transport/tcp/TcpPinnedSlabPool.cpp
@@ -1,0 +1,193 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/transport/tcp/TcpPinnedSlabPool.h"
+
+#include <string>
+#include <utility>
+
+#include "comms/uniflow/drivers/cuda/CudaApi.h"
+
+namespace uniflow {
+
+// ---------------------------------------------------------------------------
+// TcpPinnedSlab
+// ---------------------------------------------------------------------------
+
+TcpPinnedSlab::TcpPinnedSlab(
+    std::shared_ptr<TcpPinnedSlabPool> pool,
+    size_t index,
+    uint8_t* data,
+    size_t capacity)
+    : pool_(std::move(pool)), index_(index), data_(data), capacity_(capacity) {}
+
+TcpPinnedSlab::~TcpPinnedSlab() {
+  reset();
+}
+
+TcpPinnedSlab::TcpPinnedSlab(TcpPinnedSlab&& other) noexcept
+    : pool_(std::move(other.pool_)),
+      index_(other.index_),
+      data_(other.data_),
+      capacity_(other.capacity_) {
+  other.data_ = nullptr;
+  other.capacity_ = 0;
+}
+
+TcpPinnedSlab& TcpPinnedSlab::operator=(TcpPinnedSlab&& other) noexcept {
+  if (this != &other) {
+    reset();
+    pool_ = std::move(other.pool_);
+    index_ = other.index_;
+    data_ = other.data_;
+    capacity_ = other.capacity_;
+    other.data_ = nullptr;
+    other.capacity_ = 0;
+  }
+  return *this;
+}
+
+void TcpPinnedSlab::reset() {
+  if (pool_ != nullptr) {
+    // Moved out first: release() can wake a waiter that immediately reacquires
+    // this slab, and the pool must not be kept alive by this lease afterwards.
+    auto pool = std::move(pool_);
+    data_ = nullptr;
+    capacity_ = 0;
+    pool->release(index_);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// TcpPinnedSlabPool
+// ---------------------------------------------------------------------------
+
+Result<std::shared_ptr<TcpPinnedSlabPool>> TcpPinnedSlabPool::create(
+    std::shared_ptr<CudaApi> cudaApi,
+    size_t slabSize,
+    size_t slabCount,
+    size_t reservedForReader) {
+  if (cudaApi == nullptr) {
+    return Err(
+        ErrCode::InvalidArgument, "TcpPinnedSlabPool: no CUDA API available");
+  }
+  if (slabSize == 0 || slabCount == 0) {
+    return Err(
+        ErrCode::InvalidArgument,
+        "TcpPinnedSlabPool: slabSize and slabCount must both be non-zero");
+  }
+  if (reservedForReader >= slabCount) {
+    return Err(
+        ErrCode::InvalidArgument,
+        "TcpPinnedSlabPool: reservedForReader must leave at least one slab");
+  }
+  // cudaHostAllocPortable so the region is pinned with respect to every device
+  // context, not just whichever was current here: one transport stages for
+  // whatever devices its peer's segments live on.
+  auto base = cudaApi->hostAlloc(slabCount * slabSize, cudaHostAllocPortable);
+  if (!base) {
+    return std::move(base).error();
+  }
+  return std::shared_ptr<TcpPinnedSlabPool>(new TcpPinnedSlabPool(
+      std::move(cudaApi),
+      base.value(),
+      slabSize,
+      slabCount,
+      reservedForReader));
+}
+
+TcpPinnedSlabPool::TcpPinnedSlabPool(
+    std::shared_ptr<CudaApi> cudaApi,
+    void* base,
+    size_t slabSize,
+    size_t slabCount,
+    size_t reservedForReader)
+    : cudaApi_(std::move(cudaApi)),
+      base_(base),
+      slabSize_(slabSize),
+      slabCount_(slabCount),
+      reservedForReader_(reservedForReader) {
+  free_.reserve(slabCount_);
+  for (size_t i = 0; i < slabCount_; ++i) {
+    free_.push_back(i);
+  }
+}
+
+TcpPinnedSlabPool::~TcpPinnedSlabPool() {
+  if (base_ != nullptr) {
+    (void)cudaApi_->hostFree(base_);
+  }
+}
+
+TcpPinnedSlab TcpPinnedSlabPool::tryAcquire(bool allowReserved) {
+  size_t index = 0;
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    if (closed_ || free_.empty()) {
+      return TcpPinnedSlab{};
+    }
+    if (!allowReserved && free_.size() <= reservedForReader_) {
+      return TcpPinnedSlab{};
+    }
+    index = free_.back();
+    free_.pop_back();
+  }
+  return TcpPinnedSlab{
+      shared_from_this(),
+      index,
+      static_cast<uint8_t*>(base_) + index * slabSize_,
+      slabSize_};
+}
+
+Result<std::vector<TcpPinnedSlab>> TcpPinnedSlabPool::acquire(size_t count) {
+  if (count == 0) {
+    return std::vector<TcpPinnedSlab>{};
+  }
+  if (count > slabCount_ - reservedForReader_) {
+    return Err(
+        ErrCode::InvalidArgument,
+        "TcpPinnedSlabPool: asked for " + std::to_string(count) +
+            " slabs, only " + std::to_string(slabCount_ - reservedForReader_) +
+            " are available to bulk callers");
+  }
+  std::vector<size_t> indices;
+  {
+    std::unique_lock<std::mutex> lk(mu_);
+    freed_.wait(lk, [this, count]() {
+      return closed_ || free_.size() >= count + reservedForReader_;
+    });
+    if (closed_) {
+      return Err(ErrCode::NotConnected, "TcpPinnedSlabPool: pool is closed");
+    }
+    indices.assign(free_.end() - static_cast<ptrdiff_t>(count), free_.end());
+    free_.resize(free_.size() - count);
+  }
+  auto self = shared_from_this();
+  std::vector<TcpPinnedSlab> slabs;
+  slabs.reserve(count);
+  for (auto index : indices) {
+    slabs.emplace_back(
+        self,
+        index,
+        static_cast<uint8_t*>(base_) + index * slabSize_,
+        slabSize_);
+  }
+  return slabs;
+}
+
+void TcpPinnedSlabPool::close() {
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    closed_ = true;
+  }
+  freed_.notify_all();
+}
+
+void TcpPinnedSlabPool::release(size_t index) {
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    free_.push_back(index);
+  }
+  freed_.notify_all();
+}
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/TcpPinnedSlabPool.h
+++ b/comms/uniflow/transport/tcp/TcpPinnedSlabPool.h
@@ -1,0 +1,146 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "comms/uniflow/Result.h"
+
+namespace uniflow {
+
+class CudaApi;
+class TcpPinnedSlabPool;
+
+/// A borrow of one pinned staging slab. Move-only, and returned to the pool
+/// when it is destroyed, so a slab is held for exactly as long as some object
+/// owns the lease -- which on the outbound path means until the frame built in
+/// it has been handed to the socket and the queue entry is gone.
+class TcpPinnedSlab {
+ public:
+  TcpPinnedSlab() = default;
+  TcpPinnedSlab(
+      std::shared_ptr<TcpPinnedSlabPool> pool,
+      size_t index,
+      uint8_t* data,
+      size_t capacity);
+
+  ~TcpPinnedSlab();
+
+  TcpPinnedSlab(TcpPinnedSlab&& other) noexcept;
+  TcpPinnedSlab& operator=(TcpPinnedSlab&& other) noexcept;
+
+  TcpPinnedSlab(const TcpPinnedSlab&) = delete;
+  TcpPinnedSlab& operator=(const TcpPinnedSlab&) = delete;
+
+  explicit operator bool() const {
+    return pool_ != nullptr;
+  }
+  uint8_t* data() const {
+    return data_;
+  }
+  size_t capacity() const {
+    return capacity_;
+  }
+
+  /// Returns the slab to the pool early. A no-op on an empty lease.
+  void reset();
+
+ private:
+  std::shared_ptr<TcpPinnedSlabPool> pool_;
+  size_t index_{0};
+  uint8_t* data_{nullptr};
+  size_t capacity_{0};
+};
+
+/// A fixed set of equally-sized pinned host slabs, used to stage payloads
+/// between device memory and the socket.
+///
+/// Pinned rather than pageable because a device-to-host `cudaMemcpyAsync` into
+/// pageable memory is documented to complete synchronously: the thread that
+/// issues it blocks for the copy. On the get() responder that thread is the
+/// reader, and blocking it is what the staging queue exists to avoid.
+///
+/// `reservedForReader` slabs are withheld from the bulk `acquire()` path so a
+/// saturated put() cannot leave the responder with nothing to stage into.
+/// "Reserved" bounds put(), not the reader: when puts are idle the reader may
+/// use every slab, which keeps a multi-chunk get overlapping copy and transmit
+/// instead of serialising on one slab.
+class TcpPinnedSlabPool
+    : public std::enable_shared_from_this<TcpPinnedSlabPool> {
+ public:
+  /// Allocates `slabCount * slabSize` bytes of pinned host memory in one
+  /// region. Fails rather than throws, so a caller can fall back to failing one
+  /// transfer instead of the whole transport.
+  static Result<std::shared_ptr<TcpPinnedSlabPool>> create(
+      std::shared_ptr<CudaApi> cudaApi,
+      size_t slabSize,
+      size_t slabCount,
+      size_t reservedForReader);
+
+  ~TcpPinnedSlabPool();
+
+  TcpPinnedSlabPool(const TcpPinnedSlabPool&) = delete;
+  TcpPinnedSlabPool& operator=(const TcpPinnedSlabPool&) = delete;
+  TcpPinnedSlabPool(TcpPinnedSlabPool&&) = delete;
+  TcpPinnedSlabPool& operator=(TcpPinnedSlabPool&&) = delete;
+
+  size_t slabSize() const {
+    return slabSize_;
+  }
+  size_t slabCount() const {
+    return slabCount_;
+  }
+
+  /// Never blocks. `allowReserved` is for the reader thread, which must not
+  /// wait; put() passes false and so sees the pool as exhausted while the
+  /// reserved slabs are all that is left. An empty lease means "none
+  /// available", which is not an error.
+  TcpPinnedSlab tryAcquire(bool allowReserved);
+
+  /// Blocks until `count` slabs can be handed out together, drawing only on the
+  /// unreserved slabs. All-or-nothing: a caller that took what it could and
+  /// waited for the rest could deadlock against another doing the same, so a
+  /// waiter here holds nothing.
+  ///
+  /// Fails if `count` exceeds the unreserved capacity (it could never be
+  /// satisfied) or if the pool has been closed.
+  Result<std::vector<TcpPinnedSlab>> acquire(size_t count);
+
+  /// Wakes every waiter and refuses further acquisition. Outstanding leases
+  /// stay valid; this only stops new ones, so a shutdown does not pull memory
+  /// out from under a copy that is still running.
+  void close();
+
+ private:
+  friend class TcpPinnedSlab;
+
+  TcpPinnedSlabPool(
+      std::shared_ptr<CudaApi> cudaApi,
+      void* base,
+      size_t slabSize,
+      size_t slabCount,
+      size_t reservedForReader);
+
+  void release(size_t index);
+
+  std::shared_ptr<CudaApi> cudaApi_;
+  void* base_{nullptr};
+  size_t slabSize_{0};
+  size_t slabCount_{0};
+  size_t reservedForReader_{0};
+
+  std::mutex mu_;
+  // Notified on every release, not once per waiter: waiters want different
+  // counts, so the thread a notify_one picked may be unable to proceed while
+  // another could.
+  std::condition_variable freed_;
+  std::vector<size_t> free_;
+  bool closed_{false};
+};
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -766,7 +766,7 @@ Status TcpTransport::admitInflight(uint64_t reqId, TcpInflight entry) {
   return Ok();
 }
 
-bool TcpTransport::enqueueFrame(std::vector<uint8_t> frame, bool mayBlock) {
+bool TcpTransport::enqueueFrame(TcpFrame frame, bool mayBlock) {
   const size_t bytes = frame.size();
   {
     std::unique_lock<std::mutex> lk(outMu_);
@@ -799,8 +799,37 @@ bool TcpTransport::enqueueFrame(std::vector<uint8_t> frame, bool mayBlock) {
   return true;
 }
 
+bool TcpTransport::enqueueFrames(std::vector<TcpFrame> frames, bool mayBlock) {
+  if (frames.empty()) {
+    return true;
+  }
+  size_t bytes = 0;
+  for (const auto& frame : frames) {
+    bytes += frame.size();
+  }
+  {
+    std::unique_lock<std::mutex> lk(outMu_);
+    if (mayBlock) {
+      outCv_.wait(lk, [this, bytes]() {
+        return outClosed_ || connBroken_.load(std::memory_order_acquire) ||
+            outQueue_.empty() || outBytes_ + bytes <= kMaxOutQueueBytes;
+      });
+    }
+    if (outClosed_) {
+      return false;
+    }
+    for (auto& frame : frames) {
+      const size_t frameBytes = frame.size();
+      outQueue_.push_back(TcpOutItem{std::move(frame), nullptr});
+      outBytes_ += frameBytes;
+    }
+  }
+  outCv_.notify_all();
+  return true;
+}
+
 void TcpTransport::enqueueSendFrame(
-    std::vector<uint8_t> frame,
+    TcpFrame frame,
     std::shared_ptr<TcpOpState> onSent) {
   bool closed = false;
   std::shared_ptr<TcpOpState> toFail;
@@ -845,11 +874,15 @@ void TcpTransport::senderLoop() noexcept {
       }
       item = std::move(outQueue_.front());
       outQueue_.pop_front();
-      outBytes_ -= std::min(outBytes_, item.bytes.size());
+      outBytes_ -= std::min(outBytes_, item.frame.size());
     }
     outCv_.notify_all(); // room freed; wake any producer waiting for space
 
-    auto result = dataConn_->send(item.bytes).get();
+    // `item` -- and so the frame's storage, which for a staged frame is a
+    // pinned slab still on loan from the pool -- stays alive for the whole
+    // send: Conn::send only borrows the span. The slab goes back when `item` is
+    // destroyed at the end of this iteration, never at pop time.
+    auto result = dataConn_->send(item.frame.bytes()).get();
     if (!result) {
       UNIFLOW_LOG_ERROR(
           "tcp sender: send failed: {}", result.error().message());

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -19,6 +19,7 @@
 #include "comms/uniflow/controller/TcpController.h"
 #include "comms/uniflow/executor/EventBase.h"
 #include "comms/uniflow/transport/Transport.h"
+#include "comms/uniflow/transport/tcp/TcpPinnedSlabPool.h"
 
 namespace uniflow {
 
@@ -325,10 +326,53 @@ struct PendingReadReply {
   int deviceId{-1};
 };
 
+/// One outbound frame's storage: either a plain vector or a pinned staging
+/// slab. Move-only, because both kinds own the buffer the socket reads from and
+/// a slab additionally owns its place in the pool.
+///
+/// The vector constructor is deliberately implicit: most frames are small
+/// header-only messages built by serializeTcpHeader(), and they should stay
+/// written that way.
+class TcpFrame {
+ public:
+  TcpFrame() = default;
+  /* implicit */ TcpFrame(std::vector<uint8_t> bytes)
+      : vec_(std::move(bytes)), len_(vec_.size()) {}
+  /// `len` is the transmitted length, which may be shorter than the slab.
+  TcpFrame(TcpPinnedSlab slab, size_t len)
+      : slab_(std::move(slab)), len_(len) {}
+
+  ~TcpFrame() = default;
+  TcpFrame(TcpFrame&&) = default;
+  TcpFrame& operator=(TcpFrame&&) = default;
+  TcpFrame(const TcpFrame&) = delete;
+  TcpFrame& operator=(const TcpFrame&) = delete;
+
+  /// Writable view over the whole frame, for filling in the header and staging
+  /// a payload into it.
+  uint8_t* mutableData() {
+    return slab_ ? slab_.data() : vec_.data();
+  }
+  const uint8_t* data() const {
+    return slab_ ? slab_.data() : vec_.data();
+  }
+  size_t size() const {
+    return len_;
+  }
+  std::span<const uint8_t> bytes() const {
+    return {data(), len_};
+  }
+
+ private:
+  std::vector<uint8_t> vec_;
+  TcpPinnedSlab slab_;
+  size_t len_{0};
+};
+
 /// One queued outbound frame. `onSent`, when set, is completed by the sender
 /// thread once the frame is flushed to the socket (two-sided send()).
 struct TcpOutItem {
-  std::vector<uint8_t> bytes;
+  TcpFrame frame;
   std::shared_ptr<TcpOpState> onSent;
 };
 
@@ -444,12 +488,20 @@ class TcpTransport : public Transport {
   // `mayBlock` must be true only for caller threads. Returns false if the frame
   // was not queued (transport closing, or the reader hit the cap and refused
   // the connection).
-  [[nodiscard]] bool enqueueFrame(std::vector<uint8_t> frame, bool mayBlock);
+  [[nodiscard]] bool enqueueFrame(TcpFrame frame, bool mayBlock);
+  // Queues a run of frames as one indivisible step: either every frame is in
+  // outQueue_ or none is. Enqueuing them one at a time would let the sender
+  // thread start transmitting a partially built group, which for a multi-chunk
+  // put means the peer applies a prefix of a transfer this side may still fail
+  // to finish staging.
+  //
+  // `mayBlock` behaves as in enqueueFrame, and is judged against the group's
+  // total size, so a group larger than the queue cap still drains rather than
+  // waiting forever on room that will never appear.
+  [[nodiscard]] bool enqueueFrames(std::vector<TcpFrame> frames, bool mayBlock);
   // Queues a framed message whose completion is reported via `onSent` once the
   // frame is flushed (two-sided send()).
-  void enqueueSendFrame(
-      std::vector<uint8_t> frame,
-      std::shared_ptr<TcpOpState> onSent);
+  void enqueueSendFrame(TcpFrame frame, std::shared_ptr<TcpOpState> onSent);
   // Registers an in-flight request, but only if teardown has not already swept
   // the map. Returns false if the transport broke first, in which case the
   // caller must fail the op: nothing else will ever resolve it.

--- a/comms/uniflow/transport/tcp/tests/unit/TcpPinnedSlabPoolTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpPinnedSlabPoolTest.cpp
@@ -1,0 +1,200 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/transport/tcp/TcpPinnedSlabPool.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <set>
+#include <thread>
+#include <vector>
+
+#include "comms/uniflow/drivers/cuda/mock/MockCudaApi.h"
+
+namespace uniflow {
+
+// The pool's job is to make the reader's staging copy non-blocking (pinned
+// memory) without letting put() take every slab. The two properties that
+// matter, and that nothing else in the transport can enforce, are: a reserved
+// slab is unreachable from the bulk path, and a bulk acquire is all-or-nothing
+// so two of them cannot each hold a partial set and wait for the other.
+class TcpPinnedSlabPoolTest : public ::testing::Test {
+ protected:
+  static constexpr size_t kSlabSize = 128;
+  static constexpr size_t kSlabCount = 4;
+  static constexpr size_t kReserved = 1;
+
+  void SetUp() override {
+    cudaApi_ = std::make_shared<::testing::NiceMock<MockCudaApi>>();
+    // Real memory, so a test can prove the slabs are distinct, non-overlapping
+    // windows onto one region rather than trusting the arithmetic.
+    region_.assign(kSlabSize * kSlabCount, uint8_t{0});
+    ON_CALL(*cudaApi_, hostAlloc(::testing::_, ::testing::_))
+        .WillByDefault(
+            ::testing::Return(
+                Result<void*>(static_cast<void*>(region_.data()))));
+    ON_CALL(*cudaApi_, hostFree(::testing::_))
+        .WillByDefault(::testing::Return(Ok()));
+  }
+
+  std::shared_ptr<TcpPinnedSlabPool> makePool(
+      size_t slabCount = kSlabCount,
+      size_t reserved = kReserved) {
+    auto pool =
+        TcpPinnedSlabPool::create(cudaApi_, kSlabSize, slabCount, reserved);
+    EXPECT_TRUE(pool.hasValue()) << "pool creation should succeed";
+    return pool.hasValue() ? pool.value() : nullptr;
+  }
+
+  std::shared_ptr<::testing::NiceMock<MockCudaApi>> cudaApi_;
+  std::vector<uint8_t> region_;
+};
+
+TEST_F(TcpPinnedSlabPoolTest, SlabsAreDistinctWindowsOntoTheRegion) {
+  auto pool = makePool();
+  std::set<uint8_t*> seen;
+  std::vector<TcpPinnedSlab> held;
+  for (size_t i = 0; i < kSlabCount; ++i) {
+    auto slab = pool->tryAcquire(/*allowReserved=*/true);
+    ASSERT_TRUE(static_cast<bool>(slab)) << "slab " << i << " should be free";
+    EXPECT_EQ(slab.capacity(), kSlabSize);
+    EXPECT_GE(slab.data(), region_.data());
+    EXPECT_LE(slab.data() + slab.capacity(), region_.data() + region_.size());
+    EXPECT_TRUE(seen.insert(slab.data()).second)
+        << "two live leases handed out the same slab";
+    held.push_back(std::move(slab));
+  }
+  EXPECT_FALSE(static_cast<bool>(pool->tryAcquire(/*allowReserved=*/true)))
+      << "the pool is fixed-size; it must not invent a slab past the region";
+}
+
+TEST_F(TcpPinnedSlabPoolTest, ADestroyedLeaseReturnsItsSlab) {
+  auto pool = makePool(/*slabCount=*/1, /*reserved=*/0);
+  uint8_t* first = nullptr;
+  {
+    auto slab = pool->tryAcquire(/*allowReserved=*/false);
+    ASSERT_TRUE(static_cast<bool>(slab));
+    first = slab.data();
+    EXPECT_FALSE(static_cast<bool>(pool->tryAcquire(/*allowReserved=*/true)));
+  }
+  auto again = pool->tryAcquire(/*allowReserved=*/false);
+  ASSERT_TRUE(static_cast<bool>(again));
+  EXPECT_EQ(again.data(), first) << "the released slab should be reusable";
+}
+
+TEST_F(TcpPinnedSlabPoolTest, TheReserveIsUnreachableFromTheBulkPath) {
+  auto pool = makePool();
+  // Take everything the unreserved path can reach.
+  auto bulk = pool->acquire(kSlabCount - kReserved);
+  ASSERT_TRUE(bulk.hasValue());
+  EXPECT_EQ(bulk.value().size(), kSlabCount - kReserved);
+
+  EXPECT_FALSE(static_cast<bool>(pool->tryAcquire(/*allowReserved=*/false)))
+      << "put() must see the pool as exhausted while only the reserve is left";
+  auto readerSlab = pool->tryAcquire(/*allowReserved=*/true);
+  EXPECT_TRUE(static_cast<bool>(readerSlab))
+      << "the responder must still get a slab with every put slab occupied; "
+         "that is what the reserve is for";
+}
+
+TEST_F(TcpPinnedSlabPoolTest, ABulkAcquireLargerThanTheUnreservedSetIsRefused) {
+  auto pool = makePool();
+  auto tooMany = pool->acquire(kSlabCount);
+  EXPECT_TRUE(tooMany.hasError())
+      << "a request that can never be satisfied must fail rather than park the "
+         "caller forever";
+  EXPECT_EQ(tooMany.error().code(), ErrCode::InvalidArgument);
+}
+
+TEST_F(TcpPinnedSlabPoolTest, ABulkAcquireIsAllOrNothing) {
+  auto pool = makePool();
+  const size_t bulkCount = kSlabCount - kReserved;
+  auto held = pool->acquire(bulkCount);
+  ASSERT_TRUE(held.hasValue());
+
+  std::atomic<bool> completed{false};
+  std::thread waiter([&]() {
+    auto second = pool->acquire(bulkCount);
+    EXPECT_TRUE(second.hasValue());
+    EXPECT_EQ(second.value().size(), bulkCount);
+    completed.store(true, std::memory_order_release);
+  });
+
+  // Hand back one short of the full set. A waiter that took what it could get
+  // would have made partial progress here, and two such waiters would deadlock;
+  // this one must still be holding nothing.
+  held.value().pop_back();
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  EXPECT_FALSE(completed.load(std::memory_order_acquire))
+      << "a bulk acquire must not proceed on a partial set";
+
+  held.value().clear();
+  waiter.join();
+  EXPECT_TRUE(completed.load(std::memory_order_acquire));
+}
+
+TEST_F(TcpPinnedSlabPoolTest, CloseWakesWaitersAndRefusesNewLeases) {
+  auto pool = makePool();
+  auto held = pool->acquire(kSlabCount - kReserved);
+  ASSERT_TRUE(held.hasValue());
+
+  std::atomic<bool> refused{false};
+  std::thread waiter([&]() {
+    auto blocked = pool->acquire(kSlabCount - kReserved);
+    EXPECT_TRUE(blocked.hasError());
+    refused.store(true, std::memory_order_release);
+  });
+
+  // Nothing is released, so only close() can end that wait -- which is what
+  // stops a caller parked here from outliving the transport at shutdown.
+  pool->close();
+  waiter.join();
+  EXPECT_TRUE(refused.load(std::memory_order_acquire));
+  EXPECT_FALSE(static_cast<bool>(pool->tryAcquire(/*allowReserved=*/true)));
+}
+
+TEST_F(TcpPinnedSlabPoolTest, CreateRejectsAnUnusableConfiguration) {
+  EXPECT_TRUE(
+      TcpPinnedSlabPool::create(cudaApi_, 0, kSlabCount, kReserved).hasError());
+  EXPECT_TRUE(TcpPinnedSlabPool::create(cudaApi_, kSlabSize, 0, 0).hasError());
+  EXPECT_TRUE(
+      TcpPinnedSlabPool::create(cudaApi_, kSlabSize, kSlabCount, kSlabCount)
+          .hasError())
+      << "reserving every slab would leave put() unable to make progress";
+  EXPECT_TRUE(
+      TcpPinnedSlabPool::create(nullptr, kSlabSize, kSlabCount, kReserved)
+          .hasError());
+}
+
+TEST_F(TcpPinnedSlabPoolTest, CreatePropagatesAnAllocationFailure) {
+  ON_CALL(*cudaApi_, hostAlloc(::testing::_, ::testing::_))
+      .WillByDefault(
+          ::testing::Return(
+              Result<void*>(
+                  Err(ErrCode::DriverError,
+                      "test: out of pinned host "
+                      "memory"))));
+  auto pool =
+      TcpPinnedSlabPool::create(cudaApi_, kSlabSize, kSlabCount, kReserved);
+  ASSERT_TRUE(pool.hasError())
+      << "a failed pinned allocation must fail one transfer, not throw out of "
+         "the transport";
+  EXPECT_EQ(pool.error().code(), ErrCode::DriverError);
+}
+
+TEST_F(TcpPinnedSlabPoolTest, TheRegionIsFreedExactlyOnce) {
+  EXPECT_CALL(*cudaApi_, hostFree(static_cast<void*>(region_.data()))).Times(1);
+  {
+    auto pool = makePool();
+    auto slab = pool->tryAcquire(/*allowReserved=*/true);
+    // The lease outliving this scope's shared_ptr keeps the pool alive, so the
+    // region is not freed under a copy that may still be running.
+    pool.reset();
+  }
+}
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
@@ -5,11 +5,14 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <cstring>
 #include <future>
 #include <memory>
+#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -50,6 +53,66 @@ class FailingConn : public controller::Conn {
   }
   bool closed{false};
   int closeCount{0};
+};
+
+/// A connection whose send() parks until the test lets it through, so the
+/// window in which the sender thread is mid-send -- and must still own the
+/// frame's storage -- can be inspected.
+class GatedConn : public controller::Conn {
+ public:
+  std::future<Result<size_t>> send(std::span<const uint8_t> data) override {
+    std::unique_lock<std::mutex> lk(mu_);
+    sentPointer_ = data.data();
+    sentSize_ = data.size();
+    ++sendCount_;
+    entered_.notify_all();
+    // Parked inside send() rather than by returning an unfulfilled future: the
+    // sender thread calls .get() on the result either way, so this is the same
+    // wait a real socket write imposes.
+    gate_.wait(lk, [this]() { return released_; });
+    return make_ready_future<Result<size_t>>(Result<size_t>(sentSize_));
+  }
+  std::future<Result<size_t>> recv(std::vector<uint8_t>&) override {
+    return make_ready_future<Result<size_t>>(
+        Err(ErrCode::ConnectionFailed, "test: recv failed"));
+  }
+  std::future<Result<size_t>> recv(std::span<uint8_t>) override {
+    return make_ready_future<Result<size_t>>(
+        Err(ErrCode::ConnectionFailed, "test: recv failed"));
+  }
+  void close() override {}
+
+  void waitForSend() {
+    std::unique_lock<std::mutex> lk(mu_);
+    entered_.wait(lk, [this]() { return sendCount_ > 0; });
+  }
+
+  void releaseSend() {
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      released_ = true;
+    }
+    gate_.notify_all();
+  }
+
+  const uint8_t* sentPointer() {
+    std::lock_guard<std::mutex> lk(mu_);
+    return sentPointer_;
+  }
+
+  size_t sentSize() {
+    std::lock_guard<std::mutex> lk(mu_);
+    return sentSize_;
+  }
+
+ private:
+  std::mutex mu_;
+  std::condition_variable entered_;
+  std::condition_variable gate_;
+  const uint8_t* sentPointer_{nullptr};
+  size_t sentSize_{0};
+  int sendCount_{0};
+  bool released_{false};
 };
 
 class TcpTransportFrameTest : public ::testing::Test {
@@ -123,7 +186,7 @@ class TcpTransportFrameTest : public ::testing::Test {
   bool queuedErrorFrame() const {
     std::lock_guard<std::mutex> lk(transport_->outMu_);
     for (const auto& item : transport_->outQueue_) {
-      auto header = deserializeTcpHeader(item.bytes);
+      auto header = deserializeTcpHeader(item.frame.bytes());
       if (header.hasValue() &&
           static_cast<TcpOp>(header.value().op) == TcpOp::Error) {
         return true;
@@ -266,6 +329,94 @@ class TcpTransportFrameTest : public ::testing::Test {
     transport_->senderLoop();
   }
 
+  /// Installs a connection whose send() parks until released, so the sender
+  /// thread can be caught mid-send.
+  GatedConn* installGatedConn() {
+    auto conn = std::make_unique<GatedConn>();
+    auto* raw = conn.get();
+    transport_->dataConn_ = std::move(conn);
+    return raw;
+  }
+
+  /// Ends senderLoop() the way shutdown() does, without tearing the rest of the
+  /// transport down.
+  void closeOutQueue() {
+    {
+      std::lock_guard<std::mutex> lk(transport_->outMu_);
+      transport_->outClosed_ = true;
+    }
+    transport_->outCv_.notify_all();
+  }
+
+  /// A pool backed by real host memory, since the pool hands out pointers the
+  /// frames are built in and the tests dereference them. MockCudaApi::hostAlloc
+  /// otherwise returns a default-constructed Result.
+  std::shared_ptr<TcpPinnedSlabPool> makeSlabPool(
+      size_t slabCount,
+      size_t reserved) {
+    slabRegion_.assign(kTestSlabSize * slabCount, uint8_t{0});
+    ON_CALL(*cudaApi_, hostAlloc(::testing::_, ::testing::_))
+        .WillByDefault(
+            ::testing::Return(
+                Result<void*>(static_cast<void*>(slabRegion_.data()))));
+    ON_CALL(*cudaApi_, hostFree(::testing::_))
+        .WillByDefault(::testing::Return(Ok()));
+    auto pool =
+        TcpPinnedSlabPool::create(cudaApi_, kTestSlabSize, slabCount, reserved);
+    EXPECT_TRUE(pool.hasValue());
+    return pool.hasValue() ? pool.value() : nullptr;
+  }
+
+  /// Builds a header-only frame in `slab`, so a queued frame can be traced back
+  /// to the slab it was staged in.
+  static TcpFrame slabFrame(TcpPinnedSlab slab, TcpOp op, uint64_t reqId) {
+    TcpMsgHeader header;
+    header.op = static_cast<uint8_t>(op);
+    header.reqId = reqId;
+    auto bytes = serializeTcpHeader(header);
+    uint8_t* dst = slab.data();
+    if (dst == nullptr) {
+      return TcpFrame{};
+    }
+    std::copy(bytes.begin(), bytes.end(), dst);
+    return TcpFrame{std::move(slab), bytes.size()};
+  }
+
+  bool enqueueFrames(std::vector<TcpFrame> frames, bool mayBlock) {
+    return transport_->enqueueFrames(std::move(frames), mayBlock);
+  }
+
+  bool enqueueStagedFrame(TcpFrame frame) {
+    return transport_->enqueueFrame(std::move(frame), /*mayBlock=*/false);
+  }
+
+  /// reqIds of the frames currently queued, in queue order.
+  std::vector<uint64_t> queuedReqIds() {
+    std::vector<uint64_t> ids;
+    std::lock_guard<std::mutex> lk(transport_->outMu_);
+    for (const auto& item : transport_->outQueue_) {
+      auto header = deserializeTcpHeader(item.frame.bytes());
+      ids.push_back(header.hasValue() ? header.value().reqId : 0);
+    }
+    return ids;
+  }
+
+  /// Spins until `predicate` holds or the deadline passes. Used where the state
+  /// under test is changed by the sender thread and there is nothing to signal
+  /// on -- a slab returning to its pool has no observer hook.
+  template <typename Fn>
+  static bool waitFor(Fn predicate) {
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (predicate()) {
+        return true;
+      }
+      std::this_thread::yield();
+    }
+    return predicate();
+  }
+
   bool enqueueFrame(std::vector<uint8_t> frame) {
     return transport_->enqueueFrame(std::move(frame), /*mayBlock=*/false);
   }
@@ -301,6 +452,8 @@ class TcpTransportFrameTest : public ::testing::Test {
   std::vector<std::byte> segment_;
   std::vector<std::byte> pristine_;
   FailingConn* failingConn_{nullptr};
+  static constexpr size_t kTestSlabSize = 256;
+  std::vector<uint8_t> slabRegion_;
 };
 
 TEST_F(TcpTransportFrameTest, WriteToUnknownSegIdIsRejected) {
@@ -982,6 +1135,132 @@ TEST_F(TcpTransportFrameTest, VramStagingThrowDoesNotAbortTheReader) {
       << "a throw inside handleFrame must fail the connection";
   EXPECT_FALSE(readerRunning())
       << "the reader must stop rather than keep serving frames";
+}
+
+// A frame staged in a pinned slab is transmitted straight out of that slab, and
+// the slab is on loan for the whole send. Returning it when the item is popped
+// would let the next staging copy start writing into bytes the socket has not
+// read yet -- silent corruption, and only under load.
+TEST_F(TcpTransportFrameTest, ASlabFrameIsSentInPlaceAndHeldUntilTheSendEnds) {
+  setConnected();
+  auto pool = makeSlabPool(/*slabCount=*/1, /*reserved=*/0);
+  ASSERT_NE(pool, nullptr);
+  auto slab = pool->tryAcquire(/*allowReserved=*/false);
+  ASSERT_TRUE(static_cast<bool>(slab));
+  const uint8_t* slabData = slab.data();
+
+  ASSERT_TRUE(enqueueStagedFrame(
+      slabFrame(std::move(slab), TcpOp::ReadReply, /*reqId=*/11)));
+
+  auto* conn = installGatedConn();
+  std::thread sender([this]() { runSenderLoop(); });
+  conn->waitForSend();
+
+  EXPECT_EQ(conn->sentPointer(), slabData)
+      << "the span handed to the socket must point into the slab; a copy on the "
+         "way out would defeat staging there at all";
+  EXPECT_EQ(conn->sentSize(), sizeof(TcpMsgHeader));
+  EXPECT_FALSE(static_cast<bool>(pool->tryAcquire(/*allowReserved=*/true)))
+      << "the slab must still be on loan while the send is outstanding";
+
+  conn->releaseSend();
+  EXPECT_TRUE(waitFor([&]() {
+    return static_cast<bool>(pool->tryAcquire(/*allowReserved=*/true));
+  })) << "the slab must go back once the send resolves, or the pool leaks a "
+         "slab per staged reply";
+
+  closeOutQueue();
+  sender.join();
+}
+
+// The slab has to come back on the error path too. A send failure tears the
+// connection down but not the transport, so a slab stranded here is one the
+// pool never sees again.
+TEST_F(TcpTransportFrameTest, ASlabFrameIsReleasedAfterAFailedSend) {
+  setConnected();
+  installFailingConn();
+  auto pool = makeSlabPool(/*slabCount=*/1, /*reserved=*/0);
+  ASSERT_NE(pool, nullptr);
+  auto slab = pool->tryAcquire(/*allowReserved=*/false);
+  ASSERT_TRUE(static_cast<bool>(slab));
+
+  ASSERT_TRUE(enqueueStagedFrame(
+      slabFrame(std::move(slab), TcpOp::ReadReply, /*reqId=*/12)));
+
+  runSenderLoop(); // returns once send() fails
+
+  EXPECT_TRUE(static_cast<bool>(pool->tryAcquire(/*allowReserved=*/true)))
+      << "a failed send must still return the slab";
+}
+
+// Clearing the queue is the other way a frame dies. failAllPending() drops
+// every queued item, and each one owning its slab is what keeps that from
+// leaking the pool dry on a connection failure.
+TEST_F(TcpTransportFrameTest, ClearingTheOutQueueReleasesSlabFrames) {
+  setConnected();
+  auto pool = makeSlabPool(/*slabCount=*/2, /*reserved=*/0);
+  ASSERT_NE(pool, nullptr);
+  auto slabs = pool->acquire(2);
+  ASSERT_TRUE(slabs.hasValue());
+  std::vector<TcpFrame> frames;
+  frames.push_back(
+      slabFrame(std::move(slabs.value()[0]), TcpOp::ReadReply, /*reqId=*/21));
+  frames.push_back(
+      slabFrame(std::move(slabs.value()[1]), TcpOp::ReadReply, /*reqId=*/22));
+  ASSERT_TRUE(enqueueFrames(std::move(frames), /*mayBlock=*/false));
+  ASSERT_EQ(outQueueDepth(), 2u);
+
+  failAllPending();
+
+  EXPECT_EQ(outQueueDepth(), 0u);
+  auto reclaimed = pool->acquire(2);
+  EXPECT_TRUE(reclaimed.hasValue())
+      << "both slabs must be back in the pool after the queue is cleared";
+}
+
+// enqueueFrames exists so a put wave lands in the queue as one step. Enqueuing
+// chunk by chunk lets the sender start transmitting a group this side may still
+// fail to finish staging, which is a partial remote write the caller is told
+// nothing about.
+TEST_F(TcpTransportFrameTest, EnqueueFramesQueuesTheWholeGroupInOrder) {
+  setConnected();
+  std::vector<TcpFrame> frames;
+  for (uint64_t reqId = 31; reqId <= 33; ++reqId) {
+    TcpMsgHeader header;
+    header.op = static_cast<uint8_t>(TcpOp::Write);
+    header.reqId = reqId;
+    frames.emplace_back(serializeTcpHeader(header));
+  }
+  ASSERT_TRUE(enqueueFrames(std::move(frames), /*mayBlock=*/false));
+
+  EXPECT_THAT(queuedReqIds(), ::testing::ElementsAre(31u, 32u, 33u))
+      << "the group must be queued whole and in order";
+  EXPECT_EQ(outQueueBytes(), 3 * sizeof(TcpMsgHeader))
+      << "every frame in the group must be accounted against the queue cap";
+}
+
+// A closed queue must take none of the group. Half a wave queued and half
+// refused is the partial write the batch enqueue exists to prevent.
+TEST_F(TcpTransportFrameTest, EnqueueFramesQueuesNothingWhenTheQueueIsClosed) {
+  setConnected();
+  closeOutQueue();
+
+  auto pool = makeSlabPool(/*slabCount=*/2, /*reserved=*/0);
+  ASSERT_NE(pool, nullptr);
+  auto slabs = pool->acquire(2);
+  ASSERT_TRUE(slabs.hasValue());
+  std::vector<TcpFrame> frames;
+  frames.push_back(
+      slabFrame(std::move(slabs.value()[0]), TcpOp::Write, /*reqId=*/41));
+  frames.push_back(
+      slabFrame(std::move(slabs.value()[1]), TcpOp::Write, /*reqId=*/42));
+
+  EXPECT_FALSE(enqueueFrames(std::move(frames), /*mayBlock=*/false));
+  EXPECT_EQ(outQueueDepth(), 0u);
+  EXPECT_EQ(outQueueBytes(), 0u);
+  auto reclaimed = pool->acquire(2);
+  EXPECT_TRUE(reclaimed.hasValue())
+      << "a refused group must not strand the slabs it was built in";
 }
 
 // The registry's mutex protects the map, not the lifetime of the application


### PR DESCRIPTION
Summary:

# Context

The get responder stages a ReadReply's payload with `cudaMemcpyAsync` into the reply frame's `std::vector`. That buffer is pageable, and CUDA documents a device-to-host copy into pageable host memory as completing synchronously -- the call returns only once the copy is done. That is the documented contract, not something measured here; `MockCudaApi` mocks `memcpyAsync`, so no test in this stack can observe it either way. So the reader thread still blocks for the length of the copy, and still holds the registry `Lease` on its stack while it does, which is what the staging queue in D117031181 was meant to end. That diff's summary says so; this stack is what makes it true.

Fixing it needs pinned host memory to stage into, allocated once up front rather than per reply. This diff adds the pool and re-plumbs frame ownership so a frame can be backed by a slab instead of a vector. Nothing changes behaviour: the responder and `put()` still build their frames in vectors. The two diffs above this one move them.

# TcpPinnedSlabPool

One region of `cudaHostAlloc` memory, cut into equal slabs, handed out as move-only leases that return to the pool when destroyed.

`reservedForReader` slabs are withheld from the bulk acquire path. Without that, a saturated `put()` holding every slab would leave the responder with nothing to stage into, and the responder is the liveness-critical side: the peer is already blocked on the reply. "Reserved" bounds `put()`, not the reader -- `tryAcquire(allowReserved=true)` can take the last slab, so when puts are idle the reader may use all of them. Making the reserve exclusive instead would cap a multi-chunk get at one slab in flight, serialising its copies behind transmit. I did not measure that variant.

The bulk `acquire(count)` is all-or-nothing and waits holding nothing, so a caller cannot hold part of the pool while waiting for the rest. A caller that asks for more than the unreserved capacity is refused rather than parked on a condition that can never hold. Concurrent-put contention is not covered by a test; what is tested is that a partial set is never handed out. `close()` exists so a waiter cannot outlive the transport at shutdown.

TCP-local rather than extracted from `RdmaSlabPool`. The reusable parts there (`PinnedBuffer`, the allocator strategies) are file-local to the `.cpp`, and the pool itself is coupled to ibverbs through `MrSet` -- TCP needs no memory regions, no per-NIC keys, and no device pointer. Sharing would mean exporting three internal classes and threading a "no NICs" case through the one type that exists to register them.

`create()` returns a `Result` instead of throwing, because the caller (next diff) needs to fail one VRAM transfer on an allocation failure, not the transport. The header forward-declares `CudaApi` and names no vendor type, so only the `.cpp` is hipified, matching `TcpTransport`.

# TcpFrame

`TcpOutItem::bytes` becomes `TcpOutItem::frame`, a move-only `TcpFrame` holding either a vector or a slab lease plus the transmitted length. The vector constructor is implicit so the header-only frame sites (`enqueueFrame(serializeTcpHeader(header), ...)`) stay as they read today.

Slab size is `sizeof(TcpMsgHeader) + kMaxChunkSize`, header and payload contiguous, so a staged frame is still one buffer and the send path is unchanged: `Conn::send` takes a span and borrows it, so a frame transmits straight out of its slab with no copy on the way out.

The sender holds the whole `TcpOutItem` across `send(...).get()` and the slab goes back when the item is destroyed, not when it is popped. Releasing at pop time makes the pool hand that slab out again while the send is still outstanding, which is what the first negative control below demonstrates.

`outBytes_` accounts the transmitted length for both storage kinds, so the queue cap means the same thing either way.

# enqueueFrames

Admits a run of frames under one `outMu_` acquisition: either all of them are in `outQueue_` or none is. The put waves two diffs up need this -- enqueuing chunk by chunk lets the sender start transmitting a wave this side may still fail to finish staging, which is a partial remote write the caller is told nothing about. Unused here; the wave that uses it lands with it.

Differential Revision: D117053166


