### PR TITLE
comms/uniflow/tcp: stage get replies in pinned memory, and defer when it is full (#3896)

### DIFF
--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -28,10 +28,6 @@ constexpr int kDefaultHandshakeTimeoutSeconds = 30;
 
 namespace {
 
-// The controller frames each TcpConn message with a 4-byte length and caps it
-// at 64 MiB; keep each chunk (header + payload) safely under that so large
-// put/get transfers are split across multiple frames.
-constexpr size_t kMaxChunkSize = 4u << 20; // 4 MiB
 std::vector<uint8_t> makeHeaderFrame(TcpOp op, uint64_t reqId) {
   TcpMsgHeader header;
   header.op = static_cast<uint8_t>(op);
@@ -528,16 +524,64 @@ std::future<Status> TcpTransport::get(
   return future;
 }
 
-Status TcpTransport::stageReadReply(
-    std::vector<uint8_t> frame,
-    TcpSegmentRegistry::Lease lease,
-    const void* src,
-    size_t len,
-    int deviceId,
-    uint64_t reqId) {
+Result<std::shared_ptr<TcpPinnedSlabPool>> TcpTransport::stagingPool() {
+  std::lock_guard<std::mutex> lk(poolMu_);
+  if (slabPool_ != nullptr) {
+    return slabPool_;
+  }
   if (cudaApi_ == nullptr) {
     return Err(ErrCode::InvalidArgument, "tcp read: no CUDA API for VRAM");
   }
+  // Header and payload contiguous in one slab, so a staged frame is still a
+  // single buffer and the send path needs no scatter-gather.
+  auto pool = TcpPinnedSlabPool::create(
+      cudaApi_,
+      sizeof(TcpMsgHeader) + kMaxChunkSize,
+      kStagingSlabCount,
+      kStagingSlabsReservedForReader);
+  if (!pool) {
+    return std::move(pool).error();
+  }
+  slabPool_ = pool.value();
+  return slabPool_;
+}
+
+Status TcpTransport::respondToVramRead(
+    const TcpMsgHeader& replyHeader,
+    TcpSegmentRegistry::Lease lease) {
+  // A same-version peer chunks at kMaxChunkSize, so this only rejects a
+  // version-skewed peer built with a larger one. Per request, because the
+  // sender treats an oversized send as fatal and would take every unrelated
+  // transfer on the connection down with it.
+  if (replyHeader.len > kMaxChunkSize) {
+    return Err(
+        ErrCode::InvalidArgument,
+        "tcp read: VRAM read of " + std::to_string(replyHeader.len) +
+            " bytes exceeds the staging slab payload (" +
+            std::to_string(kMaxChunkSize) + ")");
+  }
+  auto pool = stagingPool();
+  if (!pool) {
+    return std::move(pool).error();
+  }
+  // Non-blocking, and allowed the reserved slab: this is the thread the reserve
+  // is held for, and it must not wait on anything.
+  auto slab = pool.value()->tryAcquire(/*allowReserved=*/true);
+  if (!slab) {
+    return deferReadReply(replyHeader, std::move(lease));
+  }
+  return startReadReply(replyHeader, std::move(lease), std::move(slab));
+}
+
+Status TcpTransport::startReadReply(
+    const TcpMsgHeader& replyHeader,
+    TcpSegmentRegistry::Lease lease,
+    TcpPinnedSlab slab) {
+  const int deviceId = lease->deviceId;
+  const void* src =
+      static_cast<const uint8_t*>(lease->ptr) + replyHeader.offset;
+  TcpFrame frame(std::move(slab), sizeof(TcpMsgHeader) + replyHeader.len);
+  std::memcpy(frame.mutableData(), &replyHeader, sizeof(replyHeader));
   cudaEvent_t event{};
   // Once the copy is enqueued, every way out of this function has to wait for
   // it. Returning an error unwinds `frame` and `lease`, and the copy is
@@ -548,10 +592,14 @@ Status TcpTransport::stageReadReply(
   bool copyIssued = false;
   try {
     CudaDeviceGuard guard(*cudaApi_, deviceId);
+    // Into pinned memory, so this returns once the copy is enqueued. The same
+    // call into a pageable destination -- a plain vector -- is specified to
+    // complete synchronously, which parks whichever thread issued it for the
+    // length of the transfer. On this path that thread is the reader.
     if (auto st = cudaApi_->memcpyAsync(
-            frame.data() + sizeof(TcpMsgHeader),
+            frame.mutableData() + sizeof(TcpMsgHeader),
             src,
-            len,
+            replyHeader.len,
             cudaMemcpyDeviceToHost,
             /*stream=*/nullptr);
         !st) {
@@ -584,10 +632,135 @@ Status TcpTransport::stageReadReply(
     std::lock_guard<std::mutex> lk(stagingMu_);
     pendingReplies_.push_back(
         PendingReadReply{
-            std::move(frame), std::move(lease), event, reqId, deviceId});
+            std::move(frame),
+            std::move(lease),
+            event,
+            replyHeader.reqId,
+            deviceId});
   }
   schedulePendingReplyPoll();
   return Ok();
+}
+
+Status TcpTransport::deferReadReply(
+    const TcpMsgHeader& replyHeader,
+    TcpSegmentRegistry::Lease lease) {
+  // The fourth admission point, and it has to agree with the other three about
+  // connBroken_. failAllPending() clears this queue precisely so a lease is not
+  // held "for as long as the transport object lives"; a reader that reaches
+  // here after that sweep would put one straight back, and nothing drains it
+  // again until drainPendingReadReplies() at teardown -- which is exactly the
+  // outcome the sweep exists to prevent. Refusing instead releases the lease as
+  // this returns, and the caller's Error frame to the peer is harmlessly
+  // refused by the same connBroken_ check on the enqueue path.
+  //
+  // Tested under stagingMu_, not before it, so the check and the push are one
+  // step against the sweep. failAllPending() runs them in the opposite order --
+  // it stores connBroken_ and only then takes stagingMu_ to swap the queue
+  // empty
+  // -- so a load outside the lock admits this interleaving, with senderLoop
+  // calling failAllPending() while the reader is still running:
+  //
+  //   reader: load connBroken_ -> false
+  //   sender: store connBroken_ = true; lock stagingMu_, swap empty
+  //   reader: lock stagingMu_, push entry
+  //
+  // That entry survives the sweep, and nothing kicks it again: senderLoop has
+  // returned, and the retirement path frees slabs without calling
+  // scheduleDeferredReadReplies(). Its lease then blocks erase() until the
+  // reader exits or teardown drains -- and a send failure does not close the
+  // connection, so nothing local bounds that. admitInflight() and
+  // admitInflightBulk() take their mutex first for the same reason.
+  {
+    std::lock_guard<std::mutex> lk(stagingMu_);
+    if (connBroken_.load(std::memory_order_acquire)) {
+      return Err(
+          ErrCode::NotConnected,
+          "tcp read: connection broken while deferring a VRAM read");
+    }
+    if (deferredReplies_.size() >= kMaxInflightRequests) {
+      return Err(
+          ErrCode::ResourceExhausted,
+          "tcp read: too many deferred VRAM reads (" +
+              std::to_string(deferredReplies_.size()) + ")");
+    }
+    deferredReplies_.push_back(
+        DeferredReadReply{
+            std::move(lease),
+            replyHeader.reqId,
+            replyHeader.segId,
+            replyHeader.offset,
+            replyHeader.len});
+  }
+  // Kicked on enqueue, not only where a slab is released.
+  //
+  // The caller reaches here because tryAcquire() just failed, and that failure
+  // and this enqueue are not one atomic step. A release landing in between --
+  // the sender retiring a frame, or the error path dropping one -- runs its own
+  // scheduleDeferredReadReplies() against a queue that is still empty and
+  // dispatches nothing, while its slab is now free. Without this kick the entry
+  // would wait for the *next* release, and on a connection that has gone idle
+  // there is no next release: the read never starts and its lease keeps erase()
+  // blocked. Redundant kicks are harmless -- startDeferredReadReplies()
+  // re-tests both the pool and the queue under the lock.
+  scheduleDeferredReadReplies();
+  return Ok();
+}
+
+void TcpTransport::scheduleDeferredReadReplies() {
+  {
+    std::lock_guard<std::mutex> lk(stagingMu_);
+    if (deferredReplies_.empty()) {
+      return;
+    }
+  }
+  evb_->dispatch([this]() noexcept { startDeferredReadReplies(); });
+}
+
+void TcpTransport::startDeferredReadReplies() {
+  auto pool = stagingPool();
+  if (!pool) {
+    return;
+  }
+  while (true) {
+    // The slab is taken before the entry, so an entry is never off the queue
+    // with nowhere to stage it. A slab that turns out not to be needed is
+    // released as this scope ends.
+    auto slab = pool.value()->tryAcquire(/*allowReserved=*/true);
+    if (!slab) {
+      return;
+    }
+    DeferredReadReply deferred;
+    {
+      std::lock_guard<std::mutex> lk(stagingMu_);
+      if (deferredReplies_.empty()) {
+        // Returning here releases the slab without using it, and deliberately
+        // does not reschedule. An entry queued between this test and that
+        // release is still covered, because deferReadReply() is the only
+        // producer and it kicks after every push, while this function runs only
+        // from evb_->dispatch() -- so that kick is serialized behind this
+        // invocation and sees the slab already back in the pool. A new producer
+        // that does not kick would reopen the window.
+        return;
+      }
+      deferred = std::move(deferredReplies_.front());
+      deferredReplies_.pop_front();
+    }
+    TcpMsgHeader replyHeader{};
+    replyHeader.op = static_cast<uint8_t>(TcpOp::ReadReply);
+    replyHeader.reqId = deferred.reqId;
+    replyHeader.segId = deferred.segId;
+    replyHeader.offset = deferred.offset;
+    replyHeader.len = deferred.len;
+    if (auto st = startReadReply(
+            replyHeader, std::move(deferred.lease), std::move(slab));
+        !st) {
+      UNIFLOW_LOG_ERROR(
+          "tcp read: deferred VRAM staging failed: {}", st.error().message());
+      (void)enqueueFrame(
+          makeHeaderFrame(TcpOp::Error, deferred.reqId), /*mayBlock=*/false);
+    }
+  }
 }
 
 void TcpTransport::schedulePendingReplyPoll() {
@@ -603,7 +776,7 @@ void TcpTransport::schedulePendingReplyPoll() {
 
 void TcpTransport::pollPendingReadReplies() {
   while (true) {
-    std::vector<uint8_t> ready;
+    TcpFrame ready;
     PendingReadReply failed;
     int failedDeviceId = -1;
     uint64_t failedReqId = 0;
@@ -661,11 +834,16 @@ void TcpTransport::pollPendingReadReplies() {
     } else if (haveFailure) {
       // Wait before `failed` goes out of scope, for the same reason
       // drainPendingReadReplies() waits: a copy that may still be running would
-      // otherwise be left writing into a freed buffer.
+      // otherwise be left writing into a slab the pool is about to hand to the
+      // next staging copy.
       waitForStagedCopy(failedDeviceId);
+      // Dropping it here releases the slab, so a deferred read may now be
+      // startable -- which is why this happens before the scheduling call
+      // below.
       failed = PendingReadReply{};
       (void)enqueueFrame(
           makeHeaderFrame(TcpOp::Error, failedReqId), /*mayBlock=*/false);
+      scheduleDeferredReadReplies();
     }
   }
 }
@@ -686,11 +864,15 @@ void TcpTransport::waitForStagedCopy(int deviceId) noexcept {
 
 void TcpTransport::drainPendingReadReplies() {
   std::deque<PendingReadReply> pending;
+  std::deque<DeferredReadReply> deferred;
   {
     std::lock_guard<std::mutex> lk(stagingMu_);
     pending.swap(pendingReplies_);
+    deferred.swap(deferredReplies_);
   }
   if (pending.empty()) {
+    // Deferred entries have no copy running, so dropping `deferred` here is all
+    // that is needed: their leases go with it and a waiting erase() proceeds.
     return;
   }
   // The device may still be writing into these frames. Freeing them now would
@@ -907,6 +1089,12 @@ void TcpTransport::senderLoop() noexcept {
     if (item.onSent) {
       item.onSent->completeOne();
     }
+    // Releases the frame's storage, and with it any staging slab, before the
+    // next wait. A deferred VRAM read may have been waiting on exactly this
+    // slab; dispatching the restart rather than running it here keeps device
+    // work off the thread whose only job is to keep the socket draining.
+    item = TcpOutItem{};
+    scheduleDeferredReadReplies();
   }
 }
 
@@ -1013,36 +1201,30 @@ void TcpTransport::handleFrameImpl(std::span<const uint8_t> frame) {
       } else if (
           entry && header.len <= entry->len &&
           header.offset <= entry->len - header.len) {
-        std::vector<uint8_t> reply(sizeof(TcpMsgHeader) + header.len);
         TcpMsgHeader replyHeader;
         replyHeader.op = static_cast<uint8_t>(TcpOp::ReadReply);
         replyHeader.reqId = header.reqId;
         replyHeader.segId = header.segId;
         replyHeader.offset = header.offset;
         replyHeader.len = header.len;
-        std::memcpy(reply.data(), &replyHeader, sizeof(replyHeader));
-        if (header.len > 0) {
-          const void* src =
-              static_cast<const uint8_t*>(entry->ptr) + header.offset;
-          if (entry->memType == MemoryType::VRAM) {
-            // Read before the lease is moved out.
-            const int deviceId = entry->deviceId;
-            // Staged rather than synchronous: the reply is queued once the copy
-            // signals. Waiting here would stop the reader draining the socket
-            // for the length of a device operation, and the lease it holds
-            // would stall any concurrent deregistration for just as long.
-            readStatus = stageReadReply(
-                std::move(reply),
-                std::move(entry),
-                src,
-                header.len,
-                deviceId,
-                header.reqId);
-          } else {
-            std::memcpy(reply.data() + sizeof(replyHeader), src, header.len);
-            (void)enqueueFrame(std::move(reply), /*mayBlock=*/false);
-          }
+        if (header.len > 0 && entry->memType == MemoryType::VRAM) {
+          // Staged into pinned memory rather than copied here: the reply is
+          // queued once the copy signals. Copying on this thread would stop the
+          // reader draining the socket for the length of a device operation,
+          // and the lease it holds would stall any concurrent deregistration
+          // for just as long.
+          readStatus = respondToVramRead(replyHeader, std::move(entry));
         } else {
+          // DRAM, or a zero-length read: a host memcpy cannot fail and cannot
+          // park the reader, so there is nothing to stage.
+          std::vector<uint8_t> reply(sizeof(TcpMsgHeader) + header.len);
+          std::memcpy(reply.data(), &replyHeader, sizeof(replyHeader));
+          if (header.len > 0) {
+            std::memcpy(
+                reply.data() + sizeof(replyHeader),
+                static_cast<const uint8_t*>(entry->ptr) + header.offset,
+                header.len);
+          }
           (void)enqueueFrame(std::move(reply), /*mayBlock=*/false);
         }
       } else {
@@ -1241,6 +1423,18 @@ void TcpTransport::failAllPending(const char* message) {
     outQueue_.clear();
     outBytes_ = 0;
   }
+  // Deferred reads will never be answered on a broken connection, and each one
+  // holds a lease. Dropped here rather than left for teardown so a
+  // deregistration is not blocked for as long as the transport object lives.
+  // pendingReplies_ is deliberately untouched: those have copies running, and
+  // freeing their frames now would hand the GPU memory the allocator has taken
+  // back. drainPendingReadReplies() waits for them.
+  std::deque<DeferredReadReply> deferred;
+  {
+    std::lock_guard<std::mutex> lk(stagingMu_);
+    deferred.swap(deferredReplies_);
+  }
+  deferred.clear();
   outCv_.notify_all(); // wake producers blocked for space so they see the break
   for (auto& state : toFail) {
     state->fail(Err(ErrCode::ConnectionFailed, message));

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -112,6 +112,9 @@ struct TcpTransportInfo {
 };
 
 class CudaApi;
+// Wire header, defined in TcpWireProtocol.h. Only referenced by private member
+// declarations here, so this header stays free of the wire format.
+struct TcpMsgHeader;
 
 /// Factory-shared registry mapping a locally-assigned segment id to the
 /// registered host buffer. registerSegment() (on the factory) populates it;
@@ -225,16 +228,20 @@ class TcpSegmentRegistry {
   /// acquires mu_ while holding another transport mutex.
   ///
   /// How long this can block is bounded by the slowest lease holder, and on the
-  /// VRAM path that is not bounded by the transport. The reader queues its Ack
-  /// and reply frames without blocking, but it holds its lease across the whole
-  /// host-staging copy, and that copy ends in a synchronize on the null stream
+  /// VRAM path that is not bounded by the transport. A read reply's lease is
+  /// held across its staging copy, and that copy runs on the null stream
   /// (handleFrame passes no stream), which waits on every blocking stream on
-  /// the device -- i.e. on unrelated application GPU work. So a caller here can
-  /// wait for an application step, and deadlocks outright if that GPU work is
-  /// itself gated on a later inbound frame, since the parked reader is the
-  /// thread that would deliver it. Giving the staging copies a dedicated
-  /// non-blocking stream removes both; until then a DRAM-only deployment is the
-  /// safe case, because there the copy under lease is a plain memcpy.
+  /// the device -- so a caller here can wait for unrelated application GPU
+  /// work. A read that arrived with the staging pool exhausted holds its lease
+  /// for longer still: its copy has not been issued yet and starts only once a
+  /// slab frees up.
+  ///
+  /// What this can no longer do is deadlock. The reader thread does not wait
+  /// for any of it -- staging is asynchronous and exhaustion defers rather than
+  /// blocks -- so it keeps delivering inbound frames, including whatever the
+  /// application's GPU work is itself waiting on. Giving the staging copies a
+  /// dedicated non-blocking stream would remove the remaining wait on unrelated
+  /// device work.
   void erase(uint64_t segId) {
     std::unique_lock<std::mutex> lk(mu_);
     auto it = segs_.find(segId);
@@ -307,25 +314,6 @@ struct PlannedChunk {
   TcpInflight entry;
 };
 
-/// A ReadReply whose payload is still being copied out of VRAM. The frame is
-/// already built, header and all; only the staging copy into its payload is
-/// outstanding.
-///
-/// The lease lives here rather than on the reader thread. It has to outlive the
-/// copy, because it is what stops the owner deregistering and freeing the
-/// source buffer underneath the GPU, but nothing requires the reader to be the
-/// thread holding it. Moving it here is what lets the reader return to the
-/// socket immediately while the segment stays protected.
-struct PendingReadReply {
-  std::vector<uint8_t> frame;
-  TcpSegmentRegistry::Lease lease;
-  /// cudaEvent_t, kept opaque so this header does not need the CUDA runtime.
-  void* event{nullptr};
-  uint64_t reqId{0};
-  /// Needed at teardown to wait on the right device's stream.
-  int deviceId{-1};
-};
-
 /// One outbound frame's storage: either a plain vector or a pinned staging
 /// slab. Move-only, because both kinds own the buffer the socket reads from and
 /// a slab additionally owns its place in the pool.
@@ -374,6 +362,42 @@ class TcpFrame {
 struct TcpOutItem {
   TcpFrame frame;
   std::shared_ptr<TcpOpState> onSent;
+};
+
+/// A ReadReply whose payload is still being copied out of VRAM. The frame is
+/// already built, header and all, in a pinned staging slab; only the copy into
+/// its payload is outstanding.
+///
+/// The lease lives here rather than on the reader thread. It has to outlive the
+/// copy, because it is what stops the owner deregistering and freeing the
+/// source buffer underneath the GPU, but nothing requires the reader to be the
+/// thread holding it. Moving it here is what lets the reader return to the
+/// socket while the segment stays protected.
+struct PendingReadReply {
+  TcpFrame frame;
+  TcpSegmentRegistry::Lease lease;
+  /// cudaEvent_t, kept opaque so this header does not need the CUDA runtime.
+  void* event{nullptr};
+  uint64_t reqId{0};
+  /// Needed at teardown to wait on the right device's stream.
+  int deviceId{-1};
+};
+
+/// A VRAM ReadReply that has not been started because no staging slab was free.
+/// Everything needed to build and launch it later is here, so the reader can
+/// record it and go straight back to the socket.
+///
+/// The lease is held even though no copy has been issued yet. It is what keeps
+/// the source buffer registered, and the point of deferring rather than
+/// dropping is that this read will still be answered out of that same buffer. A
+/// deregistration therefore waits for the deferred copy to run, not only for
+/// the ones already launched.
+struct DeferredReadReply {
+  TcpSegmentRegistry::Lease lease;
+  uint64_t reqId{0};
+  uint64_t segId{0};
+  uint64_t offset{0};
+  size_t len{0};
 };
 
 /// A posted recv() awaiting a matching inbound SEND frame.
@@ -526,31 +550,56 @@ class TcpTransport : public Transport {
   // that exception would escape put() itself, abandoning the promise while
   // whatever was already queued still lands on the peer.
   Status validateDeviceForStaging(int deviceId);
-  // Starts the D2H copy for a ReadReply and hands the frame to the staging
-  // queue, so the reader thread can go back to draining the socket instead of
-  // waiting on the device. Consumes the lease. Returns an error only if the
-  // copy could not be started, in which case nothing was queued.
-  Status stageReadReply(
-      std::vector<uint8_t> frame,
+  // Answers one VRAM ReadRequest. Acquires a staging slab without waiting; if
+  // none is free the request is deferred rather than staged, so the reader is
+  // never parked on the pool. Consumes the lease.
+  Status respondToVramRead(
+      const TcpMsgHeader& replyHeader,
+      TcpSegmentRegistry::Lease lease);
+  // Builds the reply in `slab` and starts its D2H copy, handing the frame to
+  // the staging queue so the reader can go back to draining the socket instead
+  // of waiting on the device. Consumes the lease and the slab. Returns an error
+  // only if the copy could not be started, in which case nothing was queued.
+  Status startReadReply(
+      const TcpMsgHeader& replyHeader,
       TcpSegmentRegistry::Lease lease,
-      const void* src,
-      size_t len,
-      int deviceId,
-      uint64_t reqId);
+      TcpPinnedSlab slab);
+  // Records a VRAM read to start once a slab frees up. Fails the request (the
+  // caller answers with an Error frame) if the deferred queue is full: dropping
+  // it silently would leave the peer waiting forever, and blocking here would
+  // stop the reader draining the socket.
+  Status deferReadReply(
+      const TcpMsgHeader& replyHeader,
+      TcpSegmentRegistry::Lease lease);
+  // Starts as many deferred reads as there are free slabs, oldest first. Runs
+  // on the EventBase, never inline at the point a slab is released: that point
+  // is the sender thread, and launching copies there would block the drain that
+  // frees the next slab.
+  void startDeferredReadReplies();
+  // Kicks startDeferredReadReplies() on the EventBase. Called wherever a
+  // staging slab goes back to the pool. Cheap and safe when nothing is
+  // deferred.
+  void scheduleDeferredReadReplies();
+  // The staging pool, created on first use. Building it in the constructor
+  // would charge every peer ~64 MiB of pinned host memory -- there is one
+  // transport per peer -- including the DRAM-only peers that never stage at
+  // all.
+  Result<std::shared_ptr<TcpPinnedSlabPool>> stagingPool();
   // Retires staged replies whose copy has finished, oldest first. Runs on the
   // EventBase, never on the reader thread: polling from the reader would put
   // the head-of-line block straight back.
   void pollPendingReadReplies();
   // Kicks the poll loop if it is not already running. Safe from any thread.
   void schedulePendingReplyPoll();
-  // Waits for outstanding staging copies and drops the frames. Called during
-  // teardown, because the GPU may still be writing into a pending frame's
-  // payload and that memory must not be freed underneath it.
   /// Waits for a staged D2H copy on `deviceId` whose completion is otherwise
   /// unknown, so the frame it targets can be released. Used on the paths where
   /// a copy was issued but the event never became a usable completion signal.
   void waitForStagedCopy(int deviceId) noexcept;
 
+  /// Waits for outstanding staging copies and drops the frames, then discards
+  /// whatever was still deferred. Called during teardown, because the GPU may
+  /// still be writing into a pending frame's payload and that memory must not
+  /// be freed underneath it.
   void drainPendingReadReplies();
 
   // Shared bodies for the zero-copy and copy-based send/recv overloads.
@@ -640,6 +689,21 @@ class TcpTransport : public Transport {
   // is what bounds it.
   static constexpr size_t kMaxOutQueueBytes = 64UL * 1024 * 1024;
   static constexpr size_t kMaxInflightRequests = 4096;
+  // put()'s chunk size, and the payload capacity of one staging slab. A
+  // same-version peer therefore never asks for a read larger than one slab.
+  //
+  // The controller frames each TcpConn message with a 4-byte length and caps it
+  // at 64 MiB; a chunk (header + payload) stays safely under that, so large
+  // put/get transfers are split across multiple frames.
+  static constexpr size_t kMaxChunkSize = 4UL * 1024 * 1024;
+  // ~64 MiB of pinned host memory, sized against kMaxOutQueueBytes: the pool
+  // and the out queue bound the same pipeline, so a full set of staged frames
+  // fits in the queue rather than being refused by its cap.
+  static constexpr size_t kStagingSlabCount = 16;
+  // Withheld from put(), so a saturated put cannot leave the get responder with
+  // nothing to stage into. The responder is the side the peer is already
+  // blocked on.
+  static constexpr size_t kStagingSlabsReservedForReader = 1;
   // Bytes currently queued in outQueue_. Guarded by outMu_.
   size_t outBytes_{0};
 
@@ -681,6 +745,17 @@ class TcpTransport : public Transport {
   // safe on the wire, this only costs latency -- and a transport serves one
   // peer, which in practice means one device.
   bool replyPollScheduled_{false};
+  // VRAM reads that arrived with the pool exhausted, oldest first. Bounded by
+  // kMaxInflightRequests for the same reason inflight_ is: it grows on
+  // peer-supplied frames, and the reader will not stop reading them.
+  std::deque<DeferredReadReply> deferredReplies_;
+
+  // Created on first VRAM staging need, then never replaced. Its own mutex
+  // rather than stagingMu_: acquiring a slab can wait (put(), from a caller
+  // thread), and the staging queue must stay available to the reader while it
+  // does.
+  std::mutex poolMu_;
+  std::shared_ptr<TcpPinnedSlabPool> slabPool_;
 
   // Outbound frame queue drained by the sender thread. Decoupling all sends
   // from the reader thread is what prevents a mutual-READ deadlock (two peers'

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
@@ -55,6 +55,32 @@ class FailingConn : public controller::Conn {
   int closeCount{0};
 };
 
+/// A connection that accepts every send and counts them, for the tests that
+/// need the sender to actually drain the queue.
+class CountingConn : public controller::Conn {
+ public:
+  std::future<Result<size_t>> send(std::span<const uint8_t> data) override {
+    sendCount_.fetch_add(1, std::memory_order_release);
+    return make_ready_future<Result<size_t>>(Result<size_t>(data.size()));
+  }
+  std::future<Result<size_t>> recv(std::vector<uint8_t>&) override {
+    return make_ready_future<Result<size_t>>(
+        Err(ErrCode::ConnectionFailed, "test: recv failed"));
+  }
+  std::future<Result<size_t>> recv(std::span<uint8_t>) override {
+    return make_ready_future<Result<size_t>>(
+        Err(ErrCode::ConnectionFailed, "test: recv failed"));
+  }
+  void close() override {}
+
+  int sendCount() const {
+    return sendCount_.load(std::memory_order_acquire);
+  }
+
+ private:
+  std::atomic<int> sendCount_{0};
+};
+
 /// A connection whose send() parks until the test lets it through, so the
 /// window in which the sender thread is mid-send -- and must still own the
 /// frame's storage -- can be inspected.
@@ -131,7 +157,30 @@ class TcpTransportFrameTest : public ::testing::Test {
     ON_CALL(*cudaApi_, setDevice(::testing::_))
         .WillByDefault(::testing::Return(Ok()));
     ON_CALL(*cudaApi_, streamSynchronize(::testing::_))
-        .WillByDefault(::testing::Return(Ok()));
+        .WillByDefault([this](auto) -> Status {
+          syncCount_.fetch_add(1, std::memory_order_release);
+          return Ok();
+        });
+    // Real host memory behind the staging pool: the pool hands out pointers the
+    // transport builds frames in and copies into, and the tests check that a
+    // copy landed inside this memory rather than in a vector.
+    ON_CALL(*cudaApi_, hostAlloc(::testing::_, ::testing::_))
+        .WillByDefault([this](size_t size, unsigned int) -> Result<void*> {
+          // Default-initialised rather than zeroed: this is 64 MiB per pool.
+          auto buf = std::unique_ptr<uint8_t[]>(new uint8_t[size]);
+          void* ptr = buf.get();
+          std::lock_guard<std::mutex> lk(allocMu_);
+          hostAllocs_.emplace_back(std::move(buf), size);
+          return ptr;
+        });
+    ON_CALL(*cudaApi_, hostFree(::testing::_))
+        .WillByDefault([this](void* ptr) -> Status {
+          std::lock_guard<std::mutex> lk(allocMu_);
+          std::erase_if(hostAllocs_, [ptr](const auto& alloc) {
+            return alloc.first.get() == ptr;
+          });
+          return Ok();
+        });
 
     transport_ = std::make_unique<TcpTransport>(
         /*deviceId=*/-1,
@@ -338,6 +387,33 @@ class TcpTransportFrameTest : public ::testing::Test {
     return raw;
   }
 
+  /// Installs a connection that accepts every send, for the tests that need the
+  /// queue actually drained.
+  CountingConn& installCountingConn() {
+    auto conn = std::make_unique<CountingConn>();
+    auto& ref = *conn;
+    transport_->dataConn_ = std::move(conn);
+    return ref;
+  }
+
+  static size_t deferredCap() {
+    return TcpTransport::kMaxInflightRequests;
+  }
+
+  static size_t slabPayloadCap() {
+    return TcpTransport::kMaxChunkSize;
+  }
+
+  /// Fills the deferred queue with entries holding no lease, so the overflow
+  /// boundary can be reached without the millions of requests a real peer would
+  /// have to send to get there.
+  void fillDeferredReplies(size_t n) {
+    std::lock_guard<std::mutex> lk(transport_->stagingMu_);
+    for (size_t i = 0; i < n; ++i) {
+      transport_->deferredReplies_.push_back(DeferredReadReply{});
+    }
+  }
+
   /// Ends senderLoop() the way shutdown() does, without tearing the rest of the
   /// transport down.
   void closeOutQueue() {
@@ -348,23 +424,98 @@ class TcpTransportFrameTest : public ::testing::Test {
     transport_->outCv_.notify_all();
   }
 
-  /// A pool backed by real host memory, since the pool hands out pointers the
-  /// frames are built in and the tests dereference them. MockCudaApi::hostAlloc
-  /// otherwise returns a default-constructed Result.
+  /// A standalone pool, for the frame-ownership tests. Backed by the fixture's
+  /// hostAlloc stub, so its slabs are real memory.
   std::shared_ptr<TcpPinnedSlabPool> makeSlabPool(
       size_t slabCount,
       size_t reserved) {
-    slabRegion_.assign(kTestSlabSize * slabCount, uint8_t{0});
-    ON_CALL(*cudaApi_, hostAlloc(::testing::_, ::testing::_))
-        .WillByDefault(
-            ::testing::Return(
-                Result<void*>(static_cast<void*>(slabRegion_.data()))));
-    ON_CALL(*cudaApi_, hostFree(::testing::_))
-        .WillByDefault(::testing::Return(Ok()));
     auto pool =
         TcpPinnedSlabPool::create(cudaApi_, kTestSlabSize, slabCount, reserved);
     EXPECT_TRUE(pool.hasValue());
     return pool.hasValue() ? pool.value() : nullptr;
+  }
+
+  /// The transport's own staging pool, created on the first call exactly as a
+  /// VRAM read would create it.
+  std::shared_ptr<TcpPinnedSlabPool> transportStagingPool() {
+    auto pool = transport_->stagingPool();
+    EXPECT_TRUE(pool.hasValue());
+    return pool.hasValue() ? pool.value() : nullptr;
+  }
+
+  /// Installs the stubs a staged VRAM read needs, with the copy held unfinished
+  /// until `releaseStagingCopies()`. Every copy destination is recorded, which
+  /// is how a test tells staging into the pinned pool from staging into a
+  /// vector.
+  void stubStagingCopies() {
+    ON_CALL(
+        *cudaApi_,
+        memcpyAsync(
+            ::testing::_,
+            ::testing::_,
+            ::testing::_,
+            ::testing::_,
+            ::testing::_))
+        .WillByDefault(
+            [this](void* dst, const void*, size_t, auto, auto) -> Status {
+              std::lock_guard<std::mutex> lk(copyMu_);
+              copyDsts_.push_back(dst);
+              return Ok();
+            });
+    ON_CALL(*cudaApi_, eventCreate(::testing::_))
+        .WillByDefault([](auto* event) -> Status {
+          // Spelled with auto because this TU is not hipified: cudaEvent_t is
+          // ihipEvent_t* here, and naming it does not compile under ROCm.
+          *event = {};
+          return Ok();
+        });
+    ON_CALL(*cudaApi_, eventRecord(::testing::_, ::testing::_))
+        .WillByDefault(::testing::Return(Ok()));
+    ON_CALL(*cudaApi_, eventDestroy(::testing::_))
+        .WillByDefault(::testing::Return(Ok()));
+    ON_CALL(*cudaApi_, eventQuery(::testing::_))
+        .WillByDefault([this](auto) -> Result<bool> {
+          return Result<bool>(copyDone_.load(std::memory_order_acquire));
+        });
+  }
+
+  void releaseStagingCopies() {
+    copyDone_.store(true, std::memory_order_release);
+  }
+
+  size_t stagedCopyCount() {
+    std::lock_guard<std::mutex> lk(copyMu_);
+    return copyDsts_.size();
+  }
+
+  /// True if every recorded copy destination lies inside memory the pool
+  /// allocated. A copy into a frame's vector storage fails this.
+  bool allCopiesLandedInPinnedMemory() {
+    std::lock_guard<std::mutex> lk(copyMu_);
+    std::lock_guard<std::mutex> allocLk(allocMu_);
+    for (const auto* dst : copyDsts_) {
+      const bool inside = std::any_of(
+          hostAllocs_.begin(), hostAllocs_.end(), [dst](const auto& alloc) {
+            const auto* base = alloc.first.get();
+            if (base == nullptr) {
+              return false;
+            }
+            return dst >= base && dst < base + alloc.second;
+          });
+      if (!inside) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  int syncCount() const {
+    return syncCount_.load(std::memory_order_acquire);
+  }
+
+  size_t deferredReplyCount() {
+    std::lock_guard<std::mutex> lk(transport_->stagingMu_);
+    return transport_->deferredReplies_.size();
   }
 
   /// Builds a header-only frame in `slab`, so a queued frame can be traced back
@@ -453,7 +604,12 @@ class TcpTransportFrameTest : public ::testing::Test {
   std::vector<std::byte> pristine_;
   FailingConn* failingConn_{nullptr};
   static constexpr size_t kTestSlabSize = 256;
-  std::vector<uint8_t> slabRegion_;
+  std::atomic<bool> copyDone_{false};
+  std::atomic<int> syncCount_{0};
+  std::mutex copyMu_;
+  std::vector<const void*> copyDsts_;
+  std::mutex allocMu_;
+  std::vector<std::pair<std::unique_ptr<uint8_t[]>, size_t>> hostAllocs_;
 };
 
 TEST_F(TcpTransportFrameTest, WriteToUnknownSegIdIsRejected) {
@@ -839,11 +995,16 @@ TEST_F(TcpTransportFrameTest, OversizedReadRequestIsRefusedPerRequest) {
 // reader thread, so the reader stopped draining the socket for the length of an
 // application GPU step. That re-arms the mutual-READ deadlock the reader/sender
 // split exists to prevent, and the registry lease held across the copy stalled
-// any concurrent erase() for just as long. The copy is staged instead: the
-// reader posts it and returns to the socket, and the EventBase queues the reply
-// once the copy signals.
+// any concurrent erase() for just as long.
+//
+// The copy is staged instead: issued into a pinned slab and left to run, with
+// the reply queued by the EventBase once it signals. Pinned matters -- the same
+// copy into a frame's vector storage is pageable, which CUDA specifies as
+// completing synchronously, so the reader would still be parked for the whole
+// transfer while looking asynchronous.
 TEST_F(TcpTransportFrameTest, AStagedVramReadReplyDoesNotBlockTheReader) {
   setConnected();
+  stubStagingCopies();
 
   constexpr uint64_t kVramSegId = kSegId + 200;
   constexpr size_t kLen = 64;
@@ -851,35 +1012,20 @@ TEST_F(TcpTransportFrameTest, AStagedVramReadReplyDoesNotBlockTheReader) {
   registry_->add(
       kVramSegId, vram.data(), kLen, MemoryType::VRAM, /*deviceId=*/0);
 
-  std::atomic<bool> copyDone{false};
-  ON_CALL(
-      *cudaApi_,
-      memcpyAsync(
-          ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
-      .WillByDefault(::testing::Return(Ok()));
-  ON_CALL(*cudaApi_, eventCreate(::testing::_))
-      .WillByDefault([](auto* event) -> Status {
-        // Spelled with auto because this TU is not hipified: cudaEvent_t is
-        // ihipEvent_t* here, and naming it does not compile under ROCm.
-        *event = {};
-        return Ok();
-      });
-  ON_CALL(*cudaApi_, eventRecord(::testing::_, ::testing::_))
-      .WillByDefault(::testing::Return(Ok()));
-  ON_CALL(*cudaApi_, eventDestroy(::testing::_))
-      .WillByDefault(::testing::Return(Ok()));
-  // The copy stays unfinished until the test releases it.
-  ON_CALL(*cudaApi_, eventQuery(::testing::_))
-      .WillByDefault([&](auto) -> Result<bool> {
-        return Result<bool>(copyDone.load(std::memory_order_acquire));
-      });
-
   feed(makeFrame(
       TcpOp::ReadRequest, kVramSegId, /*offset=*/0, kLen, /*payloadBytes=*/0));
 
   EXPECT_EQ(outQueueDepth(), 0u)
       << "a reply whose payload is still being copied must not be queued; the "
          "peer would receive an unfilled buffer";
+  EXPECT_EQ(stagedCopyCount(), 1u);
+  EXPECT_TRUE(allCopiesLandedInPinnedMemory())
+      << "the copy went somewhere other than a pinned slab; a device-to-host "
+         "copy into pageable memory blocks the thread that issues it, so the "
+         "reader is parked for the whole transfer";
+  EXPECT_EQ(syncCount(), 0)
+      << "the reader must not synchronize: waiting on the device is exactly "
+         "what staging exists to avoid";
 
   // The reader is not parked, so a request arriving behind the staged one is
   // answered while that copy is still running.
@@ -889,15 +1035,257 @@ TEST_F(TcpTransportFrameTest, AStagedVramReadReplyDoesNotBlockTheReader) {
       << "the reader is blocked behind the VRAM copy: a request queued after it "
          "was not answered until the device finished";
 
-  copyDone.store(true, std::memory_order_release);
+  releaseStagingCopies();
 
-  const auto deadline =
-      std::chrono::steady_clock::now() + std::chrono::seconds(5);
-  while (outQueueDepth() < 2u && std::chrono::steady_clock::now() < deadline) {
-    std::this_thread::yield();
-  }
-  EXPECT_EQ(outQueueDepth(), 2u)
+  EXPECT_TRUE(waitFor([this]() { return outQueueDepth() >= 2u; }))
       << "the staged reply must be queued once its copy signals";
+  EXPECT_EQ(outQueueDepth(), 2u);
+}
+
+// The pool is finite, so a read can arrive with nothing to stage into. It is
+// recorded and answered later rather than waited on: waiting is the
+// head-of-line block the whole staging path exists to remove, and it would be
+// worse here because the thread that frees the next slab is the sender, which
+// the reader would be holding up.
+TEST_F(TcpTransportFrameTest, AVramReadWithNoFreeSlabIsDeferredNotBlocked) {
+  setConnected();
+  stubStagingCopies();
+
+  constexpr uint64_t kVramSegId = kSegId + 210;
+  constexpr size_t kLen = 64;
+  std::vector<std::byte> vram(kLen, std::byte{0x33});
+  registry_->add(
+      kVramSegId, vram.data(), kLen, MemoryType::VRAM, /*deviceId=*/0);
+
+  // Every slab, the reserved one included: nothing is left for the responder.
+  auto pool = transportStagingPool();
+  ASSERT_NE(pool, nullptr);
+  std::vector<TcpPinnedSlab> held;
+  held.reserve(pool->slabCount());
+  for (size_t i = 0; i < pool->slabCount(); ++i) {
+    held.push_back(pool->tryAcquire(/*allowReserved=*/true));
+    ASSERT_TRUE(static_cast<bool>(held.back()));
+  }
+
+  feed(makeFrame(
+      TcpOp::ReadRequest, kVramSegId, /*offset=*/0, kLen, /*payloadBytes=*/0));
+
+  EXPECT_EQ(deferredReplyCount(), 1u)
+      << "the read must be recorded for later, not dropped: the peer is "
+         "blocked waiting for this reply";
+  EXPECT_EQ(stagedCopyCount(), 0u)
+      << "no slab was free, so no copy may have been issued -- a fallback into "
+         "pageable memory would block the reader, which is the bug this path "
+         "exists to avoid";
+  EXPECT_EQ(syncCount(), 0)
+      << "the reader must not wait on the device to make room";
+
+  // And the reader is still serving: a DRAM read behind the deferred one is
+  // answered immediately.
+  feed(makeFrame(
+      TcpOp::ReadRequest, kSegId, /*offset=*/0, kLen, /*payloadBytes=*/0));
+  EXPECT_EQ(outQueueDepth(), 1u)
+      << "a deferred VRAM read must not hold up unrelated requests";
+}
+
+// A deferral must be refused once the connection is swept. failAllPending()
+// empties the deferred queue exactly so a lease is not pinned for the lifetime
+// of the transport; a read that lands afterwards and is deferred anyway puts
+// one straight back, and nothing drains it again until teardown. Written with
+// the pool exhausted so the read has no choice but the deferral path, which is
+// the only way to reach the check.
+TEST_F(TcpTransportFrameTest, ADeferralIsRefusedOnceTheConnectionIsSwept) {
+  setConnected();
+  stubStagingCopies();
+
+  constexpr uint64_t kVramSegId = kSegId + 230;
+  constexpr size_t kLen = 64;
+  std::vector<std::byte> vram(kLen, std::byte{0x44});
+  registry_->add(
+      kVramSegId, vram.data(), kLen, MemoryType::VRAM, /*deviceId=*/0);
+
+  auto pool = transportStagingPool();
+  ASSERT_NE(pool, nullptr);
+  std::vector<TcpPinnedSlab> held;
+  held.reserve(pool->slabCount());
+  for (size_t i = 0; i < pool->slabCount(); ++i) {
+    held.push_back(pool->tryAcquire(/*allowReserved=*/true));
+    ASSERT_TRUE(static_cast<bool>(held.back()));
+  }
+
+  failAllPending();
+  ASSERT_EQ(deferredReplyCount(), 0u)
+      << "precondition: the sweep left the deferred queue empty";
+
+  feed(makeFrame(
+      TcpOp::ReadRequest, kVramSegId, /*offset=*/0, kLen, /*payloadBytes=*/0));
+
+  EXPECT_EQ(deferredReplyCount(), 0u)
+      << "a deferral after the sweep pins its segment lease until the transport "
+         "is destroyed, which is what the sweep clears the queue to avoid";
+  EXPECT_EQ(stagedCopyCount(), 0u)
+      << "nothing may be staged for a read on a broken connection";
+}
+
+// The other half of deferral: a slab coming back has to actually restart the
+// deferred read. The release that matters is the sender's, after the frame it
+// was transmitting is gone, so this drives it through senderLoop rather than
+// releasing a slab by hand.
+TEST_F(TcpTransportFrameTest, AReleasedSlabStartsTheDeferredRead) {
+  setConnected();
+  stubStagingCopies();
+
+  constexpr uint64_t kVramSegId = kSegId + 220;
+  constexpr size_t kLen = 64;
+  std::vector<std::byte> vram(kLen, std::byte{0x55});
+  registry_->add(
+      kVramSegId, vram.data(), kLen, MemoryType::VRAM, /*deviceId=*/0);
+
+  // All but one slab held, so the first read takes the last one and the second
+  // has nowhere to go.
+  auto pool = transportStagingPool();
+  ASSERT_NE(pool, nullptr);
+  std::vector<TcpPinnedSlab> held;
+  held.reserve(pool->slabCount());
+  for (size_t i = 0; i + 1 < pool->slabCount(); ++i) {
+    held.push_back(pool->tryAcquire(/*allowReserved=*/true));
+    ASSERT_TRUE(static_cast<bool>(held.back()));
+  }
+
+  feed(makeFrame(
+      TcpOp::ReadRequest, kVramSegId, /*offset=*/0, kLen, /*payloadBytes=*/0));
+  feed(makeFrame(
+      TcpOp::ReadRequest, kVramSegId, /*offset=*/0, kLen, /*payloadBytes=*/0));
+  ASSERT_EQ(stagedCopyCount(), 1u);
+  ASSERT_EQ(deferredReplyCount(), 1u);
+
+  auto& conn = installCountingConn();
+  std::thread sender([this]() { runSenderLoop(); });
+
+  // The first copy signals, its reply is queued and sent, and only then is its
+  // slab free for the deferred read.
+  releaseStagingCopies();
+  EXPECT_TRUE(waitFor([&]() { return conn.sendCount() >= 2; }))
+      << "the deferred read was never started, so its reply never went out: a "
+         "slab returning to the pool must wake it";
+  EXPECT_EQ(deferredReplyCount(), 0u);
+  EXPECT_EQ(stagedCopyCount(), 2u);
+  EXPECT_TRUE(allCopiesLandedInPinnedMemory());
+
+  closeOutQueue();
+  sender.join();
+}
+
+// A deferred read holds its lease with no copy yet issued, and that lease has
+// to keep blocking deregistration: the copy will read that buffer, just later.
+// Releasing the lease at deferral time and re-finding the segment later would
+// mean answering a read out of memory the owner had already freed.
+TEST_F(TcpTransportFrameTest, ADeferredReadStillBlocksDeregistration) {
+  setConnected();
+  stubStagingCopies();
+
+  constexpr uint64_t kVramSegId = kSegId + 230;
+  constexpr size_t kLen = 64;
+  std::vector<std::byte> vram(kLen, std::byte{0x66});
+  registry_->add(
+      kVramSegId, vram.data(), kLen, MemoryType::VRAM, /*deviceId=*/0);
+
+  auto pool = transportStagingPool();
+  ASSERT_NE(pool, nullptr);
+  std::vector<TcpPinnedSlab> held;
+  held.reserve(pool->slabCount());
+  for (size_t i = 0; i < pool->slabCount(); ++i) {
+    held.push_back(pool->tryAcquire(/*allowReserved=*/true));
+  }
+
+  feed(makeFrame(
+      TcpOp::ReadRequest, kVramSegId, /*offset=*/0, kLen, /*payloadBytes=*/0));
+  ASSERT_EQ(deferredReplyCount(), 1u);
+
+  std::atomic<bool> erased{false};
+  std::thread eraser([&]() {
+    registry_->erase(kVramSegId);
+    erased.store(true, std::memory_order_release);
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  EXPECT_FALSE(erased.load(std::memory_order_acquire))
+      << "erase() returned while a deferred read still held a lease: the owner "
+         "is now free to free a buffer this transport will still copy out of";
+
+  // Teardown discards what is deferred, which releases the lease.
+  transport_->shutdown();
+  eraser.join();
+  EXPECT_TRUE(erased.load(std::memory_order_acquire));
+  EXPECT_EQ(stagedCopyCount(), 0u)
+      << "a discarded deferred read must not have started a copy into memory "
+         "that is being torn down";
+}
+
+// A read the pool cannot serve and the deferred queue cannot hold is answered
+// with an Error rather than dropped or blocked on. Dropping it leaves the peer
+// waiting forever; blocking stops the reader; failing the connection punishes
+// every unrelated transfer on it.
+TEST_F(TcpTransportFrameTest, DeferredQueueOverflowFailsOnlyThatRequest) {
+  setConnected();
+  stubStagingCopies();
+
+  constexpr uint64_t kVramSegId = kSegId + 240;
+  constexpr size_t kLen = 64;
+  std::vector<std::byte> vram(kLen, std::byte{0x11});
+  registry_->add(
+      kVramSegId, vram.data(), kLen, MemoryType::VRAM, /*deviceId=*/0);
+
+  auto pool = transportStagingPool();
+  ASSERT_NE(pool, nullptr);
+  std::vector<TcpPinnedSlab> held;
+  held.reserve(pool->slabCount());
+  for (size_t i = 0; i < pool->slabCount(); ++i) {
+    held.push_back(pool->tryAcquire(/*allowReserved=*/true));
+  }
+  fillDeferredReplies(deferredCap());
+
+  feed(makeFrame(
+      TcpOp::ReadRequest, kVramSegId, /*offset=*/0, kLen, /*payloadBytes=*/0));
+
+  EXPECT_FALSE(connClosed())
+      << "one unservable read must not take the connection down";
+  EXPECT_TRUE(queuedErrorFrame())
+      << "the peer must be told this read failed; silence leaves it waiting for "
+         "a reply that will never come";
+  EXPECT_EQ(deferredReplyCount(), deferredCap())
+      << "the refused read must not have been queued anyway";
+}
+
+// A VRAM read larger than a staging slab cannot be served at all: our own get()
+// chunks at kMaxChunkSize, so this is the version-skew case, and it has to be a
+// per-request error rather than a fatal one for the same reason the wire-frame
+// cap is.
+TEST_F(TcpTransportFrameTest, AVramReadLargerThanASlabIsRefusedPerRequest) {
+  setConnected();
+  stubStagingCopies();
+
+  constexpr uint64_t kVramSegId = kSegId + 250;
+  const size_t oversized = slabPayloadCap() + 1;
+  // Registered, but never read from: the request is refused before any copy.
+  std::vector<std::byte> vram(1, std::byte{0x99});
+  registry_->add(
+      kVramSegId, vram.data(), oversized, MemoryType::VRAM, /*deviceId=*/0);
+
+  feed(makeFrame(
+      TcpOp::ReadRequest,
+      kVramSegId,
+      /*offset=*/0,
+      oversized,
+      /*payloadBytes=*/0));
+
+  EXPECT_FALSE(connClosed())
+      << "an oversized read must not be fatal to the connection";
+  EXPECT_TRUE(queuedErrorFrame()) << "the peer must be told this read failed";
+  EXPECT_EQ(stagedCopyCount(), 0u)
+      << "nothing may be copied for a read that cannot fit a slab";
+  EXPECT_EQ(deferredReplyCount(), 0u)
+      << "an unservable read must be refused, not deferred forever";
 }
 
 // The copy is issued before the event exists, so any failure after that point


### PR DESCRIPTION
Summary:

# Context

D117031181 moved the get responder's device copy off the reader thread: the reader posts the copy, queues nothing, and the EventBase retires the reply when the copy signals. The reader was still blocked anyway.

`cudaMemcpyAsync` staged into the reply frame's `std::vector`. That destination is pageable, and CUDA specifies a device-to-host copy into pageable host memory as completing synchronously -- the call returns only when the copy is done. So the reader was parked for the whole transfer while the code around it read as asynchronous, and it held the registry lease on its stack the entire time, which is what an `erase()` waits behind. `MockCudaApi` mocks `memcpyAsync`, so no unit test could tell the difference.

`RdmaSlabPool`, the other staging path in the tree, stages through `cudaHostAlloc` memory. I checked that one; I did not audit every transport for the same pattern.

This diff points the copy at the pinned slabs added in the diff below, which is what makes the claim already in D117031181's summary true.

# Deferral instead of a fallback

The pool is finite -- 16 slabs, one held back for this path -- so a read can arrive with nothing to stage into. Three options, and only one of them keeps the reader draining:

- Wait for a slab: the head-of-line block again, and worse than before, because the thread that frees the next slab is the sender and the reader would be holding it up.
- Fall back to a pageable buffer: this diff exists because that copy blocks the reader.
- Record the request and answer it later.

So a read that finds the pool empty is recorded -- lease included -- and the reader returns to the socket. Whenever a staging slab goes back to the pool the transport dispatches a restart on the EventBase, which starts as many deferred reads as there are free slabs. Dispatched rather than run inline: the release points are the sender thread and the reply poller, and neither should be launching device work.

The deferred queue is bounded by `kMaxInflightRequests`, like `inflight_`, since it grows on peer-supplied frames the reader will not stop accepting. Overflow answers that one request with an `Error`. Dropping it silently would leave the peer waiting forever, and failing the connection would punish every unrelated transfer on it -- the same reasoning as the wire-frame cap already in this path.

A deferred entry holds its lease with no copy issued yet, so a deregistration now waits for a copy that has not started. That is deliberate: the read will still be answered out of that buffer. What used to be reachable and no longer is, is deadlock -- the reader is never parked, so it keeps delivering the frames whatever the application's GPU work is waiting on. The `erase()` comment is updated to say so.

Teardown discards deferred entries after waiting for the copies that did launch, so their leases are released and a blocked `erase()` proceeds. `failAllPending()` discards them too: on a broken connection those reads will never be answered, and holding leases until the transport object dies would block deregistration for no reason.

# Also

- A VRAM read larger than one slab's payload is refused per request. Our own `get()` chunks at `kMaxChunkSize`, so this is the version-skew case the header version byte guards, and it has to be per-request for the same reason the wire-frame cap is.
- The pool is created on first use. There is one transport per peer, and building it in the constructor would charge a DRAM-only peer ~64 MiB of pinned host memory it never touches.
- `kMaxChunkSize` moves from the `.cpp`'s anonymous namespace to a class constant, since the slab geometry is derived from it and the tests need the boundary.
- DRAM and zero-length reads are unchanged: they never enter the device-copy path, so there is nothing to stage.

Copies still run on the null stream, which by CUDA's documented semantics means an `erase()` can still wait on unrelated device work. Untested here -- there is no per-stream path to test yet. `CudaApi` has no stream-creation method; that is the remaining half, tracked in T285791201.

Differential Revision: D117053165


