### PR TITLE
comms/uniflow/benchmarks: socket-buffer knob, phase reporting, and corrected numbers (#3897)

### DIFF
--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
@@ -21,6 +21,7 @@
 
 #include <cuda_runtime_api.h> // @manual=third-party//cuda:cuda-lazy
 
+#include <fmt/format.h>
 #include "comms/uniflow/Segment.h"
 #include "comms/uniflow/benchmarks/Rendezvous.h"
 #include "comms/uniflow/benchmarks/SegmentHelper.h"
@@ -462,8 +463,10 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
   }
 
   ScopedEventBaseThread evbThread("bench-tcp-evb");
+  controller::TcpSocketConfig sockConfig;
+  sockConfig.socketBufSize = sockBufSize_;
   auto factory = std::make_unique<TcpTransportFactory>(
-      dev, evbThread.getEventBase(), controller::TcpSocketConfig{}, host);
+      dev, evbThread.getEventBase(), sockConfig, host);
 
   // Handshake over the rendezvous control channel.
   auto localTopo = factory->getTopology();
@@ -600,12 +603,24 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
       if (aborted || !isActiveRank) {
         continue;
       }
+      // Bracket the timed loop so the phase split covers the same frames the
+      // reported bandwidth does, warmup included -- runTransfer does its own
+      // warmup internally, so the reset has to sit before the call, not inside.
+      auto* tcpTransport =
+          dynamic_cast<::uniflow::TcpTransport*>(transport.get());
+      if (tcpTransport != nullptr) {
+        tcpTransport->logAndResetPhaseStats("reset");
+      }
       auto r = runTransfer(*transport, localReg, remoteReg, size, dir, config);
       if (!r.ok) {
         // Latched rather than returned: every remaining size has a barrier the
         // peer is going to execute.
         aborted = true;
         continue;
+      }
+      if (tcpTransport != nullptr) {
+        tcpTransport->logAndResetPhaseStats(
+            fmt::format("{} size={}", dir, size));
       }
       auto stats = Stats::compute(std::move(r.latenciesUs));
       results.push_back({

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -14,8 +15,11 @@ namespace uniflow::benchmark {
 /// buffers, or VRAM staged through host memory inside the transport.
 class TcpBandwidthBenchmark : public Benchmark {
  public:
-  explicit TcpBandwidthBenchmark(std::string iface)
-      : iface_(std::move(iface)) {}
+  /// @p sockBufSize is the SO_SNDBUF/SO_RCVBUF value for the data connection;
+  /// nullopt leaves the kernel's own sizing in place, which is what lets
+  /// receive autotuning grow the window past the bandwidth-delay product.
+  TcpBandwidthBenchmark(std::string iface, std::optional<int> sockBufSize)
+      : iface_(std::move(iface)), sockBufSize_(sockBufSize) {}
 
   std::string name() const override {
     return "tcp_bandwidth";
@@ -28,6 +32,7 @@ class TcpBandwidthBenchmark : public Benchmark {
 
  private:
   std::string iface_;
+  std::optional<int> sockBufSize_;
 };
 
 } // namespace uniflow::benchmark

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -4,6 +4,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -62,6 +63,9 @@ struct CliOptions {
   int slabNum{0};
   std::vector<std::string> rdmaDevices;
   std::string tcpIface{"eth2"};
+  // SO_SNDBUF/SO_RCVBUF for the TCP data connection. Defaults to the
+  // TcpSocketConfig default; 0 leaves the kernel's sizing alone.
+  int tcpSockBuf{1 << 20};
 };
 
 std::vector<int> parseIntList(const std::string& s) {
@@ -139,6 +143,8 @@ void printUsage(const char* prog) {
       << "  --format <fmt>         table|csv|both (default: table)\n"
       << "  --rdma-devices <list>  Comma-separated RDMA device names (default: auto-discover)\n"
       << "  --tcp-iface <name>     Front-end interface for the TCP transport (default: eth2)\n"
+      << "  --tcp-sockbuf <bytes>  TCP data-connection SO_SNDBUF/SO_RCVBUF (default: 1048576,\n"
+      << "                         0 = leave unset so the kernel autotunes the window)\n"
       << "  --batch-size <n>       Number of requests per transport call (default: 1)\n"
       << "  --tx-depth <n>         Outstanding transport calls before waiting (default: 1)\n"
       << "  --num-nics <n>         Cap number of NICs to use (default: 0 = all)\n"
@@ -193,6 +199,7 @@ CliOptions parseArgs(int argc, char** argv) {
       {"cuda-devices", required_argument, nullptr, 264},
       {"gpu-nics", required_argument, nullptr, 265},
       {"tcp-iface", required_argument, nullptr, 266},
+      {"tcp-sockbuf", required_argument, nullptr, 268},
       {"no-verify", no_argument, nullptr, 267},
       {"list", no_argument, nullptr, 'l'},
       {"help", no_argument, nullptr, 'h'},
@@ -268,6 +275,18 @@ CliOptions parseArgs(int argc, char** argv) {
         break;
       case 266:
         opts.tcpIface = optarg;
+        break;
+      case 268:
+        try {
+          opts.tcpSockBuf = std::stoi(optarg);
+          if (opts.tcpSockBuf < 0) {
+            std::cerr << "Invalid value for --tcp-sockbuf: must be >= 0\n";
+            std::exit(1);
+          }
+        } catch (const std::exception&) {
+          std::cerr << "Invalid value for --tcp-sockbuf: '" << optarg << "'\n";
+          std::exit(1);
+        }
         break;
       case 'd':
         opts.direction = optarg;
@@ -420,7 +439,9 @@ int main(int argc, char** argv) {
           opts.rdmaDevices));
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::TcpBandwidthBenchmark>(
-          opts.tcpIface));
+          opts.tcpIface,
+          opts.tcpSockBuf > 0 ? std::optional<int>(opts.tcpSockBuf)
+                              : std::nullopt));
 #ifndef __HIP_PLATFORM_AMD__
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::ConnectionSetupBenchmark>());


### PR DESCRIPTION
Summary:

--tcp-sockbuf exposes the data connection's SO_SNDBUF/SO_RCVBUF so the value can be
swept instead of argued about, and the bench brackets each size's timed loop with
TcpTransport::logAndResetPhaseStats() so every bandwidth line is accompanied by where
the time went.

The script header carried get ~1.0 GB/s, which predated the pinned-staging work and
was stale by roughly 9x. It misled a full round of planning, so it is corrected here
to measured values along with the link baseline (200G, MTU 1500, RTT 0.046 ms, iperf3
15.4 GB/s single stream and 23.3 GB/s over 8) that makes the numbers interpretable.

Recipe 8 records a disproof rather than a hypothesis. The theory was that the 1 MiB
buffer pin caps a stream at window/RTT; at 0.046 ms RTT, 1 MiB permits ~22.8 GB/s, so
the window was never the constraint. A 6-point sweep with 3 repeats does show the
1 MiB pin is the worst non-degenerate setting (8.63 GB/s at 1 GiB against 9.67
unpinned, disjoint ranges), but the mechanism is autotuning being disabled while the
reader does a multi-MiB copy, not the bandwidth-delay product. The 64K arm is a
deliberate control: it drops throughput 75%, which is what makes the flat region
above 1 MiB trustworthy rather than merely consistent with a dead knob.

Also records that a --no-verify arm must never be compared against a verifying one --
that mistake inverted this exact comparison once.

Differential Revision: D117132684


