### PR TITLE
comms/uniflow/controller: apply the whole TcpSocketConfig to accepted sockets (#3904)

### DIFF
--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
@@ -21,6 +21,7 @@
 
 #include <cuda_runtime_api.h> // @manual=third-party//cuda:cuda-lazy
 
+#include <fmt/format.h>
 #include "comms/uniflow/Segment.h"
 #include "comms/uniflow/benchmarks/Rendezvous.h"
 #include "comms/uniflow/benchmarks/SegmentHelper.h"
@@ -462,8 +463,10 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
   }
 
   ScopedEventBaseThread evbThread("bench-tcp-evb");
+  controller::TcpSocketConfig sockConfig;
+  sockConfig.socketBufSize = sockBufSize_;
   auto factory = std::make_unique<TcpTransportFactory>(
-      dev, evbThread.getEventBase(), controller::TcpSocketConfig{}, host);
+      dev, evbThread.getEventBase(), sockConfig, host);
 
   // Handshake over the rendezvous control channel.
   auto localTopo = factory->getTopology();
@@ -600,12 +603,24 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
       if (aborted || !isActiveRank) {
         continue;
       }
+      // Bracket the timed loop so the phase split covers the same frames the
+      // reported bandwidth does, warmup included -- runTransfer does its own
+      // warmup internally, so the reset has to sit before the call, not inside.
+      auto* tcpTransport =
+          dynamic_cast<::uniflow::TcpTransport*>(transport.get());
+      if (tcpTransport != nullptr) {
+        tcpTransport->logAndResetPhaseStats("reset");
+      }
       auto r = runTransfer(*transport, localReg, remoteReg, size, dir, config);
       if (!r.ok) {
         // Latched rather than returned: every remaining size has a barrier the
         // peer is going to execute.
         aborted = true;
         continue;
+      }
+      if (tcpTransport != nullptr) {
+        tcpTransport->logAndResetPhaseStats(
+            fmt::format("{} size={}", dir, size));
       }
       auto stats = Stats::compute(std::move(r.latenciesUs));
       results.push_back({

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <deque>
 #include <future>
+#include <iostream>
 #include <random>
 #include <string>
 #include <utility>
@@ -450,11 +451,20 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
         "TcpBandwidthBenchmark: no global IPv6 on interface '{}'", iface_);
     return {};
   }
+  const std::string asyncGetH2dMode = asyncGetH2d_ ? "on" : "off";
+  const std::string sockBufMode =
+      sockBufSize_ ? std::to_string(*sockBufSize_) : "os-default";
+  std::cerr << "TcpBandwidthBenchmark: rank=" << bootstrap.rank
+            << " iface=" << iface_ << " async_get_h2d=" << asyncGetH2dMode
+            << " tcp_sockbuf=" << sockBufMode << '\n';
   UNIFLOW_LOG_WARN(
-      "TcpBandwidthBenchmark: rank {} using {} address {}",
+      "TcpBandwidthBenchmark: rank {} using {} address {} "
+      "async_get_h2d={} tcp_sockbuf={}",
       bootstrap.rank,
       iface_,
-      host);
+      host,
+      asyncGetH2dMode,
+      sockBufMode);
 
   const int dev = config.cudaDevice;
   BufferPair bufs;
@@ -463,10 +473,11 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
   }
 
   ScopedEventBaseThread evbThread("bench-tcp-evb");
-  controller::TcpSocketConfig sockConfig;
-  sockConfig.socketBufSize = sockBufSize_;
+  TcpTransportConfig transportConfig;
+  transportConfig.socketConfig.socketBufSize = sockBufSize_;
+  transportConfig.asyncGetH2d = asyncGetH2d_;
   auto factory = std::make_unique<TcpTransportFactory>(
-      dev, evbThread.getEventBase(), sockConfig, host);
+      dev, evbThread.getEventBase(), transportConfig, host);
 
   // Handshake over the rendezvous control channel.
   auto localTopo = factory->getTopology();
@@ -637,12 +648,13 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
           .messageRateMops = r.messageRateMops,
       });
       UNIFLOW_LOG_WARN(
-          "[rank {}] {} size={:<10} iface={} batch={:<3} txdepth={:<3} "
-          "iters={:<6} bw={:.2f} GB/s avg={:.1f} us {}",
+          "[rank {}] {} size={:<10} iface={} async_get_h2d={} batch={:<3} "
+          "txdepth={:<3} iters={:<6} bw={:.2f} GB/s avg={:.1f} us {}",
           bootstrap.rank,
           dir,
           size,
           iface_,
+          asyncGetH2dMode,
           std::max(1, config.batchSize),
           std::max(1, config.txDepth),
           r.totalOps,

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -14,8 +15,11 @@ namespace uniflow::benchmark {
 /// buffers, or VRAM staged through host memory inside the transport.
 class TcpBandwidthBenchmark : public Benchmark {
  public:
-  explicit TcpBandwidthBenchmark(std::string iface)
-      : iface_(std::move(iface)) {}
+  /// @p sockBufSize is the SO_SNDBUF/SO_RCVBUF value for the data connection;
+  /// nullopt leaves the kernel's own sizing in place, which is what lets
+  /// receive autotuning grow the window past the bandwidth-delay product.
+  TcpBandwidthBenchmark(std::string iface, std::optional<int> sockBufSize)
+      : iface_(std::move(iface)), sockBufSize_(sockBufSize) {}
 
   std::string name() const override {
     return "tcp_bandwidth";
@@ -28,6 +32,7 @@ class TcpBandwidthBenchmark : public Benchmark {
 
  private:
   std::string iface_;
+  std::optional<int> sockBufSize_;
 };
 
 } // namespace uniflow::benchmark

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h
@@ -18,8 +18,13 @@ class TcpBandwidthBenchmark : public Benchmark {
   /// @p sockBufSize is the SO_SNDBUF/SO_RCVBUF value for the data connection;
   /// nullopt leaves the kernel's own sizing in place, which is what lets
   /// receive autotuning grow the window past the bandwidth-delay product.
-  TcpBandwidthBenchmark(std::string iface, std::optional<int> sockBufSize)
-      : iface_(std::move(iface)), sockBufSize_(sockBufSize) {}
+  TcpBandwidthBenchmark(
+      std::string iface,
+      std::optional<int> sockBufSize,
+      bool asyncGetH2d = true)
+      : iface_(std::move(iface)),
+        sockBufSize_(sockBufSize),
+        asyncGetH2d_(asyncGetH2d) {}
 
   std::string name() const override {
     return "tcp_bandwidth";
@@ -33,6 +38,7 @@ class TcpBandwidthBenchmark : public Benchmark {
  private:
   std::string iface_;
   std::optional<int> sockBufSize_;
+  bool asyncGetH2d_{true};
 };
 
 } // namespace uniflow::benchmark

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -56,6 +56,7 @@ struct CliOptions {
   bool bidirectional{false};
   bool dataDirect{false};
   bool noVerify{false};
+  bool tcpAsyncH2d{true};
   std::vector<int> numStreams{1, 2, 4, 8};
   std::string topology{"fanout"};
   int pipelineDepth{2};
@@ -145,6 +146,7 @@ void printUsage(const char* prog) {
       << "  --tcp-iface <name>     Front-end interface for the TCP transport (default: eth2)\n"
       << "  --tcp-sockbuf <bytes>  TCP data-connection SO_SNDBUF/SO_RCVBUF (default: 1048576,\n"
       << "                         0 = leave unset so the kernel autotunes the window)\n"
+      << "  --no-tcp-async-h2d    Disable asynchronous TCP get() H2D (default: enabled)\n"
       << "  --batch-size <n>       Number of requests per transport call (default: 1)\n"
       << "  --tx-depth <n>         Outstanding transport calls before waiting (default: 1)\n"
       << "  --num-nics <n>         Cap number of NICs to use (default: 0 = all)\n"
@@ -200,6 +202,7 @@ CliOptions parseArgs(int argc, char** argv) {
       {"gpu-nics", required_argument, nullptr, 265},
       {"tcp-iface", required_argument, nullptr, 266},
       {"tcp-sockbuf", required_argument, nullptr, 268},
+      {"no-tcp-async-h2d", no_argument, nullptr, 269},
       {"no-verify", no_argument, nullptr, 267},
       {"list", no_argument, nullptr, 'l'},
       {"help", no_argument, nullptr, 'h'},
@@ -287,6 +290,9 @@ CliOptions parseArgs(int argc, char** argv) {
           std::cerr << "Invalid value for --tcp-sockbuf: '" << optarg << "'\n";
           std::exit(1);
         }
+        break;
+      case 269:
+        opts.tcpAsyncH2d = false;
         break;
       case 'd':
         opts.direction = optarg;
@@ -441,7 +447,8 @@ int main(int argc, char** argv) {
       std::make_unique<uniflow::benchmark::TcpBandwidthBenchmark>(
           opts.tcpIface,
           opts.tcpSockBuf > 0 ? std::optional<int>(opts.tcpSockBuf)
-                              : std::nullopt));
+                              : std::nullopt,
+          opts.tcpAsyncH2d));
 #ifndef __HIP_PLATFORM_AMD__
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::ConnectionSetupBenchmark>());

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -4,6 +4,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -62,6 +63,9 @@ struct CliOptions {
   int slabNum{0};
   std::vector<std::string> rdmaDevices;
   std::string tcpIface{"eth2"};
+  // SO_SNDBUF/SO_RCVBUF for the TCP data connection. Defaults to the
+  // TcpSocketConfig default; 0 leaves the kernel's sizing alone.
+  int tcpSockBuf{1 << 20};
 };
 
 std::vector<int> parseIntList(const std::string& s) {
@@ -139,6 +143,8 @@ void printUsage(const char* prog) {
       << "  --format <fmt>         table|csv|both (default: table)\n"
       << "  --rdma-devices <list>  Comma-separated RDMA device names (default: auto-discover)\n"
       << "  --tcp-iface <name>     Front-end interface for the TCP transport (default: eth2)\n"
+      << "  --tcp-sockbuf <bytes>  TCP data-connection SO_SNDBUF/SO_RCVBUF (default: 1048576,\n"
+      << "                         0 = leave unset so the kernel autotunes the window)\n"
       << "  --batch-size <n>       Number of requests per transport call (default: 1)\n"
       << "  --tx-depth <n>         Outstanding transport calls before waiting (default: 1)\n"
       << "  --num-nics <n>         Cap number of NICs to use (default: 0 = all)\n"
@@ -193,6 +199,7 @@ CliOptions parseArgs(int argc, char** argv) {
       {"cuda-devices", required_argument, nullptr, 264},
       {"gpu-nics", required_argument, nullptr, 265},
       {"tcp-iface", required_argument, nullptr, 266},
+      {"tcp-sockbuf", required_argument, nullptr, 268},
       {"no-verify", no_argument, nullptr, 267},
       {"list", no_argument, nullptr, 'l'},
       {"help", no_argument, nullptr, 'h'},
@@ -268,6 +275,18 @@ CliOptions parseArgs(int argc, char** argv) {
         break;
       case 266:
         opts.tcpIface = optarg;
+        break;
+      case 268:
+        try {
+          opts.tcpSockBuf = std::stoi(optarg);
+          if (opts.tcpSockBuf < 0) {
+            std::cerr << "Invalid value for --tcp-sockbuf: must be >= 0\n";
+            std::exit(1);
+          }
+        } catch (const std::exception&) {
+          std::cerr << "Invalid value for --tcp-sockbuf: '" << optarg << "'\n";
+          std::exit(1);
+        }
         break;
       case 'd':
         opts.direction = optarg;
@@ -420,7 +439,9 @@ int main(int argc, char** argv) {
           opts.rdmaDevices));
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::TcpBandwidthBenchmark>(
-          opts.tcpIface));
+          opts.tcpIface,
+          opts.tcpSockBuf > 0 ? std::optional<int>(opts.tcpSockBuf)
+                              : std::nullopt));
 #ifndef __HIP_PLATFORM_AMD__
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::ConnectionSetupBenchmark>());

--- a/comms/uniflow/controller/TcpController.cpp
+++ b/comms/uniflow/controller/TcpController.cpp
@@ -71,10 +71,6 @@ namespace {
 constexpr uint32_t kMaxMessageSize = 64 << 20;
 constexpr int kAcceptTimeoutSec = 5;
 constexpr int kConnectedTimeoutSec = 30;
-constexpr int kKeepaliveIdleSec = 60;
-constexpr int kKeepaliveIntervalSec = 5;
-constexpr int kKeepaliveCount = 3;
-constexpr int kUserTimeoutMs = 60000;
 
 // Magic value exchanged during connection handshake to validate that both
 // endpoints are uniflow controllers (rejects stray connections).
@@ -248,34 +244,68 @@ Result<int> createListenSocket(int domain) {
   return sock;
 }
 
-// Applies the connected-socket options to a freshly accepted fd.
+// Applies a TcpSocketConfig to a connected socket. Shared by the client and
+// accept paths: both need identical treatment of a connected fd, and keeping
+// one implementation is what stops the two from drifting apart again.
 //
-// Only @p socketBufSize is caller-controlled; the keepalive and timeout values
-// remain the constants above. Buffer sizing is the one option a caller has a
-// reason to override per connection: setting SO_RCVBUF explicitly disables
-// Linux receive-window autotuning, which caps a single stream at window/RTT, so
-// a bulk-data connection wants it left unset while the control connection does
-// not care.
-Status configureAcceptedSocket(
-    int sock,
-    const std::optional<int>& socketBufSize) {
-  SockOptSetter opt(sock);
-  if (socketBufSize) {
-    opt.set(SOL_SOCKET, SO_SNDBUF, *socketBufSize, "SO_SNDBUF");
-    opt.set(SOL_SOCKET, SO_RCVBUF, *socketBufSize, "SO_RCVBUF");
+// Every field falls through to the OS kernel default when nullopt, with one
+// deliberate exception -- connTimeout, see below.
+void applySocketConfig(SockOptSetter& opt, const TcpSocketConfig& config) {
+  // Buffer sizing is the option a caller most often wants left alone: setting
+  // SO_RCVBUF explicitly disables Linux receive-window autotuning, which caps a
+  // single stream at window/RTT, so a bulk-data connection wants it unset while
+  // the control connection does not care.
+  if (config.socketBufSize) {
+    opt.set(SOL_SOCKET, SO_SNDBUF, *config.socketBufSize, "SO_SNDBUF");
+    opt.set(SOL_SOCKET, SO_RCVBUF, *config.socketBufSize, "SO_RCVBUF");
   }
-  opt.set(IPPROTO_TCP, TCP_NODELAY, 1, "TCP_NODELAY");
-  opt.set(SOL_SOCKET, SO_KEEPALIVE, 1, "SO_KEEPALIVE");
-  opt.set(IPPROTO_TCP, TCP_KEEPIDLE, kKeepaliveIdleSec, "TCP_KEEPIDLE");
-  opt.set(IPPROTO_TCP, TCP_KEEPINTVL, kKeepaliveIntervalSec, "TCP_KEEPINTVL");
-  opt.set(IPPROTO_TCP, TCP_KEEPCNT, kKeepaliveCount, "TCP_KEEPCNT");
-  opt.set(IPPROTO_TCP, TCP_USER_TIMEOUT, kUserTimeoutMs, "TCP_USER_TIMEOUT");
+  if (config.tcpNoDelay) {
+    int val = *config.tcpNoDelay ? 1 : 0;
+    opt.set(IPPROTO_TCP, TCP_NODELAY, val, "TCP_NODELAY");
+  }
+  if (config.enableKeepalive) {
+    int val = *config.enableKeepalive ? 1 : 0;
+    opt.set(SOL_SOCKET, SO_KEEPALIVE, val, "SO_KEEPALIVE");
+  }
+  if (config.enableKeepalive && *config.enableKeepalive) {
+    if (config.keepaliveIdle) {
+      int val = static_cast<int>(config.keepaliveIdle->count());
+      opt.set(IPPROTO_TCP, TCP_KEEPIDLE, val, "TCP_KEEPIDLE");
+    }
+    if (config.keepaliveInterval) {
+      int val = static_cast<int>(config.keepaliveInterval->count());
+      opt.set(IPPROTO_TCP, TCP_KEEPINTVL, val, "TCP_KEEPINTVL");
+    }
+    if (config.keepaliveCount) {
+      opt.set(IPPROTO_TCP, TCP_KEEPCNT, *config.keepaliveCount, "TCP_KEEPCNT");
+    }
+  }
+  if (config.userTimeout) {
+    int val = static_cast<int>(config.userTimeout->count());
+    opt.set(IPPROTO_TCP, TCP_USER_TIMEOUT, val, "TCP_USER_TIMEOUT");
+  }
+  /*
+   * Default the send/recv timeout to kConnectedTimeoutSec when the caller does
+   * not specify one. This is the one field that does not fall through to the
+   * OS. Without it a connected socket blocks forever: a peer that accepts the
+   * TCP connection but stops responding mid-handshake (e.g. its transport setup
+   * failed) would wedge a blocking recv during the handshake exchange
+   * indefinitely, which is only reaped as an opaque process-unresponsive
+   * failure. Bounding it turns the hang into a surfaced ConnectionFailed error.
+   */
+  {
+    struct timeval tv{};
+    tv.tv_sec =
+        config.connTimeout ? config.connTimeout->count() : kConnectedTimeoutSec;
+    opt.set(SOL_SOCKET, SO_SNDTIMEO, tv, "SO_SNDTIMEO");
+    opt.set(SOL_SOCKET, SO_RCVTIMEO, tv, "SO_RCVTIMEO");
+  }
+}
 
-  struct timeval tv{};
-  tv.tv_sec = kConnectedTimeoutSec;
-  opt.set(SOL_SOCKET, SO_SNDTIMEO, tv, "SO_SNDTIMEO");
-  opt.set(SOL_SOCKET, SO_RCVTIMEO, tv, "SO_RCVTIMEO");
-
+// Applies the connected-socket options to a freshly accepted fd.
+Status configureAcceptedSocket(int sock, const TcpSocketConfig& config) {
+  SockOptSetter opt(sock);
+  applySocketConfig(opt, config);
   return opt.status();
 }
 
@@ -1058,7 +1088,7 @@ std::future<std::unique_ptr<Conn>> SyncAccept::accept(
           "TcpServer: accepted fd={} from {}",
           clientSock,
           formatAddr(clientAddr));
-      auto status = configureAcceptedSocket(clientSock, config.socketBufSize);
+      auto status = configureAcceptedSocket(clientSock, config);
       if (!status) {
         UNIFLOW_LOG_ERROR(
             "TcpServer: socket config failed fd={}: {}",
@@ -1150,7 +1180,9 @@ void AsyncAccept::teardown(int fd) {
   readyConns_ = {};
 }
 
-void AsyncAccept::acceptPendingConnections(std::atomic<int>& listenSock) {
+void AsyncAccept::acceptPendingConnections(
+    std::atomic<int>& listenSock,
+    const TcpSocketConfig& config) {
   if (!accepting_) {
     return;
   }
@@ -1208,7 +1240,7 @@ void AsyncAccept::acceptPendingConnections(std::atomic<int>& listenSock) {
 
     // configureAcceptedSocket sets 30s timeouts — must come after the
     // 500ms handshake timeout to avoid overriding it.
-    auto status = configureAcceptedSocket(conn->getFd(), socketBufSize_);
+    auto status = configureAcceptedSocket(conn->getFd(), config);
     if (!status) {
       UNIFLOW_LOG_ERROR(
           "TcpServer: async socket config failed fd={}: {}",
@@ -1239,21 +1271,13 @@ std::future<std::unique_ptr<Conn>> AsyncAccept::accept(
 
   evb_.dispatch([this,
                  &listenSock,
-                 bufSize = config.socketBufSize,
+                 cfg = config,
                  p = std::move(promise)]() mutable noexcept {
     int sock = listenSock.load();
     if (sock < 0) {
       p.set_value(nullptr);
       return;
     }
-
-    // Server-level, not per-accept: BasicTcpServer passes its own config_ to
-    // every accept() call, so every dispatch writes the same value and there is
-    // no per-call setting to lose. Nothing here binds an accepted fd to a
-    // particular accept() anyway -- connections go to whichever promise is
-    // queued first. A future per-accept override would have to travel with the
-    // connection instead.
-    socketBufSize_ = bufSize;
 
     // Lazy setup: fcntl + registerFd both on the loop thread.
     if (!accepting_) {
@@ -1266,9 +1290,17 @@ std::future<std::unique_ptr<Conn>> AsyncAccept::accept(
         p.set_value(nullptr);
         return;
       }
-      evb_.registerFd(sock, EPOLLIN, [this, &listenSock](uint32_t /*events*/) {
-        acceptPendingConnections(listenSock);
-      });
+      // The config travels with the fd registration rather than through a
+      // member: it is server-level, so freezing it when the fd is armed loses
+      // nothing -- BasicTcpServer hands its own config_ to every accept() call
+      // and never reassigns it. Nothing here binds an accepted fd to a
+      // particular accept() anyway; connections go to whichever promise is
+      // queued first. A future per-accept override would have to travel with
+      // the connection instead.
+      evb_.registerFd(
+          sock, EPOLLIN, [this, &listenSock, cfg](uint32_t /*events*/) {
+            acceptPendingConnections(listenSock, cfg);
+          });
       accepting_ = true;
     }
 
@@ -1414,54 +1446,7 @@ namespace {
 
 Status configureClientSocket(int sock, const TcpSocketConfig& config) {
   SockOptSetter opt(sock);
-
-  if (config.socketBufSize) {
-    opt.set(SOL_SOCKET, SO_SNDBUF, *config.socketBufSize, "SO_SNDBUF");
-    opt.set(SOL_SOCKET, SO_RCVBUF, *config.socketBufSize, "SO_RCVBUF");
-  }
-  if (config.tcpNoDelay) {
-    int val = *config.tcpNoDelay ? 1 : 0;
-    opt.set(IPPROTO_TCP, TCP_NODELAY, val, "TCP_NODELAY");
-  }
-  if (config.enableKeepalive) {
-    int val = *config.enableKeepalive ? 1 : 0;
-    opt.set(SOL_SOCKET, SO_KEEPALIVE, val, "SO_KEEPALIVE");
-  }
-  if (config.enableKeepalive && *config.enableKeepalive) {
-    if (config.keepaliveIdle) {
-      int val = static_cast<int>(config.keepaliveIdle->count());
-      opt.set(IPPROTO_TCP, TCP_KEEPIDLE, val, "TCP_KEEPIDLE");
-    }
-    if (config.keepaliveInterval) {
-      int val = static_cast<int>(config.keepaliveInterval->count());
-      opt.set(IPPROTO_TCP, TCP_KEEPINTVL, val, "TCP_KEEPINTVL");
-    }
-    if (config.keepaliveCount) {
-      opt.set(IPPROTO_TCP, TCP_KEEPCNT, *config.keepaliveCount, "TCP_KEEPCNT");
-    }
-  }
-  if (config.userTimeout) {
-    int val = static_cast<int>(config.userTimeout->count());
-    opt.set(IPPROTO_TCP, TCP_USER_TIMEOUT, val, "TCP_USER_TIMEOUT");
-  }
-  /*
-   * Default the send/recv timeout to kConnectedTimeoutSec when the caller does
-   * not specify one, matching configureAcceptedSocket on the server side.
-   * Without this the client's connected socket blocks forever: a peer that
-   * accepts the TCP connection but stops responding mid-handshake (e.g. its
-   * transport setup failed) would wedge the client's blocking recv during the
-   * handshake exchange indefinitely, which is only reaped as an opaque
-   * process-unresponsive failure. Bounding it turns the hang into a surfaced
-   * ConnectionFailed error.
-   */
-  {
-    struct timeval tv{};
-    tv.tv_sec =
-        config.connTimeout ? config.connTimeout->count() : kConnectedTimeoutSec;
-    opt.set(SOL_SOCKET, SO_SNDTIMEO, tv, "SO_SNDTIMEO");
-    opt.set(SOL_SOCKET, SO_RCVTIMEO, tv, "SO_RCVTIMEO");
-  }
-
+  applySocketConfig(opt, config);
   return opt.status();
 }
 

--- a/comms/uniflow/controller/TcpController.h
+++ b/comms/uniflow/controller/TcpController.h
@@ -26,6 +26,11 @@ namespace uniflow::controller {
 /// Socket configuration for TcpServer and TcpClient.
 /// Optional fields: valued → setsockopt, nullopt → OS kernel default.
 /// Default-constructed with production-tuned values.
+///
+/// Applied identically to accepted and client-side connections by
+/// applySocketConfig. connTimeout is the one field that does not fall through
+/// to the OS on nullopt: it backs SO_SNDTIMEO/SO_RCVTIMEO, which default to 30s
+/// so that an unresponsive peer cannot wedge a blocking recv forever.
 struct TcpSocketConfig {
   std::optional<std::chrono::seconds> connTimeout{std::chrono::seconds{30}};
   std::optional<int> socketBufSize{1 << 20}; // 1MB
@@ -232,14 +237,13 @@ struct AsyncAccept {
 
  private:
   // All private methods run on the loop thread only.
-  void acceptPendingConnections(std::atomic<int>& listenSock);
+  void acceptPendingConnections(
+      std::atomic<int>& listenSock,
+      const TcpSocketConfig& config);
   void teardown(int fd);
 
   EventBase& evb_;
   bool accepting_{false}; // loop-thread-only
-  // Buffer sizing for sockets accepted on the loop thread. Copied rather than
-  // referenced because accept() returns before acceptPendingConnections runs.
-  std::optional<int> socketBufSize_; // loop-thread-only
   std::queue<std::unique_ptr<Conn>> readyConns_;
   std::queue<std::promise<std::unique_ptr<Conn>>> pendingPromises_;
 };

--- a/comms/uniflow/controller/tests/TcpAsyncAcceptTest.cpp
+++ b/comms/uniflow/controller/tests/TcpAsyncAcceptTest.cpp
@@ -23,6 +23,10 @@ using namespace uniflow::controller;
 struct AddrFamily {
   std::string serverAddr;
   std::string clientHost;
+  // Stated rather than derived from clientHost: comparing against the
+  // "127.0.0.1" literal silently defaults every other spelling -- "localhost",
+  // "[::1]", a resolvable hostname -- to AF_INET6.
+  int family;
 };
 
 class TcpAsyncAcceptTest : public ::testing::TestWithParam<AddrFamily> {
@@ -113,8 +117,7 @@ TEST_P(TcpAsyncAcceptTest, SingleAsyncAccept) {
 // copy. Before the config was threaded through the accept policy,
 // configureAcceptedSocket hardcoded 1 MiB, so a caller had no way to opt out.
 TEST_P(TcpAsyncAcceptTest, UnsetSocketBufSizeLeavesKernelAutotuning) {
-  const int family = GetParam().clientHost == "127.0.0.1" ? AF_INET : AF_INET6;
-  const int kernelDefault = kernelDefaultRcvBuf(family);
+  const int kernelDefault = kernelDefaultRcvBuf(GetParam().family);
   ASSERT_GT(kernelDefault, 0);
 
   TcpSocketConfig cfg;
@@ -157,8 +160,7 @@ TEST_P(TcpAsyncAcceptTest, UnsetSocketBufSizeLeavesKernelAutotuning) {
 // enough to contain the unconfigured default would also be satisfied if
 // socketBufSize were dropped again.
 TEST_P(TcpAsyncAcceptTest, AcceptedSocketAppliesConfiguredSocketBufSize) {
-  const int family = GetParam().clientHost == "127.0.0.1" ? AF_INET : AF_INET6;
-  const int kernelDefault = kernelDefaultRcvBuf(family);
+  const int kernelDefault = kernelDefaultRcvBuf(GetParam().family);
   ASSERT_GT(kernelDefault, 0);
 
   // Scaled off the probe rather than a literal. A quarter of the default
@@ -168,7 +170,7 @@ TEST_P(TcpAsyncAcceptTest, AcceptedSocketAppliesConfiguredSocketBufSize) {
   // untouched one on any stock host. Staying below the default also keeps the
   // request clear of net.core.rmem_max, so it is not silently clamped.
   const int requested = kernelDefault / 4;
-  const int expected = rcvBufForRequest(family, requested);
+  const int expected = rcvBufForRequest(GetParam().family, requested);
   ASSERT_GT(expected, 0);
 
   // Whether the configured size is observably different from the default is a
@@ -344,14 +346,11 @@ TEST_P(TcpAsyncAcceptTest, AsyncAcceptRejectsNonUniflowClient) {
   auto future = server.accept();
 
   {
-    int sock = ::socket(
-        GetParam().clientHost == "127.0.0.1" ? AF_INET : AF_INET6,
-        SOCK_STREAM | SOCK_CLOEXEC,
-        0);
+    int sock = ::socket(GetParam().family, SOCK_STREAM | SOCK_CLOEXEC, 0);
     ASSERT_GE(sock, 0);
 
     sockaddr_storage addr{};
-    if (GetParam().clientHost == "127.0.0.1") {
+    if (GetParam().family == AF_INET) {
       auto* sa = reinterpret_cast<sockaddr_in*>(&addr);
       sa->sin_family = AF_INET;
       sa->sin_port = htons(static_cast<uint16_t>(port));
@@ -454,8 +453,8 @@ INSTANTIATE_TEST_SUITE_P(
     AddrFamilies,
     TcpAsyncAcceptTest,
     ::testing::Values(
-        AddrFamily{"127.0.0.1:0", "127.0.0.1"},
-        AddrFamily{":::0", "::1"}),
+        AddrFamily{"127.0.0.1:0", "127.0.0.1", AF_INET},
+        AddrFamily{":::0", "::1", AF_INET6}),
     [](const ::testing::TestParamInfo<AddrFamily>& info) {
-      return info.param.clientHost == "127.0.0.1" ? "IPv4" : "IPv6";
+      return info.param.family == AF_INET ? "IPv4" : "IPv6";
     });

--- a/comms/uniflow/controller/tests/TcpAsyncAcceptTest.cpp
+++ b/comms/uniflow/controller/tests/TcpAsyncAcceptTest.cpp
@@ -3,6 +3,7 @@
 #include "comms/uniflow/controller/TcpController.h"
 
 #include <arpa/inet.h>
+#include <netinet/tcp.h>
 #include <sys/socket.h>
 #include <unistd.h>
 #include <optional>
@@ -88,6 +89,26 @@ int rcvBufForRequest(int family, int request) {
 int acceptedFd(const std::unique_ptr<Conn>& conn) {
   auto* tcp = dynamic_cast<TcpConn<SyncIO>*>(conn.get());
   return tcp == nullptr ? -1 : tcp->getFd();
+}
+
+int getSockOptInt(int fd, int level, int optname) {
+  int val = 0;
+  socklen_t len = sizeof(val);
+  EXPECT_EQ(::getsockopt(fd, level, optname, &val, &len), 0);
+  return val;
+}
+
+// The value an untouched socket of this family reports, so "the kernel is still
+// in charge" is measured rather than assumed. Hardcoding 0 would encode a
+// current Linux default instead of the property under test.
+int probeSockOptInt(int family, int level, int optname) {
+  int probe = ::socket(family, SOCK_STREAM, 0);
+  if (probe < 0) {
+    return -1;
+  }
+  int val = getSockOptInt(probe, level, optname);
+  ::close(probe);
+  return val;
 }
 
 } // namespace
@@ -202,6 +223,65 @@ TEST_P(TcpAsyncAcceptTest, AcceptedSocketAppliesConfiguredSocketBufSize) {
   const int fd = acceptedFd(conn);
   ASSERT_GE(fd, 0);
   EXPECT_EQ(getRcvBuf(fd), expected);
+}
+
+// osDefaults() means "leave the OS alone", and that has to hold for accepted
+// sockets too. Before configureAcceptedSocket applied the config, it hardcoded
+// TCP_NODELAY=1 and SO_KEEPALIVE=1 regardless, so this configuration was
+// silently ignored on the server side while the client honoured it.
+TEST_P(TcpAsyncAcceptTest, AcceptedSocketLeavesOsDefaultsUntouched) {
+  const int family = GetParam().family;
+  const int probeNoDelay = probeSockOptInt(family, IPPROTO_TCP, TCP_NODELAY);
+  const int probeKeepalive = probeSockOptInt(family, SOL_SOCKET, SO_KEEPALIVE);
+  ASSERT_GE(probeNoDelay, 0);
+  ASSERT_GE(probeKeepalive, 0);
+
+  ScopedEventBaseThread evbThread("async-accept");
+  AsyncTcpServer server(
+      GetParam().serverAddr,
+      TcpSocketConfig::osDefaults(),
+      *evbThread.getEventBase());
+  auto status = server.init();
+  if (status.hasError()) {
+    GTEST_SKIP() << "Not available: " << status.error().toString();
+  }
+
+  auto future = server.accept();
+  TcpClient client;
+  auto clientConn = client.connect(clientAddr(server.getPort())).get();
+  ASSERT_NE(clientConn, nullptr) << "Client failed to connect";
+  auto conn = future.get();
+  ASSERT_NE(conn, nullptr);
+
+  const int fd = acceptedFd(conn);
+  ASSERT_GE(fd, 0);
+  EXPECT_EQ(getSockOptInt(fd, IPPROTO_TCP, TCP_NODELAY), probeNoDelay);
+  EXPECT_EQ(getSockOptInt(fd, SOL_SOCKET, SO_KEEPALIVE), probeKeepalive);
+}
+
+// A server that turns keepalive off must actually get it off. This is the case
+// that used to be a no-op with no compiler error and no failing test.
+TEST_P(TcpAsyncAcceptTest, AcceptedSocketHonoursKeepaliveDisable) {
+  TcpSocketConfig cfg;
+  cfg.enableKeepalive = false;
+
+  ScopedEventBaseThread evbThread("async-accept");
+  AsyncTcpServer server(GetParam().serverAddr, cfg, *evbThread.getEventBase());
+  auto status = server.init();
+  if (status.hasError()) {
+    GTEST_SKIP() << "Not available: " << status.error().toString();
+  }
+
+  auto future = server.accept();
+  TcpClient client;
+  auto clientConn = client.connect(clientAddr(server.getPort())).get();
+  ASSERT_NE(clientConn, nullptr) << "Client failed to connect";
+  auto conn = future.get();
+  ASSERT_NE(conn, nullptr);
+
+  const int fd = acceptedFd(conn);
+  ASSERT_GE(fd, 0);
+  EXPECT_EQ(getSockOptInt(fd, SOL_SOCKET, SO_KEEPALIVE), 0);
 }
 
 TEST_P(TcpAsyncAcceptTest, MultipleAsyncAccepts) {

--- a/comms/uniflow/drivers/cuda/mock/MockCudaApi.h
+++ b/comms/uniflow/drivers/cuda/mock/MockCudaApi.h
@@ -105,4 +105,11 @@ class MockCudaApi : public CudaApi {
   }
 };
 
+/// Vendor types for gmock matcher arguments. This header is hipified on AMD;
+/// test TUs are not, so they cannot name cudaStream_t or cudaMemcpyKind
+/// themselves. `auto` covers lambda parameters in actions -- matchers have no
+/// equivalent, so pin them through these.
+using MockStream = cudaStream_t;
+inline constexpr auto kMockMemcpyH2D = cudaMemcpyHostToDevice;
+
 } // namespace uniflow

--- a/comms/uniflow/transport/tcp/TcpPinnedSlabPool.h
+++ b/comms/uniflow/transport/tcp/TcpPinnedSlabPool.h
@@ -18,8 +18,8 @@ class TcpPinnedSlabPool;
 
 /// A borrow of one pinned staging slab. Move-only, and returned to the pool
 /// when it is destroyed, so a slab is held for exactly as long as some object
-/// owns the lease -- which on the outbound path means until the frame built in
-/// it has been handed to the socket and the queue entry is gone.
+/// owns the lease. Outbound frames retain it through socket send; inbound
+/// frames retain it through the destination copy that still reads from it.
 class TcpPinnedSlab {
  public:
   TcpPinnedSlab() = default;

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -99,7 +99,7 @@ TcpTransport::TcpTransport(
     int deviceId,
     EventBase* evb,
     std::shared_ptr<TcpSegmentRegistry> registry,
-    controller::TcpSocketConfig config,
+    TcpTransportConfig config,
     std::string host,
     std::shared_ptr<CudaApi> cudaApi)
     : deviceId_(deviceId),
@@ -116,6 +116,9 @@ TcpTransport::TcpTransport(
   if (!host.empty()) {
     host_ = std::move(host);
   }
+  h2dState_ = std::make_shared<H2dPollState>();
+  h2dState_->evb = evb_;
+  h2dState_->cudaApi = cudaApi_;
 }
 
 Status TcpTransport::hostFromDevice(
@@ -167,7 +170,7 @@ TransportInfo TcpTransport::bind() {
     return TransportInfo{};
   }
   server_ = std::make_unique<controller::AsyncTcpServer>(
-      host_ + ":0", config_, *evb_);
+      host_ + ":0", config_.socketConfig, *evb_);
   auto status = server_->init();
   if (!status) {
     UNIFLOW_LOG_ERROR(
@@ -236,7 +239,7 @@ Status TcpTransport::connect(std::span<const uint8_t> remoteInfo) {
   // This matters beyond TCP: MultiTransport::connect() connects every
   // registered transport, so on AMD a wedged TCP handshake would stall
   // connection setup even for jobs whose data path is RDMA.
-  const auto handshakeTimeout = config_.connTimeout.value_or(
+  const auto handshakeTimeout = config_.socketConfig.connTimeout.value_or(
       std::chrono::seconds{kDefaultHandshakeTimeoutSeconds});
 
   if (listener) {
@@ -260,7 +263,7 @@ Status TcpTransport::connect(std::span<const uint8_t> remoteInfo) {
     }
     conn = future.get();
   } else {
-    controller::AsyncTcpClient client(config_, *evb_);
+    controller::AsyncTcpClient client(config_.socketConfig, *evb_);
     auto future = client.connect(peer.host + ":" + std::to_string(peer.port));
     if (future.wait_for(handshakeTimeout) != std::future_status::ready) {
       UNIFLOW_LOG_ERROR(
@@ -559,6 +562,17 @@ std::future<Status> TcpTransport::get(
   }
   state->remaining = totalChunks;
 
+  if (config_.asyncGetH2d) {
+    const bool needsReceivePool = std::any_of(
+        requests.begin(), requests.end(), [](const TransferRequest& req) {
+          return req.local.size() > 0 &&
+              req.local.memType() == MemoryType::VRAM;
+        });
+    if (needsReceivePool) {
+      (void)ensureReceivePool();
+    }
+  }
+
   for (const auto& req : requests) {
     auto remoteHandle = findRemoteHandle(req.remote);
     if (!remoteHandle) {
@@ -609,6 +623,38 @@ std::future<Status> TcpTransport::get(
   }
 
   return future;
+}
+
+std::shared_ptr<TcpPinnedSlabPool> TcpTransport::ensureReceivePool() {
+  if (auto pool = std::atomic_load_explicit(
+          &receiveSlabPool_, std::memory_order_acquire)) {
+    return pool;
+  }
+  std::lock_guard<std::mutex> lk(receivePoolCreateMu_);
+  if (auto pool = std::atomic_load_explicit(
+          &receiveSlabPool_, std::memory_order_relaxed)) {
+    return pool;
+  }
+  if (receivePoolUnavailable_ || cudaApi_ == nullptr) {
+    return nullptr;
+  }
+  auto pool = TcpPinnedSlabPool::create(
+      cudaApi_, kMaxFrameSize, kReceiveSlabCount, /*reservedForReader=*/0);
+  if (!pool) {
+    receivePoolUnavailable_ = true;
+    UNIFLOW_LOG_WARN(
+        "tcp get: pinned receive pool unavailable; using vector fallback: {}",
+        pool.error().message());
+    return nullptr;
+  }
+  std::atomic_store_explicit(
+      &receiveSlabPool_, pool.value(), std::memory_order_release);
+  return pool.value();
+}
+
+std::shared_ptr<TcpPinnedSlabPool> TcpTransport::receivePoolIfCreated() {
+  return std::atomic_load_explicit(
+      &receiveSlabPool_, std::memory_order_acquire);
 }
 
 Result<std::shared_ptr<TcpPinnedSlabPool>> TcpTransport::stagingPool() {
@@ -847,6 +893,283 @@ void TcpTransport::startDeferredReadReplies() {
       (void)enqueueFrame(
           makeHeaderFrame(TcpOp::Error, deferred.reqId), /*mayBlock=*/false);
     }
+  }
+}
+
+Status TcpTransport::startAsyncH2d(
+    const TcpInflight& entry,
+    std::span<const uint8_t> payload,
+    TcpPinnedSlab slab,
+    uint64_t reqId) {
+  if (!entry.state->tryBeginWrite()) {
+    return Err(
+        ErrCode::ConnectionFailed,
+        "tcp get: operation completed before destination copy started");
+  }
+
+  auto stream = static_cast<cudaStream_t>(entry.stream);
+  cudaEvent_t event{};
+  bool copyIssued = false;
+  Status status = Ok();
+  try {
+    CudaDeviceGuard guard(*cudaApi_, entry.deviceId);
+    if (status = cudaApi_->eventCreate(&event); status.hasError()) {
+      entry.state->endWrite(status);
+      return status;
+    }
+    if (status = cudaApi_->memcpyAsync(
+            entry.dst,
+            payload.data(),
+            payload.size(),
+            cudaMemcpyHostToDevice,
+            stream);
+        status.hasError()) {
+      (void)cudaApi_->eventDestroy(event);
+      entry.state->endWrite(status);
+      return status;
+    }
+    copyIssued = true;
+    if (status = cudaApi_->eventRecord(event, stream); status.hasError()) {
+      PendingH2d uncertain{
+          entry.state,
+          std::move(slab),
+          event,
+          entry.deviceId,
+          entry.stream,
+          reqId,
+          std::chrono::steady_clock::now()};
+      const auto syncStatus =
+          waitForH2dCopy(h2dState_, uncertain.deviceId, uncertain.stream);
+      if (syncStatus.hasError()) {
+        quarantineH2d(h2dState_, std::move(uncertain));
+        return syncStatus;
+      }
+      destroyH2dEvent(h2dState_, uncertain.deviceId, uncertain.event);
+      entry.state->endWrite(Ok());
+      return Ok();
+    }
+  } catch (const std::exception& e) {
+    if (copyIssued &&
+        waitForH2dCopy(h2dState_, entry.deviceId, entry.stream).hasError()) {
+      quarantineH2d(
+          h2dState_,
+          PendingH2d{
+              entry.state,
+              std::move(slab),
+              event,
+              entry.deviceId,
+              entry.stream,
+              reqId,
+              std::chrono::steady_clock::now()});
+      return Err(
+          ErrCode::DriverError,
+          "tcp get: destination copy could not be quiesced");
+    }
+    if (event != nullptr) {
+      destroyH2dEvent(h2dState_, entry.deviceId, event);
+    }
+    status =
+        Err(ErrCode::InvalidArgument,
+            "tcp get: VRAM destination needs a selectable deviceId, got " +
+                std::to_string(entry.deviceId) + ": " + e.what());
+    entry.state->endWrite(status);
+    return status;
+  }
+
+  PendingH2d pending{
+      entry.state,
+      std::move(slab),
+      event,
+      entry.deviceId,
+      entry.stream,
+      reqId,
+      std::chrono::steady_clock::now()};
+  try {
+    std::lock_guard<std::mutex> lk(h2dState_->mu);
+    if (h2dState_->stopping) {
+      status =
+          Err(ErrCode::ConnectionFailed,
+              "tcp get: transport stopped while destination copy started");
+    } else {
+      h2dState_->pending.push_back(std::move(pending));
+      return Ok();
+    }
+  } catch (const std::exception& e) {
+    status = Err(
+        ErrCode::TransportError,
+        "tcp get: could not track destination copy: " + std::string(e.what()));
+  }
+
+  if (auto syncStatus = waitForH2dCopy(h2dState_, entry.deviceId, entry.stream);
+      syncStatus.hasError()) {
+    quarantineH2d(h2dState_, std::move(pending));
+    return syncStatus;
+  }
+  destroyH2dEvent(h2dState_, entry.deviceId, event);
+  entry.state->endWrite(status);
+  return status;
+}
+
+void TcpTransport::schedulePendingH2dPoll() {
+  auto state = h2dState_;
+  {
+    std::lock_guard<std::mutex> lk(state->mu);
+    if (state->stopping || state->pollScheduled || state->pending.empty()) {
+      return;
+    }
+    state->pollScheduled = true;
+  }
+  state->evb->dispatch(
+      [state = std::move(state)]() noexcept { pollPendingH2d(state); });
+}
+
+void TcpTransport::pollPendingH2d(
+    std::shared_ptr<H2dPollState> state) noexcept {
+  while (true) {
+    PendingH2d retired;
+    Status result = Ok();
+    bool haveRetired = false;
+    bool queryFailed = false;
+    bool reschedule = false;
+    {
+      std::lock_guard<std::mutex> lk(state->mu);
+      if (state->stopping) {
+        state->pollScheduled = false;
+        return;
+      }
+      for (auto it = state->pending.begin(); it != state->pending.end(); ++it) {
+        Result<bool> done =
+            Err(ErrCode::DriverError,
+                "tcp get: could not select device for event query");
+        try {
+          CudaDeviceGuard guard(*state->cudaApi, it->deviceId);
+          done =
+              state->cudaApi->eventQuery(static_cast<cudaEvent_t>(it->event));
+        } catch (const std::exception& e) {
+          done = Err(ErrCode::DriverError, e.what());
+        }
+        if (done.hasValue() && !done.value()) {
+          continue;
+        }
+        if (done.hasError()) {
+          result = std::move(done).error();
+          queryFailed = true;
+        }
+        retired = std::move(*it);
+        state->retiringState = retired.state;
+        state->pending.erase(it);
+        ++state->activeRetirements;
+        haveRetired = true;
+        break;
+      }
+      if (!haveRetired) {
+        if (state->pending.empty()) {
+          state->pollScheduled = false;
+          return;
+        }
+        reschedule = true;
+      }
+    }
+
+    if (reschedule) {
+      std::this_thread::yield();
+      state->evb->dispatch(
+          [state = std::move(state)]() noexcept { pollPendingH2d(state); });
+      return;
+    }
+
+    if (queryFailed) {
+      if (waitForH2dCopy(state, retired.deviceId, retired.stream).hasError()) {
+        quarantineH2d(state, std::move(retired));
+        std::lock_guard<std::mutex> lk(state->mu);
+        state->retiringState.reset();
+        --state->activeRetirements;
+        state->drained.notify_all();
+        continue;
+      }
+      result = Ok();
+    }
+    destroyH2dEvent(state, retired.deviceId, retired.event);
+    state->copyNs.fetch_add(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now() - retired.launchedAt)
+            .count(),
+        std::memory_order_relaxed);
+    state->copyCount.fetch_add(1, std::memory_order_relaxed);
+    retired.state->endWrite(std::move(result));
+    retired.slab.reset();
+
+    {
+      std::lock_guard<std::mutex> lk(state->mu);
+      state->retiringState.reset();
+      --state->activeRetirements;
+      if (state->activeRetirements == 0) {
+        state->drained.notify_all();
+      }
+    }
+  }
+}
+
+Status TcpTransport::waitForH2dCopy(
+    const std::shared_ptr<H2dPollState>& state,
+    int deviceId,
+    void* stream) noexcept {
+  try {
+    CudaDeviceGuard guard(*state->cudaApi, deviceId);
+    return state->cudaApi->streamSynchronize(static_cast<cudaStream_t>(stream));
+  } catch (const std::exception& e) {
+    return Err(ErrCode::DriverError, e.what());
+  }
+}
+
+void TcpTransport::destroyH2dEvent(
+    const std::shared_ptr<H2dPollState>& state,
+    int deviceId,
+    void* event) noexcept {
+  try {
+    CudaDeviceGuard guard(*state->cudaApi, deviceId);
+    (void)state->cudaApi->eventDestroy(static_cast<cudaEvent_t>(event));
+  } catch (const std::exception&) {
+  }
+}
+
+void TcpTransport::quarantineH2d(
+    const std::shared_ptr<H2dPollState>& state,
+    PendingH2d copy) noexcept {
+  // Neither the event nor stream established quiescence. Deliberately retain
+  // the write reservation and slab: resolving or recycling either could let
+  // the caller or pool free memory still touched by DMA.
+  copy.state->fail(
+      Err(ErrCode::DriverError,
+          "tcp get: destination copy could not be safely quiesced"));
+  std::lock_guard<std::mutex> lk(state->mu);
+  for (auto& slot : state->quarantined) {
+    if (!slot.has_value()) {
+      slot.emplace(std::move(copy));
+      state->quarantineKeepalive = state;
+      return;
+    }
+  }
+  std::terminate();
+}
+
+void TcpTransport::drainPendingH2d() {
+  auto state = h2dState_;
+  std::deque<PendingH2d> pending;
+  {
+    std::unique_lock<std::mutex> lk(state->mu);
+    pending.swap(state->pending);
+    state->drained.wait(lk, [&]() { return state->activeRetirements == 0; });
+  }
+  for (auto& copy : pending) {
+    if (waitForH2dCopy(state, copy.deviceId, copy.stream).hasError()) {
+      quarantineH2d(state, std::move(copy));
+      continue;
+    }
+    destroyH2dEvent(state, copy.deviceId, copy.event);
+    copy.state->endWrite(
+        Err(ErrCode::ConnectionFailed,
+            "tcp transport shut down during destination copy"));
   }
 }
 
@@ -1200,8 +1523,10 @@ void TcpTransport::logAndResetPhaseStats(std::string_view label) {
   const uint64_t hdrNs = rs.headerWaitNs.load(std::memory_order_relaxed);
   const uint64_t drainNs = rs.payloadDrainNs.load(std::memory_order_relaxed);
   const uint64_t bytes = rs.payloadBytes.load(std::memory_order_relaxed);
-  const uint64_t copyNs = dstCopyNs_.load(std::memory_order_relaxed);
-  const uint64_t copies = dstCopyCount_.load(std::memory_order_relaxed);
+  const uint64_t copyNs = dstCopyNs_.load(std::memory_order_relaxed) +
+      h2dState_->copyNs.load(std::memory_order_relaxed);
+  const uint64_t copies = dstCopyCount_.load(std::memory_order_relaxed) +
+      h2dState_->copyCount.load(std::memory_order_relaxed);
 
   if (frames == 0) {
     UNIFLOW_LOG_INFO("tcp phases [{}]: no frames", label);
@@ -1237,23 +1562,40 @@ void TcpTransport::logAndResetPhaseStats(std::string_view label) {
   rs.reset();
   dstCopyNs_.store(0, std::memory_order_relaxed);
   dstCopyCount_.store(0, std::memory_order_relaxed);
+  h2dState_->copyNs.store(0, std::memory_order_relaxed);
+  h2dState_->copyCount.store(0, std::memory_order_relaxed);
 }
 
 void TcpTransport::readerLoop() noexcept {
-  // Hoisted so a steady stream of same-size frames stops reallocating: recv()
-  // resize()s this to the frame length, and resizing to the size it already has
-  // neither reallocates nor value-initializes, so the per-frame malloc, 4 MiB
-  // zero-fill, and free all disappear once capacity settles at the high-water
-  // mark. Worth ~8% at 512 MiB and ~14% at 1 GiB on a 200G front-end link.
-  //
-  // Safe only because every frame is fully consumed before handleFrame()
-  // returns: the ReadReply path copies out under writeAndComplete(), and
-  // deviceFromHost() synchronizes its stream. If the H2D copy is ever made
-  // truly async, the reader would overwrite this buffer while a DMA is still
-  // sourcing from it; such a change must stage the payload in storage that
-  // outlives the frame rather than reading it from here.
+  // Reused for every frame that cannot use a receive slab: async H2D disabled,
+  // no VRAM get has created the pool yet, allocation failed, or both slabs are
+  // busy. The reader never waits for a slab, because draining the socket is
+  // what prevents mutual-READ deadlock.
   std::vector<uint8_t> msg;
   while (running_.load(std::memory_order_acquire)) {
+    TcpPinnedSlab receiveSlab;
+    if (config_.asyncGetH2d) {
+      if (auto pool = receivePoolIfCreated()) {
+        receiveSlab = pool->tryAcquire(/*allowReserved=*/true);
+      }
+    }
+    if (receiveSlab) {
+      auto result = dataConn_
+                        ->recv(
+                            std::span<uint8_t>{
+                                receiveSlab.data(), receiveSlab.capacity()})
+                        .get();
+      if (!result) {
+        break;
+      }
+      const auto* receiveData = receiveSlab.data();
+      const auto receivedSize = result.value();
+      handleFrame(
+          std::span<const uint8_t>{receiveData, receivedSize},
+          std::move(receiveSlab));
+      continue;
+    }
+
     auto result = dataConn_->recv(msg).get();
     if (!result) {
       // Connection closed, errored, or idle-timed-out; stop reading.
@@ -1269,7 +1611,9 @@ void TcpTransport::readerLoop() noexcept {
   failAllPending("tcp: reader stopped (connection closed or read error)");
 }
 
-void TcpTransport::handleFrame(std::span<const uint8_t> frame) noexcept {
+void TcpTransport::handleFrame(
+    std::span<const uint8_t> frame,
+    TcpPinnedSlab receiveSlab) noexcept {
   // An exception leaving a noexcept function is std::terminate, and the throw
   // sites in here are reachable from the wire: a ReadRequest's length sizes an
   // allocation, and the VRAM staging path throws if the segment was registered
@@ -1280,7 +1624,7 @@ void TcpTransport::handleFrame(std::span<const uint8_t> frame) noexcept {
   // protocol state that cannot be reasoned about. Stopping the reader also
   // resolves outstanding ops, so no caller is left blocked in future.get().
   try {
-    handleFrameImpl(frame);
+    handleFrameImpl(frame, std::move(receiveSlab));
   } catch (const std::exception& e) {
     UNIFLOW_LOG_ERROR(
         "tcp: frame handling raised '{}'; failing the connection", e.what());
@@ -1295,7 +1639,9 @@ void TcpTransport::handleFrame(std::span<const uint8_t> frame) noexcept {
   }
 }
 
-void TcpTransport::handleFrameImpl(std::span<const uint8_t> frame) {
+void TcpTransport::handleFrameImpl(
+    std::span<const uint8_t> frame,
+    TcpPinnedSlab receiveSlab) {
   auto headerResult = deserializeTcpHeader(frame);
   if (!headerResult) {
     UNIFLOW_LOG_ERROR(
@@ -1468,29 +1814,52 @@ void TcpTransport::handleFrameImpl(std::span<const uint8_t> frame) {
         std::lock_guard<std::mutex> lk(inflightMu_);
         auto it = inflight_.find(header.reqId);
         if (it != inflight_.end()) {
-          entry = std::move(it->second);
-          inflight_.erase(it);
+          entry = it->second;
           found = true;
         }
       }
       if (!found || !entry.state) {
         break;
       }
+
+      const auto eraseInflight = [&]() {
+        std::lock_guard<std::mutex> lk(inflightMu_);
+        inflight_.erase(header.reqId);
+      };
       if (op == TcpOp::Error) {
+        eraseInflight();
         entry.state->fail(
             Err(ErrCode::TransportError, "tcp: peer reported an error"));
       } else if (op == TcpOp::ReadReply) {
-        if (payload.size() != header.len || header.len != entry.len) {
+        if (!entry.isRead || payload.size() != header.len ||
+            header.len != entry.len) {
+          eraseInflight();
           entry.state->fail(Err(
               ErrCode::TransportError, "tcp get: read reply size mismatch"));
           break;
         }
-        // The copy into the caller's get() destination and this chunk's
-        // completion must be one step: a concurrent failAllPending() resolving
-        // the op (via a sibling chunk of the same multi-chunk get()) releases
-        // the caller to free entry.dst, so writing it either side of that
-        // resolution is a write-after-free. writeAndComplete() drops the copy
-        // if the op is already resolved.
+
+        const bool asyncH2d = config_.asyncGetH2d && receiveSlab &&
+            header.len > 0 && entry.dst != nullptr &&
+            entry.memType == MemoryType::VRAM;
+        if (asyncH2d) {
+          const auto status = startAsyncH2d(
+              entry, payload, std::move(receiveSlab), header.reqId);
+          // The pending record is visible before this erase. A concurrent
+          // failure therefore sees the state in inflight_, the H2D queue, or
+          // both, matching RDMA's handoff into transport-owned progress state.
+          eraseInflight();
+          if (status.hasValue()) {
+            schedulePendingH2dPoll();
+          }
+          break;
+        }
+
+        eraseInflight();
+        // Vector-backed VRAM replies cannot outlive this call because the
+        // reader reuses their storage. Keep that fallback synchronous, with the
+        // same reservation that prevents a concurrent failure releasing
+        // entry.dst.
         entry.state->writeAndComplete([&]() -> Status {
           if (header.len == 0 || entry.dst == nullptr) {
             return Ok();
@@ -1516,6 +1885,7 @@ void TcpTransport::handleFrameImpl(std::span<const uint8_t> frame) {
           return st;
         });
       } else { // Ack
+        eraseInflight();
         entry.state->completeOne();
       }
       break;
@@ -1563,6 +1933,17 @@ void TcpTransport::failAllPending(const char* message) {
       }
     }
     inflight_.clear();
+  }
+  {
+    std::lock_guard<std::mutex> lk(h2dState_->mu);
+    for (const auto& copy : h2dState_->pending) {
+      if (copy.state) {
+        toFail.push_back(copy.state);
+      }
+    }
+    if (h2dState_->retiringState) {
+      toFail.push_back(h2dState_->retiringState);
+    }
   }
   {
     std::lock_guard<std::mutex> lk(recvMu_);
@@ -1787,6 +2168,27 @@ void TcpTransport::shutdown() {
   // in-progress send on the sender thread. A no-op if the reader already
   // refused the connection, in which case it is on its way out anyway.
   closeDataConnOnce();
+
+  // Closed before the joins: this is the one pool with a *blocking* acquire,
+  // and the thread parked in it is not one we own. acquire() waits on `freed_`
+  // with no deadline and `closed_` as its only escape, and the put path calls
+  // it on the application's own thread, which shutdown() never joins. Without
+  // this a put() in flight across shutdown() parks forever, because the senders
+  // that would have freed a staging slab are about to be joined away.
+  //
+  // close() only sets the flag and notifies, so outstanding leases stay valid
+  // and doing this early costs nothing. The receive pool needs no equivalent --
+  // the reader only ever tryAcquire()s it. Read under poolMu_, which is what
+  // stagingPool() publishes slabPool_ under.
+  std::shared_ptr<TcpPinnedSlabPool> staging;
+  {
+    std::lock_guard<std::mutex> lk(poolMu_);
+    staging = slabPool_;
+  }
+  if (staging != nullptr) {
+    staging->close();
+  }
+
   if (reader_.joinable()) {
     reader_.join();
   }
@@ -1794,7 +2196,17 @@ void TcpTransport::shutdown() {
     sender_.join();
   }
 
+  if (auto pool = std::atomic_load_explicit(
+          &receiveSlabPool_, std::memory_order_acquire)) {
+    pool->close();
+  }
+
+  {
+    std::lock_guard<std::mutex> lk(h2dState_->mu);
+    h2dState_->stopping = true;
+  }
   failAllPending("tcp transport shut down");
+  drainPendingH2d();
 
   // After the reader is joined, so nothing can add to the queue, and before the
   // transport goes away: a staged reply's frame is memory the device may still
@@ -1823,7 +2235,7 @@ Status TcpTransportFactory::supported() {
 TcpTransportFactory::TcpTransportFactory(
     int deviceId,
     EventBase* evb,
-    controller::TcpSocketConfig config,
+    TcpTransportConfig config,
     std::string host,
     std::shared_ptr<CudaApi> cudaApi)
     : TransportFactory(TransportType::TCP),

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -2,13 +2,16 @@
 
 #pragma once
 
+#include <array>
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <cstdint>
 #include <deque>
 #include <future>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
@@ -25,6 +28,18 @@
 namespace uniflow {
 
 class TcpRemoteRegistrationHandle;
+
+/// Transport-local behavior plus the controller's socket configuration.
+/// The converting constructor preserves existing callsites that pass a bare
+/// TcpSocketConfig as the transport/factory constructor argument.
+struct TcpTransportConfig {
+  controller::TcpSocketConfig socketConfig{};
+  bool asyncGetH2d{true};
+
+  TcpTransportConfig() = default;
+  /* implicit */ TcpTransportConfig(controller::TcpSocketConfig config)
+      : socketConfig(std::move(config)) {}
+};
 
 /// Completion state shared by all requests in a single put()/get()/send()/
 /// recv() call. The call's promise is fulfilled once every request's reply has
@@ -46,33 +61,58 @@ struct TcpOpState {
     failLocked(std::move(status));
   }
 
+  /// Reserves the right to write into a caller-owned destination. Promise
+  /// resolution is deferred until every reservation retires, so the caller
+  /// cannot free the destination while a write is still in flight.
+  bool tryBeginWrite() {
+    std::lock_guard<std::mutex> lk(mu);
+    if (done) {
+      return false;
+    }
+    ++writesInFlight_;
+    return true;
+  }
+
+  /// Retires one write reservation and records that chunk's result. The first
+  /// failure wins, but is not published until every in-flight write is done.
+  void endWrite(Status status) {
+    std::lock_guard<std::mutex> lk(mu);
+    if (writesInFlight_ == 0) {
+      return;
+    }
+    --writesInFlight_;
+    if (status.hasError()) {
+      latchFailureLocked(std::move(status));
+    } else if (remaining > 0) {
+      --remaining;
+    }
+    settleLocked();
+  }
+
   /// Copies a reply payload into the caller's destination buffer (`write`) and
-  /// records that chunk's completion as one atomic step.
+  /// records that chunk's completion as one atomic lifetime reservation.
   ///
   /// Resolving this op's promise is what releases the caller to free or reuse
-  /// the destination, so a write into it may only start while the promise is
-  /// unresolved and must keep it unresolved until the write finishes. Holding
-  /// `mu` across `write` gives both: a concurrent fail() (send error, peer
-  /// disconnect, shutdown) either resolves the op first, in which case `write`
-  /// is skipped because the destination may already be gone, or it blocks
-  /// until the write is done.
+  /// the destination. The reservation keeps the promise unresolved while
+  /// `write` runs without holding `mu`; a concurrent failure is latched and
+  /// published only after the write retires. This is the same lifetime rule
+  /// used by asynchronous writes whose completion happens on another thread.
   ///
   /// `mu` is a leaf lock: nothing in this struct acquires another mutex while
   /// holding it, and no caller may hold one of the transport's container
-  /// mutexes (`inflightMu_`, `recvMu_`, `outMu_`) when calling in. `write`
-  /// therefore must only touch the destination buffer -- a memcpy or a device
-  /// copy -- and never reach back into the transport's queues.
+  /// mutexes (`inflightMu_`, `recvMu_`, `outMu_`) when calling in.
   template <typename Fn>
   void writeAndComplete(Fn&& write) {
-    std::lock_guard<std::mutex> lk(mu);
-    if (done) {
+    if (!tryBeginWrite()) {
       return;
     }
-    Status status = write();
-    if (status.hasError()) {
-      failLocked(std::move(status));
-    } else {
-      completeOneLocked();
+    try {
+      endWrite(write());
+    } catch (...) {
+      endWrite(
+          Err(ErrCode::TransportError,
+              "tcp: destination write raised an exception"));
+      throw;
     }
   }
 
@@ -84,19 +124,42 @@ struct TcpOpState {
     if (remaining > 0) {
       --remaining;
     }
-    if (remaining == 0) {
-      done = true;
-      promise.set_value(Ok());
-    }
+    settleLocked();
   }
 
   void failLocked(Status status) {
     if (done) {
       return;
     }
+    if (writesInFlight_ > 0) {
+      latchFailureLocked(std::move(status));
+      return;
+    }
     done = true;
     promise.set_value(std::move(status));
   }
+
+  void latchFailureLocked(Status status) {
+    if (!firstFailure_.has_value()) {
+      firstFailure_.emplace(std::move(status));
+    }
+  }
+
+  void settleLocked() {
+    if (done || writesInFlight_ > 0) {
+      return;
+    }
+    if (firstFailure_.has_value()) {
+      done = true;
+      promise.set_value(std::move(*firstFailure_));
+    } else if (remaining == 0) {
+      done = true;
+      promise.set_value(Ok());
+    }
+  }
+
+  size_t writesInFlight_{0};
+  std::optional<Status> firstFailure_;
 };
 
 struct TcpTransportInfo {
@@ -396,6 +459,39 @@ struct PendingReadReply {
   int deviceId{-1};
 };
 
+/// One slab-backed get destination copy waiting for its CUDA event. The write
+/// reservation and receive slab stay owned here until the GPU has finished
+/// reading the source and writing the caller's destination.
+struct PendingH2d {
+  std::shared_ptr<TcpOpState> state;
+  TcpPinnedSlab slab;
+  void* event{nullptr};
+  int deviceId{-1};
+  void* stream{nullptr};
+  uint64_t reqId{0};
+  std::chrono::steady_clock::time_point launchedAt;
+};
+
+/// Shared independently of TcpTransport so queued EventBase callbacks never
+/// retain or dereference a transport that shutdown has already destroyed.
+struct H2dPollState {
+  std::mutex mu;
+  std::condition_variable drained;
+  std::deque<PendingH2d> pending;
+  std::shared_ptr<TcpOpState> retiringState;
+  // There are exactly two receive slabs, so at most two copies can become
+  // unquiesceable. Fixed slots avoid allocating on this driver-failure path.
+  std::array<std::optional<PendingH2d>, 2> quarantined;
+  std::shared_ptr<H2dPollState> quarantineKeepalive;
+  bool pollScheduled{false};
+  bool stopping{false};
+  size_t activeRetirements{0};
+  EventBase* evb{nullptr};
+  std::shared_ptr<CudaApi> cudaApi;
+  std::atomic<uint64_t> copyNs{0};
+  std::atomic<uint64_t> copyCount{0};
+};
+
 /// A VRAM ReadReply that has not been started because no staging slab was free.
 /// Everything needed to build and launch it later is here, so the reader can
 /// record it and go straight back to the socket.
@@ -449,7 +545,7 @@ class TcpTransport : public Transport {
       int deviceId,
       EventBase* evb,
       std::shared_ptr<TcpSegmentRegistry> registry,
-      controller::TcpSocketConfig config = {},
+      TcpTransportConfig config = {},
       std::string host = "127.0.0.1",
       std::shared_ptr<CudaApi> cudaApi = nullptr);
 
@@ -470,6 +566,10 @@ class TcpTransport : public Transport {
 
   TransportState state() const noexcept override {
     return state_;
+  }
+
+  bool asyncGetH2dEnabled() const noexcept {
+    return config_.asyncGetH2d;
   }
 
   TransportInfo bind() override;
@@ -523,6 +623,7 @@ class TcpTransport : public Transport {
   // directly and assert the bounds checks reject them. Those checks are the
   // memory-safety boundary of this transport, so they are worth pinning.
   friend class TcpTransportFrameTest;
+  friend class TcpReceivePoolTest;
 
   Result<const TcpRemoteRegistrationHandle*> findRemoteHandle(
       const RemoteRegisteredSegment::Span& span) const;
@@ -538,13 +639,18 @@ class TcpTransport : public Transport {
  private:
   // Sender thread: drains outQueue_ and performs all socket sends.
   void senderLoop() noexcept;
-  // Handles one fully-received inbound frame (reader thread).
-  void handleFrame(std::span<const uint8_t> frame) noexcept;
+  // Handles one fully-received inbound frame (reader thread). `receiveSlab`
+  // owns frame.data() when the reader received directly into pinned memory.
+  void handleFrame(
+      std::span<const uint8_t> frame,
+      TcpPinnedSlab receiveSlab = {}) noexcept;
   // The body of handleFrame(), allowed to throw. Peer-supplied lengths size
   // allocations in here and the VRAM staging path throws on an invalid
   // deviceId, so handleFrame() is the boundary that stops either reaching the
   // top of the reader thread.
-  void handleFrameImpl(std::span<const uint8_t> frame);
+  void handleFrameImpl(
+      std::span<const uint8_t> frame,
+      TcpPinnedSlab receiveSlab);
   // Queues one fire-and-forget framed message for the sender thread.
   // `mayBlock` must be true only for caller threads. Returns false if the frame
   // was not queued (transport closing, or the reader hit the cap and refused
@@ -637,6 +743,33 @@ class TcpTransport : public Transport {
   // transport per peer -- including the DRAM-only peers that never stage at
   // all.
   Result<std::shared_ptr<TcpPinnedSlabPool>> stagingPool();
+  // The independent inbound pool. It is created only for async-enabled,
+  // non-zero VRAM get(), and is sized to the wire cap because recv(span)
+  // consumes the length prefix before it can reject an undersized buffer.
+  std::shared_ptr<TcpPinnedSlabPool> ensureReceivePool();
+  // Reader-only lookup: never allocates and never blocks.
+  std::shared_ptr<TcpPinnedSlabPool> receivePoolIfCreated();
+  // Starts a slab-backed get destination copy. On success the pending queue
+  // owns `slab` and the caller's write reservation until event retirement.
+  Status startAsyncH2d(
+      const TcpInflight& entry,
+      std::span<const uint8_t> payload,
+      TcpPinnedSlab slab,
+      uint64_t reqId);
+  void schedulePendingH2dPoll();
+  static void pollPendingH2d(std::shared_ptr<H2dPollState> state) noexcept;
+  static Status waitForH2dCopy(
+      const std::shared_ptr<H2dPollState>& state,
+      int deviceId,
+      void* stream) noexcept;
+  static void destroyH2dEvent(
+      const std::shared_ptr<H2dPollState>& state,
+      int deviceId,
+      void* event) noexcept;
+  static void quarantineH2d(
+      const std::shared_ptr<H2dPollState>& state,
+      PendingH2d copy) noexcept;
+  void drainPendingH2d();
   // Retires staged replies whose copy has finished, oldest first. Runs on the
   // EventBase, never on the reader thread: polling from the reader would put
   // the head-of-line block straight back.
@@ -696,7 +829,7 @@ class TcpTransport : public Transport {
   EventBase* evb_{nullptr};
   std::shared_ptr<TcpSegmentRegistry> registry_;
   std::shared_ptr<CudaApi> cudaApi_;
-  controller::TcpSocketConfig config_;
+  TcpTransportConfig config_;
   std::string name_{"tcp"};
   // Atomic: written by bind()/connect()/shutdown() and read by the
   // put/get/send/recv guards and state(), which callers may invoke from any
@@ -715,6 +848,7 @@ class TcpTransport : public Transport {
   // nothing more.
   std::atomic<uint64_t> dstCopyNs_{0};
   std::atomic<uint64_t> dstCopyCount_{0};
+  std::shared_ptr<H2dPollState> h2dState_;
 
   // Serialises bind()/connect()/shutdown(), which together own server_,
   // dataConn_, reader_ and sender_. Without it a shutdown() concurrent with an
@@ -767,6 +901,9 @@ class TcpTransport : public Transport {
   // many chunks either reaches the queue whole or not at all.
   static constexpr size_t kMaxPutWaveChunks =
       kStagingSlabCount - kStagingSlabsReservedForReader;
+  // Two full wire frames can remain pinned while Phase 3d retires H2D copies;
+  // exhaustion falls back to the reusable vector instead of blocking receive.
+  static constexpr size_t kReceiveSlabCount = 2;
   // Bytes currently queued in outQueue_. Guarded by outMu_.
   size_t outBytes_{0};
 
@@ -820,6 +957,14 @@ class TcpTransport : public Transport {
   std::mutex poolMu_;
   std::shared_ptr<TcpPinnedSlabPool> slabPool_;
 
+  // Separate from the outbound/responder staging pool: receive slabs must hold
+  // any legal wire frame, not just one kMaxChunkSize payload.
+  std::mutex receivePoolCreateMu_;
+  // Accessed with the std::atomic_load/store free functions, which support
+  // shared_ptr before std::atomic<shared_ptr> is available in the toolchain.
+  std::shared_ptr<TcpPinnedSlabPool> receiveSlabPool_;
+  bool receivePoolUnavailable_{false};
+
   // Outbound frame queue drained by the sender thread. Decoupling all sends
   // from the reader thread is what prevents a mutual-READ deadlock (two peers'
   // readers both blocked mid-send while neither drains its recv).
@@ -850,7 +995,7 @@ class TcpTransportFactory : public TransportFactory {
   explicit TcpTransportFactory(
       int deviceId,
       EventBase* evb,
-      controller::TcpSocketConfig config = {},
+      TcpTransportConfig config = {},
       std::string host = "127.0.0.1",
       std::shared_ptr<CudaApi> cudaApi = nullptr);
 
@@ -871,7 +1016,7 @@ class TcpTransportFactory : public TransportFactory {
  private:
   int deviceId_{-1};
   EventBase* evb_{nullptr};
-  controller::TcpSocketConfig config_;
+  TcpTransportConfig config_;
   std::string host_{"127.0.0.1"};
   std::shared_ptr<CudaApi> cudaApi_;
   std::shared_ptr<TcpSegmentRegistry> registry_{

--- a/comms/uniflow/transport/tcp/tests/unit/TcpReceivePoolTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpReceivePoolTest.cpp
@@ -1,0 +1,402 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/transport/tcp/TcpTransport.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstring>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <span>
+#include <vector>
+
+#include "comms/uniflow/Segment.h"
+#include "comms/uniflow/drivers/cuda/mock/MockCudaApi.h"
+#include "comms/uniflow/executor/ScopedEventBaseThread.h"
+#include "comms/uniflow/transport/tcp/TcpRegistrationHandle.h"
+#include "comms/uniflow/transport/tcp/TcpWireProtocol.h"
+
+namespace uniflow {
+
+class SegmentTest {
+ public:
+  static RegisteredSegment
+  makeRegistered(void* buf, size_t len, MemoryType memType, int deviceId) {
+    return RegisteredSegment(buf, len, memType, deviceId);
+  }
+
+  static RemoteRegisteredSegment makeRemote(
+      void* buf,
+      size_t len,
+      std::unique_ptr<RemoteRegistrationHandle> handle) {
+    RemoteRegisteredSegment remote(buf, len);
+    remote.handles_.push_back(std::move(handle));
+    return remote;
+  }
+};
+
+namespace {
+
+class ScriptedRecvConn final : public controller::Conn {
+ public:
+  explicit ScriptedRecvConn(std::vector<uint8_t> frame)
+      : frame_(std::move(frame)) {}
+
+  std::future<Result<size_t>> send(std::span<const uint8_t> data) override {
+    return make_ready_future<Result<size_t>>(Result<size_t>(data.size()));
+  }
+
+  std::future<Result<size_t>> recv(std::vector<uint8_t>& data) override {
+    ++vectorRecvs_;
+    return next([&]() { data = frame_; });
+  }
+
+  std::future<Result<size_t>> recv(std::span<uint8_t> data) override {
+    ++spanRecvs_;
+    return next([&]() {
+      ASSERT_GE(data.size(), frame_.size());
+      std::memcpy(data.data(), frame_.data(), frame_.size());
+    });
+  }
+
+  void close() override {}
+
+  int spanRecvs() const {
+    return spanRecvs_;
+  }
+
+  int vectorRecvs() const {
+    return vectorRecvs_;
+  }
+
+ private:
+  template <typename Fill>
+  std::future<Result<size_t>> next(Fill&& fill) {
+    if (delivered_) {
+      return make_ready_future<Result<size_t>>(
+          Err(ErrCode::ConnectionFailed, "test: end of script"));
+    }
+    delivered_ = true;
+    fill();
+    return make_ready_future<Result<size_t>>(Result<size_t>(frame_.size()));
+  }
+
+  std::vector<uint8_t> frame_;
+  bool delivered_{false};
+  int spanRecvs_{0};
+  int vectorRecvs_{0};
+};
+
+} // namespace
+
+class TcpReceivePoolTest : public ::testing::Test {
+ protected:
+  static constexpr size_t kLen = 64;
+  static constexpr uint64_t kRemoteSegId = 17;
+
+  void SetUp() override {
+    evbThread_ =
+        std::make_unique<ScopedEventBaseThread>("tcp-receive-pool-test");
+    cudaApi_ = std::make_shared<::testing::NiceMock<MockCudaApi>>();
+    ON_CALL(*cudaApi_, getDevice())
+        .WillByDefault(::testing::Return(Result<int>(0)));
+    ON_CALL(*cudaApi_, setDevice(::testing::_))
+        .WillByDefault(::testing::Return(Ok()));
+    ON_CALL(*cudaApi_, hostAlloc(::testing::_, ::testing::_))
+        .WillByDefault([this](size_t size, unsigned int) -> Result<void*> {
+          auto memory = std::make_unique<uint8_t[]>(size);
+          void* result = memory.get();
+          std::lock_guard<std::mutex> lk(allocMu_);
+          allocations_.push_back(std::move(memory));
+          return result;
+        });
+    ON_CALL(*cudaApi_, hostFree(::testing::_))
+        .WillByDefault([this](void* ptr) -> Status {
+          std::lock_guard<std::mutex> lk(allocMu_);
+          std::erase_if(allocations_, [ptr](const auto& allocation) {
+            return allocation.get() == ptr;
+          });
+          return Ok();
+        });
+  }
+
+  void TearDown() override {
+    if (transport_) {
+      transport_->shutdown();
+      transport_.reset();
+    }
+    evbThread_.reset();
+  }
+
+  void makeTransport(bool asyncGetH2d = true) {
+    TcpTransportConfig config;
+    config.asyncGetH2d = asyncGetH2d;
+    transport_ = std::make_unique<TcpTransport>(
+        /*deviceId=*/-1,
+        evbThread_->getEventBase(),
+        std::make_shared<TcpSegmentRegistry>(),
+        config,
+        /*host=*/"127.0.0.1",
+        cudaApi_);
+  }
+
+  std::future<Status> issueGet(size_t len, MemoryType memType) {
+    localBytes_.resize(len == 0 ? 1 : len);
+    auto local = SegmentTest::makeRegistered(
+        localBytes_.data(), len, memType, memType == MemoryType::VRAM ? 0 : -1);
+    auto remote = SegmentTest::makeRemote(
+        reinterpret_cast<void*>(0x100000),
+        len,
+        std::make_unique<TcpRemoteRegistrationHandle>(kRemoteSegId, len));
+    const TransferRequest request{local.span(), remote.span()};
+    transport_->state_ = TransportState::Connected;
+    return transport_->get(std::span<const TransferRequest>{&request, 1});
+  }
+
+  static std::vector<uint8_t> ackFrame() {
+    TcpMsgHeader header;
+    header.op = static_cast<uint8_t>(TcpOp::Ack);
+    header.reqId = 999;
+    return serializeTcpHeader(header);
+  }
+
+  static std::vector<uint8_t> readReplyFrame(uint64_t reqId, size_t len) {
+    TcpMsgHeader header;
+    header.op = static_cast<uint8_t>(TcpOp::ReadReply);
+    header.reqId = reqId;
+    header.len = len;
+    std::vector<uint8_t> frame(sizeof(header) + len, uint8_t{0xCD});
+    std::memcpy(frame.data(), &header, sizeof(header));
+    return frame;
+  }
+
+  std::shared_ptr<TcpPinnedSlabPool> receivePool() {
+    return transport_->receivePoolIfCreated();
+  }
+
+  std::shared_ptr<TcpPinnedSlabPool> createReceivePool() {
+    return transport_->ensureReceivePool();
+  }
+
+  void failPending() {
+    transport_->failAllPending("test cleanup");
+  }
+
+  void runReader(std::unique_ptr<ScriptedRecvConn> conn) {
+    scriptedConn_ = conn.get();
+    transport_->dataConn_ = std::move(conn);
+    transport_->running_.store(true, std::memory_order_release);
+    transport_->readerLoop();
+  }
+
+  std::future<Status>
+  postVramRead(void* destination, void* stream = nullptr, size_t len = kLen) {
+    auto state = std::make_shared<TcpOpState>();
+    state->remaining = 1;
+    auto future = state->promise.get_future();
+    transport_->inflight_[1] = TcpInflight{
+        state,
+        destination,
+        len,
+        /*isRead=*/true,
+        MemoryType::VRAM,
+        /*deviceId=*/0,
+        stream};
+    return future;
+  }
+
+  void handleFrame(std::span<const uint8_t> frame, TcpPinnedSlab slab) {
+    transport_->handleFrame(frame, std::move(slab));
+  }
+
+  std::unique_ptr<ScopedEventBaseThread> evbThread_;
+  std::shared_ptr<::testing::NiceMock<MockCudaApi>> cudaApi_;
+  std::unique_ptr<TcpTransport> transport_;
+  ScriptedRecvConn* scriptedConn_{nullptr};
+  std::mutex allocMu_;
+  std::vector<std::unique_ptr<uint8_t[]>> allocations_;
+  std::vector<uint8_t> localBytes_;
+};
+
+TEST_F(TcpReceivePoolTest, PoolIsLazyAndOnlyCreatedForEnabledNonZeroVramGet) {
+  makeTransport();
+  EXPECT_EQ(receivePool(), nullptr);
+
+  auto dram = issueGet(kLen, MemoryType::DRAM);
+  EXPECT_EQ(receivePool(), nullptr);
+  failPending();
+  EXPECT_TRUE(dram.get().hasError());
+
+  transport_->shutdown();
+  transport_.reset();
+  makeTransport();
+  auto vram = issueGet(kLen, MemoryType::VRAM);
+  auto pool = receivePool();
+  ASSERT_NE(pool, nullptr);
+  EXPECT_EQ(pool->slabSize(), kMaxFrameSize);
+  EXPECT_EQ(pool->slabCount(), 2);
+  failPending();
+  EXPECT_TRUE(vram.get().hasError());
+
+  transport_->shutdown();
+  transport_.reset();
+  makeTransport(/*asyncGetH2d=*/false);
+  auto disabled = issueGet(kLen, MemoryType::VRAM);
+  EXPECT_EQ(receivePool(), nullptr);
+  failPending();
+  EXPECT_TRUE(disabled.get().hasError());
+}
+
+TEST_F(TcpReceivePoolTest, AllocationFailureFallsBackWithoutRetrying) {
+  makeTransport();
+  EXPECT_CALL(*cudaApi_, hostAlloc(::testing::_, ::testing::_))
+      .Times(1)
+      .WillOnce(
+          ::testing::Return(
+              Result<void*>(Err(
+                  ErrCode::DriverError, "test: pinned allocation failed"))));
+
+  auto first = issueGet(kLen, MemoryType::VRAM);
+  EXPECT_EQ(receivePool(), nullptr);
+  auto second = issueGet(kLen, MemoryType::VRAM);
+  EXPECT_EQ(receivePool(), nullptr);
+
+  runReader(std::make_unique<ScriptedRecvConn>(ackFrame()));
+  EXPECT_EQ(scriptedConn_->spanRecvs(), 0);
+  EXPECT_EQ(scriptedConn_->vectorRecvs(), 2);
+  EXPECT_TRUE(first.get().hasError());
+  EXPECT_TRUE(second.get().hasError());
+}
+
+TEST_F(TcpReceivePoolTest, ReaderUsesSlabAndFallsBackToVectorWhenPoolIsBusy) {
+  makeTransport();
+  auto pool = createReceivePool();
+  ASSERT_NE(pool, nullptr);
+
+  runReader(std::make_unique<ScriptedRecvConn>(ackFrame()));
+  EXPECT_EQ(scriptedConn_->spanRecvs(), 2);
+  EXPECT_EQ(scriptedConn_->vectorRecvs(), 0);
+
+  auto first = pool->tryAcquire(/*allowReserved=*/true);
+  auto second = pool->tryAcquire(/*allowReserved=*/true);
+  ASSERT_TRUE(first);
+  ASSERT_TRUE(second);
+  runReader(std::make_unique<ScriptedRecvConn>(ackFrame()));
+  EXPECT_EQ(scriptedConn_->spanRecvs(), 0);
+  EXPECT_EQ(scriptedConn_->vectorRecvs(), 2);
+}
+
+TEST_F(TcpReceivePoolTest, VramReadReplyKeepsSlabUntilEventCompletes) {
+  makeTransport();
+  auto pool = createReceivePool();
+  ASSERT_NE(pool, nullptr);
+  auto slab = pool->tryAcquire(/*allowReserved=*/true);
+  ASSERT_TRUE(slab);
+  auto frame = readReplyFrame(/*reqId=*/1, kLen);
+  ASSERT_LE(frame.size(), slab.capacity());
+  std::memcpy(slab.data(), frame.data(), frame.size());
+  const auto bytes = std::span<const uint8_t>{slab.data(), frame.size()};
+
+  std::vector<uint8_t> destination(kLen);
+  auto* const callerStream = reinterpret_cast<void*>(0xCA11);
+  auto future = postVramRead(destination.data(), callerStream);
+
+  std::mutex queryMu;
+  std::condition_variable queryCv;
+  bool queried = false;
+  std::atomic<bool> copyDone{false};
+  EXPECT_CALL(
+      *cudaApi_,
+      memcpyAsync(
+          destination.data(),
+          ::testing::_,
+          kLen,
+          kMockMemcpyH2D,
+          static_cast<MockStream>(callerStream)))
+      .WillOnce([&](void* dst, const void* src, size_t len, auto, auto) {
+        std::memcpy(dst, src, len);
+        return Ok();
+      });
+  EXPECT_CALL(*cudaApi_, eventCreate(::testing::_))
+      .WillOnce([](auto* event) -> Status {
+        *event = {};
+        return Ok();
+      });
+  EXPECT_CALL(
+      *cudaApi_,
+      eventRecord(::testing::_, static_cast<MockStream>(callerStream)))
+      .WillOnce(::testing::Return(Ok()));
+  EXPECT_CALL(*cudaApi_, eventQuery(::testing::_))
+      .WillRepeatedly([&](auto) -> Result<bool> {
+        {
+          std::lock_guard<std::mutex> lk(queryMu);
+          queried = true;
+        }
+        queryCv.notify_all();
+        return copyDone.load(std::memory_order_acquire);
+      });
+  EXPECT_CALL(*cudaApi_, eventDestroy(::testing::_))
+      .WillOnce(::testing::Return(Ok()));
+  EXPECT_CALL(*cudaApi_, streamSynchronize(::testing::_)).Times(0);
+
+  handleFrame(bytes, std::move(slab));
+  {
+    std::unique_lock<std::mutex> lk(queryMu);
+    ASSERT_TRUE(queryCv.wait_for(
+        lk, std::chrono::seconds(5), [&]() { return queried; }));
+  }
+
+  auto onlyFreeSlab = pool->tryAcquire(/*allowReserved=*/true);
+  ASSERT_TRUE(onlyFreeSlab);
+  EXPECT_FALSE(pool->tryAcquire(/*allowReserved=*/true));
+  EXPECT_EQ(
+      future.wait_for(std::chrono::milliseconds(0)),
+      std::future_status::timeout);
+
+  copyDone.store(true, std::memory_order_release);
+  ASSERT_EQ(
+      future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  EXPECT_TRUE(future.get().hasValue());
+  onlyFreeSlab.reset();
+  EXPECT_TRUE(pool->tryAcquire(/*allowReserved=*/true));
+}
+
+TEST_F(TcpReceivePoolTest, VectorBackedVramReadReplyRemainsSynchronous) {
+  makeTransport();
+  auto frame = readReplyFrame(/*reqId=*/1, kLen);
+  std::vector<uint8_t> destination(kLen);
+  auto* const callerStream = reinterpret_cast<void*>(0xCA11);
+  auto future = postVramRead(destination.data(), callerStream);
+
+  EXPECT_CALL(*cudaApi_, eventCreate(::testing::_)).Times(0);
+  EXPECT_CALL(
+      *cudaApi_,
+      memcpyAsync(
+          destination.data(),
+          ::testing::_,
+          kLen,
+          kMockMemcpyH2D,
+          static_cast<MockStream>(callerStream)))
+      .WillOnce([&](void* dst, const void* src, size_t len, auto, auto) {
+        std::memcpy(dst, src, len);
+        return Ok();
+      });
+  EXPECT_CALL(
+      *cudaApi_, streamSynchronize(static_cast<MockStream>(callerStream)))
+      .WillOnce(::testing::Return(Ok()));
+
+  handleFrame(frame, {});
+
+  ASSERT_EQ(
+      future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  EXPECT_TRUE(future.get().hasValue());
+  EXPECT_EQ(destination, std::vector<uint8_t>(kLen, uint8_t{0xCD}));
+}
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportConnectTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportConnectTest.cpp
@@ -214,6 +214,27 @@ class TcpTransportTopologyTest : public ::testing::Test {
   std::unique_ptr<TcpTransportFactory> factory_;
 };
 
+TEST(TcpTransportConfigTest, AsyncGetH2dDefaultsOn) {
+  EXPECT_TRUE(TcpTransportConfig{}.asyncGetH2d);
+}
+
+TEST_F(TcpTransportTopologyTest, FactoryPropagatesDisabledAsyncGetH2d) {
+  TcpTransportConfig config;
+  config.asyncGetH2d = false;
+  TcpTransportFactory factory(
+      /*deviceId=*/-1,
+      evbThread_->getEventBase(),
+      config,
+      /*host=*/"127.0.0.1");
+
+  auto result = factory.createTransport(factory.getTopology());
+
+  ASSERT_TRUE(result.hasValue()) << result.error().message();
+  auto* transport = dynamic_cast<TcpTransport*>(result.value().get());
+  ASSERT_NE(transport, nullptr);
+  EXPECT_FALSE(transport->asyncGetH2dEnabled());
+}
+
 TEST_F(TcpTransportTopologyTest, TopologyIsAVersionedCapabilityBlob) {
   const std::vector<uint8_t> topology = factory_->getTopology();
 

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
@@ -13,6 +13,7 @@
 #include <future>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <thread>
 #include <vector>
 
@@ -293,6 +294,14 @@ class TcpTransportFrameTest : public ::testing::Test {
     transport_->handleFrame(frame);
   }
 
+  void feed(std::span<const uint8_t> frame, TcpPinnedSlab slab) {
+    transport_->handleFrame(frame, std::move(slab));
+  }
+
+  std::shared_ptr<TcpPinnedSlabPool> receivePool() {
+    return transport_->ensureReceivePool();
+  }
+
   /// True if the transport queued at least one Error frame back to the peer.
   bool queuedErrorFrame() const {
     std::lock_guard<std::mutex> lk(transport_->outMu_);
@@ -322,7 +331,8 @@ class TcpTransportFrameTest : public ::testing::Test {
   /// multi-chunk get() does. Chunk reqId 1 targets `dst`; the rest stand in for
   /// siblings whose replies have not arrived yet. VRAM so the copy runs through
   /// the mocked CudaApi. Returns the caller's future.
-  std::future<Status> postReadChunks(void* dst, size_t len, size_t chunks) {
+  std::future<Status>
+  postReadChunks(void* dst, size_t len, size_t chunks, void* stream = nullptr) {
     auto state = std::make_shared<TcpOpState>();
     state->remaining = chunks;
     auto future = state->promise.get_future();
@@ -335,7 +345,7 @@ class TcpTransportFrameTest : public ::testing::Test {
           /*isRead=*/true,
           MemoryType::VRAM,
           /*deviceId=*/0,
-          /*stream=*/nullptr};
+          stream};
     }
     return future;
   }
@@ -773,12 +783,158 @@ TEST_F(TcpTransportFrameTest, InBoundsWriteIsApplied) {
   EXPECT_FALSE(queuedErrorFrame());
 }
 
-// A READ_REPLY copies its payload into the caller's get() destination after
-// dropping inflightMu_. Resolving the op's future is what releases the caller
-// to free that destination, so the copy and the resolution must be one atomic
-// step. failAllPending() (send error, peer disconnect, shutdown) can resolve
-// the op mid-copy via a *sibling* chunk of the same multi-chunk get(), which
-// shares the op state -- a silent write-after-free.
+TEST(TcpOpStateTest, FailureWaitsForReservedWriteToRetire) {
+  TcpOpState state;
+  state.remaining = 1;
+  auto future = state.promise.get_future();
+
+  ASSERT_TRUE(state.tryBeginWrite());
+  state.fail(Err(ErrCode::ConnectionFailed, "test failure"));
+  EXPECT_EQ(
+      future.wait_for(std::chrono::milliseconds(0)),
+      std::future_status::timeout);
+
+  state.endWrite(Ok());
+  ASSERT_EQ(
+      future.wait_for(std::chrono::milliseconds(0)), std::future_status::ready);
+  const Status status = future.get();
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::ConnectionFailed);
+}
+
+TEST(TcpOpStateTest, SuccessfulReservedWritesCompleteTheOperation) {
+  TcpOpState state;
+  state.remaining = 2;
+  auto future = state.promise.get_future();
+
+  ASSERT_TRUE(state.tryBeginWrite());
+  ASSERT_TRUE(state.tryBeginWrite());
+  state.endWrite(Ok());
+  EXPECT_EQ(
+      future.wait_for(std::chrono::milliseconds(0)),
+      std::future_status::timeout);
+
+  state.endWrite(Ok());
+  EXPECT_FALSE(future.get().hasError());
+  EXPECT_FALSE(state.tryBeginWrite());
+}
+
+TEST(TcpOpStateTest, ReservedWriteFailureWinsAndResolvesExactlyOnce) {
+  TcpOpState state;
+  state.remaining = 2;
+  auto future = state.promise.get_future();
+
+  ASSERT_TRUE(state.tryBeginWrite());
+  ASSERT_TRUE(state.tryBeginWrite());
+  state.endWrite(Err(ErrCode::DriverError, "copy failed"));
+  EXPECT_EQ(
+      future.wait_for(std::chrono::milliseconds(0)),
+      std::future_status::timeout);
+
+  state.fail(Err(ErrCode::ConnectionFailed, "later failure"));
+  state.endWrite(Ok());
+  const Status status = future.get();
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::DriverError);
+}
+
+TEST(TcpOpStateTest, WriteReservationIsRefusedAfterFailure) {
+  TcpOpState state;
+  state.remaining = 1;
+  auto future = state.promise.get_future();
+
+  state.fail(Err(ErrCode::ConnectionFailed, "test failure"));
+  EXPECT_FALSE(state.tryBeginWrite());
+  EXPECT_TRUE(future.get().hasError());
+}
+
+TEST(TcpOpStateTest, ThrowingSynchronousWriteRetiresItsReservation) {
+  TcpOpState state;
+  state.remaining = 1;
+  auto future = state.promise.get_future();
+
+  EXPECT_THROW(
+      state.writeAndComplete(
+          []() -> Status { throw std::runtime_error("test exception"); }),
+      std::runtime_error);
+
+  ASSERT_EQ(
+      future.wait_for(std::chrono::milliseconds(0)), std::future_status::ready);
+  const Status status = future.get();
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::TransportError);
+  EXPECT_FALSE(state.tryBeginWrite());
+}
+
+TEST_F(TcpTransportFrameTest, AsyncReadReplyFailureWaitsForEventRetirement) {
+  constexpr size_t kLen = 64;
+  std::vector<uint8_t> dst(kLen, 0);
+  auto* const callerStream = reinterpret_cast<void*>(0xCA11);
+  // Chunk 2 remains in inflight_ so failAllPending() can latch an error while
+  // chunk 1's asynchronous destination write is still reserved.
+  auto future = postReadChunks(dst.data(), kLen, /*chunks=*/2, callerStream);
+
+  auto pool = receivePool();
+  ASSERT_NE(pool, nullptr);
+  auto slab = pool->tryAcquire(/*allowReserved=*/true);
+  ASSERT_TRUE(slab);
+  auto frame = makeFrame(TcpOp::ReadReply, kSegId, /*offset=*/0, kLen, kLen);
+  ASSERT_LE(frame.size(), slab.capacity());
+  std::memcpy(slab.data(), frame.data(), frame.size());
+  const auto bytes = std::span<const uint8_t>{slab.data(), frame.size()};
+
+  std::atomic<bool> copyDone{false};
+  EXPECT_CALL(
+      *cudaApi_,
+      memcpyAsync(
+          dst.data(),
+          ::testing::_,
+          kLen,
+          kMockMemcpyH2D,
+          static_cast<MockStream>(callerStream)))
+      .WillOnce([&](void* d, const void* s, size_t n, auto, auto) -> Status {
+        std::memcpy(d, s, n);
+        return Ok();
+      });
+  EXPECT_CALL(*cudaApi_, eventCreate(::testing::_))
+      .WillOnce([](auto* event) -> Status {
+        *event = {};
+        return Ok();
+      });
+  EXPECT_CALL(
+      *cudaApi_,
+      eventRecord(::testing::_, static_cast<MockStream>(callerStream)))
+      .WillOnce(::testing::Return(Ok()));
+  EXPECT_CALL(*cudaApi_, eventQuery(::testing::_))
+      .WillRepeatedly([&](auto) -> Result<bool> {
+        return copyDone.load(std::memory_order_acquire);
+      });
+  EXPECT_CALL(*cudaApi_, eventDestroy(::testing::_))
+      .WillOnce(::testing::Return(Ok()));
+  EXPECT_CALL(*cudaApi_, streamSynchronize(::testing::_)).Times(0);
+
+  feed(bytes, std::move(slab));
+  auto onlyFreeSlab = pool->tryAcquire(/*allowReserved=*/true);
+  ASSERT_TRUE(onlyFreeSlab);
+  failAllPending();
+
+  EXPECT_EQ(
+      future.wait_for(std::chrono::milliseconds(100)),
+      std::future_status::timeout)
+      << "the failure must remain latched until the async destination write "
+         "retires";
+  EXPECT_FALSE(pool->tryAcquire(/*allowReserved=*/true));
+
+  copyDone.store(true, std::memory_order_release);
+  ASSERT_EQ(
+      future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  EXPECT_TRUE(future.get().hasError());
+  EXPECT_EQ(dst, std::vector<uint8_t>(kLen, uint8_t{0xCD}));
+}
+
+// A vector-backed READ_REPLY still copies synchronously. Resolving the op's
+// future is what releases the caller to free its destination, so that fallback
+// copy and completion remain one atomic lifetime reservation.
 TEST_F(TcpTransportFrameTest, ReadReplyCopyKeepsTheGetUnresolvedWhileItRuns) {
   constexpr size_t kLen = 64;
   std::vector<uint8_t> dst(kLen, 0);
@@ -1332,6 +1488,52 @@ TEST_F(TcpTransportFrameTest, ADeferredReadStillBlocksDeregistration) {
   EXPECT_EQ(stagedCopyCount(), 0u)
       << "a discarded deferred read must not have started a copy into memory "
          "that is being torn down";
+}
+
+// A thread parked in the staging pool's blocking acquire() must be released by
+// shutdown(). acquire() waits on `freed_` with no deadline and `closed_` as its
+// only escape, and it runs on the application's own put() thread -- which
+// shutdown() never joins and nothing else wakes. Before shutdown() closed this
+// pool, a put() in flight across teardown parked forever, because the sender
+// that would have returned a staging slab was joined away first.
+//
+// Written against the pool directly rather than through put(): reaching the
+// blocking acquire() through put() needs a live peer and a full wave, and the
+// property under test belongs to shutdown()'s ordering, not to the put path.
+TEST_F(TcpTransportFrameTest, ShutdownReleasesAThreadParkedInStagingAcquire) {
+  setConnected();
+  stubStagingCopies();
+
+  auto pool = transportStagingPool();
+  ASSERT_NE(pool, nullptr);
+
+  // Hold every slab so the acquire below cannot be satisfied.
+  std::vector<TcpPinnedSlab> held;
+  held.reserve(pool->slabCount());
+  for (size_t i = 0; i < pool->slabCount(); ++i) {
+    held.push_back(pool->tryAcquire(/*allowReserved=*/true));
+    ASSERT_TRUE(static_cast<bool>(held.back()));
+  }
+
+  std::atomic<bool> returned{false};
+  std::thread parked([&]() {
+    // Blocks: nothing is free, and this test never releases `held`.
+    auto leases = pool->acquire(1);
+    // Either outcome is fine; the point is that it *returns*.
+    (void)leases;
+    returned.store(true, std::memory_order_release);
+  });
+
+  // Give it time to reach the wait rather than racing the assertion below.
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  ASSERT_FALSE(returned.load(std::memory_order_acquire))
+      << "precondition: the acquire must actually be parked";
+
+  transport_->shutdown();
+  parked.join();
+  EXPECT_TRUE(returned.load(std::memory_order_acquire))
+      << "shutdown() must close the staging pool; otherwise a put() in flight "
+         "across teardown never comes back";
 }
 
 // A read the pool cannot serve and the deferred queue cannot hold is answered


### PR DESCRIPTION
Summary:

D117132557 threaded TcpSocketConfig into the accept path but
configureAcceptedSocket consumed only socketBufSize and hardcoded the other
seven fields. That is a worse shape than the old `int acceptRetryCnt`

Differential Revision: D117409938


