### PR TITLE
comms/uniflow/benchmarks: TCP bandwidth bench + MI350 MAST enablement (#3907)

### DIFF
--- a/comms/uniflow/benchmarks/BenchmarkRunner.h
+++ b/comms/uniflow/benchmarks/BenchmarkRunner.h
@@ -43,6 +43,12 @@ struct BenchmarkConfig {
   int pipelineDepth{2}; // send/recv staging pipeline depth
   size_t slabSize{0}; // 0 = use chunk-size
   int slabNum{0}; // 0 = use pipeline-depth
+  /*
+   * Run a correctness sweep before the timed loop. A bandwidth number proves
+   * nothing about the bytes: a transport that moved garbage, or nothing, still
+   * reports excellent throughput.
+   */
+  bool verify{true};
 };
 
 class Benchmark {

--- a/comms/uniflow/benchmarks/Rendezvous.cpp
+++ b/comms/uniflow/benchmarks/Rendezvous.cpp
@@ -121,7 +121,13 @@ Result<std::vector<PeerConnection>> Rendezvous::establish(
 
 /// Retry recv on EAGAIN — the peer may be slow to reach the barrier during
 /// long benchmark runs, causing SO_RCVTIMEO to fire.
-/// With a 1-second SO_RCVTIMEO, 300 retries ≈ 5 minutes before giving up.
+///
+/// The bound is 300 retries x the connection's SO_RCVTIMEO. The rendezvous is
+/// built with a default TcpSocketConfig, whose connTimeout is 30s, so that is
+/// ~2.5 hours -- not the ~5 minutes an earlier version of this comment claimed
+/// from a 1-second timeout. Worth knowing before reading a stalled two-host run
+/// as a deadlock: a rank stranded at a barrier its peer will never reach sits
+/// here for hours rather than failing fast.
 static Result<size_t> recvRetryEagain(
     controller::Conn& conn,
     std::vector<uint8_t>& buf) {

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
@@ -1,0 +1,654 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h"
+
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <deque>
+#include <future>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <cuda_runtime_api.h> // @manual=third-party//cuda:cuda-lazy
+
+#include "comms/uniflow/Segment.h"
+#include "comms/uniflow/benchmarks/Rendezvous.h"
+#include "comms/uniflow/benchmarks/SegmentHelper.h"
+#include "comms/uniflow/benchmarks/Stats.h"
+#include "comms/uniflow/executor/ScopedEventBaseThread.h"
+#include "comms/uniflow/logging/Logger.h"
+#include "comms/uniflow/transport/tcp/TcpTransport.h"
+
+namespace uniflow::benchmark {
+
+namespace {
+
+// Fixed so a verification failure reproduces exactly; logged with the banner.
+constexpr uint64_t kVerifySeed = 0x5EED1234;
+
+/// First global (non-link-local) IPv6 address on `iface`, or "" if none.
+std::string getInterfaceIpv6(const std::string& iface) {
+  struct ifaddrs* ifaddr = nullptr;
+  if (getifaddrs(&ifaddr) != 0) {
+    return "";
+  }
+  std::string result;
+  for (auto* ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr == nullptr || ifa->ifa_addr->sa_family != AF_INET6 ||
+        iface != ifa->ifa_name) {
+      continue;
+    }
+    auto* sa = reinterpret_cast<sockaddr_in6*>(ifa->ifa_addr);
+    if (sa->sin6_addr.s6_addr[0] == 0xfe &&
+        (sa->sin6_addr.s6_addr[1] & 0xc0) == 0x80) {
+      continue; // link-local
+    }
+    char buf[INET6_ADDRSTRLEN] = {};
+    if (inet_ntop(AF_INET6, &sa->sin6_addr, buf, sizeof(buf)) != nullptr) {
+      result = buf;
+      break;
+    }
+  }
+  freeifaddrs(ifaddr);
+  return result;
+}
+
+// A src/dst buffer pair (DRAM or VRAM), freed on destruction.
+struct BufferPair {
+  void* src{nullptr};
+  void* dst{nullptr};
+  bool useGpu{false};
+  MemoryType memType{MemoryType::DRAM};
+  int device{0};
+
+  BufferPair() = default;
+  BufferPair(const BufferPair&) = delete;
+  BufferPair& operator=(const BufferPair&) = delete;
+
+  ~BufferPair() {
+    if (useGpu) {
+      if (src) {
+        (void)cudaFree(src);
+      }
+      if (dst) {
+        (void)cudaFree(dst);
+      }
+    } else {
+      std::free(src);
+      std::free(dst);
+    }
+  }
+};
+
+bool allocPair(BufferPair& bufs, size_t maxSize, int cudaDevice) {
+  bufs.useGpu = cudaDevice >= 0;
+  bufs.memType = bufs.useGpu ? MemoryType::VRAM : MemoryType::DRAM;
+  bufs.device = bufs.useGpu ? cudaDevice : 0;
+
+  if (bufs.useGpu) {
+    if (cudaSetDevice(bufs.device) != cudaSuccess ||
+        cudaMalloc(&bufs.src, maxSize) != cudaSuccess ||
+        cudaMalloc(&bufs.dst, maxSize) != cudaSuccess) {
+      UNIFLOW_LOG_ERROR("TcpBandwidthBenchmark: cudaMalloc failed");
+      return false;
+    }
+    if (cudaMemset(bufs.src, 0xAB, maxSize) != cudaSuccess ||
+        cudaMemset(bufs.dst, 0x00, maxSize) != cudaSuccess ||
+        cudaDeviceSynchronize() != cudaSuccess) {
+      UNIFLOW_LOG_ERROR("TcpBandwidthBenchmark: cuda buffer init failed");
+      return false;
+    }
+  } else {
+    bufs.src = std::malloc(maxSize);
+    bufs.dst = std::malloc(maxSize);
+    if (bufs.src == nullptr || bufs.dst == nullptr) {
+      UNIFLOW_LOG_ERROR("TcpBandwidthBenchmark: malloc failed");
+      return false;
+    }
+    std::memset(bufs.src, 0xAB, maxSize);
+    std::memset(bufs.dst, 0x00, maxSize);
+  }
+  return true;
+}
+
+// [uint64_t dstAddr | registration payload]
+std::vector<uint8_t> serializeReg(
+    uint64_t dstAddr,
+    const std::vector<uint8_t>& regPayload) {
+  std::vector<uint8_t> buf(sizeof(dstAddr) + regPayload.size());
+  std::memcpy(buf.data(), &dstAddr, sizeof(dstAddr));
+  std::memcpy(
+      buf.data() + sizeof(dstAddr), regPayload.data(), regPayload.size());
+  return buf;
+}
+
+struct TransferResult {
+  bool ok{false};
+  double bandwidthGBs{0};
+  double messageRateMops{0};
+  int totalOps{0};
+  std::vector<double> latenciesUs;
+};
+
+// Warmup then a pipelined timed loop keeping up to txDepth put/get calls in
+// flight over the single TCP connection.
+TransferResult runTransfer(
+    Transport& transport,
+    RegisteredSegment& localReg,
+    RemoteRegisteredSegment& remoteReg,
+    size_t size,
+    const std::string& dir,
+    const BenchmarkConfig& config) {
+  using Clock = std::chrono::steady_clock;
+  const int batchSize = std::max(1, config.batchSize);
+  const int txDepth = std::max(1, config.txDepth);
+
+  std::vector<TransferRequest> batch;
+  batch.reserve(batchSize);
+  for (int i = 0; i < batchSize; ++i) {
+    batch.push_back(
+        TransferRequest{
+            .local = localReg.span(size_t{0}, size),
+            .remote = remoteReg.span(size_t{0}, size)});
+  }
+
+  const int numBatches =
+      std::max(1, (config.iterations + batchSize - 1) / batchSize);
+  const int totalOps = numBatches * batchSize;
+
+  auto submit = [&]() -> std::future<Status> {
+    return (dir == "put") ? transport.put(batch, {}) : transport.get(batch, {});
+  };
+
+  TransferResult out;
+
+  for (int i = 0; i < config.warmupIterations; ++i) {
+    if (submit().get().hasError()) {
+      UNIFLOW_LOG_ERROR(
+          "TcpBandwidthBenchmark: warmup {} failed at size {}", dir, size);
+      return out;
+    }
+  }
+
+  std::deque<std::pair<std::future<Status>, Clock::time_point>> inflight;
+  std::vector<double> latenciesUs;
+  latenciesUs.reserve(numBatches);
+
+  auto completeOne = [&]() -> bool {
+    auto& [fut, submitTime] = inflight.front();
+    auto status = fut.get();
+    auto done = Clock::now();
+    if (status.hasError()) {
+      inflight.pop_front();
+      UNIFLOW_LOG_ERROR(
+          "TcpBandwidthBenchmark: {} failed at size {}: {}",
+          dir,
+          size,
+          status.error().message());
+      for (auto& [f, _] : inflight) {
+        f.wait();
+      }
+      return false;
+    }
+    latenciesUs.push_back(
+        std::chrono::duration<double, std::micro>(done - submitTime).count() /
+        batchSize);
+    inflight.pop_front();
+    return true;
+  };
+
+  auto start = Clock::now();
+  for (int b = 0; b < numBatches; ++b) {
+    if (static_cast<int>(inflight.size()) >= txDepth) {
+      if (!completeOne()) {
+        return out;
+      }
+    }
+    // Timestamp before submit(), not as a sibling argument to emplace_back:
+    // argument evaluation order is unspecified, so Clock::now() could be
+    // evaluated after submit() returns. That matters now that put() applies
+    // backpressure and blocks inside submit() while enqueueing chunks -- the
+    // blocked time would fall outside the measured interval and the reported
+    // latency would be a fraction of the real one (bandwidth, bracketed by
+    // start/end, stayed correct).
+    auto submitTime = Clock::now();
+    inflight.emplace_back(submit(), submitTime);
+  }
+  while (!inflight.empty()) {
+    if (!completeOne()) {
+      return out;
+    }
+  }
+  auto end = Clock::now();
+
+  double sec = std::chrono::duration<double>(end - start).count();
+  double bytes = static_cast<double>(size) * static_cast<double>(totalOps);
+  out.ok = true;
+  out.bandwidthGBs = (sec > 0) ? (bytes / sec) / 1e9 : 0;
+  out.messageRateMops = (sec > 0) ? (totalOps / sec) / 1e6 : 0;
+  out.totalOps = totalOps;
+  out.latenciesUs = std::move(latenciesUs);
+  return out;
+}
+
+// Byte value at an absolute offset. The period far exceeds any transfer here,
+// so a chunk landing at the wrong offset -- or duplicated, dropped, or
+// reordered -- changes the bytes. A pattern repeating every 256 bytes (say
+// `offset & 0xFF`) is blind to whole-chunk misplacement, because chunk
+// boundaries are multiples of 256. `round` is mixed in so each pass differs.
+uint8_t patternAt(uint64_t offset, uint64_t round) {
+  uint64_t x = offset + 0x9E3779B97F4A7C15ULL * (round + 1);
+  x ^= x >> 33;
+  x *= 0xFF51AFD7ED558CCDULL;
+  x ^= x >> 33;
+  x *= 0xC4CEB9FE1A85EC53ULL;
+  x ^= x >> 33;
+  return static_cast<uint8_t>(x);
+}
+
+// Transfer sizes for the correctness sweep, clamped to maxLen. Boundaries are
+// enumerated rather than sampled: every failure this transport has had sits on
+// one, and a uniform draw over [1, 1 GiB] puts ~99% of its samples above 2 MiB,
+// so it would neither reliably hit a boundary nor cover small transfers.
+std::vector<size_t> verifySizes(size_t maxLen) {
+  constexpr size_t kChunk = 4UL * 1024 * 1024; // kMaxChunkSize in TcpTransport
+  constexpr size_t kFrameCap = 64UL * 1024 * 1024; // kMaxFrameSize
+  std::vector<size_t> sizes{
+      1,
+      3,
+      4095, // unaligned tails
+      4096,
+      4097,
+      kChunk - 1, // chunk boundary: +1 leaves a 1-byte final chunk
+      kChunk,
+      kChunk + 1,
+      2 * kChunk, // exact multiple: no remainder chunk at all
+      2 * kChunk + 1,
+      kFrameCap - 1, // wire-frame cap edges
+      kFrameCap,
+      kFrameCap + 1,
+      kFrameCap + kChunk, // just past the outbound queue cap
+      2 * kFrameCap, // 128 MiB: a reply-path cap here killed the connection
+  };
+
+  // Log-uniform so small sizes actually appear. Fixed seed: a failure must
+  // reproduce, and the seed is logged with the phase banner.
+  std::mt19937_64 rng(kVerifySeed);
+  std::uniform_real_distribution<double> logDist(
+      0.0, std::log(static_cast<double>(maxLen)));
+  for (int i = 0; i < 8; ++i) {
+    sizes.push_back(
+        std::max<size_t>(1, static_cast<size_t>(std::exp(logDist(rng)))));
+  }
+
+  std::erase_if(sizes, [maxLen](size_t s) { return s > maxLen; });
+  std::sort(sizes.begin(), sizes.end());
+  sizes.erase(std::unique(sizes.begin(), sizes.end()), sizes.end());
+  return sizes;
+}
+
+// Host<->buffer copies that work for both DRAM and VRAM buffers.
+bool writeBuf(
+    const BufferPair& bufs,
+    size_t offset,
+    const uint8_t* src,
+    size_t len) {
+  auto* dst = static_cast<uint8_t*>(bufs.src) + offset;
+  if (!bufs.useGpu) {
+    std::copy_n(src, len, dst);
+    return true;
+  }
+  return cudaMemcpy(dst, src, len, cudaMemcpyHostToDevice) == cudaSuccess &&
+      cudaDeviceSynchronize() == cudaSuccess;
+}
+
+bool readBuf(const BufferPair& bufs, size_t offset, uint8_t* dst, size_t len) {
+  const auto* src = static_cast<const uint8_t*>(bufs.src) + offset;
+  if (!bufs.useGpu) {
+    std::copy_n(src, len, dst);
+    return true;
+  }
+  return cudaMemcpy(dst, src, len, cudaMemcpyDeviceToHost) == cudaSuccess &&
+      cudaDeviceSynchronize() == cudaSuccess;
+}
+
+// Boundary + randomized size/offset sweep with content verification, run before
+// the timed loop. A bandwidth number says nothing about the bytes: a transport
+// that moved garbage, or nothing at all, still reports excellent throughput.
+//
+// Each case is a round trip -- put local src into the peer's dst, zero src,
+// then get it back -- so no peer-side code is needed; the passive rank just
+// serves. Known blind spot: put and get address the remote with the same
+// offset, so a transfer placed at a uniformly shifted remote offset would
+// cancel out. Chunk misordering within a transfer does not cancel, because
+// put's Write path and get's ReadRequest/ReadReply path reassemble
+// independently.
+bool verifyTransfers(
+    Transport& transport,
+    RegisteredSegment& localReg,
+    RemoteRegisteredSegment& remoteReg,
+    const BufferPair& bufs,
+    size_t maxSize,
+    int rank) {
+  const std::vector<size_t> sizes = verifySizes(maxSize);
+  std::mt19937_64 offsetRng(kVerifySeed);
+  std::vector<uint8_t> expected;
+  std::vector<uint8_t> actual;
+  uint64_t round = 0;
+  size_t cases = 0;
+
+  UNIFLOW_LOG_WARN(
+      "[rank {}] verify: {} sizes x up to 2 offsets, seed {:#x} "
+      "(--no-verify to skip)",
+      rank,
+      sizes.size(),
+      kVerifySeed);
+
+  for (size_t len : sizes) {
+    // Offset 0 always; plus one unaligned offset when the segment has room, so
+    // the responder's `offset <= entry->len - len` bounds check and the
+    // `baseOffset + off` chunk arithmetic are exercised away from 0.
+    std::vector<size_t> offsets{0};
+    if (maxSize > len) {
+      offsets.push_back(
+          std::uniform_int_distribution<size_t>(1, maxSize - len)(offsetRng));
+    }
+
+    for (size_t offset : offsets) {
+      ++round;
+      ++cases;
+      expected.resize(len);
+      for (size_t i = 0; i < len; ++i) {
+        expected[i] = patternAt(offset + i, round);
+      }
+      if (!writeBuf(bufs, offset, expected.data(), len)) {
+        UNIFLOW_LOG_ERROR("verify: staging src failed (len {})", len);
+        return false;
+      }
+
+      std::vector<TransferRequest> req{TransferRequest{
+          .local = localReg.span(offset, len),
+          .remote = remoteReg.span(offset, len)}};
+      if (auto st = transport.put(req, {}).get(); st.hasError()) {
+        UNIFLOW_LOG_ERROR(
+            "verify: put failed at len {} offset {}: {}",
+            len,
+            offset,
+            st.error().message());
+        return false;
+      }
+
+      // Zero src so the get has to refill it: otherwise a get that moved
+      // nothing would pass against the bytes put() just staged there.
+      std::vector<uint8_t> zeros(len, 0);
+      if (!writeBuf(bufs, offset, zeros.data(), len)) {
+        UNIFLOW_LOG_ERROR("verify: zeroing src failed (len {})", len);
+        return false;
+      }
+      if (auto st = transport.get(req, {}).get(); st.hasError()) {
+        UNIFLOW_LOG_ERROR(
+            "verify: get failed at len {} offset {}: {}",
+            len,
+            offset,
+            st.error().message());
+        return false;
+      }
+
+      actual.assign(len, 0);
+      if (!readBuf(bufs, offset, actual.data(), len)) {
+        UNIFLOW_LOG_ERROR("verify: reading src back failed (len {})", len);
+        return false;
+      }
+      if (actual != expected) {
+        size_t bad = 0;
+        while (bad < len && actual[bad] == expected[bad]) {
+          ++bad;
+        }
+        UNIFLOW_LOG_ERROR(
+            "verify: DATA MISMATCH at len {} offset {}: first bad byte {} "
+            "(absolute {}), expected {:#x} got {:#x}",
+            len,
+            offset,
+            bad,
+            offset + bad,
+            expected[bad],
+            actual[bad]);
+        return false;
+      }
+    }
+  }
+
+  UNIFLOW_LOG_WARN("[rank {}] verify: {} cases passed", rank, cases);
+  return true;
+}
+
+} // namespace
+
+std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
+    const BenchmarkConfig& config,
+    std::vector<PeerConnection>& peers,
+    const BootstrapConfig& bootstrap) {
+  if (peers.empty()) {
+    UNIFLOW_LOG_WARN("TcpBandwidthBenchmark: no peers, skipping");
+    return {};
+  }
+
+  const std::string host = getInterfaceIpv6(iface_);
+  if (host.empty()) {
+    UNIFLOW_LOG_ERROR(
+        "TcpBandwidthBenchmark: no global IPv6 on interface '{}'", iface_);
+    return {};
+  }
+  UNIFLOW_LOG_WARN(
+      "TcpBandwidthBenchmark: rank {} using {} address {}",
+      bootstrap.rank,
+      iface_,
+      host);
+
+  const int dev = config.cudaDevice;
+  BufferPair bufs;
+  if (!allocPair(bufs, config.maxSize, dev)) {
+    return {};
+  }
+
+  ScopedEventBaseThread evbThread("bench-tcp-evb");
+  auto factory = std::make_unique<TcpTransportFactory>(
+      dev, evbThread.getEventBase(), controller::TcpSocketConfig{}, host);
+
+  // Handshake over the rendezvous control channel.
+  auto localTopo = factory->getTopology();
+  auto remoteTopo =
+      exchangeMetadata(*peers[0].ctrl, localTopo, bootstrap.isRank0());
+  if (!remoteTopo) {
+    UNIFLOW_LOG_ERROR("TcpBandwidthBenchmark: topology exchange failed");
+    return {};
+  }
+  auto transportResult =
+      factory->createTransport(std::move(remoteTopo).value());
+  if (!transportResult) {
+    UNIFLOW_LOG_ERROR(
+        "TcpBandwidthBenchmark: createTransport failed: {}",
+        transportResult.error().message());
+    return {};
+  }
+  auto transport = std::move(transportResult).value();
+
+  auto localInfo = transport->bind();
+  auto remoteInfo =
+      exchangeMetadata(*peers[0].ctrl, localInfo, bootstrap.isRank0());
+  if (!remoteInfo) {
+    UNIFLOW_LOG_ERROR("TcpBandwidthBenchmark: transport info exchange failed");
+    transport->shutdown();
+    return {};
+  }
+  if (auto st = transport->connect(std::move(remoteInfo).value());
+      st.hasError()) {
+    UNIFLOW_LOG_ERROR(
+        "TcpBandwidthBenchmark: connect failed: {}", st.error().message());
+    transport->shutdown();
+    return {};
+  }
+
+  // Register src/dst, exchange the dst registration so each side can address
+  // the peer's destination segment.
+  Segment srcSeg(bufs.src, config.maxSize, bufs.memType, bufs.device);
+  Segment dstSeg(bufs.dst, config.maxSize, bufs.memType, bufs.device);
+  auto srcReg = factory->registerSegment(srcSeg);
+  auto dstReg = factory->registerSegment(dstSeg);
+  if (!srcReg || !dstReg) {
+    UNIFLOW_LOG_ERROR("TcpBandwidthBenchmark: registerSegment failed");
+    transport->shutdown();
+    return {};
+  }
+  auto localPayload = serializeReg(
+      reinterpret_cast<uint64_t>(bufs.dst), dstReg.value()->serialize());
+  auto remotePayload =
+      exchangeMetadata(*peers[0].ctrl, localPayload, bootstrap.isRank0());
+  if (!remotePayload || remotePayload.value().size() < sizeof(uint64_t)) {
+    UNIFLOW_LOG_ERROR("TcpBandwidthBenchmark: registration exchange failed");
+    transport->shutdown();
+    return {};
+  }
+  uint64_t remoteDstAddr = 0;
+  std::memcpy(
+      &remoteDstAddr, remotePayload.value().data(), sizeof(remoteDstAddr));
+  std::vector<uint8_t> remoteRegPayload(
+      remotePayload.value().begin() + sizeof(uint64_t),
+      remotePayload.value().end());
+  auto remoteHandle =
+      factory->importSegment(config.maxSize, std::move(remoteRegPayload));
+  if (!remoteHandle) {
+    UNIFLOW_LOG_ERROR(
+        "TcpBandwidthBenchmark: importSegment failed: {}",
+        remoteHandle.error().message());
+    transport->shutdown();
+    return {};
+  }
+
+  auto localReg =
+      SegmentTest::makeRegistered(srcSeg, std::move(srcReg.value()));
+  auto remoteReg = SegmentTest::makeRemote(
+      // NOLINTNEXTLINE(performance-no-int-to-ptr)
+      reinterpret_cast<void*>(remoteDstAddr),
+      config.maxSize,
+      std::move(remoteHandle.value()));
+  auto localDstHandle = std::move(dstReg.value()); // keep alive
+
+  // Message-size sweep.
+  std::vector<BenchmarkResult> results;
+  const bool isActiveRank = config.bidirectional || bootstrap.isRank0();
+  auto sizes = generateSizes(config.minSize, config.maxSize);
+
+  // Correctness before performance. Both ranks must reach the same barriers, so
+  // the passive rank waits here while the active rank runs the sweep.
+  //
+  // A rank that gives up on its own work latches a flag and keeps meeting the
+  // peer at every rendezvous below, doing no work and recording no results.
+  // Returning instead would leave the peer waiting at one it never reaches, and
+  // the peer does not fail fast: barrier() retries EAGAIN 300 times against a
+  // 30s SO_RCVTIMEO, so a stranded rank looks hung for hours, not seconds.
+  bool verifyFailed = false;
+  if (config.verify) {
+    if (!barrier(peers, bootstrap)) {
+      UNIFLOW_LOG_ERROR("TcpBandwidthBenchmark: pre-verify barrier failed");
+      transport->shutdown();
+      return {};
+    }
+    if (isActiveRank &&
+        !verifyTransfers(
+            *transport,
+            localReg,
+            remoteReg,
+            bufs,
+            config.maxSize,
+            bootstrap.rank)) {
+      UNIFLOW_LOG_ERROR(
+          "TcpBandwidthBenchmark: correctness sweep FAILED; not reporting "
+          "bandwidth for a transport that does not move bytes correctly");
+      verifyFailed = true;
+    }
+    if (!barrier(peers, bootstrap)) {
+      UNIFLOW_LOG_ERROR("TcpBandwidthBenchmark: post-verify barrier failed");
+      transport->shutdown();
+      return {};
+    }
+  }
+
+  auto runDirection = [&](const std::string& dir) {
+    // Seeded from the verify result: a failed correctness sweep still walks the
+    // whole size sweep, meeting every barrier and reporting nothing.
+    //
+    // A failing barrier() is the exception and does return: the rendezvous
+    // channel is gone, and every later one would only time out in turn.
+    bool aborted = verifyFailed;
+
+    for (auto size : sizes) {
+      if (!barrier(peers, bootstrap)) {
+        UNIFLOW_LOG_ERROR("TcpBandwidthBenchmark: barrier failed");
+        return;
+      }
+      if (aborted || !isActiveRank) {
+        continue;
+      }
+      auto r = runTransfer(*transport, localReg, remoteReg, size, dir, config);
+      if (!r.ok) {
+        // Latched rather than returned: every remaining size has a barrier the
+        // peer is going to execute.
+        aborted = true;
+        continue;
+      }
+      auto stats = Stats::compute(std::move(r.latenciesUs));
+      results.push_back({
+          .benchmarkName = name(),
+          .transport = "tcp",
+          .direction = dir,
+          .messageSize = size,
+          .iterations = r.totalOps,
+          .batchSize = std::max(1, config.batchSize),
+          .txDepth = std::max(1, config.txDepth),
+          .chunkSize = config.chunkSize,
+          .bandwidthGBs = r.bandwidthGBs,
+          .latency = stats,
+          .messageRateMops = r.messageRateMops,
+      });
+      UNIFLOW_LOG_WARN(
+          "[rank {}] {} size={:<10} iface={} batch={:<3} txdepth={:<3} "
+          "iters={:<6} bw={:.2f} GB/s avg={:.1f} us {}",
+          bootstrap.rank,
+          dir,
+          size,
+          iface_,
+          std::max(1, config.batchSize),
+          std::max(1, config.txDepth),
+          r.totalOps,
+          r.bandwidthGBs,
+          stats.avg,
+          config.bidirectional ? "(bidirectional)" : "(unidirectional)");
+    }
+  };
+
+  if (config.direction == "put" || config.direction == "both") {
+    runDirection("put");
+  }
+  if (config.direction == "get" || config.direction == "both") {
+    runDirection("get");
+  }
+
+  if (!barrier(peers, bootstrap)) {
+    UNIFLOW_LOG_WARN("TcpBandwidthBenchmark: final barrier failed");
+  }
+  transport->shutdown();
+  return results;
+}
+
+} // namespace uniflow::benchmark

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h
@@ -1,0 +1,33 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "comms/uniflow/benchmarks/BenchmarkRunner.h"
+
+namespace uniflow::benchmark {
+
+/// Measures TCP transport put/get bandwidth across message sizes over a chosen
+/// front-end interface (default eth2). Single point-to-point connection; DRAM
+/// buffers, or VRAM staged through host memory inside the transport.
+class TcpBandwidthBenchmark : public Benchmark {
+ public:
+  explicit TcpBandwidthBenchmark(std::string iface)
+      : iface_(std::move(iface)) {}
+
+  std::string name() const override {
+    return "tcp_bandwidth";
+  }
+
+  std::vector<BenchmarkResult> run(
+      const BenchmarkConfig& config,
+      std::vector<PeerConnection>& peers,
+      const BootstrapConfig& bootstrap) override;
+
+ private:
+  std::string iface_;
+};
+
+} // namespace uniflow::benchmark

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -14,6 +14,7 @@
 #include "comms/uniflow/benchmarks/Reporter.h"
 #include "comms/uniflow/benchmarks/bench/RdmaBandwidthBenchmark.h"
 #include "comms/uniflow/benchmarks/bench/SendRecvBandwidthBenchmark.h"
+#include "comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h"
 #include "comms/uniflow/logging/Logger.h"
 
 // ConnectionSetup/NVLink/NcclSendRecv benchmarks are NVIDIA-only (they depend
@@ -53,12 +54,14 @@ struct CliOptions {
   std::vector<std::vector<std::string>> gpuNicGroups;
   bool bidirectional{false};
   bool dataDirect{false};
+  bool noVerify{false};
   std::vector<int> numStreams{1, 2, 4, 8};
   std::string topology{"fanout"};
   int pipelineDepth{2};
   size_t slabSize{0};
   int slabNum{0};
   std::vector<std::string> rdmaDevices;
+  std::string tcpIface{"eth2"};
 };
 
 std::vector<int> parseIntList(const std::string& s) {
@@ -122,18 +125,20 @@ void printUsage(const char* prog) {
       << "\n"
       << "Options:\n"
       << "  --benchmark <name>     Benchmark to run (default: all)\n"
-      << "  --transport <type>     Transport backend: nvlink|rdma (default: nvlink)\n"
+      << "  --transport <type>     Transport backend: nvlink|rdma|tcp (default: nvlink)\n"
       << "  --min-size <bytes>     Minimum message size (default: 1)\n"
       << "  --max-size <bytes>     Maximum message size (default: 1073741824)\n"
       << "  --iterations <n>       Iterations per size (default: 100)\n"
       << "  --warmup <n>           Warmup iterations (default: 10)\n"
       << "  --loop-count <n>       Transport calls per timed iteration (default: 1)\n"
       << "  --bidirectional        Both ranks transfer simultaneously (default: unidirectional)\n"
+      << "  --no-verify            Skip the pre-timing correctness sweep (tcp_bandwidth)\n"
       << "  --direction <dir>      put|get|both (default: both)\n"
       << "  --num-streams <list>   Comma-separated stream counts (default: 1,2,4,8)\n"
       << "  --output <path>        CSV output file path\n"
       << "  --format <fmt>         table|csv|both (default: table)\n"
       << "  --rdma-devices <list>  Comma-separated RDMA device names (default: auto-discover)\n"
+      << "  --tcp-iface <name>     Front-end interface for the TCP transport (default: eth2)\n"
       << "  --batch-size <n>       Number of requests per transport call (default: 1)\n"
       << "  --tx-depth <n>         Outstanding transport calls before waiting (default: 1)\n"
       << "  --num-nics <n>         Cap number of NICs to use (default: 0 = all)\n"
@@ -187,6 +192,8 @@ CliOptions parseArgs(int argc, char** argv) {
       {"data-direct", no_argument, nullptr, 263},
       {"cuda-devices", required_argument, nullptr, 264},
       {"gpu-nics", required_argument, nullptr, 265},
+      {"tcp-iface", required_argument, nullptr, 266},
+      {"no-verify", no_argument, nullptr, 267},
       {"list", no_argument, nullptr, 'l'},
       {"help", no_argument, nullptr, 'h'},
       {nullptr, 0, nullptr, 0},
@@ -250,11 +257,17 @@ CliOptions parseArgs(int argc, char** argv) {
       case 263:
         opts.dataDirect = true;
         break;
+      case 267:
+        opts.noVerify = true;
+        break;
       case 264:
         opts.cudaDevices = parseIntList(optarg);
         break;
       case 265:
         opts.gpuNicGroups = parseNicGroups(optarg);
+        break;
+      case 266:
+        opts.tcpIface = optarg;
         break;
       case 'd':
         opts.direction = optarg;
@@ -405,6 +418,9 @@ int main(int argc, char** argv) {
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::RdmaBandwidthBenchmark>(
           opts.rdmaDevices));
+  runner.registerBenchmark(
+      std::make_unique<uniflow::benchmark::TcpBandwidthBenchmark>(
+          opts.tcpIface));
 #ifndef __HIP_PLATFORM_AMD__
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::ConnectionSetupBenchmark>());
@@ -444,6 +460,7 @@ int main(int argc, char** argv) {
   config.loopCount = opts.loopCount;
   config.bidirectional = opts.bidirectional;
   config.dataDirect = opts.dataDirect;
+  config.verify = !opts.noVerify;
   config.direction = opts.direction;
   config.batchSize = opts.batchSize;
   config.txDepth = opts.txDepth;

--- a/comms/uniflow/benchmarks/run_mast_benchmarks.py
+++ b/comms/uniflow/benchmarks/run_mast_benchmarks.py
@@ -1,6 +1,47 @@
 #!/usr/bin/env python3
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
+"""Build the uniflow disagg-serving fbpkg, launch MAST jobs, poll, and gate.
+
+NVIDIA (default): host_type=grandteton_80g_roce (H100), package
+`uniflow_disagg_bench_mast`.
+
+AMD (MI350X / gfx950) -- DRAFT: use the ROCm fbpkg + an AMD MAST host/cluster:
+
+    run_mast_benchmarks.py \\
+        --target fbcode//comms/uniflow/benchmarks:uniflow_disagg_bench_mast_mi350 \\
+        --host-type t20_gtt_mi350x_8 \\
+        --hpc-cluster-uuid MastProdCluster \\
+        --rm-attribution ai_infra_training_rnd_amd \\
+        --hpc-identity networkai_comms_tools \\
+        --model-type-name infra_benchmarking_unibench \\
+        --hpc-job-oncall hpc_comms_lib \\
+        --locality-constraints "region;maz" \\
+        --layout cn --connector uniflow
+
+AMD notes:
+  * Values verified against a real MI350X MAST job (unibench run
+    uni_1785210828_...): cluster MastProdCluster; entitlement == rm_attribution
+    == ai_infra_training_rnd_amd (tenantPath
+    root/cfp/ai_rnd/ai_systems_rnd/ai_infra_training_rnd_tc/ai_infra_training_rnd_amd);
+    hpc_identity networkai_comms_tools; model_type_name infra_benchmarking_unibench;
+    oncall hpc_comms_lib; region maz. Set the extra fields via --rm-attribution /
+    --hpc-identity / --model-type-name / --hpc-job-oncall as needed.
+  * host_type is the torchx named resource t20_gtt_mi350x_8 (8-GPU MI350X RoCE
+    node) -- NOT the capacity SKU t20_gt_mi350x_roce (torchx rejects it) and NOT
+    the t16_gti_mi350x inference SKU (no RDMA backend NICs).
+  * --gpu-memory-utilization defaults to 0.5 on MI350X/MI300 host types (288GB
+    GPUs OOM at the NVIDIA 0.9 default); pass it explicitly to override.
+  * There is no torchx "entitlement" scheduler arg -- the AMD pool is selected
+    via --rm-attribution ai_infra_training_rnd_amd.
+  * Prefer --layout cn (cross-node): it rides the RDMA transport, which is
+    ROCm-ready. Single-node (sn) has no landed intra-node fast path on AMD
+    (NVLink is NVIDIA-only; XGMI P2P is unlanded), so it falls back to RDMA/TCP.
+  * The CUDA-centric env (PYTORCH_CUDA_ALLOC_CONF, TORCH_NCCL_*) maps to the
+    RCCL path under vLLM's ROCm runtime; adjust only if a run needs
+    RCCL-specific tuning.
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -283,6 +324,7 @@ class MastConfig:
     job_timeout_sec: int
     progress_idle_timeout_sec: int
     progress_check_interval_sec: int
+    kv_transport: str = "rdma"
 
     @property
     def scheduler_args(self) -> str:
@@ -308,6 +350,10 @@ class MastConfig:
             "PROCESS_MEMORY_AUTO_MEASUREMENT": "1",
             "TORCH_NCCL_ASYNC_ERROR_HANDLING": "1",
         }
+        # Steer the uniflow connector onto a specific KV transport (rdma default;
+        # tcp is host-staged for VRAM). Read by uniflow_connector.py.
+        if self.kv_transport and self.kv_transport != "rdma":
+            values["UNIFLOW_KV_TRANSPORT"] = self.kv_transport
         return ",".join(f"{key}={value}" for key, value in values.items())
 
 
@@ -1576,13 +1622,15 @@ class FbpkgBuilder:
 
     @staticmethod
     def _extract_package(lines: Sequence[str]) -> str:
-        pattern = re.compile(r"\b(uniflow_disagg_bench_mast:[0-9a-f]{32})\b")
+        # Match the NVIDIA package `uniflow_disagg_bench_mast` and arch-suffixed
+        # variants (e.g. `uniflow_disagg_bench_mast_mi350`).
+        pattern = re.compile(r"\b(uniflow_disagg_bench_mast[a-z0-9_]*:[0-9a-f]{32})\b")
         for line in reversed(lines):
             match = pattern.search(line)
             if match:
                 return match.group(1)
         raise RuntimeError(
-            "Unable to find `uniflow_disagg_bench_mast:<hash>` in fbpkg output"
+            "Unable to find `uniflow_disagg_bench_mast[<arch>]:<hash>` in fbpkg output"
         )
 
 
@@ -2222,7 +2270,7 @@ def parse_args() -> argparse.Namespace:
             "performance mode. Defaults to the selected profile value."
         ),
     )
-    parser.add_argument("--gpu-memory-utilization", type=float, default=0.9)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=None)
     parser.add_argument("--mode")
     parser.add_argument("--timeout", type=int)
     parser.add_argument(
@@ -2242,6 +2290,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--locality-constraints", default="region;eag")
     parser.add_argument("--model-type-name", default="gen_ai_default")
     parser.add_argument("--opec-tag", default="DEDICATED_ONLY")
+    parser.add_argument(
+        "--kv-transport",
+        choices=["rdma", "tcp"],
+        default="rdma",
+        help=(
+            "KV-transfer transport for the uniflow connector (default: rdma). "
+            "tcp host-stages VRAM and is slower; used to validate the TCP path."
+        ),
+    )
     parser.add_argument(
         "--presto-identity", default="svc:chronos_secgrp_networkai_mast_job_identity"
     )
@@ -2467,6 +2524,14 @@ def profile_value(args: argparse.Namespace, profile: BenchmarkProfile, name: str
     return value if value is not None else getattr(profile, name)
 
 
+def _resolve_gpu_mem_util(args: argparse.Namespace) -> float:
+    if args.gpu_memory_utilization is not None:
+        return args.gpu_memory_utilization
+    # 288GB MI350X/MI300 GPUs OOM at the NVIDIA 0.9 default; use a lower default.
+    host = args.host_type.lower()
+    return 0.5 if ("mi350" in host or "mi300" in host) else 0.9
+
+
 def make_workload(args: argparse.Namespace, profile: BenchmarkProfile) -> Workload:
     return Workload(
         model=args.model,
@@ -2477,7 +2542,7 @@ def make_workload(args: argparse.Namespace, profile: BenchmarkProfile) -> Worklo
         num_prompts=profile_value(args, profile, "num_prompts"),
         output_len=profile_value(args, profile, "output_len"),
         concurrency=profile_value(args, profile, "concurrency"),
-        gpu_memory_utilization=args.gpu_memory_utilization,
+        gpu_memory_utilization=_resolve_gpu_mem_util(args),
         mode=profile_value(args, profile, "mode"),
         timeout=profile_value(args, profile, "timeout"),
         validate_performance_outputs=args.validate_performance_outputs,
@@ -2523,6 +2588,7 @@ def main() -> int:
         model_type_name=args.model_type_name,
         opec_tag=args.opec_tag,
         host_type=args.host_type,
+        kv_transport=args.kv_transport,
         presto_identity=args.presto_identity,
         poll_interval_sec=args.poll_interval_sec,
         job_timeout_sec=profile_value(args, profile, "job_timeout_sec"),

--- a/comms/uniflow/controller/Controller.h
+++ b/comms/uniflow/controller/Controller.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <atomic>
+#include <cstdint>
 #include <future>
 #include <memory>
 #include <span>
@@ -47,6 +49,38 @@ class Conn {
   /// Called by Connection::shutdown() to release whatever thread is parked in
   /// recv(); that thread belongs to the caller, not to Connection.
   virtual void close() {}
+
+  /// Splits recv() time into "waiting for the next frame to start" and
+  /// "draining a frame that has started". For a length-prefixed stream those
+  /// are the block on the length prefix and the block on the payload, which is
+  /// the only place the two can be told apart -- above this layer a recv() is
+  /// one opaque wait.
+  ///
+  /// headerWaitNs is a first-byte latency: for a get it covers the network
+  /// round trip plus everything the peer did before it started replying, so it
+  /// separates "the remote is slow" from "our drain is slow". Relaxed atomics,
+  /// written only by the reader thread; a torn read across a reset costs a
+  /// misattributed sample, never correctness.
+  struct RecvPhaseStats {
+    std::atomic<uint64_t> headerWaitNs{0};
+    std::atomic<uint64_t> payloadDrainNs{0};
+    std::atomic<uint64_t> frames{0};
+    std::atomic<uint64_t> payloadBytes{0};
+
+    void reset() {
+      headerWaitNs.store(0, std::memory_order_relaxed);
+      payloadDrainNs.store(0, std::memory_order_relaxed);
+      frames.store(0, std::memory_order_relaxed);
+      payloadBytes.store(0, std::memory_order_relaxed);
+    }
+  };
+
+  RecvPhaseStats& recvPhaseStats() {
+    return recvPhaseStats_;
+  }
+
+ private:
+  RecvPhaseStats recvPhaseStats_;
 };
 
 class Server {

--- a/comms/uniflow/controller/TcpController.cpp
+++ b/comms/uniflow/controller/TcpController.cpp
@@ -532,12 +532,19 @@ Result<size_t> TcpConn<IOPolicy>::syncRecv(std::vector<uint8_t>& data) {
     return Err(ErrCode::NotConnected, "Socket is not connected");
   }
 
+  // Split the wait: blocking on the length prefix is first-byte latency,
+  // blocking on the payload is drain time. Two clock reads per frame (~20ns
+  // each) against a frame that takes hundreds of microseconds.
+  auto& stats = recvPhaseStats();
+  const auto tStart = std::chrono::steady_clock::now();
+
   uint32_t rawLen = 0;
   if (!recvAll(&rawLen, sizeof(rawLen))) {
     return Err(
         ErrCode::ConnectionFailed,
         "recv header failed: " + std::system_category().message(errno));
   }
+  const auto tFirstByte = std::chrono::steady_clock::now();
 
   uint32_t len = ntohl(rawLen);
   if (len > kMaxMessageSize) {
@@ -554,6 +561,17 @@ Result<size_t> TcpConn<IOPolicy>::syncRecv(std::vector<uint8_t>& data) {
         ErrCode::ConnectionFailed,
         "recv payload failed: " + std::system_category().message(errno));
   }
+
+  const auto tDone = std::chrono::steady_clock::now();
+  using ns = std::chrono::nanoseconds;
+  stats.headerWaitNs.fetch_add(
+      std::chrono::duration_cast<ns>(tFirstByte - tStart).count(),
+      std::memory_order_relaxed);
+  stats.payloadDrainNs.fetch_add(
+      std::chrono::duration_cast<ns>(tDone - tFirstByte).count(),
+      std::memory_order_relaxed);
+  stats.frames.fetch_add(1, std::memory_order_relaxed);
+  stats.payloadBytes.fetch_add(len, std::memory_order_relaxed);
 
   UNIFLOW_LOG_DEBUG("TcpConn::recv: fd={} bytes={}", sock_, len);
   return static_cast<size_t>(len);

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -1185,6 +1185,60 @@ void TcpTransport::senderLoop() noexcept {
   }
 }
 
+// Logs the get-path phase split and zeroes it, so a caller can bracket one
+// measurement. Reports the reader's own view: time blocked waiting for a frame
+// to start (first-byte latency -- network plus whatever the peer did before
+// replying), time draining a frame once started, and time in the copy to the
+// caller's destination. Anything unaccounted for is reader-thread work between
+// those points.
+void TcpTransport::logAndResetPhaseStats(std::string_view label) {
+  if (dataConn_ == nullptr) {
+    return;
+  }
+  auto& rs = dataConn_->recvPhaseStats();
+  const uint64_t frames = rs.frames.load(std::memory_order_relaxed);
+  const uint64_t hdrNs = rs.headerWaitNs.load(std::memory_order_relaxed);
+  const uint64_t drainNs = rs.payloadDrainNs.load(std::memory_order_relaxed);
+  const uint64_t bytes = rs.payloadBytes.load(std::memory_order_relaxed);
+  const uint64_t copyNs = dstCopyNs_.load(std::memory_order_relaxed);
+  const uint64_t copies = dstCopyCount_.load(std::memory_order_relaxed);
+
+  if (frames == 0) {
+    UNIFLOW_LOG_INFO("tcp phases [{}]: no frames", label);
+  } else {
+    const double totalNs =
+        static_cast<double>(hdrNs) + static_cast<double>(drainNs);
+    const auto pct = [totalNs](uint64_t v) {
+      return totalNs > 0.0 ? 100.0 * static_cast<double>(v) / totalNs : 0.0;
+    };
+    // Drain throughput is bytes/drainNs: what the socket managed while a frame
+    // was actually in flight, with the inter-frame stall excluded. Comparing it
+    // to end-to-end bandwidth says whether the gap is on the wire or between
+    // frames.
+    const double drainGBps = drainNs > 0
+        ? static_cast<double>(bytes) / static_cast<double>(drainNs)
+        : 0.0;
+    UNIFLOW_LOG_INFO(
+        "tcp phases [{}]: frames={} bytes={} | first-byte {:.1f}us/frame "
+        "({:.1f}%) | drain {:.1f}us/frame ({:.1f}%, {:.2f} GB/s) | dstcopy "
+        "{:.1f}us x{} ({:.1f}% of wire)",
+        label,
+        frames,
+        bytes,
+        static_cast<double>(hdrNs) / frames / 1000.0,
+        pct(hdrNs),
+        static_cast<double>(drainNs) / frames / 1000.0,
+        pct(drainNs),
+        drainGBps,
+        copies > 0 ? static_cast<double>(copyNs) / copies / 1000.0 : 0.0,
+        copies,
+        pct(copyNs));
+  }
+  rs.reset();
+  dstCopyNs_.store(0, std::memory_order_relaxed);
+  dstCopyCount_.store(0, std::memory_order_relaxed);
+}
+
 void TcpTransport::readerLoop() noexcept {
   // Hoisted so a steady stream of same-size frames stops reallocating: recv()
   // resize()s this to the frame length, and resizing to the size it already has
@@ -1441,16 +1495,25 @@ void TcpTransport::handleFrameImpl(std::span<const uint8_t> frame) {
           if (header.len == 0 || entry.dst == nullptr) {
             return Ok();
           }
+          const auto tCopyStart = std::chrono::steady_clock::now();
+          Status st = Ok();
           if (entry.memType == MemoryType::VRAM) {
-            return deviceFromHost(
+            st = deviceFromHost(
                 entry.dst,
                 payload.data(),
                 header.len,
                 entry.deviceId,
                 entry.stream);
+          } else {
+            std::memcpy(entry.dst, payload.data(), header.len);
           }
-          std::memcpy(entry.dst, payload.data(), header.len);
-          return Ok();
+          dstCopyNs_.fetch_add(
+              std::chrono::duration_cast<std::chrono::nanoseconds>(
+                  std::chrono::steady_clock::now() - tCopyStart)
+                  .count(),
+              std::memory_order_relaxed);
+          dstCopyCount_.fetch_add(1, std::memory_order_relaxed);
+          return st;
         });
       } else { // Ack
         entry.state->completeOne();

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -1186,8 +1186,20 @@ void TcpTransport::senderLoop() noexcept {
 }
 
 void TcpTransport::readerLoop() noexcept {
+  // Hoisted so a steady stream of same-size frames stops reallocating: recv()
+  // resize()s this to the frame length, and resizing to the size it already has
+  // neither reallocates nor value-initializes, so the per-frame malloc, 4 MiB
+  // zero-fill, and free all disappear once capacity settles at the high-water
+  // mark. Worth ~8% at 512 MiB and ~14% at 1 GiB on a 200G front-end link.
+  //
+  // Safe only because every frame is fully consumed before handleFrame()
+  // returns: the ReadReply path copies out under writeAndComplete(), and
+  // deviceFromHost() synchronizes its stream. If the H2D copy is ever made
+  // truly async, the reader would overwrite this buffer while a DMA is still
+  // sourcing from it; such a change must stage the payload in storage that
+  // outlives the frame rather than reading it from here.
+  std::vector<uint8_t> msg;
   while (running_.load(std::memory_order_acquire)) {
-    std::vector<uint8_t> msg;
     auto result = dataConn_->recv(msg).get();
     if (!result) {
       // Connection closed, errored, or idle-timed-out; stop reading.

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -329,16 +329,7 @@ std::future<Status> TcpTransport::put(
   // flush it and a Write the peer has applied cannot be recalled. A bail from
   // the middle of the send loop therefore reports failure to the caller while a
   // partial write has landed remotely, with nothing telling the peer about it.
-  struct PlannedRequest {
-    uint64_t segId{0};
-    uint64_t baseOffset{0};
-    const uint8_t* src{nullptr};
-    size_t len{0};
-    bool vram{false};
-    int deviceId{-1};
-  };
-  std::vector<PlannedRequest> planned;
-  planned.reserve(requests.size());
+  std::vector<PlannedPutFrame> planned;
   std::vector<PlannedChunk> chunks;
 
   for (const auto& req : requests) {
@@ -365,23 +356,26 @@ std::future<Status> TcpTransport::put(
         return future;
       }
     }
-    planned.push_back(
-        PlannedRequest{
-            remoteHandle.value()->segId(),
-            static_cast<uint64_t>(req.remote.remoteOffset_),
-            static_cast<const uint8_t*>(req.local.data()),
-            len,
-            vram,
-            deviceId});
+    const auto segId = remoteHandle.value()->segId();
+    const auto baseOffset = static_cast<uint64_t>(req.remote.remoteOffset_);
+    const auto* src = static_cast<const uint8_t*>(req.local.data());
 
     size_t off = 0;
     do {
       const size_t chunk = std::min(kMaxChunkSize, len - off);
+      const uint64_t reqId = nextReqId_.fetch_add(1, std::memory_order_relaxed);
       chunks.push_back(
           PlannedChunk{
-              nextReqId_.fetch_add(1, std::memory_order_relaxed),
+              reqId, chunk, TcpInflight{state, nullptr, chunk, false}});
+      planned.push_back(
+          PlannedPutFrame{
+              reqId,
+              segId,
+              baseOffset + off,
+              src + off,
               chunk,
-              TcpInflight{state, nullptr, chunk, false}});
+              vram,
+              deviceId});
       off += chunk;
     } while (off < len);
   }
@@ -395,53 +389,146 @@ std::future<Status> TcpTransport::put(
 
   // Commit. Only a genuine staging error or transport teardown remains
   // reachable, and both abandon the reservations for frames never queued.
-  size_t chunkIdx = 0;
-  for (const auto& req : planned) {
-    size_t off = 0;
-    do {
-      const uint64_t reqId = chunks[chunkIdx].reqId;
-      const size_t chunk = chunks[chunkIdx].len;
-      ++chunkIdx;
-      std::vector<uint8_t> frame(sizeof(TcpMsgHeader) + chunk);
+  //
+  // VRAM chunks are staged and queued in waves rather than one at a time. A
+  // per-chunk commit puts each Write in the queue as soon as its own copy
+  // finishes, so a copy that fails partway through a transfer leaves the peer
+  // holding the chunks that went before it -- a partial write at offsets the
+  // caller is never told about, and one the peer has no way to notice. A wave
+  // is queued only once every copy in it has succeeded.
+  void* stream = options.stream.has_value()
+      ? static_cast<void*>(options.stream.value())
+      : nullptr;
+  size_t idx = 0;
+  while (idx < planned.size()) {
+    const auto& first = planned[idx];
+    if (!first.vram || first.len == 0) {
+      // A host memcpy cannot fail and cannot park this thread, so there is
+      // nothing to stage and nothing a wave would protect.
+      std::vector<uint8_t> frame(sizeof(TcpMsgHeader) + first.len);
       TcpMsgHeader header;
       header.op = static_cast<uint8_t>(TcpOp::Write);
-      header.reqId = reqId;
-      header.segId = req.segId;
-      header.offset = req.baseOffset + off;
-      header.len = static_cast<uint64_t>(chunk);
+      header.reqId = first.reqId;
+      header.segId = first.segId;
+      header.offset = first.offset;
+      header.len = static_cast<uint64_t>(first.len);
       std::memcpy(frame.data(), &header, sizeof(header));
-      if (chunk > 0) {
-        Status st = Ok();
-        if (req.vram) {
-          st = hostFromDevice(
-              frame.data() + sizeof(header),
-              req.src + off,
-              chunk,
-              req.deviceId,
-              options.stream.has_value()
-                  ? static_cast<void*>(options.stream.value())
-                  : nullptr);
-        } else {
-          std::memcpy(frame.data() + sizeof(header), req.src + off, chunk);
-        }
-        if (!st) {
-          abandonInflight(chunks, chunkIdx - 1);
-          state->fail(std::move(st));
-          return future;
-        }
+      if (first.len > 0) {
+        std::memcpy(frame.data() + sizeof(header), first.src, first.len);
       }
       if (!enqueueFrame(std::move(frame), /*mayBlock=*/true)) {
-        abandonInflight(chunks, chunkIdx - 1);
+        abandonInflight(chunks, idx);
         state->fail(
             Err(ErrCode::NotConnected,
                 "tcp put: transport closed before the write was queued"));
         return future;
       }
-      off += chunk;
-    } while (off < req.len);
+      ++idx;
+      continue;
+    }
+
+    size_t waveEnd = idx;
+    while (waveEnd < planned.size() && planned[waveEnd].vram &&
+           planned[waveEnd].len > 0 && waveEnd - idx < kMaxPutWaveChunks) {
+      ++waveEnd;
+    }
+    auto staged = stagePutWave(
+        std::span<const PlannedPutFrame>(planned).subspan(idx, waveEnd - idx),
+        stream);
+    if (!staged) {
+      abandonInflight(chunks, idx);
+      state->fail(std::move(staged).error());
+      return future;
+    }
+    if (!enqueueFrames(std::move(staged).value(), /*mayBlock=*/true)) {
+      abandonInflight(chunks, idx);
+      state->fail(
+          Err(ErrCode::NotConnected,
+              "tcp put: transport closed before the write was queued"));
+      return future;
+    }
+    idx = waveEnd;
   }
 
   return future;
+}
+
+Result<std::vector<TcpFrame>> TcpTransport::stagePutWave(
+    std::span<const PlannedPutFrame> wave,
+    void* stream) {
+  auto pool = stagingPool();
+  if (!pool) {
+    return std::move(pool).error();
+  }
+  // All-or-nothing, and this thread holds no slab while it waits: a caller that
+  // took what was free and waited for the rest would deadlock against another
+  // doing the same.
+  auto leases = pool.value()->acquire(wave.size());
+  if (!leases) {
+    return std::move(leases).error();
+  }
+
+  auto s = static_cast<cudaStream_t>(stream);
+  std::vector<TcpFrame> frames;
+  frames.reserve(wave.size());
+  // Devices whose copies were launched, so the wait below covers each of them
+  // once. A bare synchronize would only cover whichever device happened to be
+  // current, leaving copies on any other still running.
+  std::vector<int> launchedDevices;
+  Status staging = Ok();
+  for (size_t i = 0; i < wave.size(); ++i) {
+    const auto& chunk = wave[i];
+    TcpMsgHeader header;
+    header.op = static_cast<uint8_t>(TcpOp::Write);
+    header.reqId = chunk.reqId;
+    header.segId = chunk.segId;
+    header.offset = chunk.offset;
+    header.len = static_cast<uint64_t>(chunk.len);
+    // The frame owns the slab from here on, so every path out of this function
+    // returns it exactly once.
+    frames.emplace_back(
+        std::move(leases.value()[i]), sizeof(TcpMsgHeader) + chunk.len);
+    std::memcpy(frames.back().mutableData(), &header, sizeof(header));
+    try {
+      CudaDeviceGuard guard(*cudaApi_, chunk.deviceId);
+      staging = cudaApi_->memcpyAsync(
+          frames.back().mutableData() + sizeof(TcpMsgHeader),
+          chunk.src,
+          chunk.len,
+          cudaMemcpyDeviceToHost,
+          s);
+    } catch (const std::exception& e) {
+      staging =
+          Err(ErrCode::InvalidArgument,
+              "tcp put: VRAM staging needs a selectable deviceId, got " +
+                  std::to_string(chunk.deviceId) + ": " + e.what());
+    }
+    if (!staging) {
+      break;
+    }
+    if (std::find(
+            launchedDevices.begin(), launchedDevices.end(), chunk.deviceId) ==
+        launchedDevices.end()) {
+      launchedDevices.push_back(chunk.deviceId);
+    }
+  }
+  // One wait per wave rather than one per chunk: the copies are already in
+  // flight together, and waiting on each in turn is what serialised staging
+  // against itself.
+  for (auto deviceId : launchedDevices) {
+    try {
+      CudaDeviceGuard guard(*cudaApi_, deviceId);
+      if (auto st = cudaApi_->streamSynchronize(s); !st && staging) {
+        staging = std::move(st);
+      }
+    } catch (const std::exception&) {
+      // The device is already unusable; there is nothing left to wait for.
+    }
+  }
+  if (!staging) {
+    return std::move(staging).error();
+  }
+  return frames;
 }
 
 std::future<Status> TcpTransport::get(

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -28,10 +28,6 @@ constexpr int kDefaultHandshakeTimeoutSeconds = 30;
 
 namespace {
 
-// The controller frames each TcpConn message with a 4-byte length and caps it
-// at 64 MiB; keep each chunk (header + payload) safely under that so large
-// put/get transfers are split across multiple frames.
-constexpr size_t kMaxChunkSize = 4u << 20; // 4 MiB
 std::vector<uint8_t> makeHeaderFrame(TcpOp op, uint64_t reqId) {
   TcpMsgHeader header;
   header.op = static_cast<uint8_t>(op);
@@ -528,16 +524,64 @@ std::future<Status> TcpTransport::get(
   return future;
 }
 
-Status TcpTransport::stageReadReply(
-    std::vector<uint8_t> frame,
-    TcpSegmentRegistry::Lease lease,
-    const void* src,
-    size_t len,
-    int deviceId,
-    uint64_t reqId) {
+Result<std::shared_ptr<TcpPinnedSlabPool>> TcpTransport::stagingPool() {
+  std::lock_guard<std::mutex> lk(poolMu_);
+  if (slabPool_ != nullptr) {
+    return slabPool_;
+  }
   if (cudaApi_ == nullptr) {
     return Err(ErrCode::InvalidArgument, "tcp read: no CUDA API for VRAM");
   }
+  // Header and payload contiguous in one slab, so a staged frame is still a
+  // single buffer and the send path needs no scatter-gather.
+  auto pool = TcpPinnedSlabPool::create(
+      cudaApi_,
+      sizeof(TcpMsgHeader) + kMaxChunkSize,
+      kStagingSlabCount,
+      kStagingSlabsReservedForReader);
+  if (!pool) {
+    return std::move(pool).error();
+  }
+  slabPool_ = pool.value();
+  return slabPool_;
+}
+
+Status TcpTransport::respondToVramRead(
+    const TcpMsgHeader& replyHeader,
+    TcpSegmentRegistry::Lease lease) {
+  // A same-version peer chunks at kMaxChunkSize, so this only rejects a
+  // version-skewed peer built with a larger one. Per request, because the
+  // sender treats an oversized send as fatal and would take every unrelated
+  // transfer on the connection down with it.
+  if (replyHeader.len > kMaxChunkSize) {
+    return Err(
+        ErrCode::InvalidArgument,
+        "tcp read: VRAM read of " + std::to_string(replyHeader.len) +
+            " bytes exceeds the staging slab payload (" +
+            std::to_string(kMaxChunkSize) + ")");
+  }
+  auto pool = stagingPool();
+  if (!pool) {
+    return std::move(pool).error();
+  }
+  // Non-blocking, and allowed the reserved slab: this is the thread the reserve
+  // is held for, and it must not wait on anything.
+  auto slab = pool.value()->tryAcquire(/*allowReserved=*/true);
+  if (!slab) {
+    return deferReadReply(replyHeader, std::move(lease));
+  }
+  return startReadReply(replyHeader, std::move(lease), std::move(slab));
+}
+
+Status TcpTransport::startReadReply(
+    const TcpMsgHeader& replyHeader,
+    TcpSegmentRegistry::Lease lease,
+    TcpPinnedSlab slab) {
+  const int deviceId = lease->deviceId;
+  const void* src =
+      static_cast<const uint8_t*>(lease->ptr) + replyHeader.offset;
+  TcpFrame frame(std::move(slab), sizeof(TcpMsgHeader) + replyHeader.len);
+  std::memcpy(frame.mutableData(), &replyHeader, sizeof(replyHeader));
   cudaEvent_t event{};
   // Once the copy is enqueued, every way out of this function has to wait for
   // it. Returning an error unwinds `frame` and `lease`, and the copy is
@@ -548,10 +592,14 @@ Status TcpTransport::stageReadReply(
   bool copyIssued = false;
   try {
     CudaDeviceGuard guard(*cudaApi_, deviceId);
+    // Into pinned memory, so this returns once the copy is enqueued. The same
+    // call into a pageable destination -- a plain vector -- is specified to
+    // complete synchronously, which parks whichever thread issued it for the
+    // length of the transfer. On this path that thread is the reader.
     if (auto st = cudaApi_->memcpyAsync(
-            frame.data() + sizeof(TcpMsgHeader),
+            frame.mutableData() + sizeof(TcpMsgHeader),
             src,
-            len,
+            replyHeader.len,
             cudaMemcpyDeviceToHost,
             /*stream=*/nullptr);
         !st) {
@@ -584,10 +632,135 @@ Status TcpTransport::stageReadReply(
     std::lock_guard<std::mutex> lk(stagingMu_);
     pendingReplies_.push_back(
         PendingReadReply{
-            std::move(frame), std::move(lease), event, reqId, deviceId});
+            std::move(frame),
+            std::move(lease),
+            event,
+            replyHeader.reqId,
+            deviceId});
   }
   schedulePendingReplyPoll();
   return Ok();
+}
+
+Status TcpTransport::deferReadReply(
+    const TcpMsgHeader& replyHeader,
+    TcpSegmentRegistry::Lease lease) {
+  // The fourth admission point, and it has to agree with the other three about
+  // connBroken_. failAllPending() clears this queue precisely so a lease is not
+  // held "for as long as the transport object lives"; a reader that reaches
+  // here after that sweep would put one straight back, and nothing drains it
+  // again until drainPendingReadReplies() at teardown -- which is exactly the
+  // outcome the sweep exists to prevent. Refusing instead releases the lease as
+  // this returns, and the caller's Error frame to the peer is harmlessly
+  // refused by the same connBroken_ check on the enqueue path.
+  //
+  // Tested under stagingMu_, not before it, so the check and the push are one
+  // step against the sweep. failAllPending() runs them in the opposite order --
+  // it stores connBroken_ and only then takes stagingMu_ to swap the queue
+  // empty
+  // -- so a load outside the lock admits this interleaving, with senderLoop
+  // calling failAllPending() while the reader is still running:
+  //
+  //   reader: load connBroken_ -> false
+  //   sender: store connBroken_ = true; lock stagingMu_, swap empty
+  //   reader: lock stagingMu_, push entry
+  //
+  // That entry survives the sweep, and nothing kicks it again: senderLoop has
+  // returned, and the retirement path frees slabs without calling
+  // scheduleDeferredReadReplies(). Its lease then blocks erase() until the
+  // reader exits or teardown drains -- and a send failure does not close the
+  // connection, so nothing local bounds that. admitInflight() and
+  // admitInflightBulk() take their mutex first for the same reason.
+  {
+    std::lock_guard<std::mutex> lk(stagingMu_);
+    if (connBroken_.load(std::memory_order_acquire)) {
+      return Err(
+          ErrCode::NotConnected,
+          "tcp read: connection broken while deferring a VRAM read");
+    }
+    if (deferredReplies_.size() >= kMaxInflightRequests) {
+      return Err(
+          ErrCode::ResourceExhausted,
+          "tcp read: too many deferred VRAM reads (" +
+              std::to_string(deferredReplies_.size()) + ")");
+    }
+    deferredReplies_.push_back(
+        DeferredReadReply{
+            std::move(lease),
+            replyHeader.reqId,
+            replyHeader.segId,
+            replyHeader.offset,
+            replyHeader.len});
+  }
+  // Kicked on enqueue, not only where a slab is released.
+  //
+  // The caller reaches here because tryAcquire() just failed, and that failure
+  // and this enqueue are not one atomic step. A release landing in between --
+  // the sender retiring a frame, or the error path dropping one -- runs its own
+  // scheduleDeferredReadReplies() against a queue that is still empty and
+  // dispatches nothing, while its slab is now free. Without this kick the entry
+  // would wait for the *next* release, and on a connection that has gone idle
+  // there is no next release: the read never starts and its lease keeps erase()
+  // blocked. Redundant kicks are harmless -- startDeferredReadReplies()
+  // re-tests both the pool and the queue under the lock.
+  scheduleDeferredReadReplies();
+  return Ok();
+}
+
+void TcpTransport::scheduleDeferredReadReplies() {
+  {
+    std::lock_guard<std::mutex> lk(stagingMu_);
+    if (deferredReplies_.empty()) {
+      return;
+    }
+  }
+  evb_->dispatch([this]() noexcept { startDeferredReadReplies(); });
+}
+
+void TcpTransport::startDeferredReadReplies() {
+  auto pool = stagingPool();
+  if (!pool) {
+    return;
+  }
+  while (true) {
+    // The slab is taken before the entry, so an entry is never off the queue
+    // with nowhere to stage it. A slab that turns out not to be needed is
+    // released as this scope ends.
+    auto slab = pool.value()->tryAcquire(/*allowReserved=*/true);
+    if (!slab) {
+      return;
+    }
+    DeferredReadReply deferred;
+    {
+      std::lock_guard<std::mutex> lk(stagingMu_);
+      if (deferredReplies_.empty()) {
+        // Returning here releases the slab without using it, and deliberately
+        // does not reschedule. An entry queued between this test and that
+        // release is still covered, because deferReadReply() is the only
+        // producer and it kicks after every push, while this function runs only
+        // from evb_->dispatch() -- so that kick is serialized behind this
+        // invocation and sees the slab already back in the pool. A new producer
+        // that does not kick would reopen the window.
+        return;
+      }
+      deferred = std::move(deferredReplies_.front());
+      deferredReplies_.pop_front();
+    }
+    TcpMsgHeader replyHeader{};
+    replyHeader.op = static_cast<uint8_t>(TcpOp::ReadReply);
+    replyHeader.reqId = deferred.reqId;
+    replyHeader.segId = deferred.segId;
+    replyHeader.offset = deferred.offset;
+    replyHeader.len = deferred.len;
+    if (auto st = startReadReply(
+            replyHeader, std::move(deferred.lease), std::move(slab));
+        !st) {
+      UNIFLOW_LOG_ERROR(
+          "tcp read: deferred VRAM staging failed: {}", st.error().message());
+      (void)enqueueFrame(
+          makeHeaderFrame(TcpOp::Error, deferred.reqId), /*mayBlock=*/false);
+    }
+  }
 }
 
 void TcpTransport::schedulePendingReplyPoll() {
@@ -603,7 +776,7 @@ void TcpTransport::schedulePendingReplyPoll() {
 
 void TcpTransport::pollPendingReadReplies() {
   while (true) {
-    std::vector<uint8_t> ready;
+    TcpFrame ready;
     PendingReadReply failed;
     int failedDeviceId = -1;
     uint64_t failedReqId = 0;
@@ -661,11 +834,16 @@ void TcpTransport::pollPendingReadReplies() {
     } else if (haveFailure) {
       // Wait before `failed` goes out of scope, for the same reason
       // drainPendingReadReplies() waits: a copy that may still be running would
-      // otherwise be left writing into a freed buffer.
+      // otherwise be left writing into a slab the pool is about to hand to the
+      // next staging copy.
       waitForStagedCopy(failedDeviceId);
+      // Dropping it here releases the slab, so a deferred read may now be
+      // startable -- which is why this happens before the scheduling call
+      // below.
       failed = PendingReadReply{};
       (void)enqueueFrame(
           makeHeaderFrame(TcpOp::Error, failedReqId), /*mayBlock=*/false);
+      scheduleDeferredReadReplies();
     }
   }
 }
@@ -686,11 +864,15 @@ void TcpTransport::waitForStagedCopy(int deviceId) noexcept {
 
 void TcpTransport::drainPendingReadReplies() {
   std::deque<PendingReadReply> pending;
+  std::deque<DeferredReadReply> deferred;
   {
     std::lock_guard<std::mutex> lk(stagingMu_);
     pending.swap(pendingReplies_);
+    deferred.swap(deferredReplies_);
   }
   if (pending.empty()) {
+    // Deferred entries have no copy running, so dropping `deferred` here is all
+    // that is needed: their leases go with it and a waiting erase() proceeds.
     return;
   }
   // The device may still be writing into these frames. Freeing them now would
@@ -907,6 +1089,12 @@ void TcpTransport::senderLoop() noexcept {
     if (item.onSent) {
       item.onSent->completeOne();
     }
+    // Releases the frame's storage, and with it any staging slab, before the
+    // next wait. A deferred VRAM read may have been waiting on exactly this
+    // slab; dispatching the restart rather than running it here keeps device
+    // work off the thread whose only job is to keep the socket draining.
+    item = TcpOutItem{};
+    scheduleDeferredReadReplies();
   }
 }
 
@@ -1013,36 +1201,30 @@ void TcpTransport::handleFrameImpl(std::span<const uint8_t> frame) {
       } else if (
           entry && header.len <= entry->len &&
           header.offset <= entry->len - header.len) {
-        std::vector<uint8_t> reply(sizeof(TcpMsgHeader) + header.len);
         TcpMsgHeader replyHeader;
         replyHeader.op = static_cast<uint8_t>(TcpOp::ReadReply);
         replyHeader.reqId = header.reqId;
         replyHeader.segId = header.segId;
         replyHeader.offset = header.offset;
         replyHeader.len = header.len;
-        std::memcpy(reply.data(), &replyHeader, sizeof(replyHeader));
-        if (header.len > 0) {
-          const void* src =
-              static_cast<const uint8_t*>(entry->ptr) + header.offset;
-          if (entry->memType == MemoryType::VRAM) {
-            // Read before the lease is moved out.
-            const int deviceId = entry->deviceId;
-            // Staged rather than synchronous: the reply is queued once the copy
-            // signals. Waiting here would stop the reader draining the socket
-            // for the length of a device operation, and the lease it holds
-            // would stall any concurrent deregistration for just as long.
-            readStatus = stageReadReply(
-                std::move(reply),
-                std::move(entry),
-                src,
-                header.len,
-                deviceId,
-                header.reqId);
-          } else {
-            std::memcpy(reply.data() + sizeof(replyHeader), src, header.len);
-            (void)enqueueFrame(std::move(reply), /*mayBlock=*/false);
-          }
+        if (header.len > 0 && entry->memType == MemoryType::VRAM) {
+          // Staged into pinned memory rather than copied here: the reply is
+          // queued once the copy signals. Copying on this thread would stop the
+          // reader draining the socket for the length of a device operation,
+          // and the lease it holds would stall any concurrent deregistration
+          // for just as long.
+          readStatus = respondToVramRead(replyHeader, std::move(entry));
         } else {
+          // DRAM, or a zero-length read: a host memcpy cannot fail and cannot
+          // park the reader, so there is nothing to stage.
+          std::vector<uint8_t> reply(sizeof(TcpMsgHeader) + header.len);
+          std::memcpy(reply.data(), &replyHeader, sizeof(replyHeader));
+          if (header.len > 0) {
+            std::memcpy(
+                reply.data() + sizeof(replyHeader),
+                static_cast<const uint8_t*>(entry->ptr) + header.offset,
+                header.len);
+          }
           (void)enqueueFrame(std::move(reply), /*mayBlock=*/false);
         }
       } else {
@@ -1241,6 +1423,18 @@ void TcpTransport::failAllPending(const char* message) {
     outQueue_.clear();
     outBytes_ = 0;
   }
+  // Deferred reads will never be answered on a broken connection, and each one
+  // holds a lease. Dropped here rather than left for teardown so a
+  // deregistration is not blocked for as long as the transport object lives.
+  // pendingReplies_ is deliberately untouched: those have copies running, and
+  // freeing their frames now would hand the GPU memory the allocator has taken
+  // back. drainPendingReadReplies() waits for them.
+  std::deque<DeferredReadReply> deferred;
+  {
+    std::lock_guard<std::mutex> lk(stagingMu_);
+    deferred.swap(deferredReplies_);
+  }
+  deferred.clear();
   outCv_.notify_all(); // wake producers blocked for space so they see the break
   for (auto& state : toFail) {
     state->fail(Err(ErrCode::ConnectionFailed, message));

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -314,6 +314,18 @@ struct PlannedChunk {
   TcpInflight entry;
 };
 
+/// The same chunk resolved down to the addresses a Write frame needs. Built in
+/// put()'s pre-flight pass, so the commit pass has no decisions left to make.
+struct PlannedPutFrame {
+  uint64_t reqId{0};
+  uint64_t segId{0};
+  uint64_t offset{0};
+  const uint8_t* src{nullptr};
+  size_t len{0};
+  bool vram{false};
+  int deviceId{-1};
+};
+
 /// One outbound frame's storage: either a plain vector or a pinned staging
 /// slab. Move-only, because both kinds own the buffer the socket reads from and
 /// a slab additionally owns its place in the pool.
@@ -462,6 +474,23 @@ class TcpTransport : public Transport {
   TransportInfo bind() override;
   Status connect(std::span<const uint8_t> remoteInfo) override;
 
+  /// Writes the local spans into the peer's registered segments.
+  ///
+  /// What a failed put() promises about the peer's memory, and what it does
+  /// not:
+  ///
+  /// - A put of at most kMaxPutWaveChunks chunks -- 60 MiB of payload at the
+  ///   4 MiB chunk size, which covers the great majority of calls -- either
+  ///   queues every one of its frames or none of them. A host-staging failure
+  ///   queues nothing, so the peer's segment is untouched.
+  /// - A larger put is split into waves of that size, and the guarantee holds
+  /// per
+  ///   wave. A failure in wave N+1 can leave wave N applied on the peer, with
+  ///   nothing telling the peer which offsets those were.
+  /// - At every size this is staging-and-queue atomicity, not a remote
+  ///   transaction. Frames that reach the queue are frames the peer will apply;
+  ///   a connection that breaks mid-wave still leaves a partial write. Aborting
+  ///   at the wire level needs a protocol change, tracked in T285791201.
   std::future<Status> put(
       std::span<const TransferRequest> requests,
       const RequestOptions& options = {}) override;
@@ -564,6 +593,21 @@ class TcpTransport : public Transport {
       const TcpMsgHeader& replyHeader,
       TcpSegmentRegistry::Lease lease,
       TcpPinnedSlab slab);
+  // Stages one wave of VRAM Write frames: takes a slab per chunk, issues every
+  // copy, then waits for all of them. Returns the frames only if every copy
+  // succeeded, so the caller can queue the wave as one step and a failure
+  // queues nothing.
+  //
+  // Blocks until the pool can hand out the whole wave, so it must not be called
+  // holding outMu_ -- the thread that frees those slabs is the sender, and it
+  // needs that mutex to make progress.
+  //
+  // The wait covers every copy that was launched even when a later one fails. A
+  // slab handed back while the GPU is still writing into it goes straight to
+  // the next staging copy, and the two then race over the same bytes.
+  Result<std::vector<TcpFrame>> stagePutWave(
+      std::span<const PlannedPutFrame> wave,
+      void* stream);
   // Records a VRAM read to start once a slab frees up. Fails the request (the
   // caller answers with an Error frame) if the deferred queue is full: dropping
   // it silently would leave the peer waiting forever, and blocking here would
@@ -704,6 +748,11 @@ class TcpTransport : public Transport {
   // nothing to stage into. The responder is the side the peer is already
   // blocked on.
   static constexpr size_t kStagingSlabsReservedForReader = 1;
+  // Chunks staged, and so queued, as one indivisible wave. Everything put()
+  // promises about partial writes is bounded by this: a put of at most this
+  // many chunks either reaches the queue whole or not at all.
+  static constexpr size_t kMaxPutWaveChunks =
+      kStagingSlabCount - kStagingSlabsReservedForReader;
   // Bytes currently queued in outQueue_. Guarded by outMu_.
   size_t outBytes_{0};
 

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -11,6 +11,7 @@
 #include <mutex>
 #include <span>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -528,6 +529,13 @@ class TcpTransport : public Transport {
 
   // Reader thread: blocking recv + demultiplex until the connection closes.
   void readerLoop() noexcept;
+
+ public:
+  /// Logs the get-path phase split (first-byte / drain / destination copy) and
+  /// zeroes it so callers can bracket a single measurement.
+  void logAndResetPhaseStats(std::string_view label);
+
+ private:
   // Sender thread: drains outQueue_ and performs all socket sends.
   void senderLoop() noexcept;
   // Handles one fully-received inbound frame (reader thread).
@@ -701,6 +709,12 @@ class TcpTransport : public Transport {
 
   std::unique_ptr<controller::AsyncTcpServer> server_;
   std::unique_ptr<controller::Conn> dataConn_;
+
+  // get-path copy accounting, paired with Conn::RecvPhaseStats. Reader thread
+  // only; relaxed because a torn read across a reset misattributes a sample and
+  // nothing more.
+  std::atomic<uint64_t> dstCopyNs_{0};
+  std::atomic<uint64_t> dstCopyCount_{0};
 
   // Serialises bind()/connect()/shutdown(), which together own server_,
   // dataConn_, reader_ and sender_. Without it a shutdown() concurrent with an

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -112,6 +112,9 @@ struct TcpTransportInfo {
 };
 
 class CudaApi;
+// Wire header, defined in TcpWireProtocol.h. Only referenced by private member
+// declarations here, so this header stays free of the wire format.
+struct TcpMsgHeader;
 
 /// Factory-shared registry mapping a locally-assigned segment id to the
 /// registered host buffer. registerSegment() (on the factory) populates it;
@@ -225,16 +228,20 @@ class TcpSegmentRegistry {
   /// acquires mu_ while holding another transport mutex.
   ///
   /// How long this can block is bounded by the slowest lease holder, and on the
-  /// VRAM path that is not bounded by the transport. The reader queues its Ack
-  /// and reply frames without blocking, but it holds its lease across the whole
-  /// host-staging copy, and that copy ends in a synchronize on the null stream
+  /// VRAM path that is not bounded by the transport. A read reply's lease is
+  /// held across its staging copy, and that copy runs on the null stream
   /// (handleFrame passes no stream), which waits on every blocking stream on
-  /// the device -- i.e. on unrelated application GPU work. So a caller here can
-  /// wait for an application step, and deadlocks outright if that GPU work is
-  /// itself gated on a later inbound frame, since the parked reader is the
-  /// thread that would deliver it. Giving the staging copies a dedicated
-  /// non-blocking stream removes both; until then a DRAM-only deployment is the
-  /// safe case, because there the copy under lease is a plain memcpy.
+  /// the device -- so a caller here can wait for unrelated application GPU
+  /// work. A read that arrived with the staging pool exhausted holds its lease
+  /// for longer still: its copy has not been issued yet and starts only once a
+  /// slab frees up.
+  ///
+  /// What this can no longer do is deadlock. The reader thread does not wait
+  /// for any of it -- staging is asynchronous and exhaustion defers rather than
+  /// blocks -- so it keeps delivering inbound frames, including whatever the
+  /// application's GPU work is itself waiting on. Giving the staging copies a
+  /// dedicated non-blocking stream would remove the remaining wait on unrelated
+  /// device work.
   void erase(uint64_t segId) {
     std::unique_lock<std::mutex> lk(mu_);
     auto it = segs_.find(segId);
@@ -307,25 +314,6 @@ struct PlannedChunk {
   TcpInflight entry;
 };
 
-/// A ReadReply whose payload is still being copied out of VRAM. The frame is
-/// already built, header and all; only the staging copy into its payload is
-/// outstanding.
-///
-/// The lease lives here rather than on the reader thread. It has to outlive the
-/// copy, because it is what stops the owner deregistering and freeing the
-/// source buffer underneath the GPU, but nothing requires the reader to be the
-/// thread holding it. Moving it here is what lets the reader return to the
-/// socket immediately while the segment stays protected.
-struct PendingReadReply {
-  std::vector<uint8_t> frame;
-  TcpSegmentRegistry::Lease lease;
-  /// cudaEvent_t, kept opaque so this header does not need the CUDA runtime.
-  void* event{nullptr};
-  uint64_t reqId{0};
-  /// Needed at teardown to wait on the right device's stream.
-  int deviceId{-1};
-};
-
 /// One outbound frame's storage: either a plain vector or a pinned staging
 /// slab. Move-only, because both kinds own the buffer the socket reads from and
 /// a slab additionally owns its place in the pool.
@@ -374,6 +362,42 @@ class TcpFrame {
 struct TcpOutItem {
   TcpFrame frame;
   std::shared_ptr<TcpOpState> onSent;
+};
+
+/// A ReadReply whose payload is still being copied out of VRAM. The frame is
+/// already built, header and all, in a pinned staging slab; only the copy into
+/// its payload is outstanding.
+///
+/// The lease lives here rather than on the reader thread. It has to outlive the
+/// copy, because it is what stops the owner deregistering and freeing the
+/// source buffer underneath the GPU, but nothing requires the reader to be the
+/// thread holding it. Moving it here is what lets the reader return to the
+/// socket while the segment stays protected.
+struct PendingReadReply {
+  TcpFrame frame;
+  TcpSegmentRegistry::Lease lease;
+  /// cudaEvent_t, kept opaque so this header does not need the CUDA runtime.
+  void* event{nullptr};
+  uint64_t reqId{0};
+  /// Needed at teardown to wait on the right device's stream.
+  int deviceId{-1};
+};
+
+/// A VRAM ReadReply that has not been started because no staging slab was free.
+/// Everything needed to build and launch it later is here, so the reader can
+/// record it and go straight back to the socket.
+///
+/// The lease is held even though no copy has been issued yet. It is what keeps
+/// the source buffer registered, and the point of deferring rather than
+/// dropping is that this read will still be answered out of that same buffer. A
+/// deregistration therefore waits for the deferred copy to run, not only for
+/// the ones already launched.
+struct DeferredReadReply {
+  TcpSegmentRegistry::Lease lease;
+  uint64_t reqId{0};
+  uint64_t segId{0};
+  uint64_t offset{0};
+  size_t len{0};
 };
 
 /// A posted recv() awaiting a matching inbound SEND frame.
@@ -526,31 +550,56 @@ class TcpTransport : public Transport {
   // that exception would escape put() itself, abandoning the promise while
   // whatever was already queued still lands on the peer.
   Status validateDeviceForStaging(int deviceId);
-  // Starts the D2H copy for a ReadReply and hands the frame to the staging
-  // queue, so the reader thread can go back to draining the socket instead of
-  // waiting on the device. Consumes the lease. Returns an error only if the
-  // copy could not be started, in which case nothing was queued.
-  Status stageReadReply(
-      std::vector<uint8_t> frame,
+  // Answers one VRAM ReadRequest. Acquires a staging slab without waiting; if
+  // none is free the request is deferred rather than staged, so the reader is
+  // never parked on the pool. Consumes the lease.
+  Status respondToVramRead(
+      const TcpMsgHeader& replyHeader,
+      TcpSegmentRegistry::Lease lease);
+  // Builds the reply in `slab` and starts its D2H copy, handing the frame to
+  // the staging queue so the reader can go back to draining the socket instead
+  // of waiting on the device. Consumes the lease and the slab. Returns an error
+  // only if the copy could not be started, in which case nothing was queued.
+  Status startReadReply(
+      const TcpMsgHeader& replyHeader,
       TcpSegmentRegistry::Lease lease,
-      const void* src,
-      size_t len,
-      int deviceId,
-      uint64_t reqId);
+      TcpPinnedSlab slab);
+  // Records a VRAM read to start once a slab frees up. Fails the request (the
+  // caller answers with an Error frame) if the deferred queue is full: dropping
+  // it silently would leave the peer waiting forever, and blocking here would
+  // stop the reader draining the socket.
+  Status deferReadReply(
+      const TcpMsgHeader& replyHeader,
+      TcpSegmentRegistry::Lease lease);
+  // Starts as many deferred reads as there are free slabs, oldest first. Runs
+  // on the EventBase, never inline at the point a slab is released: that point
+  // is the sender thread, and launching copies there would block the drain that
+  // frees the next slab.
+  void startDeferredReadReplies();
+  // Kicks startDeferredReadReplies() on the EventBase. Called wherever a
+  // staging slab goes back to the pool. Cheap and safe when nothing is
+  // deferred.
+  void scheduleDeferredReadReplies();
+  // The staging pool, created on first use. Building it in the constructor
+  // would charge every peer ~64 MiB of pinned host memory -- there is one
+  // transport per peer -- including the DRAM-only peers that never stage at
+  // all.
+  Result<std::shared_ptr<TcpPinnedSlabPool>> stagingPool();
   // Retires staged replies whose copy has finished, oldest first. Runs on the
   // EventBase, never on the reader thread: polling from the reader would put
   // the head-of-line block straight back.
   void pollPendingReadReplies();
   // Kicks the poll loop if it is not already running. Safe from any thread.
   void schedulePendingReplyPoll();
-  // Waits for outstanding staging copies and drops the frames. Called during
-  // teardown, because the GPU may still be writing into a pending frame's
-  // payload and that memory must not be freed underneath it.
   /// Waits for a staged D2H copy on `deviceId` whose completion is otherwise
   /// unknown, so the frame it targets can be released. Used on the paths where
   /// a copy was issued but the event never became a usable completion signal.
   void waitForStagedCopy(int deviceId) noexcept;
 
+  /// Waits for outstanding staging copies and drops the frames, then discards
+  /// whatever was still deferred. Called during teardown, because the GPU may
+  /// still be writing into a pending frame's payload and that memory must not
+  /// be freed underneath it.
   void drainPendingReadReplies();
 
   // Shared bodies for the zero-copy and copy-based send/recv overloads.
@@ -640,6 +689,21 @@ class TcpTransport : public Transport {
   // is what bounds it.
   static constexpr size_t kMaxOutQueueBytes = 64UL * 1024 * 1024;
   static constexpr size_t kMaxInflightRequests = 4096;
+  // put()'s chunk size, and the payload capacity of one staging slab. A
+  // same-version peer therefore never asks for a read larger than one slab.
+  //
+  // The controller frames each TcpConn message with a 4-byte length and caps it
+  // at 64 MiB; a chunk (header + payload) stays safely under that, so large
+  // put/get transfers are split across multiple frames.
+  static constexpr size_t kMaxChunkSize = 4UL * 1024 * 1024;
+  // ~64 MiB of pinned host memory, sized against kMaxOutQueueBytes: the pool
+  // and the out queue bound the same pipeline, so a full set of staged frames
+  // fits in the queue rather than being refused by its cap.
+  static constexpr size_t kStagingSlabCount = 16;
+  // Withheld from put(), so a saturated put cannot leave the get responder with
+  // nothing to stage into. The responder is the side the peer is already
+  // blocked on.
+  static constexpr size_t kStagingSlabsReservedForReader = 1;
   // Bytes currently queued in outQueue_. Guarded by outMu_.
   size_t outBytes_{0};
 
@@ -681,6 +745,17 @@ class TcpTransport : public Transport {
   // safe on the wire, this only costs latency -- and a transport serves one
   // peer, which in practice means one device.
   bool replyPollScheduled_{false};
+  // VRAM reads that arrived with the pool exhausted, oldest first. Bounded by
+  // kMaxInflightRequests for the same reason inflight_ is: it grows on
+  // peer-supplied frames, and the reader will not stop reading them.
+  std::deque<DeferredReadReply> deferredReplies_;
+
+  // Created on first VRAM staging need, then never replaced. Its own mutex
+  // rather than stagingMu_: acquiring a slab can wait (put(), from a caller
+  // thread), and the staging queue must stay available to the reader while it
+  // does.
+  std::mutex poolMu_;
+  std::shared_ptr<TcpPinnedSlabPool> slabPool_;
 
   // Outbound frame queue drained by the sender thread. Decoupling all sends
   // from the reader thread is what prevents a mutual-READ deadlock (two peers'

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
@@ -55,6 +55,32 @@ class FailingConn : public controller::Conn {
   int closeCount{0};
 };
 
+/// A connection that accepts every send and counts them, for the tests that
+/// need the sender to actually drain the queue.
+class CountingConn : public controller::Conn {
+ public:
+  std::future<Result<size_t>> send(std::span<const uint8_t> data) override {
+    sendCount_.fetch_add(1, std::memory_order_release);
+    return make_ready_future<Result<size_t>>(Result<size_t>(data.size()));
+  }
+  std::future<Result<size_t>> recv(std::vector<uint8_t>&) override {
+    return make_ready_future<Result<size_t>>(
+        Err(ErrCode::ConnectionFailed, "test: recv failed"));
+  }
+  std::future<Result<size_t>> recv(std::span<uint8_t>) override {
+    return make_ready_future<Result<size_t>>(
+        Err(ErrCode::ConnectionFailed, "test: recv failed"));
+  }
+  void close() override {}
+
+  int sendCount() const {
+    return sendCount_.load(std::memory_order_acquire);
+  }
+
+ private:
+  std::atomic<int> sendCount_{0};
+};
+
 /// A connection whose send() parks until the test lets it through, so the
 /// window in which the sender thread is mid-send -- and must still own the
 /// frame's storage -- can be inspected.
@@ -131,7 +157,30 @@ class TcpTransportFrameTest : public ::testing::Test {
     ON_CALL(*cudaApi_, setDevice(::testing::_))
         .WillByDefault(::testing::Return(Ok()));
     ON_CALL(*cudaApi_, streamSynchronize(::testing::_))
-        .WillByDefault(::testing::Return(Ok()));
+        .WillByDefault([this](auto) -> Status {
+          syncCount_.fetch_add(1, std::memory_order_release);
+          return Ok();
+        });
+    // Real host memory behind the staging pool: the pool hands out pointers the
+    // transport builds frames in and copies into, and the tests check that a
+    // copy landed inside this memory rather than in a vector.
+    ON_CALL(*cudaApi_, hostAlloc(::testing::_, ::testing::_))
+        .WillByDefault([this](size_t size, unsigned int) -> Result<void*> {
+          // Default-initialised rather than zeroed: this is 64 MiB per pool.
+          auto buf = std::unique_ptr<uint8_t[]>(new uint8_t[size]);
+          void* ptr = buf.get();
+          std::lock_guard<std::mutex> lk(allocMu_);
+          hostAllocs_.emplace_back(std::move(buf), size);
+          return ptr;
+        });
+    ON_CALL(*cudaApi_, hostFree(::testing::_))
+        .WillByDefault([this](void* ptr) -> Status {
+          std::lock_guard<std::mutex> lk(allocMu_);
+          std::erase_if(hostAllocs_, [ptr](const auto& alloc) {
+            return alloc.first.get() == ptr;
+          });
+          return Ok();
+        });
 
     transport_ = std::make_unique<TcpTransport>(
         /*deviceId=*/-1,
@@ -338,6 +387,33 @@ class TcpTransportFrameTest : public ::testing::Test {
     return raw;
   }
 
+  /// Installs a connection that accepts every send, for the tests that need the
+  /// queue actually drained.
+  CountingConn& installCountingConn() {
+    auto conn = std::make_unique<CountingConn>();
+    auto& ref = *conn;
+    transport_->dataConn_ = std::move(conn);
+    return ref;
+  }
+
+  static size_t deferredCap() {
+    return TcpTransport::kMaxInflightRequests;
+  }
+
+  static size_t slabPayloadCap() {
+    return TcpTransport::kMaxChunkSize;
+  }
+
+  /// Fills the deferred queue with entries holding no lease, so the overflow
+  /// boundary can be reached without the millions of requests a real peer would
+  /// have to send to get there.
+  void fillDeferredReplies(size_t n) {
+    std::lock_guard<std::mutex> lk(transport_->stagingMu_);
+    for (size_t i = 0; i < n; ++i) {
+      transport_->deferredReplies_.push_back(DeferredReadReply{});
+    }
+  }
+
   /// Ends senderLoop() the way shutdown() does, without tearing the rest of the
   /// transport down.
   void closeOutQueue() {
@@ -348,23 +424,98 @@ class TcpTransportFrameTest : public ::testing::Test {
     transport_->outCv_.notify_all();
   }
 
-  /// A pool backed by real host memory, since the pool hands out pointers the
-  /// frames are built in and the tests dereference them. MockCudaApi::hostAlloc
-  /// otherwise returns a default-constructed Result.
+  /// A standalone pool, for the frame-ownership tests. Backed by the fixture's
+  /// hostAlloc stub, so its slabs are real memory.
   std::shared_ptr<TcpPinnedSlabPool> makeSlabPool(
       size_t slabCount,
       size_t reserved) {
-    slabRegion_.assign(kTestSlabSize * slabCount, uint8_t{0});
-    ON_CALL(*cudaApi_, hostAlloc(::testing::_, ::testing::_))
-        .WillByDefault(
-            ::testing::Return(
-                Result<void*>(static_cast<void*>(slabRegion_.data()))));
-    ON_CALL(*cudaApi_, hostFree(::testing::_))
-        .WillByDefault(::testing::Return(Ok()));
     auto pool =
         TcpPinnedSlabPool::create(cudaApi_, kTestSlabSize, slabCount, reserved);
     EXPECT_TRUE(pool.hasValue());
     return pool.hasValue() ? pool.value() : nullptr;
+  }
+
+  /// The transport's own staging pool, created on the first call exactly as a
+  /// VRAM read would create it.
+  std::shared_ptr<TcpPinnedSlabPool> transportStagingPool() {
+    auto pool = transport_->stagingPool();
+    EXPECT_TRUE(pool.hasValue());
+    return pool.hasValue() ? pool.value() : nullptr;
+  }
+
+  /// Installs the stubs a staged VRAM read needs, with the copy held unfinished
+  /// until `releaseStagingCopies()`. Every copy destination is recorded, which
+  /// is how a test tells staging into the pinned pool from staging into a
+  /// vector.
+  void stubStagingCopies() {
+    ON_CALL(
+        *cudaApi_,
+        memcpyAsync(
+            ::testing::_,
+            ::testing::_,
+            ::testing::_,
+            ::testing::_,
+            ::testing::_))
+        .WillByDefault(
+            [this](void* dst, const void*, size_t, auto, auto) -> Status {
+              std::lock_guard<std::mutex> lk(copyMu_);
+              copyDsts_.push_back(dst);
+              return Ok();
+            });
+    ON_CALL(*cudaApi_, eventCreate(::testing::_))
+        .WillByDefault([](auto* event) -> Status {
+          // Spelled with auto because this TU is not hipified: cudaEvent_t is
+          // ihipEvent_t* here, and naming it does not compile under ROCm.
+          *event = {};
+          return Ok();
+        });
+    ON_CALL(*cudaApi_, eventRecord(::testing::_, ::testing::_))
+        .WillByDefault(::testing::Return(Ok()));
+    ON_CALL(*cudaApi_, eventDestroy(::testing::_))
+        .WillByDefault(::testing::Return(Ok()));
+    ON_CALL(*cudaApi_, eventQuery(::testing::_))
+        .WillByDefault([this](auto) -> Result<bool> {
+          return Result<bool>(copyDone_.load(std::memory_order_acquire));
+        });
+  }
+
+  void releaseStagingCopies() {
+    copyDone_.store(true, std::memory_order_release);
+  }
+
+  size_t stagedCopyCount() {
+    std::lock_guard<std::mutex> lk(copyMu_);
+    return copyDsts_.size();
+  }
+
+  /// True if every recorded copy destination lies inside memory the pool
+  /// allocated. A copy into a frame's vector storage fails this.
+  bool allCopiesLandedInPinnedMemory() {
+    std::lock_guard<std::mutex> lk(copyMu_);
+    std::lock_guard<std::mutex> allocLk(allocMu_);
+    for (const auto* dst : copyDsts_) {
+      const bool inside = std::any_of(
+          hostAllocs_.begin(), hostAllocs_.end(), [dst](const auto& alloc) {
+            const auto* base = alloc.first.get();
+            if (base == nullptr) {
+              return false;
+            }
+            return dst >= base && dst < base + alloc.second;
+          });
+      if (!inside) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  int syncCount() const {
+    return syncCount_.load(std::memory_order_acquire);
+  }
+
+  size_t deferredReplyCount() {
+    std::lock_guard<std::mutex> lk(transport_->stagingMu_);
+    return transport_->deferredReplies_.size();
   }
 
   /// Builds a header-only frame in `slab`, so a queued frame can be traced back
@@ -453,7 +604,12 @@ class TcpTransportFrameTest : public ::testing::Test {
   std::vector<std::byte> pristine_;
   FailingConn* failingConn_{nullptr};
   static constexpr size_t kTestSlabSize = 256;
-  std::vector<uint8_t> slabRegion_;
+  std::atomic<bool> copyDone_{false};
+  std::atomic<int> syncCount_{0};
+  std::mutex copyMu_;
+  std::vector<const void*> copyDsts_;
+  std::mutex allocMu_;
+  std::vector<std::pair<std::unique_ptr<uint8_t[]>, size_t>> hostAllocs_;
 };
 
 TEST_F(TcpTransportFrameTest, WriteToUnknownSegIdIsRejected) {
@@ -839,11 +995,16 @@ TEST_F(TcpTransportFrameTest, OversizedReadRequestIsRefusedPerRequest) {
 // reader thread, so the reader stopped draining the socket for the length of an
 // application GPU step. That re-arms the mutual-READ deadlock the reader/sender
 // split exists to prevent, and the registry lease held across the copy stalled
-// any concurrent erase() for just as long. The copy is staged instead: the
-// reader posts it and returns to the socket, and the EventBase queues the reply
-// once the copy signals.
+// any concurrent erase() for just as long.
+//
+// The copy is staged instead: issued into a pinned slab and left to run, with
+// the reply queued by the EventBase once it signals. Pinned matters -- the same
+// copy into a frame's vector storage is pageable, which CUDA specifies as
+// completing synchronously, so the reader would still be parked for the whole
+// transfer while looking asynchronous.
 TEST_F(TcpTransportFrameTest, AStagedVramReadReplyDoesNotBlockTheReader) {
   setConnected();
+  stubStagingCopies();
 
   constexpr uint64_t kVramSegId = kSegId + 200;
   constexpr size_t kLen = 64;
@@ -851,35 +1012,20 @@ TEST_F(TcpTransportFrameTest, AStagedVramReadReplyDoesNotBlockTheReader) {
   registry_->add(
       kVramSegId, vram.data(), kLen, MemoryType::VRAM, /*deviceId=*/0);
 
-  std::atomic<bool> copyDone{false};
-  ON_CALL(
-      *cudaApi_,
-      memcpyAsync(
-          ::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_))
-      .WillByDefault(::testing::Return(Ok()));
-  ON_CALL(*cudaApi_, eventCreate(::testing::_))
-      .WillByDefault([](auto* event) -> Status {
-        // Spelled with auto because this TU is not hipified: cudaEvent_t is
-        // ihipEvent_t* here, and naming it does not compile under ROCm.
-        *event = {};
-        return Ok();
-      });
-  ON_CALL(*cudaApi_, eventRecord(::testing::_, ::testing::_))
-      .WillByDefault(::testing::Return(Ok()));
-  ON_CALL(*cudaApi_, eventDestroy(::testing::_))
-      .WillByDefault(::testing::Return(Ok()));
-  // The copy stays unfinished until the test releases it.
-  ON_CALL(*cudaApi_, eventQuery(::testing::_))
-      .WillByDefault([&](auto) -> Result<bool> {
-        return Result<bool>(copyDone.load(std::memory_order_acquire));
-      });
-
   feed(makeFrame(
       TcpOp::ReadRequest, kVramSegId, /*offset=*/0, kLen, /*payloadBytes=*/0));
 
   EXPECT_EQ(outQueueDepth(), 0u)
       << "a reply whose payload is still being copied must not be queued; the "
          "peer would receive an unfilled buffer";
+  EXPECT_EQ(stagedCopyCount(), 1u);
+  EXPECT_TRUE(allCopiesLandedInPinnedMemory())
+      << "the copy went somewhere other than a pinned slab; a device-to-host "
+         "copy into pageable memory blocks the thread that issues it, so the "
+         "reader is parked for the whole transfer";
+  EXPECT_EQ(syncCount(), 0)
+      << "the reader must not synchronize: waiting on the device is exactly "
+         "what staging exists to avoid";
 
   // The reader is not parked, so a request arriving behind the staged one is
   // answered while that copy is still running.
@@ -889,15 +1035,257 @@ TEST_F(TcpTransportFrameTest, AStagedVramReadReplyDoesNotBlockTheReader) {
       << "the reader is blocked behind the VRAM copy: a request queued after it "
          "was not answered until the device finished";
 
-  copyDone.store(true, std::memory_order_release);
+  releaseStagingCopies();
 
-  const auto deadline =
-      std::chrono::steady_clock::now() + std::chrono::seconds(5);
-  while (outQueueDepth() < 2u && std::chrono::steady_clock::now() < deadline) {
-    std::this_thread::yield();
-  }
-  EXPECT_EQ(outQueueDepth(), 2u)
+  EXPECT_TRUE(waitFor([this]() { return outQueueDepth() >= 2u; }))
       << "the staged reply must be queued once its copy signals";
+  EXPECT_EQ(outQueueDepth(), 2u);
+}
+
+// The pool is finite, so a read can arrive with nothing to stage into. It is
+// recorded and answered later rather than waited on: waiting is the
+// head-of-line block the whole staging path exists to remove, and it would be
+// worse here because the thread that frees the next slab is the sender, which
+// the reader would be holding up.
+TEST_F(TcpTransportFrameTest, AVramReadWithNoFreeSlabIsDeferredNotBlocked) {
+  setConnected();
+  stubStagingCopies();
+
+  constexpr uint64_t kVramSegId = kSegId + 210;
+  constexpr size_t kLen = 64;
+  std::vector<std::byte> vram(kLen, std::byte{0x33});
+  registry_->add(
+      kVramSegId, vram.data(), kLen, MemoryType::VRAM, /*deviceId=*/0);
+
+  // Every slab, the reserved one included: nothing is left for the responder.
+  auto pool = transportStagingPool();
+  ASSERT_NE(pool, nullptr);
+  std::vector<TcpPinnedSlab> held;
+  held.reserve(pool->slabCount());
+  for (size_t i = 0; i < pool->slabCount(); ++i) {
+    held.push_back(pool->tryAcquire(/*allowReserved=*/true));
+    ASSERT_TRUE(static_cast<bool>(held.back()));
+  }
+
+  feed(makeFrame(
+      TcpOp::ReadRequest, kVramSegId, /*offset=*/0, kLen, /*payloadBytes=*/0));
+
+  EXPECT_EQ(deferredReplyCount(), 1u)
+      << "the read must be recorded for later, not dropped: the peer is "
+         "blocked waiting for this reply";
+  EXPECT_EQ(stagedCopyCount(), 0u)
+      << "no slab was free, so no copy may have been issued -- a fallback into "
+         "pageable memory would block the reader, which is the bug this path "
+         "exists to avoid";
+  EXPECT_EQ(syncCount(), 0)
+      << "the reader must not wait on the device to make room";
+
+  // And the reader is still serving: a DRAM read behind the deferred one is
+  // answered immediately.
+  feed(makeFrame(
+      TcpOp::ReadRequest, kSegId, /*offset=*/0, kLen, /*payloadBytes=*/0));
+  EXPECT_EQ(outQueueDepth(), 1u)
+      << "a deferred VRAM read must not hold up unrelated requests";
+}
+
+// A deferral must be refused once the connection is swept. failAllPending()
+// empties the deferred queue exactly so a lease is not pinned for the lifetime
+// of the transport; a read that lands afterwards and is deferred anyway puts
+// one straight back, and nothing drains it again until teardown. Written with
+// the pool exhausted so the read has no choice but the deferral path, which is
+// the only way to reach the check.
+TEST_F(TcpTransportFrameTest, ADeferralIsRefusedOnceTheConnectionIsSwept) {
+  setConnected();
+  stubStagingCopies();
+
+  constexpr uint64_t kVramSegId = kSegId + 230;
+  constexpr size_t kLen = 64;
+  std::vector<std::byte> vram(kLen, std::byte{0x44});
+  registry_->add(
+      kVramSegId, vram.data(), kLen, MemoryType::VRAM, /*deviceId=*/0);
+
+  auto pool = transportStagingPool();
+  ASSERT_NE(pool, nullptr);
+  std::vector<TcpPinnedSlab> held;
+  held.reserve(pool->slabCount());
+  for (size_t i = 0; i < pool->slabCount(); ++i) {
+    held.push_back(pool->tryAcquire(/*allowReserved=*/true));
+    ASSERT_TRUE(static_cast<bool>(held.back()));
+  }
+
+  failAllPending();
+  ASSERT_EQ(deferredReplyCount(), 0u)
+      << "precondition: the sweep left the deferred queue empty";
+
+  feed(makeFrame(
+      TcpOp::ReadRequest, kVramSegId, /*offset=*/0, kLen, /*payloadBytes=*/0));
+
+  EXPECT_EQ(deferredReplyCount(), 0u)
+      << "a deferral after the sweep pins its segment lease until the transport "
+         "is destroyed, which is what the sweep clears the queue to avoid";
+  EXPECT_EQ(stagedCopyCount(), 0u)
+      << "nothing may be staged for a read on a broken connection";
+}
+
+// The other half of deferral: a slab coming back has to actually restart the
+// deferred read. The release that matters is the sender's, after the frame it
+// was transmitting is gone, so this drives it through senderLoop rather than
+// releasing a slab by hand.
+TEST_F(TcpTransportFrameTest, AReleasedSlabStartsTheDeferredRead) {
+  setConnected();
+  stubStagingCopies();
+
+  constexpr uint64_t kVramSegId = kSegId + 220;
+  constexpr size_t kLen = 64;
+  std::vector<std::byte> vram(kLen, std::byte{0x55});
+  registry_->add(
+      kVramSegId, vram.data(), kLen, MemoryType::VRAM, /*deviceId=*/0);
+
+  // All but one slab held, so the first read takes the last one and the second
+  // has nowhere to go.
+  auto pool = transportStagingPool();
+  ASSERT_NE(pool, nullptr);
+  std::vector<TcpPinnedSlab> held;
+  held.reserve(pool->slabCount());
+  for (size_t i = 0; i + 1 < pool->slabCount(); ++i) {
+    held.push_back(pool->tryAcquire(/*allowReserved=*/true));
+    ASSERT_TRUE(static_cast<bool>(held.back()));
+  }
+
+  feed(makeFrame(
+      TcpOp::ReadRequest, kVramSegId, /*offset=*/0, kLen, /*payloadBytes=*/0));
+  feed(makeFrame(
+      TcpOp::ReadRequest, kVramSegId, /*offset=*/0, kLen, /*payloadBytes=*/0));
+  ASSERT_EQ(stagedCopyCount(), 1u);
+  ASSERT_EQ(deferredReplyCount(), 1u);
+
+  auto& conn = installCountingConn();
+  std::thread sender([this]() { runSenderLoop(); });
+
+  // The first copy signals, its reply is queued and sent, and only then is its
+  // slab free for the deferred read.
+  releaseStagingCopies();
+  EXPECT_TRUE(waitFor([&]() { return conn.sendCount() >= 2; }))
+      << "the deferred read was never started, so its reply never went out: a "
+         "slab returning to the pool must wake it";
+  EXPECT_EQ(deferredReplyCount(), 0u);
+  EXPECT_EQ(stagedCopyCount(), 2u);
+  EXPECT_TRUE(allCopiesLandedInPinnedMemory());
+
+  closeOutQueue();
+  sender.join();
+}
+
+// A deferred read holds its lease with no copy yet issued, and that lease has
+// to keep blocking deregistration: the copy will read that buffer, just later.
+// Releasing the lease at deferral time and re-finding the segment later would
+// mean answering a read out of memory the owner had already freed.
+TEST_F(TcpTransportFrameTest, ADeferredReadStillBlocksDeregistration) {
+  setConnected();
+  stubStagingCopies();
+
+  constexpr uint64_t kVramSegId = kSegId + 230;
+  constexpr size_t kLen = 64;
+  std::vector<std::byte> vram(kLen, std::byte{0x66});
+  registry_->add(
+      kVramSegId, vram.data(), kLen, MemoryType::VRAM, /*deviceId=*/0);
+
+  auto pool = transportStagingPool();
+  ASSERT_NE(pool, nullptr);
+  std::vector<TcpPinnedSlab> held;
+  held.reserve(pool->slabCount());
+  for (size_t i = 0; i < pool->slabCount(); ++i) {
+    held.push_back(pool->tryAcquire(/*allowReserved=*/true));
+  }
+
+  feed(makeFrame(
+      TcpOp::ReadRequest, kVramSegId, /*offset=*/0, kLen, /*payloadBytes=*/0));
+  ASSERT_EQ(deferredReplyCount(), 1u);
+
+  std::atomic<bool> erased{false};
+  std::thread eraser([&]() {
+    registry_->erase(kVramSegId);
+    erased.store(true, std::memory_order_release);
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  EXPECT_FALSE(erased.load(std::memory_order_acquire))
+      << "erase() returned while a deferred read still held a lease: the owner "
+         "is now free to free a buffer this transport will still copy out of";
+
+  // Teardown discards what is deferred, which releases the lease.
+  transport_->shutdown();
+  eraser.join();
+  EXPECT_TRUE(erased.load(std::memory_order_acquire));
+  EXPECT_EQ(stagedCopyCount(), 0u)
+      << "a discarded deferred read must not have started a copy into memory "
+         "that is being torn down";
+}
+
+// A read the pool cannot serve and the deferred queue cannot hold is answered
+// with an Error rather than dropped or blocked on. Dropping it leaves the peer
+// waiting forever; blocking stops the reader; failing the connection punishes
+// every unrelated transfer on it.
+TEST_F(TcpTransportFrameTest, DeferredQueueOverflowFailsOnlyThatRequest) {
+  setConnected();
+  stubStagingCopies();
+
+  constexpr uint64_t kVramSegId = kSegId + 240;
+  constexpr size_t kLen = 64;
+  std::vector<std::byte> vram(kLen, std::byte{0x11});
+  registry_->add(
+      kVramSegId, vram.data(), kLen, MemoryType::VRAM, /*deviceId=*/0);
+
+  auto pool = transportStagingPool();
+  ASSERT_NE(pool, nullptr);
+  std::vector<TcpPinnedSlab> held;
+  held.reserve(pool->slabCount());
+  for (size_t i = 0; i < pool->slabCount(); ++i) {
+    held.push_back(pool->tryAcquire(/*allowReserved=*/true));
+  }
+  fillDeferredReplies(deferredCap());
+
+  feed(makeFrame(
+      TcpOp::ReadRequest, kVramSegId, /*offset=*/0, kLen, /*payloadBytes=*/0));
+
+  EXPECT_FALSE(connClosed())
+      << "one unservable read must not take the connection down";
+  EXPECT_TRUE(queuedErrorFrame())
+      << "the peer must be told this read failed; silence leaves it waiting for "
+         "a reply that will never come";
+  EXPECT_EQ(deferredReplyCount(), deferredCap())
+      << "the refused read must not have been queued anyway";
+}
+
+// A VRAM read larger than a staging slab cannot be served at all: our own get()
+// chunks at kMaxChunkSize, so this is the version-skew case, and it has to be a
+// per-request error rather than a fatal one for the same reason the wire-frame
+// cap is.
+TEST_F(TcpTransportFrameTest, AVramReadLargerThanASlabIsRefusedPerRequest) {
+  setConnected();
+  stubStagingCopies();
+
+  constexpr uint64_t kVramSegId = kSegId + 250;
+  const size_t oversized = slabPayloadCap() + 1;
+  // Registered, but never read from: the request is refused before any copy.
+  std::vector<std::byte> vram(1, std::byte{0x99});
+  registry_->add(
+      kVramSegId, vram.data(), oversized, MemoryType::VRAM, /*deviceId=*/0);
+
+  feed(makeFrame(
+      TcpOp::ReadRequest,
+      kVramSegId,
+      /*offset=*/0,
+      oversized,
+      /*payloadBytes=*/0));
+
+  EXPECT_FALSE(connClosed())
+      << "an oversized read must not be fatal to the connection";
+  EXPECT_TRUE(queuedErrorFrame()) << "the peer must be told this read failed";
+  EXPECT_EQ(stagedCopyCount(), 0u)
+      << "nothing may be copied for a read that cannot fit a slab";
+  EXPECT_EQ(deferredReplyCount(), 0u)
+      << "an unservable read must be refused, not deferred forever";
 }
 
 // The copy is issued before the event exists, so any failure after that point

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
@@ -16,11 +16,33 @@
 #include <thread>
 #include <vector>
 
+#include "comms/uniflow/Segment.h"
 #include "comms/uniflow/drivers/cuda/mock/MockCudaApi.h"
 #include "comms/uniflow/executor/ScopedEventBaseThread.h"
+#include "comms/uniflow/transport/tcp/TcpRegistrationHandle.h"
 #include "comms/uniflow/transport/tcp/TcpWireProtocol.h"
 
 namespace uniflow {
+
+/// Builds RegisteredSegment / RemoteRegisteredSegment without a factory,
+/// through the `friend class SegmentTest` seam in Segment.h. The name has to be
+/// exactly this to match that declaration.
+class SegmentTest {
+ public:
+  static RegisteredSegment
+  makeRegistered(void* buf, size_t len, MemoryType memType, int deviceId) {
+    return RegisteredSegment(buf, len, memType, deviceId);
+  }
+
+  static RemoteRegisteredSegment makeRemote(
+      void* buf,
+      size_t len,
+      std::unique_ptr<RemoteRegistrationHandle> handle) {
+    RemoteRegisteredSegment remote(buf, len);
+    remote.handles_.push_back(std::move(handle));
+    return remote;
+  }
+};
 
 // handleFrame() acts on peer-supplied segId/offset/len before touching a
 // registered buffer, so its bounds checks are this transport's memory-safety
@@ -141,6 +163,44 @@ class GatedConn : public controller::Conn {
   bool released_{false};
 };
 
+/// A VRAM put of `len` bytes, held together so the segments outlive the request
+/// that borrows them. The source is never read -- memcpyAsync is mocked -- but
+/// it has to be a real allocation of the full length, because put() chunks by
+/// size.
+class VramPut {
+ public:
+  explicit VramPut(size_t len)
+      : src_(len),
+        local_(
+            SegmentTest::makeRegistered(
+                src_.data(),
+                len,
+                MemoryType::VRAM,
+                /*deviceId=*/0)),
+        remote_(
+            SegmentTest::makeRemote(
+                // The peer's address is never dereferenced here: TCP sends the
+                // segId and offset and lets the peer resolve them.
+                // NOLINTNEXTLINE(performance-no-int-to-ptr)
+                reinterpret_cast<void*>(0x100000),
+                len,
+                std::make_unique<TcpRemoteRegistrationHandle>(
+                    kRemoteSegId,
+                    len))),
+        request_(TransferRequest{local_.span(), remote_.span()}) {}
+
+  std::span<const TransferRequest> requests() const {
+    return {&request_, 1};
+  }
+
+ private:
+  static constexpr uint64_t kRemoteSegId = 7;
+  std::vector<uint8_t> src_;
+  RegisteredSegment local_;
+  RemoteRegisteredSegment remote_;
+  TransferRequest request_;
+};
+
 class TcpTransportFrameTest : public ::testing::Test {
  protected:
   static constexpr uint64_t kSegId = 42;
@@ -159,6 +219,8 @@ class TcpTransportFrameTest : public ::testing::Test {
     ON_CALL(*cudaApi_, streamSynchronize(::testing::_))
         .WillByDefault([this](auto) -> Status {
           syncCount_.fetch_add(1, std::memory_order_release);
+          std::unique_lock<std::mutex> lk(syncMu_);
+          syncReleased_.wait(lk, [this]() { return !syncsGated_; });
           return Ok();
         });
     // Real host memory behind the staging pool: the pool hands out pointers the
@@ -460,6 +522,9 @@ class TcpTransportFrameTest : public ::testing::Test {
             [this](void* dst, const void*, size_t, auto, auto) -> Status {
               std::lock_guard<std::mutex> lk(copyMu_);
               copyDsts_.push_back(dst);
+              if (failCopyAt_ != 0 && copyDsts_.size() == failCopyAt_) {
+                return Err(ErrCode::DriverError, "test: staging copy failed");
+              }
               return Ok();
             });
     ON_CALL(*cudaApi_, eventCreate(::testing::_))
@@ -481,6 +546,30 @@ class TcpTransportFrameTest : public ::testing::Test {
 
   void releaseStagingCopies() {
     copyDone_.store(true, std::memory_order_release);
+  }
+
+  /// Fails the copy issued after `succeeding` others, so a wave can fail with
+  /// copies already in flight -- the case where releasing slabs early would let
+  /// a later copy write into a buffer the GPU is still filling.
+  void failCopyAfter(size_t succeeding) {
+    std::lock_guard<std::mutex> lk(copyMu_);
+    failCopyAt_ = succeeding + 1;
+  }
+
+  /// Holds every staging wait open, so the window between "all copies issued"
+  /// and "all copies finished" can be inspected. Without it that window closes
+  /// too fast to assert anything about.
+  void gateStagingWaits() {
+    std::lock_guard<std::mutex> lk(syncMu_);
+    syncsGated_ = true;
+  }
+
+  void releaseStagingWaits() {
+    {
+      std::lock_guard<std::mutex> lk(syncMu_);
+      syncsGated_ = false;
+    }
+    syncReleased_.notify_all();
   }
 
   size_t stagedCopyCount() {
@@ -516,6 +605,25 @@ class TcpTransportFrameTest : public ::testing::Test {
   size_t deferredReplyCount() {
     std::lock_guard<std::mutex> lk(transport_->stagingMu_);
     return transport_->deferredReplies_.size();
+  }
+
+  std::future<Status> put(std::span<const TransferRequest> requests) {
+    return transport_->put(requests, RequestOptions{});
+  }
+
+  static constexpr size_t waveCap() {
+    return TcpTransport::kMaxPutWaveChunks;
+  }
+
+  /// How many slabs the pool will still hand out. Drains with tryAcquire rather
+  /// than a bulk acquire so a test asserting "nothing was stranded" reports the
+  /// shortfall instead of waiting for slabs that are never coming back.
+  static size_t freeSlabs(TcpPinnedSlabPool& pool) {
+    std::vector<TcpPinnedSlab> held;
+    while (auto slab = pool.tryAcquire(/*allowReserved=*/true)) {
+      held.push_back(std::move(slab));
+    }
+    return held.size();
   }
 
   /// Builds a header-only frame in `slab`, so a queued frame can be traced back
@@ -610,6 +718,10 @@ class TcpTransportFrameTest : public ::testing::Test {
   std::vector<const void*> copyDsts_;
   std::mutex allocMu_;
   std::vector<std::pair<std::unique_ptr<uint8_t[]>, size_t>> hostAllocs_;
+  std::mutex syncMu_;
+  std::condition_variable syncReleased_;
+  bool syncsGated_{false};
+  size_t failCopyAt_{0};
 };
 
 TEST_F(TcpTransportFrameTest, WriteToUnknownSegIdIsRejected) {
@@ -1649,6 +1761,138 @@ TEST_F(TcpTransportFrameTest, EnqueueFramesQueuesNothingWhenTheQueueIsClosed) {
   auto reclaimed = pool->acquire(2);
   EXPECT_TRUE(reclaimed.hasValue())
       << "a refused group must not strand the slabs it was built in";
+}
+
+// A put stages every chunk of a wave and only then queues them, so a staging
+// failure partway through leaves the peer untouched instead of holding the
+// chunks that happened to copy first. Before this the commit loop queued each
+// chunk as its own copy finished, and the sender could already have flushed
+// them: the caller was told the put failed while some of it had landed, at
+// offsets nobody could name.
+//
+// This is the whole-wave case, which is what nearly every put is.
+TEST_F(TcpTransportFrameTest, AFullWaveReachesTheQueueOnlyOnceEveryCopyIsDone) {
+  setConnected();
+  stubStagingCopies();
+  gateStagingWaits();
+
+  const size_t chunks = waveCap();
+  VramPut transfer(chunks * slabPayloadCap());
+  std::thread putter([&]() { (void)put(transfer.requests()); });
+
+  // Every copy in the wave is in flight...
+  EXPECT_TRUE(waitFor([&]() { return stagedCopyCount() == chunks; }))
+      << "the wave must issue all of its copies before waiting on any of them; "
+         "waiting per chunk is what serialised staging against itself";
+  // ...and nothing is queued, because none of them has finished.
+  EXPECT_EQ(outQueueDepth(), 0u)
+      << "a Write reached the queue before its wave had finished staging; the "
+         "sender may already have put a partial transfer on the wire";
+  EXPECT_TRUE(allCopiesLandedInPinnedMemory());
+
+  releaseStagingWaits();
+
+  EXPECT_TRUE(waitFor([&]() { return outQueueDepth() == chunks; }))
+      << "the whole wave must be queued once its copies are done";
+  auto ids = queuedReqIds();
+  ASSERT_EQ(ids.size(), chunks);
+  EXPECT_TRUE(std::is_sorted(ids.begin(), ids.end()))
+      << "the wave must keep the caller's chunk order";
+  putter.join();
+}
+
+// A staging failure inside a wave must queue nothing at all, and must not hand
+// a slab back while the GPU is still writing into it. Copies already launched
+// keep running after a later one fails; a slab released underneath one of them
+// goes straight to the next staging copy, and the two then race over the same
+// bytes.
+TEST_F(TcpTransportFrameTest, AFailedWaveQueuesNothingAndDrainsWhatItLaunched) {
+  setConnected();
+  stubStagingCopies();
+  failCopyAfter(2);
+
+  const size_t chunks = waveCap();
+  VramPut transfer(chunks * slabPayloadCap());
+  auto future = put(transfer.requests());
+
+  ASSERT_EQ(
+      future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  EXPECT_TRUE(future.get().hasError()) << "the caller must be told it failed";
+  EXPECT_EQ(outQueueDepth(), 0u)
+      << "a wave that failed to stage must queue nothing; anything queued is a "
+         "partial write the peer will apply and nobody will hear about";
+  EXPECT_GE(syncCount(), 1)
+      << "the copies that were launched must be waited for before their slabs "
+         "go back to the pool, or the next staging copy writes into a buffer "
+         "the GPU is still filling";
+
+  auto pool = transportStagingPool();
+  ASSERT_NE(pool, nullptr);
+  EXPECT_EQ(freeSlabs(*pool), pool->slabCount())
+      << "a failed wave must strand none of its slabs, and must leave none of "
+         "them held by a frame it queued";
+}
+
+// Above one wave the guarantee is per wave, not per put, and that boundary is
+// documented on put(). This pins it: with 16 chunks the first 15 are queued --
+// and so may reach the peer -- while the 16th has not been staged at all.
+// Whatever this test asserts is what callers are promised, so it is worth being
+// explicit that the promise stops here.
+TEST_F(TcpTransportFrameTest, APutLargerThanOneWaveIsAtomicOnlyPerWave) {
+  setConnected();
+  stubStagingCopies();
+  releaseStagingCopies();
+
+  const size_t chunks = waveCap() + 1;
+  VramPut transfer(chunks * slabPayloadCap());
+  // On its own thread because it is expected to park: nothing drains the queue,
+  // so the first wave's slabs stay on loan and the second wave has nothing to
+  // stage into.
+  auto putResult = std::async(
+      std::launch::async, [&]() { return put(transfer.requests()).get(); });
+
+  EXPECT_TRUE(waitFor([&]() { return outQueueDepth() == waveCap(); }));
+  EXPECT_EQ(outQueueDepth(), waveCap())
+      << "the documented boundary moved: a put above one wave is expected to "
+         "queue its first wave before the rest has been staged";
+  EXPECT_EQ(stagedCopyCount(), waveCap())
+      << "the second wave must not be staged until slabs come back";
+
+  // And teardown must not strand the parked put. It is released by the queue
+  // being dropped, which is what hands its slabs back; a caller thread is not
+  // one shutdown() can join its way out of, so nothing else would.
+  transport_->shutdown();
+  ASSERT_EQ(
+      putResult.wait_for(std::chrono::seconds(5)), std::future_status::ready)
+      << "teardown left a put parked waiting for staging slabs";
+  EXPECT_TRUE(putResult.get().hasError());
+}
+
+// Two waves, a queue whose cap (64 MiB) is only just above one wave (60 MiB),
+// and a pool that only refills as the sender drains. Every one of those can
+// block a put, and they depend on each other: the wave waits for slabs, the
+// slabs wait for the sender, and the sender needs the queue mutex the wave must
+// therefore not be holding.
+TEST_F(TcpTransportFrameTest, BackToBackWavesDrainWithoutDeadlock) {
+  setConnected();
+  stubStagingCopies();
+  releaseStagingCopies();
+  auto& conn = installCountingConn();
+  std::thread sender([this]() { runSenderLoop(); });
+
+  const size_t chunks = 2 * waveCap();
+  VramPut transfer(chunks * slabPayloadCap());
+  // The future stays open -- nothing Acks these writes -- so the frames
+  // reaching the connection are what says both waves got through.
+  auto future = put(transfer.requests());
+
+  EXPECT_TRUE(waitFor([&]() {
+    return static_cast<size_t>(conn.sendCount()) == chunks;
+  })) << "both waves must make it out; a wave holding slabs while it waits for "
+         "queue room, or holding outMu_ while it waits for slabs, deadlocks here";
+
+  closeOutQueue();
+  sender.join();
 }
 
 // The registry's mutex protects the map, not the lifetime of the application


### PR DESCRIPTION
Summary:

Adds a tcp_bandwidth benchmark to uniflow_bench (single-connection put/get
over a chosen front-end iface, --tcp-iface, DRAM or VRAM host-staged) and the
AMD MI350X (gfx950/ROCm 7.0) MAST packaging: fbpkg builders
uniflow_disagg_bench_mast_mi350 and standalone_benchmark_mast_mi350, plus
run_mast_benchmarks.py support for the AMD pool (--entitlement, arch-suffixed
package parsing, t20 MI350X RoCE host docs).

Differential Revision: D114431546


