### PR TITLE
comms/uniflow/tcp: overlap VRAM put staging with transmission (#3909)

### DIFF
--- a/comms/uniflow/drivers/cuda/CudaApi.cpp
+++ b/comms/uniflow/drivers/cuda/CudaApi.cpp
@@ -205,6 +205,11 @@ Result<bool> CudaApi::eventQuery(cudaEvent_t event) {
   return false; // unreachable
 }
 
+Status CudaApi::eventSynchronize(cudaEvent_t event) {
+  CUDA_CHECK(cudaEventSynchronize(event), ErrCode::DriverError);
+  return Ok();
+}
+
 Status CudaApi::eventDestroy(cudaEvent_t event) {
   CUDA_CHECK(cudaEventDestroy(event), ErrCode::DriverError);
   return Ok();

--- a/comms/uniflow/drivers/cuda/CudaApi.h
+++ b/comms/uniflow/drivers/cuda/CudaApi.h
@@ -88,6 +88,14 @@ class CudaApi {
   /// Returns true if the event has completed, false if still in-flight.
   virtual Result<bool> eventQuery(cudaEvent_t event);
 
+  /// Block the calling thread until a recorded event completes. Waits on the
+  /// one event rather than the stream it was recorded on, so work queued after
+  /// it is not waited for -- which is what a caller pipelining several batches
+  /// on one stream needs. Prefer this over polling eventQuery on a thread that
+  /// has nothing else to do: the poll burns a core that the rest of the process
+  /// is contending for.
+  virtual Status eventSynchronize(cudaEvent_t event);
+
   virtual Status eventDestroy(cudaEvent_t event);
 
   // --- IPC (cross-process device memory sharing) ---

--- a/comms/uniflow/drivers/cuda/mock/MockCudaApi.h
+++ b/comms/uniflow/drivers/cuda/mock/MockCudaApi.h
@@ -77,6 +77,7 @@ class MockCudaApi : public CudaApi {
       (cudaEvent_t event, cudaStream_t stream),
       (override));
   MOCK_METHOD(Result<bool>, eventQuery, (cudaEvent_t event), (override));
+  MOCK_METHOD(Status, eventSynchronize, (cudaEvent_t event), (override));
   MOCK_METHOD(Status, eventDestroy, (cudaEvent_t event), (override));
 
   MOCK_METHOD(Result<std::string>, getDeviceArch, (int device), (override));

--- a/comms/uniflow/drivers/cuda/tests/CudaApiTest.cpp
+++ b/comms/uniflow/drivers/cuda/tests/CudaApiTest.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <vector>
 
 namespace uniflow {
 namespace {
@@ -58,6 +59,44 @@ TEST(CudaApiTest, IpcGetMemHandleReturnsNonZeroHandle) {
   // A valid exported IPC handle is not all-zero.
   const CudaApi::IpcMemHandle zero{};
   EXPECT_NE(handle.value(), zero);
+}
+
+TEST(CudaApiTest, EventSynchronizeReturnsOnlyOnceTheEventCompleted) {
+  CudaApi api;
+  if (!hasGpu(api)) {
+    GTEST_SKIP() << "no GPU available";
+  }
+  ASSERT_FALSE(api.setDevice(0).hasError());
+
+  void* devPtr = nullptr;
+  ASSERT_EQ(cudaMalloc(&devPtr, 4096), cudaSuccess);
+  std::unique_ptr<void, void (*)(void*)> devGuard(devPtr, [](void* p) {
+    if (p != nullptr) {
+      (void)cudaFree(p);
+    }
+  });
+  std::vector<uint8_t> host(4096, 0);
+
+  cudaEvent_t event{};
+  ASSERT_FALSE(api.eventCreate(&event).hasError());
+
+  ASSERT_FALSE(api.memcpyAsync(
+                      host.data(),
+                      devPtr,
+                      host.size(),
+                      cudaMemcpyDeviceToHost,
+                      /*stream=*/nullptr)
+                   .hasError());
+  ASSERT_FALSE(api.eventRecord(event, /*stream=*/nullptr).hasError());
+
+  EXPECT_FALSE(api.eventSynchronize(event).hasError());
+  // The point of the blocking wait: the copy is done by the time it returns, so
+  // a caller does not have to poll to know that.
+  auto done = api.eventQuery(event);
+  ASSERT_FALSE(done.hasError());
+  EXPECT_TRUE(done.value());
+
+  EXPECT_FALSE(api.eventDestroy(event).hasError());
 }
 
 } // namespace

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <deque>
 #include <exception>
 #include <filesystem>
 #include <fstream>
@@ -841,10 +842,52 @@ std::future<Status> TcpTransport::put(
   void* stream = options.stream.has_value()
       ? static_cast<void*>(options.stream.value())
       : nullptr;
+  // Waves whose copies are launched but not yet waited for. Keeping more than
+  // one here is what overlaps staging with transmission: the copy engine stays
+  // busy through the gap where the previous wave is waited for, queued and
+  // sent. Every exit path below either retires or abandons these, because
+  // dropping one with a copy still running would return its slab under an
+  // active DMA.
+  std::deque<PendingPutWave> inFlight;
+  // Retires and queues launched waves, oldest first, until at most `keep`
+  // remain. Returns false once it has already failed the operation, so callers
+  // just return. Everything before the wave it failed on stays
+  // queued-or-failed, which is the invariant abandonInflight() relies on.
+  const auto drainWaves = [&](size_t keep) -> bool {
+    while (inFlight.size() > keep) {
+      auto& oldest = inFlight.front();
+      const size_t failFrom = oldest.startIdx;
+      if (auto st = retirePutWave(oldest); !st) {
+        inFlight.pop_front();
+        abandonPutWaves(inFlight);
+        abandonInflight(chunks, failFrom);
+        state->fail(std::move(st));
+        return false;
+      }
+      auto frames = std::move(oldest.frames);
+      inFlight.pop_front();
+      if (!enqueueFrames(std::move(frames), /*mayBlock=*/true)) {
+        abandonPutWaves(inFlight);
+        abandonInflight(chunks, failFrom);
+        state->fail(
+            Err(ErrCode::NotConnected,
+                "tcp put: transport closed before the write was queued"));
+        return false;
+      }
+    }
+    return true;
+  };
   size_t idx = 0;
   while (idx < planned.size()) {
     const auto& first = planned[idx];
     if (!first.vram || first.len == 0) {
+      // Drain first: a DRAM chunk queued ahead of an earlier VRAM wave that is
+      // still in flight would break the "everything before idx is queued"
+      // invariant, and a later staging failure would then abandon an admission
+      // whose frame is already on its way to the peer.
+      if (!drainWaves(0)) {
+        return future;
+      }
       // A host memcpy cannot fail and cannot park this thread, so there is
       // nothing to stage and nothing a wave would protect.
       std::vector<uint8_t> frame(sizeof(TcpMsgHeader) + first.len);
@@ -869,58 +912,86 @@ std::future<Status> TcpTransport::put(
       continue;
     }
 
+    // Breaking on deviceId is what makes one event per wave correct: a wave
+    // spanning devices would leave the other device's copies unwaited and
+    // return their slabs under live DMA. Waves are therefore at most
+    // kMaxPutWaveChunks chunks, not exactly that many.
     size_t waveEnd = idx;
     while (waveEnd < planned.size() && planned[waveEnd].vram &&
-           planned[waveEnd].len > 0 && waveEnd - idx < kMaxPutWaveChunks) {
+           planned[waveEnd].len > 0 &&
+           planned[waveEnd].deviceId == first.deviceId &&
+           waveEnd - idx < kMaxPutWaveChunks) {
       ++waveEnd;
     }
-    auto staged = stagePutWave(
+    // Drain before launching, not after. This is what bounds the window to
+    // kMaxPutWavesInFlight - 1 waves held at the moment of acquire, which is
+    // the assumption kStagingSlabCount is sized against. Launching first would
+    // hold a whole extra wave's slabs across the acquire, and with a tight pool
+    // that acquire could only be satisfied by this same thread -- the frames
+    // holding those slabs are still sitting unqueued in `inFlight`.
+    if (!drainWaves(kMaxPutWavesInFlight - 1)) {
+      return future;
+    }
+    auto launched = launchPutWave(
         std::span<const PlannedPutFrame>(planned).subspan(idx, waveEnd - idx),
-        stream);
-    if (!staged) {
-      abandonInflight(chunks, idx);
-      state->fail(std::move(staged).error());
+        stream,
+        idx);
+    if (!launched) {
+      // Abandon from the oldest wave still held, not from this one: the waves
+      // in `inFlight` are earlier than idx and are about to be dropped
+      // unqueued, so their admissions have to go too or nothing ever retires
+      // them.
+      const size_t failFrom =
+          inFlight.empty() ? idx : inFlight.front().startIdx;
+      abandonPutWaves(inFlight);
+      abandonInflight(chunks, failFrom);
+      state->fail(std::move(launched).error());
       return future;
     }
-    if (!enqueueFrames(std::move(staged).value(), /*mayBlock=*/true)) {
-      abandonInflight(chunks, idx);
-      state->fail(
-          Err(ErrCode::NotConnected,
-              "tcp put: transport closed before the write was queued"));
-      return future;
-    }
+    inFlight.push_back(std::move(launched).value());
     idx = waveEnd;
+  }
+
+  // put() returns only once every frame is queued, so the trailing waves are
+  // retired here. Launch order matches queue order, so the wire sees what a
+  // synchronous stage would have produced.
+  if (!drainWaves(0)) {
+    return future;
   }
 
   return future;
 }
 
-Result<std::vector<TcpFrame>> TcpTransport::stagePutWave(
+Result<PendingPutWave> TcpTransport::launchPutWave(
     std::span<const PlannedPutFrame> wave,
-    void* stream) {
+    void* stream,
+    size_t startIdx) {
   auto pool = stagingPool();
   if (!pool) {
     return std::move(pool).error();
   }
   // All-or-nothing, and this thread holds no slab while it waits: a caller that
   // took what was free and waited for the rest would deadlock against another
-  // doing the same.
+  // doing the same. This acquire is also the backpressure that bounds how many
+  // waves can be in flight -- the pool is sized so it does not block a healthy
+  // sender, so when it does block the sender has genuinely fallen behind.
   auto leases = pool.value()->acquire(wave.size());
   if (!leases) {
     return std::move(leases).error();
   }
 
   auto s = static_cast<cudaStream_t>(stream);
-  // Spans the launches and the synchronize below, so bytes/this is the D2H
-  // bandwidth the put path actually gets, not the device's peak.
-  const auto tStageStart = std::chrono::steady_clock::now();
-  size_t waveBytes = 0;
-  std::vector<TcpFrame> frames;
-  frames.reserve(wave.size());
-  // Devices whose copies were launched, so the wait below covers each of them
-  // once. A bare synchronize would only cover whichever device happened to be
-  // current, leaving copies on any other still running.
-  std::vector<int> launchedDevices;
+  PendingPutWave pending;
+  pending.startIdx = startIdx;
+  pending.stream = stream;
+  // Starts before the launches, so a wave's residency covers issuing its copies
+  // as well as waiting for them.
+  pending.launchedAt = std::chrono::steady_clock::now();
+  pending.frames.reserve(wave.size());
+  // Every chunk in a wave is on one device and one stream, so they retire in
+  // order and a single event at the end covers the whole wave. put() guarantees
+  // the single device by breaking each wave at a device boundary.
+  pending.deviceId = wave.empty() ? -1 : wave[0].deviceId;
   Status staging = Ok();
   for (size_t i = 0; i < wave.size(); ++i) {
     const auto& chunk = wave[i];
@@ -932,13 +1003,13 @@ Result<std::vector<TcpFrame>> TcpTransport::stagePutWave(
     header.len = static_cast<uint64_t>(chunk.len);
     // The frame owns the slab from here on, so every path out of this function
     // returns it exactly once.
-    frames.emplace_back(
+    pending.frames.emplace_back(
         std::move(leases.value()[i]), sizeof(TcpMsgHeader) + chunk.len);
-    std::memcpy(frames.back().mutableData(), &header, sizeof(header));
+    std::memcpy(pending.frames.back().mutableData(), &header, sizeof(header));
     try {
       CudaDeviceGuard guard(*cudaApi_, chunk.deviceId);
       staging = cudaApi_->memcpyAsync(
-          frames.back().mutableData() + sizeof(TcpMsgHeader),
+          pending.frames.back().mutableData() + sizeof(TcpMsgHeader),
           chunk.src,
           chunk.len,
           cudaMemcpyDeviceToHost,
@@ -952,42 +1023,102 @@ Result<std::vector<TcpFrame>> TcpTransport::stagePutWave(
     if (!staging) {
       break;
     }
-    waveBytes += chunk.len;
-    if (std::find(
-            launchedDevices.begin(), launchedDevices.end(), chunk.deviceId) ==
-        launchedDevices.end()) {
-      launchedDevices.push_back(chunk.deviceId);
+    pending.bytes += chunk.len;
+  }
+
+  if (staging) {
+    try {
+      CudaDeviceGuard guard(*cudaApi_, pending.deviceId);
+      cudaEvent_t event{};
+      staging = cudaApi_->eventCreate(&event);
+      if (staging) {
+        pending.event = event;
+        staging = cudaApi_->eventRecord(event, s);
+      }
+    } catch (const std::exception& e) {
+      staging = Err(ErrCode::DriverError, e.what());
     }
   }
-  // One wait per wave rather than one per chunk: the copies are already in
-  // flight together, and waiting on each in turn is what serialised staging
-  // against itself.
-  for (auto deviceId : launchedDevices) {
+
+  if (!staging) {
+    // Copies may already be running against these slabs, and a wave that never
+    // got its event recorded has nothing to wait on. Quiesce the caller's
+    // stream before the frames -- and so the leases -- are destroyed on return.
     try {
-      CudaDeviceGuard guard(*cudaApi_, deviceId);
-      if (auto st = cudaApi_->streamSynchronize(s); !st && staging) {
-        staging = std::move(st);
-      }
+      CudaDeviceGuard guard(*cudaApi_, pending.deviceId);
+      (void)cudaApi_->streamSynchronize(s);
     } catch (const std::exception&) {
       // The device is already unusable; there is nothing left to wait for.
     }
-  }
-  if (!staging) {
+    if (pending.event != nullptr) {
+      try {
+        CudaDeviceGuard guard(*cudaApi_, pending.deviceId);
+        (void)cudaApi_->eventDestroy(static_cast<cudaEvent_t>(pending.event));
+      } catch (const std::exception&) {
+        // Leaking an event is preferable to throwing out of a failure path.
+      }
+      pending.event = nullptr;
+    }
     return std::move(staging).error();
   }
-  // Recorded after the synchronize, so it covers the full wait for the copies.
-  // Only successful waves are counted: a failed one abandons partway and its
-  // timing would not describe the copy path.
+  return pending;
+}
+
+Status TcpTransport::retirePutWave(PendingPutWave& wave) {
+  Status result = Ok();
+  if (wave.event != nullptr) {
+    try {
+      CudaDeviceGuard guard(*cudaApi_, wave.deviceId);
+      result = cudaApi_->eventSynchronize(static_cast<cudaEvent_t>(wave.event));
+    } catch (const std::exception& e) {
+      result = Err(ErrCode::DriverError, e.what());
+    }
+    if (!result) {
+      // The event is unusable, so the wait it was meant to provide did not
+      // happen. Fall back to quiescing the stream the copies were launched on:
+      // over-waiting is the safe direction, because these slabs cannot be
+      // released while any copy might still be writing into them.
+      try {
+        CudaDeviceGuard guard(*cudaApi_, wave.deviceId);
+        (void)cudaApi_->streamSynchronize(
+            static_cast<cudaStream_t>(wave.stream));
+      } catch (const std::exception&) {
+        // The device is already unusable; there is nothing left to wait for.
+      }
+    }
+    try {
+      CudaDeviceGuard guard(*cudaApi_, wave.deviceId);
+      (void)cudaApi_->eventDestroy(static_cast<cudaEvent_t>(wave.event));
+    } catch (const std::exception&) {
+      // Leaking an event is preferable to throwing out of a teardown path.
+    }
+    wave.event = nullptr;
+  }
+  // Only successful waves are counted: a failed one gives up partway and its
+  // timing would not describe a wave's residency.
+  if (!result) {
+    return result;
+  }
   stagingNs_.fetch_add(
       static_cast<uint64_t>(
           std::chrono::duration_cast<std::chrono::nanoseconds>(
-              std::chrono::steady_clock::now() - tStageStart)
+              std::chrono::steady_clock::now() - wave.launchedAt)
               .count()),
       std::memory_order_relaxed);
-  stagingBytes_.fetch_add(waveBytes, std::memory_order_relaxed);
+  stagingBytes_.fetch_add(wave.bytes, std::memory_order_relaxed);
   stagingWaves_.fetch_add(1, std::memory_order_relaxed);
-  stagingChunks_.fetch_add(wave.size(), std::memory_order_relaxed);
-  return frames;
+  stagingChunks_.fetch_add(wave.frames.size(), std::memory_order_relaxed);
+  return result;
+}
+
+void TcpTransport::abandonPutWaves(std::deque<PendingPutWave>& waves) noexcept {
+  // Wait before dropping: a slab returned to the pool while its copy is still
+  // running goes straight to the next staging copy, and the two then race over
+  // the same bytes.
+  for (auto& wave : waves) {
+    (void)retirePutWave(wave);
+  }
+  waves.clear();
 }
 
 std::future<Status> TcpTransport::get(
@@ -2116,18 +2247,13 @@ void TcpTransport::logAndResetPhaseStats(std::string_view label) {
   const uint64_t stgWaves = stagingWaves_.load(std::memory_order_relaxed);
   const uint64_t stgChunks = stagingChunks_.load(std::memory_order_relaxed);
   if (stgWaves > 0) {
-    // bytes/ns is GB/s directly (1e9 bytes per second per byte-per-ns).
-    const double stgGBps = stgNs > 0
-        ? static_cast<double>(stgBytes) / static_cast<double>(stgNs)
-        : 0.0;
     UNIFLOW_LOG_INFO(
-        "tcp d2h staging [{}]: waves={} chunks={} bytes={} | {:.2f} GB/s | "
+        "tcp put wave residency [{}]: waves={} chunks={} bytes={} | "
         "{:.1f}us/wave {:.1f}us/chunk",
         label,
         stgWaves,
         stgChunks,
         stgBytes,
-        stgGBps,
         static_cast<double>(stgNs) / static_cast<double>(stgWaves) / 1000.0,
         stgChunks > 0 ? static_cast<double>(stgNs) /
                 static_cast<double>(stgChunks) / 1000.0

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -559,6 +559,28 @@ struct PendingH2d {
   std::chrono::steady_clock::time_point launchedAt;
 };
 
+/// One wave of put frames whose D2H copies have been launched but not yet
+/// waited for. The frames own their staging slabs, so holding this record is
+/// what keeps the pinned destination alive while the DMA is still writing it.
+///
+/// `startIdx` is the wave's first index into put()'s chunk plan, so a failure
+/// here can abandon exactly the admissions from this wave onward.
+///
+/// Single-device by construction: put() breaks a wave at a device boundary, so
+/// one event recorded on `deviceId` covers every copy in it.
+struct PendingPutWave {
+  std::vector<TcpFrame> frames;
+  /// cudaEvent_t, kept opaque so this header does not need the CUDA runtime.
+  void* event{nullptr};
+  int deviceId{-1};
+  /// The caller's stream, so the fallback wait covers the stream the copies
+  /// were launched on rather than whatever the null stream happens to hold.
+  void* stream{nullptr};
+  size_t startIdx{0};
+  size_t bytes{0};
+  std::chrono::steady_clock::time_point launchedAt;
+};
+
 /// Shared independently of TcpTransport so queued EventBase callbacks never
 /// retain or dereference a transport that shutdown has already destroyed.
 struct H2dPollState {
@@ -674,9 +696,10 @@ class TcpTransport : public Transport {
   /// destination as undefined until a later put over it succeeds, and do not
   /// read it in between:
   ///
-  /// - Any put may partially apply. Work is staged and queued in waves of
-  ///   kMaxPutWaveChunks; a failure in wave N+1 leaves wave N queued, and
-  ///   queued frames are frames the peer applies.
+  /// - Any put may partially apply. Work is staged and queued in waves of at
+  ///   most kMaxPutWaveChunks chunks -- fewer where a wave meets a device
+  ///   boundary or a DRAM chunk -- and a failure in wave N+1 leaves wave N
+  ///   queued, and queued frames are frames the peer applies.
   /// - What did apply is not a prefix. Frames are striped across lanes, which
   ///   are independent sockets that fail independently, so a break leaves an
   ///   arbitrary subset with holes at offsets the caller cannot determine.
@@ -817,21 +840,38 @@ class TcpTransport : public Transport {
       const TcpMsgHeader& replyHeader,
       TcpSegmentRegistry::Lease lease,
       TcpPinnedSlab slab);
-  // Stages one wave of VRAM Write frames: takes a slab per chunk, issues every
-  // copy, then waits for all of them. Returns the frames only if every copy
-  // succeeded, so the caller can queue the wave as one step and a failure
-  // queues nothing.
+  // Stages one wave of VRAM Write frames in two halves, so a wave's copies can
+  // run while the previous wave is being queued and sent. A single call that
+  // launched and waited kept the copy engine idle for the whole
+  // queue-and-transmit gap, which measured as ~55% of a VRAM put's wall time
+  // spent staging against a D2H path twice as fast as the put itself.
   //
-  // Blocks until the pool can hand out the whole wave, so it must not be called
-  // holding outMu_ -- the thread that frees those slabs is the sender, and it
-  // needs that mutex to make progress.
+  // launchPutWave takes a slab per chunk, issues every copy, and records one
+  // event -- correct with one event because put() never forms a wave spanning
+  // devices. It blocks until the pool can hand out the whole wave, so it must
+  // not be called holding outMu_: the thread that frees those slabs is the
+  // sender, and it needs that mutex to make progress. That block is also the
+  // backpressure bounding how many waves can be in flight.
   //
-  // The wait covers every copy that was launched even when a later one fails. A
-  // slab handed back while the GPU is still writing into it goes straight to
-  // the next staging copy, and the two then race over the same bytes.
-  Result<std::vector<TcpFrame>> stagePutWave(
+  // The returned record owns the slabs, so the caller must either retire it or
+  // abandon it. Dropping one outright while its copies still run would hand a
+  // slab back under an active DMA, and the next staging copy would then race
+  // the GPU over the same bytes.
+  Result<PendingPutWave> launchPutWave(
       std::span<const PlannedPutFrame> wave,
-      void* stream);
+      void* stream,
+      size_t startIdx);
+  // Waits for one launched wave's copies to finish and destroys its event.
+  // Waits on the event rather than the stream, because the stream also carries
+  // later waves' copies and waiting for those would give back the overlap.
+  //
+  // Leaves the frames in place for the caller to queue, so a failure here can
+  // still drop them before any of them reaches a lane.
+  Status retirePutWave(PendingPutWave& wave);
+  // Waits out every launched wave without queueing any of it, for the unwind
+  // paths. The wait is not optional: the slabs cannot be released while the
+  // copies are still writing into them.
+  void abandonPutWaves(std::deque<PendingPutWave>& waves) noexcept;
   // Records a VRAM read to start once a slab frees up. Fails the request (the
   // caller answers with an Error frame) if the deferred queue is full: dropping
   // it silently would leave the peer waiting forever, and blocking here would
@@ -849,9 +889,12 @@ class TcpTransport : public Transport {
   // deferred.
   void scheduleDeferredReadReplies();
   // The staging pool, created on first use. Building it in the constructor
-  // would charge every peer ~64 MiB of pinned host memory -- there is one
-  // transport per peer -- including the DRAM-only peers that never stage at
-  // all.
+  // would charge every peer kStagingSlabCount slabs of pinned host memory --
+  // ~124 MiB, and there is one transport per peer -- including the DRAM-only
+  // peers that never stage at all.
+  //
+  // Named as the constant, not restated as a number: the previous wording
+  // hardcoded a figure and went stale when kStagingSlabCount was re-derived.
   Result<std::shared_ptr<TcpPinnedSlabPool>> stagingPool();
   // The independent inbound pool. It is created only for async-enabled,
   // non-zero VRAM get(), and is sized to the wire cap because recv(span)
@@ -1012,14 +1055,17 @@ class TcpTransport : public Transport {
   std::atomic<uint64_t> receiveSlabAttempts_{0};
   std::atomic<uint64_t> receiveSlabMisses_{0};
   std::atomic<uint64_t> vectorReceiveCount_{0};
-  // put-path D2H staging accounting. `stagingNs_` covers the whole span
-  // stagePutWave() spends getting a wave's payload into pinned host memory --
-  // the memcpyAsync launches plus the synchronize that waits for them -- so
-  // stagingBytes_/stagingNs_ is the effective device-to-host bandwidth this
-  // path achieves, launch overhead included. That number is the ceiling on VRAM
-  // put: no amount of queueing, lane count or CPU saving can move a transfer
-  // faster than its bytes reach the host. Written only by caller threads inside
-  // stagePutWave; relaxed because a torn read misreports one sample.
+  // put-path staging accounting. `stagingNs_` covers a wave's residency: from
+  // the memcpyAsync launches to the event wait that retires them. Because waves
+  // now overlap, that span includes time the next wave was being launched in,
+  // so the per-wave intervals overlap each other and their sum can exceed wall
+  // time. Read it as how long a wave stays in flight, NOT as D2H bandwidth --
+  // bytes/ns here is no longer a rate the device achieves. For the real D2H
+  // figure see the commit that added these counters, which measured it at 43-47
+  // GB/s while staging was still serialised against transmit.
+  //
+  // Written only by caller threads inside retirePutWave; relaxed because a torn
+  // read misreports one sample.
   std::atomic<uint64_t> stagingNs_{0};
   std::atomic<uint64_t> stagingBytes_{0};
   std::atomic<uint64_t> stagingWaves_{0};
@@ -1083,10 +1129,6 @@ class TcpTransport : public Transport {
   // request loop must derive their chunk from this same function or the reply
   // count will not match what the operation waits for.
   static size_t adaptiveGetChunk(size_t len, size_t laneCount);
-  // ~64 MiB of pinned host memory, sized against kMaxOutQueueBytes: the pool
-  // and the out queue bound the same pipeline, so a full set of staged frames
-  // fits in the queue rather than being refused by its cap.
-  static constexpr size_t kStagingSlabCount = 16;
   // Withheld from put(), so a saturated put cannot leave the get responder with
   // nothing to stage into. The responder is the side the peer is already
   // blocked on.
@@ -1094,15 +1136,44 @@ class TcpTransport : public Transport {
   // Chunks staged, and so queued, as one indivisible wave. Everything put()
   // promises about partial writes is bounded by this: a put of at most this
   // many chunks either reaches the queue whole or not at all.
-  // Half the usable pool, not all of it. A wave sized to the whole pool cannot
-  // begin staging until the previous one has drained completely, because its
-  // all-or-nothing acquire needs every slab back, so staging never overlaps
-  // transmit. Halving it keeps a wave's worth of slabs free for the next wave,
-  // which measured a large gain on GB-scale puts at no cost in pinned memory.
-  // The ratio is what matters, not the constant: this stays correct if the pool
-  // size changes.
-  static constexpr size_t kMaxPutWaveChunks =
-      (kStagingSlabCount - kStagingSlabsReservedForReader) / 2;
+  //
+  // 28 MiB, well under kMaxOutQueueBytes so a whole wave is admissible to the
+  // queue in one step rather than being refused by its cap. This is the primary
+  // knob of the three: the staging pool is sized from it below, not the other
+  // way round.
+  static constexpr size_t kMaxPutWaveChunks = 7;
+  // How many launched-but-unretired waves put() keeps. This is what buys the
+  // overlap: at 1 the caller waits for a wave's copies immediately after
+  // launching them, so the copy engine idles for the whole queue-and-transmit
+  // gap between waves. At 2 the next wave's copies are already running while
+  // the previous one is being waited for, queued and sent.
+  static constexpr size_t kMaxPutWavesInFlight = 2;
+  // Sized so acquire() does not block a caller that is holding a fully staged
+  // wave. At the moment put() acquires for a new wave, three things are already
+  // outstanding: the kMaxPutWavesInFlight - 1 waves it holds in its own deque,
+  // up to kMaxOutQueueBytes worth of frames it has queued but the sender has
+  // not drained yet, and the wave it is asking for -- plus the reader's
+  // reservation, which acquire() counts on top of the request.
+  //
+  // Getting this wrong is not a small loss, which is why it is derived rather
+  // than picked. At 16 slabs the arithmetic leaves acquire() 2 free against the
+  // 8 it needs, so every wave blocks -- and blocks while withholding a wave of
+  // already-copied frames from the sender, because they are only queued on the
+  // next trip round put()'s loop. Measured on two hosts at 1 GiB that was 16.9
+  // GB/s against 22.9 for waiting on each wave in turn: 26% worse than not
+  // overlapping at all. Sized from the invariant it measured 32.0.
+  //
+  // ~124 MiB of pinned host memory per peer that actually stages. The pool is
+  // created on first use, so DRAM-only peers still pay nothing for it.
+  static constexpr size_t kStagingSlabCount =
+      (kMaxPutWavesInFlight - 1) * kMaxPutWaveChunks +
+      kMaxOutQueueBytes / kMaxChunkSize + kMaxPutWaveChunks +
+      kStagingSlabsReservedForReader;
+  static_assert(
+      kStagingSlabCount >= kMaxPutWavesInFlight * kMaxPutWaveChunks +
+              kStagingSlabsReservedForReader,
+      "the pool must hold every wave the window keeps in flight at once, or "
+      "put() deadlocks against slabs only it can release");
   // Two full wire frames can remain pinned while Phase 3d retires H2D copies;
   // exhaustion falls back to the reusable vector instead of blocking receive.
   static constexpr size_t kReceiveSlabCount = 2;

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <stdexcept>
 #include <thread>
+#include <type_traits>
 #include <vector>
 
 #include "comms/uniflow/Segment.h"
@@ -170,14 +171,14 @@ class GatedConn : public controller::Conn {
 /// size.
 class VramPut {
  public:
-  explicit VramPut(size_t len)
+  explicit VramPut(size_t len, int deviceId = 0)
       : src_(len),
         local_(
             SegmentTest::makeRegistered(
                 src_.data(),
                 len,
                 MemoryType::VRAM,
-                /*deviceId=*/0)),
+                deviceId)),
         remote_(
             SegmentTest::makeRemote(
                 // The peer's address is never dereferenced here: TCP sends the
@@ -192,6 +193,10 @@ class VramPut {
 
   std::span<const TransferRequest> requests() const {
     return {&request_, 1};
+  }
+
+  const TransferRequest& request() const {
+    return request_;
   }
 
  private:
@@ -218,12 +223,38 @@ class TcpTransportFrameTest : public ::testing::Test {
     ON_CALL(*cudaApi_, getDevice())
         .WillByDefault(::testing::Return(Result<int>(0)));
     ON_CALL(*cudaApi_, setDevice(::testing::_))
-        .WillByDefault(::testing::Return(Ok()));
+        .WillByDefault([this](int device) -> Status {
+          currentDevice_.store(device, std::memory_order_release);
+          return Ok();
+        });
     ON_CALL(*cudaApi_, streamSynchronize(::testing::_))
-        .WillByDefault([this](auto) -> Status {
+        .WillByDefault([this](auto stream) -> Status {
+          {
+            std::lock_guard<std::mutex> lk(syncMu_);
+            streamSyncStreams_.push_back(static_cast<const void*>(stream));
+          }
           syncCount_.fetch_add(1, std::memory_order_release);
           std::unique_lock<std::mutex> lk(syncMu_);
           syncReleased_.wait(lk, [this]() { return !syncsGated_; });
+          return Ok();
+        });
+    // The put path waits per wave on its own event rather than on the stream,
+    // so this is the wait the success path actually takes. Gated by the same
+    // switch as streamSynchronize, so a test can hold every staging wait open
+    // regardless of which one the code under test picks.
+    ON_CALL(*cudaApi_, eventSynchronize(::testing::_))
+        .WillByDefault([this](auto) -> Status {
+          {
+            std::lock_guard<std::mutex> lk(syncMu_);
+            eventSyncDevices_.push_back(
+                currentDevice_.load(std::memory_order_acquire));
+          }
+          eventSyncCount_.fetch_add(1, std::memory_order_release);
+          std::unique_lock<std::mutex> lk(syncMu_);
+          syncReleased_.wait(lk, [this]() { return !syncsGated_; });
+          if (failEventSync_.load(std::memory_order_acquire)) {
+            return Err(ErrCode::DriverError, "test: event wait failed");
+          }
           return Ok();
         });
     // Real host memory behind the staging pool: the pool hands out pointers the
@@ -559,10 +590,15 @@ class TcpTransportFrameTest : public ::testing::Test {
               return Ok();
             });
     ON_CALL(*cudaApi_, eventCreate(::testing::_))
-        .WillByDefault([](auto* event) -> Status {
+        .WillByDefault([this](auto* event) -> Status {
+          // Non-null on purpose: the put path reads a null event as "no event
+          // was recorded" and skips the per-wave wait, so a zeroed handle would
+          // quietly disable the path under test.
+          //
           // Spelled with auto because this TU is not hipified: cudaEvent_t is
           // ihipEvent_t* here, and naming it does not compile under ROCm.
-          *event = {};
+          *event =
+              reinterpret_cast<std::decay_t<decltype(*event)>>(&fakeEvent_);
           return Ok();
         });
     ON_CALL(*cudaApi_, eventRecord(::testing::_, ::testing::_))
@@ -633,6 +669,29 @@ class TcpTransportFrameTest : public ::testing::Test {
     return syncCount_.load(std::memory_order_acquire);
   }
 
+  int eventSyncCount() const {
+    return eventSyncCount_.load(std::memory_order_acquire);
+  }
+
+  /// The device current at each per-wave event wait, in wait order. One entry
+  /// per wave retired, which is how a test tells a single wave spanning devices
+  /// from one wave per device.
+  std::vector<int> eventSyncDevices() {
+    std::lock_guard<std::mutex> lk(syncMu_);
+    return eventSyncDevices_;
+  }
+
+  std::vector<const void*> streamSyncStreams() {
+    std::lock_guard<std::mutex> lk(syncMu_);
+    return streamSyncStreams_;
+  }
+
+  /// Makes the per-wave event wait unusable, so the retire path has to fall
+  /// back to quiescing the stream.
+  void failEventSyncs() {
+    failEventSync_.store(true, std::memory_order_release);
+  }
+
   size_t deferredReplyCount() {
     std::lock_guard<std::mutex> lk(transport_->stagingMu_);
     return transport_->deferredReplies_.size();
@@ -642,8 +701,20 @@ class TcpTransportFrameTest : public ::testing::Test {
     return transport_->put(requests, RequestOptions{});
   }
 
+  std::future<Status> putOnStream(
+      std::span<const TransferRequest> requests,
+      void* stream) {
+    RequestOptions options;
+    options.stream = stream;
+    return transport_->put(requests, options);
+  }
+
   static constexpr size_t waveCap() {
     return TcpTransport::kMaxPutWaveChunks;
+  }
+
+  static constexpr size_t wavesInFlight() {
+    return TcpTransport::kMaxPutWavesInFlight;
   }
 
   static size_t getChunk(size_t len, size_t laneCount) {
@@ -755,12 +826,20 @@ class TcpTransportFrameTest : public ::testing::Test {
   static constexpr size_t kTestSlabSize = 256;
   std::atomic<bool> copyDone_{false};
   std::atomic<int> syncCount_{0};
+  std::atomic<int> eventSyncCount_{0};
+  std::atomic<int> currentDevice_{0};
+  std::atomic<bool> failEventSync_{false};
+  /// Storage a fake cudaEvent_t can point at, so the handle the stubs hand out
+  /// is non-null without inventing an address.
+  uint8_t fakeEvent_{0};
   std::mutex copyMu_;
   std::vector<const void*> copyDsts_;
   std::mutex allocMu_;
   std::vector<std::pair<std::unique_ptr<uint8_t[]>, size_t>> hostAllocs_;
   std::mutex syncMu_;
   std::condition_variable syncReleased_;
+  std::vector<int> eventSyncDevices_;
+  std::vector<const void*> streamSyncStreams_;
   bool syncsGated_{false};
   size_t failCopyAt_{0};
 };
@@ -2182,6 +2261,150 @@ TEST_F(TcpTransportFrameTest, AFailedWaveQueuesNothingAndDrainsWhatItLaunched) {
          "them held by a frame it queued";
 }
 
+// A put spanning three or more waves must complete. The window put() keeps is
+// two waves deep, and each wave holds half the usable staging pool, so wave
+// three's all-or-nothing acquire cannot be satisfied while two waves are still
+// held. Draining after launching parks the caller in acquire() waiting for
+// slabs only it can release -- the frames holding them are sitting unqueued in
+// its own deque -- so any put of three waves hangs forever. Draining before
+// launching leaves at most one wave held, and the sender frees the rest.
+TEST_F(TcpTransportFrameTest, APutOfThreeWavesCompletes) {
+  setConnected();
+  stubStagingCopies();
+  releaseStagingCopies();
+  auto& conn = installCountingConn();
+  std::thread sender([this]() { runSenderLoop(); });
+
+  const size_t chunks = 3 * waveCap();
+  VramPut transfer(chunks * slabPayloadCap());
+  // The future stays open -- nothing Acks these writes -- so the frames
+  // reaching the connection are what says the put got all the way through.
+  auto future = put(transfer.requests());
+
+  EXPECT_TRUE(waitFor([&]() {
+    return static_cast<size_t>(conn.sendCount()) == chunks;
+  })) << "a put deeper than the in-flight window must still finish; holding "
+         "every launched wave while acquiring the next one deadlocks here";
+
+  closeOutQueue();
+  sender.join();
+}
+
+// One event per wave is only correct while a wave stays on one device, so the
+// wave-forming scan has to break at a device boundary. Without that break a put
+// carrying chunks on two devices records its single event on the first chunk's
+// device, leaves the other device's copies unwaited, and returns their slabs to
+// the pool with a DMA still writing into them.
+TEST_F(TcpTransportFrameTest, AWaveNeverSpansDevices) {
+  setConnected();
+  stubStagingCopies();
+  releaseStagingCopies();
+
+  // One chunk each, so a wave that ignored the device boundary would hold both.
+  VramPut onDevice0(slabPayloadCap(), /*deviceId=*/0);
+  VramPut onDevice1(slabPayloadCap(), /*deviceId=*/1);
+  const std::vector<TransferRequest> requests{
+      onDevice0.request(), onDevice1.request()};
+
+  auto future = put(requests);
+  ASSERT_EQ(
+      future.wait_for(std::chrono::seconds(5)), std::future_status::timeout)
+      << "the put is queued but unacked, so it must not resolve yet";
+
+  EXPECT_EQ(outQueueDepth(), 2u) << "both chunks must be queued";
+  const std::vector<int> expected{0, 1};
+  EXPECT_EQ(eventSyncDevices(), expected)
+      << "the two devices' copies must be waited for as two waves, each under "
+         "its own device; one wave here means one device's copies were never "
+         "waited for and its slab went back to the pool under a live DMA";
+}
+
+// The property the split exists for. Wave N+1's copies must already be issued
+// while wave N is still being waited for -- that is the overlap, and it is what
+// keeps the copy engine busy through the gap where a wave is queued and sent.
+// A throughput number alone cannot say whether this happened.
+TEST_F(
+    TcpTransportFrameTest,
+    TheNextWavesCopiesAreIssuedBeforeThisWaveIsWaited) {
+  setConnected();
+  stubStagingCopies();
+  releaseStagingCopies();
+  // Hold the first wave's wait open, so the state at that instant is
+  // observable. Without this the window closes too fast to assert anything.
+  gateStagingWaits();
+  auto& conn = installCountingConn();
+  std::thread sender([this]() { runSenderLoop(); });
+
+  const size_t chunks = 3 * waveCap();
+  VramPut transfer(chunks * slabPayloadCap());
+  std::thread putter([&]() { (void)put(transfer.requests()); });
+
+  ASSERT_TRUE(waitFor([&]() { return eventSyncCount() >= 1; }))
+      << "the first wave must be waited for once the window is full";
+  EXPECT_GE(stagedCopyCount(), wavesInFlight() * waveCap())
+      << "only the first wave's copies were issued before it was waited for, "
+         "so the copy engine sits idle for the whole queue-and-transmit gap -- "
+         "which is the serialised behaviour this change replaces";
+
+  releaseStagingWaits();
+  EXPECT_TRUE(waitFor(
+      [&]() { return static_cast<size_t>(conn.sendCount()) == chunks; }));
+
+  putter.join();
+  closeOutQueue();
+  sender.join();
+}
+
+// Waiting on the stream would wait for every wave queued on it, including the
+// ones deliberately launched to run in the background, which is exactly the
+// overlap this change creates. The success path must therefore wait on the
+// wave's own event and nothing else.
+TEST_F(TcpTransportFrameTest, ASuccessfulPutNeverSynchronizesTheStream) {
+  setConnected();
+  stubStagingCopies();
+  releaseStagingCopies();
+  EXPECT_CALL(*cudaApi_, streamSynchronize(::testing::_)).Times(0);
+
+  const size_t chunks = 2 * waveCap();
+  VramPut transfer(chunks * slabPayloadCap());
+  auto future = put(transfer.requests());
+  ASSERT_EQ(
+      future.wait_for(std::chrono::seconds(5)), std::future_status::timeout)
+      << "the put is queued but unacked, so it must not resolve yet";
+
+  EXPECT_EQ(outQueueDepth(), chunks) << "every chunk must be queued";
+  EXPECT_GE(eventSyncCount(), 2) << "each wave must be waited for on its event";
+}
+
+// When the per-wave event wait fails there is nothing left that covers the
+// copies, so the retire path falls back to quiescing the stream. It has to be
+// the stream the copies were launched on: the null stream does not cover a
+// caller-supplied one, so falling back to it would release slabs with the DMA
+// still running -- the very case the fallback exists to prevent.
+TEST_F(TcpTransportFrameTest, AnUnusableEventFallsBackToTheCallersStream) {
+  setConnected();
+  stubStagingCopies();
+  releaseStagingCopies();
+  failEventSyncs();
+
+  // Never dereferenced: memcpyAsync and the waits are all stubbed, and the only
+  // thing under test is which handle the fallback wait is given.
+  // NOLINTNEXTLINE(performance-no-int-to-ptr)
+  void* callerStream = reinterpret_cast<void*>(0xF00D);
+  VramPut transfer(slabPayloadCap());
+  auto future = putOnStream(transfer.requests(), callerStream);
+
+  ASSERT_EQ(
+      future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  EXPECT_TRUE(future.get().hasError())
+      << "a wave whose copies could not be waited for must fail the put";
+  const std::vector<const void*> expected{callerStream};
+  EXPECT_EQ(streamSyncStreams(), expected)
+      << "the fallback must quiesce the caller's stream; synchronizing the "
+         "null stream leaves the caller's copies running over slabs that are "
+         "on their way back to the pool";
+}
+
 // A get no larger than one chunk is one frame, and a frame takes one lane, so
 // it leaves every other lane idle. These are the sizes where splitting pays,
 // and the ones where it does not.
@@ -2243,21 +2466,28 @@ TEST_F(TcpTransportFrameTest, AdaptiveGetChunkAgreesWithFrameCount) {
 
 // put() tells callers a failed put may have partially applied, and that what
 // applied is not a prefix. This is the test that makes that true rather than
-// merely written down: the first wave stages and queues, the second fails, and
-// the caller is told it failed while the first wave's frames are already on
-// their way to a peer that will apply them and never hear otherwise.
+// merely written down: earlier waves reach the queue, a later one fails, and
+// the caller is told it failed while a peer that will apply those frames is
+// never told anything.
+//
+// The failure has to be in the third wave, not the second. put() keeps two
+// waves in flight, so wave N is only queued when wave N+2 is launched: failing
+// the second wave's first copy would find the first wave still unqueued and
+// drop it, and the put would not be partial at all.
 //
 // Deliberately not asserted: that the put parks. It used to, because a wave
 // sized to the whole pool left the next wave nothing to stage into, and a test
 // resting on that would go red purely from resizing the wave.
-TEST_F(TcpTransportFrameTest, AFailedPutAboveOneWaveLeavesEarlierWavesQueued) {
+TEST_F(
+    TcpTransportFrameTest,
+    AFailedPutAboveTheWaveWindowLeavesEarlierWavesQueued) {
   setConnected();
   stubStagingCopies();
   releaseStagingCopies();
-  // Succeed through the first wave, then fail the second wave's first copy.
-  failCopyAfter(waveCap());
+  // Succeed through the window, then fail the first copy of the wave after it.
+  failCopyAfter(wavesInFlight() * waveCap());
 
-  const size_t chunks = waveCap() + 1;
+  const size_t chunks = wavesInFlight() * waveCap() + 1;
   VramPut transfer(chunks * slabPayloadCap());
   auto future = put(transfer.requests());
 
@@ -2265,10 +2495,11 @@ TEST_F(TcpTransportFrameTest, AFailedPutAboveOneWaveLeavesEarlierWavesQueued) {
       future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
   EXPECT_TRUE(future.get().hasError()) << "the caller must be told it failed";
   EXPECT_EQ(outQueueDepth(), waveCap())
-      << "the first wave must still be queued: a failed put is documented as "
-         "possibly partial, and this is the case that makes it so";
-  EXPECT_EQ(stagedCopyCount(), waveCap() + 1)
-      << "the failure must be the second wave's copy, not something earlier";
+      << "the wave that had already been retired must still be queued: a "
+         "failed put is documented as possibly partial, and this is the case "
+         "that makes it so";
+  EXPECT_EQ(stagedCopyCount(), wavesInFlight() * waveCap() + 1)
+      << "the failure must be the copy after the window, not something earlier";
 }
 
 // A put long enough that both limits bind several times over: the pool refills


### PR DESCRIPTION
Summary:

The parent commit measured where a VRAM put's time goes. D2H staging runs at
43-47 GB/s while the put itself gets 24, so the copy engine is not the ceiling; but at
1 GiB, 1295 waves x 667.6us is 864ms of staging against a 1564ms run, so 55% of wall
time is spent inside stagePutWave(). Fully serialised staging and transmission predicts
19.4 GB/s and fully overlapped predicts about 35 -- the measured 24 sits much closer to
serialised, because the per-wave streamSynchronize on the caller thread is what stops
the next wave's copies from being launched while the previous one is queued and sent.

This overlaps them. stagePutWave() splits into launchPutWave() and retirePutWave(), and
put() keeps a bounded window of launched-but-unretired waves in a local deque: wave N+1's
copies are issued before wave N is waited for and queued, so the copy engine keeps
working through the queue-and-transmit gap.

put() stays synchronous and still returns only once every frame is queued, so nothing
about the promise, the Ack path, or the caller's buffer lifetime changes. All new state
is local to put() and unwound on every exit path, so shutdown() needs no new hook.
Backpressure is still the staging pool: acquire() blocks until a whole wave's slabs are
free, and slabs free as the sender drains the frames holding them.

Three things this needed beyond the split:

Drain before launching, not after. Waves are half the usable pool
(kMaxPutWaveChunks = (16-1)/2 = 7) and acquire(7) waits for 8 free, so two in-flight
waves hold 14 and leave 2. Launching the third wave before retiring the first parks the
caller in acquire() waiting for slabs only it can release -- the frames holding them are
still sitting unqueued in its own deque. That deadlocks every VRAM put of 3+ waves
(~84 MiB up), i.e. every size in the sweep. Draining to kMaxPutWavesInFlight - 1 first
leaves at most one wave held, so a wave's worth is either free or being freed by the
sender. Note the pool caps the window at 2, so kMaxPutWavesInFlight is a guard rather
than a tuning knob; going deeper means shrinking wave size, which is a separate measured
experiment.

Break a wave at a device boundary. put() flattens all requests into one plan and takes
deviceId per request, so a put can carry chunks on different devices, and the wave scan
broke only on vram/len/chunk-count. One event per wave is only correct while a wave stays
on one device: a wave spanning two would leave the other device's copies unwaited and
return their slabs under live DMA. The scan now also breaks on deviceId, which makes
one-event-per-wave true by construction and keeps the retire path single-device. Waves
are therefore at most kMaxPutWaveChunks chunks, and put()'s partial-write contract says
"at most" accordingly.

Fall back to the caller's stream. When the event wait fails there is nothing left
covering the copies, so the retire path quiesces the stream instead -- and it has to be
the stream the copies were launched on. PendingPutWave carries `stream` for that, as
PendingH2d already does.

The per-wave wait is CudaApi::eventSynchronize (previous diff) rather than a spin on
eventQuery: spinning would burn a core against the 8 sender threads and the readers on
the exact benchmark this change is judged by, and it cannot wait for one wave without
over-waiting the stream.

Metric semantics change with it. Once waves overlap, launch->retire spans the next wave's
launch, so the per-wave intervals overlap each other, their sum can exceed wall time, and
bytes/ns stops being a rate the device achieves. The counters are kept but redefined as
wave residency -- how long a wave stays in flight -- and the GB/s figure is dropped from
the log line. For the D2H number itself see the parent commit, which established it at
43-47 GB/s while staging was still serialised against transmit.

Folded in D118010136, which added the CudaApi primitive this depends on and had no other
caller. It was a virtual method, a mock entry and a unit test for an API nothing used, so
there was nothing to review it against on its own:

CudaApi exposed eventCreate/eventRecord/eventQuery/eventDestroy but no blocking wait on a
single event, and neither existing option suits the caller thread here. Polling eventQuery
burns a core -- affordable on the EventBase paths that do it today, since they re-dispatch
between polls, but not on a caller thread competing with the sender threads and readers.
streamSynchronize waits for the whole stream, which is strictly more than asked for: a
caller pipelining several batches on one stream cannot wait for the first without also
waiting for the ones it deliberately queued behind it, which is the pipelining it wanted.
cudaEventSynchronize blocks on the one recorded event and ignores anything queued after
it. Adding it behind CudaApi rather than reaching around the seam is what keeps the put
path mockable. (eventCreate passes cudaEventDisableTiming, which affects only
eventElapsedTime; a disabled-timing event is still recordable, queryable and waitable.)

Reviewed By: yexiangd

Differential Revision: D118010137


