### PR TITLE
comms/uniflow/tcp: count data sockets per NIC, and widen the lane hello to match (#3922)

### DIFF
--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -319,7 +319,8 @@ MultiTransportFactory::MultiTransportFactory(
     auto tcp = std::make_shared<TcpTransportFactory>(
         deviceId,
         eventBaseThread_->getEventBase(),
-        controller::TcpSocketConfig{},
+        options_.tcpTransportConfig ? *options_.tcpTransportConfig
+                                    : TcpTransportConfig{},
         tcpHost);
     factories_.emplace_back(std::move(tcp));
   } else {

--- a/comms/uniflow/MultiTransport.h
+++ b/comms/uniflow/MultiTransport.h
@@ -51,7 +51,8 @@ struct MultiTransportFactoryOptions {
   bool enableTcp{false};
   std::string tcpBindHost{};
   // Overrides for the TCP data transport: socket options, lane count
-  // (numSockets), and the devices lanes bind to. Null keeps the
+  // (numSocketsPerDevice, applied per device), and the devices lanes bind to.
+  // Null keeps the
   // TcpTransportConfig defaults, so this is an override seam rather than
   // required config, and it is the only way to reach lane striping from outside
   // the transport.

--- a/comms/uniflow/MultiTransport.h
+++ b/comms/uniflow/MultiTransport.h
@@ -12,6 +12,10 @@
 
 namespace uniflow {
 
+// Defined in transport/tcp/TcpTransport.h, which this header cannot include:
+// TCP is AMD-only, so the type is not available on every platform.
+struct TcpTransportConfig;
+
 enum class CpuNicSelectionPolicy {
   kAll,
   kNumaLocalBounded,
@@ -46,6 +50,18 @@ struct MultiTransportFactoryOptions {
   // loopback (e.g. same-host testing).
   bool enableTcp{false};
   std::string tcpBindHost{};
+  // Overrides for the TCP data transport: socket options, lane count
+  // (numSockets), and the devices lanes bind to. Null keeps the
+  // TcpTransportConfig defaults, so this is an override seam rather than
+  // required config, and it is the only way to reach lane striping from outside
+  // the transport.
+  //
+  // Held by pointer, and the type only forward-declared, because TCP is
+  // AMD-only (see the ovr_config//gpu:amd deps in BUCK): a by-value member
+  // would drag TcpTransport.h into every consumer of this header and fail to
+  // compile where the transport is not built. The struct layout stays
+  // platform-independent this way, so callers need no #ifdef to leave it unset.
+  std::shared_ptr<const TcpTransportConfig> tcpTransportConfig;
 };
 
 class MultiTransport {

--- a/comms/uniflow/Uniflow.cpp
+++ b/comms/uniflow/Uniflow.cpp
@@ -17,6 +17,7 @@ MultiTransportFactoryOptions makeFactoryOptions(
   options.preferredTransport = config.preferredTransport;
   options.intraNodeTransport = config.intraNodeTransport;
   options.interNodeTransport = config.interNodeTransport;
+  options.tcpTransportConfig = config.tcpTransportConfig;
   return options;
 }
 

--- a/comms/uniflow/Uniflow.h
+++ b/comms/uniflow/Uniflow.h
@@ -35,6 +35,11 @@ struct UniflowAgentConfig {
   // a case's first choice (intra-node -> RDMA/TCP; inter-node -> TCP).
   std::optional<TransportType> intraNodeTransport;
   std::optional<TransportType> interNodeTransport;
+  // Forwarded to MultiTransportFactoryOptions::tcpTransportConfig -- socket
+  // options, lane count, and lane device binding for the TCP data path. Null
+  // keeps the transport's own defaults. See that field for why it is a pointer
+  // to a forward-declared type.
+  std::shared_ptr<const TcpTransportConfig> tcpTransportConfig;
 };
 
 class UniflowAgent {

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
@@ -21,6 +21,7 @@
 
 #include <cuda_runtime_api.h> // @manual=third-party//cuda:cuda-lazy
 
+#include <fmt/format.h>
 #include "comms/uniflow/Segment.h"
 #include "comms/uniflow/benchmarks/Rendezvous.h"
 #include "comms/uniflow/benchmarks/SegmentHelper.h"
@@ -462,8 +463,10 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
   }
 
   ScopedEventBaseThread evbThread("bench-tcp-evb");
+  controller::TcpSocketConfig sockConfig;
+  sockConfig.socketBufSize = sockBufSize_;
   auto factory = std::make_unique<TcpTransportFactory>(
-      dev, evbThread.getEventBase(), controller::TcpSocketConfig{}, host);
+      dev, evbThread.getEventBase(), sockConfig, host);
 
   // Handshake over the rendezvous control channel.
   auto localTopo = factory->getTopology();
@@ -600,12 +603,24 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
       if (aborted || !isActiveRank) {
         continue;
       }
+      // Bracket the timed loop so the phase split covers the same frames the
+      // reported bandwidth does, warmup included -- runTransfer does its own
+      // warmup internally, so the reset has to sit before the call, not inside.
+      auto* tcpTransport =
+          dynamic_cast<::uniflow::TcpTransport*>(transport.get());
+      if (tcpTransport != nullptr) {
+        tcpTransport->logAndResetPhaseStats("reset");
+      }
       auto r = runTransfer(*transport, localReg, remoteReg, size, dir, config);
       if (!r.ok) {
         // Latched rather than returned: every remaining size has a barrier the
         // peer is going to execute.
         aborted = true;
         continue;
+      }
+      if (tcpTransport != nullptr) {
+        tcpTransport->logAndResetPhaseStats(
+            fmt::format("{} size={}", dir, size));
       }
       auto stats = Stats::compute(std::move(r.latenciesUs));
       results.push_back({

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <deque>
 #include <future>
+#include <iostream>
 #include <random>
 #include <string>
 #include <utility>
@@ -450,11 +451,20 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
         "TcpBandwidthBenchmark: no global IPv6 on interface '{}'", iface_);
     return {};
   }
+  const std::string asyncGetH2dMode = asyncGetH2d_ ? "on" : "off";
+  const std::string sockBufMode =
+      sockBufSize_ ? std::to_string(*sockBufSize_) : "os-default";
+  std::cerr << "TcpBandwidthBenchmark: rank=" << bootstrap.rank
+            << " iface=" << iface_ << " async_get_h2d=" << asyncGetH2dMode
+            << " tcp_sockbuf=" << sockBufMode << '\n';
   UNIFLOW_LOG_WARN(
-      "TcpBandwidthBenchmark: rank {} using {} address {}",
+      "TcpBandwidthBenchmark: rank {} using {} address {} "
+      "async_get_h2d={} tcp_sockbuf={}",
       bootstrap.rank,
       iface_,
-      host);
+      host,
+      asyncGetH2dMode,
+      sockBufMode);
 
   const int dev = config.cudaDevice;
   BufferPair bufs;
@@ -463,10 +473,11 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
   }
 
   ScopedEventBaseThread evbThread("bench-tcp-evb");
-  controller::TcpSocketConfig sockConfig;
-  sockConfig.socketBufSize = sockBufSize_;
+  TcpTransportConfig transportConfig;
+  transportConfig.socketConfig.socketBufSize = sockBufSize_;
+  transportConfig.asyncGetH2d = asyncGetH2d_;
   auto factory = std::make_unique<TcpTransportFactory>(
-      dev, evbThread.getEventBase(), sockConfig, host);
+      dev, evbThread.getEventBase(), transportConfig, host);
 
   // Handshake over the rendezvous control channel.
   auto localTopo = factory->getTopology();
@@ -637,12 +648,13 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
           .messageRateMops = r.messageRateMops,
       });
       UNIFLOW_LOG_WARN(
-          "[rank {}] {} size={:<10} iface={} batch={:<3} txdepth={:<3} "
-          "iters={:<6} bw={:.2f} GB/s avg={:.1f} us {}",
+          "[rank {}] {} size={:<10} iface={} async_get_h2d={} batch={:<3} "
+          "txdepth={:<3} iters={:<6} bw={:.2f} GB/s avg={:.1f} us {}",
           bootstrap.rank,
           dir,
           size,
           iface_,
+          asyncGetH2dMode,
           std::max(1, config.batchSize),
           std::max(1, config.txDepth),
           r.totalOps,

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
@@ -476,6 +476,7 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
   TcpTransportConfig transportConfig;
   transportConfig.socketConfig.socketBufSize = sockBufSize_;
   transportConfig.asyncGetH2d = asyncGetH2d_;
+  transportConfig.numSockets = numSockets_;
   auto factory = std::make_unique<TcpTransportFactory>(
       dev, evbThread.getEventBase(), transportConfig, host);
 

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
@@ -2,8 +2,6 @@
 
 #include "comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h"
 
-#include <arpa/inet.h>
-#include <ifaddrs.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
 
@@ -27,6 +25,7 @@
 #include "comms/uniflow/benchmarks/Rendezvous.h"
 #include "comms/uniflow/benchmarks/SegmentHelper.h"
 #include "comms/uniflow/benchmarks/Stats.h"
+#include "comms/uniflow/controller/TcpController.h"
 #include "comms/uniflow/executor/ScopedEventBaseThread.h"
 #include "comms/uniflow/logging/Logger.h"
 #include "comms/uniflow/transport/tcp/TcpTransport.h"
@@ -38,31 +37,15 @@ namespace {
 // Fixed so a verification failure reproduces exactly; logged with the banner.
 constexpr uint64_t kVerifySeed = 0x5EED1234;
 
-/// First global (non-link-local) IPv6 address on `iface`, or "" if none.
+/// First live global (non-link-local, non-deprecated) IPv6 address on `iface`,
+/// or "" if none. Delegates to the controller so that the deprecated-address
+/// filtering is shared with the transport's own per-device resolution: several
+/// MI350 frontend NICs carry a deprecated address alongside their live one, and
+/// binding the deprecated one yields a working socket the peer will not reply
+/// to.
 std::string getInterfaceIpv6(const std::string& iface) {
-  struct ifaddrs* ifaddr = nullptr;
-  if (getifaddrs(&ifaddr) != 0) {
-    return "";
-  }
-  std::string result;
-  for (auto* ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
-    if (ifa->ifa_addr == nullptr || ifa->ifa_addr->sa_family != AF_INET6 ||
-        iface != ifa->ifa_name) {
-      continue;
-    }
-    auto* sa = reinterpret_cast<sockaddr_in6*>(ifa->ifa_addr);
-    if (sa->sin6_addr.s6_addr[0] == 0xfe &&
-        (sa->sin6_addr.s6_addr[1] & 0xc0) == 0x80) {
-      continue; // link-local
-    }
-    char buf[INET6_ADDRSTRLEN] = {};
-    if (inet_ntop(AF_INET6, &sa->sin6_addr, buf, sizeof(buf)) != nullptr) {
-      result = buf;
-      break;
-    }
-  }
-  freeifaddrs(ifaddr);
-  return result;
+  auto addr = controller::deviceGlobalIpv6(iface);
+  return addr ? addr.value() : std::string{};
 }
 
 // A src/dst buffer pair (DRAM or VRAM), freed on destruction.
@@ -445,26 +428,43 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
     return {};
   }
 
-  const std::string host = getInterfaceIpv6(iface_);
+  // With striping the transport binds one listener per device and resolves each
+  // device's address itself, so the address advertised for endpoint 0 must be
+  // the one belonging to the first device rather than to --tcp-iface.
+  const std::string addrDevice = bindDevs_.empty() ? iface_ : bindDevs_.front();
+  const std::string host = getInterfaceIpv6(addrDevice);
   if (host.empty()) {
     UNIFLOW_LOG_ERROR(
-        "TcpBandwidthBenchmark: no global IPv6 on interface '{}'", iface_);
+        "TcpBandwidthBenchmark: no live global IPv6 on interface '{}'",
+        addrDevice);
     return {};
   }
   const std::string asyncGetH2dMode = asyncGetH2d_ ? "on" : "off";
   const std::string sockBufMode =
       sockBufSize_ ? std::to_string(*sockBufSize_) : "os-default";
+  // Recorded in the run log because the whole point of the flag is that an
+  // interface label alone does not tell you which NIC carried the traffic.
+  std::string bindDevMode;
+  for (const auto& d : bindDevs_) {
+    bindDevMode += bindDevMode.empty() ? d : "," + d;
+  }
+  if (bindDevMode.empty()) {
+    bindDevMode = "off";
+  }
   std::cerr << "TcpBandwidthBenchmark: rank=" << bootstrap.rank
             << " iface=" << iface_ << " async_get_h2d=" << asyncGetH2dMode
-            << " tcp_sockbuf=" << sockBufMode << '\n';
+            << " tcp_sockbuf=" << sockBufMode << " bind_dev=" << bindDevMode
+            << " sockets=" << numSockets_ << '\n';
   UNIFLOW_LOG_WARN(
       "TcpBandwidthBenchmark: rank {} using {} address {} "
-      "async_get_h2d={} tcp_sockbuf={}",
+      "async_get_h2d={} tcp_sockbuf={} bind_dev={} sockets={}",
       bootstrap.rank,
-      iface_,
+      addrDevice,
       host,
       asyncGetH2dMode,
-      sockBufMode);
+      sockBufMode,
+      bindDevMode,
+      numSockets_);
 
   const int dev = config.cudaDevice;
   BufferPair bufs;
@@ -475,6 +475,7 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
   ScopedEventBaseThread evbThread("bench-tcp-evb");
   TcpTransportConfig transportConfig;
   transportConfig.socketConfig.socketBufSize = sockBufSize_;
+  transportConfig.bindToDevices = bindDevs_;
   transportConfig.asyncGetH2d = asyncGetH2d_;
   transportConfig.numSockets = numSockets_;
   auto factory = std::make_unique<TcpTransportFactory>(

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
@@ -451,20 +451,25 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
   if (bindDevMode.empty()) {
     bindDevMode = "off";
   }
+  const size_t totalLanes =
+      socketsPerNic_ * std::max<size_t>(bindDevs_.size(), 1);
   std::cerr << "TcpBandwidthBenchmark: rank=" << bootstrap.rank
             << " iface=" << iface_ << " async_get_h2d=" << asyncGetH2dMode
             << " tcp_sockbuf=" << sockBufMode << " bind_dev=" << bindDevMode
-            << " sockets=" << numSockets_ << '\n';
+            << " sockets_per_nic=" << socketsPerNic_
+            << " total_lanes=" << totalLanes << '\n';
   UNIFLOW_LOG_WARN(
       "TcpBandwidthBenchmark: rank {} using {} address {} "
-      "async_get_h2d={} tcp_sockbuf={} bind_dev={} sockets={}",
+      "async_get_h2d={} tcp_sockbuf={} bind_dev={} sockets_per_nic={} "
+      "total_lanes={}",
       bootstrap.rank,
       addrDevice,
       host,
       asyncGetH2dMode,
       sockBufMode,
       bindDevMode,
-      numSockets_);
+      socketsPerNic_,
+      totalLanes);
 
   const int dev = config.cudaDevice;
   BufferPair bufs;
@@ -477,7 +482,7 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
   transportConfig.socketConfig.socketBufSize = sockBufSize_;
   transportConfig.bindToDevices = bindDevs_;
   transportConfig.asyncGetH2d = asyncGetH2d_;
-  transportConfig.numSockets = numSockets_;
+  transportConfig.numSocketsPerDevice = socketsPerNic_;
   auto factory = std::make_unique<TcpTransportFactory>(
       dev, evbThread.getEventBase(), transportConfig, host);
 

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -14,8 +15,11 @@ namespace uniflow::benchmark {
 /// buffers, or VRAM staged through host memory inside the transport.
 class TcpBandwidthBenchmark : public Benchmark {
  public:
-  explicit TcpBandwidthBenchmark(std::string iface)
-      : iface_(std::move(iface)) {}
+  /// @p sockBufSize is the SO_SNDBUF/SO_RCVBUF value for the data connection;
+  /// nullopt leaves the kernel's own sizing in place, which is what lets
+  /// receive autotuning grow the window past the bandwidth-delay product.
+  TcpBandwidthBenchmark(std::string iface, std::optional<int> sockBufSize)
+      : iface_(std::move(iface)), sockBufSize_(sockBufSize) {}
 
   std::string name() const override {
     return "tcp_bandwidth";
@@ -28,6 +32,7 @@ class TcpBandwidthBenchmark : public Benchmark {
 
  private:
   std::string iface_;
+  std::optional<int> sockBufSize_;
 };
 
 } // namespace uniflow::benchmark

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h
@@ -18,8 +18,13 @@ class TcpBandwidthBenchmark : public Benchmark {
   /// @p sockBufSize is the SO_SNDBUF/SO_RCVBUF value for the data connection;
   /// nullopt leaves the kernel's own sizing in place, which is what lets
   /// receive autotuning grow the window past the bandwidth-delay product.
-  TcpBandwidthBenchmark(std::string iface, std::optional<int> sockBufSize)
-      : iface_(std::move(iface)), sockBufSize_(sockBufSize) {}
+  TcpBandwidthBenchmark(
+      std::string iface,
+      std::optional<int> sockBufSize,
+      bool asyncGetH2d = true)
+      : iface_(std::move(iface)),
+        sockBufSize_(sockBufSize),
+        asyncGetH2d_(asyncGetH2d) {}
 
   std::string name() const override {
     return "tcp_bandwidth";
@@ -33,6 +38,7 @@ class TcpBandwidthBenchmark : public Benchmark {
  private:
   std::string iface_;
   std::optional<int> sockBufSize_;
+  bool asyncGetH2d_{true};
 };
 
 } // namespace uniflow::benchmark

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h
@@ -18,15 +18,21 @@ class TcpBandwidthBenchmark : public Benchmark {
   /// @p sockBufSize is the SO_SNDBUF/SO_RCVBUF value for the data connection;
   /// nullopt leaves the kernel's own sizing in place, which is what lets
   /// receive autotuning grow the window past the bandwidth-delay product.
+  /// @p bindDevs are the network devices to pin egress to via SO_BINDTODEVICE,
+  /// one listener per device and lane i placed on device i % size(). Empty
+  /// leaves egress to the routing table, in which case @p iface only selects a
+  /// source address and routing still decides which NIC traffic leaves through.
   TcpBandwidthBenchmark(
       std::string iface,
       std::optional<int> sockBufSize,
       bool asyncGetH2d = true,
-      size_t numSockets = 4)
+      size_t numSockets = 4,
+      std::vector<std::string> bindDevs = {})
       : iface_(std::move(iface)),
         sockBufSize_(sockBufSize),
         asyncGetH2d_(asyncGetH2d),
-        numSockets_(numSockets) {}
+        numSockets_(numSockets),
+        bindDevs_(std::move(bindDevs)) {}
 
   std::string name() const override {
     return "tcp_bandwidth";
@@ -42,6 +48,7 @@ class TcpBandwidthBenchmark : public Benchmark {
   std::optional<int> sockBufSize_;
   bool asyncGetH2d_{true};
   size_t numSockets_{4};
+  std::vector<std::string> bindDevs_;
 };
 
 } // namespace uniflow::benchmark

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h
@@ -26,12 +26,12 @@ class TcpBandwidthBenchmark : public Benchmark {
       std::string iface,
       std::optional<int> sockBufSize,
       bool asyncGetH2d = true,
-      size_t numSockets = 4,
+      size_t socketsPerNic = 4,
       std::vector<std::string> bindDevs = {})
       : iface_(std::move(iface)),
         sockBufSize_(sockBufSize),
         asyncGetH2d_(asyncGetH2d),
-        numSockets_(numSockets),
+        socketsPerNic_(socketsPerNic),
         bindDevs_(std::move(bindDevs)) {}
 
   std::string name() const override {
@@ -47,7 +47,8 @@ class TcpBandwidthBenchmark : public Benchmark {
   std::string iface_;
   std::optional<int> sockBufSize_;
   bool asyncGetH2d_{true};
-  size_t numSockets_{4};
+  // Lanes per bound device; total is this times the device count.
+  size_t socketsPerNic_{4};
   std::vector<std::string> bindDevs_;
 };
 

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.h
@@ -21,10 +21,12 @@ class TcpBandwidthBenchmark : public Benchmark {
   TcpBandwidthBenchmark(
       std::string iface,
       std::optional<int> sockBufSize,
-      bool asyncGetH2d = true)
+      bool asyncGetH2d = true,
+      size_t numSockets = 4)
       : iface_(std::move(iface)),
         sockBufSize_(sockBufSize),
-        asyncGetH2d_(asyncGetH2d) {}
+        asyncGetH2d_(asyncGetH2d),
+        numSockets_(numSockets) {}
 
   std::string name() const override {
     return "tcp_bandwidth";
@@ -39,6 +41,7 @@ class TcpBandwidthBenchmark : public Benchmark {
   std::string iface_;
   std::optional<int> sockBufSize_;
   bool asyncGetH2d_{true};
+  size_t numSockets_{4};
 };
 
 } // namespace uniflow::benchmark

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -70,9 +70,10 @@ struct CliOptions {
   // SO_SNDBUF/SO_RCVBUF for the TCP data connection. Defaults to the
   // TcpSocketConfig default; 0 leaves the kernel's sizing alone.
   int tcpSockBuf{0};
-  // Parallel TCP data sockets per peer. Tracks the TcpTransportConfig default;
-  // 1 keeps the pre-lane wire format.
-  size_t tcpNumSockets{4};
+  // Parallel TCP data sockets per bound device. Tracks the TcpTransportConfig
+  // default; the total is this times the device count, and 1 with no bound
+  // devices keeps the pre-lane wire format.
+  size_t tcpSocketsPerNic{4};
   // Pin TCP egress to --tcp-iface via SO_BINDTODEVICE. Opt-in: without it
   // --tcp-iface only selects a source address and routing chooses the NIC.
   bool tcpBindDev{false};
@@ -189,17 +190,19 @@ void printUsage(const char* prog) {
       << "                         which leaves it unset so the kernel autotunes the\n"
       << "                         window; setting it explicitly disables autotuning)\n"
       << "  --no-tcp-async-h2d    Disable asynchronous TCP get() H2D (default: enabled)\n"
-      << "  --tcp-num-sockets <n>  Parallel TCP data sockets per peer (default: 4). Both\n"
-      << "                         peers must agree; a single socket keeps the pre-lane\n"
-      << "                         wire format\n"
+      << "  --tcp-sockets-per-nic <n>  Parallel TCP data sockets per bound device\n"
+      << "                         (default: 4). Total lanes is this times the device\n"
+      << "                         count, so 4 with two --tcp-bind-devs is 8 lanes. Both\n"
+      << "                         peers must agree; 1 with no bound devices keeps the\n"
+      << "                         pre-lane wire format\n"
       << "  --tcp-bind-dev         Pin TCP egress to --tcp-iface via SO_BINDTODEVICE\n"
       << "                         (default: off, so routing picks the egress NIC and\n"
       << "                         --tcp-iface only selects the source address)\n"
       << "  --tcp-bind-devs <l>    Comma-separated devices to stripe lanes across, e.g.\n"
       << "                         \"eth1,eth2\". Lane i goes to device i%count, one\n"
       << "                         listener per device. Overrides --tcp-bind-dev; both\n"
-      << "                         peers must name the same number of devices, and\n"
-      << "                         --tcp-num-sockets must be at least that count\n"
+      << "                         peers must name the same number of devices; lanes\n"
+      << "                         are per device, so each gets --tcp-sockets-per-nic\n"
       << "  --batch-size <n>       Number of requests per transport call (default: 1)\n"
       << "  --tx-depth <n>         Outstanding transport calls before waiting (default: 1)\n"
       << "  --num-nics <n>         Cap number of NICs to use (default: 0 = all)\n"
@@ -256,7 +259,7 @@ CliOptions parseArgs(int argc, char** argv) {
       {"tcp-iface", required_argument, nullptr, 266},
       {"tcp-sockbuf", required_argument, nullptr, 268},
       {"no-tcp-async-h2d", no_argument, nullptr, 269},
-      {"tcp-num-sockets", required_argument, nullptr, 270},
+      {"tcp-sockets-per-nic", required_argument, nullptr, 270},
       {"tcp-bind-dev", no_argument, nullptr, 271},
       {"tcp-bind-devs", required_argument, nullptr, 272},
       {"no-verify", no_argument, nullptr, 267},
@@ -354,12 +357,13 @@ CliOptions parseArgs(int argc, char** argv) {
         try {
           const int parsed = std::stoi(optarg);
           if (parsed < 1) {
-            std::cerr << "Invalid value for --tcp-num-sockets: must be >= 1\n";
+            std::cerr
+                << "Invalid value for --tcp-sockets-per-nic: must be >= 1\n";
             std::exit(1);
           }
-          opts.tcpNumSockets = static_cast<size_t>(parsed);
+          opts.tcpSocketsPerNic = static_cast<size_t>(parsed);
         } catch (const std::exception&) {
-          std::cerr << "Invalid value for --tcp-num-sockets: '" << optarg
+          std::cerr << "Invalid value for --tcp-sockets-per-nic: '" << optarg
                     << "'\n";
           std::exit(1);
         }
@@ -525,7 +529,7 @@ int main(int argc, char** argv) {
           opts.tcpSockBuf > 0 ? std::optional<int>(opts.tcpSockBuf)
                               : std::nullopt,
           opts.tcpAsyncH2d,
-          opts.tcpNumSockets,
+          opts.tcpSocketsPerNic,
           tcpBindDevList(opts)));
 #ifndef __HIP_PLATFORM_AMD__
   runner.registerBenchmark(

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -63,6 +63,9 @@ struct CliOptions {
   size_t slabSize{0};
   int slabNum{0};
   std::vector<std::string> rdmaDevices;
+  // Selects which local IPv6 address the TCP transport binds and advertises,
+  // and nothing else. Which NIC actually carries the bytes is a separate axis
+  // -- see --tcp-bind-dev below.
   std::string tcpIface{"eth2"};
   // SO_SNDBUF/SO_RCVBUF for the TCP data connection. Defaults to the
   // TcpSocketConfig default; 0 leaves the kernel's sizing alone.
@@ -96,6 +99,10 @@ std::vector<int> parseIntList(const std::string& s) {
 
 // --tcp-bind-devs wins over --tcp-bind-dev, which is just the single-device
 // shorthand for whatever --tcp-iface names. Empty means no device binding.
+//
+// --tcp-iface keeps selecting the source address either way, so when striping
+// it wants to name one of the bound devices: pointing it at an unbound NIC
+// advertises an address on a device carrying no lanes.
 std::vector<std::string> tcpBindDevList(const CliOptions& opts) {
   std::vector<std::string> devices;
   if (!opts.tcpBindDevs.empty()) {
@@ -175,7 +182,9 @@ void printUsage(const char* prog) {
       << "  --output <path>        CSV output file path\n"
       << "  --format <fmt>         table|csv|both (default: table)\n"
       << "  --rdma-devices <list>  Comma-separated RDMA device names (default: auto-discover)\n"
-      << "  --tcp-iface <name>     Front-end interface for the TCP transport (default: eth2)\n"
+      << "  --tcp-iface <name>     Interface whose address the TCP transport binds and\n"
+      << "                         advertises (default: eth2). Selects the source address\n"
+      << "                         only -- see --tcp-bind-dev to pin the egress NIC\n"
       << "  --tcp-sockbuf <bytes>  TCP data-connection SO_SNDBUF/SO_RCVBUF (default: 0,\n"
       << "                         which leaves it unset so the kernel autotunes the\n"
       << "                         window; setting it explicitly disables autotuning)\n"

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -56,6 +56,7 @@ struct CliOptions {
   bool bidirectional{false};
   bool dataDirect{false};
   bool noVerify{false};
+  bool tcpAsyncH2d{true};
   std::vector<int> numStreams{1, 2, 4, 8};
   std::string topology{"fanout"};
   int pipelineDepth{2};
@@ -145,6 +146,7 @@ void printUsage(const char* prog) {
       << "  --tcp-iface <name>     Front-end interface for the TCP transport (default: eth2)\n"
       << "  --tcp-sockbuf <bytes>  TCP data-connection SO_SNDBUF/SO_RCVBUF (default: 1048576,\n"
       << "                         0 = leave unset so the kernel autotunes the window)\n"
+      << "  --no-tcp-async-h2d    Disable asynchronous TCP get() H2D (default: enabled)\n"
       << "  --batch-size <n>       Number of requests per transport call (default: 1)\n"
       << "  --tx-depth <n>         Outstanding transport calls before waiting (default: 1)\n"
       << "  --num-nics <n>         Cap number of NICs to use (default: 0 = all)\n"
@@ -200,6 +202,7 @@ CliOptions parseArgs(int argc, char** argv) {
       {"gpu-nics", required_argument, nullptr, 265},
       {"tcp-iface", required_argument, nullptr, 266},
       {"tcp-sockbuf", required_argument, nullptr, 268},
+      {"no-tcp-async-h2d", no_argument, nullptr, 269},
       {"no-verify", no_argument, nullptr, 267},
       {"list", no_argument, nullptr, 'l'},
       {"help", no_argument, nullptr, 'h'},
@@ -287,6 +290,9 @@ CliOptions parseArgs(int argc, char** argv) {
           std::cerr << "Invalid value for --tcp-sockbuf: '" << optarg << "'\n";
           std::exit(1);
         }
+        break;
+      case 269:
+        opts.tcpAsyncH2d = false;
         break;
       case 'd':
         opts.direction = optarg;
@@ -441,7 +447,8 @@ int main(int argc, char** argv) {
       std::make_unique<uniflow::benchmark::TcpBandwidthBenchmark>(
           opts.tcpIface,
           opts.tcpSockBuf > 0 ? std::optional<int>(opts.tcpSockBuf)
-                              : std::nullopt));
+                              : std::nullopt,
+          opts.tcpAsyncH2d));
 #ifndef __HIP_PLATFORM_AMD__
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::ConnectionSetupBenchmark>());

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -4,6 +4,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -62,6 +63,9 @@ struct CliOptions {
   int slabNum{0};
   std::vector<std::string> rdmaDevices;
   std::string tcpIface{"eth2"};
+  // SO_SNDBUF/SO_RCVBUF for the TCP data connection. Defaults to the
+  // TcpSocketConfig default; 0 leaves the kernel's sizing alone.
+  int tcpSockBuf{1 << 20};
 };
 
 std::vector<int> parseIntList(const std::string& s) {
@@ -139,6 +143,8 @@ void printUsage(const char* prog) {
       << "  --format <fmt>         table|csv|both (default: table)\n"
       << "  --rdma-devices <list>  Comma-separated RDMA device names (default: auto-discover)\n"
       << "  --tcp-iface <name>     Front-end interface for the TCP transport (default: eth2)\n"
+      << "  --tcp-sockbuf <bytes>  TCP data-connection SO_SNDBUF/SO_RCVBUF (default: 1048576,\n"
+      << "                         0 = leave unset so the kernel autotunes the window)\n"
       << "  --batch-size <n>       Number of requests per transport call (default: 1)\n"
       << "  --tx-depth <n>         Outstanding transport calls before waiting (default: 1)\n"
       << "  --num-nics <n>         Cap number of NICs to use (default: 0 = all)\n"
@@ -193,6 +199,7 @@ CliOptions parseArgs(int argc, char** argv) {
       {"cuda-devices", required_argument, nullptr, 264},
       {"gpu-nics", required_argument, nullptr, 265},
       {"tcp-iface", required_argument, nullptr, 266},
+      {"tcp-sockbuf", required_argument, nullptr, 268},
       {"no-verify", no_argument, nullptr, 267},
       {"list", no_argument, nullptr, 'l'},
       {"help", no_argument, nullptr, 'h'},
@@ -268,6 +275,18 @@ CliOptions parseArgs(int argc, char** argv) {
         break;
       case 266:
         opts.tcpIface = optarg;
+        break;
+      case 268:
+        try {
+          opts.tcpSockBuf = std::stoi(optarg);
+          if (opts.tcpSockBuf < 0) {
+            std::cerr << "Invalid value for --tcp-sockbuf: must be >= 0\n";
+            std::exit(1);
+          }
+        } catch (const std::exception&) {
+          std::cerr << "Invalid value for --tcp-sockbuf: '" << optarg << "'\n";
+          std::exit(1);
+        }
         break;
       case 'd':
         opts.direction = optarg;
@@ -420,7 +439,9 @@ int main(int argc, char** argv) {
           opts.rdmaDevices));
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::TcpBandwidthBenchmark>(
-          opts.tcpIface));
+          opts.tcpIface,
+          opts.tcpSockBuf > 0 ? std::optional<int>(opts.tcpSockBuf)
+                              : std::nullopt));
 #ifndef __HIP_PLATFORM_AMD__
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::ConnectionSetupBenchmark>());

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -66,7 +66,10 @@ struct CliOptions {
   std::string tcpIface{"eth2"};
   // SO_SNDBUF/SO_RCVBUF for the TCP data connection. Defaults to the
   // TcpSocketConfig default; 0 leaves the kernel's sizing alone.
-  int tcpSockBuf{1 << 20};
+  int tcpSockBuf{0};
+  // Parallel TCP data sockets per peer. Tracks the TcpTransportConfig default;
+  // 1 keeps the pre-lane wire format.
+  size_t tcpNumSockets{4};
 };
 
 std::vector<int> parseIntList(const std::string& s) {
@@ -144,9 +147,13 @@ void printUsage(const char* prog) {
       << "  --format <fmt>         table|csv|both (default: table)\n"
       << "  --rdma-devices <list>  Comma-separated RDMA device names (default: auto-discover)\n"
       << "  --tcp-iface <name>     Front-end interface for the TCP transport (default: eth2)\n"
-      << "  --tcp-sockbuf <bytes>  TCP data-connection SO_SNDBUF/SO_RCVBUF (default: 1048576,\n"
-      << "                         0 = leave unset so the kernel autotunes the window)\n"
+      << "  --tcp-sockbuf <bytes>  TCP data-connection SO_SNDBUF/SO_RCVBUF (default: 0,\n"
+      << "                         which leaves it unset so the kernel autotunes the\n"
+      << "                         window; setting it explicitly disables autotuning)\n"
       << "  --no-tcp-async-h2d    Disable asynchronous TCP get() H2D (default: enabled)\n"
+      << "  --tcp-num-sockets <n>  Parallel TCP data sockets per peer (default: 4). Both\n"
+      << "                         peers must agree; a single socket keeps the pre-lane\n"
+      << "                         wire format\n"
       << "  --batch-size <n>       Number of requests per transport call (default: 1)\n"
       << "  --tx-depth <n>         Outstanding transport calls before waiting (default: 1)\n"
       << "  --num-nics <n>         Cap number of NICs to use (default: 0 = all)\n"
@@ -203,6 +210,7 @@ CliOptions parseArgs(int argc, char** argv) {
       {"tcp-iface", required_argument, nullptr, 266},
       {"tcp-sockbuf", required_argument, nullptr, 268},
       {"no-tcp-async-h2d", no_argument, nullptr, 269},
+      {"tcp-num-sockets", required_argument, nullptr, 270},
       {"no-verify", no_argument, nullptr, 267},
       {"list", no_argument, nullptr, 'l'},
       {"help", no_argument, nullptr, 'h'},
@@ -293,6 +301,20 @@ CliOptions parseArgs(int argc, char** argv) {
         break;
       case 269:
         opts.tcpAsyncH2d = false;
+        break;
+      case 270:
+        try {
+          const int parsed = std::stoi(optarg);
+          if (parsed < 1) {
+            std::cerr << "Invalid value for --tcp-num-sockets: must be >= 1\n";
+            std::exit(1);
+          }
+          opts.tcpNumSockets = static_cast<size_t>(parsed);
+        } catch (const std::exception&) {
+          std::cerr << "Invalid value for --tcp-num-sockets: '" << optarg
+                    << "'\n";
+          std::exit(1);
+        }
         break;
       case 'd':
         opts.direction = optarg;
@@ -448,7 +470,8 @@ int main(int argc, char** argv) {
           opts.tcpIface,
           opts.tcpSockBuf > 0 ? std::optional<int>(opts.tcpSockBuf)
                               : std::nullopt,
-          opts.tcpAsyncH2d));
+          opts.tcpAsyncH2d,
+          opts.tcpNumSockets));
 #ifndef __HIP_PLATFORM_AMD__
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::ConnectionSetupBenchmark>());

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -70,6 +70,13 @@ struct CliOptions {
   // Parallel TCP data sockets per peer. Tracks the TcpTransportConfig default;
   // 1 keeps the pre-lane wire format.
   size_t tcpNumSockets{4};
+  // Pin TCP egress to --tcp-iface via SO_BINDTODEVICE. Opt-in: without it
+  // --tcp-iface only selects a source address and routing chooses the NIC.
+  bool tcpBindDev{false};
+  // Devices to stripe TCP lanes across, e.g. "eth1,eth2". Overrides
+  // --tcp-bind-dev. Names are per-host, so the two hosts may need different
+  // lists for the same pair of physical ports.
+  std::string tcpBindDevs;
 };
 
 std::vector<int> parseIntList(const std::string& s) {
@@ -85,6 +92,28 @@ std::vector<int> parseIntList(const std::string& s) {
     }
   }
   return result;
+}
+
+// --tcp-bind-devs wins over --tcp-bind-dev, which is just the single-device
+// shorthand for whatever --tcp-iface names. Empty means no device binding.
+std::vector<std::string> tcpBindDevList(const CliOptions& opts) {
+  std::vector<std::string> devices;
+  if (!opts.tcpBindDevs.empty()) {
+    std::istringstream iss(opts.tcpBindDevs);
+    std::string token;
+    while (std::getline(iss, token, ',')) {
+      if (!token.empty()) {
+        devices.push_back(token);
+      }
+    }
+    if (devices.empty()) {
+      std::cerr << "Invalid --tcp-bind-devs: '" << opts.tcpBindDevs << "'\n";
+      std::exit(1);
+    }
+  } else if (opts.tcpBindDev) {
+    devices.push_back(opts.tcpIface);
+  }
+  return devices;
 }
 
 std::vector<std::string> parseStringList(const std::string& s) {
@@ -154,6 +183,14 @@ void printUsage(const char* prog) {
       << "  --tcp-num-sockets <n>  Parallel TCP data sockets per peer (default: 4). Both\n"
       << "                         peers must agree; a single socket keeps the pre-lane\n"
       << "                         wire format\n"
+      << "  --tcp-bind-dev         Pin TCP egress to --tcp-iface via SO_BINDTODEVICE\n"
+      << "                         (default: off, so routing picks the egress NIC and\n"
+      << "                         --tcp-iface only selects the source address)\n"
+      << "  --tcp-bind-devs <l>    Comma-separated devices to stripe lanes across, e.g.\n"
+      << "                         \"eth1,eth2\". Lane i goes to device i%count, one\n"
+      << "                         listener per device. Overrides --tcp-bind-dev; both\n"
+      << "                         peers must name the same number of devices, and\n"
+      << "                         --tcp-num-sockets must be at least that count\n"
       << "  --batch-size <n>       Number of requests per transport call (default: 1)\n"
       << "  --tx-depth <n>         Outstanding transport calls before waiting (default: 1)\n"
       << "  --num-nics <n>         Cap number of NICs to use (default: 0 = all)\n"
@@ -211,6 +248,8 @@ CliOptions parseArgs(int argc, char** argv) {
       {"tcp-sockbuf", required_argument, nullptr, 268},
       {"no-tcp-async-h2d", no_argument, nullptr, 269},
       {"tcp-num-sockets", required_argument, nullptr, 270},
+      {"tcp-bind-dev", no_argument, nullptr, 271},
+      {"tcp-bind-devs", required_argument, nullptr, 272},
       {"no-verify", no_argument, nullptr, 267},
       {"list", no_argument, nullptr, 'l'},
       {"help", no_argument, nullptr, 'h'},
@@ -315,6 +354,12 @@ CliOptions parseArgs(int argc, char** argv) {
                     << "'\n";
           std::exit(1);
         }
+        break;
+      case 271:
+        opts.tcpBindDev = true;
+        break;
+      case 272:
+        opts.tcpBindDevs = optarg;
         break;
       case 'd':
         opts.direction = optarg;
@@ -471,7 +516,8 @@ int main(int argc, char** argv) {
           opts.tcpSockBuf > 0 ? std::optional<int>(opts.tcpSockBuf)
                               : std::nullopt,
           opts.tcpAsyncH2d,
-          opts.tcpNumSockets));
+          opts.tcpNumSockets,
+          tcpBindDevList(opts)));
 #ifndef __HIP_PLATFORM_AMD__
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::ConnectionSetupBenchmark>());

--- a/comms/uniflow/benchmarks/run_mast_benchmarks.py
+++ b/comms/uniflow/benchmarks/run_mast_benchmarks.py
@@ -297,6 +297,7 @@ class Workload:
     mode: str
     timeout: int
     validate_performance_outputs: bool
+    perf_only: bool = False
 
     @property
     def measured_requests(self) -> int:
@@ -325,6 +326,7 @@ class MastConfig:
     progress_idle_timeout_sec: int
     progress_check_interval_sec: int
     kv_transport: str = "rdma"
+    accuracy_max_token_divergence: int = 0
 
     @property
     def scheduler_args(self) -> str:
@@ -354,6 +356,25 @@ class MastConfig:
         # tcp is host-staged for VRAM). Read by uniflow_connector.py.
         if self.kv_transport and self.kv_transport != "rdma":
             values["UNIFLOW_KV_TRANSPORT"] = self.kv_transport
+        # MI350/MI300 (ROCm) vLLM enablement recipe: pin attention/GEMM to the
+        # known-good ROCm path. Default ROCm attention kernels can produce a
+        # degenerate ("!!!") forward pass on MI350 (see SEV S685789 class); these
+        # flags match the MI350 vLLM enablement doc. Dense-model only (no
+        # MoE/MLA/FP8 flags). NVIDIA hosts are left untouched.
+        host = (self.host_type or "").lower()
+        if "mi350" in host or "mi300" in host:
+            # Only the three flags below are recognized by the packaged vLLM build
+            # and are what actually stabilize the MI350 forward pass (eliminate the
+            # degenerate all-'!' output). VLLM_USE_TRITON_FLASH_ATTN /
+            # VLLM_FLASH_ATTN_VERSION are "Unknown vLLM env var" in this build, so
+            # they are intentionally omitted.
+            values.update(
+                {
+                    "FLASH_ATTENTION_TRITON_AMD_ENABLE": "TRUE",
+                    "VLLM_ROCM_USE_AITER": "0",
+                    "HIPBLASLT_ALLOW_TF32": "1",
+                }
+            )
         return ",".join(f"{key}={value}" for key, value in values.items())
 
 
@@ -1882,6 +1903,15 @@ class MastBenchmarkRunner:
         ]
         if self.workload.validate_performance_outputs:
             cmd.append("--validate-performance-outputs")
+        if self.workload.perf_only:
+            cmd.append("--perf-only")
+        if self.config.accuracy_max_token_divergence > 0:
+            cmd.extend(
+                [
+                    "--accuracy-max-token-divergence",
+                    str(self.config.accuracy_max_token_divergence),
+                ]
+            )
         if spec.connector_key == "nixl":
             cmd.extend(
                 [
@@ -2282,6 +2312,15 @@ def parse_args() -> argparse.Namespace:
             "for publishable correctness runs."
         ),
     )
+    parser.add_argument(
+        "--perf-only",
+        action="store_true",
+        help=(
+            "Accuracy mode: skip the correctness gate and only measure "
+            "performance (TTFT/TPOT/throughput). Perf is emitted regardless of "
+            "output correctness. Intended for perf sweeps."
+        ),
+    )
     parser.add_argument("--host-type", default="grandteton_80g_roce")
     parser.add_argument("--hpc-identity", default="networkai_mast_job_identity")
     parser.add_argument("--hpc-cluster-uuid", default="MastGenAICluster")
@@ -2297,6 +2336,16 @@ def parse_args() -> argparse.Namespace:
         help=(
             "KV-transfer transport for the uniflow connector (default: rdma). "
             "tcp host-stages VRAM and is slower; used to validate the TCP path."
+        ),
+    )
+    parser.add_argument(
+        "--accuracy-max-token-divergence",
+        type=int,
+        default=0,
+        help=(
+            "Forwarded to disagg_entry: tolerate up to N differing whitespace "
+            "tokens between a disagg output and its standalone baseline before "
+            "counting a correctness mismatch (default 0 = strict exact match)."
         ),
     )
     parser.add_argument(
@@ -2546,6 +2595,7 @@ def make_workload(args: argparse.Namespace, profile: BenchmarkProfile) -> Worklo
         mode=profile_value(args, profile, "mode"),
         timeout=profile_value(args, profile, "timeout"),
         validate_performance_outputs=args.validate_performance_outputs,
+        perf_only=args.perf_only,
     )
 
 
@@ -2589,6 +2639,7 @@ def main() -> int:
         opec_tag=args.opec_tag,
         host_type=args.host_type,
         kv_transport=args.kv_transport,
+        accuracy_max_token_divergence=args.accuracy_max_token_divergence,
         presto_identity=args.presto_identity,
         poll_interval_sec=args.poll_interval_sec,
         job_timeout_sec=profile_value(args, profile, "job_timeout_sec"),

--- a/comms/uniflow/controller/TcpController.cpp
+++ b/comms/uniflow/controller/TcpController.cpp
@@ -613,12 +613,16 @@ Result<size_t> TcpConn<IOPolicy>::syncRecv(std::span<uint8_t> buf) {
     return Err(ErrCode::NotConnected, "Socket is not connected");
   }
 
+  auto& stats = recvPhaseStats();
+  const auto tStart = std::chrono::steady_clock::now();
+
   uint32_t rawLen = 0;
   if (!recvAll(&rawLen, sizeof(rawLen))) {
     return Err(
         ErrCode::ConnectionFailed,
         "recv header failed: " + std::system_category().message(errno));
   }
+  const auto tFirstByte = std::chrono::steady_clock::now();
 
   uint32_t len = ntohl(rawLen);
   if (len > kMaxMessageSize) {
@@ -641,6 +645,17 @@ Result<size_t> TcpConn<IOPolicy>::syncRecv(std::span<uint8_t> buf) {
         ErrCode::ConnectionFailed,
         "recv payload failed: " + std::system_category().message(errno));
   }
+
+  const auto tDone = std::chrono::steady_clock::now();
+  using ns = std::chrono::nanoseconds;
+  stats.headerWaitNs.fetch_add(
+      std::chrono::duration_cast<ns>(tFirstByte - tStart).count(),
+      std::memory_order_relaxed);
+  stats.payloadDrainNs.fetch_add(
+      std::chrono::duration_cast<ns>(tDone - tFirstByte).count(),
+      std::memory_order_relaxed);
+  stats.frames.fetch_add(1, std::memory_order_relaxed);
+  stats.payloadBytes.fetch_add(len, std::memory_order_relaxed);
 
   UNIFLOW_LOG_DEBUG("TcpConn::recv(span): fd={} bytes={}", sock_, len);
   return static_cast<size_t>(len);

--- a/comms/uniflow/controller/TcpController.cpp
+++ b/comms/uniflow/controller/TcpController.cpp
@@ -381,12 +381,11 @@ bool TcpConn<IOPolicy>::sendAll(const void* buf, size_t len) {
 // for these sockets, and widening it here would hide a non-blocking data socket
 // rather than fix one.
 template <typename IOPolicy>
-bool TcpConn<IOPolicy>::sendAllVec(iovec* iov, int iovCnt) {
-  int idx = 0;
-  while (idx < iovCnt) {
+bool TcpConn<IOPolicy>::sendAllVec(std::span<iovec> iov) {
+  while (!iov.empty()) {
     msghdr msg{};
-    msg.msg_iov = iov + idx;
-    msg.msg_iovlen = static_cast<size_t>(iovCnt - idx);
+    msg.msg_iov = iov.data();
+    msg.msg_iovlen = iov.size();
     ssize_t n = ::sendmsg(sock_, &msg, MSG_NOSIGNAL);
     if (n < 0) {
       if (errno == EINTR) {
@@ -407,13 +406,14 @@ bool TcpConn<IOPolicy>::sendAllVec(iovec* iov, int iovCnt) {
     // covered by tests -- an attempt to force it with an oversized payload did
     // not reach this branch.
     auto consumed = static_cast<size_t>(n);
-    while (idx < iovCnt && consumed >= iov[idx].iov_len) {
-      consumed -= iov[idx].iov_len;
-      ++idx;
+    while (!iov.empty() && consumed >= iov.front().iov_len) {
+      consumed -= iov.front().iov_len;
+      iov = iov.subspan(1);
     }
-    if (idx < iovCnt && consumed > 0) {
-      iov[idx].iov_base = static_cast<uint8_t*>(iov[idx].iov_base) + consumed;
-      iov[idx].iov_len -= consumed;
+    if (!iov.empty() && consumed > 0) {
+      iov.front().iov_base =
+          static_cast<uint8_t*>(iov.front().iov_base) + consumed;
+      iov.front().iov_len -= consumed;
     }
   }
   return true;
@@ -541,14 +541,14 @@ Result<size_t> TcpConn<IOPolicy>::syncSend(std::span<const uint8_t> data) {
   iovec iov[2];
   iov[0].iov_base = &len;
   iov[0].iov_len = sizeof(len);
-  int iovCnt = 1;
+  size_t iovCnt = 1;
   if (!data.empty()) {
     // const_cast: iovec has no const variant, and sendmsg only reads.
     iov[1].iov_base = const_cast<uint8_t*>(data.data());
     iov[1].iov_len = data.size();
     iovCnt = 2;
   }
-  if (!sendAllVec(iov, iovCnt)) {
+  if (!sendAllVec(std::span{iov}.first(iovCnt))) {
     return Err(
         ErrCode::ConnectionFailed,
         "send frame failed: " + std::system_category().message(errno));

--- a/comms/uniflow/controller/TcpController.cpp
+++ b/comms/uniflow/controller/TcpController.cpp
@@ -4,6 +4,7 @@
 
 #include <arpa/inet.h>
 #include <fcntl.h>
+#include <net/if.h>
 #include <netinet/tcp.h>
 #include <sys/epoll.h>
 #include <sys/socket.h>
@@ -13,7 +14,9 @@
 #include <cerrno>
 #include <charconv>
 #include <cstring>
+#include <fstream>
 #include <stdexcept>
+#include <string>
 #include <system_error>
 #include <thread>
 
@@ -59,6 +62,18 @@ Status TcpSocketConfig::validate() const {
   }
   if (acceptRetryCnt <= 0) {
     return Err(ErrCode::InvalidArgument, "acceptRetryCnt must be positive");
+  }
+  if (bindToDevice) {
+    if (bindToDevice->empty()) {
+      return Err(ErrCode::InvalidArgument, "bindToDevice must not be empty");
+    }
+    // The kernel copies the name into an IFNAMSIZ buffer and needs room for the
+    // terminator, so reject an over-long name here instead of letting
+    // setsockopt fail with an opaque error.
+    if (bindToDevice->size() >= IFNAMSIZ) {
+      return Err(
+          ErrCode::InvalidArgument, "bindToDevice too long: " + *bindToDevice);
+    }
   }
   if (retryTimeout.count() < 0) {
     return Err(ErrCode::InvalidArgument, "retryTimeout must be non-negative");
@@ -108,6 +123,22 @@ class SockOptSetter {
     return Ok();
   }
 };
+
+// Pins the socket's egress to `device` via SO_BINDTODEVICE. Must be called
+// before bind() or connect(): the option only takes effect on the route
+// selection made at that point, so applying it to an already-connected fd is
+// too late to move any traffic.
+Status bindSocketToDevice(int sock, const std::string& device) {
+  char ifname[IFNAMSIZ]{};
+  device.copy(ifname, sizeof(ifname) - 1);
+  SockOptSetter opt(sock);
+  opt.set(
+      SOL_SOCKET,
+      SO_BINDTODEVICE,
+      ifname,
+      fmt::format("SO_BINDTODEVICE({})", device).c_str());
+  return opt.status();
+}
 
 // Aligned with ctran/bootstrap/Socket.cc::shouldRetry().
 bool shouldRetry(int errcode) {
@@ -217,12 +248,22 @@ std::string formatAddr(const sockaddr_storage& addr) {
   return std::string(buf) + ":" + std::to_string(ntohs(sa->sin_port));
 }
 
-Result<int> createListenSocket(int domain) {
+Result<int> createListenSocket(
+    int domain,
+    const std::optional<std::string>& bindDevice) {
   int sock = ::socket(domain, SOCK_STREAM | SOCK_CLOEXEC, 0);
   if (sock < 0) {
     return Err(
         ErrCode::ConnectionFailed,
         "socket creation failed: " + std::system_category().message(errno));
+  }
+
+  if (bindDevice) {
+    auto status = bindSocketToDevice(sock, *bindDevice);
+    if (!status) {
+      ::close(sock);
+      return std::move(status).error();
+    }
   }
 
   SockOptSetter opt(sock);
@@ -342,6 +383,52 @@ Status setHandshakeTimeout(int sock) {
 }
 
 } // namespace
+
+Result<std::string> deviceGlobalIpv6(const std::string& device) {
+  // Read /proc/net/if_inet6 rather than getifaddrs(): the address flags are the
+  // point, and getifaddrs() does not expose them (ifa_flags carries the
+  // interface's IFF_* bits, not the address's IFA_F_* bits). A deprecated
+  // address is still returned by getifaddrs() and still binds successfully, so
+  // picking one silently produces a working socket bound to an address the peer
+  // is not supposed to reply to. On the MI350 hosts every frontend NIC except
+  // eth2 carries a deprecated address alongside its live one, and enumeration
+  // order is not specified, so the deprecated one can win.
+  std::ifstream f("/proc/net/if_inet6");
+  if (!f) {
+    return Err(
+        ErrCode::InvalidArgument,
+        "cannot open /proc/net/if_inet6 to resolve device " + device);
+  }
+
+  // Columns: address(32 hex, no colons) ifindex prefixlen scope flags name
+  std::string hex, ifindex, prefixLen, scope, flags, name;
+  while (f >> hex >> ifindex >> prefixLen >> scope >> flags >> name) {
+    if (name != device || hex.size() != 32) {
+      continue;
+    }
+    // Scope 0 is global; this skips link-local (0x20) and host (0x10).
+    if (std::stoul(scope, nullptr, 16) != 0) {
+      continue;
+    }
+    constexpr unsigned long kIfaFDeprecated = 0x20;
+    if ((std::stoul(flags, nullptr, 16) & kIfaFDeprecated) != 0) {
+      continue;
+    }
+    in6_addr addr{};
+    for (size_t i = 0; i < sizeof(addr.s6_addr); ++i) {
+      addr.s6_addr[i] =
+          static_cast<uint8_t>(std::stoul(hex.substr(i * 2, 2), nullptr, 16));
+    }
+    char buf[INET6_ADDRSTRLEN] = {};
+    if (inet_ntop(AF_INET6, &addr, buf, sizeof(buf)) == nullptr) {
+      continue;
+    }
+    return std::string(buf);
+  }
+  return Err(
+      ErrCode::InvalidArgument,
+      "no live global IPv6 address on device " + device);
+}
 
 // ---------------------------------------------------------------------------
 // TcpConn<IOPolicy> — shared sync methods
@@ -1398,7 +1485,7 @@ Status BasicTcpServer<AcceptPolicy>::init() {
   }
   int domain = domainResult.value();
 
-  auto sockResult = createListenSocket(domain);
+  auto sockResult = createListenSocket(domain, config_.bindToDevice);
   if (!sockResult) {
     UNIFLOW_LOG_ERROR("TcpServer: socket creation failed on {}", id_);
     return std::move(sockResult).error();
@@ -1588,6 +1675,15 @@ std::future<std::unique_ptr<Conn>> SyncConnect::connect(
       return make_ready_future(std::unique_ptr<Conn>(nullptr));
     }
 
+    if (config.bindToDevice) {
+      auto status = bindSocketToDevice(sock, *config.bindToDevice);
+      if (!status) {
+        UNIFLOW_LOG_ERROR("TcpClient: {}: {}", id, status.error().toString());
+        ::close(sock);
+        return make_ready_future(std::unique_ptr<Conn>(nullptr));
+      }
+    }
+
     if (::connect(
             sock,
             reinterpret_cast<sockaddr*>(&resolved->addr),
@@ -1637,6 +1733,15 @@ std::future<std::unique_ptr<Conn>> AsyncConnect::connect(
         "TcpClient: socket creation failed: {}",
         std::system_category().message(errno));
     return make_ready_future(std::unique_ptr<Conn>(nullptr));
+  }
+
+  if (config.bindToDevice) {
+    auto bindStatus = bindSocketToDevice(sock, *config.bindToDevice);
+    if (!bindStatus) {
+      UNIFLOW_LOG_ERROR("TcpClient: {}", bindStatus.error().toString());
+      ::close(sock);
+      return make_ready_future(std::unique_ptr<Conn>(nullptr));
+    }
   }
 
   int rc = ::connect(

--- a/comms/uniflow/controller/TcpController.cpp
+++ b/comms/uniflow/controller/TcpController.cpp
@@ -71,10 +71,6 @@ namespace {
 constexpr uint32_t kMaxMessageSize = 64 << 20;
 constexpr int kAcceptTimeoutSec = 5;
 constexpr int kConnectedTimeoutSec = 30;
-constexpr int kKeepaliveIdleSec = 60;
-constexpr int kKeepaliveIntervalSec = 5;
-constexpr int kKeepaliveCount = 3;
-constexpr int kUserTimeoutMs = 60000;
 
 // Magic value exchanged during connection handshake to validate that both
 // endpoints are uniflow controllers (rejects stray connections).
@@ -248,34 +244,68 @@ Result<int> createListenSocket(int domain) {
   return sock;
 }
 
-// Applies the connected-socket options to a freshly accepted fd.
+// Applies a TcpSocketConfig to a connected socket. Shared by the client and
+// accept paths: both need identical treatment of a connected fd, and keeping
+// one implementation is what stops the two from drifting apart again.
 //
-// Only @p socketBufSize is caller-controlled; the keepalive and timeout values
-// remain the constants above. Buffer sizing is the one option a caller has a
-// reason to override per connection: setting SO_RCVBUF explicitly disables
-// Linux receive-window autotuning, which caps a single stream at window/RTT, so
-// a bulk-data connection wants it left unset while the control connection does
-// not care.
-Status configureAcceptedSocket(
-    int sock,
-    const std::optional<int>& socketBufSize) {
-  SockOptSetter opt(sock);
-  if (socketBufSize) {
-    opt.set(SOL_SOCKET, SO_SNDBUF, *socketBufSize, "SO_SNDBUF");
-    opt.set(SOL_SOCKET, SO_RCVBUF, *socketBufSize, "SO_RCVBUF");
+// Every field falls through to the OS kernel default when nullopt, with one
+// deliberate exception -- connTimeout, see below.
+void applySocketConfig(SockOptSetter& opt, const TcpSocketConfig& config) {
+  // Buffer sizing is the option a caller most often wants left alone: setting
+  // SO_RCVBUF explicitly disables Linux receive-window autotuning, which caps a
+  // single stream at window/RTT, so a bulk-data connection wants it unset while
+  // the control connection does not care.
+  if (config.socketBufSize) {
+    opt.set(SOL_SOCKET, SO_SNDBUF, *config.socketBufSize, "SO_SNDBUF");
+    opt.set(SOL_SOCKET, SO_RCVBUF, *config.socketBufSize, "SO_RCVBUF");
   }
-  opt.set(IPPROTO_TCP, TCP_NODELAY, 1, "TCP_NODELAY");
-  opt.set(SOL_SOCKET, SO_KEEPALIVE, 1, "SO_KEEPALIVE");
-  opt.set(IPPROTO_TCP, TCP_KEEPIDLE, kKeepaliveIdleSec, "TCP_KEEPIDLE");
-  opt.set(IPPROTO_TCP, TCP_KEEPINTVL, kKeepaliveIntervalSec, "TCP_KEEPINTVL");
-  opt.set(IPPROTO_TCP, TCP_KEEPCNT, kKeepaliveCount, "TCP_KEEPCNT");
-  opt.set(IPPROTO_TCP, TCP_USER_TIMEOUT, kUserTimeoutMs, "TCP_USER_TIMEOUT");
+  if (config.tcpNoDelay) {
+    int val = *config.tcpNoDelay ? 1 : 0;
+    opt.set(IPPROTO_TCP, TCP_NODELAY, val, "TCP_NODELAY");
+  }
+  if (config.enableKeepalive) {
+    int val = *config.enableKeepalive ? 1 : 0;
+    opt.set(SOL_SOCKET, SO_KEEPALIVE, val, "SO_KEEPALIVE");
+  }
+  if (config.enableKeepalive && *config.enableKeepalive) {
+    if (config.keepaliveIdle) {
+      int val = static_cast<int>(config.keepaliveIdle->count());
+      opt.set(IPPROTO_TCP, TCP_KEEPIDLE, val, "TCP_KEEPIDLE");
+    }
+    if (config.keepaliveInterval) {
+      int val = static_cast<int>(config.keepaliveInterval->count());
+      opt.set(IPPROTO_TCP, TCP_KEEPINTVL, val, "TCP_KEEPINTVL");
+    }
+    if (config.keepaliveCount) {
+      opt.set(IPPROTO_TCP, TCP_KEEPCNT, *config.keepaliveCount, "TCP_KEEPCNT");
+    }
+  }
+  if (config.userTimeout) {
+    int val = static_cast<int>(config.userTimeout->count());
+    opt.set(IPPROTO_TCP, TCP_USER_TIMEOUT, val, "TCP_USER_TIMEOUT");
+  }
+  /*
+   * Default the send/recv timeout to kConnectedTimeoutSec when the caller does
+   * not specify one. This is the one field that does not fall through to the
+   * OS. Without it a connected socket blocks forever: a peer that accepts the
+   * TCP connection but stops responding mid-handshake (e.g. its transport setup
+   * failed) would wedge a blocking recv during the handshake exchange
+   * indefinitely, which is only reaped as an opaque process-unresponsive
+   * failure. Bounding it turns the hang into a surfaced ConnectionFailed error.
+   */
+  {
+    struct timeval tv{};
+    tv.tv_sec =
+        config.connTimeout ? config.connTimeout->count() : kConnectedTimeoutSec;
+    opt.set(SOL_SOCKET, SO_SNDTIMEO, tv, "SO_SNDTIMEO");
+    opt.set(SOL_SOCKET, SO_RCVTIMEO, tv, "SO_RCVTIMEO");
+  }
+}
 
-  struct timeval tv{};
-  tv.tv_sec = kConnectedTimeoutSec;
-  opt.set(SOL_SOCKET, SO_SNDTIMEO, tv, "SO_SNDTIMEO");
-  opt.set(SOL_SOCKET, SO_RCVTIMEO, tv, "SO_RCVTIMEO");
-
+// Applies the connected-socket options to a freshly accepted fd.
+Status configureAcceptedSocket(int sock, const TcpSocketConfig& config) {
+  SockOptSetter opt(sock);
+  applySocketConfig(opt, config);
   return opt.status();
 }
 
@@ -1058,7 +1088,7 @@ std::future<std::unique_ptr<Conn>> SyncAccept::accept(
           "TcpServer: accepted fd={} from {}",
           clientSock,
           formatAddr(clientAddr));
-      auto status = configureAcceptedSocket(clientSock, config.socketBufSize);
+      auto status = configureAcceptedSocket(clientSock, config);
       if (!status) {
         UNIFLOW_LOG_ERROR(
             "TcpServer: socket config failed fd={}: {}",
@@ -1150,7 +1180,9 @@ void AsyncAccept::teardown(int fd) {
   readyConns_ = {};
 }
 
-void AsyncAccept::acceptPendingConnections(std::atomic<int>& listenSock) {
+void AsyncAccept::acceptPendingConnections(
+    std::atomic<int>& listenSock,
+    const TcpSocketConfig& config) {
   if (!accepting_) {
     return;
   }
@@ -1208,7 +1240,7 @@ void AsyncAccept::acceptPendingConnections(std::atomic<int>& listenSock) {
 
     // configureAcceptedSocket sets 30s timeouts — must come after the
     // 500ms handshake timeout to avoid overriding it.
-    auto status = configureAcceptedSocket(conn->getFd(), socketBufSize_);
+    auto status = configureAcceptedSocket(conn->getFd(), config);
     if (!status) {
       UNIFLOW_LOG_ERROR(
           "TcpServer: async socket config failed fd={}: {}",
@@ -1239,21 +1271,13 @@ std::future<std::unique_ptr<Conn>> AsyncAccept::accept(
 
   evb_.dispatch([this,
                  &listenSock,
-                 bufSize = config.socketBufSize,
+                 cfg = config,
                  p = std::move(promise)]() mutable noexcept {
     int sock = listenSock.load();
     if (sock < 0) {
       p.set_value(nullptr);
       return;
     }
-
-    // Server-level, not per-accept: BasicTcpServer passes its own config_ to
-    // every accept() call, so every dispatch writes the same value and there is
-    // no per-call setting to lose. Nothing here binds an accepted fd to a
-    // particular accept() anyway -- connections go to whichever promise is
-    // queued first. A future per-accept override would have to travel with the
-    // connection instead.
-    socketBufSize_ = bufSize;
 
     // Lazy setup: fcntl + registerFd both on the loop thread.
     if (!accepting_) {
@@ -1266,9 +1290,17 @@ std::future<std::unique_ptr<Conn>> AsyncAccept::accept(
         p.set_value(nullptr);
         return;
       }
-      evb_.registerFd(sock, EPOLLIN, [this, &listenSock](uint32_t /*events*/) {
-        acceptPendingConnections(listenSock);
-      });
+      // The config travels with the fd registration rather than through a
+      // member: it is server-level, so freezing it when the fd is armed loses
+      // nothing -- BasicTcpServer hands its own config_ to every accept() call
+      // and never reassigns it. Nothing here binds an accepted fd to a
+      // particular accept() anyway; connections go to whichever promise is
+      // queued first. A future per-accept override would have to travel with
+      // the connection instead.
+      evb_.registerFd(
+          sock, EPOLLIN, [this, &listenSock, cfg](uint32_t /*events*/) {
+            acceptPendingConnections(listenSock, cfg);
+          });
       accepting_ = true;
     }
 
@@ -1414,54 +1446,7 @@ namespace {
 
 Status configureClientSocket(int sock, const TcpSocketConfig& config) {
   SockOptSetter opt(sock);
-
-  if (config.socketBufSize) {
-    opt.set(SOL_SOCKET, SO_SNDBUF, *config.socketBufSize, "SO_SNDBUF");
-    opt.set(SOL_SOCKET, SO_RCVBUF, *config.socketBufSize, "SO_RCVBUF");
-  }
-  if (config.tcpNoDelay) {
-    int val = *config.tcpNoDelay ? 1 : 0;
-    opt.set(IPPROTO_TCP, TCP_NODELAY, val, "TCP_NODELAY");
-  }
-  if (config.enableKeepalive) {
-    int val = *config.enableKeepalive ? 1 : 0;
-    opt.set(SOL_SOCKET, SO_KEEPALIVE, val, "SO_KEEPALIVE");
-  }
-  if (config.enableKeepalive && *config.enableKeepalive) {
-    if (config.keepaliveIdle) {
-      int val = static_cast<int>(config.keepaliveIdle->count());
-      opt.set(IPPROTO_TCP, TCP_KEEPIDLE, val, "TCP_KEEPIDLE");
-    }
-    if (config.keepaliveInterval) {
-      int val = static_cast<int>(config.keepaliveInterval->count());
-      opt.set(IPPROTO_TCP, TCP_KEEPINTVL, val, "TCP_KEEPINTVL");
-    }
-    if (config.keepaliveCount) {
-      opt.set(IPPROTO_TCP, TCP_KEEPCNT, *config.keepaliveCount, "TCP_KEEPCNT");
-    }
-  }
-  if (config.userTimeout) {
-    int val = static_cast<int>(config.userTimeout->count());
-    opt.set(IPPROTO_TCP, TCP_USER_TIMEOUT, val, "TCP_USER_TIMEOUT");
-  }
-  /*
-   * Default the send/recv timeout to kConnectedTimeoutSec when the caller does
-   * not specify one, matching configureAcceptedSocket on the server side.
-   * Without this the client's connected socket blocks forever: a peer that
-   * accepts the TCP connection but stops responding mid-handshake (e.g. its
-   * transport setup failed) would wedge the client's blocking recv during the
-   * handshake exchange indefinitely, which is only reaped as an opaque
-   * process-unresponsive failure. Bounding it turns the hang into a surfaced
-   * ConnectionFailed error.
-   */
-  {
-    struct timeval tv{};
-    tv.tv_sec =
-        config.connTimeout ? config.connTimeout->count() : kConnectedTimeoutSec;
-    opt.set(SOL_SOCKET, SO_SNDTIMEO, tv, "SO_SNDTIMEO");
-    opt.set(SOL_SOCKET, SO_RCVTIMEO, tv, "SO_RCVTIMEO");
-  }
-
+  applySocketConfig(opt, config);
   return opt.status();
 }
 

--- a/comms/uniflow/controller/TcpController.h
+++ b/comms/uniflow/controller/TcpController.h
@@ -13,6 +13,7 @@
 #include <optional>
 #include <queue>
 #include <span>
+#include <string>
 #include <vector>
 
 #include "comms/uniflow/controller/Controller.h"
@@ -22,6 +23,13 @@ class EventBase;
 } // namespace uniflow
 
 namespace uniflow::controller {
+
+/// First live global IPv6 address on `device`, or an error if it has none.
+///
+/// Deprecated addresses (IFA_F_DEPRECATED) are skipped: they bind successfully
+/// and so are indistinguishable from a live address at the socket layer, but a
+/// peer is not supposed to reply to them.
+Result<std::string> deviceGlobalIpv6(const std::string& device);
 
 /// Socket configuration for TcpServer and TcpClient.
 /// Optional fields: valued → setsockopt, nullopt → OS kernel default.
@@ -42,6 +50,14 @@ struct TcpSocketConfig {
   std::optional<int> keepaliveCount{3};
   std::optional<std::chrono::milliseconds> userTimeout{
       std::chrono::milliseconds{60000}};
+
+  /// Network device (e.g. "eth2") to pin egress to via SO_BINDTODEVICE.
+  /// Unset by default: without it the kernel routing table picks the egress
+  /// device, so binding a source address on the listener still leaves no
+  /// control over which NIC traffic actually leaves through. Opt-in because
+  /// forcing egress onto one device breaks connectivity wherever routing was
+  /// selecting a different, working NIC.
+  std::optional<std::string> bindToDevice;
 
   int acceptRetryCnt{5};
   size_t connectRetries{10};

--- a/comms/uniflow/controller/TcpController.h
+++ b/comms/uniflow/controller/TcpController.h
@@ -145,7 +145,7 @@ class TcpConn : public Conn {
   bool sendAll(const void* buf, size_t len);
   /// Vectored sendAll: one syscall for the length prefix plus payload. Mutates
   /// @p iov to track partial writes, so it must not be reused by the caller.
-  bool sendAllVec(iovec* iov, int iovCnt);
+  bool sendAllVec(std::span<iovec> iov);
   bool recvAll(void* buf, size_t len);
   bool exchangeMagic();
   Result<size_t> syncSend(std::span<const uint8_t> data);

--- a/comms/uniflow/controller/TcpController.h
+++ b/comms/uniflow/controller/TcpController.h
@@ -26,6 +26,11 @@ namespace uniflow::controller {
 /// Socket configuration for TcpServer and TcpClient.
 /// Optional fields: valued → setsockopt, nullopt → OS kernel default.
 /// Default-constructed with production-tuned values.
+///
+/// Applied identically to accepted and client-side connections by
+/// applySocketConfig. connTimeout is the one field that does not fall through
+/// to the OS on nullopt: it backs SO_SNDTIMEO/SO_RCVTIMEO, which default to 30s
+/// so that an unresponsive peer cannot wedge a blocking recv forever.
 struct TcpSocketConfig {
   std::optional<std::chrono::seconds> connTimeout{std::chrono::seconds{30}};
   std::optional<int> socketBufSize{1 << 20}; // 1MB
@@ -232,14 +237,13 @@ struct AsyncAccept {
 
  private:
   // All private methods run on the loop thread only.
-  void acceptPendingConnections(std::atomic<int>& listenSock);
+  void acceptPendingConnections(
+      std::atomic<int>& listenSock,
+      const TcpSocketConfig& config);
   void teardown(int fd);
 
   EventBase& evb_;
   bool accepting_{false}; // loop-thread-only
-  // Buffer sizing for sockets accepted on the loop thread. Copied rather than
-  // referenced because accept() returns before acceptPendingConnections runs.
-  std::optional<int> socketBufSize_; // loop-thread-only
   std::queue<std::unique_ptr<Conn>> readyConns_;
   std::queue<std::promise<std::unique_ptr<Conn>>> pendingPromises_;
 };

--- a/comms/uniflow/controller/tests/TcpAsyncAcceptTest.cpp
+++ b/comms/uniflow/controller/tests/TcpAsyncAcceptTest.cpp
@@ -23,6 +23,10 @@ using namespace uniflow::controller;
 struct AddrFamily {
   std::string serverAddr;
   std::string clientHost;
+  // Stated rather than derived from clientHost: comparing against the
+  // "127.0.0.1" literal silently defaults every other spelling -- "localhost",
+  // "[::1]", a resolvable hostname -- to AF_INET6.
+  int family;
 };
 
 class TcpAsyncAcceptTest : public ::testing::TestWithParam<AddrFamily> {
@@ -113,8 +117,7 @@ TEST_P(TcpAsyncAcceptTest, SingleAsyncAccept) {
 // copy. Before the config was threaded through the accept policy,
 // configureAcceptedSocket hardcoded 1 MiB, so a caller had no way to opt out.
 TEST_P(TcpAsyncAcceptTest, UnsetSocketBufSizeLeavesKernelAutotuning) {
-  const int family = GetParam().clientHost == "127.0.0.1" ? AF_INET : AF_INET6;
-  const int kernelDefault = kernelDefaultRcvBuf(family);
+  const int kernelDefault = kernelDefaultRcvBuf(GetParam().family);
   ASSERT_GT(kernelDefault, 0);
 
   TcpSocketConfig cfg;
@@ -157,8 +160,7 @@ TEST_P(TcpAsyncAcceptTest, UnsetSocketBufSizeLeavesKernelAutotuning) {
 // enough to contain the unconfigured default would also be satisfied if
 // socketBufSize were dropped again.
 TEST_P(TcpAsyncAcceptTest, AcceptedSocketAppliesConfiguredSocketBufSize) {
-  const int family = GetParam().clientHost == "127.0.0.1" ? AF_INET : AF_INET6;
-  const int kernelDefault = kernelDefaultRcvBuf(family);
+  const int kernelDefault = kernelDefaultRcvBuf(GetParam().family);
   ASSERT_GT(kernelDefault, 0);
 
   // Scaled off the probe rather than a literal. A quarter of the default
@@ -168,7 +170,7 @@ TEST_P(TcpAsyncAcceptTest, AcceptedSocketAppliesConfiguredSocketBufSize) {
   // untouched one on any stock host. Staying below the default also keeps the
   // request clear of net.core.rmem_max, so it is not silently clamped.
   const int requested = kernelDefault / 4;
-  const int expected = rcvBufForRequest(family, requested);
+  const int expected = rcvBufForRequest(GetParam().family, requested);
   ASSERT_GT(expected, 0);
 
   // Whether the configured size is observably different from the default is a
@@ -344,14 +346,11 @@ TEST_P(TcpAsyncAcceptTest, AsyncAcceptRejectsNonUniflowClient) {
   auto future = server.accept();
 
   {
-    int sock = ::socket(
-        GetParam().clientHost == "127.0.0.1" ? AF_INET : AF_INET6,
-        SOCK_STREAM | SOCK_CLOEXEC,
-        0);
+    int sock = ::socket(GetParam().family, SOCK_STREAM | SOCK_CLOEXEC, 0);
     ASSERT_GE(sock, 0);
 
     sockaddr_storage addr{};
-    if (GetParam().clientHost == "127.0.0.1") {
+    if (GetParam().family == AF_INET) {
       auto* sa = reinterpret_cast<sockaddr_in*>(&addr);
       sa->sin_family = AF_INET;
       sa->sin_port = htons(static_cast<uint16_t>(port));
@@ -454,8 +453,8 @@ INSTANTIATE_TEST_SUITE_P(
     AddrFamilies,
     TcpAsyncAcceptTest,
     ::testing::Values(
-        AddrFamily{"127.0.0.1:0", "127.0.0.1"},
-        AddrFamily{":::0", "::1"}),
+        AddrFamily{"127.0.0.1:0", "127.0.0.1", AF_INET},
+        AddrFamily{":::0", "::1", AF_INET6}),
     [](const ::testing::TestParamInfo<AddrFamily>& info) {
-      return info.param.clientHost == "127.0.0.1" ? "IPv4" : "IPv6";
+      return info.param.family == AF_INET ? "IPv4" : "IPv6";
     });

--- a/comms/uniflow/controller/tests/TcpAsyncAcceptTest.cpp
+++ b/comms/uniflow/controller/tests/TcpAsyncAcceptTest.cpp
@@ -3,6 +3,7 @@
 #include "comms/uniflow/controller/TcpController.h"
 
 #include <arpa/inet.h>
+#include <netinet/tcp.h>
 #include <sys/socket.h>
 #include <unistd.h>
 #include <optional>
@@ -88,6 +89,26 @@ int rcvBufForRequest(int family, int request) {
 int acceptedFd(const std::unique_ptr<Conn>& conn) {
   auto* tcp = dynamic_cast<TcpConn<SyncIO>*>(conn.get());
   return tcp == nullptr ? -1 : tcp->getFd();
+}
+
+int getSockOptInt(int fd, int level, int optname) {
+  int val = 0;
+  socklen_t len = sizeof(val);
+  EXPECT_EQ(::getsockopt(fd, level, optname, &val, &len), 0);
+  return val;
+}
+
+// The value an untouched socket of this family reports, so "the kernel is still
+// in charge" is measured rather than assumed. Hardcoding 0 would encode a
+// current Linux default instead of the property under test.
+int probeSockOptInt(int family, int level, int optname) {
+  int probe = ::socket(family, SOCK_STREAM, 0);
+  if (probe < 0) {
+    return -1;
+  }
+  int val = getSockOptInt(probe, level, optname);
+  ::close(probe);
+  return val;
 }
 
 } // namespace
@@ -202,6 +223,65 @@ TEST_P(TcpAsyncAcceptTest, AcceptedSocketAppliesConfiguredSocketBufSize) {
   const int fd = acceptedFd(conn);
   ASSERT_GE(fd, 0);
   EXPECT_EQ(getRcvBuf(fd), expected);
+}
+
+// osDefaults() means "leave the OS alone", and that has to hold for accepted
+// sockets too. Before configureAcceptedSocket applied the config, it hardcoded
+// TCP_NODELAY=1 and SO_KEEPALIVE=1 regardless, so this configuration was
+// silently ignored on the server side while the client honoured it.
+TEST_P(TcpAsyncAcceptTest, AcceptedSocketLeavesOsDefaultsUntouched) {
+  const int family = GetParam().family;
+  const int probeNoDelay = probeSockOptInt(family, IPPROTO_TCP, TCP_NODELAY);
+  const int probeKeepalive = probeSockOptInt(family, SOL_SOCKET, SO_KEEPALIVE);
+  ASSERT_GE(probeNoDelay, 0);
+  ASSERT_GE(probeKeepalive, 0);
+
+  ScopedEventBaseThread evbThread("async-accept");
+  AsyncTcpServer server(
+      GetParam().serverAddr,
+      TcpSocketConfig::osDefaults(),
+      *evbThread.getEventBase());
+  auto status = server.init();
+  if (status.hasError()) {
+    GTEST_SKIP() << "Not available: " << status.error().toString();
+  }
+
+  auto future = server.accept();
+  TcpClient client;
+  auto clientConn = client.connect(clientAddr(server.getPort())).get();
+  ASSERT_NE(clientConn, nullptr) << "Client failed to connect";
+  auto conn = future.get();
+  ASSERT_NE(conn, nullptr);
+
+  const int fd = acceptedFd(conn);
+  ASSERT_GE(fd, 0);
+  EXPECT_EQ(getSockOptInt(fd, IPPROTO_TCP, TCP_NODELAY), probeNoDelay);
+  EXPECT_EQ(getSockOptInt(fd, SOL_SOCKET, SO_KEEPALIVE), probeKeepalive);
+}
+
+// A server that turns keepalive off must actually get it off. This is the case
+// that used to be a no-op with no compiler error and no failing test.
+TEST_P(TcpAsyncAcceptTest, AcceptedSocketHonoursKeepaliveDisable) {
+  TcpSocketConfig cfg;
+  cfg.enableKeepalive = false;
+
+  ScopedEventBaseThread evbThread("async-accept");
+  AsyncTcpServer server(GetParam().serverAddr, cfg, *evbThread.getEventBase());
+  auto status = server.init();
+  if (status.hasError()) {
+    GTEST_SKIP() << "Not available: " << status.error().toString();
+  }
+
+  auto future = server.accept();
+  TcpClient client;
+  auto clientConn = client.connect(clientAddr(server.getPort())).get();
+  ASSERT_NE(clientConn, nullptr) << "Client failed to connect";
+  auto conn = future.get();
+  ASSERT_NE(conn, nullptr);
+
+  const int fd = acceptedFd(conn);
+  ASSERT_GE(fd, 0);
+  EXPECT_EQ(getSockOptInt(fd, SOL_SOCKET, SO_KEEPALIVE), 0);
 }
 
 TEST_P(TcpAsyncAcceptTest, MultipleAsyncAccepts) {

--- a/comms/uniflow/controller/tests/TcpAsyncConnectTest.cpp
+++ b/comms/uniflow/controller/tests/TcpAsyncConnectTest.cpp
@@ -184,6 +184,46 @@ TEST_F(TcpAsyncConnectMiscTest, AsyncConnectRejectsNonUniflowServer) {
   ::close(listenSock);
 }
 
+// The async client is the path the TCP transport's lanes actually use, so it
+// gets its own coverage of the device binding rather than relying on the sync
+// client's.
+TEST_P(TcpAsyncConnectTest, AsyncConnectBoundToLoopbackDevice) {
+  ScopedEventBaseThread evbThread("async-connect");
+  TcpServer server(GetParam().serverAddr);
+  auto status = server.init();
+  if (status.hasError()) {
+    GTEST_SKIP() << "Not available: " << status.error().toString();
+  }
+  int port = server.getPort();
+
+  std::unique_ptr<Conn> serverConn;
+  std::thread acceptThread([&]() { serverConn = server.accept().get(); });
+
+  TcpSocketConfig cfg;
+  cfg.bindToDevice = "lo";
+  AsyncTcpClient client(cfg, *evbThread.getEventBase());
+  auto conn = client.connect(clientAddr(port)).get();
+  EXPECT_NE(conn, nullptr);
+
+  acceptThread.join();
+  EXPECT_NE(serverConn, nullptr);
+}
+
+TEST_P(TcpAsyncConnectTest, AsyncConnectToNonexistentDeviceFails) {
+  ScopedEventBaseThread evbThread("async-connect");
+  TcpServer server(GetParam().serverAddr);
+  auto status = server.init();
+  if (status.hasError()) {
+    GTEST_SKIP() << "Not available: " << status.error().toString();
+  }
+  int port = server.getPort();
+
+  TcpSocketConfig cfg;
+  cfg.bindToDevice = "nonexistent0";
+  AsyncTcpClient client(cfg, *evbThread.getEventBase());
+  EXPECT_EQ(client.connect(clientAddr(port)).get(), nullptr);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     AddrFamilies,
     TcpAsyncConnectTest,

--- a/comms/uniflow/controller/tests/TcpConnTest.cpp
+++ b/comms/uniflow/controller/tests/TcpConnTest.cpp
@@ -120,6 +120,31 @@ TEST_P(TcpConnTest, SendRecvBidirectional) {
   EXPECT_TRUE(recv3.empty());
 }
 
+TEST_P(TcpConnTest, SpanRecvRecordsPhaseStats) {
+  auto [clientConn, serverConn] = connectPair();
+  ASSERT_NE(clientConn, nullptr);
+  ASSERT_NE(serverConn, nullptr);
+
+  std::vector<uint8_t> sent(4096, 0xA5);
+  std::vector<uint8_t> received(sent.size());
+  ASSERT_TRUE(clientConn->send(sent).get().hasValue());
+
+  auto recvResult = serverConn->recv(std::span<uint8_t>(received)).get();
+  ASSERT_TRUE(recvResult.hasValue()) << recvResult.error().toString();
+  EXPECT_EQ(recvResult.value(), sent.size());
+  EXPECT_EQ(received, sent);
+
+  auto& stats = serverConn->recvPhaseStats();
+  EXPECT_EQ(stats.frames.load(std::memory_order_relaxed), 1);
+  EXPECT_EQ(stats.payloadBytes.load(std::memory_order_relaxed), sent.size());
+
+  stats.reset();
+  EXPECT_EQ(stats.headerWaitNs.load(std::memory_order_relaxed), 0);
+  EXPECT_EQ(stats.payloadDrainNs.load(std::memory_order_relaxed), 0);
+  EXPECT_EQ(stats.frames.load(std::memory_order_relaxed), 0);
+  EXPECT_EQ(stats.payloadBytes.load(std::memory_order_relaxed), 0);
+}
+
 TEST_P(TcpConnTest, SendRecvLargeData) {
   auto [clientConn, serverConn] = connectPair();
   ASSERT_NE(clientConn, nullptr);

--- a/comms/uniflow/controller/tests/TcpServerClientTest.cpp
+++ b/comms/uniflow/controller/tests/TcpServerClientTest.cpp
@@ -2,6 +2,15 @@
 
 #include "comms/uniflow/controller/TcpController.h"
 
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+#include <fstream>
+#include <string>
 #include <thread>
 
 #include <gtest/gtest.h>
@@ -377,4 +386,167 @@ TEST_F(TcpSocketConfigTest, ExplicitKeepaliveDisableIsValid) {
 
   acceptThread.join();
   EXPECT_NE(serverConn, nullptr);
+}
+
+TEST_F(TcpSocketConfigTest, DefaultsLeaveBindToDeviceUnset) {
+  EXPECT_FALSE(TcpSocketConfig{}.bindToDevice.has_value());
+  EXPECT_FALSE(TcpSocketConfig::osDefaults().bindToDevice.has_value());
+}
+
+TEST_F(TcpSocketConfigTest, ValidateRejectsEmptyBindToDevice) {
+  auto cfg = TcpSocketConfig{};
+  cfg.bindToDevice = "";
+  auto status = cfg.validate();
+  EXPECT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::InvalidArgument);
+}
+
+TEST_F(TcpSocketConfigTest, ValidateRejectsOverlongBindToDevice) {
+  auto cfg = TcpSocketConfig{};
+  cfg.bindToDevice = std::string(IFNAMSIZ, 'e');
+  auto status = cfg.validate();
+  EXPECT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::InvalidArgument);
+}
+
+TEST_F(TcpSocketConfigTest, ValidateAcceptsLongestBindToDevice) {
+  auto cfg = TcpSocketConfig{};
+  cfg.bindToDevice = std::string(IFNAMSIZ - 1, 'e');
+  EXPECT_TRUE(cfg.validate().hasValue());
+}
+
+TEST_F(TcpSocketConfigTest, BindToLoopbackDeviceConnectionSucceeds) {
+  auto cfg = TcpSocketConfig{};
+  cfg.bindToDevice = "lo";
+
+  TcpServer server("127.0.0.1:0", cfg);
+  auto status = server.init();
+  ASSERT_TRUE(status.hasValue()) << status.error().toString();
+
+  std::unique_ptr<Conn> serverConn;
+  std::thread acceptThread([&]() { serverConn = server.accept().get(); });
+
+  TcpClient client(cfg);
+  auto clientConn =
+      client.connect("127.0.0.1:" + std::to_string(server.getPort())).get();
+  EXPECT_NE(clientConn, nullptr);
+
+  acceptThread.join();
+  EXPECT_NE(serverConn, nullptr);
+}
+
+// Accepted sockets inherit sk_bound_dev_if from the listener, so the accept
+// path needs no explicit binding. Asserted here because that is a kernel
+// behaviour the design relies on rather than something this code enforces.
+TEST_F(TcpSocketConfigTest, AcceptedSocketInheritsListenerDevice) {
+  auto cfg = TcpSocketConfig{};
+  cfg.bindToDevice = "lo";
+
+  TcpServer server("127.0.0.1:0", cfg);
+  auto status = server.init();
+  ASSERT_TRUE(status.hasValue()) << status.error().toString();
+
+  std::unique_ptr<Conn> serverConn;
+  std::thread acceptThread([&]() { serverConn = server.accept().get(); });
+
+  TcpClient client(TcpSocketConfig{});
+  auto clientConn =
+      client.connect("127.0.0.1:" + std::to_string(server.getPort())).get();
+  ASSERT_NE(clientConn, nullptr);
+
+  acceptThread.join();
+  ASSERT_NE(serverConn, nullptr);
+
+  auto* tcpConn = dynamic_cast<TcpConn<SyncIO>*>(serverConn.get());
+  ASSERT_NE(tcpConn, nullptr);
+
+  char boundDev[IFNAMSIZ] = {};
+  socklen_t len = sizeof(boundDev);
+  ASSERT_EQ(
+      ::getsockopt(
+          tcpConn->getFd(), SOL_SOCKET, SO_BINDTODEVICE, boundDev, &len),
+      0);
+  EXPECT_STREQ(boundDev, "lo");
+}
+
+TEST_F(TcpSocketConfigTest, BindToNonexistentDeviceFailsNamingIt) {
+  auto cfg = TcpSocketConfig{};
+  cfg.bindToDevice = "nonexistent0";
+
+  TcpServer server("127.0.0.1:0", cfg);
+  auto status = server.init();
+  ASSERT_TRUE(status.hasError());
+  EXPECT_NE(status.error().toString().find("nonexistent0"), std::string::npos)
+      << status.error().toString();
+}
+
+TEST_F(TcpSocketConfigTest, ClientBindToNonexistentDeviceFails) {
+  TcpServer server("127.0.0.1:0");
+  auto status = server.init();
+  ASSERT_TRUE(status.hasValue()) << status.error().toString();
+
+  auto cfg = TcpSocketConfig{};
+  cfg.bindToDevice = "nonexistent0";
+  cfg.connectRetries = 0;
+
+  TcpClient client(cfg);
+  auto clientConn =
+      client.connect("127.0.0.1:" + std::to_string(server.getPort())).get();
+  EXPECT_EQ(clientConn, nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// deviceGlobalIpv6
+// ---------------------------------------------------------------------------
+
+TEST(DeviceGlobalIpv6Test, UnknownDeviceReportsError) {
+  auto addr = deviceGlobalIpv6("nonexistent0");
+
+  ASSERT_TRUE(addr.hasError());
+  EXPECT_EQ(addr.error().code(), ErrCode::InvalidArgument);
+}
+
+// ::1 is host-scope, not global. Returning it would hand the transport an
+// address no peer can reach, so the scope filter has to exclude it.
+TEST(DeviceGlobalIpv6Test, LoopbackHasNoGlobalAddress) {
+  auto addr = deviceGlobalIpv6("lo");
+
+  ASSERT_TRUE(addr.hasError())
+      << "unexpectedly resolved lo to " << addr.value();
+  EXPECT_EQ(addr.error().code(), ErrCode::InvalidArgument);
+}
+
+// Whatever comes back must be usable as a bind address, which is the only
+// property the transport relies on. Skipped where the host has no global IPv6.
+TEST(DeviceGlobalIpv6Test, ResolvedAddressIsBindable) {
+  std::ifstream f("/proc/net/if_inet6");
+  ASSERT_TRUE(f.good());
+  std::string hex, ifindex, prefixLen, scope, flags, name;
+  std::string candidate;
+  while (f >> hex >> ifindex >> prefixLen >> scope >> flags >> name) {
+    if (std::stoul(scope, nullptr, 16) == 0 &&
+        (std::stoul(flags, nullptr, 16) & 0x20) == 0) {
+      candidate = name;
+      break;
+    }
+  }
+  if (candidate.empty()) {
+    GTEST_SKIP() << "host has no live global IPv6 address";
+  }
+
+  auto addr = deviceGlobalIpv6(candidate);
+  ASSERT_TRUE(addr.hasValue()) << addr.error().message();
+
+  in6_addr parsed{};
+  EXPECT_EQ(inet_pton(AF_INET6, addr.value().c_str(), &parsed), 1)
+      << "deviceGlobalIpv6 returned unparseable address " << addr.value();
+
+  int sock = ::socket(AF_INET6, SOCK_STREAM, 0);
+  ASSERT_GE(sock, 0);
+  sockaddr_in6 sa{};
+  sa.sin6_family = AF_INET6;
+  sa.sin6_addr = parsed;
+  EXPECT_EQ(::bind(sock, reinterpret_cast<sockaddr*>(&sa), sizeof(sa)), 0)
+      << "cannot bind " << addr.value() << ": " << std::strerror(errno);
+  ::close(sock);
 }

--- a/comms/uniflow/drivers/cuda/mock/MockCudaApi.h
+++ b/comms/uniflow/drivers/cuda/mock/MockCudaApi.h
@@ -105,4 +105,11 @@ class MockCudaApi : public CudaApi {
   }
 };
 
+/// Vendor types for gmock matcher arguments. This header is hipified on AMD;
+/// test TUs are not, so they cannot name cudaStream_t or cudaMemcpyKind
+/// themselves. `auto` covers lambda parameters in actions -- matchers have no
+/// equivalent, so pin them through these.
+using MockStream = cudaStream_t;
+inline constexpr auto kMockMemcpyH2D = cudaMemcpyHostToDevice;
+
 } // namespace uniflow

--- a/comms/uniflow/transport/tcp/TcpPinnedSlabPool.h
+++ b/comms/uniflow/transport/tcp/TcpPinnedSlabPool.h
@@ -18,8 +18,8 @@ class TcpPinnedSlabPool;
 
 /// A borrow of one pinned staging slab. Move-only, and returned to the pool
 /// when it is destroyed, so a slab is held for exactly as long as some object
-/// owns the lease -- which on the outbound path means until the frame built in
-/// it has been handed to the socket and the queue entry is gone.
+/// owns the lease. Outbound frames retain it through socket send; inbound
+/// frames retain it through the destination copy that still reads from it.
 class TcpPinnedSlab {
  public:
   TcpPinnedSlab() = default;

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -9,6 +9,8 @@
 #include <cstdint>
 #include <cstring>
 #include <exception>
+#include <future>
+#include <memory>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -58,15 +60,41 @@ std::string hostOrderKey(const std::string& host) {
 // TcpTransportInfo
 // ---------------------------------------------------------------------------
 
+TcpTransportInfo::Endpoint TcpTransportInfo::endpointAt(size_t index) const {
+  if (index == 0 || index > extraEndpoints.size()) {
+    return Endpoint{host, port};
+  }
+  return extraEndpoints[index - 1];
+}
+
 TransportInfo TcpTransportInfo::serialize() const {
   Header header{
       .port = port,
       .hostLen = static_cast<uint16_t>(host.size()),
   };
-  TransportInfo data(sizeof(Header) + host.size());
+  size_t extraBytes = 0;
+  for (const auto& ep : extraEndpoints) {
+    extraBytes += sizeof(Header) + ep.host.size();
+  }
+  TransportInfo data(sizeof(Header) + host.size() + extraBytes);
   std::memcpy(data.data(), &header, sizeof(header));
   if (!host.empty()) {
     std::memcpy(data.data() + sizeof(header), host.data(), host.size());
+  }
+  // Same {port, hostLen, host} shape repeated, so with no extra endpoints the
+  // bytes are identical to a build that predates striping.
+  size_t offset = sizeof(header) + host.size();
+  for (const auto& ep : extraEndpoints) {
+    Header extra{
+        .port = ep.port,
+        .hostLen = static_cast<uint16_t>(ep.host.size()),
+    };
+    std::memcpy(data.data() + offset, &extra, sizeof(extra));
+    offset += sizeof(extra);
+    if (!ep.host.empty()) {
+      std::memcpy(data.data() + offset, ep.host.data(), ep.host.size());
+      offset += ep.host.size();
+    }
   }
   return data;
 }
@@ -79,7 +107,7 @@ Result<TcpTransportInfo> TcpTransportInfo::deserialize(
 
   Header header;
   std::memcpy(&header, data.data(), sizeof(header));
-  if (data.size() != sizeof(header) + header.hostLen) {
+  if (data.size() < sizeof(header) + header.hostLen) {
     return Err(ErrCode::InvalidArgument, "tcp transport info size mismatch");
   }
 
@@ -88,6 +116,31 @@ Result<TcpTransportInfo> TcpTransportInfo::deserialize(
   info.host.assign(
       reinterpret_cast<const char*>(data.data() + sizeof(header)),
       header.hostLen);
+
+  // Anything left over is extra endpoints. Consuming exactly the remainder
+  // keeps the old exact-size guarantee: trailing junk is still rejected.
+  size_t offset = sizeof(header) + header.hostLen;
+  while (offset < data.size()) {
+    if (data.size() - offset < sizeof(Header)) {
+      return Err(
+          ErrCode::InvalidArgument,
+          "tcp transport info has a truncated extra endpoint");
+    }
+    Header extra;
+    std::memcpy(&extra, data.data() + offset, sizeof(extra));
+    offset += sizeof(extra);
+    if (data.size() - offset < extra.hostLen) {
+      return Err(
+          ErrCode::InvalidArgument,
+          "tcp transport info extra endpoint host is truncated");
+    }
+    Endpoint ep;
+    ep.port = extra.port;
+    ep.host.assign(
+        reinterpret_cast<const char*>(data.data() + offset), extra.hostLen);
+    offset += extra.hostLen;
+    info.extraEndpoints.push_back(std::move(ep));
+  }
   return info;
 }
 
@@ -169,22 +222,65 @@ TransportInfo TcpTransport::bind() {
     UNIFLOW_LOG_ERROR("TcpTransport::bind: transport is already shut down");
     return TransportInfo{};
   }
-  server_ = std::make_unique<controller::AsyncTcpServer>(
-      host_ + ":0", config_.socketConfig, *evb_);
-  auto status = server_->init();
-  if (!status) {
-    UNIFLOW_LOG_ERROR(
-        "TcpTransport::bind: server init failed: {}", status.error().message());
-    state_ = TransportState::Error;
-    server_.reset();
-    return TransportInfo{};
+  // One listener per device when striping, otherwise a single listener on host_
+  // with egress left to the routing table. Each device's listener binds that
+  // device's own address *and* sets SO_BINDTODEVICE, because accepted sockets
+  // inherit the listener's device binding and that inheritance is what puts
+  // `get` payload on the intended NIC.
+  std::vector<std::pair<std::string, std::optional<std::string>>> targets;
+  if (config_.bindToDevices.empty()) {
+    targets.emplace_back(host_, std::nullopt);
+  } else {
+    for (const auto& device : config_.bindToDevices) {
+      auto addr = controller::deviceGlobalIpv6(device);
+      if (!addr) {
+        UNIFLOW_LOG_ERROR(
+            "TcpTransport::bind: cannot resolve device {}: {}",
+            device,
+            addr.error().message());
+        state_ = TransportState::Error;
+        return TransportInfo{};
+      }
+      targets.emplace_back(addr.value(), device);
+    }
   }
-  port_ = static_cast<uint16_t>(server_->getPort());
+
+  servers_.clear();
+  localEndpoints_.clear();
+  for (const auto& [addr, device] : targets) {
+    auto socketConfig = config_.socketConfig;
+    if (device) {
+      socketConfig.bindToDevice = device;
+    }
+    auto server = std::make_unique<controller::AsyncTcpServer>(
+        addr + ":0", socketConfig, *evb_);
+    auto status = server->init();
+    if (!status) {
+      UNIFLOW_LOG_ERROR(
+          "TcpTransport::bind: server init failed for {}{}: {}",
+          addr,
+          device ? fmt::format(" (dev {})", *device) : "",
+          status.error().message());
+      state_ = TransportState::Error;
+      servers_.clear();
+      localEndpoints_.clear();
+      return TransportInfo{};
+    }
+    localEndpoints_.push_back({addr, static_cast<uint16_t>(server->getPort())});
+    servers_.push_back(std::move(server));
+  }
+
+  // Endpoint 0 stays the transport's identity: it orders the listener/dialer
+  // roles and it is what a single-device peer sees.
+  host_ = localEndpoints_.front().host;
+  port_ = localEndpoints_.front().port;
   state_ = TransportState::Initialized;
 
   TcpTransportInfo info;
   info.host = host_;
   info.port = port_;
+  info.extraEndpoints.assign(
+      localEndpoints_.begin() + 1, localEndpoints_.end());
   return info.serialize();
 }
 
@@ -253,6 +349,30 @@ Status TcpTransport::connect(std::span<const uint8_t> remoteInfo) {
             " lanes the hello can address");
   }
 
+  // Both peers derive lane-to-device placement from the lane index, so they
+  // must agree on the device count. The dialer can check this up front because
+  // the listener advertises one endpoint per device; catching it here gives a
+  // clear error instead of a handshake timeout on the lanes that map to a
+  // device the peer never bound.
+  const size_t localDevices =
+      config_.bindToDevices.empty() ? 1 : config_.bindToDevices.size();
+  if (peer.endpointCount() != localDevices) {
+    state_ = TransportState::Error;
+    return Err(
+        ErrCode::InvalidArgument,
+        "tcp connect: peer advertised " + std::to_string(peer.endpointCount()) +
+            " device endpoints, local is configured for " +
+            std::to_string(localDevices) + "; both peers must agree");
+  }
+  if (laneCount < localDevices) {
+    state_ = TransportState::Error;
+    return Err(
+        ErrCode::InvalidArgument,
+        "tcp connect: numSockets " + std::to_string(laneCount) +
+            " is below the " + std::to_string(localDevices) +
+            " configured devices, so some device would carry no lane");
+  }
+
   if (auto status = establishLanes(listener, peer, laneCount, handshakeTimeout);
       !status) {
     state_ = TransportState::Error;
@@ -294,84 +414,133 @@ Status TcpTransport::establishLanes(
   const bool exchangeHello = laneCount > 1;
 
   if (listener) {
-    if (!server_) {
+    if (servers_.empty()) {
       return Err(ErrCode::ConnectionFailed, "tcp connect: no server bound");
     }
+    // Lane i lives on device i % D, so listener d owns exactly the lanes
+    // congruent to d.
+    //
+    // Every listener must be armed before this thread blocks on any of them.
+    // AsyncAccept registers its listen fd with the EventBase lazily, on the
+    // first accept() call, and an accepted socket's magic exchange runs from
+    // that fd's EPOLLIN handler. An unarmed listener therefore leaves a
+    // dialed-in connection sitting in the kernel backlog with nobody completing
+    // its handshake, so the dialer's exchange times out after 500ms. Accepting
+    // device-by-device without pre-arming deadlocks as soon as one device owns
+    // two lanes: this thread waits for device 0's second lane, which the dialer
+    // only dials after device 1's lane succeeds, which it cannot.
+    const size_t deviceCount = servers_.size();
     uint64_t sessionId = 0;
     std::vector<bool> filled(laneCount, false);
-    for (size_t accepted = 0; accepted < laneCount; ++accepted) {
-      auto future = server_->accept();
-      if (future.wait_for(handshakeTimeout) != std::future_status::ready) {
-        // shutdown() resolves the queued promise with nullptr (via teardown),
-        // so the get() below returns immediately instead of blocking. Safe from
-        // this thread: AsyncAccept::shutdown marshals teardown onto the
-        // EventBase thread and waits when called from outside the loop.
-        UNIFLOW_LOG_ERROR(
-            "TcpTransport::connect: only {} of {} lanes dialed in within {}s; "
-            "tearing down listener {}:{}",
-            accepted,
-            laneCount,
-            handshakeTimeout.count(),
-            host_,
-            port_);
-        server_->shutdown();
+    std::vector<size_t> quota(deviceCount);
+    for (size_t d = 0; d < deviceCount; ++d) {
+      // Lanes d, d+D, d+2D, ... land on this listener.
+      quota[d] =
+          laneCount / deviceCount + (d < laneCount % deviceCount ? 1 : 0);
+    }
+    // One outstanding accept per listener, purely to arm the fds. Once armed a
+    // listener keeps accepting and handshaking arrivals into readyConns_
+    // whether or not this thread is currently waiting on it.
+    std::vector<std::future<std::unique_ptr<controller::Conn>>> armed(
+        deviceCount);
+    for (size_t d = 0; d < deviceCount; ++d) {
+      if (quota[d] > 0) {
+        armed[d] = servers_[d]->accept();
       }
-      auto conn = future.get();
-      if (!conn) {
-        return Err(
-            ErrCode::ConnectionFailed, "tcp connect: data connection failed");
-      }
+    }
+    size_t accepted = 0;
+    for (size_t dev = 0; dev < deviceCount; ++dev) {
+      for (size_t n = 0; n < quota[dev]; ++n, ++accepted) {
+        auto future = armed[dev].valid() ? std::move(armed[dev])
+                                         : servers_[dev]->accept();
+        if (future.wait_for(handshakeTimeout) != std::future_status::ready) {
+          // shutdown() resolves the queued promise with nullptr (via teardown),
+          // so the get() below returns immediately instead of blocking. Safe
+          // from this thread: AsyncAccept::shutdown marshals teardown onto the
+          // EventBase thread and waits when called from outside the loop.
+          UNIFLOW_LOG_ERROR(
+              "TcpTransport::connect: only {} of {} lanes dialed in within {}s; "
+              "tearing down listener {}:{} (dev {} of {})",
+              accepted,
+              laneCount,
+              handshakeTimeout.count(),
+              localEndpoints_[dev].host,
+              localEndpoints_[dev].port,
+              dev,
+              deviceCount);
+          servers_[dev]->shutdown();
+        }
+        auto conn = future.get();
+        if (!conn) {
+          return Err(
+              ErrCode::ConnectionFailed, "tcp connect: data connection failed");
+        }
 
-      // Accept order is not lane identity: the peer dials the lanes without
-      // any ordering guarantee, so the index has to come off the wire.
-      size_t laneIdx = accepted;
-      if (exchangeHello) {
-        std::vector<uint8_t> msg;
-        auto received = conn->recv(msg).get();
-        if (!received) {
-          return Err(
-              ErrCode::ConnectionFailed,
-              "tcp connect: lane hello not received: " +
-                  received.error().message());
+        // Accept order is not lane identity: the peer dials the lanes without
+        // any ordering guarantee, so the index has to come off the wire.
+        size_t laneIdx = accepted;
+        if (exchangeHello) {
+          std::vector<uint8_t> msg;
+          auto received = conn->recv(msg).get();
+          if (!received) {
+            return Err(
+                ErrCode::ConnectionFailed,
+                "tcp connect: lane hello not received: " +
+                    received.error().message());
+          }
+          auto helloResult = TcpLaneHello::deserialize(
+              std::span<const uint8_t>{msg.data(), received.value()});
+          if (!helloResult) {
+            return std::move(helloResult).error();
+          }
+          const auto hello = helloResult.value();
+          if (hello.laneCount != laneCount) {
+            return Err(
+                ErrCode::InvalidArgument,
+                "tcp connect: peer configured " +
+                    std::to_string(hello.laneCount) + " lanes, local is " +
+                    std::to_string(laneCount) + "; both peers must agree");
+          }
+          if (hello.laneIndex >= laneCount) {
+            return Err(
+                ErrCode::InvalidArgument,
+                "tcp connect: lane index " + std::to_string(hello.laneIndex) +
+                    " out of range for " + std::to_string(laneCount) +
+                    " lanes");
+          }
+          if (accepted == 0) {
+            sessionId = hello.sessionId;
+          } else if (hello.sessionId != sessionId) {
+            // A second dialer reaching this listener would otherwise take a
+            // lane and leave the real peer one short, hanging both.
+            return Err(
+                ErrCode::ConnectionFailed,
+                "tcp connect: lane session mismatch; another peer is dialing "
+                "this listener");
+          }
+          laneIdx = hello.laneIndex;
+          if (filled[laneIdx]) {
+            return Err(
+                ErrCode::ConnectionFailed,
+                "tcp connect: duplicate lane index " + std::to_string(laneIdx));
+          }
+          // The mapping is derived, not negotiated, so a lane arriving on the
+          // wrong listener means the peers disagree on device count. Left
+          // undetected it would silently place this lane's payload on the wrong
+          // NIC, which is exactly the mislabeling this feature exists to fix.
+          if (laneIdx % deviceCount != dev) {
+            return Err(
+                ErrCode::InvalidArgument,
+                "tcp connect: lane " + std::to_string(laneIdx) +
+                    " arrived on device " + std::to_string(dev) +
+                    " but maps to " + std::to_string(laneIdx % deviceCount) +
+                    "; peers disagree on device count (" +
+                    std::to_string(deviceCount) + " local)");
+          }
         }
-        auto helloResult = TcpLaneHello::deserialize(
-            std::span<const uint8_t>{msg.data(), received.value()});
-        if (!helloResult) {
-          return std::move(helloResult).error();
-        }
-        const auto hello = helloResult.value();
-        if (hello.laneCount != laneCount) {
-          return Err(
-              ErrCode::InvalidArgument,
-              "tcp connect: peer configured " +
-                  std::to_string(hello.laneCount) + " lanes, local is " +
-                  std::to_string(laneCount) + "; both peers must agree");
-        }
-        if (hello.laneIndex >= laneCount) {
-          return Err(
-              ErrCode::InvalidArgument,
-              "tcp connect: lane index " + std::to_string(hello.laneIndex) +
-                  " out of range for " + std::to_string(laneCount) + " lanes");
-        }
-        if (accepted == 0) {
-          sessionId = hello.sessionId;
-        } else if (hello.sessionId != sessionId) {
-          // A second dialer reaching this listener would otherwise take a lane
-          // and leave the real peer one short, hanging both.
-          return Err(
-              ErrCode::ConnectionFailed,
-              "tcp connect: lane session mismatch; another peer is dialing "
-              "this listener");
-        }
-        laneIdx = hello.laneIndex;
-        if (filled[laneIdx]) {
-          return Err(
-              ErrCode::ConnectionFailed,
-              "tcp connect: duplicate lane index " + std::to_string(laneIdx));
-        }
+        filled[laneIdx] = true;
+        lanes_[laneIdx]->conn = std::move(conn);
       }
-      filled[laneIdx] = true;
-      lanes_[laneIdx]->conn = std::move(conn);
     }
   } else {
     // Only has to distinguish this dialer from another one racing for the same
@@ -382,15 +551,28 @@ Status TcpTransport::establishLanes(
         static_cast<uint64_t>(
             std::chrono::steady_clock::now().time_since_epoch().count());
     for (size_t i = 0; i < laneCount; ++i) {
-      controller::AsyncTcpClient client(config_.socketConfig, *evb_);
-      auto future = client.connect(peer.host + ":" + std::to_string(peer.port));
+      // Same derived mapping as the listener: lane i on device i % D, dialing
+      // the endpoint the peer advertised for that device. Binding the dialer
+      // matters for `put` and for the request headers; the listener's own
+      // binding is what carries `get` payload.
+      const size_t deviceCount =
+          config_.bindToDevices.empty() ? 1 : config_.bindToDevices.size();
+      const size_t dev = i % deviceCount;
+      auto socketConfig = config_.socketConfig;
+      if (!config_.bindToDevices.empty()) {
+        socketConfig.bindToDevice = config_.bindToDevices[dev];
+      }
+      const auto target = peer.endpointAt(dev);
+      controller::AsyncTcpClient client(socketConfig, *evb_);
+      auto future =
+          client.connect(target.host + ":" + std::to_string(target.port));
       if (future.wait_for(handshakeTimeout) != std::future_status::ready) {
         UNIFLOW_LOG_ERROR(
             "TcpTransport::connect: lane {} dial to {}:{} did not complete "
             "within {}s",
             i,
-            peer.host,
-            peer.port,
+            target.host,
+            target.port,
             handshakeTimeout.count());
         // No teardown hook on the client side; abandon the attempt. The future
         // owns its own state, so letting it go out of scope is safe.
@@ -1702,15 +1884,27 @@ void TcpTransport::senderLoop(size_t laneIdx) noexcept {
 // caller's destination. Anything unaccounted for is reader-thread work between
 // those points.
 void TcpTransport::logAndResetPhaseStats(std::string_view label) {
-  auto* conn = primaryConn();
-  if (conn == nullptr) {
+  if (lanes_.empty()) {
     return;
   }
-  auto& rs = conn->recvPhaseStats();
-  const uint64_t frames = rs.frames.load(std::memory_order_relaxed);
-  const uint64_t hdrNs = rs.headerWaitNs.load(std::memory_order_relaxed);
-  const uint64_t drainNs = rs.payloadDrainNs.load(std::memory_order_relaxed);
-  const uint64_t bytes = rs.payloadBytes.load(std::memory_order_relaxed);
+  // Summed over every lane: each lane has its own reader and its own stats, so
+  // reading lane 0 alone would report 1/N of the traffic and hide any imbalance
+  // between lanes. Per-lane frame counts are logged too, since an uneven split
+  // is itself a finding.
+  uint64_t frames = 0, hdrNs = 0, drainNs = 0, bytes = 0;
+  std::string perLaneFrames;
+  for (size_t i = 0; i < lanes_.size(); ++i) {
+    if (lanes_[i] == nullptr || lanes_[i]->conn == nullptr) {
+      continue;
+    }
+    auto& lrs = lanes_[i]->conn->recvPhaseStats();
+    const uint64_t lf = lrs.frames.load(std::memory_order_relaxed);
+    frames += lf;
+    hdrNs += lrs.headerWaitNs.load(std::memory_order_relaxed);
+    drainNs += lrs.payloadDrainNs.load(std::memory_order_relaxed);
+    bytes += lrs.payloadBytes.load(std::memory_order_relaxed);
+    perLaneFrames += (i == 0 ? "" : ",") + std::to_string(lf);
+  }
   const uint64_t copyNs = dstCopyNs_.load(std::memory_order_relaxed) +
       h2dState_->copyNs.load(std::memory_order_relaxed);
   const uint64_t copies = dstCopyCount_.load(std::memory_order_relaxed) +
@@ -1741,7 +1935,7 @@ void TcpTransport::logAndResetPhaseStats(std::string_view label) {
         "tcp phases [{}]: frames={} bytes={} | first-byte {:.1f}us/frame "
         "({:.1f}%) | drain {:.1f}us/frame ({:.1f}%, {:.2f} GB/s) | dstcopy "
         "{:.1f}us x{} ({:.1f}% of wire) | receive_slabs attempts={} misses={} "
-        "vector_recvs={}",
+        "vector_recvs={} | lanes={} frames_per_lane=[{}]",
         label,
         frames,
         bytes,
@@ -1755,9 +1949,15 @@ void TcpTransport::logAndResetPhaseStats(std::string_view label) {
         pct(copyNs),
         slabAttempts,
         slabMisses,
-        vectorReceives);
+        vectorReceives,
+        lanes_.size(),
+        perLaneFrames);
   }
-  rs.reset();
+  for (auto& lane : lanes_) {
+    if (lane != nullptr && lane->conn != nullptr) {
+      lane->conn->recvPhaseStats().reset();
+    }
+  }
   dstCopyNs_.store(0, std::memory_order_relaxed);
   dstCopyCount_.store(0, std::memory_order_relaxed);
   h2dState_->copyNs.store(0, std::memory_order_relaxed);

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -1527,6 +1527,12 @@ void TcpTransport::logAndResetPhaseStats(std::string_view label) {
       h2dState_->copyNs.load(std::memory_order_relaxed);
   const uint64_t copies = dstCopyCount_.load(std::memory_order_relaxed) +
       h2dState_->copyCount.load(std::memory_order_relaxed);
+  const uint64_t slabAttempts =
+      receiveSlabAttempts_.load(std::memory_order_relaxed);
+  const uint64_t slabMisses =
+      receiveSlabMisses_.load(std::memory_order_relaxed);
+  const uint64_t vectorReceives =
+      vectorReceiveCount_.load(std::memory_order_relaxed);
 
   if (frames == 0) {
     UNIFLOW_LOG_INFO("tcp phases [{}]: no frames", label);
@@ -1546,7 +1552,8 @@ void TcpTransport::logAndResetPhaseStats(std::string_view label) {
     UNIFLOW_LOG_INFO(
         "tcp phases [{}]: frames={} bytes={} | first-byte {:.1f}us/frame "
         "({:.1f}%) | drain {:.1f}us/frame ({:.1f}%, {:.2f} GB/s) | dstcopy "
-        "{:.1f}us x{} ({:.1f}% of wire)",
+        "{:.1f}us x{} ({:.1f}% of wire) | receive_slabs attempts={} misses={} "
+        "vector_recvs={}",
         label,
         frames,
         bytes,
@@ -1557,13 +1564,19 @@ void TcpTransport::logAndResetPhaseStats(std::string_view label) {
         drainGBps,
         copies > 0 ? static_cast<double>(copyNs) / copies / 1000.0 : 0.0,
         copies,
-        pct(copyNs));
+        pct(copyNs),
+        slabAttempts,
+        slabMisses,
+        vectorReceives);
   }
   rs.reset();
   dstCopyNs_.store(0, std::memory_order_relaxed);
   dstCopyCount_.store(0, std::memory_order_relaxed);
   h2dState_->copyNs.store(0, std::memory_order_relaxed);
   h2dState_->copyCount.store(0, std::memory_order_relaxed);
+  receiveSlabAttempts_.store(0, std::memory_order_relaxed);
+  receiveSlabMisses_.store(0, std::memory_order_relaxed);
+  vectorReceiveCount_.store(0, std::memory_order_relaxed);
 }
 
 void TcpTransport::readerLoop() noexcept {
@@ -1576,7 +1589,11 @@ void TcpTransport::readerLoop() noexcept {
     TcpPinnedSlab receiveSlab;
     if (config_.asyncGetH2d) {
       if (auto pool = receivePoolIfCreated()) {
+        receiveSlabAttempts_.fetch_add(1, std::memory_order_relaxed);
         receiveSlab = pool->tryAcquire(/*allowReserved=*/true);
+        if (!receiveSlab) {
+          receiveSlabMisses_.fetch_add(1, std::memory_order_relaxed);
+        }
       }
     }
     if (receiveSlab) {
@@ -1596,6 +1613,7 @@ void TcpTransport::readerLoop() noexcept {
       continue;
     }
 
+    vectorReceiveCount_.fetch_add(1, std::memory_order_relaxed);
     auto result = dataConn_->recv(msg).get();
     if (!result) {
       // Connection closed, errored, or idle-timed-out; stop reading.
@@ -2148,7 +2166,7 @@ std::future<Status> TcpTransport::recv(
 }
 
 void TcpTransport::shutdown() {
-  std::lock_guard<std::mutex> lk(lifecycleMu_);
+  std::lock_guard<std::mutex> lifecycleLock(lifecycleMu_);
   // One-shot, but checked under the mutex rather than before taking it:
   // shutdown() is called twice in the normal flow (MultiTransport::shutdown()
   // then ~TcpTransport), and the second caller must not return while the first
@@ -2159,7 +2177,7 @@ void TcpTransport::shutdown() {
   running_.store(false, std::memory_order_release);
 
   {
-    std::lock_guard<std::mutex> lk(outMu_);
+    std::lock_guard<std::mutex> outLock(outMu_);
     outClosed_ = true;
   }
   outCv_.notify_all();

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -99,7 +99,7 @@ TcpTransport::TcpTransport(
     int deviceId,
     EventBase* evb,
     std::shared_ptr<TcpSegmentRegistry> registry,
-    controller::TcpSocketConfig config,
+    TcpTransportConfig config,
     std::string host,
     std::shared_ptr<CudaApi> cudaApi)
     : deviceId_(deviceId),
@@ -116,6 +116,9 @@ TcpTransport::TcpTransport(
   if (!host.empty()) {
     host_ = std::move(host);
   }
+  h2dState_ = std::make_shared<H2dPollState>();
+  h2dState_->evb = evb_;
+  h2dState_->cudaApi = cudaApi_;
 }
 
 Status TcpTransport::hostFromDevice(
@@ -167,7 +170,7 @@ TransportInfo TcpTransport::bind() {
     return TransportInfo{};
   }
   server_ = std::make_unique<controller::AsyncTcpServer>(
-      host_ + ":0", config_, *evb_);
+      host_ + ":0", config_.socketConfig, *evb_);
   auto status = server_->init();
   if (!status) {
     UNIFLOW_LOG_ERROR(
@@ -236,7 +239,7 @@ Status TcpTransport::connect(std::span<const uint8_t> remoteInfo) {
   // This matters beyond TCP: MultiTransport::connect() connects every
   // registered transport, so on AMD a wedged TCP handshake would stall
   // connection setup even for jobs whose data path is RDMA.
-  const auto handshakeTimeout = config_.connTimeout.value_or(
+  const auto handshakeTimeout = config_.socketConfig.connTimeout.value_or(
       std::chrono::seconds{kDefaultHandshakeTimeoutSeconds});
 
   if (listener) {
@@ -260,7 +263,7 @@ Status TcpTransport::connect(std::span<const uint8_t> remoteInfo) {
     }
     conn = future.get();
   } else {
-    controller::AsyncTcpClient client(config_, *evb_);
+    controller::AsyncTcpClient client(config_.socketConfig, *evb_);
     auto future = client.connect(peer.host + ":" + std::to_string(peer.port));
     if (future.wait_for(handshakeTimeout) != std::future_status::ready) {
       UNIFLOW_LOG_ERROR(
@@ -559,6 +562,17 @@ std::future<Status> TcpTransport::get(
   }
   state->remaining = totalChunks;
 
+  if (config_.asyncGetH2d) {
+    const bool needsReceivePool = std::any_of(
+        requests.begin(), requests.end(), [](const TransferRequest& req) {
+          return req.local.size() > 0 &&
+              req.local.memType() == MemoryType::VRAM;
+        });
+    if (needsReceivePool) {
+      (void)ensureReceivePool();
+    }
+  }
+
   for (const auto& req : requests) {
     auto remoteHandle = findRemoteHandle(req.remote);
     if (!remoteHandle) {
@@ -609,6 +623,38 @@ std::future<Status> TcpTransport::get(
   }
 
   return future;
+}
+
+std::shared_ptr<TcpPinnedSlabPool> TcpTransport::ensureReceivePool() {
+  if (auto pool = std::atomic_load_explicit(
+          &receiveSlabPool_, std::memory_order_acquire)) {
+    return pool;
+  }
+  std::lock_guard<std::mutex> lk(receivePoolCreateMu_);
+  if (auto pool = std::atomic_load_explicit(
+          &receiveSlabPool_, std::memory_order_relaxed)) {
+    return pool;
+  }
+  if (receivePoolUnavailable_ || cudaApi_ == nullptr) {
+    return nullptr;
+  }
+  auto pool = TcpPinnedSlabPool::create(
+      cudaApi_, kMaxFrameSize, kReceiveSlabCount, /*reservedForReader=*/0);
+  if (!pool) {
+    receivePoolUnavailable_ = true;
+    UNIFLOW_LOG_WARN(
+        "tcp get: pinned receive pool unavailable; using vector fallback: {}",
+        pool.error().message());
+    return nullptr;
+  }
+  std::atomic_store_explicit(
+      &receiveSlabPool_, pool.value(), std::memory_order_release);
+  return pool.value();
+}
+
+std::shared_ptr<TcpPinnedSlabPool> TcpTransport::receivePoolIfCreated() {
+  return std::atomic_load_explicit(
+      &receiveSlabPool_, std::memory_order_acquire);
 }
 
 Result<std::shared_ptr<TcpPinnedSlabPool>> TcpTransport::stagingPool() {
@@ -847,6 +893,283 @@ void TcpTransport::startDeferredReadReplies() {
       (void)enqueueFrame(
           makeHeaderFrame(TcpOp::Error, deferred.reqId), /*mayBlock=*/false);
     }
+  }
+}
+
+Status TcpTransport::startAsyncH2d(
+    const TcpInflight& entry,
+    std::span<const uint8_t> payload,
+    TcpPinnedSlab slab,
+    uint64_t reqId) {
+  if (!entry.state->tryBeginWrite()) {
+    return Err(
+        ErrCode::ConnectionFailed,
+        "tcp get: operation completed before destination copy started");
+  }
+
+  auto stream = static_cast<cudaStream_t>(entry.stream);
+  cudaEvent_t event{};
+  bool copyIssued = false;
+  Status status = Ok();
+  try {
+    CudaDeviceGuard guard(*cudaApi_, entry.deviceId);
+    if (status = cudaApi_->eventCreate(&event); status.hasError()) {
+      entry.state->endWrite(status);
+      return status;
+    }
+    if (status = cudaApi_->memcpyAsync(
+            entry.dst,
+            payload.data(),
+            payload.size(),
+            cudaMemcpyHostToDevice,
+            stream);
+        status.hasError()) {
+      (void)cudaApi_->eventDestroy(event);
+      entry.state->endWrite(status);
+      return status;
+    }
+    copyIssued = true;
+    if (status = cudaApi_->eventRecord(event, stream); status.hasError()) {
+      PendingH2d uncertain{
+          entry.state,
+          std::move(slab),
+          event,
+          entry.deviceId,
+          entry.stream,
+          reqId,
+          std::chrono::steady_clock::now()};
+      const auto syncStatus =
+          waitForH2dCopy(h2dState_, uncertain.deviceId, uncertain.stream);
+      if (syncStatus.hasError()) {
+        quarantineH2d(h2dState_, std::move(uncertain));
+        return syncStatus;
+      }
+      destroyH2dEvent(h2dState_, uncertain.deviceId, uncertain.event);
+      entry.state->endWrite(Ok());
+      return Ok();
+    }
+  } catch (const std::exception& e) {
+    if (copyIssued &&
+        waitForH2dCopy(h2dState_, entry.deviceId, entry.stream).hasError()) {
+      quarantineH2d(
+          h2dState_,
+          PendingH2d{
+              entry.state,
+              std::move(slab),
+              event,
+              entry.deviceId,
+              entry.stream,
+              reqId,
+              std::chrono::steady_clock::now()});
+      return Err(
+          ErrCode::DriverError,
+          "tcp get: destination copy could not be quiesced");
+    }
+    if (event != nullptr) {
+      destroyH2dEvent(h2dState_, entry.deviceId, event);
+    }
+    status =
+        Err(ErrCode::InvalidArgument,
+            "tcp get: VRAM destination needs a selectable deviceId, got " +
+                std::to_string(entry.deviceId) + ": " + e.what());
+    entry.state->endWrite(status);
+    return status;
+  }
+
+  PendingH2d pending{
+      entry.state,
+      std::move(slab),
+      event,
+      entry.deviceId,
+      entry.stream,
+      reqId,
+      std::chrono::steady_clock::now()};
+  try {
+    std::lock_guard<std::mutex> lk(h2dState_->mu);
+    if (h2dState_->stopping) {
+      status =
+          Err(ErrCode::ConnectionFailed,
+              "tcp get: transport stopped while destination copy started");
+    } else {
+      h2dState_->pending.push_back(std::move(pending));
+      return Ok();
+    }
+  } catch (const std::exception& e) {
+    status = Err(
+        ErrCode::TransportError,
+        "tcp get: could not track destination copy: " + std::string(e.what()));
+  }
+
+  if (auto syncStatus = waitForH2dCopy(h2dState_, entry.deviceId, entry.stream);
+      syncStatus.hasError()) {
+    quarantineH2d(h2dState_, std::move(pending));
+    return syncStatus;
+  }
+  destroyH2dEvent(h2dState_, entry.deviceId, event);
+  entry.state->endWrite(status);
+  return status;
+}
+
+void TcpTransport::schedulePendingH2dPoll() {
+  auto state = h2dState_;
+  {
+    std::lock_guard<std::mutex> lk(state->mu);
+    if (state->stopping || state->pollScheduled || state->pending.empty()) {
+      return;
+    }
+    state->pollScheduled = true;
+  }
+  state->evb->dispatch(
+      [state = std::move(state)]() noexcept { pollPendingH2d(state); });
+}
+
+void TcpTransport::pollPendingH2d(
+    std::shared_ptr<H2dPollState> state) noexcept {
+  while (true) {
+    PendingH2d retired;
+    Status result = Ok();
+    bool haveRetired = false;
+    bool queryFailed = false;
+    bool reschedule = false;
+    {
+      std::lock_guard<std::mutex> lk(state->mu);
+      if (state->stopping) {
+        state->pollScheduled = false;
+        return;
+      }
+      for (auto it = state->pending.begin(); it != state->pending.end(); ++it) {
+        Result<bool> done =
+            Err(ErrCode::DriverError,
+                "tcp get: could not select device for event query");
+        try {
+          CudaDeviceGuard guard(*state->cudaApi, it->deviceId);
+          done =
+              state->cudaApi->eventQuery(static_cast<cudaEvent_t>(it->event));
+        } catch (const std::exception& e) {
+          done = Err(ErrCode::DriverError, e.what());
+        }
+        if (done.hasValue() && !done.value()) {
+          continue;
+        }
+        if (done.hasError()) {
+          result = std::move(done).error();
+          queryFailed = true;
+        }
+        retired = std::move(*it);
+        state->retiringState = retired.state;
+        state->pending.erase(it);
+        ++state->activeRetirements;
+        haveRetired = true;
+        break;
+      }
+      if (!haveRetired) {
+        if (state->pending.empty()) {
+          state->pollScheduled = false;
+          return;
+        }
+        reschedule = true;
+      }
+    }
+
+    if (reschedule) {
+      std::this_thread::yield();
+      state->evb->dispatch(
+          [state = std::move(state)]() noexcept { pollPendingH2d(state); });
+      return;
+    }
+
+    if (queryFailed) {
+      if (waitForH2dCopy(state, retired.deviceId, retired.stream).hasError()) {
+        quarantineH2d(state, std::move(retired));
+        std::lock_guard<std::mutex> lk(state->mu);
+        state->retiringState.reset();
+        --state->activeRetirements;
+        state->drained.notify_all();
+        continue;
+      }
+      result = Ok();
+    }
+    destroyH2dEvent(state, retired.deviceId, retired.event);
+    state->copyNs.fetch_add(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now() - retired.launchedAt)
+            .count(),
+        std::memory_order_relaxed);
+    state->copyCount.fetch_add(1, std::memory_order_relaxed);
+    retired.state->endWrite(std::move(result));
+    retired.slab.reset();
+
+    {
+      std::lock_guard<std::mutex> lk(state->mu);
+      state->retiringState.reset();
+      --state->activeRetirements;
+      if (state->activeRetirements == 0) {
+        state->drained.notify_all();
+      }
+    }
+  }
+}
+
+Status TcpTransport::waitForH2dCopy(
+    const std::shared_ptr<H2dPollState>& state,
+    int deviceId,
+    void* stream) noexcept {
+  try {
+    CudaDeviceGuard guard(*state->cudaApi, deviceId);
+    return state->cudaApi->streamSynchronize(static_cast<cudaStream_t>(stream));
+  } catch (const std::exception& e) {
+    return Err(ErrCode::DriverError, e.what());
+  }
+}
+
+void TcpTransport::destroyH2dEvent(
+    const std::shared_ptr<H2dPollState>& state,
+    int deviceId,
+    void* event) noexcept {
+  try {
+    CudaDeviceGuard guard(*state->cudaApi, deviceId);
+    (void)state->cudaApi->eventDestroy(static_cast<cudaEvent_t>(event));
+  } catch (const std::exception&) {
+  }
+}
+
+void TcpTransport::quarantineH2d(
+    const std::shared_ptr<H2dPollState>& state,
+    PendingH2d copy) noexcept {
+  // Neither the event nor stream established quiescence. Deliberately retain
+  // the write reservation and slab: resolving or recycling either could let
+  // the caller or pool free memory still touched by DMA.
+  copy.state->fail(
+      Err(ErrCode::DriverError,
+          "tcp get: destination copy could not be safely quiesced"));
+  std::lock_guard<std::mutex> lk(state->mu);
+  for (auto& slot : state->quarantined) {
+    if (!slot.has_value()) {
+      slot.emplace(std::move(copy));
+      state->quarantineKeepalive = state;
+      return;
+    }
+  }
+  std::terminate();
+}
+
+void TcpTransport::drainPendingH2d() {
+  auto state = h2dState_;
+  std::deque<PendingH2d> pending;
+  {
+    std::unique_lock<std::mutex> lk(state->mu);
+    pending.swap(state->pending);
+    state->drained.wait(lk, [&]() { return state->activeRetirements == 0; });
+  }
+  for (auto& copy : pending) {
+    if (waitForH2dCopy(state, copy.deviceId, copy.stream).hasError()) {
+      quarantineH2d(state, std::move(copy));
+      continue;
+    }
+    destroyH2dEvent(state, copy.deviceId, copy.event);
+    copy.state->endWrite(
+        Err(ErrCode::ConnectionFailed,
+            "tcp transport shut down during destination copy"));
   }
 }
 
@@ -1200,8 +1523,10 @@ void TcpTransport::logAndResetPhaseStats(std::string_view label) {
   const uint64_t hdrNs = rs.headerWaitNs.load(std::memory_order_relaxed);
   const uint64_t drainNs = rs.payloadDrainNs.load(std::memory_order_relaxed);
   const uint64_t bytes = rs.payloadBytes.load(std::memory_order_relaxed);
-  const uint64_t copyNs = dstCopyNs_.load(std::memory_order_relaxed);
-  const uint64_t copies = dstCopyCount_.load(std::memory_order_relaxed);
+  const uint64_t copyNs = dstCopyNs_.load(std::memory_order_relaxed) +
+      h2dState_->copyNs.load(std::memory_order_relaxed);
+  const uint64_t copies = dstCopyCount_.load(std::memory_order_relaxed) +
+      h2dState_->copyCount.load(std::memory_order_relaxed);
 
   if (frames == 0) {
     UNIFLOW_LOG_INFO("tcp phases [{}]: no frames", label);
@@ -1237,23 +1562,40 @@ void TcpTransport::logAndResetPhaseStats(std::string_view label) {
   rs.reset();
   dstCopyNs_.store(0, std::memory_order_relaxed);
   dstCopyCount_.store(0, std::memory_order_relaxed);
+  h2dState_->copyNs.store(0, std::memory_order_relaxed);
+  h2dState_->copyCount.store(0, std::memory_order_relaxed);
 }
 
 void TcpTransport::readerLoop() noexcept {
-  // Hoisted so a steady stream of same-size frames stops reallocating: recv()
-  // resize()s this to the frame length, and resizing to the size it already has
-  // neither reallocates nor value-initializes, so the per-frame malloc, 4 MiB
-  // zero-fill, and free all disappear once capacity settles at the high-water
-  // mark. Worth ~8% at 512 MiB and ~14% at 1 GiB on a 200G front-end link.
-  //
-  // Safe only because every frame is fully consumed before handleFrame()
-  // returns: the ReadReply path copies out under writeAndComplete(), and
-  // deviceFromHost() synchronizes its stream. If the H2D copy is ever made
-  // truly async, the reader would overwrite this buffer while a DMA is still
-  // sourcing from it; such a change must stage the payload in storage that
-  // outlives the frame rather than reading it from here.
+  // Reused for every frame that cannot use a receive slab: async H2D disabled,
+  // no VRAM get has created the pool yet, allocation failed, or both slabs are
+  // busy. The reader never waits for a slab, because draining the socket is
+  // what prevents mutual-READ deadlock.
   std::vector<uint8_t> msg;
   while (running_.load(std::memory_order_acquire)) {
+    TcpPinnedSlab receiveSlab;
+    if (config_.asyncGetH2d) {
+      if (auto pool = receivePoolIfCreated()) {
+        receiveSlab = pool->tryAcquire(/*allowReserved=*/true);
+      }
+    }
+    if (receiveSlab) {
+      auto result = dataConn_
+                        ->recv(
+                            std::span<uint8_t>{
+                                receiveSlab.data(), receiveSlab.capacity()})
+                        .get();
+      if (!result) {
+        break;
+      }
+      const auto* receiveData = receiveSlab.data();
+      const auto receivedSize = result.value();
+      handleFrame(
+          std::span<const uint8_t>{receiveData, receivedSize},
+          std::move(receiveSlab));
+      continue;
+    }
+
     auto result = dataConn_->recv(msg).get();
     if (!result) {
       // Connection closed, errored, or idle-timed-out; stop reading.
@@ -1269,7 +1611,9 @@ void TcpTransport::readerLoop() noexcept {
   failAllPending("tcp: reader stopped (connection closed or read error)");
 }
 
-void TcpTransport::handleFrame(std::span<const uint8_t> frame) noexcept {
+void TcpTransport::handleFrame(
+    std::span<const uint8_t> frame,
+    TcpPinnedSlab receiveSlab) noexcept {
   // An exception leaving a noexcept function is std::terminate, and the throw
   // sites in here are reachable from the wire: a ReadRequest's length sizes an
   // allocation, and the VRAM staging path throws if the segment was registered
@@ -1280,7 +1624,7 @@ void TcpTransport::handleFrame(std::span<const uint8_t> frame) noexcept {
   // protocol state that cannot be reasoned about. Stopping the reader also
   // resolves outstanding ops, so no caller is left blocked in future.get().
   try {
-    handleFrameImpl(frame);
+    handleFrameImpl(frame, std::move(receiveSlab));
   } catch (const std::exception& e) {
     UNIFLOW_LOG_ERROR(
         "tcp: frame handling raised '{}'; failing the connection", e.what());
@@ -1295,7 +1639,9 @@ void TcpTransport::handleFrame(std::span<const uint8_t> frame) noexcept {
   }
 }
 
-void TcpTransport::handleFrameImpl(std::span<const uint8_t> frame) {
+void TcpTransport::handleFrameImpl(
+    std::span<const uint8_t> frame,
+    TcpPinnedSlab receiveSlab) {
   auto headerResult = deserializeTcpHeader(frame);
   if (!headerResult) {
     UNIFLOW_LOG_ERROR(
@@ -1468,29 +1814,52 @@ void TcpTransport::handleFrameImpl(std::span<const uint8_t> frame) {
         std::lock_guard<std::mutex> lk(inflightMu_);
         auto it = inflight_.find(header.reqId);
         if (it != inflight_.end()) {
-          entry = std::move(it->second);
-          inflight_.erase(it);
+          entry = it->second;
           found = true;
         }
       }
       if (!found || !entry.state) {
         break;
       }
+
+      const auto eraseInflight = [&]() {
+        std::lock_guard<std::mutex> lk(inflightMu_);
+        inflight_.erase(header.reqId);
+      };
       if (op == TcpOp::Error) {
+        eraseInflight();
         entry.state->fail(
             Err(ErrCode::TransportError, "tcp: peer reported an error"));
       } else if (op == TcpOp::ReadReply) {
-        if (payload.size() != header.len || header.len != entry.len) {
+        if (!entry.isRead || payload.size() != header.len ||
+            header.len != entry.len) {
+          eraseInflight();
           entry.state->fail(Err(
               ErrCode::TransportError, "tcp get: read reply size mismatch"));
           break;
         }
-        // The copy into the caller's get() destination and this chunk's
-        // completion must be one step: a concurrent failAllPending() resolving
-        // the op (via a sibling chunk of the same multi-chunk get()) releases
-        // the caller to free entry.dst, so writing it either side of that
-        // resolution is a write-after-free. writeAndComplete() drops the copy
-        // if the op is already resolved.
+
+        const bool asyncH2d = config_.asyncGetH2d && receiveSlab &&
+            header.len > 0 && entry.dst != nullptr &&
+            entry.memType == MemoryType::VRAM;
+        if (asyncH2d) {
+          const auto status = startAsyncH2d(
+              entry, payload, std::move(receiveSlab), header.reqId);
+          // The pending record is visible before this erase. A concurrent
+          // failure therefore sees the state in inflight_, the H2D queue, or
+          // both, matching RDMA's handoff into transport-owned progress state.
+          eraseInflight();
+          if (status.hasValue()) {
+            schedulePendingH2dPoll();
+          }
+          break;
+        }
+
+        eraseInflight();
+        // Vector-backed VRAM replies cannot outlive this call because the
+        // reader reuses their storage. Keep that fallback synchronous, with the
+        // same reservation that prevents a concurrent failure releasing
+        // entry.dst.
         entry.state->writeAndComplete([&]() -> Status {
           if (header.len == 0 || entry.dst == nullptr) {
             return Ok();
@@ -1516,6 +1885,7 @@ void TcpTransport::handleFrameImpl(std::span<const uint8_t> frame) {
           return st;
         });
       } else { // Ack
+        eraseInflight();
         entry.state->completeOne();
       }
       break;
@@ -1563,6 +1933,17 @@ void TcpTransport::failAllPending(const char* message) {
       }
     }
     inflight_.clear();
+  }
+  {
+    std::lock_guard<std::mutex> lk(h2dState_->mu);
+    for (const auto& copy : h2dState_->pending) {
+      if (copy.state) {
+        toFail.push_back(copy.state);
+      }
+    }
+    if (h2dState_->retiringState) {
+      toFail.push_back(h2dState_->retiringState);
+    }
   }
   {
     std::lock_guard<std::mutex> lk(recvMu_);
@@ -1787,6 +2168,27 @@ void TcpTransport::shutdown() {
   // in-progress send on the sender thread. A no-op if the reader already
   // refused the connection, in which case it is on its way out anyway.
   closeDataConnOnce();
+
+  // Closed before the joins: this is the one pool with a *blocking* acquire,
+  // and the thread parked in it is not one we own. acquire() waits on `freed_`
+  // with no deadline and `closed_` as its only escape, and the put path calls
+  // it on the application's own thread, which shutdown() never joins. Without
+  // this a put() in flight across shutdown() parks forever, because the senders
+  // that would have freed a staging slab are about to be joined away.
+  //
+  // close() only sets the flag and notifies, so outstanding leases stay valid
+  // and doing this early costs nothing. The receive pool needs no equivalent --
+  // the reader only ever tryAcquire()s it. Read under poolMu_, which is what
+  // stagingPool() publishes slabPool_ under.
+  std::shared_ptr<TcpPinnedSlabPool> staging;
+  {
+    std::lock_guard<std::mutex> lk(poolMu_);
+    staging = slabPool_;
+  }
+  if (staging != nullptr) {
+    staging->close();
+  }
+
   if (reader_.joinable()) {
     reader_.join();
   }
@@ -1794,7 +2196,17 @@ void TcpTransport::shutdown() {
     sender_.join();
   }
 
+  if (auto pool = std::atomic_load_explicit(
+          &receiveSlabPool_, std::memory_order_acquire)) {
+    pool->close();
+  }
+
+  {
+    std::lock_guard<std::mutex> lk(h2dState_->mu);
+    h2dState_->stopping = true;
+  }
   failAllPending("tcp transport shut down");
+  drainPendingH2d();
 
   // After the reader is joined, so nothing can add to the queue, and before the
   // transport goes away: a staged reply's frame is memory the device may still
@@ -1823,7 +2235,7 @@ Status TcpTransportFactory::supported() {
 TcpTransportFactory::TcpTransportFactory(
     int deviceId,
     EventBase* evb,
-    controller::TcpSocketConfig config,
+    TcpTransportConfig config,
     std::string host,
     std::shared_ptr<CudaApi> cudaApi)
     : TransportFactory(TransportType::TCP),

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -190,7 +190,7 @@ TransportInfo TcpTransport::bind() {
 
 Status TcpTransport::connect(std::span<const uint8_t> remoteInfo) {
   // Held across the handshake wait below, so a concurrent shutdown() cannot
-  // interleave with the installation of dataConn_/reader_/sender_ at the end of
+  // interleave with the installation of lanes_ at the end of
   // this function. The flag check is what stops a connect() queued behind a
   // completed shutdown() from bringing the transport back to life.
   std::lock_guard<std::mutex> lk(lifecycleMu_);
@@ -227,7 +227,6 @@ Status TcpTransport::connect(std::span<const uint8_t> remoteInfo) {
   }
   const bool listener = localKey < peerKey;
 
-  std::unique_ptr<controller::Conn> conn;
   // Both handshake waits are bounded. AsyncAccept::accept() queues a promise
   // that is resolved only by an inbound connection or by teardown, so an
   // unbounded get() here wedges this thread forever if the dialing peer dies
@@ -242,62 +241,205 @@ Status TcpTransport::connect(std::span<const uint8_t> remoteInfo) {
   const auto handshakeTimeout = config_.socketConfig.connTimeout.value_or(
       std::chrono::seconds{kDefaultHandshakeTimeoutSeconds});
 
-  if (listener) {
-    if (!server_) {
-      state_ = TransportState::Error;
-      return Err(ErrCode::ConnectionFailed, "tcp connect: no server bound");
-    }
-    auto future = server_->accept();
-    if (future.wait_for(handshakeTimeout) != std::future_status::ready) {
-      // shutdown() resolves the queued promise with nullptr (via teardown), so
-      // the get() below returns immediately instead of blocking. Safe from this
-      // thread: AsyncAccept::shutdown marshals teardown onto the EventBase
-      // thread and waits when called from outside the loop.
-      UNIFLOW_LOG_ERROR(
-          "TcpTransport::connect: no peer dialed in within {}s; tearing down "
-          "listener {}:{}",
-          handshakeTimeout.count(),
-          host_,
-          port_);
-      server_->shutdown();
-    }
-    conn = future.get();
-  } else {
-    controller::AsyncTcpClient client(config_.socketConfig, *evb_);
-    auto future = client.connect(peer.host + ":" + std::to_string(peer.port));
-    if (future.wait_for(handshakeTimeout) != std::future_status::ready) {
-      UNIFLOW_LOG_ERROR(
-          "TcpTransport::connect: dial to {}:{} did not complete within {}s",
-          peer.host,
-          peer.port,
-          handshakeTimeout.count());
-      // No teardown hook on the client side; abandon the attempt. The future
-      // owns its own state, so letting it go out of scope is safe.
-      state_ = TransportState::Error;
-      return Err(ErrCode::ConnectionFailed, "tcp connect: dial timed out");
-    }
-    conn = future.get();
-  }
-
-  if (!conn) {
+  // The lane hello addresses lanes with a uint8_t.
+  constexpr size_t kMaxLanes = 255;
+  const size_t laneCount = std::max<size_t>(config_.numSockets, 1);
+  if (laneCount > kMaxLanes) {
     state_ = TransportState::Error;
     return Err(
-        ErrCode::ConnectionFailed, "tcp connect: data connection failed");
+        ErrCode::InvalidArgument,
+        "tcp connect: numSockets " + std::to_string(laneCount) +
+            " exceeds the " + std::to_string(kMaxLanes) +
+            " lanes the hello can address");
   }
 
-  dataConn_ = std::move(conn);
+  if (auto status = establishLanes(listener, peer, laneCount, handshakeTimeout);
+      !status) {
+    state_ = TransportState::Error;
+    return status;
+  }
+
   running_.store(true, std::memory_order_release);
-  reader_ = std::thread([this]() { readerLoop(); });
-  sender_ = std::thread([this]() { senderLoop(); });
+  // Started only once every lane is installed, so a reader can never index a
+  // lane connect() has not filled in yet.
+  for (size_t i = 0; i < lanes_.size(); ++i) {
+    lanes_[i]->reader = std::thread([this, i]() { readerLoop(i); });
+    lanes_[i]->sender = std::thread([this, i]() { senderLoop(i); });
+  }
   state_ = TransportState::Connected;
   UNIFLOW_LOG_INFO(
-      "TcpTransport: connected (listener={}) {}:{} <-> {}:{}",
+      "TcpTransport: connected (listener={} lanes={}) {}:{} <-> {}:{}",
       listener,
+      lanes_.size(),
       host_,
       port_,
       peer.host,
       peer.port);
   return Ok();
+}
+
+// Fills lanes_ so that lane i on one peer is lane i on the other. With one lane
+// this is exactly the pre-lane path: no hello is exchanged, so the wire stays
+// byte-identical and a peer built before lanes existed still interoperates.
+Status TcpTransport::establishLanes(
+    bool listener,
+    const TcpTransportInfo& peer,
+    size_t laneCount,
+    std::chrono::seconds handshakeTimeout) {
+  lanes_.clear();
+  lanes_.reserve(laneCount);
+  for (size_t i = 0; i < laneCount; ++i) {
+    lanes_.push_back(std::make_unique<TcpLane>());
+  }
+  const bool exchangeHello = laneCount > 1;
+
+  if (listener) {
+    if (!server_) {
+      return Err(ErrCode::ConnectionFailed, "tcp connect: no server bound");
+    }
+    uint64_t sessionId = 0;
+    std::vector<bool> filled(laneCount, false);
+    for (size_t accepted = 0; accepted < laneCount; ++accepted) {
+      auto future = server_->accept();
+      if (future.wait_for(handshakeTimeout) != std::future_status::ready) {
+        // shutdown() resolves the queued promise with nullptr (via teardown),
+        // so the get() below returns immediately instead of blocking. Safe from
+        // this thread: AsyncAccept::shutdown marshals teardown onto the
+        // EventBase thread and waits when called from outside the loop.
+        UNIFLOW_LOG_ERROR(
+            "TcpTransport::connect: only {} of {} lanes dialed in within {}s; "
+            "tearing down listener {}:{}",
+            accepted,
+            laneCount,
+            handshakeTimeout.count(),
+            host_,
+            port_);
+        server_->shutdown();
+      }
+      auto conn = future.get();
+      if (!conn) {
+        return Err(
+            ErrCode::ConnectionFailed, "tcp connect: data connection failed");
+      }
+
+      // Accept order is not lane identity: the peer dials the lanes without
+      // any ordering guarantee, so the index has to come off the wire.
+      size_t laneIdx = accepted;
+      if (exchangeHello) {
+        std::vector<uint8_t> msg;
+        auto received = conn->recv(msg).get();
+        if (!received) {
+          return Err(
+              ErrCode::ConnectionFailed,
+              "tcp connect: lane hello not received: " +
+                  received.error().message());
+        }
+        auto helloResult = TcpLaneHello::deserialize(
+            std::span<const uint8_t>{msg.data(), received.value()});
+        if (!helloResult) {
+          return std::move(helloResult).error();
+        }
+        const auto hello = helloResult.value();
+        if (hello.laneCount != laneCount) {
+          return Err(
+              ErrCode::InvalidArgument,
+              "tcp connect: peer configured " +
+                  std::to_string(hello.laneCount) + " lanes, local is " +
+                  std::to_string(laneCount) + "; both peers must agree");
+        }
+        if (hello.laneIndex >= laneCount) {
+          return Err(
+              ErrCode::InvalidArgument,
+              "tcp connect: lane index " + std::to_string(hello.laneIndex) +
+                  " out of range for " + std::to_string(laneCount) + " lanes");
+        }
+        if (accepted == 0) {
+          sessionId = hello.sessionId;
+        } else if (hello.sessionId != sessionId) {
+          // A second dialer reaching this listener would otherwise take a lane
+          // and leave the real peer one short, hanging both.
+          return Err(
+              ErrCode::ConnectionFailed,
+              "tcp connect: lane session mismatch; another peer is dialing "
+              "this listener");
+        }
+        laneIdx = hello.laneIndex;
+        if (filled[laneIdx]) {
+          return Err(
+              ErrCode::ConnectionFailed,
+              "tcp connect: duplicate lane index " + std::to_string(laneIdx));
+        }
+      }
+      filled[laneIdx] = true;
+      lanes_[laneIdx]->conn = std::move(conn);
+    }
+  } else {
+    // Only has to distinguish this dialer from another one racing for the same
+    // listener, so the local port plus a clock reading is enough and avoids
+    // pulling in a random-number dependency.
+    const uint64_t sessionId =
+        (static_cast<uint64_t>(port_) << 48) ^
+        static_cast<uint64_t>(
+            std::chrono::steady_clock::now().time_since_epoch().count());
+    for (size_t i = 0; i < laneCount; ++i) {
+      controller::AsyncTcpClient client(config_.socketConfig, *evb_);
+      auto future = client.connect(peer.host + ":" + std::to_string(peer.port));
+      if (future.wait_for(handshakeTimeout) != std::future_status::ready) {
+        UNIFLOW_LOG_ERROR(
+            "TcpTransport::connect: lane {} dial to {}:{} did not complete "
+            "within {}s",
+            i,
+            peer.host,
+            peer.port,
+            handshakeTimeout.count());
+        // No teardown hook on the client side; abandon the attempt. The future
+        // owns its own state, so letting it go out of scope is safe.
+        return Err(ErrCode::ConnectionFailed, "tcp connect: dial timed out");
+      }
+      auto conn = future.get();
+      if (!conn) {
+        return Err(
+            ErrCode::ConnectionFailed, "tcp connect: data connection failed");
+      }
+      if (exchangeHello) {
+        TcpLaneHello hello;
+        hello.laneIndex = static_cast<uint8_t>(i);
+        hello.laneCount = static_cast<uint8_t>(laneCount);
+        hello.sessionId = sessionId;
+        // Named, so the buffer outlives the send rather than depending on
+        // temporary lifetime across the future.
+        const auto bytes = hello.serialize();
+        auto sent = conn->send(bytes).get();
+        if (!sent) {
+          return Err(
+              ErrCode::ConnectionFailed,
+              "tcp connect: lane hello send failed: " + sent.error().message());
+        }
+      }
+      lanes_[i]->conn = std::move(conn);
+    }
+  }
+  return Ok();
+}
+
+size_t TcpTransport::laneCapBytes() const {
+  const size_t lanes = lanes_.empty() ? 1 : lanes_.size();
+  return kMaxOutQueueBytes / lanes;
+}
+
+size_t TcpTransport::pickLane() {
+  if (lanes_.size() <= 1) {
+    return 0;
+  }
+  return static_cast<size_t>(
+      nextLane_.fetch_add(1, std::memory_order_relaxed) % lanes_.size());
+}
+
+controller::Conn* TcpTransport::primaryConn() const {
+  if (lanes_.empty() || lanes_[0] == nullptr) {
+    return nullptr;
+  }
+  return lanes_[0]->conn.get();
 }
 
 Result<const TcpRemoteRegistrationHandle*> TcpTransport::findRemoteHandle(
@@ -1237,8 +1379,8 @@ void TcpTransport::pollPendingReadReplies() {
       evb_->dispatch([this]() noexcept { pollPendingReadReplies(); });
       return;
     }
-    // Queued outside the lock: enqueueFrame takes outMu_, and holding two of
-    // the transport's mutexes at once is how lock cycles start.
+    // Queued outside the lock: enqueueFrame takes a lane mutex, and holding two
+    // of the transport's mutexes at once is how lock cycles start.
     if (haveReady) {
       (void)enqueueFrame(std::move(ready), /*mayBlock=*/false);
     } else if (haveFailure) {
@@ -1359,18 +1501,30 @@ Status TcpTransport::admitInflight(uint64_t reqId, TcpInflight entry) {
 }
 
 bool TcpTransport::enqueueFrame(TcpFrame frame, bool mayBlock) {
+  // No lanes means connect() never ran (or teardown already cleared them).
+  // Indexing here would be undefined; refusing matches the documented contract
+  // that a frame may simply not be queued.
+  if (lanes_.empty()) {
+    return false;
+  }
   const size_t bytes = frame.size();
+  // Every frame this queues -- Write, ReadRequest, ReadReply, Ack, Error --
+  // carries its own reqId/segId/offset, so the peer places it without needing
+  // arrival order and any lane is equivalent. Only Send is order-sensitive, and
+  // it does not come through here (see enqueueSendFrame).
+  auto& lane = *lanes_[pickLane()];
+  const size_t cap = laneCapBytes();
   {
-    std::unique_lock<std::mutex> lk(outMu_);
+    std::unique_lock<std::mutex> lk(lane.mu);
     if (mayBlock) {
       // Caller threads absorb backpressure by waiting, which is real
       // backpressure: an application issuing put/get faster than the link
       // drains slows down instead of growing the queue. An empty queue always
       // admits, however large the frame, or a payload bigger than the cap could
       // never drain and would wedge here forever.
-      outCv_.wait(lk, [this, bytes]() {
-        return outClosed_ || connBroken_.load(std::memory_order_acquire) ||
-            outQueue_.empty() || outBytes_ + bytes <= kMaxOutQueueBytes;
+      lane.cv.wait(lk, [this, &lane, bytes, cap]() {
+        return lane.outClosed || connBroken_.load(std::memory_order_acquire) ||
+            lane.queue.empty() || lane.bytes + bytes <= cap;
       });
     }
     // The reader thread deliberately gets no cap. It is producing replies the
@@ -1381,13 +1535,13 @@ bool TcpTransport::enqueueFrame(TcpFrame frame, bool mayBlock) {
     // the connection. It cannot wait either: that stops it draining the socket
     // and reintroduces the mutual-READ deadlock the reader/sender split exists
     // to avoid. What bounds this queue is the drain rate, not a byte cap.
-    if (outClosed_) {
+    if (lane.outClosed) {
       return false;
     }
-    outQueue_.push_back(TcpOutItem{std::move(frame), nullptr});
-    outBytes_ += bytes;
+    lane.queue.push_back(TcpOutItem{std::move(frame), nullptr});
+    lane.bytes += bytes;
   }
-  outCv_.notify_all();
+  lane.cv.notify_all();
   return true;
 }
 
@@ -1395,55 +1549,82 @@ bool TcpTransport::enqueueFrames(std::vector<TcpFrame> frames, bool mayBlock) {
   if (frames.empty()) {
     return true;
   }
+  // No lanes means connect() never ran (or teardown already cleared them).
+  // Indexing here would be undefined; refusing matches the documented contract
+  // that a frame may simply not be queued.
+  if (lanes_.empty()) {
+    return false;
+  }
   size_t bytes = 0;
   for (const auto& frame : frames) {
     bytes += frame.size();
   }
+  // One lane for the whole group, so a single mutex makes the insert atomic and
+  // no sender can transmit a partial group. Judged against the group total, as
+  // before.
+  auto& lane = *lanes_[pickLane()];
+  const size_t cap = laneCapBytes();
   {
-    std::unique_lock<std::mutex> lk(outMu_);
+    std::unique_lock<std::mutex> lk(lane.mu);
     if (mayBlock) {
-      outCv_.wait(lk, [this, bytes]() {
-        return outClosed_ || connBroken_.load(std::memory_order_acquire) ||
-            outQueue_.empty() || outBytes_ + bytes <= kMaxOutQueueBytes;
+      lane.cv.wait(lk, [this, &lane, bytes, cap]() {
+        return lane.outClosed || connBroken_.load(std::memory_order_acquire) ||
+            lane.queue.empty() || lane.bytes + bytes <= cap;
       });
     }
-    if (outClosed_) {
+    if (lane.outClosed) {
       return false;
     }
     for (auto& frame : frames) {
       const size_t frameBytes = frame.size();
-      outQueue_.push_back(TcpOutItem{std::move(frame), nullptr});
-      outBytes_ += frameBytes;
+      lane.queue.push_back(TcpOutItem{std::move(frame), nullptr});
+      lane.bytes += frameBytes;
     }
   }
-  outCv_.notify_all();
+  lane.cv.notify_all();
   return true;
 }
 
 void TcpTransport::enqueueSendFrame(
     TcpFrame frame,
     std::shared_ptr<TcpOpState> onSent) {
+  if (lanes_.empty()) {
+    // Same reasoning as enqueueFrame's guard, but this path owns a promise, so
+    // it must be failed rather than dropped or the caller waits forever.
+    if (onSent) {
+      onSent->fail(
+          Err(ErrCode::NotConnected, "tcp send: transport not connected"));
+    }
+    return;
+  }
   bool closed = false;
   std::shared_ptr<TcpOpState> toFail;
   const size_t bytes = frame.size();
+  // Pinned to lane 0, never striped. send()/recv() are a two-sided rendezvous
+  // matched in FIFO order through pendingRecvs_/unmatchedSends_, so the Nth
+  // SEND must be the Nth the peer's reader sees. Spreading these across lanes
+  // would let them arrive out of order and pair a SEND with the wrong recv --
+  // silent data corruption rather than an error.
+  auto& lane = *lanes_[0];
+  const size_t cap = laneCapBytes();
   {
-    std::unique_lock<std::mutex> lk(outMu_);
+    std::unique_lock<std::mutex> lk(lane.mu);
     // send() runs on a caller thread, so it can wait for room.
-    outCv_.wait(lk, [this, bytes]() {
-      return outClosed_ || connBroken_.load(std::memory_order_acquire) ||
-          outQueue_.empty() || outBytes_ + bytes <= kMaxOutQueueBytes;
+    lane.cv.wait(lk, [this, &lane, bytes, cap]() {
+      return lane.outClosed || connBroken_.load(std::memory_order_acquire) ||
+          lane.queue.empty() || lane.bytes + bytes <= cap;
     });
-    if (outClosed_) {
+    if (lane.outClosed) {
       closed = true;
       // Taken over here so each path has exactly one owner: the queue takes it
       // when the frame is enqueued, this does when it cannot be.
       toFail = std::move(onSent);
     } else {
-      outQueue_.push_back(TcpOutItem{std::move(frame), std::move(onSent)});
-      outBytes_ += bytes;
+      lane.queue.push_back(TcpOutItem{std::move(frame), std::move(onSent)});
+      lane.bytes += bytes;
     }
   }
-  // Settled outside outMu_ so TcpOpState::mu stays a leaf lock: a caller woken
+  // Settled outside the lane mutex so TcpOpState::mu stays a leaf lock: a woken
   // by this promise may re-enter the transport from its error path, and it must
   // not find a container mutex still held by the thread that woke it.
   if (closed) {
@@ -1452,44 +1633,50 @@ void TcpTransport::enqueueSendFrame(
     }
     return;
   }
-  outCv_.notify_all();
+  lane.cv.notify_all();
 }
 
-void TcpTransport::senderLoop() noexcept {
+void TcpTransport::senderLoop(size_t laneIdx) noexcept {
+  // The only writer on this lane's socket, which is what keeps TcpConn's
+  // single-writer requirement satisfied while N lanes run at once. Captured
+  // once, because connect() installs every lane before this thread starts and
+  // never replaces them.
+  auto& lane = *lanes_[laneIdx];
+  auto* conn = lane.conn.get();
+  if (conn == nullptr) {
+    return;
+  }
   for (;;) {
     TcpOutItem item;
     {
-      std::unique_lock<std::mutex> lk(outMu_);
-      outCv_.wait(lk, [this]() { return outClosed_ || !outQueue_.empty(); });
-      if (outClosed_) {
+      std::unique_lock<std::mutex> lk(lane.mu);
+      lane.cv.wait(
+          lk, [&lane]() { return lane.outClosed || !lane.queue.empty(); });
+      if (lane.outClosed) {
         return;
       }
-      item = std::move(outQueue_.front());
-      outQueue_.pop_front();
-      outBytes_ -= std::min(outBytes_, item.frame.size());
+      item = std::move(lane.queue.front());
+      lane.queue.pop_front();
+      lane.bytes -= std::min(lane.bytes, item.frame.size());
     }
-    outCv_.notify_all(); // room freed; wake any producer waiting for space
+    lane.cv.notify_all(); // room freed; wake any producer waiting for space
 
     // `item` -- and so the frame's storage, which for a staged frame is a
     // pinned slab still on loan from the pool -- stays alive for the whole
     // send: Conn::send only borrows the span. The slab goes back when `item` is
     // destroyed at the end of this iteration, never at pop time.
-    auto result = dataConn_->send(item.frame.bytes()).get();
+    auto result = conn->send(item.frame.bytes()).get();
     if (!result) {
       UNIFLOW_LOG_ERROR(
           "tcp sender: send failed: {}", result.error().message());
-      // Close the out queue before unwinding. Nothing drains outQueue_ once
-      // this thread returns, and enqueueFrame() gates only on outClosed_, so
-      // the still-running reader thread would keep appending
+      // Close EVERY lane's queue before unwinding, not just this one. Nothing
+      // drains a queue once its sender returns, and enqueueFrame() gates only
+      // on outClosed, so the still-running readers would keep appending
       // Ack/Error/ReadReply frames -- the last up to kMaxChunkSize each -- to a
-      // queue with no consumer. failAllPending() clears it exactly once, so
-      // without this the growth is unbounded and driven by whatever the peer
-      // keeps requesting.
-      {
-        std::lock_guard<std::mutex> lk(outMu_);
-        outClosed_ = true;
-      }
-      outCv_.notify_all();
+      // queue with no consumer. A failed lane also takes the whole transport
+      // down, so leaving the other lanes admitting work would queue frames for
+      // a connection that is already gone.
+      closeAllLaneQueues();
       if (item.onSent) {
         item.onSent->fail(Err(ErrCode::ConnectionFailed, "tcp: send failed"));
       }
@@ -1515,10 +1702,11 @@ void TcpTransport::senderLoop() noexcept {
 // caller's destination. Anything unaccounted for is reader-thread work between
 // those points.
 void TcpTransport::logAndResetPhaseStats(std::string_view label) {
-  if (dataConn_ == nullptr) {
+  auto* conn = primaryConn();
+  if (conn == nullptr) {
     return;
   }
-  auto& rs = dataConn_->recvPhaseStats();
+  auto& rs = conn->recvPhaseStats();
   const uint64_t frames = rs.frames.load(std::memory_order_relaxed);
   const uint64_t hdrNs = rs.headerWaitNs.load(std::memory_order_relaxed);
   const uint64_t drainNs = rs.payloadDrainNs.load(std::memory_order_relaxed);
@@ -1579,7 +1767,13 @@ void TcpTransport::logAndResetPhaseStats(std::string_view label) {
   vectorReceiveCount_.store(0, std::memory_order_relaxed);
 }
 
-void TcpTransport::readerLoop() noexcept {
+void TcpTransport::readerLoop(size_t laneIdx) noexcept {
+  // One socket per reader: TcpConn is not safe for concurrent operations, and
+  // the single-reader-per-socket invariant is what keeps it so.
+  auto* conn = lanes_[laneIdx]->conn.get();
+  if (conn == nullptr) {
+    return;
+  }
   // Reused for every frame that cannot use a receive slab: async H2D disabled,
   // no VRAM get has created the pool yet, allocation failed, or both slabs are
   // busy. The reader never waits for a slab, because draining the socket is
@@ -1597,8 +1791,7 @@ void TcpTransport::readerLoop() noexcept {
       }
     }
     if (receiveSlab) {
-      auto result = dataConn_
-                        ->recv(
+      auto result = conn->recv(
                             std::span<uint8_t>{
                                 receiveSlab.data(), receiveSlab.capacity()})
                         .get();
@@ -1614,7 +1807,7 @@ void TcpTransport::readerLoop() noexcept {
     }
 
     vectorReceiveCount_.fetch_add(1, std::memory_order_relaxed);
-    auto result = dataConn_->recv(msg).get();
+    auto result = conn->recv(msg).get();
     if (!result) {
       // Connection closed, errored, or idle-timed-out; stop reading.
       break;
@@ -1795,7 +1988,7 @@ void TcpTransport::handleFrameImpl(
             "tcp recv: unmatched inbound sends exceed {} bytes; closing the "
             "connection",
             kMaxUnmatchedSendBytes);
-        closeDataConnOnce();
+        closeLanesOnce();
         break;
       }
       if (matched && state) {
@@ -1920,18 +2113,36 @@ void TcpTransport::handleFrameImpl(
   }
 }
 
-void TcpTransport::closeDataConnOnce() {
+void TcpTransport::closeAllLaneQueues() {
+  // Marks every lane's queue closed and wakes everyone waiting on it: senders
+  // so they exit, and producers blocked for room so they observe the close
+  // instead of waiting for space that will never be freed.
+  for (auto& lane : lanes_) {
+    if (lane == nullptr) {
+      continue;
+    }
+    {
+      std::lock_guard<std::mutex> lk(lane->mu);
+      lane->outClosed = true;
+    }
+    lane->cv.notify_all();
+  }
+}
+
+void TcpTransport::closeLanesOnce() {
   // Conn::close() tests the fd, closes it, then clears it, with no
-  // synchronisation. The reader refuses the connection on unmatched-send
-  // overflow while an application thread can be in shutdown() doing the same,
-  // and neither holds lifecycleMu_ (the reader must not, since shutdown() holds
-  // it across reader_.join()). Both callers can therefore observe the fd open
+  // synchronisation. A reader refuses the connection on unmatched-send overflow
+  // while an application thread can be in shutdown() doing the same, and
+  // neither holds lifecycleMu_ (a reader must not, since shutdown() holds it
+  // across the reader joins). Both callers can therefore observe the fd open
   // and both ::close() it, and the second reaps a descriptor that another
-  // thread in the process may already have been handed by open/socket/accept.
-  // Winning this exchange is what earns the right to close.
-  if (dataConn_ != nullptr &&
-      !dataConnClosed_.exchange(true, std::memory_order_acq_rel)) {
-    dataConn_->close();
+  // thread in the process may already have been handed. Winning the exchange
+  // for a lane is what earns the right to close it.
+  for (auto& lane : lanes_) {
+    if (lane != nullptr && lane->conn != nullptr &&
+        !lane->closed.exchange(true, std::memory_order_acq_rel)) {
+      lane->conn->close();
+    }
   }
 }
 
@@ -1974,15 +2185,18 @@ void TcpTransport::failAllPending(const char* message) {
     unmatchedSends_.clear();
     unmatchedBytes_ = 0;
   }
-  {
-    std::lock_guard<std::mutex> lk(outMu_);
-    for (auto& item : outQueue_) {
+  for (auto& lane : lanes_) {
+    if (lane == nullptr) {
+      continue;
+    }
+    std::lock_guard<std::mutex> lk(lane->mu);
+    for (auto& item : lane->queue) {
       if (item.onSent) {
         toFail.push_back(std::move(item.onSent));
       }
     }
-    outQueue_.clear();
-    outBytes_ = 0;
+    lane->queue.clear();
+    lane->bytes = 0;
   }
   // Deferred reads will never be answered on a broken connection, and each one
   // holds a lease. Dropped here rather than left for teardown so a
@@ -1996,7 +2210,12 @@ void TcpTransport::failAllPending(const char* message) {
     deferred.swap(deferredReplies_);
   }
   deferred.clear();
-  outCv_.notify_all(); // wake producers blocked for space so they see the break
+  // Wake producers blocked for space on every lane so they see the break.
+  for (auto& lane : lanes_) {
+    if (lane != nullptr) {
+      lane->cv.notify_all();
+    }
+  }
   for (auto& state : toFail) {
     state->fail(Err(ErrCode::ConnectionFailed, message));
   }
@@ -2176,16 +2395,12 @@ void TcpTransport::shutdown() {
   }
   running_.store(false, std::memory_order_release);
 
-  {
-    std::lock_guard<std::mutex> outLock(outMu_);
-    outClosed_ = true;
-  }
-  outCv_.notify_all();
+  closeAllLaneQueues();
 
-  // Closing the data connection unblocks the reader's blocking recv and any
-  // in-progress send on the sender thread. A no-op if the reader already
-  // refused the connection, in which case it is on its way out anyway.
-  closeDataConnOnce();
+  // Closing the data connections unblocks the readers' blocking recv and any
+  // in-progress send on the sender thread. A no-op for a lane a reader already
+  // refused, in which case it is on its way out anyway.
+  closeLanesOnce();
 
   // Closed before the joins: this is the one pool with a *blocking* acquire,
   // and the thread parked in it is not one we own. acquire() waits on `freed_`
@@ -2207,11 +2422,16 @@ void TcpTransport::shutdown() {
     staging->close();
   }
 
-  if (reader_.joinable()) {
-    reader_.join();
-  }
-  if (sender_.joinable()) {
-    sender_.join();
+  for (auto& lane : lanes_) {
+    if (lane == nullptr) {
+      continue;
+    }
+    if (lane->reader.joinable()) {
+      lane->reader.join();
+    }
+    if (lane->sender.joinable()) {
+      lane->sender.join();
+    }
   }
 
   if (auto pool = std::atomic_load_explicit(

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -337,18 +337,6 @@ Status TcpTransport::connect(std::span<const uint8_t> remoteInfo) {
   const auto handshakeTimeout = config_.socketConfig.connTimeout.value_or(
       std::chrono::seconds{kDefaultHandshakeTimeoutSeconds});
 
-  // The lane hello addresses lanes with a uint8_t.
-  constexpr size_t kMaxLanes = 255;
-  const size_t laneCount = std::max<size_t>(config_.numSockets, 1);
-  if (laneCount > kMaxLanes) {
-    state_ = TransportState::Error;
-    return Err(
-        ErrCode::InvalidArgument,
-        "tcp connect: numSockets " + std::to_string(laneCount) +
-            " exceeds the " + std::to_string(kMaxLanes) +
-            " lanes the hello can address");
-  }
-
   // Both peers derive lane-to-device placement from the lane index, so they
   // must agree on the device count. The dialer can check this up front because
   // the listener advertises one endpoint per device; catching it here gives a
@@ -364,13 +352,22 @@ Status TcpTransport::connect(std::span<const uint8_t> remoteInfo) {
             " device endpoints, local is configured for " +
             std::to_string(localDevices) + "; both peers must agree");
   }
-  if (laneCount < localDevices) {
+
+  // Lanes are configured per device, so every device gets a full complement and
+  // no device can end up without a lane. It is the product that has to fit the
+  // uint16_t the hello addresses lanes with.
+  constexpr size_t kMaxLanes = 1024;
+  const size_t lanesPerDevice =
+      std::max<size_t>(config_.numSocketsPerDevice, 1);
+  const size_t laneCount = lanesPerDevice * localDevices;
+  if (laneCount > kMaxLanes) {
     state_ = TransportState::Error;
     return Err(
         ErrCode::InvalidArgument,
-        "tcp connect: numSockets " + std::to_string(laneCount) +
-            " is below the " + std::to_string(localDevices) +
-            " configured devices, so some device would carry no lane");
+        "tcp connect: numSocketsPerDevice " + std::to_string(lanesPerDevice) +
+            " across " + std::to_string(localDevices) + " devices is " +
+            std::to_string(laneCount) + " lanes, above the " +
+            std::to_string(kMaxLanes) + " the hello can address");
   }
 
   if (auto status = establishLanes(listener, peer, laneCount, handshakeTimeout);
@@ -585,8 +582,8 @@ Status TcpTransport::establishLanes(
       }
       if (exchangeHello) {
         TcpLaneHello hello;
-        hello.laneIndex = static_cast<uint8_t>(i);
-        hello.laneCount = static_cast<uint8_t>(laneCount);
+        hello.laneIndex = static_cast<uint16_t>(i);
+        hello.laneCount = static_cast<uint16_t>(laneCount);
         hello.sessionId = sessionId;
         // Named, so the buffer outlives the send rather than depending on
         // temporary lifetime across the future.

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -848,6 +848,9 @@ class TcpTransport : public Transport {
   // nothing more.
   std::atomic<uint64_t> dstCopyNs_{0};
   std::atomic<uint64_t> dstCopyCount_{0};
+  std::atomic<uint64_t> receiveSlabAttempts_{0};
+  std::atomic<uint64_t> receiveSlabMisses_{0};
+  std::atomic<uint64_t> vectorReceiveCount_{0};
   std::shared_ptr<H2dPollState> h2dState_;
 
   // Serialises bind()/connect()/shutdown(), which together own server_,

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -35,16 +35,23 @@ class TcpRemoteRegistrationHandle;
 struct TcpTransportConfig {
   controller::TcpSocketConfig socketConfig{};
   bool asyncGetH2d{true};
-  // Number of parallel data sockets ("lanes") per peer. One TCP connection is
-  // bounded by what a single sender thread can push, so more lanes are the only
-  // way past that. Measured on MI350/eth2, 4 MiB get: 10.78 GB/s at 1 lane,
-  // 15.81 at 2, 23.14 at 4, and 23.10 at 8 -- 4 reaches 99.5% of the 23.25 GB/s
-  // NIC ceiling and 8 adds threads for nothing, which is why 4 is the default.
+  // Number of parallel data sockets ("lanes") per bound device, not per peer.
+  // The total for a connection is this times the device count, so the default
+  // of 4 gives 4 lanes on one NIC and 8 across two -- each device gets a full
+  // complement rather than the connection's lanes being divided among them.
   //
-  // Both peers must agree: above 1 the lanes exchange a TcpLaneHello, so a peer
-  // defaulting to 4 cannot talk to one that predates lanes or is pinned to 1.
-  // Set this to 1 on both sides for mixed-version interoperability.
-  size_t numSockets{4};
+  // One TCP connection is bounded by what a single sender thread can push, so
+  // more lanes are the only way past that. Measured on MI350/eth2, 4 MiB get:
+  // 10.78 GB/s at 1 lane, 15.81 at 2, 23.14 at 4, and 23.10 at 8 -- 4 reaches
+  // 99.5% of the 23.25 GB/s NIC ceiling and 8 adds threads for nothing, which
+  // is why 4 is the default. That ceiling is per NIC, which is what makes
+  // per-device the right unit.
+  //
+  // Both peers must agree, and so must their device counts: above 1 total lane
+  // the lanes exchange a TcpLaneHello, so a peer defaulting to 4 cannot talk to
+  // one that predates lanes or is pinned to 1. Set this to 1 with no bound
+  // devices on both sides for mixed-version interoperability.
+  size_t numSocketsPerDevice{4};
 
   /// Network devices to stripe lanes across, e.g. {"eth1", "eth2"}. Empty (the
   /// default) leaves egress to the routing table, exactly as before.
@@ -56,9 +63,11 @@ struct TcpTransportConfig {
   /// name the same number of devices, because each side derives the
   /// lane-to-device mapping from the lane index alone.
   ///
-  /// Size numSockets at about 4 lanes per device: one 200G NIC saturates near 4
-  /// lanes (~21 GB/s), so 2 devices need 8 to reach ~35 GB/s. Two devices with
-  /// only 4 lanes total reaches 27.6 GB/s, leaving both NICs half-fed.
+  /// numSocketsPerDevice applies to each device, so striping does not dilute
+  /// the per-NIC lane count: the default 4 gives 8 lanes across 2 devices,
+  /// which is what reaches ~35 GB/s. Splitting 4 lanes total across 2 devices
+  /// reaches only 27.6 GB/s, leaving both NICs half-fed -- the configuration
+  /// this per-device unit exists to make unreachable.
   ///
   /// Only worth enabling for large transfers. Measured on MI350, get, median of
   /// 3, 2 devices against 1: 1.00x at 8 MiB, 1.45x at 16 MiB, 1.63x at 64 MiB.
@@ -590,7 +599,8 @@ struct TcpPendingRecv {
 
 /// Native, self-contained TCP data transport.
 ///
-/// Establishes `numSockets` full-duplex data connections ("lanes") per peer
+/// Establishes `numSocketsPerDevice` full-duplex data connections ("lanes") per
+/// bound device
 /// (deterministic listener/dialer role by host:port ordering, lane identity
 /// from an explicit hello). Per connection:
 ///  - reader, one per lane: blocking recv + demultiplex; never blocks on a
@@ -943,8 +953,9 @@ class TcpTransport : public Transport {
   std::vector<TcpTransportInfo::Endpoint> localEndpoints_;
 
   /// One data socket plus the reader thread that drains it. Phase 1 establishes
-  /// numSockets lanes but sends everything on lane 0, so only establishment,
-  /// reader topology and teardown differ from the single-socket path.
+  /// the configured lanes but sends everything on lane 0, so only
+  /// establishment, reader topology and teardown differ from the single-socket
+  /// path.
   struct TcpLane {
     std::unique_ptr<controller::Conn> conn;
     std::thread reader;

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -35,6 +35,16 @@ class TcpRemoteRegistrationHandle;
 struct TcpTransportConfig {
   controller::TcpSocketConfig socketConfig{};
   bool asyncGetH2d{true};
+  // Number of parallel data sockets ("lanes") per peer. One TCP connection is
+  // bounded by what a single sender thread can push, so more lanes are the only
+  // way past that. Measured on MI350/eth2, 4 MiB get: 10.78 GB/s at 1 lane,
+  // 15.81 at 2, 23.14 at 4, and 23.10 at 8 -- 4 reaches 99.5% of the 23.25 GB/s
+  // NIC ceiling and 8 adds threads for nothing, which is why 4 is the default.
+  //
+  // Both peers must agree: above 1 the lanes exchange a TcpLaneHello, so a peer
+  // defaulting to 4 cannot talk to one that predates lanes or is pinned to 1.
+  // Set this to 1 on both sides for mixed-version interoperability.
+  size_t numSockets{4};
 
   TcpTransportConfig() = default;
   /* implicit */ TcpTransportConfig(controller::TcpSocketConfig config)
@@ -100,7 +110,7 @@ struct TcpOpState {
   ///
   /// `mu` is a leaf lock: nothing in this struct acquires another mutex while
   /// holding it, and no caller may hold one of the transport's container
-  /// mutexes (`inflightMu_`, `recvMu_`, `outMu_`) when calling in.
+  /// mutexes (`inflightMu_`, `recvMu_`, a lane's `mu`) when calling in.
   template <typename Fn>
   void writeAndComplete(Fn&& write) {
     if (!tryBeginWrite()) {
@@ -526,13 +536,18 @@ struct TcpPendingRecv {
 
 /// Native, self-contained TCP data transport.
 ///
-/// Establishes one full-duplex data connection per peer (deterministic
-/// listener/dialer role by host:port ordering). Three threads run per
-/// connection:
-///  - reader: blocking recv + demultiplex; never blocks on a send, so it always
-///    drains inbound (avoids the mutual-READ deadlock).
-///  - sender: drains an outbound frame queue and performs all socket sends
-///    (requests, ACKs, READ replies), serialized by construction.
+/// Establishes `numSockets` full-duplex data connections ("lanes") per peer
+/// (deterministic listener/dialer role by host:port ordering, lane identity
+/// from an explicit hello). Per connection:
+///  - reader, one per lane: blocking recv + demultiplex; never blocks on a
+///  send,
+///    so it always drains inbound (avoids the mutual-READ deadlock).
+///  - sender, one per transport: drains an outbound frame queue and performs
+///  all
+///    socket sends (requests, ACKs, READ replies), serialized by construction.
+///    Sends every frame on lane 0 -- the extra lanes are established and
+///    drained but not yet used outbound, so throughput is unchanged until
+///    striping schedules across them.
 ///
 /// put() copies a local buffer into a peer segment (WRITE + ACK). get() is
 /// emulated as a pull: READ_REQUEST -> peer replies READ_REPLY with the data.
@@ -628,8 +643,10 @@ class TcpTransport : public Transport {
   Result<const TcpRemoteRegistrationHandle*> findRemoteHandle(
       const RemoteRegisteredSegment::Span& span) const;
 
-  // Reader thread: blocking recv + demultiplex until the connection closes.
-  void readerLoop() noexcept;
+  // Reader thread, one per lane: blocking recv + demultiplex on that lane's
+  // socket until it closes. Takes the lane index rather than reading a single
+  // member, because each reader owns exactly one socket.
+  void readerLoop(size_t laneIdx) noexcept;
 
  public:
   /// Logs the get-path phase split (first-byte / drain / destination copy) and
@@ -637,8 +654,10 @@ class TcpTransport : public Transport {
   void logAndResetPhaseStats(std::string_view label);
 
  private:
-  // Sender thread: drains outQueue_ and performs all socket sends.
-  void senderLoop() noexcept;
+  // Sender thread, one per lane: drains that lane's queue and performs its
+  // socket sends. One writer per socket, which is what keeps TcpConn's
+  // single-writer requirement satisfied.
+  void senderLoop(size_t laneIdx) noexcept;
   // Handles one fully-received inbound frame (reader thread). `receiveSlab`
   // owns frame.data() when the reader received directly into pinned memory.
   void handleFrame(
@@ -656,11 +675,17 @@ class TcpTransport : public Transport {
   // was not queued (transport closing, or the reader hit the cap and refused
   // the connection).
   [[nodiscard]] bool enqueueFrame(TcpFrame frame, bool mayBlock);
-  // Queues a run of frames as one indivisible step: either every frame is in
-  // outQueue_ or none is. Enqueuing them one at a time would let the sender
-  // thread start transmitting a partially built group, which for a multi-chunk
-  // put means the peer applies a prefix of a transfer this side may still fail
-  // to finish staging.
+  // Queues a run of frames as one indivisible step: either every frame is
+  // queued or none is. Enqueuing them one at a time would let a sender thread
+  // start transmitting a partially built group, which for a multi-chunk put
+  // means the peer applies a prefix of a transfer this side may still fail to
+  // finish staging.
+  //
+  // The whole group therefore goes on ONE lane, so a single lock makes it
+  // atomic. Spreading a group across lanes would need every target lane's mutex
+  // held at once, and the room-waiting inside would then be a deadlock: a
+  // producer holding lanes 0..k-1 while waiting for room on lane k blocks the
+  // very senders that would free it.
   //
   // `mayBlock` behaves as in enqueueFrame, and is judged against the group's
   // total size, so a group larger than the queue cap still drains rather than
@@ -820,10 +845,25 @@ class TcpTransport : public Transport {
       void* stream = nullptr);
   // Fails every pending put/get/recv/queued-send; marks the conn broken.
   void failAllPending(const char* message);
-  // Closes the data connection, at most once for the lifetime of the transport.
-  // Both the reader thread and shutdown() refuse the connection, so this has
-  // two concurrent callers.
-  void closeDataConnOnce();
+  // Closes every lane's socket, each at most once for the lifetime of the
+  // transport. Both the reader threads and shutdown() refuse the connection, so
+  // this has concurrent callers. Any lane failing takes the whole transport
+  // down, so there is no partial-close path.
+  void closeLanesOnce();
+  // Marks every lane's outbound queue closed and wakes its waiters. Used by
+  // shutdown() and by a sender whose send failed, since one failed lane takes
+  // the whole transport down.
+  void closeAllLaneQueues();
+  // Establishes `laneCount` data sockets, either by accepting or by dialing,
+  // and fills lanes_ so that index i on one peer is index i on the other.
+  Status establishLanes(
+      bool listener,
+      const TcpTransportInfo& peer,
+      size_t laneCount,
+      std::chrono::seconds handshakeTimeout);
+  // Lane 0's socket, or nullptr before connect(). Phase 1 sends everything on
+  // lane 0 and reports its stats.
+  controller::Conn* primaryConn() const;
 
   [[maybe_unused]] int deviceId_{-1};
   EventBase* evb_{nullptr};
@@ -841,7 +881,36 @@ class TcpTransport : public Transport {
   uint16_t port_{0};
 
   std::unique_ptr<controller::AsyncTcpServer> server_;
-  std::unique_ptr<controller::Conn> dataConn_;
+
+  /// One data socket plus the reader thread that drains it. Phase 1 establishes
+  /// numSockets lanes but sends everything on lane 0, so only establishment,
+  /// reader topology and teardown differ from the single-socket path.
+  struct TcpLane {
+    std::unique_ptr<controller::Conn> conn;
+    std::thread reader;
+    std::thread sender;
+    // Gates this lane's close(). Conn::close() is a check-then-act on a bare
+    // fd, so two callers seeing it open both close it, and the second reaps a
+    // descriptor some unrelated thread may already have been handed.
+    std::atomic<bool> closed{false};
+
+    // This lane's outbound queue, drained by its own sender. Per-lane rather
+    // than shared so the senders never contend on one mutex -- a shared queue
+    // with N senders would serialise exactly the work striping exists to
+    // parallelise, and would also let one frame of a group be picked up while
+    // the rest are still being queued.
+    std::mutex mu;
+    std::condition_variable cv;
+    std::deque<TcpOutItem> queue;
+    size_t bytes{0};
+    bool outClosed{false};
+  };
+  // Indirected because TcpLane holds an atomic and a thread, so it is neither
+  // copyable nor movable and the vector must never have to relocate it. Written
+  // only by connect() under lifecycleMu_, and read by the reader threads, the
+  // sender thread and shutdown() -- all of which run only after connect() has
+  // installed every lane.
+  std::vector<std::unique_ptr<TcpLane>> lanes_;
 
   // get-path copy accounting, paired with Conn::RecvPhaseStats. Reader thread
   // only; relaxed because a torn read across a reset misattributes a sample and
@@ -854,7 +923,7 @@ class TcpTransport : public Transport {
   std::shared_ptr<H2dPollState> h2dState_;
 
   // Serialises bind()/connect()/shutdown(), which together own server_,
-  // dataConn_, reader_ and sender_. Without it a shutdown() concurrent with an
+  // lanes_ and their threads. Without it a shutdown() concurrent with an
   // in-progress connect() races a unique_ptr and two std::thread objects, and
   // -- because connect() parks for the whole handshake -- can let connect()
   // install a live connection and both threads *after* shutdown() has already
@@ -865,14 +934,13 @@ class TcpTransport : public Transport {
   // by config_.connTimeout) instead of interleaving with it. Deliberately NOT
   // taken by put/get/send/recv, which keep reading state_/connBroken_
   // atomically so a transfer is never serialised against a connect. Safe to
-  // hold across the reader_/sender_ joins in shutdown(): neither loop, nor
-  // failAllPending(), ever acquires it.
-  // Bounds on the outbound queue and the in-flight map, for work this side
-  // originates: outQueue_ holds whole payloads, and inflight_ one entry per
-  // outstanding chunk, so an application issuing put/get faster than the link
-  // drains would otherwise grow both without limit. Caller threads wait for
-  // room, which is real backpressure -- the application slows down and nothing
-  // breaks.
+  // hold across the per-lane reader/sender joins in shutdown(): neither loop,
+  // nor failAllPending(), ever acquires it. Bounds on the outbound queue and
+  // the in-flight map, for work this side originates: the lane queues hold
+  // whole payloads, and inflight_ one entry per outstanding chunk, so an
+  // application issuing put/get faster than the link drains would otherwise
+  // grow both without limit. Caller threads wait for room, which is real
+  // backpressure -- the application slows down and nothing breaks.
   //
   // kMaxOutQueueBytes deliberately does NOT apply to the reader thread's
   // replies. A get of N bytes legitimately requires up to N bytes of ReadReply
@@ -907,8 +975,14 @@ class TcpTransport : public Transport {
   // Two full wire frames can remain pinned while Phase 3d retires H2D copies;
   // exhaustion falls back to the reusable vector instead of blocking receive.
   static constexpr size_t kReceiveSlabCount = 2;
-  // Bytes currently queued in outQueue_. Guarded by outMu_.
-  size_t outBytes_{0};
+  // Per-lane queue cap, so the aggregate bound stays kMaxOutQueueBytes however
+  // many lanes are configured. An empty lane admits any frame regardless (see
+  // enqueueFrame), so dividing cannot make an oversized frame undrainable.
+  size_t laneCapBytes() const;
+  // Round-robins a lane for one frame. put/get frames each carry their own
+  // reqId/segId/offset, so the peer reassembles them without ordering help and
+  // any lane will do.
+  size_t pickLane();
 
   // Cap on bytes buffered in unmatchedSends_. The reader thread never stops
   // draining the socket -- that is what avoids the mutual-READ deadlock -- so
@@ -928,14 +1002,11 @@ class TcpTransport : public Transport {
   // first to finish rather than returning while teardown is still running.
   std::atomic<bool> shutdown_{false};
 
-  std::thread reader_;
-  std::thread sender_;
+  // Round-robin cursor for lane selection. Relaxed: an occasional duplicate or
+  // skipped index only perturbs balance, and nothing reads it for correctness.
+  std::atomic<uint64_t> nextLane_{0};
   std::atomic<bool> running_{false};
   std::atomic<bool> connBroken_{false};
-  // Gates closeDataConnOnce(). Conn::close() is a check-then-act on a bare fd,
-  // so two callers seeing it open both close it; the second reaps a descriptor
-  // some unrelated thread has since been handed.
-  std::atomic<bool> dataConnClosed_{false};
 
   // Guards the staging queue, which the reader thread appends to and the
   // EventBase drains.
@@ -967,14 +1038,6 @@ class TcpTransport : public Transport {
   // shared_ptr before std::atomic<shared_ptr> is available in the toolchain.
   std::shared_ptr<TcpPinnedSlabPool> receiveSlabPool_;
   bool receivePoolUnavailable_{false};
-
-  // Outbound frame queue drained by the sender thread. Decoupling all sends
-  // from the reader thread is what prevents a mutual-READ deadlock (two peers'
-  // readers both blocked mid-send while neither drains its recv).
-  std::mutex outMu_;
-  std::condition_variable outCv_;
-  std::deque<TcpOutItem> outQueue_;
-  bool outClosed_{false};
 
   std::mutex inflightMu_;
   std::unordered_map<uint64_t, TcpInflight> inflight_;

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -2,13 +2,16 @@
 
 #pragma once
 
+#include <array>
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <cstdint>
 #include <deque>
 #include <future>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
@@ -25,6 +28,18 @@
 namespace uniflow {
 
 class TcpRemoteRegistrationHandle;
+
+/// Transport-local behavior plus the controller's socket configuration.
+/// The converting constructor preserves existing callsites that pass a bare
+/// TcpSocketConfig as the transport/factory constructor argument.
+struct TcpTransportConfig {
+  controller::TcpSocketConfig socketConfig{};
+  bool asyncGetH2d{true};
+
+  TcpTransportConfig() = default;
+  /* implicit */ TcpTransportConfig(controller::TcpSocketConfig config)
+      : socketConfig(std::move(config)) {}
+};
 
 /// Completion state shared by all requests in a single put()/get()/send()/
 /// recv() call. The call's promise is fulfilled once every request's reply has
@@ -46,33 +61,58 @@ struct TcpOpState {
     failLocked(std::move(status));
   }
 
+  /// Reserves the right to write into a caller-owned destination. Promise
+  /// resolution is deferred until every reservation retires, so the caller
+  /// cannot free the destination while a write is still in flight.
+  bool tryBeginWrite() {
+    std::lock_guard<std::mutex> lk(mu);
+    if (done) {
+      return false;
+    }
+    ++writesInFlight_;
+    return true;
+  }
+
+  /// Retires one write reservation and records that chunk's result. The first
+  /// failure wins, but is not published until every in-flight write is done.
+  void endWrite(Status status) {
+    std::lock_guard<std::mutex> lk(mu);
+    if (writesInFlight_ == 0) {
+      return;
+    }
+    --writesInFlight_;
+    if (status.hasError()) {
+      latchFailureLocked(std::move(status));
+    } else if (remaining > 0) {
+      --remaining;
+    }
+    settleLocked();
+  }
+
   /// Copies a reply payload into the caller's destination buffer (`write`) and
-  /// records that chunk's completion as one atomic step.
+  /// records that chunk's completion as one atomic lifetime reservation.
   ///
   /// Resolving this op's promise is what releases the caller to free or reuse
-  /// the destination, so a write into it may only start while the promise is
-  /// unresolved and must keep it unresolved until the write finishes. Holding
-  /// `mu` across `write` gives both: a concurrent fail() (send error, peer
-  /// disconnect, shutdown) either resolves the op first, in which case `write`
-  /// is skipped because the destination may already be gone, or it blocks
-  /// until the write is done.
+  /// the destination. The reservation keeps the promise unresolved while
+  /// `write` runs without holding `mu`; a concurrent failure is latched and
+  /// published only after the write retires. This is the same lifetime rule
+  /// used by asynchronous writes whose completion happens on another thread.
   ///
   /// `mu` is a leaf lock: nothing in this struct acquires another mutex while
   /// holding it, and no caller may hold one of the transport's container
-  /// mutexes (`inflightMu_`, `recvMu_`, `outMu_`) when calling in. `write`
-  /// therefore must only touch the destination buffer -- a memcpy or a device
-  /// copy -- and never reach back into the transport's queues.
+  /// mutexes (`inflightMu_`, `recvMu_`, `outMu_`) when calling in.
   template <typename Fn>
   void writeAndComplete(Fn&& write) {
-    std::lock_guard<std::mutex> lk(mu);
-    if (done) {
+    if (!tryBeginWrite()) {
       return;
     }
-    Status status = write();
-    if (status.hasError()) {
-      failLocked(std::move(status));
-    } else {
-      completeOneLocked();
+    try {
+      endWrite(write());
+    } catch (...) {
+      endWrite(
+          Err(ErrCode::TransportError,
+              "tcp: destination write raised an exception"));
+      throw;
     }
   }
 
@@ -84,19 +124,42 @@ struct TcpOpState {
     if (remaining > 0) {
       --remaining;
     }
-    if (remaining == 0) {
-      done = true;
-      promise.set_value(Ok());
-    }
+    settleLocked();
   }
 
   void failLocked(Status status) {
     if (done) {
       return;
     }
+    if (writesInFlight_ > 0) {
+      latchFailureLocked(std::move(status));
+      return;
+    }
     done = true;
     promise.set_value(std::move(status));
   }
+
+  void latchFailureLocked(Status status) {
+    if (!firstFailure_.has_value()) {
+      firstFailure_.emplace(std::move(status));
+    }
+  }
+
+  void settleLocked() {
+    if (done || writesInFlight_ > 0) {
+      return;
+    }
+    if (firstFailure_.has_value()) {
+      done = true;
+      promise.set_value(std::move(*firstFailure_));
+    } else if (remaining == 0) {
+      done = true;
+      promise.set_value(Ok());
+    }
+  }
+
+  size_t writesInFlight_{0};
+  std::optional<Status> firstFailure_;
 };
 
 struct TcpTransportInfo {
@@ -396,6 +459,39 @@ struct PendingReadReply {
   int deviceId{-1};
 };
 
+/// One slab-backed get destination copy waiting for its CUDA event. The write
+/// reservation and receive slab stay owned here until the GPU has finished
+/// reading the source and writing the caller's destination.
+struct PendingH2d {
+  std::shared_ptr<TcpOpState> state;
+  TcpPinnedSlab slab;
+  void* event{nullptr};
+  int deviceId{-1};
+  void* stream{nullptr};
+  uint64_t reqId{0};
+  std::chrono::steady_clock::time_point launchedAt;
+};
+
+/// Shared independently of TcpTransport so queued EventBase callbacks never
+/// retain or dereference a transport that shutdown has already destroyed.
+struct H2dPollState {
+  std::mutex mu;
+  std::condition_variable drained;
+  std::deque<PendingH2d> pending;
+  std::shared_ptr<TcpOpState> retiringState;
+  // There are exactly two receive slabs, so at most two copies can become
+  // unquiesceable. Fixed slots avoid allocating on this driver-failure path.
+  std::array<std::optional<PendingH2d>, 2> quarantined;
+  std::shared_ptr<H2dPollState> quarantineKeepalive;
+  bool pollScheduled{false};
+  bool stopping{false};
+  size_t activeRetirements{0};
+  EventBase* evb{nullptr};
+  std::shared_ptr<CudaApi> cudaApi;
+  std::atomic<uint64_t> copyNs{0};
+  std::atomic<uint64_t> copyCount{0};
+};
+
 /// A VRAM ReadReply that has not been started because no staging slab was free.
 /// Everything needed to build and launch it later is here, so the reader can
 /// record it and go straight back to the socket.
@@ -449,7 +545,7 @@ class TcpTransport : public Transport {
       int deviceId,
       EventBase* evb,
       std::shared_ptr<TcpSegmentRegistry> registry,
-      controller::TcpSocketConfig config = {},
+      TcpTransportConfig config = {},
       std::string host = "127.0.0.1",
       std::shared_ptr<CudaApi> cudaApi = nullptr);
 
@@ -470,6 +566,10 @@ class TcpTransport : public Transport {
 
   TransportState state() const noexcept override {
     return state_;
+  }
+
+  bool asyncGetH2dEnabled() const noexcept {
+    return config_.asyncGetH2d;
   }
 
   TransportInfo bind() override;
@@ -523,6 +623,7 @@ class TcpTransport : public Transport {
   // directly and assert the bounds checks reject them. Those checks are the
   // memory-safety boundary of this transport, so they are worth pinning.
   friend class TcpTransportFrameTest;
+  friend class TcpReceivePoolTest;
 
   Result<const TcpRemoteRegistrationHandle*> findRemoteHandle(
       const RemoteRegisteredSegment::Span& span) const;
@@ -538,13 +639,18 @@ class TcpTransport : public Transport {
  private:
   // Sender thread: drains outQueue_ and performs all socket sends.
   void senderLoop() noexcept;
-  // Handles one fully-received inbound frame (reader thread).
-  void handleFrame(std::span<const uint8_t> frame) noexcept;
+  // Handles one fully-received inbound frame (reader thread). `receiveSlab`
+  // owns frame.data() when the reader received directly into pinned memory.
+  void handleFrame(
+      std::span<const uint8_t> frame,
+      TcpPinnedSlab receiveSlab = {}) noexcept;
   // The body of handleFrame(), allowed to throw. Peer-supplied lengths size
   // allocations in here and the VRAM staging path throws on an invalid
   // deviceId, so handleFrame() is the boundary that stops either reaching the
   // top of the reader thread.
-  void handleFrameImpl(std::span<const uint8_t> frame);
+  void handleFrameImpl(
+      std::span<const uint8_t> frame,
+      TcpPinnedSlab receiveSlab);
   // Queues one fire-and-forget framed message for the sender thread.
   // `mayBlock` must be true only for caller threads. Returns false if the frame
   // was not queued (transport closing, or the reader hit the cap and refused
@@ -637,6 +743,33 @@ class TcpTransport : public Transport {
   // transport per peer -- including the DRAM-only peers that never stage at
   // all.
   Result<std::shared_ptr<TcpPinnedSlabPool>> stagingPool();
+  // The independent inbound pool. It is created only for async-enabled,
+  // non-zero VRAM get(), and is sized to the wire cap because recv(span)
+  // consumes the length prefix before it can reject an undersized buffer.
+  std::shared_ptr<TcpPinnedSlabPool> ensureReceivePool();
+  // Reader-only lookup: never allocates and never blocks.
+  std::shared_ptr<TcpPinnedSlabPool> receivePoolIfCreated();
+  // Starts a slab-backed get destination copy. On success the pending queue
+  // owns `slab` and the caller's write reservation until event retirement.
+  Status startAsyncH2d(
+      const TcpInflight& entry,
+      std::span<const uint8_t> payload,
+      TcpPinnedSlab slab,
+      uint64_t reqId);
+  void schedulePendingH2dPoll();
+  static void pollPendingH2d(std::shared_ptr<H2dPollState> state) noexcept;
+  static Status waitForH2dCopy(
+      const std::shared_ptr<H2dPollState>& state,
+      int deviceId,
+      void* stream) noexcept;
+  static void destroyH2dEvent(
+      const std::shared_ptr<H2dPollState>& state,
+      int deviceId,
+      void* event) noexcept;
+  static void quarantineH2d(
+      const std::shared_ptr<H2dPollState>& state,
+      PendingH2d copy) noexcept;
+  void drainPendingH2d();
   // Retires staged replies whose copy has finished, oldest first. Runs on the
   // EventBase, never on the reader thread: polling from the reader would put
   // the head-of-line block straight back.
@@ -696,7 +829,7 @@ class TcpTransport : public Transport {
   EventBase* evb_{nullptr};
   std::shared_ptr<TcpSegmentRegistry> registry_;
   std::shared_ptr<CudaApi> cudaApi_;
-  controller::TcpSocketConfig config_;
+  TcpTransportConfig config_;
   std::string name_{"tcp"};
   // Atomic: written by bind()/connect()/shutdown() and read by the
   // put/get/send/recv guards and state(), which callers may invoke from any
@@ -715,6 +848,7 @@ class TcpTransport : public Transport {
   // nothing more.
   std::atomic<uint64_t> dstCopyNs_{0};
   std::atomic<uint64_t> dstCopyCount_{0};
+  std::shared_ptr<H2dPollState> h2dState_;
 
   // Serialises bind()/connect()/shutdown(), which together own server_,
   // dataConn_, reader_ and sender_. Without it a shutdown() concurrent with an
@@ -767,6 +901,9 @@ class TcpTransport : public Transport {
   // many chunks either reaches the queue whole or not at all.
   static constexpr size_t kMaxPutWaveChunks =
       kStagingSlabCount - kStagingSlabsReservedForReader;
+  // Two full wire frames can remain pinned while Phase 3d retires H2D copies;
+  // exhaustion falls back to the reusable vector instead of blocking receive.
+  static constexpr size_t kReceiveSlabCount = 2;
   // Bytes currently queued in outQueue_. Guarded by outMu_.
   size_t outBytes_{0};
 
@@ -820,6 +957,14 @@ class TcpTransport : public Transport {
   std::mutex poolMu_;
   std::shared_ptr<TcpPinnedSlabPool> slabPool_;
 
+  // Separate from the outbound/responder staging pool: receive slabs must hold
+  // any legal wire frame, not just one kMaxChunkSize payload.
+  std::mutex receivePoolCreateMu_;
+  // Accessed with the std::atomic_load/store free functions, which support
+  // shared_ptr before std::atomic<shared_ptr> is available in the toolchain.
+  std::shared_ptr<TcpPinnedSlabPool> receiveSlabPool_;
+  bool receivePoolUnavailable_{false};
+
   // Outbound frame queue drained by the sender thread. Decoupling all sends
   // from the reader thread is what prevents a mutual-READ deadlock (two peers'
   // readers both blocked mid-send while neither drains its recv).
@@ -850,7 +995,7 @@ class TcpTransportFactory : public TransportFactory {
   explicit TcpTransportFactory(
       int deviceId,
       EventBase* evb,
-      controller::TcpSocketConfig config = {},
+      TcpTransportConfig config = {},
       std::string host = "127.0.0.1",
       std::shared_ptr<CudaApi> cudaApi = nullptr);
 
@@ -871,7 +1016,7 @@ class TcpTransportFactory : public TransportFactory {
  private:
   int deviceId_{-1};
   EventBase* evb_{nullptr};
-  controller::TcpSocketConfig config_;
+  TcpTransportConfig config_;
   std::string host_{"127.0.0.1"};
   std::shared_ptr<CudaApi> cudaApi_;
   std::shared_ptr<TcpSegmentRegistry> registry_{

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -46,6 +46,37 @@ struct TcpTransportConfig {
   // Set this to 1 on both sides for mixed-version interoperability.
   size_t numSockets{4};
 
+  /// Network devices to stripe lanes across, e.g. {"eth1", "eth2"}. Empty (the
+  /// default) leaves egress to the routing table, exactly as before.
+  ///
+  /// Lane i is placed on device i % bindToDevices.size(), so the listener needs
+  /// one bound socket per device: for a `get` the bulk data flows listener to
+  /// dialer and the listener's egress follows its own routing table, so binding
+  /// only the dialer would leave `get` traffic on a single NIC. Both peers must
+  /// name the same number of devices, because each side derives the
+  /// lane-to-device mapping from the lane index alone.
+  ///
+  /// Size numSockets at about 4 lanes per device: one 200G NIC saturates near 4
+  /// lanes (~21 GB/s), so 2 devices need 8 to reach ~35 GB/s. Two devices with
+  /// only 4 lanes total reaches 27.6 GB/s, leaving both NICs half-fed.
+  ///
+  /// Only worth enabling for large transfers. Measured on MI350, get, median of
+  /// 3, 2 devices against 1: 1.00x at 8 MiB, 1.45x at 16 MiB, 1.63x at 64 MiB.
+  /// At 1-4 MiB the path is latency-bound and striping is neutral to slightly
+  /// negative.
+  ///
+  /// Pairing two ports on one PCI card measured the same as two ports on
+  /// separate cards (34.0 against 34.7-35.4 GB/s at 8 lanes, 64 MiB), even
+  /// though raw iperf3 on this hardware shows a clear card limit. This path
+  /// tops out around 276 Gbit/s, under the ~289 Gbit/s a single card sustains,
+  /// so the card is not yet the binding constraint -- the receive-side H2D copy
+  /// is, at roughly 73% of wire time. Card affinity starts to matter once that
+  /// is fixed.
+  ///
+  /// Device names are per-host and need not match between peers: the same
+  /// physical port is eth3 on one MI350 host and eth0 on the next.
+  std::vector<std::string> bindToDevices;
+
   TcpTransportConfig() = default;
   /* implicit */ TcpTransportConfig(controller::TcpSocketConfig config)
       : socketConfig(std::move(config)) {}
@@ -180,6 +211,29 @@ struct TcpTransportInfo {
 
   std::string host{"127.0.0.1"};
   uint16_t port{0};
+
+  /// One listener socket's address, as advertised to the peer.
+  struct Endpoint {
+    std::string host;
+    uint16_t port{0};
+  };
+
+  /// Additional listeners, one per extra device when striping. Endpoint 0 is
+  /// (host, port) above, so this holds devices 1..D-1 and stays empty unless
+  /// TcpTransportConfig::bindToDevices names more than one device.
+  ///
+  /// Appended after the host bytes instead of being counted in Header, so a
+  /// single-device transport serializes byte-identically to a build that
+  /// predates striping. A multi-device one does not: the extra bytes fail the
+  /// old exact-size check, so striping requires this build on both peers.
+  std::vector<Endpoint> extraEndpoints;
+
+  /// Endpoint `index`, counting (host, port) as 0. Maps a lane to the listener
+  /// it belongs on. Indices past the end clamp to endpoint 0.
+  Endpoint endpointAt(size_t index) const;
+  size_t endpointCount() const {
+    return 1 + extraEndpoints.size();
+  }
 
   TransportInfo serialize() const;
   static Result<TcpTransportInfo> deserialize(std::span<const uint8_t> data);
@@ -880,7 +934,13 @@ class TcpTransport : public Transport {
   std::string host_{"127.0.0.1"};
   uint16_t port_{0};
 
-  std::unique_ptr<controller::AsyncTcpServer> server_;
+  /// One listener per entry in TcpTransportConfig::bindToDevices, or exactly
+  /// one unbound listener when that list is empty. servers_[d] owns the lanes
+  /// with index % servers_.size() == d.
+  std::vector<std::unique_ptr<controller::AsyncTcpServer>> servers_;
+
+  /// Endpoints advertised by bind(), parallel to servers_.
+  std::vector<TcpTransportInfo::Endpoint> localEndpoints_;
 
   /// One data socket plus the reader thread that drains it. Phase 1 establishes
   /// numSockets lanes but sends everything on lane 0, so only establishment,

--- a/comms/uniflow/transport/tcp/TcpWireProtocol.h
+++ b/comms/uniflow/transport/tcp/TcpWireProtocol.h
@@ -127,9 +127,12 @@ constexpr uint32_t kTcpLaneMagic{0x554C414E}; // "ULAN"
 struct __attribute__((packed)) TcpLaneHello {
   uint32_t magic{kTcpLaneMagic};
   uint8_t version{kTcpWireVersion};
-  uint8_t laneIndex{0};
-  uint8_t laneCount{1};
-  uint8_t rsvd{0};
+  // 16-bit, so these bound the lane count rather than the reverse: a uint8_t
+  // capped a connection at 255 lanes, and lanes are now counted per device, so
+  // the ceiling is reached by device count as much as by configuration. The
+  // spare byte this replaces was not enough on its own.
+  uint16_t laneIndex{0};
+  uint16_t laneCount{1};
   uint64_t sessionId{0};
 
   std::vector<uint8_t> serialize() const {
@@ -163,6 +166,6 @@ struct __attribute__((packed)) TcpLaneHello {
   }
 };
 
-static_assert(sizeof(TcpLaneHello) == 16);
+static_assert(sizeof(TcpLaneHello) == 17);
 
 } // namespace uniflow

--- a/comms/uniflow/transport/tcp/TcpWireProtocol.h
+++ b/comms/uniflow/transport/tcp/TcpWireProtocol.h
@@ -106,4 +106,63 @@ struct __attribute__((packed)) TcpTopologyInfo {
   }
 };
 
+constexpr uint32_t kTcpLaneMagic{0x554C414E}; // "ULAN"
+
+/// Identifies one data socket within a multi-lane connection. The dialer sends
+/// this on each socket immediately after it is established; the listener reads
+/// it before using the socket, and places it at `laneIndex`. Accept order is
+/// deliberately not used as identity: the sockets are dialed concurrently with
+/// no ordering guarantee, so pairing lane N to lane N on both sides needs the
+/// index carried explicitly.
+///
+/// Only exchanged when more than one lane is configured. A single-lane
+/// transport therefore stays byte-identical on the wire to one built before
+/// lanes existed, which is what lets kTcpWireVersion stay at its current value:
+/// bumping it would make every new peer incompatible with every old one, and a
+/// rollout of that kind should not be spent on a field only multi-lane peers
+/// read.
+///
+/// sessionId is echoed by every lane of one connection, so a stray dialer
+/// reaching this listener is rejected rather than silently occupying a lane.
+struct __attribute__((packed)) TcpLaneHello {
+  uint32_t magic{kTcpLaneMagic};
+  uint8_t version{kTcpWireVersion};
+  uint8_t laneIndex{0};
+  uint8_t laneCount{1};
+  uint8_t rsvd{0};
+  uint64_t sessionId{0};
+
+  std::vector<uint8_t> serialize() const {
+    std::vector<uint8_t> data(sizeof(TcpLaneHello));
+    std::memcpy(data.data(), this, sizeof(TcpLaneHello));
+    return data;
+  }
+
+  static Result<TcpLaneHello> deserialize(std::span<const uint8_t> data) {
+    if (data.size() != sizeof(TcpLaneHello)) {
+      return Err(
+          ErrCode::InvalidArgument,
+          "tcp lane hello size mismatch: expected " +
+              std::to_string(sizeof(TcpLaneHello)) + " bytes, got " +
+              std::to_string(data.size()));
+    }
+    TcpLaneHello hello;
+    std::memcpy(&hello, data.data(), sizeof(TcpLaneHello));
+    if (hello.magic != kTcpLaneMagic) {
+      return Err(
+          ErrCode::InvalidArgument,
+          "tcp lane hello bad magic " + std::to_string(hello.magic));
+    }
+    if (hello.version != kTcpWireVersion) {
+      return Err(
+          ErrCode::InvalidArgument,
+          "unsupported tcp wire version " + std::to_string(hello.version) +
+              " in lane hello");
+    }
+    return hello;
+  }
+};
+
+static_assert(sizeof(TcpLaneHello) == 16);
+
 } // namespace uniflow

--- a/comms/uniflow/transport/tcp/tests/unit/TcpReceivePoolTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpReceivePoolTest.cpp
@@ -367,6 +367,127 @@ TEST_F(TcpReceivePoolTest, VramReadReplyKeepsSlabUntilEventCompletes) {
   EXPECT_TRUE(pool->tryAcquire(/*allowReserved=*/true));
 }
 
+TEST_F(
+    TcpReceivePoolTest,
+    EventRecordFailureCompletesGetWhenStreamSynchronizationSucceeds) {
+  makeTransport();
+  auto pool = createReceivePool();
+  ASSERT_NE(pool, nullptr);
+  auto slab = pool->tryAcquire(/*allowReserved=*/true);
+  ASSERT_TRUE(slab);
+  auto frame = readReplyFrame(/*reqId=*/1, kLen);
+  ASSERT_LE(frame.size(), slab.capacity());
+  std::memcpy(slab.data(), frame.data(), frame.size());
+  const auto bytes = std::span<const uint8_t>{slab.data(), frame.size()};
+
+  std::vector<uint8_t> destination(kLen);
+  auto* const callerStream = reinterpret_cast<void*>(0xCA11);
+  auto future = postVramRead(destination.data(), callerStream);
+
+  EXPECT_CALL(
+      *cudaApi_,
+      memcpyAsync(
+          destination.data(),
+          ::testing::_,
+          kLen,
+          kMockMemcpyH2D,
+          static_cast<MockStream>(callerStream)))
+      .WillOnce([&](void* dst, const void* src, size_t len, auto, auto) {
+        std::memcpy(dst, src, len);
+        return Ok();
+      });
+  EXPECT_CALL(*cudaApi_, eventCreate(::testing::_))
+      .WillOnce([](auto* event) -> Status {
+        *event = {};
+        return Ok();
+      });
+  EXPECT_CALL(
+      *cudaApi_,
+      eventRecord(::testing::_, static_cast<MockStream>(callerStream)))
+      .WillOnce(
+          ::testing::Return(
+              Err(ErrCode::DriverError, "test: event record failed")));
+  EXPECT_CALL(
+      *cudaApi_, streamSynchronize(static_cast<MockStream>(callerStream)))
+      .WillOnce(::testing::Return(Ok()));
+  EXPECT_CALL(*cudaApi_, eventDestroy(::testing::_))
+      .WillOnce(::testing::Return(Ok()));
+  EXPECT_CALL(*cudaApi_, eventQuery(::testing::_)).Times(0);
+
+  handleFrame(bytes, std::move(slab));
+
+  ASSERT_EQ(
+      future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  EXPECT_TRUE(future.get().hasValue());
+  EXPECT_TRUE(
+      std::all_of(destination.begin(), destination.end(), [](uint8_t b) {
+        return b == uint8_t{0xCD};
+      }));
+  auto returnedSlabs = pool->acquire(2);
+  EXPECT_TRUE(returnedSlabs.hasValue());
+}
+
+TEST_F(
+    TcpReceivePoolTest,
+    EventQueryFailureCompletesGetWhenStreamSynchronizationSucceeds) {
+  makeTransport();
+  auto pool = createReceivePool();
+  ASSERT_NE(pool, nullptr);
+  auto slab = pool->tryAcquire(/*allowReserved=*/true);
+  ASSERT_TRUE(slab);
+  auto frame = readReplyFrame(/*reqId=*/1, kLen);
+  ASSERT_LE(frame.size(), slab.capacity());
+  std::memcpy(slab.data(), frame.data(), frame.size());
+  const auto bytes = std::span<const uint8_t>{slab.data(), frame.size()};
+
+  std::vector<uint8_t> destination(kLen);
+  auto* const callerStream = reinterpret_cast<void*>(0xCA11);
+  auto future = postVramRead(destination.data(), callerStream);
+
+  EXPECT_CALL(
+      *cudaApi_,
+      memcpyAsync(
+          destination.data(),
+          ::testing::_,
+          kLen,
+          kMockMemcpyH2D,
+          static_cast<MockStream>(callerStream)))
+      .WillOnce([&](void* dst, const void* src, size_t len, auto, auto) {
+        std::memcpy(dst, src, len);
+        return Ok();
+      });
+  EXPECT_CALL(*cudaApi_, eventCreate(::testing::_))
+      .WillOnce([](auto* event) -> Status {
+        *event = {};
+        return Ok();
+      });
+  EXPECT_CALL(
+      *cudaApi_,
+      eventRecord(::testing::_, static_cast<MockStream>(callerStream)))
+      .WillOnce(::testing::Return(Ok()));
+  EXPECT_CALL(*cudaApi_, eventQuery(::testing::_))
+      .WillOnce([](auto) -> Result<bool> {
+        return Err(ErrCode::DriverError, "test: event query failed");
+      });
+  EXPECT_CALL(
+      *cudaApi_, streamSynchronize(static_cast<MockStream>(callerStream)))
+      .WillOnce(::testing::Return(Ok()));
+  EXPECT_CALL(*cudaApi_, eventDestroy(::testing::_))
+      .WillOnce(::testing::Return(Ok()));
+
+  handleFrame(bytes, std::move(slab));
+
+  ASSERT_EQ(
+      future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  EXPECT_TRUE(future.get().hasValue());
+  EXPECT_TRUE(
+      std::all_of(destination.begin(), destination.end(), [](uint8_t b) {
+        return b == uint8_t{0xCD};
+      }));
+  auto returnedSlabs = pool->acquire(2);
+  EXPECT_TRUE(returnedSlabs.hasValue());
+}
+
 TEST_F(TcpReceivePoolTest, VectorBackedVramReadReplyRemainsSynchronous) {
   makeTransport();
   auto frame = readReplyFrame(/*reqId=*/1, kLen);

--- a/comms/uniflow/transport/tcp/tests/unit/TcpReceivePoolTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpReceivePoolTest.cpp
@@ -1,0 +1,402 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/transport/tcp/TcpTransport.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstring>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <span>
+#include <vector>
+
+#include "comms/uniflow/Segment.h"
+#include "comms/uniflow/drivers/cuda/mock/MockCudaApi.h"
+#include "comms/uniflow/executor/ScopedEventBaseThread.h"
+#include "comms/uniflow/transport/tcp/TcpRegistrationHandle.h"
+#include "comms/uniflow/transport/tcp/TcpWireProtocol.h"
+
+namespace uniflow {
+
+class SegmentTest {
+ public:
+  static RegisteredSegment
+  makeRegistered(void* buf, size_t len, MemoryType memType, int deviceId) {
+    return RegisteredSegment(buf, len, memType, deviceId);
+  }
+
+  static RemoteRegisteredSegment makeRemote(
+      void* buf,
+      size_t len,
+      std::unique_ptr<RemoteRegistrationHandle> handle) {
+    RemoteRegisteredSegment remote(buf, len);
+    remote.handles_.push_back(std::move(handle));
+    return remote;
+  }
+};
+
+namespace {
+
+class ScriptedRecvConn final : public controller::Conn {
+ public:
+  explicit ScriptedRecvConn(std::vector<uint8_t> frame)
+      : frame_(std::move(frame)) {}
+
+  std::future<Result<size_t>> send(std::span<const uint8_t> data) override {
+    return make_ready_future<Result<size_t>>(Result<size_t>(data.size()));
+  }
+
+  std::future<Result<size_t>> recv(std::vector<uint8_t>& data) override {
+    ++vectorRecvs_;
+    return next([&]() { data = frame_; });
+  }
+
+  std::future<Result<size_t>> recv(std::span<uint8_t> data) override {
+    ++spanRecvs_;
+    return next([&]() {
+      ASSERT_GE(data.size(), frame_.size());
+      std::memcpy(data.data(), frame_.data(), frame_.size());
+    });
+  }
+
+  void close() override {}
+
+  int spanRecvs() const {
+    return spanRecvs_;
+  }
+
+  int vectorRecvs() const {
+    return vectorRecvs_;
+  }
+
+ private:
+  template <typename Fill>
+  std::future<Result<size_t>> next(Fill&& fill) {
+    if (delivered_) {
+      return make_ready_future<Result<size_t>>(
+          Err(ErrCode::ConnectionFailed, "test: end of script"));
+    }
+    delivered_ = true;
+    fill();
+    return make_ready_future<Result<size_t>>(Result<size_t>(frame_.size()));
+  }
+
+  std::vector<uint8_t> frame_;
+  bool delivered_{false};
+  int spanRecvs_{0};
+  int vectorRecvs_{0};
+};
+
+} // namespace
+
+class TcpReceivePoolTest : public ::testing::Test {
+ protected:
+  static constexpr size_t kLen = 64;
+  static constexpr uint64_t kRemoteSegId = 17;
+
+  void SetUp() override {
+    evbThread_ =
+        std::make_unique<ScopedEventBaseThread>("tcp-receive-pool-test");
+    cudaApi_ = std::make_shared<::testing::NiceMock<MockCudaApi>>();
+    ON_CALL(*cudaApi_, getDevice())
+        .WillByDefault(::testing::Return(Result<int>(0)));
+    ON_CALL(*cudaApi_, setDevice(::testing::_))
+        .WillByDefault(::testing::Return(Ok()));
+    ON_CALL(*cudaApi_, hostAlloc(::testing::_, ::testing::_))
+        .WillByDefault([this](size_t size, unsigned int) -> Result<void*> {
+          auto memory = std::make_unique<uint8_t[]>(size);
+          void* result = memory.get();
+          std::lock_guard<std::mutex> lk(allocMu_);
+          allocations_.push_back(std::move(memory));
+          return result;
+        });
+    ON_CALL(*cudaApi_, hostFree(::testing::_))
+        .WillByDefault([this](void* ptr) -> Status {
+          std::lock_guard<std::mutex> lk(allocMu_);
+          std::erase_if(allocations_, [ptr](const auto& allocation) {
+            return allocation.get() == ptr;
+          });
+          return Ok();
+        });
+  }
+
+  void TearDown() override {
+    if (transport_) {
+      transport_->shutdown();
+      transport_.reset();
+    }
+    evbThread_.reset();
+  }
+
+  void makeTransport(bool asyncGetH2d = true) {
+    TcpTransportConfig config;
+    config.asyncGetH2d = asyncGetH2d;
+    transport_ = std::make_unique<TcpTransport>(
+        /*deviceId=*/-1,
+        evbThread_->getEventBase(),
+        std::make_shared<TcpSegmentRegistry>(),
+        config,
+        /*host=*/"127.0.0.1",
+        cudaApi_);
+  }
+
+  std::future<Status> issueGet(size_t len, MemoryType memType) {
+    localBytes_.resize(len == 0 ? 1 : len);
+    auto local = SegmentTest::makeRegistered(
+        localBytes_.data(), len, memType, memType == MemoryType::VRAM ? 0 : -1);
+    auto remote = SegmentTest::makeRemote(
+        reinterpret_cast<void*>(0x100000),
+        len,
+        std::make_unique<TcpRemoteRegistrationHandle>(kRemoteSegId, len));
+    const TransferRequest request{local.span(), remote.span()};
+    transport_->state_ = TransportState::Connected;
+    return transport_->get(std::span<const TransferRequest>{&request, 1});
+  }
+
+  static std::vector<uint8_t> ackFrame() {
+    TcpMsgHeader header;
+    header.op = static_cast<uint8_t>(TcpOp::Ack);
+    header.reqId = 999;
+    return serializeTcpHeader(header);
+  }
+
+  static std::vector<uint8_t> readReplyFrame(uint64_t reqId, size_t len) {
+    TcpMsgHeader header;
+    header.op = static_cast<uint8_t>(TcpOp::ReadReply);
+    header.reqId = reqId;
+    header.len = len;
+    std::vector<uint8_t> frame(sizeof(header) + len, uint8_t{0xCD});
+    std::memcpy(frame.data(), &header, sizeof(header));
+    return frame;
+  }
+
+  std::shared_ptr<TcpPinnedSlabPool> receivePool() {
+    return transport_->receivePoolIfCreated();
+  }
+
+  std::shared_ptr<TcpPinnedSlabPool> createReceivePool() {
+    return transport_->ensureReceivePool();
+  }
+
+  void failPending() {
+    transport_->failAllPending("test cleanup");
+  }
+
+  void runReader(std::unique_ptr<ScriptedRecvConn> conn) {
+    scriptedConn_ = conn.get();
+    transport_->dataConn_ = std::move(conn);
+    transport_->running_.store(true, std::memory_order_release);
+    transport_->readerLoop();
+  }
+
+  std::future<Status>
+  postVramRead(void* destination, void* stream = nullptr, size_t len = kLen) {
+    auto state = std::make_shared<TcpOpState>();
+    state->remaining = 1;
+    auto future = state->promise.get_future();
+    transport_->inflight_[1] = TcpInflight{
+        state,
+        destination,
+        len,
+        /*isRead=*/true,
+        MemoryType::VRAM,
+        /*deviceId=*/0,
+        stream};
+    return future;
+  }
+
+  void handleFrame(std::span<const uint8_t> frame, TcpPinnedSlab slab) {
+    transport_->handleFrame(frame, std::move(slab));
+  }
+
+  std::unique_ptr<ScopedEventBaseThread> evbThread_;
+  std::shared_ptr<::testing::NiceMock<MockCudaApi>> cudaApi_;
+  std::unique_ptr<TcpTransport> transport_;
+  ScriptedRecvConn* scriptedConn_{nullptr};
+  std::mutex allocMu_;
+  std::vector<std::unique_ptr<uint8_t[]>> allocations_;
+  std::vector<uint8_t> localBytes_;
+};
+
+TEST_F(TcpReceivePoolTest, PoolIsLazyAndOnlyCreatedForEnabledNonZeroVramGet) {
+  makeTransport();
+  EXPECT_EQ(receivePool(), nullptr);
+
+  auto dram = issueGet(kLen, MemoryType::DRAM);
+  EXPECT_EQ(receivePool(), nullptr);
+  failPending();
+  EXPECT_TRUE(dram.get().hasError());
+
+  transport_->shutdown();
+  transport_.reset();
+  makeTransport();
+  auto vram = issueGet(kLen, MemoryType::VRAM);
+  auto pool = receivePool();
+  ASSERT_NE(pool, nullptr);
+  EXPECT_EQ(pool->slabSize(), kMaxFrameSize);
+  EXPECT_EQ(pool->slabCount(), 2);
+  failPending();
+  EXPECT_TRUE(vram.get().hasError());
+
+  transport_->shutdown();
+  transport_.reset();
+  makeTransport(/*asyncGetH2d=*/false);
+  auto disabled = issueGet(kLen, MemoryType::VRAM);
+  EXPECT_EQ(receivePool(), nullptr);
+  failPending();
+  EXPECT_TRUE(disabled.get().hasError());
+}
+
+TEST_F(TcpReceivePoolTest, AllocationFailureFallsBackWithoutRetrying) {
+  makeTransport();
+  EXPECT_CALL(*cudaApi_, hostAlloc(::testing::_, ::testing::_))
+      .Times(1)
+      .WillOnce(
+          ::testing::Return(
+              Result<void*>(Err(
+                  ErrCode::DriverError, "test: pinned allocation failed"))));
+
+  auto first = issueGet(kLen, MemoryType::VRAM);
+  EXPECT_EQ(receivePool(), nullptr);
+  auto second = issueGet(kLen, MemoryType::VRAM);
+  EXPECT_EQ(receivePool(), nullptr);
+
+  runReader(std::make_unique<ScriptedRecvConn>(ackFrame()));
+  EXPECT_EQ(scriptedConn_->spanRecvs(), 0);
+  EXPECT_EQ(scriptedConn_->vectorRecvs(), 2);
+  EXPECT_TRUE(first.get().hasError());
+  EXPECT_TRUE(second.get().hasError());
+}
+
+TEST_F(TcpReceivePoolTest, ReaderUsesSlabAndFallsBackToVectorWhenPoolIsBusy) {
+  makeTransport();
+  auto pool = createReceivePool();
+  ASSERT_NE(pool, nullptr);
+
+  runReader(std::make_unique<ScriptedRecvConn>(ackFrame()));
+  EXPECT_EQ(scriptedConn_->spanRecvs(), 2);
+  EXPECT_EQ(scriptedConn_->vectorRecvs(), 0);
+
+  auto first = pool->tryAcquire(/*allowReserved=*/true);
+  auto second = pool->tryAcquire(/*allowReserved=*/true);
+  ASSERT_TRUE(first);
+  ASSERT_TRUE(second);
+  runReader(std::make_unique<ScriptedRecvConn>(ackFrame()));
+  EXPECT_EQ(scriptedConn_->spanRecvs(), 0);
+  EXPECT_EQ(scriptedConn_->vectorRecvs(), 2);
+}
+
+TEST_F(TcpReceivePoolTest, VramReadReplyKeepsSlabUntilEventCompletes) {
+  makeTransport();
+  auto pool = createReceivePool();
+  ASSERT_NE(pool, nullptr);
+  auto slab = pool->tryAcquire(/*allowReserved=*/true);
+  ASSERT_TRUE(slab);
+  auto frame = readReplyFrame(/*reqId=*/1, kLen);
+  ASSERT_LE(frame.size(), slab.capacity());
+  std::memcpy(slab.data(), frame.data(), frame.size());
+  const auto bytes = std::span<const uint8_t>{slab.data(), frame.size()};
+
+  std::vector<uint8_t> destination(kLen);
+  auto* const callerStream = reinterpret_cast<void*>(0xCA11);
+  auto future = postVramRead(destination.data(), callerStream);
+
+  std::mutex queryMu;
+  std::condition_variable queryCv;
+  bool queried = false;
+  std::atomic<bool> copyDone{false};
+  EXPECT_CALL(
+      *cudaApi_,
+      memcpyAsync(
+          destination.data(),
+          ::testing::_,
+          kLen,
+          kMockMemcpyH2D,
+          static_cast<MockStream>(callerStream)))
+      .WillOnce([&](void* dst, const void* src, size_t len, auto, auto) {
+        std::memcpy(dst, src, len);
+        return Ok();
+      });
+  EXPECT_CALL(*cudaApi_, eventCreate(::testing::_))
+      .WillOnce([](auto* event) -> Status {
+        *event = {};
+        return Ok();
+      });
+  EXPECT_CALL(
+      *cudaApi_,
+      eventRecord(::testing::_, static_cast<MockStream>(callerStream)))
+      .WillOnce(::testing::Return(Ok()));
+  EXPECT_CALL(*cudaApi_, eventQuery(::testing::_))
+      .WillRepeatedly([&](auto) -> Result<bool> {
+        {
+          std::lock_guard<std::mutex> lk(queryMu);
+          queried = true;
+        }
+        queryCv.notify_all();
+        return copyDone.load(std::memory_order_acquire);
+      });
+  EXPECT_CALL(*cudaApi_, eventDestroy(::testing::_))
+      .WillOnce(::testing::Return(Ok()));
+  EXPECT_CALL(*cudaApi_, streamSynchronize(::testing::_)).Times(0);
+
+  handleFrame(bytes, std::move(slab));
+  {
+    std::unique_lock<std::mutex> lk(queryMu);
+    ASSERT_TRUE(queryCv.wait_for(
+        lk, std::chrono::seconds(5), [&]() { return queried; }));
+  }
+
+  auto onlyFreeSlab = pool->tryAcquire(/*allowReserved=*/true);
+  ASSERT_TRUE(onlyFreeSlab);
+  EXPECT_FALSE(pool->tryAcquire(/*allowReserved=*/true));
+  EXPECT_EQ(
+      future.wait_for(std::chrono::milliseconds(0)),
+      std::future_status::timeout);
+
+  copyDone.store(true, std::memory_order_release);
+  ASSERT_EQ(
+      future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  EXPECT_TRUE(future.get().hasValue());
+  onlyFreeSlab.reset();
+  EXPECT_TRUE(pool->tryAcquire(/*allowReserved=*/true));
+}
+
+TEST_F(TcpReceivePoolTest, VectorBackedVramReadReplyRemainsSynchronous) {
+  makeTransport();
+  auto frame = readReplyFrame(/*reqId=*/1, kLen);
+  std::vector<uint8_t> destination(kLen);
+  auto* const callerStream = reinterpret_cast<void*>(0xCA11);
+  auto future = postVramRead(destination.data(), callerStream);
+
+  EXPECT_CALL(*cudaApi_, eventCreate(::testing::_)).Times(0);
+  EXPECT_CALL(
+      *cudaApi_,
+      memcpyAsync(
+          destination.data(),
+          ::testing::_,
+          kLen,
+          kMockMemcpyH2D,
+          static_cast<MockStream>(callerStream)))
+      .WillOnce([&](void* dst, const void* src, size_t len, auto, auto) {
+        std::memcpy(dst, src, len);
+        return Ok();
+      });
+  EXPECT_CALL(
+      *cudaApi_, streamSynchronize(static_cast<MockStream>(callerStream)))
+      .WillOnce(::testing::Return(Ok()));
+
+  handleFrame(frame, {});
+
+  ASSERT_EQ(
+      future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  EXPECT_TRUE(future.get().hasValue());
+  EXPECT_EQ(destination, std::vector<uint8_t>(kLen, uint8_t{0xCD}));
+}
+
+} // namespace uniflow

--- a/comms/uniflow/transport/tcp/tests/unit/TcpReceivePoolTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpReceivePoolTest.cpp
@@ -144,6 +144,10 @@ class TcpReceivePoolTest : public ::testing::Test {
         config,
         /*host=*/"127.0.0.1",
         cudaApi_);
+
+    // These tests drive the outbound path without connecting a peer, so give
+    // the transport the single lane that path indexes.
+    transport_->lanes_.push_back(std::make_unique<TcpTransport::TcpLane>());
   }
 
   std::future<Status> issueGet(size_t len, MemoryType memType) {
@@ -190,9 +194,9 @@ class TcpReceivePoolTest : public ::testing::Test {
 
   void runReader(std::unique_ptr<ScriptedRecvConn> conn) {
     scriptedConn_ = conn.get();
-    transport_->dataConn_ = std::move(conn);
+    transport_->lanes_[0]->conn = std::move(conn);
     transport_->running_.store(true, std::memory_order_release);
-    transport_->readerLoop();
+    transport_->readerLoop(0);
   }
 
   std::future<Status>

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportConnectTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportConnectTest.cpp
@@ -214,6 +214,27 @@ class TcpTransportTopologyTest : public ::testing::Test {
   std::unique_ptr<TcpTransportFactory> factory_;
 };
 
+TEST(TcpTransportConfigTest, AsyncGetH2dDefaultsOn) {
+  EXPECT_TRUE(TcpTransportConfig{}.asyncGetH2d);
+}
+
+TEST_F(TcpTransportTopologyTest, FactoryPropagatesDisabledAsyncGetH2d) {
+  TcpTransportConfig config;
+  config.asyncGetH2d = false;
+  TcpTransportFactory factory(
+      /*deviceId=*/-1,
+      evbThread_->getEventBase(),
+      config,
+      /*host=*/"127.0.0.1");
+
+  auto result = factory.createTransport(factory.getTopology());
+
+  ASSERT_TRUE(result.hasValue()) << result.error().message();
+  auto* transport = dynamic_cast<TcpTransport*>(result.value().get());
+  ASSERT_NE(transport, nullptr);
+  EXPECT_FALSE(transport->asyncGetH2dEnabled());
+}
+
 TEST_F(TcpTransportTopologyTest, TopologyIsAVersionedCapabilityBlob) {
   const std::vector<uint8_t> topology = factory_->getTopology();
 

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportConnectTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportConnectTest.cpp
@@ -385,7 +385,7 @@ TEST_F(TcpTransportConnectTest, RejectsPeerWithDifferentDeviceCount) {
   controller::TcpSocketConfig socketConfig;
   socketConfig.connTimeout = std::chrono::seconds{2};
   TcpTransportConfig config{socketConfig};
-  config.numSockets = 2;
+  config.numSocketsPerDevice = 2;
   // The device list is left empty, so this transport binds exactly one
   // endpoint. That is the case being contrasted against a peer that advertises
   // two.
@@ -414,8 +414,8 @@ TEST_F(TcpTransportConnectTest, RejectsPeerWithDifferentDeviceCount) {
   local->shutdown();
 }
 
-// numSockets below the device count would leave a bound listener with no lane.
-// Not covered here: reaching that guard requires two locally bound devices, so
-// it needs a host with two globally addressed NICs rather than a unit test.
+// There is no longer a guard for "fewer lanes than devices": lanes are counted
+// per device, so the product is always at least the device count and that state
+// is unreachable by construction.
 
 } // namespace uniflow

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportConnectTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportConnectTest.cpp
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cstdint>
+#include <cstring>
 #include <memory>
 #include <vector>
 
@@ -278,5 +280,142 @@ TEST_F(TcpTransportTopologyTest, CreateTransportValidatesPeerTopology) {
       << "createTransport must not build against an incompatible peer";
   EXPECT_EQ(result.error().code(), ErrCode::TopologyDisconnect);
 }
+
+// ---------------------------------------------------------------------------
+// TcpTransportInfo: multi-endpoint wire format for device striping
+// ---------------------------------------------------------------------------
+
+// The compatibility claim for striping rests entirely on this: one endpoint has
+// to serialize to exactly the pre-striping bytes, or every existing peer
+// breaks.
+TEST(TcpTransportInfoTest, SingleEndpointWireIsUnchanged) {
+  TcpTransportInfo info;
+  info.host = "2401:db00::1";
+  info.port = 4242;
+
+  const auto bytes = info.serialize();
+
+  std::vector<uint8_t> expected(sizeof(TcpTransportInfo::Header));
+  TcpTransportInfo::Header header{
+      .port = 4242,
+      .hostLen = static_cast<uint16_t>(info.host.size()),
+  };
+  std::memcpy(expected.data(), &header, sizeof(header));
+  expected.insert(expected.end(), info.host.begin(), info.host.end());
+
+  EXPECT_EQ(std::vector<uint8_t>(bytes.begin(), bytes.end()), expected)
+      << "a single-device transport must stay byte-identical to a peer that "
+         "predates striping";
+}
+
+TEST(TcpTransportInfoTest, ExtraEndpointsRoundTrip) {
+  TcpTransportInfo info;
+  info.host = "2401:db00::1";
+  info.port = 100;
+  info.extraEndpoints.push_back({"2401:db00::2", 200});
+  info.extraEndpoints.push_back({"2401:db00::3", 300});
+
+  auto parsed = TcpTransportInfo::deserialize(info.serialize());
+
+  ASSERT_TRUE(parsed.hasValue()) << parsed.error().message();
+  EXPECT_EQ(parsed.value().host, "2401:db00::1");
+  EXPECT_EQ(parsed.value().port, 100);
+  EXPECT_EQ(parsed.value().endpointCount(), 3u);
+  ASSERT_EQ(parsed.value().extraEndpoints.size(), 2u);
+  EXPECT_EQ(parsed.value().extraEndpoints[0].host, "2401:db00::2");
+  EXPECT_EQ(parsed.value().extraEndpoints[0].port, 200);
+  EXPECT_EQ(parsed.value().extraEndpoints[1].host, "2401:db00::3");
+  EXPECT_EQ(parsed.value().extraEndpoints[1].port, 300);
+}
+
+// endpointAt is what maps a lane to its device, so an off-by-one here would put
+// a lane's payload on the wrong NIC.
+TEST(TcpTransportInfoTest, EndpointAtIndexesFromZero) {
+  TcpTransportInfo info;
+  info.host = "2401:db00::1";
+  info.port = 100;
+  info.extraEndpoints.push_back({"2401:db00::2", 200});
+
+  EXPECT_EQ(info.endpointAt(0).host, "2401:db00::1");
+  EXPECT_EQ(info.endpointAt(0).port, 100);
+  EXPECT_EQ(info.endpointAt(1).host, "2401:db00::2");
+  EXPECT_EQ(info.endpointAt(1).port, 200);
+  // Out of range clamps to endpoint 0 rather than reading past the end.
+  EXPECT_EQ(info.endpointAt(2).host, "2401:db00::1");
+}
+
+// The old format enforced an exact size. That check is what rejects a corrupt
+// or truncated info, so parsing extras must not silently accept a short tail.
+TEST(TcpTransportInfoTest, RejectsTruncatedExtraEndpoint) {
+  TcpTransportInfo info;
+  info.host = "2401:db00::1";
+  info.port = 100;
+  info.extraEndpoints.push_back({"2401:db00::2", 200});
+
+  auto bytes = info.serialize();
+  std::vector<uint8_t> truncated(bytes.begin(), bytes.end() - 4);
+
+  auto parsed = TcpTransportInfo::deserialize(truncated);
+
+  ASSERT_TRUE(parsed.hasError())
+      << "a truncated extra endpoint must be rejected, not silently dropped";
+  EXPECT_EQ(parsed.error().code(), ErrCode::InvalidArgument);
+}
+
+TEST(TcpTransportInfoTest, RejectsTrailingGarbage) {
+  TcpTransportInfo info;
+  info.host = "2401:db00::1";
+  info.port = 100;
+
+  auto bytes = info.serialize();
+  std::vector<uint8_t> extended(bytes.begin(), bytes.end());
+  extended.push_back(0x01); // shorter than a Header, so not a valid endpoint
+
+  auto parsed = TcpTransportInfo::deserialize(extended);
+
+  ASSERT_TRUE(parsed.hasError());
+  EXPECT_EQ(parsed.error().code(), ErrCode::InvalidArgument);
+}
+
+// Placement is derived from the lane index on both sides rather than
+// negotiated, so a device-count mismatch has to be caught up front. Left
+// undetected it would put lanes on the wrong NIC, which is the exact class of
+// silent mislabeling that motivated device binding.
+TEST_F(TcpTransportConnectTest, RejectsPeerWithDifferentDeviceCount) {
+  controller::TcpSocketConfig socketConfig;
+  socketConfig.connTimeout = std::chrono::seconds{2};
+  TcpTransportConfig config{socketConfig};
+  config.numSockets = 2;
+  // The device list is left empty, so this transport binds exactly one
+  // endpoint. That is the case being contrasted against a peer that advertises
+  // two.
+  auto local = std::make_unique<TcpTransport>(
+      /*deviceId=*/-1,
+      evbThread_->getEventBase(),
+      registry_,
+      config,
+      /*host=*/"127.0.0.1");
+
+  const TransportInfo self = local->bind();
+  ASSERT_FALSE(self.empty());
+  auto peer = TcpTransportInfo::deserialize(self);
+  ASSERT_TRUE(peer.hasValue()) << peer.error().message();
+
+  TcpTransportInfo striped = peer.value();
+  striped.port = static_cast<uint16_t>(striped.port + 1);
+  striped.extraEndpoints.push_back({striped.host, striped.port});
+
+  const Status status = local->connect(striped.serialize());
+
+  ASSERT_TRUE(status.hasError())
+      << "a peer striping across more devices must be rejected, not silently "
+         "collapsed onto one NIC";
+  EXPECT_EQ(status.error().code(), ErrCode::InvalidArgument);
+  local->shutdown();
+}
+
+// numSockets below the device count would leave a bound listener with no lane.
+// Not covered here: reaching that guard requires two locally bound devices, so
+// it needs a host with two globally addressed NICs rather than a unit test.
 
 } // namespace uniflow

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
@@ -253,6 +253,10 @@ class TcpTransportFrameTest : public ::testing::Test {
         /*host=*/"127.0.0.1",
         cudaApi_);
 
+    // These tests drive the outbound path without connecting a peer, so give
+    // the transport the single lane that path indexes.
+    lane0();
+
     // A registered DRAM segment filled with a known pattern, so any
     // out-of-contract write is detectable.
     segment_.assign(kSegLen, std::byte{0xAB});
@@ -303,9 +307,9 @@ class TcpTransportFrameTest : public ::testing::Test {
   }
 
   /// True if the transport queued at least one Error frame back to the peer.
-  bool queuedErrorFrame() const {
-    std::lock_guard<std::mutex> lk(transport_->outMu_);
-    for (const auto& item : transport_->outQueue_) {
+  bool queuedErrorFrame() {
+    std::lock_guard<std::mutex> lk(lane0().mu);
+    for (const auto& item : lane0().queue) {
       auto header = deserializeTcpHeader(item.frame.bytes());
       if (header.hasValue() &&
           static_cast<TcpOp>(header.value().op) == TcpOp::Error) {
@@ -406,8 +410,8 @@ class TcpTransportFrameTest : public ::testing::Test {
   }
 
   size_t outQueueBytes() {
-    std::lock_guard<std::mutex> lk(transport_->outMu_);
-    return transport_->outBytes_;
+    std::lock_guard<std::mutex> lk(lane0().mu);
+    return lane0().bytes;
   }
 
   static constexpr size_t outQueueCap() {
@@ -421,12 +425,27 @@ class TcpTransportFrameTest : public ::testing::Test {
   // Far from the reqIds the tests pick by hand, so filler cannot collide.
   static constexpr uint64_t kFillReqIdBase = 1'000'000;
 
+  /// Lane 0, created on demand. These tests all run single-lane, so lane 0 is
+  /// the entire outbound queue and its cap equals kMaxOutQueueBytes.
+  TcpTransport::TcpLane& lane0() {
+    if (transport_->lanes_.empty()) {
+      transport_->lanes_.push_back(std::make_unique<TcpTransport::TcpLane>());
+    }
+    return *transport_->lanes_[0];
+  }
+
+  /// Installs `conn` as lane 0, creating the lane when the transport was never
+  /// connected.
+  void installLaneConn(std::unique_ptr<controller::Conn> conn) {
+    lane0().conn = std::move(conn);
+  }
+
   /// Installs a connection whose send() always fails, so senderLoop() can be
   /// driven down its error path without a peer.
   void installFailingConn() {
     auto conn = std::make_unique<FailingConn>();
     failingConn_ = conn.get();
-    transport_->dataConn_ = std::move(conn);
+    installLaneConn(std::move(conn));
   }
 
   bool connClosed() const {
@@ -447,7 +466,7 @@ class TcpTransportFrameTest : public ::testing::Test {
   }
 
   void runSenderLoop() {
-    transport_->senderLoop();
+    transport_->senderLoop(0);
   }
 
   /// Installs a connection whose send() parks until released, so the sender
@@ -455,7 +474,7 @@ class TcpTransportFrameTest : public ::testing::Test {
   GatedConn* installGatedConn() {
     auto conn = std::make_unique<GatedConn>();
     auto* raw = conn.get();
-    transport_->dataConn_ = std::move(conn);
+    installLaneConn(std::move(conn));
     return raw;
   }
 
@@ -464,7 +483,7 @@ class TcpTransportFrameTest : public ::testing::Test {
   CountingConn& installCountingConn() {
     auto conn = std::make_unique<CountingConn>();
     auto& ref = *conn;
-    transport_->dataConn_ = std::move(conn);
+    installLaneConn(std::move(conn));
     return ref;
   }
 
@@ -490,10 +509,10 @@ class TcpTransportFrameTest : public ::testing::Test {
   /// transport down.
   void closeOutQueue() {
     {
-      std::lock_guard<std::mutex> lk(transport_->outMu_);
-      transport_->outClosed_ = true;
+      std::lock_guard<std::mutex> lk(lane0().mu);
+      lane0().outClosed = true;
     }
-    transport_->outCv_.notify_all();
+    lane0().cv.notify_all();
   }
 
   /// A standalone pool, for the frame-ownership tests. Backed by the fixture's
@@ -662,8 +681,8 @@ class TcpTransportFrameTest : public ::testing::Test {
   /// reqIds of the frames currently queued, in queue order.
   std::vector<uint64_t> queuedReqIds() {
     std::vector<uint64_t> ids;
-    std::lock_guard<std::mutex> lk(transport_->outMu_);
-    for (const auto& item : transport_->outQueue_) {
+    std::lock_guard<std::mutex> lk(lane0().mu);
+    for (const auto& item : lane0().queue) {
       auto header = deserializeTcpHeader(item.frame.bytes());
       ids.push_back(header.hasValue() ? header.value().reqId : 0);
     }
@@ -697,8 +716,8 @@ class TcpTransportFrameTest : public ::testing::Test {
   }
 
   size_t outQueueDepth() {
-    std::lock_guard<std::mutex> lk(transport_->outMu_);
-    return transport_->outQueue_.size();
+    std::lock_guard<std::mutex> lk(lane0().mu);
+    return lane0().queue.size();
   }
 
   /// send()/recv() are gated on the Connected state; these tests drive the

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
@@ -13,6 +13,7 @@
 #include <future>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <thread>
 #include <vector>
 
@@ -293,6 +294,14 @@ class TcpTransportFrameTest : public ::testing::Test {
     transport_->handleFrame(frame);
   }
 
+  void feed(std::span<const uint8_t> frame, TcpPinnedSlab slab) {
+    transport_->handleFrame(frame, std::move(slab));
+  }
+
+  std::shared_ptr<TcpPinnedSlabPool> receivePool() {
+    return transport_->ensureReceivePool();
+  }
+
   /// True if the transport queued at least one Error frame back to the peer.
   bool queuedErrorFrame() const {
     std::lock_guard<std::mutex> lk(transport_->outMu_);
@@ -322,7 +331,8 @@ class TcpTransportFrameTest : public ::testing::Test {
   /// multi-chunk get() does. Chunk reqId 1 targets `dst`; the rest stand in for
   /// siblings whose replies have not arrived yet. VRAM so the copy runs through
   /// the mocked CudaApi. Returns the caller's future.
-  std::future<Status> postReadChunks(void* dst, size_t len, size_t chunks) {
+  std::future<Status>
+  postReadChunks(void* dst, size_t len, size_t chunks, void* stream = nullptr) {
     auto state = std::make_shared<TcpOpState>();
     state->remaining = chunks;
     auto future = state->promise.get_future();
@@ -335,7 +345,7 @@ class TcpTransportFrameTest : public ::testing::Test {
           /*isRead=*/true,
           MemoryType::VRAM,
           /*deviceId=*/0,
-          /*stream=*/nullptr};
+          stream};
     }
     return future;
   }
@@ -773,12 +783,158 @@ TEST_F(TcpTransportFrameTest, InBoundsWriteIsApplied) {
   EXPECT_FALSE(queuedErrorFrame());
 }
 
-// A READ_REPLY copies its payload into the caller's get() destination after
-// dropping inflightMu_. Resolving the op's future is what releases the caller
-// to free that destination, so the copy and the resolution must be one atomic
-// step. failAllPending() (send error, peer disconnect, shutdown) can resolve
-// the op mid-copy via a *sibling* chunk of the same multi-chunk get(), which
-// shares the op state -- a silent write-after-free.
+TEST(TcpOpStateTest, FailureWaitsForReservedWriteToRetire) {
+  TcpOpState state;
+  state.remaining = 1;
+  auto future = state.promise.get_future();
+
+  ASSERT_TRUE(state.tryBeginWrite());
+  state.fail(Err(ErrCode::ConnectionFailed, "test failure"));
+  EXPECT_EQ(
+      future.wait_for(std::chrono::milliseconds(0)),
+      std::future_status::timeout);
+
+  state.endWrite(Ok());
+  ASSERT_EQ(
+      future.wait_for(std::chrono::milliseconds(0)), std::future_status::ready);
+  const Status status = future.get();
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::ConnectionFailed);
+}
+
+TEST(TcpOpStateTest, SuccessfulReservedWritesCompleteTheOperation) {
+  TcpOpState state;
+  state.remaining = 2;
+  auto future = state.promise.get_future();
+
+  ASSERT_TRUE(state.tryBeginWrite());
+  ASSERT_TRUE(state.tryBeginWrite());
+  state.endWrite(Ok());
+  EXPECT_EQ(
+      future.wait_for(std::chrono::milliseconds(0)),
+      std::future_status::timeout);
+
+  state.endWrite(Ok());
+  EXPECT_FALSE(future.get().hasError());
+  EXPECT_FALSE(state.tryBeginWrite());
+}
+
+TEST(TcpOpStateTest, ReservedWriteFailureWinsAndResolvesExactlyOnce) {
+  TcpOpState state;
+  state.remaining = 2;
+  auto future = state.promise.get_future();
+
+  ASSERT_TRUE(state.tryBeginWrite());
+  ASSERT_TRUE(state.tryBeginWrite());
+  state.endWrite(Err(ErrCode::DriverError, "copy failed"));
+  EXPECT_EQ(
+      future.wait_for(std::chrono::milliseconds(0)),
+      std::future_status::timeout);
+
+  state.fail(Err(ErrCode::ConnectionFailed, "later failure"));
+  state.endWrite(Ok());
+  const Status status = future.get();
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::DriverError);
+}
+
+TEST(TcpOpStateTest, WriteReservationIsRefusedAfterFailure) {
+  TcpOpState state;
+  state.remaining = 1;
+  auto future = state.promise.get_future();
+
+  state.fail(Err(ErrCode::ConnectionFailed, "test failure"));
+  EXPECT_FALSE(state.tryBeginWrite());
+  EXPECT_TRUE(future.get().hasError());
+}
+
+TEST(TcpOpStateTest, ThrowingSynchronousWriteRetiresItsReservation) {
+  TcpOpState state;
+  state.remaining = 1;
+  auto future = state.promise.get_future();
+
+  EXPECT_THROW(
+      state.writeAndComplete(
+          []() -> Status { throw std::runtime_error("test exception"); }),
+      std::runtime_error);
+
+  ASSERT_EQ(
+      future.wait_for(std::chrono::milliseconds(0)), std::future_status::ready);
+  const Status status = future.get();
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::TransportError);
+  EXPECT_FALSE(state.tryBeginWrite());
+}
+
+TEST_F(TcpTransportFrameTest, AsyncReadReplyFailureWaitsForEventRetirement) {
+  constexpr size_t kLen = 64;
+  std::vector<uint8_t> dst(kLen, 0);
+  auto* const callerStream = reinterpret_cast<void*>(0xCA11);
+  // Chunk 2 remains in inflight_ so failAllPending() can latch an error while
+  // chunk 1's asynchronous destination write is still reserved.
+  auto future = postReadChunks(dst.data(), kLen, /*chunks=*/2, callerStream);
+
+  auto pool = receivePool();
+  ASSERT_NE(pool, nullptr);
+  auto slab = pool->tryAcquire(/*allowReserved=*/true);
+  ASSERT_TRUE(slab);
+  auto frame = makeFrame(TcpOp::ReadReply, kSegId, /*offset=*/0, kLen, kLen);
+  ASSERT_LE(frame.size(), slab.capacity());
+  std::memcpy(slab.data(), frame.data(), frame.size());
+  const auto bytes = std::span<const uint8_t>{slab.data(), frame.size()};
+
+  std::atomic<bool> copyDone{false};
+  EXPECT_CALL(
+      *cudaApi_,
+      memcpyAsync(
+          dst.data(),
+          ::testing::_,
+          kLen,
+          kMockMemcpyH2D,
+          static_cast<MockStream>(callerStream)))
+      .WillOnce([&](void* d, const void* s, size_t n, auto, auto) -> Status {
+        std::memcpy(d, s, n);
+        return Ok();
+      });
+  EXPECT_CALL(*cudaApi_, eventCreate(::testing::_))
+      .WillOnce([](auto* event) -> Status {
+        *event = {};
+        return Ok();
+      });
+  EXPECT_CALL(
+      *cudaApi_,
+      eventRecord(::testing::_, static_cast<MockStream>(callerStream)))
+      .WillOnce(::testing::Return(Ok()));
+  EXPECT_CALL(*cudaApi_, eventQuery(::testing::_))
+      .WillRepeatedly([&](auto) -> Result<bool> {
+        return copyDone.load(std::memory_order_acquire);
+      });
+  EXPECT_CALL(*cudaApi_, eventDestroy(::testing::_))
+      .WillOnce(::testing::Return(Ok()));
+  EXPECT_CALL(*cudaApi_, streamSynchronize(::testing::_)).Times(0);
+
+  feed(bytes, std::move(slab));
+  auto onlyFreeSlab = pool->tryAcquire(/*allowReserved=*/true);
+  ASSERT_TRUE(onlyFreeSlab);
+  failAllPending();
+
+  EXPECT_EQ(
+      future.wait_for(std::chrono::milliseconds(100)),
+      std::future_status::timeout)
+      << "the failure must remain latched until the async destination write "
+         "retires";
+  EXPECT_FALSE(pool->tryAcquire(/*allowReserved=*/true));
+
+  copyDone.store(true, std::memory_order_release);
+  ASSERT_EQ(
+      future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  EXPECT_TRUE(future.get().hasError());
+  EXPECT_EQ(dst, std::vector<uint8_t>(kLen, uint8_t{0xCD}));
+}
+
+// A vector-backed READ_REPLY still copies synchronously. Resolving the op's
+// future is what releases the caller to free its destination, so that fallback
+// copy and completion remain one atomic lifetime reservation.
 TEST_F(TcpTransportFrameTest, ReadReplyCopyKeepsTheGetUnresolvedWhileItRuns) {
   constexpr size_t kLen = 64;
   std::vector<uint8_t> dst(kLen, 0);
@@ -1332,6 +1488,52 @@ TEST_F(TcpTransportFrameTest, ADeferredReadStillBlocksDeregistration) {
   EXPECT_EQ(stagedCopyCount(), 0u)
       << "a discarded deferred read must not have started a copy into memory "
          "that is being torn down";
+}
+
+// A thread parked in the staging pool's blocking acquire() must be released by
+// shutdown(). acquire() waits on `freed_` with no deadline and `closed_` as its
+// only escape, and it runs on the application's own put() thread -- which
+// shutdown() never joins and nothing else wakes. Before shutdown() closed this
+// pool, a put() in flight across teardown parked forever, because the sender
+// that would have returned a staging slab was joined away first.
+//
+// Written against the pool directly rather than through put(): reaching the
+// blocking acquire() through put() needs a live peer and a full wave, and the
+// property under test belongs to shutdown()'s ordering, not to the put path.
+TEST_F(TcpTransportFrameTest, ShutdownReleasesAThreadParkedInStagingAcquire) {
+  setConnected();
+  stubStagingCopies();
+
+  auto pool = transportStagingPool();
+  ASSERT_NE(pool, nullptr);
+
+  // Hold every slab so the acquire below cannot be satisfied.
+  std::vector<TcpPinnedSlab> held;
+  held.reserve(pool->slabCount());
+  for (size_t i = 0; i < pool->slabCount(); ++i) {
+    held.push_back(pool->tryAcquire(/*allowReserved=*/true));
+    ASSERT_TRUE(static_cast<bool>(held.back()));
+  }
+
+  std::atomic<bool> returned{false};
+  std::thread parked([&]() {
+    // Blocks: nothing is free, and this test never releases `held`.
+    auto leases = pool->acquire(1);
+    // Either outcome is fine; the point is that it *returns*.
+    (void)leases;
+    returned.store(true, std::memory_order_release);
+  });
+
+  // Give it time to reach the wait rather than racing the assertion below.
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  ASSERT_FALSE(returned.load(std::memory_order_acquire))
+      << "precondition: the acquire must actually be parked";
+
+  transport_->shutdown();
+  parked.join();
+  EXPECT_TRUE(returned.load(std::memory_order_acquire))
+      << "shutdown() must close the staging pool; otherwise a put() in flight "
+         "across teardown never comes back";
 }
 
 // A read the pool cannot serve and the deferred queue cannot hold is answered


### PR DESCRIPTION
Summary:

Folded from two adjacent diffs; each half is stated separately below so the two
arguments stay reviewable on their own terms.

 --- count lanes per NIC (was D117721988) -------------------------------------

`numSockets` was the total lane count for a connection, so striping divided it:
the default 4 gave 4 lanes on one NIC and still only 4 across two, two lanes per
device. That is the configuration measured at 27.6 GB/s with both NICs half-fed,
against ~35 GB/s for 8 lanes. Reaching the striped number required every caller
to know to double the value, and nothing enforced it -- the only guard was that
lanes must not fall *below* the device count.

The lane count is now per device: `laneCount = numSocketsPerDevice * devices`.
The default 4 gives 4 lanes on one NIC, unchanged, and 8 across two. The field
and CLI flag are renamed (`numSocketsPerDevice`, `--tcp-sockets-per-nic`) because
the value's meaning changed; leaving the old names would let a stale
`--tcp-num-sockets 8` silently become 16 lanes.

Two consequences fall out of the arithmetic:
- The `kMaxLanes` 255 cap now applies to the product, not the configured value,
  since the lane hello addresses lanes with a uint8_t.
- The "lanes below device count" guard is unreachable: the product is always at
  least the device count. Removed, along with the test comment describing it.

Because 4 lanes per device is what the per-NIC ceiling measurement actually
supports -- one 200G NIC saturates near 4 lanes at ~21 GB/s -- per-device is also
the unit the default was always implicitly expressed in.

 --- widen the hello fields that count forced (was D117726316) ----------------

`kMaxLanes` was 255 because `TcpLaneHello::laneIndex` and `laneCount` were each a
`uint8_t`. That ceiling now binds sooner than it used to: lanes are counted per
device, so the total is `numSocketsPerDevice * devices` and the device count
contributes to it, rather than the total being something a caller states
directly.

Both fields become `uint16_t` and the spare `rsvd` byte goes away, taking the
struct from 16 to 17 bytes and its static_assert with it. `kMaxLanes` is raised
to 1024.

Raising the constant alone would have been silently wrong rather than merely
insufficient: the send path casts with `static_cast<uint8_t>(i)`, so lane 256
would have gone out as index 0, two lanes would have claimed the same slot, and
the listener would have mis-paired sockets with no error anywhere.

kTcpWireVersion is deliberately not bumped. The hello is only exchanged when
more than one lane is configured, so a single-lane transport stays byte-identical
to a peer built before lanes existed, and only multi-lane peers read these bytes
-- the same reasoning already recorded on the struct for why adding it did not
need a version bump. Multi-lane peers across this change do not interoperate,
which is acceptable while that code is unlanded.

Differential Revision: D117721988
