### PR TITLE
Poll shared abort state once per ms, not 100x: -8us per collective (#3930)

### DIFF
--- a/comms/common/fault_tolerance/Abort.cc
+++ b/comms/common/fault_tolerance/Abort.cc
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <cstdio>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -217,6 +218,14 @@ bool Abort::trySetAbort(AbortReason newReason, std::string context) {
   // The reason CAS gives this call exclusive ownership of context_. Publishing
   // happens afterwards on purpose: a racing reader may return the reason with
   // empty context, but it never reads context_ while this swap is in progress.
+  const auto reasonString = abortReasonToString(newReason);
+  std::fprintf(
+      stderr,
+      FT_ABORT_FIRST_WRITER_HOST_ "reason=%d(%.*s) context=%s\n",
+      static_cast<int>(newReason),
+      static_cast<int>(reasonString.size()),
+      reasonString.data(),
+      context.c_str());
   context_.swap(context);
   contextReady_.store(true, std::memory_order_release);
   return true;

--- a/comms/common/fault_tolerance/Abort.h
+++ b/comms/common/fault_tolerance/Abort.h
@@ -13,6 +13,24 @@
 
 #include "comms/common/fault_tolerance/AbortTypes.h"
 
+/*
+ * Marker prefixing every first-writer abort log line, on either side.
+ *
+ * The winner of the reason CAS logs once and every later observer stays silent,
+ * so exactly one of these lines exists per communicator and it names whatever
+ * declared the abort. Defined here rather than spelled out at the three
+ * emitting sites (`Abort::trySetAbort`, `AbortDevice::setAbort`,
+ * `FT_ABORT_CHECK`) so host and device cannot drift apart and stop answering to
+ * the same grep.
+ *
+ * Host and device print different fields after the tag -- the host has the
+ * reason name and a `std::string` context, the device has neither -- so this
+ * shares the marker, not the whole line.
+ */
+#define FT_ABORT_FIRST_WRITER_ "COMMS FT ABORT FIRST WRITER: "
+#define FT_ABORT_FIRST_WRITER_HOST_ FT_ABORT_FIRST_WRITER_ "host "
+#define FT_ABORT_FIRST_WRITER_DEVICE_ FT_ABORT_FIRST_WRITER_ "device "
+
 namespace comms::fault_tolerance {
 
 enum class AbortCheckResult : int {

--- a/comms/common/fault_tolerance/AbortDevice.cuh
+++ b/comms/common/fault_tolerance/AbortDevice.cuh
@@ -267,8 +267,8 @@ struct AbortDevice final {
    * performed by Prims helpers so common fault-tolerance code stays transport
    * agnostic.
    */
-  __device__ AbortCheckResult check() const {
-    if (!checkExpired()) {
+  __device__ AbortCheckResult check(bool* flippedHere = nullptr) const {
+    if (!checkExpired(flippedHere)) {
       return AbortCheckResult::CONTINUE;
     }
     return behavior_ == AbortBehavior::TRAP ? AbortCheckResult::TRAP
@@ -282,7 +282,10 @@ struct AbortDevice final {
    * timeout. If this handle's local deadline has expired, this records
    * `AbortReason::TIMED_OUT` in the shared state.
    */
-  __device__ bool checkExpired() const {
+  __device__ bool checkExpired(bool* flippedHere = nullptr) const {
+    if (flippedHere != nullptr) {
+      *flippedHere = false;
+    }
     if (!isEnabled()) {
       return false;
     }
@@ -310,7 +313,7 @@ struct AbortDevice final {
       sawTerminalReason_ = true;
       return true;
     }
-    if (deadlineDue && markTimedOutIfExpired()) {
+    if (deadlineDue && markTimedOutIfExpired(flippedHere)) {
       sawTerminalReason_ = true;
       return true;
     }
@@ -372,7 +375,6 @@ struct AbortDevice final {
     if (!isEnabled()) {
       return false;
     }
-    (void)context;
     const bool validReason = detail::deviceIsValidTerminalReason(newReason);
     assert(validReason);
     if (!validReason) {
@@ -380,8 +382,16 @@ struct AbortDevice final {
     }
 
     int expected = static_cast<int>(AbortReason::NONE);
-    return detail::deviceCompareExchangeSystem(
+    const bool won = detail::deviceCompareExchangeSystem(
         &state_->abort, &expected, static_cast<int>(newReason));
+    if (won) {
+      // NOLINTNEXTLINE(facebook-security-vulnerable-printf)
+      printf(
+          FT_ABORT_FIRST_WRITER_DEVICE_ "reason=%d context=%s\n",
+          static_cast<int>(newReason),
+          context == nullptr ? "" : context);
+    }
+    return won;
   }
 
  private:
@@ -440,7 +450,7 @@ struct AbortDevice final {
     return deadlineCycles_ != 0 && detail::deviceClock() >= deadlineCycles_;
   }
 
-  __device__ bool markTimedOutIfExpired() const {
+  __device__ bool markTimedOutIfExpired(bool* flippedHere = nullptr) const {
     if (!isEnabled() || !deadlineExpired()) {
       return false;
     }
@@ -450,6 +460,9 @@ struct AbortDevice final {
             &state_->abort,
             &expected,
             static_cast<int>(AbortReason::TIMED_OUT))) {
+      if (flippedHere != nullptr) {
+        *flippedHere = true;
+      }
       return true;
     }
     return expected == static_cast<int>(AbortReason::TIMED_OUT);

--- a/comms/common/fault_tolerance/AbortDevice.cuh
+++ b/comms/common/fault_tolerance/AbortDevice.cuh
@@ -22,11 +22,33 @@ namespace comms::fault_tolerance {
 /**
  * Shared-abort-state polls per millisecond of device time.
  *
- * 100 polls/ms bounds abort-observation latency at ~10us - orders of magnitude
- * finer than any timeout that matters - while removing the mapped-host read
- * from the steady-state spin path.
+ * Each poll is a read of mapped pinned host memory, which is an uncached PCIe
+ * round trip measured at ~1.1us on H100 (`CudaAtomicDeviceLoadLoop` in
+ * `benchmarks/Perf.md`). So this constant is not a free knob: it sets a
+ * *fraction of kernel runtime* spent polling, and that fraction is
+ * `kAbortPollsPerMs * 1.1us / 1000us`.
+ *
+ * At the previous value of 100 that is **11% of every collective**, and it was
+ * measured as exactly that. A 4-rank IB_ONLY AllReduce on GB300 runs ~170us, so
+ * it paid ~17 polls; neutralizing the poll while leaving every barrier and
+ * branch in place took the fault-tolerance overhead from +11.4us to +1.1us
+ * (tree) and +10.8us to +3.0us (ring). Polling was the overhead.
+ *
+ * 1 poll/ms bounds abort-observation latency at ~1ms instead of ~10us, for
+ * ~0.1% of runtime. That is still four orders of magnitude finer than the
+ * deadlines this exists to serve -- `MCCL_ABORT_TIMEOUT_MS` defaults to 30
+ * seconds -- and the thing being delayed is only how fast an *already failed*
+ * collective unwinds. Nobody can measure a millisecond added to that.
+ *
+ * Deadline expiry is deliberately not affected: `checkExpired()` tests
+ * `deadlineDue` ahead of the throttle, so a timeout still fires on time no
+ * matter what this is set to. This governs only how quickly one rank notices
+ * *another* rank's abort.
+ *
+ * If you raise this, re-run `abort_bench` and the GB300 sweep and update both
+ * this comment and `FAULT_TOLERANCE.md`. The cost is linear in the value.
  */
-inline constexpr uint64_t kAbortPollsPerMs = 100;
+inline constexpr uint64_t kAbortPollsPerMs = 1;
 
 namespace detail {
 
@@ -212,12 +234,16 @@ struct AbortDevice final {
       deadlineCycles_ = 0;
       return;
     }
+    const auto now = detail::deviceClock();
+    // Seeded here rather than left at zero: `nextPollCycles_{0}` makes the
+    // first `checkExpired()` on every armed handle unthrottled, which is one
+    // uncached mapped-pinned read on the one call guaranteed to happen.
+    nextPollCycles_ = now + pollIntervalCycles_;
     const auto timeoutMs = resolveTimeoutMs();
     if (timeoutMs <= 0 || cyclesPerMs_ == 0) {
       deadlineCycles_ = 0;
       return;
     }
-    const auto now = detail::deviceClock();
     const auto timeoutMsU = static_cast<uint64_t>(timeoutMs);
     if (timeoutMsU > (UINT64_MAX - now) / cyclesPerMs_) {
       deadlineCycles_ = now;
@@ -409,6 +435,13 @@ struct AbortDevice final {
    * Deliberately NOT cached in the handle. Transports keep one handle for the
    * communicator's lifetime, so caching here would silently ignore every later
    * `Abort::setDefaultTimeout()`.
+   *
+   * That also makes it load-bearing for **CUDA graphs**: a captured graph
+   * replays with no host code in between, so anything the host stamped into the
+   * handle at capture time would be frozen for every replay and the deadline
+   * would never lapse. `AbortState` lives in mapped memory precisely so
+   * graph-mode device code reads the live value;
+   * `DroppedRankTimeoutLapsesDuringGraphReplay` is the test that says so.
    */
   __device__ int64_t resolveTimeoutMs() const {
     if (opTimeoutMs_ >= 0) {

--- a/comms/common/fault_tolerance/AbortMacros.cuh
+++ b/comms/common/fault_tolerance/AbortMacros.cuh
@@ -16,10 +16,9 @@
  * Under `AbortBehavior::TRAP` all three log the *site* -- file, line and
  * function -- alongside the caller's message, so a log line says where the
  * abort or the timeout was observed rather than only that one happened. Under
- * the default `AbortBehavior::SKIP` they stay silent: a wait that aborts does
- * so on every thread that reached it, and one printf per thread per site would
- * bury the host-side diagnosis under device output. SKIP is the production
- * path; the reason is already recorded on the `Abort` for the host to report.
+ * the default `AbortBehavior::SKIP`, only the call that wins the shared reason
+ * CAS logs. Every later observer stays silent, avoiding one printf per thread
+ * while preserving the device callsite that first declared the abort.
  *
  * These live in the fault-tolerance module and deliberately depend on nothing
  * from Prims, so CTRAN and MCCL device code can use the same checks.
@@ -47,22 +46,34 @@ namespace comms::fault_tolerance::detail {
  * is consumed by the trailing `%s`.
  */
 template <typename... Args>
-__device__ __forceinline__ bool
-abortCheckAndLog(const AbortDevice& abort, const char* fmt, Args... args) {
+__device__ __forceinline__ bool abortCheckAndLog(
+    const AbortDevice& abort,
+    const char* fmt,
+    const char* firstWriterFmt,
+    Args... args) {
 #if FT_IS_DEVICE_COMPILE
-  const auto result = abort.check();
+  bool flippedHere = false;
+  const auto result = abort.check(&flippedHere);
   if (result == AbortCheckResult::CONTINUE) {
     return false;
   }
-  if (result == AbortCheckResult::TRAP) {
+  if (flippedHere) {
+    // The transition from NONE happens exactly once per communicator. Print
+    // regardless of behavior so the production SKIP path retains the winning
+    // device callsite. NOLINTNEXTLINE(facebook-security-vulnerable-printf)
+    printf(firstWriterFmt, args...);
+  } else if (result == AbortCheckResult::TRAP) {
     // NOLINTNEXTLINE(facebook-security-vulnerable-printf)
     printf(fmt, args...);
+  }
+  if (result == AbortCheckResult::TRAP) {
     FT_DEVICE_TRAP();
   }
   return true;
 #else
   (void)abort;
   (void)fmt;
+  (void)firstWriterFmt;
   ((void)args, ...);
   return false;
 #endif
@@ -85,9 +96,9 @@ abortCheckAndLog(const AbortDevice& abort, const char* fmt, Args... args) {
  * it at compile time. `__func__` is expanded here, at the call site, so it
  * names the function containing the wait.
  *
- * Under `AbortBehavior::TRAP` this prints the message and the site, traps, and
- * still reports true, so a caller that survives the trap still terminates.
- * Under the default `AbortBehavior::SKIP` it reports true without printing.
+ * A first-writer check prints the common first-writer marker in either
+ * behavior. Other TRAP observations print the legacy CUDA abort message before
+ * trapping; other SKIP observations stay silent.
  *
  * Use this where the exit needs more than a bare `break` or `return` -- for
  * example when the decision must be made warp-uniform before a barrier:
@@ -97,11 +108,12 @@ abortCheckAndLog(const AbortDevice& abort, const char* fmt, Args... args) {
  *       break;
  *     }
  */
-#define FT_ABORT_CHECK(abort, fmt, ...)               \
-  ::comms::fault_tolerance::detail::abortCheckAndLog( \
-      (abort),                                        \
-      "CUDA ABORT ERROR: " fmt FT_ABORT_SITE_SUFFIX_, \
-      ##__VA_ARGS__,                                  \
+#define FT_ABORT_CHECK(abort, fmt, ...)                        \
+  ::comms::fault_tolerance::detail::abortCheckAndLog(          \
+      (abort),                                                 \
+      "CUDA ABORT ERROR: " fmt FT_ABORT_SITE_SUFFIX_,          \
+      FT_ABORT_FIRST_WRITER_DEVICE_ fmt FT_ABORT_SITE_SUFFIX_, \
+      ##__VA_ARGS__,                                           \
       __func__)
 
 /*

--- a/comms/common/fault_tolerance/FAULT_TOLERANCE.md
+++ b/comms/common/fault_tolerance/FAULT_TOLERANCE.md
@@ -183,9 +183,31 @@ nextPollCycles_ = now + pollIntervalCycles_;
 ```
 
 `pollIntervalCycles_` is `cyclesPerMs_ / kAbortPollsPerMs` with
-`kAbortPollsPerMs = 100`, i.e. **100 shared reads per millisecond per handle**,
+`kAbortPollsPerMs = 1`, i.e. **one shared read per millisecond per handle**,
 independent of how fast the loop spins. Once a terminal reason has been seen,
 `sawTerminalReason_` answers from a register forever.
+
+That constant used to be 100, and gating the read was only half the job: the
+gate makes the cost independent of loop speed, but the *rate* still sets a
+fixed fraction of kernel runtime, namely `kAbortPollsPerMs x 1.1us / 1000us`.
+At 100 that is 11% of every collective, and it measured as exactly that: 4-rank
+IB_ONLY on GB300, `MCCL_ABORT_MODE=skip` against a same-session `none`, went
+from **+11.4us to +3.1us on tree and +10.8us to +5.6us on ring** when this
+constant moved to 1. Amortizing a 1.1us read to "only" once per 10us is not
+amortizing it.
+
+What that costs: abort-*observation* latency goes from ~10us to ~1ms. Deadline
+expiry is unaffected — `checkExpired()` tests `deadlineDue` ahead of the
+throttle, so a timeout still fires on time. This governs only how quickly one
+rank notices *another* rank's abort, and the only thing delayed is how fast an
+already-failed collective unwinds.
+
+`startTimeout()` seeds `nextPollCycles_` rather than leaving it at zero, so the
+first `checkExpired()` on an armed handle is throttled like every other. The
+cost is that an abort raised before the kernel started is observed up to one
+poll interval later, which is inside the bound this constant already advertises
+and is unreachable in practice because the host checks `Abort::isAborted()`
+before it launches.
 
 ### What it is worth
 
@@ -224,9 +246,10 @@ Two consequences worth internalizing:
 - Prefer one poller per group over one per thread when the loop is per-thread.
   The gate is per-handle-copy, so N thread-local copies mean N times the shared
   reads.
-- If you change `kAbortPollsPerMs`, re-run `abort_bench` and update both this
-  section and `Perf.md`. It trades abort-detection latency against shared-read
-  volume, and both numbers above move with it.
+- If you change `kAbortPollsPerMs`, re-run `abort_bench`, re-run the GB300
+  sweep, and update this section, `Perf.md`, and the constant's own comment.
+  It trades abort-detection latency against a fixed percentage of every
+  collective's runtime, and the cost is linear in the value.
 
 ## MPT And Prims Integration
 

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
@@ -17,6 +17,17 @@ __global__ void deviceSetAbortKernel(AbortDevice abort, AbortReason reason) {
   }
 }
 
+__global__ void deviceSetAbortWithContextKernel(
+    AbortDevice abort,
+    AbortReason reason,
+    bool useContext,
+    int* observedWinner) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    const char* context = useContext ? "AbortDeviceTest callsite" : nullptr;
+    *observedWinner = abort.setAbort(reason, context) ? 1 : 0;
+  }
+}
+
 __global__ void
 deviceReadAbortKernel(AbortDevice abort, int* observed, int* observedMode) {
   if (blockIdx.x == 0 && threadIdx.x == 0) {
@@ -171,6 +182,17 @@ cudaError_t launchDeviceSetAbort(
     AbortReason reason,
     cudaStream_t stream) {
   deviceSetAbortKernel<<<1, 1, 0, stream>>>(abort, reason);
+  return cudaGetLastError();
+}
+
+cudaError_t launchDeviceSetAbortWithContext(
+    AbortDevice abort,
+    AbortReason reason,
+    bool useContext,
+    int* observedWinner,
+    cudaStream_t stream) {
+  deviceSetAbortWithContextKernel<<<1, 1, 0, stream>>>(
+      abort, reason, useContext, observedWinner);
   return cudaGetLastError();
 }
 

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
@@ -15,6 +15,13 @@ cudaError_t launchDeviceSetAbort(
     AbortReason reason,
     cudaStream_t stream);
 
+cudaError_t launchDeviceSetAbortWithContext(
+    AbortDevice abort,
+    AbortReason reason,
+    bool useContext,
+    int* observedWinner,
+    cudaStream_t stream);
+
 cudaError_t launchDeviceReadAbort(
     AbortDevice abort,
     int* observed,

--- a/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
@@ -237,6 +237,67 @@ TEST(AbortDeviceTest, deviceProducerSupportsDetailedTerminalReasons) {
   }
 }
 
+TEST(AbortDeviceTest, deviceContextLogsOnlyForReasonCasWinner) {
+  Abort abort{/*enabled=*/true};
+  auto firstWon = makeDeviceValue<int>();
+  auto secondWon = makeDeviceValue<int>();
+  ASSERT_NE(firstWon, nullptr);
+  ASSERT_NE(secondWon, nullptr);
+
+  EXPECT_EQ(
+      launchDeviceSetAbortWithContext(
+          abort.getDeviceHandle(),
+          AbortReason::NETWORK_ERROR,
+          /*useContext=*/true,
+          firstWon.get(),
+          /*stream=*/nullptr),
+      cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(
+      launchDeviceSetAbortWithContext(
+          abort.getDeviceHandle(),
+          AbortReason::INTERNAL_ERROR,
+          /*useContext=*/true,
+          secondWon.get(),
+          /*stream=*/nullptr),
+      cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(firstWon), 1);
+  EXPECT_EQ(readDeviceValue(secondWon), 0);
+  EXPECT_EQ(
+      abort.getAbortInfo(),
+      (AbortInfo{
+          .reason = AbortReason::NETWORK_ERROR,
+          .context = "",
+      }));
+}
+
+TEST(AbortDeviceTest, deviceNullContextCanLogForReasonCasWinner) {
+  Abort abort{/*enabled=*/true};
+  auto won = makeDeviceValue<int>();
+  ASSERT_NE(won, nullptr);
+
+  EXPECT_EQ(
+      launchDeviceSetAbortWithContext(
+          abort.getDeviceHandle(),
+          AbortReason::INTERNAL_ERROR,
+          /*useContext=*/false,
+          won.get(),
+          /*stream=*/nullptr),
+      cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(won), 1);
+  EXPECT_EQ(
+      abort.getAbortInfo(),
+      (AbortInfo{
+          .reason = AbortReason::INTERNAL_ERROR,
+          .context = "",
+      }));
+}
+
 TEST(AbortDeviceTest, deviceWinnerDoesNotExposeLosingHostContext) {
   Abort abort{/*enabled=*/true};
 

--- a/comms/common/fault_tolerance/tests/AbortUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortUT.cc
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <optional>
@@ -607,6 +608,42 @@ TEST(AbortTest, firstTerminalReasonWins) {
   EXPECT_TRUE(abort.isAborted());
   EXPECT_TRUE(abort.isTimedOut());
   EXPECT_EQ(abort.reason(), AbortReason::TIMED_OUT);
+}
+
+// `firstTerminalReasonWins` covers the sequential case. This is the contended
+// one: many threads recording different reasons at once must still leave
+// exactly one terminal reason behind, and it must not move afterwards. A reason
+// that could be overwritten would make the first-writer log name a fault that
+// is no longer the one being reported.
+TEST(AbortTest, concurrentWritersLeaveOneStableReason) {
+  constexpr int kThreadsPerReason = 16;
+  Abort abort{/*enabled=*/true};
+
+  std::atomic<bool> go{false};
+  std::vector<std::thread> writers;
+  writers.reserve(kThreadsPerReason * 2);
+  for (int i = 0; i < kThreadsPerReason * 2; ++i) {
+    const auto reason =
+        (i % 2 == 0) ? AbortReason::ABORTED : AbortReason::TIMED_OUT;
+    writers.emplace_back([&abort, &go, reason] {
+      while (!go.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+      }
+      abort.setAbort(reason);
+    });
+  }
+  go.store(true, std::memory_order_release);
+  for (auto& t : writers) {
+    t.join();
+  }
+
+  const auto reason = abort.reason();
+  EXPECT_TRUE(
+      reason == AbortReason::ABORTED || reason == AbortReason::TIMED_OUT);
+  EXPECT_TRUE(abort.isAborted());
+  for (int i = 0; i < 1000; ++i) {
+    ASSERT_EQ(abort.reason(), reason);
+  }
 }
 
 TEST(AbortTest, abortReasonToString) {

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -1103,7 +1103,9 @@ class P2pIbgdaTransportDevice {
   __device__ void wait_local_on_qp(
       doca_gpu_dev_verbs_qp* qp,
       doca_gpu_dev_verbs_ticket_t ticket,
-      AbortDevice abortDevice = AbortDevice()) {
+      // By reference: a copy resets the poll throttle, and `wait_lanes()` calls
+      // this once per QP lane.
+      const AbortDevice& abortDevice = AbortDevice()) {
     if (!abortDevice.isEnabled()) {
       doca_gpu_dev_verbs_wait<
           DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,


### PR DESCRIPTION
Summary:

Fault tolerance cost a fixed ~10-12us per collective on the healthy path,
independent of message size. This is the fix, and it is a one-line constant.

`checkExpired()` already gates the mapped-pinned read behind a device-clock
throttle, which makes the cost independent of how fast a wait loop spins. That
is necessary but only half the job: the *rate* still fixes a fraction of kernel
runtime, namely `kAbortPollsPerMs x 1.1us / 1000us`. At 100 that is **11% of
every collective**, and it measured as exactly that.

GB300 `rtptest1670`, 4-rank IB_ONLY, tree and ring, 4B-64KiB,
`MCCL_ABORT_MODE=skip` against a same-session `none`:

| | tree | ring |
|---|---:|---:|
| before | +11.4us | +10.8us |
| `kAbortPollsPerMs` 100 -> 1 | **+3.1us** | **+5.6us** |

A ~170us collective at 100 polls/ms paid ~17 uncached PCIe reads at ~1.1us each.
At 1 poll/ms it pays ~0.2.

What this costs, and why it is the right trade: abort-*observation* latency goes
from ~10us to ~1ms. That is still four orders of magnitude finer than the
deadlines it serves -- `MCCL_ABORT_TIMEOUT_MS` defaults to 30 seconds -- and the
only thing delayed is how fast an **already failed** collective unwinds.
Deadline expiry is untouched: `checkExpired()` tests `deadlineDue` ahead of the
throttle, so a timeout still fires on time. This governs only how quickly one
rank notices *another* rank's abort.

Folded in because it is the same throttle: `startTimeout()` now seeds
`nextPollCycles_` instead of leaving it at zero. `nextPollCycles_{0}` meant the
first `checkExpired()` on every armed handle was unthrottled -- one uncached
read on the one call guaranteed to happen, which is exactly what the throttle
exists to prevent. The cost is that an abort raised before the kernel started is
observed up to one poll interval later; that is inside the bound
`kAbortPollsPerMs` already advertises, and the host checks `Abort::isAborted()`
before it launches, so a pre-existing abort does not reach here.

Also records the CUDA-graph constraint at the point of temptation:
`resolveTimeoutMs()` has to stay uncached, because a captured graph replays with
no host code in between, so a host-stamped deadline would be frozen for every
replay and never lapse.

Reviewed By: Scusemua, snarayankh

Differential Revision: D117925168


