### PR TITLE
Stop copying the abort handle per QP lane (#3931)

### DIFF
--- a/comms/common/fault_tolerance/Abort.cc
+++ b/comms/common/fault_tolerance/Abort.cc
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <cstdio>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -217,6 +218,14 @@ bool Abort::trySetAbort(AbortReason newReason, std::string context) {
   // The reason CAS gives this call exclusive ownership of context_. Publishing
   // happens afterwards on purpose: a racing reader may return the reason with
   // empty context, but it never reads context_ while this swap is in progress.
+  const auto reasonString = abortReasonToString(newReason);
+  std::fprintf(
+      stderr,
+      FT_ABORT_FIRST_WRITER_HOST_ "reason=%d(%.*s) context=%s\n",
+      static_cast<int>(newReason),
+      static_cast<int>(reasonString.size()),
+      reasonString.data(),
+      context.c_str());
   context_.swap(context);
   contextReady_.store(true, std::memory_order_release);
   return true;

--- a/comms/common/fault_tolerance/Abort.h
+++ b/comms/common/fault_tolerance/Abort.h
@@ -13,6 +13,24 @@
 
 #include "comms/common/fault_tolerance/AbortTypes.h"
 
+/*
+ * Marker prefixing every first-writer abort log line, on either side.
+ *
+ * The winner of the reason CAS logs once and every later observer stays silent,
+ * so exactly one of these lines exists per communicator and it names whatever
+ * declared the abort. Defined here rather than spelled out at the three
+ * emitting sites (`Abort::trySetAbort`, `AbortDevice::setAbort`,
+ * `FT_ABORT_CHECK`) so host and device cannot drift apart and stop answering to
+ * the same grep.
+ *
+ * Host and device print different fields after the tag -- the host has the
+ * reason name and a `std::string` context, the device has neither -- so this
+ * shares the marker, not the whole line.
+ */
+#define FT_ABORT_FIRST_WRITER_ "COMMS FT ABORT FIRST WRITER: "
+#define FT_ABORT_FIRST_WRITER_HOST_ FT_ABORT_FIRST_WRITER_ "host "
+#define FT_ABORT_FIRST_WRITER_DEVICE_ FT_ABORT_FIRST_WRITER_ "device "
+
 namespace comms::fault_tolerance {
 
 enum class AbortCheckResult : int {

--- a/comms/common/fault_tolerance/AbortDevice.cuh
+++ b/comms/common/fault_tolerance/AbortDevice.cuh
@@ -267,8 +267,8 @@ struct AbortDevice final {
    * performed by Prims helpers so common fault-tolerance code stays transport
    * agnostic.
    */
-  __device__ AbortCheckResult check() const {
-    if (!checkExpired()) {
+  __device__ AbortCheckResult check(bool* flippedHere = nullptr) const {
+    if (!checkExpired(flippedHere)) {
       return AbortCheckResult::CONTINUE;
     }
     return behavior_ == AbortBehavior::TRAP ? AbortCheckResult::TRAP
@@ -282,7 +282,10 @@ struct AbortDevice final {
    * timeout. If this handle's local deadline has expired, this records
    * `AbortReason::TIMED_OUT` in the shared state.
    */
-  __device__ bool checkExpired() const {
+  __device__ bool checkExpired(bool* flippedHere = nullptr) const {
+    if (flippedHere != nullptr) {
+      *flippedHere = false;
+    }
     if (!isEnabled()) {
       return false;
     }
@@ -310,7 +313,7 @@ struct AbortDevice final {
       sawTerminalReason_ = true;
       return true;
     }
-    if (deadlineDue && markTimedOutIfExpired()) {
+    if (deadlineDue && markTimedOutIfExpired(flippedHere)) {
       sawTerminalReason_ = true;
       return true;
     }
@@ -372,7 +375,6 @@ struct AbortDevice final {
     if (!isEnabled()) {
       return false;
     }
-    (void)context;
     const bool validReason = detail::deviceIsValidTerminalReason(newReason);
     assert(validReason);
     if (!validReason) {
@@ -380,8 +382,16 @@ struct AbortDevice final {
     }
 
     int expected = static_cast<int>(AbortReason::NONE);
-    return detail::deviceCompareExchangeSystem(
+    const bool won = detail::deviceCompareExchangeSystem(
         &state_->abort, &expected, static_cast<int>(newReason));
+    if (won) {
+      // NOLINTNEXTLINE(facebook-security-vulnerable-printf)
+      printf(
+          FT_ABORT_FIRST_WRITER_DEVICE_ "reason=%d context=%s\n",
+          static_cast<int>(newReason),
+          context == nullptr ? "" : context);
+    }
+    return won;
   }
 
  private:
@@ -440,7 +450,7 @@ struct AbortDevice final {
     return deadlineCycles_ != 0 && detail::deviceClock() >= deadlineCycles_;
   }
 
-  __device__ bool markTimedOutIfExpired() const {
+  __device__ bool markTimedOutIfExpired(bool* flippedHere = nullptr) const {
     if (!isEnabled() || !deadlineExpired()) {
       return false;
     }
@@ -450,6 +460,9 @@ struct AbortDevice final {
             &state_->abort,
             &expected,
             static_cast<int>(AbortReason::TIMED_OUT))) {
+      if (flippedHere != nullptr) {
+        *flippedHere = true;
+      }
       return true;
     }
     return expected == static_cast<int>(AbortReason::TIMED_OUT);

--- a/comms/common/fault_tolerance/AbortMacros.cuh
+++ b/comms/common/fault_tolerance/AbortMacros.cuh
@@ -16,10 +16,9 @@
  * Under `AbortBehavior::TRAP` all three log the *site* -- file, line and
  * function -- alongside the caller's message, so a log line says where the
  * abort or the timeout was observed rather than only that one happened. Under
- * the default `AbortBehavior::SKIP` they stay silent: a wait that aborts does
- * so on every thread that reached it, and one printf per thread per site would
- * bury the host-side diagnosis under device output. SKIP is the production
- * path; the reason is already recorded on the `Abort` for the host to report.
+ * the default `AbortBehavior::SKIP`, only the call that wins the shared reason
+ * CAS logs. Every later observer stays silent, avoiding one printf per thread
+ * while preserving the device callsite that first declared the abort.
  *
  * These live in the fault-tolerance module and deliberately depend on nothing
  * from Prims, so CTRAN and MCCL device code can use the same checks.
@@ -47,22 +46,34 @@ namespace comms::fault_tolerance::detail {
  * is consumed by the trailing `%s`.
  */
 template <typename... Args>
-__device__ __forceinline__ bool
-abortCheckAndLog(const AbortDevice& abort, const char* fmt, Args... args) {
+__device__ __forceinline__ bool abortCheckAndLog(
+    const AbortDevice& abort,
+    const char* fmt,
+    const char* firstWriterFmt,
+    Args... args) {
 #if FT_IS_DEVICE_COMPILE
-  const auto result = abort.check();
+  bool flippedHere = false;
+  const auto result = abort.check(&flippedHere);
   if (result == AbortCheckResult::CONTINUE) {
     return false;
   }
-  if (result == AbortCheckResult::TRAP) {
+  if (flippedHere) {
+    // The transition from NONE happens exactly once per communicator. Print
+    // regardless of behavior so the production SKIP path retains the winning
+    // device callsite. NOLINTNEXTLINE(facebook-security-vulnerable-printf)
+    printf(firstWriterFmt, args...);
+  } else if (result == AbortCheckResult::TRAP) {
     // NOLINTNEXTLINE(facebook-security-vulnerable-printf)
     printf(fmt, args...);
+  }
+  if (result == AbortCheckResult::TRAP) {
     FT_DEVICE_TRAP();
   }
   return true;
 #else
   (void)abort;
   (void)fmt;
+  (void)firstWriterFmt;
   ((void)args, ...);
   return false;
 #endif
@@ -85,9 +96,9 @@ abortCheckAndLog(const AbortDevice& abort, const char* fmt, Args... args) {
  * it at compile time. `__func__` is expanded here, at the call site, so it
  * names the function containing the wait.
  *
- * Under `AbortBehavior::TRAP` this prints the message and the site, traps, and
- * still reports true, so a caller that survives the trap still terminates.
- * Under the default `AbortBehavior::SKIP` it reports true without printing.
+ * A first-writer check prints the common first-writer marker in either
+ * behavior. Other TRAP observations print the legacy CUDA abort message before
+ * trapping; other SKIP observations stay silent.
  *
  * Use this where the exit needs more than a bare `break` or `return` -- for
  * example when the decision must be made warp-uniform before a barrier:
@@ -97,11 +108,12 @@ abortCheckAndLog(const AbortDevice& abort, const char* fmt, Args... args) {
  *       break;
  *     }
  */
-#define FT_ABORT_CHECK(abort, fmt, ...)               \
-  ::comms::fault_tolerance::detail::abortCheckAndLog( \
-      (abort),                                        \
-      "CUDA ABORT ERROR: " fmt FT_ABORT_SITE_SUFFIX_, \
-      ##__VA_ARGS__,                                  \
+#define FT_ABORT_CHECK(abort, fmt, ...)                        \
+  ::comms::fault_tolerance::detail::abortCheckAndLog(          \
+      (abort),                                                 \
+      "CUDA ABORT ERROR: " fmt FT_ABORT_SITE_SUFFIX_,          \
+      FT_ABORT_FIRST_WRITER_DEVICE_ fmt FT_ABORT_SITE_SUFFIX_, \
+      ##__VA_ARGS__,                                           \
       __func__)
 
 /*

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
@@ -17,6 +17,17 @@ __global__ void deviceSetAbortKernel(AbortDevice abort, AbortReason reason) {
   }
 }
 
+__global__ void deviceSetAbortWithContextKernel(
+    AbortDevice abort,
+    AbortReason reason,
+    bool useContext,
+    int* observedWinner) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    const char* context = useContext ? "AbortDeviceTest callsite" : nullptr;
+    *observedWinner = abort.setAbort(reason, context) ? 1 : 0;
+  }
+}
+
 __global__ void
 deviceReadAbortKernel(AbortDevice abort, int* observed, int* observedMode) {
   if (blockIdx.x == 0 && threadIdx.x == 0) {
@@ -171,6 +182,17 @@ cudaError_t launchDeviceSetAbort(
     AbortReason reason,
     cudaStream_t stream) {
   deviceSetAbortKernel<<<1, 1, 0, stream>>>(abort, reason);
+  return cudaGetLastError();
+}
+
+cudaError_t launchDeviceSetAbortWithContext(
+    AbortDevice abort,
+    AbortReason reason,
+    bool useContext,
+    int* observedWinner,
+    cudaStream_t stream) {
+  deviceSetAbortWithContextKernel<<<1, 1, 0, stream>>>(
+      abort, reason, useContext, observedWinner);
   return cudaGetLastError();
 }
 

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
@@ -15,6 +15,13 @@ cudaError_t launchDeviceSetAbort(
     AbortReason reason,
     cudaStream_t stream);
 
+cudaError_t launchDeviceSetAbortWithContext(
+    AbortDevice abort,
+    AbortReason reason,
+    bool useContext,
+    int* observedWinner,
+    cudaStream_t stream);
+
 cudaError_t launchDeviceReadAbort(
     AbortDevice abort,
     int* observed,

--- a/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
@@ -237,6 +237,67 @@ TEST(AbortDeviceTest, deviceProducerSupportsDetailedTerminalReasons) {
   }
 }
 
+TEST(AbortDeviceTest, deviceContextLogsOnlyForReasonCasWinner) {
+  Abort abort{/*enabled=*/true};
+  auto firstWon = makeDeviceValue<int>();
+  auto secondWon = makeDeviceValue<int>();
+  ASSERT_NE(firstWon, nullptr);
+  ASSERT_NE(secondWon, nullptr);
+
+  EXPECT_EQ(
+      launchDeviceSetAbortWithContext(
+          abort.getDeviceHandle(),
+          AbortReason::NETWORK_ERROR,
+          /*useContext=*/true,
+          firstWon.get(),
+          /*stream=*/nullptr),
+      cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(
+      launchDeviceSetAbortWithContext(
+          abort.getDeviceHandle(),
+          AbortReason::INTERNAL_ERROR,
+          /*useContext=*/true,
+          secondWon.get(),
+          /*stream=*/nullptr),
+      cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(firstWon), 1);
+  EXPECT_EQ(readDeviceValue(secondWon), 0);
+  EXPECT_EQ(
+      abort.getAbortInfo(),
+      (AbortInfo{
+          .reason = AbortReason::NETWORK_ERROR,
+          .context = "",
+      }));
+}
+
+TEST(AbortDeviceTest, deviceNullContextCanLogForReasonCasWinner) {
+  Abort abort{/*enabled=*/true};
+  auto won = makeDeviceValue<int>();
+  ASSERT_NE(won, nullptr);
+
+  EXPECT_EQ(
+      launchDeviceSetAbortWithContext(
+          abort.getDeviceHandle(),
+          AbortReason::INTERNAL_ERROR,
+          /*useContext=*/false,
+          won.get(),
+          /*stream=*/nullptr),
+      cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(won), 1);
+  EXPECT_EQ(
+      abort.getAbortInfo(),
+      (AbortInfo{
+          .reason = AbortReason::INTERNAL_ERROR,
+          .context = "",
+      }));
+}
+
 TEST(AbortDeviceTest, deviceWinnerDoesNotExposeLosingHostContext) {
   Abort abort{/*enabled=*/true};
 

--- a/comms/common/fault_tolerance/tests/AbortUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortUT.cc
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <optional>
@@ -607,6 +608,42 @@ TEST(AbortTest, firstTerminalReasonWins) {
   EXPECT_TRUE(abort.isAborted());
   EXPECT_TRUE(abort.isTimedOut());
   EXPECT_EQ(abort.reason(), AbortReason::TIMED_OUT);
+}
+
+// `firstTerminalReasonWins` covers the sequential case. This is the contended
+// one: many threads recording different reasons at once must still leave
+// exactly one terminal reason behind, and it must not move afterwards. A reason
+// that could be overwritten would make the first-writer log name a fault that
+// is no longer the one being reported.
+TEST(AbortTest, concurrentWritersLeaveOneStableReason) {
+  constexpr int kThreadsPerReason = 16;
+  Abort abort{/*enabled=*/true};
+
+  std::atomic<bool> go{false};
+  std::vector<std::thread> writers;
+  writers.reserve(kThreadsPerReason * 2);
+  for (int i = 0; i < kThreadsPerReason * 2; ++i) {
+    const auto reason =
+        (i % 2 == 0) ? AbortReason::ABORTED : AbortReason::TIMED_OUT;
+    writers.emplace_back([&abort, &go, reason] {
+      while (!go.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+      }
+      abort.setAbort(reason);
+    });
+  }
+  go.store(true, std::memory_order_release);
+  for (auto& t : writers) {
+    t.join();
+  }
+
+  const auto reason = abort.reason();
+  EXPECT_TRUE(
+      reason == AbortReason::ABORTED || reason == AbortReason::TIMED_OUT);
+  EXPECT_TRUE(abort.isAborted());
+  for (int i = 0; i < 1000; ++i) {
+    ASSERT_EQ(abort.reason(), reason);
+  }
 }
 
 TEST(AbortTest, abortReasonToString) {

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -1103,7 +1103,9 @@ class P2pIbgdaTransportDevice {
   __device__ void wait_local_on_qp(
       doca_gpu_dev_verbs_qp* qp,
       doca_gpu_dev_verbs_ticket_t ticket,
-      AbortDevice abortDevice = AbortDevice()) {
+      // By reference: a copy resets the poll throttle, and `wait_lanes()` calls
+      // this once per QP lane.
+      const AbortDevice& abortDevice = AbortDevice()) {
     if (!abortDevice.isEnabled()) {
       doca_gpu_dev_verbs_wait<
           DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,


### PR DESCRIPTION
Summary:

`P2pIbgdaTransportDevice::wait_local_on_qp()` took its `AbortDevice` **by
value**. A copy gets a fresh poll throttle (`nextPollCycles_ = 0`) and a fresh
`sawTerminalReason_`, so the first abort check inside every call reads mapped
pinned host memory unthrottled -- an uncached PCIe round trip, measured at
~1.1us on H100.

`wait_lanes()` calls it once per QP lane in a loop, so the copy multiplied that
by the lane count. `flush()` and `drain_flush_lanes()` reach it the same way.

All three callers already hold a `const AbortDevice&`; this was the only place
making a copy. Taking it by reference is what the throttle was designed for --
the handle is the per-thread kernel-entry copy, so its throttle state is already
private to one poller, which is the invariant `AbortDevice` documents. It also
makes `sawTerminalReason_` behave as its own docstring says ("once this handle
has observed one it can answer from a register forever") rather than being reset
on every lane.

Moved to the bottom of the stack so it lands independently of the diagnostics
work that used to sit below it.

Its end-to-end effect on the tree/ring path is unmeasured, and I would rather
say so than imply a number: I could not statically establish whether the fused
AllReduce Phase-2 progress state machine reaches `wait_local`/`flush` for the
IB_ONLY topology, since it normally uses the non-copying
`is_local_completion_ready()`. This is a strict improvement on the paths that do
reach it and costs nothing on the paths that do not.

Reviewed By: Scusemua

Differential Revision: D117902111


