### PR TITLE
Log the operation number and deadline at every device abort

### DIFF
--- a/comms/common/fault_tolerance/Abort.h
+++ b/comms/common/fault_tolerance/Abort.h
@@ -18,18 +18,30 @@
  *
  * The winner of the reason CAS logs once and every later observer stays silent,
  * so exactly one of these lines exists per communicator and it names whatever
- * declared the abort. Defined here rather than spelled out at the three
- * emitting sites (`Abort::trySetAbort`, `AbortDevice::setAbort`,
- * `FT_ABORT_CHECK`) so host and device cannot drift apart and stop answering to
- * the same grep.
+ * declared the abort. Defined here rather than spelled out at the emitting
+ * sites (`Abort::trySetAbort` on the host, `detail::deviceLogFirstWriter` on
+ * the device) so host and device cannot drift apart and stop answering to the
+ * same grep.
  *
- * Host and device print different fields after the tag -- the host has the
- * reason name and a `std::string` context, the device has neither -- so this
- * shares the marker, not the whole line.
+ * Host and device print different fields after the tag -- the host has a
+ * `std::string` context it can persist, the device only what the winning
+ * callsite passed -- so this shares the marker, not the whole line.
  */
 #define FT_ABORT_FIRST_WRITER_ "COMMS FT ABORT FIRST WRITER: "
 #define FT_ABORT_FIRST_WRITER_HOST_ FT_ABORT_FIRST_WRITER_ "host "
 #define FT_ABORT_FIRST_WRITER_DEVICE_ FT_ABORT_FIRST_WRITER_ "device "
+
+/*
+ * Marker prefixing the *observation* line a `FT_ABORT_*` macro adds.
+ *
+ * Distinct from the first-writer marker on purpose. The transition itself is
+ * one event and logs one line; a macro call site can only say where the abort
+ * was noticed, which is a different and repeatable thing. Giving it its own tag
+ * keeps `FT_ABORT_FIRST_WRITER_` meaning exactly "this line is the transition",
+ * so counting occurrences of that marker stays a valid check that the CAS fired
+ * once.
+ */
+#define FT_ABORT_SITE_ "COMMS FT ABORT SITE: "
 
 namespace comms::fault_tolerance {
 

--- a/comms/common/fault_tolerance/AbortDevice.cuh
+++ b/comms/common/fault_tolerance/AbortDevice.cuh
@@ -308,6 +308,14 @@ struct AbortDevice final {
   }
 
   /**
+   * Device-clock value this handle's deadline expires at, or zero when no
+   * device deadline is active. Cold-path diagnostics only.
+   */
+  __host__ __device__ uint64_t deadlineCycles() const {
+    return deadlineCycles_;
+  }
+
+  /**
    * Starts this handle's device-side timeout from the shared default duration.
    *
    * Non-positive or unset default timeouts leave the device deadline inactive.

--- a/comms/common/fault_tolerance/AbortDevice.cuh
+++ b/comms/common/fault_tolerance/AbortDevice.cuh
@@ -61,6 +61,44 @@ inline constexpr uint64_t kAbortPollsPerMs = 1;
 inline constexpr const char* kDeadlineExpiredContext =
     "device deadline expired";
 
+/**
+ * Linkage for the cold abort-context log.
+ *
+ * The abort *check* must stay inline -- it is the throttle gate, on every spin
+ * iteration of every wait. The *log* is the opposite: it runs at most once per
+ * communicator, and inlining it copies a `printf` and its argument marshalling
+ * into every one of the ~60 abort call sites in every consuming translation
+ * unit. Emitting it once per TU instead is 5.8% less SASS across the 50 fused
+ * AllReduce tree kernels.
+ *
+ * `inline` in both compilation passes, `noinline` only in the device pass, and
+ * all three parts are load-bearing:
+ *
+ * - `inline` in the host pass, where `__device__` is stripped and an
+ *   external-linkage definition would land in every including TU.
+ * - `inline` in the device pass too, because not every consumer is
+ *   whole-program: `comms/ctran` device-links its objects, so external device
+ *   linkage is `nvlink error : Multiple definition of ...`.
+ * - `noinline` only in the device pass, because gcc -- the nvcc host compiler
+ *   for the AllReduce targets -- rejects `inline` plus `noinline` under
+ *   `-Werror`, and there is nothing to gain from it in a pass where the
+ *   function is never called.
+ *
+ * `__attribute__((noinline))` rather than CUDA's `__noinline__`: the latter is
+ * only defined by `crt/host_defines.h` under `__CUDACC__`, and this header is
+ * also included by plain host translation units.
+ */
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#define COMMS_FT_ABORT_LOG_LINKAGE __device__ inline __attribute__((noinline))
+#else
+#define COMMS_FT_ABORT_LOG_LINKAGE __device__ inline
+#endif
+
+// Declared before `detail` so the abort log, which lives there, can take the
+// handle it reports on. The handle is defined below, after the helpers its own
+// members call, and the log is defined after the handle.
+struct AbortDevice;
+
 namespace detail {
 
 inline int hostCurrentDevice() {
@@ -113,6 +151,34 @@ inline uint64_t hostDeviceCyclesPerMs(int device) {
 #endif
 }
 
+/**
+ * Device spelling of `abortReasonToString()`.
+ *
+ * The host version returns `std::string_view`, which is not usable as a printf
+ * argument from device code, so the names are duplicated here as literals.
+ * Keep the two in sync when `AbortReason` gains a value.
+ */
+__device__ __forceinline__ const char* deviceAbortReasonName(
+    AbortReason reason) {
+  switch (reason) {
+    case AbortReason::NONE:
+      return "none";
+    case AbortReason::ABORTED:
+      return "aborted";
+    case AbortReason::TIMED_OUT:
+      return "timed_out";
+    case AbortReason::BOOTSTRAP_POLL:
+      return "bootstrap_poll";
+    case AbortReason::NETWORK_ERROR:
+      return "network_error";
+    case AbortReason::INTERNAL_ERROR:
+      return "internal_error";
+    case AbortReason::IBRC_PROXY_TIMEOUT:
+      return "ibrc_proxy_timeout";
+  }
+  return "unknown";
+}
+
 __device__ __forceinline__ bool deviceIsValidTerminalReason(
     AbortReason reason) {
   switch (reason) {
@@ -160,7 +226,7 @@ __device__ __forceinline__ void publishContextReady(AbortState* state) {
 }
 
 /**
- * Emits the device first-writer line for a transition this call just won.
+ * Emits the one device abort line, from the transition that just won the CAS.
  *
  * Every device path that takes `AbortState::abort` from `NONE` to a terminal
  * reason ends here -- `AbortDevice::setAbort`, `AbortFlag::setAbort`, and the
@@ -168,23 +234,35 @@ __device__ __forceinline__ void publishContextReady(AbortState* state) {
  * `deviceTrySetAbort`. There is no second emitter, so the marker has one
  * spelling and one field list, and counting it counts transitions.
  *
+ * The identity and timing every abort has -- which operation, which deadline,
+ * how long it waited -- go on this same line rather than a second one. Two
+ * printfs from two aborting threads interleave, and once they do there is no
+ * way to tell which context belongs to which marker; one printf per transition
+ * cannot be torn apart. It also means the fields are formatted in exactly one
+ * place, so adding one cannot land in some emitters and miss others.
+ *
+ * `abort` may be null. `AbortFlag` deliberately carries no per-operation
+ * identity or arm-site clock state, so its transitions print the marker, the
+ * reason and the context with the timing fields reported as unarmed.
+ *
  * `FT_ABORT_CHECK` adds a separate `FT_ABORT_SITE_` line carrying the caller's
  * message and source location. That is an observation, not a transition, so it
  * deliberately does not reuse this marker.
+ *
+ * Declared here and defined after `AbortDevice` because it reads the handle.
+ * `COMMS_FT_ABORT_LOG_LINKAGE` keeps the body out of line in the device pass:
+ * it runs at most once per communicator, and inlining it would copy the printf
+ * and its argument marshalling into every `setAbort()` and every deadline check
+ * in every consuming translation unit.
  */
-__device__ __forceinline__ void deviceLogFirstWriter(
+COMMS_FT_ABORT_LOG_LINKAGE void deviceLogFirstWriter(
+    const AbortDevice* abort,
     AbortReason reason,
-    const char* context) {
-  // NOLINTNEXTLINE(facebook-security-vulnerable-printf)
-  printf(
-      FT_ABORT_FIRST_WRITER_DEVICE_ "reason=%d context=%s\n",
-      static_cast<int>(reason),
-      context == nullptr ? "" : context);
-}
+    const char* context);
 
 /**
  * Records a terminal reason from device code, first-writer-wins, and emits the
- * common first-writer marker if this call is the winner.
+ * abort line if this call is the winner.
  *
  * Shared by both device writers of `AbortState::abort` -- `AbortDevice` and
  * `AbortFlag`. They differ in what else they carry (a poll throttle, a
@@ -192,8 +270,9 @@ __device__ __forceinline__ void deviceLogFirstWriter(
  * it are the same event, and a writer that transitions without logging leaves
  * an abort with no greppable origin.
  *
- * Takes the raw `AbortState*` rather than either handle type so it can be
- * defined once, before both, without a forward declaration dance.
+ * Takes the raw `AbortState*` for the CAS and a separate, nullable
+ * `AbortDevice*` for the log. Splitting them is what lets `AbortFlag` -- which
+ * has state but no handle -- use the same transition as `AbortDevice`.
  *
  * `observed` reports the reason already in place when the CAS loses. A caller
  * that needs to distinguish "someone else recorded the reason I wanted" from
@@ -202,6 +281,7 @@ __device__ __forceinline__ void deviceLogFirstWriter(
  */
 __device__ __forceinline__ bool deviceTrySetAbort(
     AbortState* state,
+    const AbortDevice* abort,
     AbortReason newReason,
     const char* context,
     AbortReason* observed = nullptr) {
@@ -221,7 +301,7 @@ __device__ __forceinline__ bool deviceTrySetAbort(
     // Device context is intentionally not persisted in mapped host state, so
     // the winner completes the readiness protocol immediately.
     publishContextReady(state);
-    deviceLogFirstWriter(newReason, context);
+    deviceLogFirstWriter(abort, newReason, context);
   } else if (observed != nullptr) {
     // The CAS wrote back what it found, so this costs no extra read.
     *observed = static_cast<AbortReason>(expected);
@@ -308,11 +388,47 @@ struct AbortDevice final {
   }
 
   /**
+   * Stamps the collective operation number this handle belongs to.
+   *
+   * Diagnostic only: nothing branches on it. It exists so an abort log line can
+   * be joined against colltrace and against the other ranks' lines for the same
+   * operation, which is otherwise impossible -- a device wait can see a signal
+   * value but has no way to know which collective it belongs to.
+   *
+   * Same rule as `setOpTimeoutMs()`: set it on a per-operation COPY of the
+   * handle. Communicator-scoped handles are shared, so mutating one in place
+   * would misattribute later operations.
+   */
+  __host__ __device__ void setOpId(uint64_t opId) {
+    opId_ = opId;
+  }
+
+  __host__ __device__ uint64_t opId() const {
+    return opId_;
+  }
+
+  /**
+   * Device-clock value when `startTimeout()` last armed this handle, or zero if
+   * it was never armed. Cold-path diagnostics only.
+   */
+  __host__ __device__ uint64_t startCycles() const {
+    return startCycles_;
+  }
+
+  /**
    * Device-clock value this handle's deadline expires at, or zero when no
    * device deadline is active. Cold-path diagnostics only.
    */
   __host__ __device__ uint64_t deadlineCycles() const {
     return deadlineCycles_;
+  }
+
+  /**
+   * Device clock cycles per millisecond for the device this handle targets.
+   * Cold-path diagnostics only.
+   */
+  __host__ __device__ uint64_t cyclesPerMs() const {
+    return cyclesPerMs_;
   }
 
   /**
@@ -324,8 +440,9 @@ struct AbortDevice final {
    * than silently creating an effectively infinite deadline.
    */
   __device__ void startTimeout() {
+    deadlineCycles_ = 0;
+    startCycles_ = 0;
     if (!isEnabled()) {
-      deadlineCycles_ = 0;
       return;
     }
     const auto now = detail::deviceClock();
@@ -333,9 +450,12 @@ struct AbortDevice final {
     // first `checkExpired()` on every armed handle unthrottled, which is one
     // uncached mapped-pinned read on the one call guaranteed to happen.
     nextPollCycles_ = now + pollIntervalCycles_;
+    // Stamped before the deadline is resolved, and stamped even when no
+    // deadline results. Diagnostics need "how long has this been waiting",
+    // which is a property of the arm site, not of whether a deadline was armed.
+    startCycles_ = now;
     const auto timeoutMs = resolveTimeoutMs();
     if (timeoutMs <= 0 || cyclesPerMs_ == 0) {
-      deadlineCycles_ = 0;
       return;
     }
     const auto timeoutMsU = static_cast<uint64_t>(timeoutMs);
@@ -482,28 +602,6 @@ struct AbortDevice final {
   }
 
   /**
-   * Records the first shared abort reason from device code.
-   *
-   * Every non-`NONE` AbortReason is terminal. `AbortReason::NONE` and unknown
-   * enum values are invalid; debug/device assert builds catch them, and
-   * release-compatible builds return before touching shared state. The CAS
-   * only transitions the shared state from `NONE`, so later writers cannot
-   * overwrite the first terminal reason. `context` matches the host API but is
-   * never persisted in shared state; device-side diagnostics may consume it at
-   * the winning callsite without adding mapped-memory traffic.
-   *
-   * Returns whether this call performed the `NONE` to terminal transition.
-   */
-  __device__ bool setAbort(
-      AbortReason newReason = AbortReason::ABORTED,
-      const char* context = nullptr) const {
-    return detail::deviceTrySetAbort(state_, newReason, context);
-  }
-
- private:
-  friend class Abort;
-
-  /**
    * Deadline duration for this operation, in milliseconds.
    *
    * A per-operation override wins because it is the more specific request and
@@ -529,6 +627,30 @@ struct AbortDevice final {
     }
     return getTimeoutMs();
   }
+
+  /**
+   * Records the first shared abort reason from device code.
+   *
+   * Every non-`NONE` AbortReason is terminal. `AbortReason::NONE` and unknown
+   * enum values are invalid; debug/device assert builds catch them, and
+   * release-compatible builds return before touching shared state. The CAS
+   * only transitions the shared state from `NONE`, so later writers cannot
+   * overwrite the first terminal reason. `context` matches the host API but is
+   * never persisted in shared state; device-side diagnostics may consume it at
+   * the winning callsite without adding mapped-memory traffic.
+   *
+   * Returns whether this call performed the `NONE` to terminal transition.
+   */
+  __device__ bool setAbort(
+      AbortReason newReason = AbortReason::ABORTED,
+      const char* context = nullptr) const {
+    // `this` is what lets the emitted line carry the per-operation identity and
+    // arm-site clock state; `AbortFlag` passes null and reports them unarmed.
+    return detail::deviceTrySetAbort(state_, this, newReason, context);
+  }
+
+ private:
+  friend class Abort;
 
   /**
    * Creates a device handle for mapped pinned state owned by `Abort`.
@@ -589,6 +711,7 @@ struct AbortDevice final {
     AbortReason observed = AbortReason::NONE;
     if (detail::deviceTrySetAbort(
             state_,
+            this,
             AbortReason::TIMED_OUT,
             kDeadlineExpiredContext,
             &observed)) {
@@ -625,6 +748,12 @@ struct AbortDevice final {
   int64_t opTimeoutMs_{-1};
 
   /**
+   * Collective operation number, for diagnostics only. Travels by value with
+   * the rest of the handle, so reading it costs no shared-state access.
+   */
+  uint64_t opId_{0};
+
+  /**
    * Minimum device-clock cycles between reads of the mapped shared state.
    *
    * Bounds abort-observation latency to one interval while keeping spin loops
@@ -655,7 +784,86 @@ struct AbortDevice final {
    * the copied handle and is not part of the host-owned shared state.
    */
   uint64_t deadlineCycles_{0};
+
+  /**
+   * Device clock value at the last `startTimeout()`, or zero if never armed.
+   *
+   * Purely diagnostic: it lets a log line report how long the operation had
+   * been running. Stamped rather than derived because there is nothing to
+   * derive it from -- no other field records when the wait began.
+   */
+  uint64_t startCycles_{0};
 };
+
+// Copied by value into kernel argument structs and copied again per block, so
+// growth is not free. Two 8-byte diagnostic fields -- `opId_` and
+// `startCycles_` -- are the deliberate budget; anything more should go through
+// mapped state instead.
+static_assert(sizeof(AbortDevice) <= 80);
+
+namespace detail {
+
+COMMS_FT_ABORT_LOG_LINKAGE void deviceLogFirstWriter(
+    const AbortDevice* abort,
+    AbortReason reason,
+    const char* context) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  const uint64_t now = deviceClock();
+  // A null handle is `AbortFlag`, which carries none of this by design. It
+  // takes the same path as an unarmed handle rather than a separate format, so
+  // the line has one shape no matter which writer produced it.
+  const uint64_t startCycles = abort != nullptr ? abort->startCycles() : 0;
+  const uint64_t deadlineCycles =
+      abort != nullptr ? abort->deadlineCycles() : 0;
+  const uint64_t cyclesPerMs = abort != nullptr ? abort->cyclesPerMs() : 0;
+  const unsigned long long opId =
+      abort != nullptr ? static_cast<unsigned long long>(abort->opId()) : 0ULL;
+  // An unarmed handle has no origin to measure from, so report -1 rather than
+  // an elapsed time counted from clock zero. `now >= startCycles` is part of
+  // the guard, not a redundant check: the subtraction is unsigned, and
+  // `deviceClock()` is per-SM, so a handle armed on one SM and logged from
+  // another can read backwards. Without this a few cycles of skew print as an
+  // elapsed_ms near 10^13.
+  const bool armed = startCycles != 0 && cyclesPerMs != 0 && now >= startCycles;
+  const uint64_t elapsedCycles = armed ? now - startCycles : 0;
+  // The only division on this path.
+  const int64_t elapsedMs =
+      armed ? static_cast<int64_t>(elapsedCycles / cyclesPerMs) : -1;
+  // Read live rather than stamped at arm time. Stamping it would cost 8 bytes
+  // in a handle that travels in kernel arguments and is copied again per block,
+  // and the host is not expected to move the communicator timeout mid-operation
+  // -- so the live value and the armed one agree in every case that matters,
+  // and this is a cold path where the mapped-pinned read is free.
+  const int64_t timeoutMs = abort != nullptr ? abort->resolveTimeoutMs() : -1;
+  // One printf, not two. Two would interleave across aborting threads and leave
+  // no way to attribute a context line to its marker.
+  // NOLINTNEXTLINE(facebook-security-vulnerable-printf)
+  printf(
+      FT_ABORT_FIRST_WRITER_DEVICE_
+      "reason=%s context=%s op=%llu "
+      "timeout_ms=%lld elapsed_ms=%lld "
+      "elapsed_cycles=%llu deadline_cycles=%llu "
+      "now_cycles=%llu cycles_per_ms=%llu "
+      "block=%d thread=%d\n",
+      deviceAbortReasonName(reason),
+      context == nullptr ? "" : context,
+      opId,
+      static_cast<long long>(timeoutMs),
+      static_cast<long long>(elapsedMs),
+      static_cast<unsigned long long>(elapsedCycles),
+      static_cast<unsigned long long>(deadlineCycles),
+      static_cast<unsigned long long>(now),
+      static_cast<unsigned long long>(cyclesPerMs),
+      static_cast<int>(blockIdx.x),
+      static_cast<int>(threadIdx.x));
+#else
+  (void)abort;
+  (void)reason;
+  (void)context;
+#endif
+}
+
+} // namespace detail
 
 /**
  * A poll-state-free view of the shared abort state, safe to store in device
@@ -696,19 +904,27 @@ struct AbortFlag final {
    * system-scope CAS, which is exactly what the shared state is for. Only
    * *polling* needs per-thread throttle state, and this type has none.
    *
-   * The winner emits the same first-writer marker `AbortDevice` does, and
-   * publishes `contextReady` on the same terms, through the same helper. That
-   * costs this type nothing it was built to avoid: the `printf` is gated on the
-   * CAS win, so it happens at most once per communicator, and it adds no
-   * mutable state and no poll. Without it the IBRC proxy watchdogs -- which
-   * reach the shared reason only through this type -- can leave a communicator
-   * aborted with no greppable origin at all, and the `context` they pass
-   * describing which watchdog fired is discarded.
+   * The winner emits the same line `AbortDevice` does, and publishes
+   * `contextReady` on the same terms, through the same helper. That costs this
+   * type nothing it was built to avoid: the `printf` is gated on the CAS win,
+   * so it happens at most once per communicator, and it adds no mutable state
+   * and no poll. Without it the IBRC proxy watchdogs -- which reach the shared
+   * reason only through this type -- can leave a communicator aborted with no
+   * greppable origin at all, and the `context` they pass describing which
+   * watchdog fired is discarded.
+   *
+   * The handle argument is null because this type has none: no `opId`, no
+   * arm-site clock. The line still carries the marker, the reason and the
+   * context, and reports the timing fields as unarmed. That is the honest
+   * answer -- these fields are properties of an operation's handle, and a
+   * communicator-scoped flag is not one -- and it is why they are printed as
+   * unarmed rather than omitted, so the line's shape never varies.
    */
   __device__ bool setAbort(
       AbortReason newReason = AbortReason::ABORTED,
       const char* context = nullptr) const {
-    return detail::deviceTrySetAbort(state_, newReason, context);
+    return detail::deviceTrySetAbort(
+        state_, /*abort=*/nullptr, newReason, context);
   }
 
   /**

--- a/comms/common/fault_tolerance/AbortDevice.cuh
+++ b/comms/common/fault_tolerance/AbortDevice.cuh
@@ -50,6 +50,17 @@ namespace comms::fault_tolerance {
  */
 inline constexpr uint64_t kAbortPollsPerMs = 1;
 
+/*
+ * `context` the deadline path passes when it records `TIMED_OUT`.
+ *
+ * Named rather than spelled at the call site so the test that asserts the line
+ * cannot drift from the line itself. Unlike `FT_ABORT_FIRST_WRITER_`, this is
+ * not a grep contract anyone outside the code depends on -- it is one writer's
+ * description of itself -- so sharing the constant is the right coupling.
+ */
+inline constexpr const char* kDeadlineExpiredContext =
+    "device deadline expired";
+
 namespace detail {
 
 inline int hostCurrentDevice() {
@@ -146,6 +157,76 @@ deviceCompareExchangeSystem(int* value, int* expected, int desired) {
 __device__ __forceinline__ void publishContextReady(AbortState* state) {
   int expected = 0;
   (void)deviceCompareExchangeSystem(&state->contextReady, &expected, 1);
+}
+
+/**
+ * Emits the device first-writer line for a transition this call just won.
+ *
+ * Every device path that takes `AbortState::abort` from `NONE` to a terminal
+ * reason ends here -- `AbortDevice::setAbort`, `AbortFlag::setAbort`, and the
+ * deadline CAS in `markTimedOutIfExpired`, all of which reach it through
+ * `deviceTrySetAbort`. There is no second emitter, so the marker has one
+ * spelling and one field list, and counting it counts transitions.
+ *
+ * `FT_ABORT_CHECK` adds a separate `FT_ABORT_SITE_` line carrying the caller's
+ * message and source location. That is an observation, not a transition, so it
+ * deliberately does not reuse this marker.
+ */
+__device__ __forceinline__ void deviceLogFirstWriter(
+    AbortReason reason,
+    const char* context) {
+  // NOLINTNEXTLINE(facebook-security-vulnerable-printf)
+  printf(
+      FT_ABORT_FIRST_WRITER_DEVICE_ "reason=%d context=%s\n",
+      static_cast<int>(reason),
+      context == nullptr ? "" : context);
+}
+
+/**
+ * Records a terminal reason from device code, first-writer-wins, and emits the
+ * common first-writer marker if this call is the winner.
+ *
+ * Shared by both device writers of `AbortState::abort` -- `AbortDevice` and
+ * `AbortFlag`. They differ in what else they carry (a poll throttle, a
+ * per-operation identity), but the transition itself and the line that reports
+ * it are the same event, and a writer that transitions without logging leaves
+ * an abort with no greppable origin.
+ *
+ * Takes the raw `AbortState*` rather than either handle type so it can be
+ * defined once, before both, without a forward declaration dance.
+ *
+ * `observed` reports the reason already in place when the CAS loses. A caller
+ * that needs to distinguish "someone else recorded the reason I wanted" from
+ * "someone else recorded a different one" would otherwise have to re-read
+ * mapped pinned state, which is the one read this whole path exists to avoid.
+ */
+__device__ __forceinline__ bool deviceTrySetAbort(
+    AbortState* state,
+    AbortReason newReason,
+    const char* context,
+    AbortReason* observed = nullptr) {
+  if (state == nullptr) {
+    return false;
+  }
+  const bool validReason = deviceIsValidTerminalReason(newReason);
+  assert(validReason);
+  if (!validReason) {
+    return false;
+  }
+
+  int expected = static_cast<int>(AbortReason::NONE);
+  const bool won = deviceCompareExchangeSystem(
+      &state->abort, &expected, static_cast<int>(newReason));
+  if (won) {
+    // Device context is intentionally not persisted in mapped host state, so
+    // the winner completes the readiness protocol immediately.
+    publishContextReady(state);
+    deviceLogFirstWriter(newReason, context);
+  } else if (observed != nullptr) {
+    // The CAS wrote back what it found, so this costs no extra read.
+    *observed = static_cast<AbortReason>(expected);
+  }
+  return won;
 }
 
 } // namespace detail
@@ -297,6 +378,9 @@ struct AbortDevice final {
    * the caller should preserve legacy Prims trap behavior; the trap itself is
    * performed by Prims helpers so common fault-tolerance code stays transport
    * agnostic.
+   *
+   * `flippedHere`, when passed, reports whether this call won the deadline CAS.
+   * It is safe to pass anywhere: the transition logs itself either way.
    */
   __device__ AbortCheckResult check(bool* flippedHere = nullptr) const {
     if (!checkExpired(flippedHere)) {
@@ -312,6 +396,8 @@ struct AbortDevice final {
    * Returns true for either an explicit abort or an expired local device
    * timeout. If this handle's local deadline has expired, this records
    * `AbortReason::TIMED_OUT` in the shared state.
+   *
+   * `flippedHere`, when passed, reports whether this call won the deadline CAS.
    */
   __device__ bool checkExpired(bool* flippedHere = nullptr) const {
     if (flippedHere != nullptr) {
@@ -403,28 +489,7 @@ struct AbortDevice final {
   __device__ bool setAbort(
       AbortReason newReason = AbortReason::ABORTED,
       const char* context = nullptr) const {
-    if (!isEnabled()) {
-      return false;
-    }
-    const bool validReason = detail::deviceIsValidTerminalReason(newReason);
-    assert(validReason);
-    if (!validReason) {
-      return false;
-    }
-
-    int expected = static_cast<int>(AbortReason::NONE);
-    const bool won = detail::deviceCompareExchangeSystem(
-        &state_->abort, &expected, static_cast<int>(newReason));
-    if (won) {
-      // Device context is intentionally not persisted in mapped host state.
-      detail::publishContextReady(state_);
-      // NOLINTNEXTLINE(facebook-security-vulnerable-printf)
-      printf(
-          FT_ABORT_FIRST_WRITER_DEVICE_ "reason=%d context=%s\n",
-          static_cast<int>(newReason),
-          context == nullptr ? "" : context);
-    }
-    return won;
+    return detail::deviceTrySetAbort(state_, newReason, context);
   }
 
  private:
@@ -490,23 +555,41 @@ struct AbortDevice final {
     return deadlineCycles_ != 0 && detail::deviceClock() >= deadlineCycles_;
   }
 
+  /**
+   * Records `TIMED_OUT` when this handle's deadline has lapsed.
+   *
+   * Goes through `detail::deviceTrySetAbort` rather than running its own CAS,
+   * so the deadline transitions and logs on exactly the same terms as
+   * `setAbort()` does. This used to be the one device writer that could take
+   * the shared reason silently: most production waits observe their own
+   * deadline through `groupAborted()` or a bare `isAborted()`, and every later
+   * observer takes the `reason() != NONE` early return without transitioning,
+   * so nobody was left who could report the origin.
+   *
+   * `flippedHere` is a plain out-param -- "this call won the CAS" -- and has no
+   * bearing on whether the line is emitted. `FT_ABORT_CHECK` reads it to decide
+   * whether to add its own site line, not to decide whether anything logs.
+   *
+   * Returns true for a CAS loss to another `TIMED_OUT` writer as well as for a
+   * win, because either way the deadline is recorded by the time this returns.
+   */
   __device__ bool markTimedOutIfExpired(bool* flippedHere = nullptr) const {
     if (!isEnabled() || !deadlineExpired()) {
       return false;
     }
 
-    int expected = static_cast<int>(AbortReason::NONE);
-    if (detail::deviceCompareExchangeSystem(
-            &state_->abort,
-            &expected,
-            static_cast<int>(AbortReason::TIMED_OUT))) {
-      detail::publishContextReady(state_);
+    AbortReason observed = AbortReason::NONE;
+    if (detail::deviceTrySetAbort(
+            state_,
+            AbortReason::TIMED_OUT,
+            kDeadlineExpiredContext,
+            &observed)) {
       if (flippedHere != nullptr) {
         *flippedHere = true;
       }
       return true;
     }
-    return expected == static_cast<int>(AbortReason::TIMED_OUT);
+    return observed == AbortReason::TIMED_OUT;
   }
 
   /**
@@ -604,28 +687,20 @@ struct AbortFlag final {
    * Writing shared state is safe to do from a shared handle -- it is a
    * system-scope CAS, which is exactly what the shared state is for. Only
    * *polling* needs per-thread throttle state, and this type has none.
-   * Device context is not persisted, so a winning writer publishes
-   * `contextReady` immediately after the reason.
+   *
+   * The winner emits the same first-writer marker `AbortDevice` does, and
+   * publishes `contextReady` on the same terms, through the same helper. That
+   * costs this type nothing it was built to avoid: the `printf` is gated on the
+   * CAS win, so it happens at most once per communicator, and it adds no
+   * mutable state and no poll. Without it the IBRC proxy watchdogs -- which
+   * reach the shared reason only through this type -- can leave a communicator
+   * aborted with no greppable origin at all, and the `context` they pass
+   * describing which watchdog fired is discarded.
    */
   __device__ bool setAbort(
       AbortReason newReason = AbortReason::ABORTED,
       const char* context = nullptr) const {
-    if (!isEnabled()) {
-      return false;
-    }
-    (void)context;
-    const bool validReason = detail::deviceIsValidTerminalReason(newReason);
-    assert(validReason);
-    if (!validReason) {
-      return false;
-    }
-    int expected = static_cast<int>(AbortReason::NONE);
-    const bool won = detail::deviceCompareExchangeSystem(
-        &state_->abort, &expected, static_cast<int>(newReason));
-    if (won) {
-      detail::publishContextReady(state_);
-    }
-    return won;
+    return detail::deviceTrySetAbort(state_, newReason, context);
   }
 
   /**

--- a/comms/common/fault_tolerance/AbortMacros.cuh
+++ b/comms/common/fault_tolerance/AbortMacros.cuh
@@ -20,6 +20,11 @@
  * CAS logs. Every later observer stays silent, avoiding one printf per thread
  * while preserving the device callsite that first declared the abort.
  *
+ * The site line is separate from, and additional to, the first-writer line the
+ * transition emits for itself in `AbortDevice.cuh`. Two markers because they
+ * answer two questions -- what declared the abort, and where it was seen -- and
+ * only the first is once-per-communicator by construction.
+ *
  * These live in the fault-tolerance module and deliberately depend on nothing
  * from Prims, so CTRAN and MCCL device code can use the same checks.
  */
@@ -41,15 +46,21 @@
 namespace comms::fault_tolerance::detail {
 
 /*
- * Shared body behind the macros. `fmt` already carries the caller's message
- * plus the source location; the function name arrives as the last argument and
- * is consumed by the trailing `%s`.
+ * Shared body behind the macros. Both formats already carry the caller's
+ * message plus the source location; the function name arrives as the last
+ * argument and is consumed by the trailing `%s`.
+ *
+ * This no longer emits the first-writer marker. `abort.check()` reaches
+ * `markTimedOutIfExpired`, which records the reason through
+ * `detail::deviceTrySetAbort` and logs the transition from inside it, so by the
+ * time `flippedHere` comes back true the line has already been printed. All
+ * this adds is where the abort was noticed.
  */
 template <typename... Args>
 __device__ __forceinline__ bool abortCheckAndLog(
     const AbortDevice& abort,
     const char* fmt,
-    const char* firstWriterFmt,
+    const char* siteFmt,
     Args... args) {
 #if FT_IS_DEVICE_COMPILE
   bool flippedHere = false;
@@ -58,10 +69,11 @@ __device__ __forceinline__ bool abortCheckAndLog(
     return false;
   }
   if (flippedHere) {
-    // The transition from NONE happens exactly once per communicator. Print
-    // regardless of behavior so the production SKIP path retains the winning
-    // device callsite. NOLINTNEXTLINE(facebook-security-vulnerable-printf)
-    printf(firstWriterFmt, args...);
+    // Gated on winning the CAS, which happens exactly once per communicator, so
+    // this is one line per abort rather than one per observing thread. Printed
+    // regardless of behavior so the production SKIP path keeps the callsite.
+    // NOLINTNEXTLINE(facebook-security-vulnerable-printf)
+    printf(siteFmt, args...);
   } else if (result == AbortCheckResult::TRAP) {
     // NOLINTNEXTLINE(facebook-security-vulnerable-printf)
     printf(fmt, args...);
@@ -73,7 +85,7 @@ __device__ __forceinline__ bool abortCheckAndLog(
 #else
   (void)abort;
   (void)fmt;
-  (void)firstWriterFmt;
+  (void)siteFmt;
   ((void)args, ...);
   return false;
 #endif
@@ -96,9 +108,11 @@ __device__ __forceinline__ bool abortCheckAndLog(
  * it at compile time. `__func__` is expanded here, at the call site, so it
  * names the function containing the wait.
  *
- * A first-writer check prints the common first-writer marker in either
- * behavior. Other TRAP observations print the legacy CUDA abort message before
- * trapping; other SKIP observations stay silent.
+ * The call that wins the deadline CAS prints an `FT_ABORT_SITE_` line in either
+ * behavior, naming the wait that noticed it; the transition's own first-writer
+ * line is emitted separately, from inside the CAS. Other TRAP observations
+ * print the legacy CUDA abort message before trapping; other SKIP observations
+ * stay silent.
  *
  * Use this where the exit needs more than a bare `break` or `return` -- for
  * example when the decision must be made warp-uniform before a barrier:
@@ -108,12 +122,12 @@ __device__ __forceinline__ bool abortCheckAndLog(
  *       break;
  *     }
  */
-#define FT_ABORT_CHECK(abort, fmt, ...)                        \
-  ::comms::fault_tolerance::detail::abortCheckAndLog(          \
-      (abort),                                                 \
-      "CUDA ABORT ERROR: " fmt FT_ABORT_SITE_SUFFIX_,          \
-      FT_ABORT_FIRST_WRITER_DEVICE_ fmt FT_ABORT_SITE_SUFFIX_, \
-      ##__VA_ARGS__,                                           \
+#define FT_ABORT_CHECK(abort, fmt, ...)               \
+  ::comms::fault_tolerance::detail::abortCheckAndLog( \
+      (abort),                                        \
+      "CUDA ABORT ERROR: " fmt FT_ABORT_SITE_SUFFIX_, \
+      FT_ABORT_SITE_ fmt FT_ABORT_SITE_SUFFIX_,       \
+      ##__VA_ARGS__,                                  \
       __func__)
 
 /*

--- a/comms/common/fault_tolerance/FAULT_TOLERANCE.md
+++ b/comms/common/fault_tolerance/FAULT_TOLERANCE.md
@@ -52,8 +52,10 @@ rules the detail exists to serve.
    work-in-progress paths. A spin loop that reaches main without an abort check
    is a hang waiting to happen.
 10. **Per-operation timeouts come only from the collective API.** The
-    communicator deadline stays late-bound in shared state so `setTimeout()` is
-    observed by already-created device handles.
+    communicator deadline stays late-bound in shared state, read by the device.
+    Do not cache it in the handle: a captured CUDA graph replays with no host
+    code, so a host-stamped value is frozen for every replay. See
+    *Per-operation timeouts*.
 11. **Validate a timeout's sign, not its size.** Choosing a sane magnitude is
     the caller's job; `std::chrono` types already make unit mistakes unlikely.
     A negative value must be rejected, because at the `AbortDevice` layer it
@@ -393,14 +395,40 @@ handle, calls `AbortDevice::setOpTimeoutMs()` on that copy, and stores it in the
 kernel arguments, so the override travels by value and costs no shared-state
 read.
 
-When no per-operation timeout is supplied the override stays unset and the
-device reads the communicator timeout from shared state on every
-`startTimeout()`. That keeps it late-bound, so `IComm::setTimeout()` is observed
-even by transports that cache one device handle for the communicator's lifetime.
+When no per-operation timeout is supplied the override stays unset and
+`startTimeout()` reads the communicator timeout from mapped shared state.
+
+That read is not free, and it is worth knowing how unfree before optimizing it.
+Collectives arm on *every thread* -- `abortDevice.start()` at the top of the
+AllReduce tree and ring kernels is not leader-gated, because the poll throttle
+state it initializes has to be per-poller. Reads of one mapped cacheline from
+different warps serialize completely, so the cost is linear in warps at the full
+uncached-PCIe rate. Measured with `ArmOnly*` in `benchmarks/AbortBench.cc`:
+
+| Launch shape | Warps | Arm cost |
+|---|---:|---:|
+| 1 x 1 | 1 | +1.35us |
+| 1 x 640 *(the real AllReduce shape)* | 20 | **+20.8us** |
+| 8 x 640 | 160 | +166.5us |
+
+1.04us per warp, dead linear.
+
+**And yet moving it off the device is the wrong fix**, which is the useful part
+of this measurement. Resolving the timeout on the host and stamping it into the
+handle removes all of the above in microbenchmark and changes the collective by
+**zero** -- the arm reads overlap with real kernel work, which an empty-kernel
+benchmark cannot show. It also breaks CUDA graphs: a captured graph replays with
+no host code in between, so the stamp is frozen and the deadline never lapses.
+`AbortState` lives in mapped memory precisely so graph-mode device code can read
+the live value.
+
+What actually costs is the poll *rate*, not this one read per arm -- see
+*Where the healthy-path overhead went*.
 
 `MCCL_ABORT_TIMEOUT_MS` seeds only the communicator timeout. It is never turned
-into a per-operation override: doing so would snapshot it at launch and defeat
-that late-binding.
+into a per-operation override: `opTimeoutMs()` means "the caller asked for this
+deadline", and conflating it with the communicator default would lose that
+distinction in the abort log.
 
 ## Integration Notes
 

--- a/comms/common/fault_tolerance/FAULT_TOLERANCE.md
+++ b/comms/common/fault_tolerance/FAULT_TOLERANCE.md
@@ -253,6 +253,53 @@ Two consequences worth internalizing:
   It trades abort-detection latency against a fixed percentage of every
   collective's runtime, and the cost is linear in the value.
 
+## What the abort log costs, and where it lives
+
+The section above is about the *check*. The *log* has the opposite constraint
+and is the other easy way to make abort handling expensive.
+
+The check must stay inlined -- it is the throttle gate, on every spin iteration
+of every wait. The log runs at most once per communicator, after something has
+already gone wrong, so its runtime cost is irrelevant. Its **static** cost is
+not: with RDC off, an inlined log body is copied into every abort call site in
+every kernel that includes `AbortDevice.cuh` -- about 60 call sites, multiplied
+across every consuming translation unit.
+
+So `detail::deviceLogFirstWriter()` is `noinline`, emitting one copy per
+translation unit. Counted on
+`//comms/mccl/collectives/allreduce:allreduce_fused_tree_device`
+(50 kernels across sm_80 and sm_90a): **6,930,608 instructions against 7,163,792
+inlined, 5.8% less**.
+
+That function is also the *only* device emitter. Every path that takes the
+shared reason from `NONE` to terminal -- `AbortDevice::setAbort()`,
+`AbortFlag::setAbort()`, and the deadline CAS in `markTimedOutIfExpired()` --
+reaches it through `detail::deviceTrySetAbort()`, so there is one format string
+and one field list. A `FT_ABORT_*` macro adds a second line under a *different*
+marker, `COMMS FT ABORT SITE:`, naming where the abort was observed; that is an
+observation rather than a transition, which is why it does not reuse the
+first-writer marker. Counting `COMMS FT ABORT FIRST WRITER:` therefore counts
+transitions, and it should be exactly one per communicator.
+
+The identity and timing fields (`op`, `timeout_ms`, `elapsed_ms`, and the raw
+cycle counts) ride on the first-writer line itself rather than on a line of
+their own. Two printfs interleave across aborting threads, and once they do
+there is no way to attribute a context line to its marker.
+
+Two things that are easy to get wrong here:
+
+- **64-bit division is expensive, not the `printf`.** Deriving a millisecond
+  value from cycle counts calls `__cuda_sm20_div_u64`, a device software
+  routine. The log does exactly one of them, for `elapsed_ms`; `timeout_ms` is
+  read live from mapped state rather than divided out of the deadline. Reading
+  it live also keeps it out of the handle, which is copied into every kernel
+  argument struct and again per block.
+- **The linkage needs `inline` in both compilation passes** and `noinline` in
+  only the device pass. `comms/ctran` device-links its objects, so external
+  device linkage there is `nvlink error : Multiple definition`; and gcc rejects
+  `inline` plus `noinline` under `-Werror`. See the comment on
+  `COMMS_FT_ABORT_LOG_LINKAGE`.
+
 ## MPT And Prims Integration
 
 `MultiPeerTransport` is the device-handle propagation point for Prims

--- a/comms/common/fault_tolerance/benchmarks/AbortBench.cc
+++ b/comms/common/fault_tolerance/benchmarks/AbortBench.cc
@@ -680,6 +680,75 @@ BENCHMARK_COUNTERS(AbortSignalHostDeviceRoundTrip, counters, iters) {
       folly::UserMetric(iters, folly::UserMetric::Type::METRIC);
 }
 
+// Attributes the per-launch cost of arming a device deadline, which is the
+// leading suspect for FT's fixed healthy-path overhead.
+//
+// `startTimeout()` resolves the communicator deadline through
+// `getTimeoutMs()`, an uncached read of mapped pinned host memory. Every block
+// does it at kernel entry, and they all hit the same cacheline. This launches
+// a kernel that does nothing else, so the enabled-minus-disabled difference is
+// the arm cost with launch overhead subtracted out.
+void runArmOnlyBenchmark(
+    folly::UserCounters& counters,
+    uint32_t iters,
+    bool enabled,
+    int blocks,
+    int threads) {
+  folly::BenchmarkSuspender suspender;
+  Abort abort{enabled};
+  if (enabled) {
+    abort.setDefaultTimeout(std::chrono::milliseconds{60000});
+  }
+  auto handle = abort.getDeviceHandle();
+  auto sink = makeDeviceValue<uint64_t>();
+  CHECK_NE(sink, nullptr);
+  // Warm the context so the first launch's lazy init is not attributed here.
+  CHECK_EQ(
+      launchAbortDeviceArmOnly(
+          handle, sink.get(), blocks, threads, /*stream=*/nullptr),
+      cudaSuccess);
+  CHECK_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  suspender.dismiss();
+
+  for (uint32_t i = 0; i < iters; ++i) {
+    CHECK_EQ(
+        launchAbortDeviceArmOnly(
+            handle, sink.get(), blocks, threads, /*stream=*/nullptr),
+        cudaSuccess);
+    CHECK_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  }
+  suspender.rehire();
+  counters["warps"] = folly::UserMetric(
+      static_cast<int64_t>(blocks) * ((threads + 31) / 32),
+      folly::UserMetric::Type::METRIC);
+}
+
+// 1x640 is the real AllReduce tree/ring launch shape (`kBlockSize = 640`).
+// The rest bracket it so the scaling is visible rather than asserted.
+BENCHMARK_COUNTERS(ArmOnlyDisabled1x1, counters, iters) {
+  runArmOnlyBenchmark(counters, iters, /*enabled=*/false, 1, 1);
+}
+
+BENCHMARK_COUNTERS(ArmOnlyEnabled1x1, counters, iters) {
+  runArmOnlyBenchmark(counters, iters, /*enabled=*/true, 1, 1);
+}
+
+BENCHMARK_COUNTERS(ArmOnlyDisabled1x640, counters, iters) {
+  runArmOnlyBenchmark(counters, iters, /*enabled=*/false, 1, 640);
+}
+
+BENCHMARK_COUNTERS(ArmOnlyEnabled1x640, counters, iters) {
+  runArmOnlyBenchmark(counters, iters, /*enabled=*/true, 1, 640);
+}
+
+BENCHMARK_COUNTERS(ArmOnlyDisabled8x640, counters, iters) {
+  runArmOnlyBenchmark(counters, iters, /*enabled=*/false, 8, 640);
+}
+
+BENCHMARK_COUNTERS(ArmOnlyEnabled8x640, counters, iters) {
+  runArmOnlyBenchmark(counters, iters, /*enabled=*/true, 8, 640);
+}
+
 BENCHMARK_COUNTERS(AbortSignalDeviceDevicePingPong, counters, iters) {
   folly::BenchmarkSuspender suspender;
   const auto iterations = checkedIterationCount(iters);

--- a/comms/common/fault_tolerance/benchmarks/AbortBench.cu
+++ b/comms/common/fault_tolerance/benchmarks/AbortBench.cu
@@ -178,7 +178,29 @@ __global__ void abortDeviceIsAbortedLoadLoopKernel(
   *sink = local;
 }
 
+__global__ void abortDeviceArmOnlyKernel(AbortDevice abort, uint64_t* sink) {
+  // Deliberately NOT leader-gated: the collectives arm on every thread (see
+  // `abortDevice.start()` at the top of the AllReduce tree/ring kernels), and
+  // reproducing that is the point of this benchmark.
+  abort.startTimeout();
+  // Consume the result so the arm cannot be optimized away, without adding a
+  // store on the measured path: the deadline is a clock value and is never 1.
+  if (abort.deadlineCycles() == 1) {
+    *sink = 1;
+  }
+}
+
 } // namespace
+
+cudaError_t launchAbortDeviceArmOnly(
+    AbortDevice abort,
+    uint64_t* sink,
+    int blocks,
+    int threads,
+    cudaStream_t stream) {
+  abortDeviceArmOnlyKernel<<<blocks, threads, 0, stream>>>(abort, sink);
+  return cudaGetLastError();
+}
 
 cudaError_t launchDeviceLoadLoop(
     int* flag,

--- a/comms/common/fault_tolerance/benchmarks/AbortBench.cuh
+++ b/comms/common/fault_tolerance/benchmarks/AbortBench.cuh
@@ -48,6 +48,22 @@ cudaError_t launchDeviceToDevicePingPong(
     uint64_t maxWaitCycles,
     cudaStream_t stream);
 
+// One `startTimeout()` per *thread* and nothing else, which is the shape of a
+// collective kernel's entry: the AllReduce tree and ring kernels arm on every
+// thread, not once per block, and reproducing that is the point. So a 1x640
+// launch performs 640 arms, and the per-warp figures in `Perf.md` are read from
+// that -- treating the count as per-block would understate the cost by the
+// block width.
+//
+// Run it against an enabled and a disabled handle and the difference is the
+// whole arm-site cost, separated from launch overhead.
+cudaError_t launchAbortDeviceArmOnly(
+    AbortDevice abort,
+    uint64_t* sink,
+    int blocks,
+    int threads,
+    cudaStream_t stream);
+
 cudaError_t launchAbortDeviceDefaultTimeoutLoadLoop(
     AbortDevice abort,
     int64_t* sink,

--- a/comms/common/fault_tolerance/benchmarks/Perf.md
+++ b/comms/common/fault_tolerance/benchmarks/Perf.md
@@ -191,3 +191,35 @@ polls include the backoff noted above.
 |---|---:|---:|---|
 | Host/device signal RTT | `AbortSignalHostDeviceRoundTrip`: 4.24us (2.12us one way) | `AbortSignalHostDeviceRoundTrip`: 3.08us (1.54us one way) | CPU requester to persistent GPU responder and back over mapped pinned atomics. |
 | Device/device signal ping-pong | `AbortSignalDeviceDevicePingPong`: 6.34us (3.17us one way) | `AbortSignalDeviceDevicePingPong`: 4.61us (2.31us one way) | Two CUDA blocks exchanging request/response over mapped pinned atomics. |
+
+## Arming a device deadline
+
+Collected 2026-09-08 on `devgpu012.mwg1` (`NVIDIA H100`) with the `ArmOnly*`
+rows. Each launches a kernel that calls `startTimeout()` and nothing else, so
+enabled-minus-disabled is the arm cost with launch overhead subtracted out.
+Arming is **not** leader-gated in the collectives -- `abortDevice.start()` runs
+on every thread, because the poll throttle state it initializes must be
+per-poller -- so the relevant axis is warps, not blocks, and a 1 x 640 launch
+performs 640 arms rather than one.
+
+| Launch shape | Warps | Disabled | Enabled | Arm cost |
+|---|---:|---:|---:|---:|
+| 1 x 1 | 1 | 7.43us | 8.84us | +1.41us |
+| 1 x 640 | 20 | 7.35us | 26.06us | **+18.71us** |
+| 8 x 640 | 160 | 7.41us | 152.23us | +144.82us |
+
+`startTimeout()` reads `state_->timeoutMs` from mapped pinned memory. That is an
+uncached PCIe read, and reads of one cacheline from different warps serialize,
+so the cost is linear in warps: **0.94us per warp** at 20 and **0.91us** at 160.
+1 x 640 is the real AllReduce tree/ring launch shape (`kBlockSize = 640`).
+
+The 1 x 1 row does not sit on that line (+1.41us for one warp) and is not
+expected to -- a single-warp launch still pays the one-time cost of pulling the
+cacheline in, with no other warp to amortize it against. Read the slope from the
+20- and 160-warp rows.
+
+Read this as an upper bound on what the arm site can cost, not as a collective
+regression. These reads overlap with real kernel work, so removing them moves an
+end-to-end collective by zero; the poll rate, not the arm, is what made fault
+tolerance expensive. Do not resolve the timeout on the host to "fix" this table:
+`AbortState` is mapped precisely so a replayed CUDA graph reads a live deadline.

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
@@ -181,6 +181,23 @@ __global__ void deviceWaitForTimeoutStartAliasKernel(
   *observedCheckExpired = 0;
 }
 
+__global__ void deviceReadArmedClockStateKernel(
+    AbortDevice abort,
+    unsigned long long* observedStartCycles,
+    unsigned long long* observedDeadlineCycles,
+    unsigned long long* observedCyclesPerMs,
+    unsigned long long* observedOpId) {
+  if (blockIdx.x != 0 || threadIdx.x != 0) {
+    return;
+  }
+
+  abort.startTimeout();
+  *observedStartCycles = abort.startCycles();
+  *observedDeadlineCycles = abort.deadlineCycles();
+  *observedCyclesPerMs = abort.cyclesPerMs();
+  *observedOpId = abort.opId();
+}
+
 __global__ void deviceCancelAndRestartTimeoutKernel(
     AbortDevice abort,
     int* observedAfterCancel,
@@ -354,6 +371,22 @@ cudaError_t launchDeviceCancelAndRestartTimeout(
     cudaStream_t stream) {
   deviceCancelAndRestartTimeoutKernel<<<1, 1, 0, stream>>>(
       abort, observedAfterCancel, observedMode, maxIterations);
+  return cudaGetLastError();
+}
+
+cudaError_t launchDeviceReadArmedClockState(
+    AbortDevice abort,
+    unsigned long long* observedStartCycles,
+    unsigned long long* observedDeadlineCycles,
+    unsigned long long* observedCyclesPerMs,
+    unsigned long long* observedOpId,
+    cudaStream_t stream) {
+  deviceReadArmedClockStateKernel<<<1, 1, 0, stream>>>(
+      abort,
+      observedStartCycles,
+      observedDeadlineCycles,
+      observedCyclesPerMs,
+      observedOpId);
   return cudaGetLastError();
 }
 

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
@@ -55,6 +55,18 @@ __global__ void devicePublishReasonWithoutContextKernel(
   }
 }
 
+__global__ void flagSetAbortWithContextKernel(
+    AbortDevice abort,
+    AbortReason reason,
+    bool useContext,
+    int* observedWinner) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    const char* context = useContext ? "AbortFlagTest callsite" : nullptr;
+    const AbortFlag flag{abort};
+    *observedWinner = flag.setAbort(reason, context) ? 1 : 0;
+  }
+}
+
 __global__ void
 deviceReadAbortKernel(AbortDevice abort, int* observed, int* observedMode) {
   if (blockIdx.x == 0 && threadIdx.x == 0) {
@@ -241,6 +253,17 @@ cudaError_t launchDevicePublishReasonWithoutContext(
     cudaStream_t stream) {
   devicePublishReasonWithoutContextKernel<<<1, 1, 0, stream>>>(
       abort, reason, observedWinner);
+  return cudaGetLastError();
+}
+
+cudaError_t launchFlagSetAbortWithContext(
+    AbortDevice abort,
+    AbortReason reason,
+    bool useContext,
+    int* observedWinner,
+    cudaStream_t stream) {
+  flagSetAbortWithContextKernel<<<1, 1, 0, stream>>>(
+      abort, reason, useContext, observedWinner);
   return cudaGetLastError();
 }
 

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
@@ -102,6 +102,17 @@ cudaError_t launchDeviceCancelAndRestartTimeout(
     int maxIterations,
     cudaStream_t stream);
 
+// Arms the handle and reports the arm-site clock state that the abort context
+// log line is derived from, so the derivation can be checked against the
+// timeout the caller actually asked for.
+cudaError_t launchDeviceReadArmedClockState(
+    AbortDevice abort,
+    unsigned long long* observedStartCycles,
+    unsigned long long* observedDeadlineCycles,
+    unsigned long long* observedCyclesPerMs,
+    unsigned long long* observedOpId,
+    cudaStream_t stream);
+
 // FT_ABORT_* macro coverage. Each kernel runs a bounded spin loop that can only
 // end through the macro under test, and reports how many iterations it took, so
 // a macro that fails to terminate shows up as the loop bound rather than a

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
@@ -35,6 +35,17 @@ cudaError_t launchDevicePublishReasonWithoutContext(
     int* observedWinner,
     cudaStream_t stream);
 
+// Records a terminal reason through `AbortFlag`, the poll-state-free handle the
+// IBRC transport stores in device memory, rather than through `AbortDevice`.
+// The two are separate writers of the same shared reason and must produce the
+// same first-writer line.
+cudaError_t launchFlagSetAbortWithContext(
+    AbortDevice abort,
+    AbortReason reason,
+    bool useContext,
+    int* observedWinner,
+    cudaStream_t stream);
+
 cudaError_t launchDeviceReadAbort(
     AbortDevice abort,
     int* observed,

--- a/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
@@ -332,7 +332,7 @@ TEST(AbortDeviceTest, deviceContextLogsOnlyForReasonCasWinner) {
       firstOut,
       ::testing::HasSubstr(
           std::string{kFirstWriterMarker} + "device reason=" +
-          std::to_string(static_cast<int>(AbortReason::NETWORK_ERROR)) +
+          std::string{abortReasonToString(AbortReason::NETWORK_ERROR)} +
           " context=AbortDeviceTest callsite"))
       << "captured: " << firstOut;
 
@@ -373,8 +373,8 @@ TEST(AbortDeviceTest, deviceNullContextCanLogForReasonCasWinner) {
       out,
       ::testing::HasSubstr(
           std::string{kFirstWriterMarker} + "device reason=" +
-          std::to_string(static_cast<int>(AbortReason::INTERNAL_ERROR)) +
-          " context=\n"))
+          std::string{abortReasonToString(AbortReason::INTERNAL_ERROR)} +
+          " context= op="))
       << "captured: " << out;
 }
 
@@ -405,7 +405,7 @@ TEST(AbortDeviceTest, flagSetAbortEmitsFirstWriterMarker) {
       out,
       ::testing::HasSubstr(
           std::string{kFirstWriterMarker} + "device reason=" +
-          std::to_string(static_cast<int>(AbortReason::IBRC_PROXY_TIMEOUT)) +
+          std::string{abortReasonToString(AbortReason::IBRC_PROXY_TIMEOUT)} +
           " context=AbortFlagTest callsite"))
       << "captured: " << out;
 }
@@ -803,7 +803,7 @@ TEST(AbortDeviceTest, directTimeoutViaIsAbortedEmitsTheMarker) {
       out,
       ::testing::HasSubstr(
           std::string{kFirstWriterMarker} + "device reason=" +
-          std::to_string(static_cast<int>(AbortReason::TIMED_OUT)) +
+          std::string{abortReasonToString(AbortReason::TIMED_OUT)} +
           " context=" + kDeadlineExpiredContext))
       << "captured: " << out;
   // Exactly one, even though the kernel polls in a loop: the line is gated on
@@ -834,7 +834,7 @@ TEST(AbortDeviceTest, directTimeoutViaCheckExpiredEmitsTheMarker) {
       out,
       ::testing::HasSubstr(
           std::string{kFirstWriterMarker} + "device reason=" +
-          std::to_string(static_cast<int>(AbortReason::TIMED_OUT)) +
+          std::string{abortReasonToString(AbortReason::TIMED_OUT)} +
           " context=" + kDeadlineExpiredContext))
       << "captured: " << out;
   EXPECT_EQ(countSubstr(out, kFirstWriterMarker), 1U) << "captured: " << out;
@@ -992,6 +992,150 @@ TEST(AbortDeviceTest, perOpTimeoutOverridesCommunicatorDefault) {
       elapsedMs,
       static_cast<float>(kDeviceTimeoutExpectedMs) + kDeviceTimeoutAccuracyMs)
       << "per-op override did not take precedence over the 60s comm default";
+}
+
+// The abort context log reports `timeout_ms` and `elapsed_ms` as arithmetic
+// over the arm-site clock state rather than as stored values. This checks that
+// derivation against the timeout the caller actually asked for -- a log line
+// that silently reports the wrong deadline is worse than one that reports none.
+TEST(AbortDeviceTest, armedClockStateRecoversTheRequestedTimeout) {
+  constexpr int64_t kRequestedTimeoutMs = 2500;
+  constexpr uint64_t kOpId = 987654321;
+
+  Abort abort{/*enabled=*/true};
+  abort.setDefaultTimeout(std::chrono::milliseconds{kRequestedTimeoutMs});
+
+  auto handle = abort.getDeviceHandle();
+  handle.setOpId(kOpId);
+
+  auto startCycles = makeDeviceValue<unsigned long long>();
+  auto deadlineCycles = makeDeviceValue<unsigned long long>();
+  auto cyclesPerMs = makeDeviceValue<unsigned long long>();
+  auto opId = makeDeviceValue<unsigned long long>();
+  ASSERT_NE(startCycles, nullptr);
+  ASSERT_NE(deadlineCycles, nullptr);
+  ASSERT_NE(cyclesPerMs, nullptr);
+  ASSERT_NE(opId, nullptr);
+
+  EXPECT_EQ(
+      launchDeviceReadArmedClockState(
+          handle,
+          startCycles.get(),
+          deadlineCycles.get(),
+          cyclesPerMs.get(),
+          opId.get(),
+          /*stream=*/nullptr),
+      cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  const auto observedStart = readDeviceValue(startCycles);
+  const auto observedDeadline = readDeviceValue(deadlineCycles);
+  const auto observedCyclesPerMs = readDeviceValue(cyclesPerMs);
+
+  EXPECT_EQ(readDeviceValue(opId), kOpId) << "op number must survive the copy";
+  EXPECT_GT(observedCyclesPerMs, 0U);
+  EXPECT_GT(observedStart, 0U) << "arming must stamp an origin to measure from";
+  EXPECT_GT(observedDeadline, observedStart);
+  EXPECT_EQ(
+      static_cast<int64_t>(
+          (observedDeadline - observedStart) / observedCyclesPerMs),
+      kRequestedTimeoutMs);
+}
+
+// An unarmed handle has no origin, so the log must be able to tell "never
+// armed" from "armed at clock zero" and report -1 rather than an elapsed time
+// counted from the start of the device's uptime.
+TEST(AbortDeviceTest, unarmedHandleReportsNoArmSite) {
+  Abort abort{/*enabled=*/true};
+  const auto handle = abort.getDeviceHandle();
+
+  // `startCycles == 0` is the field that actually encodes "never armed", and it
+  // is what makes the log's `armed` predicate false and its `elapsed_ms` -1.
+  // Asserting only `opId`/`cyclesPerMs` would leave this test passing through a
+  // regression in the arm-site origin, which is the thing it exists to protect.
+  EXPECT_EQ(handle.startCycles(), 0U)
+      << "an unarmed handle must have no origin to measure from";
+  EXPECT_EQ(handle.deadlineCycles(), 0U);
+  EXPECT_EQ(handle.opId(), 0U);
+  EXPECT_GT(handle.cyclesPerMs(), 0U)
+      << "the clock conversion is captured at handle creation, not at arm time";
+}
+
+// The two tests above check the arm-site state the context fields are derived
+// from. This checks the fields as *rendered*, which is a different claim: the
+// derivation can be correct while the printf that reports it is missing an
+// argument, has them out of order, or was never reached. The clock-state tests
+// pass in all three cases.
+//
+// It is also what pins the merge. `op`, `timeout_ms` and `elapsed_ms` used to
+// be a second `COMMS FT ABORT CONTEXT:` line; asserting they appear on the
+// first-writer line itself is what fails if anything splits them back apart.
+TEST(AbortDeviceTest, deviceFirstWriterLineCarriesTheAbortContext) {
+  constexpr int64_t kRequestedTimeoutMs = 2500;
+  constexpr uint64_t kOpId = 987654321;
+
+  Abort abort{/*enabled=*/true};
+  abort.setDefaultTimeout(std::chrono::milliseconds{kRequestedTimeoutMs});
+
+  auto handle = abort.getDeviceHandle();
+  handle.setOpId(kOpId);
+
+  auto won = makeDeviceValue<int>();
+  ASSERT_NE(won, nullptr);
+
+  FT_CAPTURE_DEVICE_STDOUT(out, [&] {
+    return launchDeviceSetAbortWithContext(
+        handle,
+        AbortReason::NETWORK_ERROR,
+        /*useContext=*/true,
+        won.get(),
+        /*stream=*/nullptr);
+  });
+
+  EXPECT_EQ(readDeviceValue(won), 1);
+  EXPECT_THAT(
+      out,
+      ::testing::HasSubstr(
+          std::string{kFirstWriterMarker} + "device reason=" +
+          std::string{abortReasonToString(AbortReason::NETWORK_ERROR)} +
+          " context=AbortDeviceTest callsite op=" + std::to_string(kOpId) +
+          " timeout_ms=" + std::to_string(kRequestedTimeoutMs)))
+      << "captured: " << out;
+  // This handle was never armed, so there is no origin to measure from and the
+  // log has to say so rather than counting from clock zero.
+  EXPECT_THAT(out, ::testing::HasSubstr("elapsed_ms=-1"))
+      << "captured: " << out;
+  // Still one line, carrying all of it.
+  EXPECT_EQ(countSubstr(out, kFirstWriterMarker), 1U) << "captured: " << out;
+}
+
+// `AbortFlag` has no handle to report on -- no `opId`, no arm-site clock. The
+// line still has to appear and keep its shape, with the timing fields reported
+// as unarmed, or the IBRC watchdogs that abort only through this type produce a
+// line that parses differently from every other abort.
+TEST(AbortDeviceTest, flagFirstWriterLineReportsUnarmedContext) {
+  Abort abort{/*enabled=*/true};
+  auto won = makeDeviceValue<int>();
+  ASSERT_NE(won, nullptr);
+
+  FT_CAPTURE_DEVICE_STDOUT(out, [&] {
+    return launchFlagSetAbortWithContext(
+        abort.getDeviceHandle(),
+        AbortReason::IBRC_PROXY_TIMEOUT,
+        /*useContext=*/true,
+        won.get(),
+        /*stream=*/nullptr);
+  });
+
+  EXPECT_EQ(readDeviceValue(won), 1);
+  EXPECT_THAT(
+      out,
+      ::testing::HasSubstr(
+          std::string{kFirstWriterMarker} + "device reason=" +
+          std::string{abortReasonToString(AbortReason::IBRC_PROXY_TIMEOUT)} +
+          " context=AbortFlagTest callsite op=0 timeout_ms=-1 elapsed_ms=-1"))
+      << "captured: " << out;
+  EXPECT_EQ(countSubstr(out, kFirstWriterMarker), 1U) << "captured: " << out;
 }
 
 TEST(AbortDeviceTest, perOpTimeoutUnsetFallsBackToCommunicatorDefault) {
@@ -1368,7 +1512,7 @@ TEST(AbortMacrosTest, TimeoutFirstWriterEmitsTheMarker) {
       out,
       ::testing::HasSubstr(
           std::string{kFirstWriterMarker} + "device reason=" +
-          std::to_string(static_cast<int>(AbortReason::TIMED_OUT)) +
+          std::string{abortReasonToString(AbortReason::TIMED_OUT)} +
           " context=" + kDeadlineExpiredContext))
       << "captured: " << out;
   // The observation, carrying what only the callsite knows.

--- a/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
@@ -6,12 +6,15 @@
 #include <cstdint>
 #include <cstdio>
 #include <memory>
+#include <string>
 #include <thread>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "comms/common/fault_tolerance/Abort.h"
 #include "comms/common/fault_tolerance/tests/AbortDeviceTest.cuh"
+#include "comms/common/fault_tolerance/tests/AbortLogMarkers.h"
 
 namespace comms::fault_tolerance::testing {
 namespace {
@@ -58,6 +61,57 @@ void destroyEvent(cudaEvent_t event) {
   if (event != nullptr) {
     EXPECT_EQ(cudaEventDestroy(event), cudaSuccess);
   }
+}
+
+// Captured stdout plus the CUDA status of the launch that produced it.
+//
+// The status has to travel with the text: `ASSERT_*` cannot be used in a
+// value-returning helper, and reporting a launch or sync failure with
+// `EXPECT_*` inside the helper lets the test carry on and match against a
+// capture that may be empty -- so the real failure is a CUDA error but what
+// gets reported is a missing substring.
+struct DeviceCapture {
+  std::string out;
+  cudaError_t status{cudaSuccess};
+};
+
+// Runs `launch`, drains the device printf FIFO, and returns everything the
+// process wrote to stdout meanwhile.
+//
+// The synchronize has to happen *inside* the capture window. Device `printf`
+// appends to a per-context FIFO that the runtime drains only on kernel
+// completion, synchronization, or context destruction, so reading the capture
+// before syncing returns an empty string and the test silently proves nothing.
+template <typename Launch>
+DeviceCapture captureDeviceStdoutWithStatus(Launch&& launch) {
+  ::testing::internal::CaptureStdout();
+  const cudaError_t launched = launch();
+  const cudaError_t synced = cudaDeviceSynchronize();
+  std::string captured = ::testing::internal::GetCapturedStdout();
+  return DeviceCapture{
+      std::move(captured), launched != cudaSuccess ? launched : synced};
+}
+
+// Binds `outVar` to the captured stdout, failing the test at this line if the
+// launch or the synchronize errored. A macro because `ASSERT_*` cannot appear
+// in the value-returning helper above, and because the point of asserting is to
+// stop before the substring matching that would otherwise report the CUDA
+// failure as a missing log line.
+#define FT_CAPTURE_DEVICE_STDOUT(outVar, ...)                     \
+  std::string outVar;                                             \
+  do {                                                            \
+    auto ftCapture_ = captureDeviceStdoutWithStatus(__VA_ARGS__); \
+    ASSERT_EQ(ftCapture_.status, cudaSuccess);                    \
+    outVar = std::move(ftCapture_.out);                           \
+  } while (0)
+
+size_t countSubstr(const std::string& haystack, const std::string& needle) {
+  size_t count = 0;
+  for (size_t pos = haystack.find(needle); pos != std::string::npos;
+       pos = haystack.find(needle, pos + needle.size())) {
+    ++count;
+  }
+  return count;
 }
 
 } // namespace
@@ -244,25 +298,23 @@ TEST(AbortDeviceTest, deviceContextLogsOnlyForReasonCasWinner) {
   ASSERT_NE(firstWon, nullptr);
   ASSERT_NE(secondWon, nullptr);
 
-  EXPECT_EQ(
-      launchDeviceSetAbortWithContext(
-          abort.getDeviceHandle(),
-          AbortReason::NETWORK_ERROR,
-          /*useContext=*/true,
-          firstWon.get(),
-          /*stream=*/nullptr),
-      cudaSuccess);
-  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  FT_CAPTURE_DEVICE_STDOUT(firstOut, [&] {
+    return launchDeviceSetAbortWithContext(
+        abort.getDeviceHandle(),
+        AbortReason::NETWORK_ERROR,
+        /*useContext=*/true,
+        firstWon.get(),
+        /*stream=*/nullptr);
+  });
 
-  EXPECT_EQ(
-      launchDeviceSetAbortWithContext(
-          abort.getDeviceHandle(),
-          AbortReason::INTERNAL_ERROR,
-          /*useContext=*/true,
-          secondWon.get(),
-          /*stream=*/nullptr),
-      cudaSuccess);
-  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  FT_CAPTURE_DEVICE_STDOUT(secondOut, [&] {
+    return launchDeviceSetAbortWithContext(
+        abort.getDeviceHandle(),
+        AbortReason::INTERNAL_ERROR,
+        /*useContext=*/true,
+        secondWon.get(),
+        /*stream=*/nullptr);
+  });
 
   EXPECT_EQ(readDeviceValue(firstWon), 1);
   EXPECT_EQ(readDeviceValue(secondWon), 0);
@@ -272,6 +324,23 @@ TEST(AbortDeviceTest, deviceContextLogsOnlyForReasonCasWinner) {
           .reason = AbortReason::NETWORK_ERROR,
           .context = "",
       }));
+
+  // The winner's line, in full. Asserting the rendered text rather than only
+  // the CAS result is the point: the boolean is unchanged if the printf is
+  // deleted or its arguments are wrong.
+  EXPECT_THAT(
+      firstOut,
+      ::testing::HasSubstr(
+          std::string{kFirstWriterMarker} + "device reason=" +
+          std::to_string(static_cast<int>(AbortReason::NETWORK_ERROR)) +
+          " context=AbortDeviceTest callsite"))
+      << "captured: " << firstOut;
+
+  // The loser is silent, and silence is the property that keeps one aborted
+  // communicator from producing one line per observing thread.
+  EXPECT_EQ(countSubstr(secondOut, kFirstWriterMarker), 0U)
+      << "captured: " << secondOut;
+  EXPECT_EQ(countSubstr(firstOut + secondOut, kFirstWriterMarker), 1U);
 }
 
 TEST(AbortDeviceTest, deviceNullContextCanLogForReasonCasWinner) {
@@ -279,15 +348,14 @@ TEST(AbortDeviceTest, deviceNullContextCanLogForReasonCasWinner) {
   auto won = makeDeviceValue<int>();
   ASSERT_NE(won, nullptr);
 
-  EXPECT_EQ(
-      launchDeviceSetAbortWithContext(
-          abort.getDeviceHandle(),
-          AbortReason::INTERNAL_ERROR,
-          /*useContext=*/false,
-          won.get(),
-          /*stream=*/nullptr),
-      cudaSuccess);
-  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  FT_CAPTURE_DEVICE_STDOUT(out, [&] {
+    return launchDeviceSetAbortWithContext(
+        abort.getDeviceHandle(),
+        AbortReason::INTERNAL_ERROR,
+        /*useContext=*/false,
+        won.get(),
+        /*stream=*/nullptr);
+  });
 
   EXPECT_EQ(readDeviceValue(won), 1);
   EXPECT_EQ(
@@ -296,6 +364,72 @@ TEST(AbortDeviceTest, deviceNullContextCanLogForReasonCasWinner) {
           .reason = AbortReason::INTERNAL_ERROR,
           .context = "",
       }));
+
+  // The log belongs to the CAS win, not to whether a diagnostic string was
+  // supplied. This is the regression guard for the `context != nullptr` guard
+  // that used to sit on the printf: with it restored, the line disappears
+  // entirely and this fails.
+  EXPECT_THAT(
+      out,
+      ::testing::HasSubstr(
+          std::string{kFirstWriterMarker} + "device reason=" +
+          std::to_string(static_cast<int>(AbortReason::INTERNAL_ERROR)) +
+          " context=\n"))
+      << "captured: " << out;
+}
+
+// `AbortFlag` is the other device writer of the shared reason -- the
+// poll-state-free handle the IBRC transport keeps in device memory, and the one
+// its proxy watchdogs abort through. It must produce the same first-writer line
+// as `AbortDevice`, or a watchdog abort leaves no greppable origin at all.
+TEST(AbortDeviceTest, flagSetAbortEmitsFirstWriterMarker) {
+  Abort abort{/*enabled=*/true};
+  auto won = makeDeviceValue<int>();
+  ASSERT_NE(won, nullptr);
+
+  FT_CAPTURE_DEVICE_STDOUT(out, [&] {
+    return launchFlagSetAbortWithContext(
+        abort.getDeviceHandle(),
+        AbortReason::IBRC_PROXY_TIMEOUT,
+        /*useContext=*/true,
+        won.get(),
+        /*stream=*/nullptr);
+  });
+
+  EXPECT_EQ(readDeviceValue(won), 1);
+  EXPECT_EQ(abort.reason(), AbortReason::IBRC_PROXY_TIMEOUT);
+
+  // Including the context. The IBRC watchdogs already pass one naming which
+  // watchdog fired; before this it was accepted and dropped.
+  EXPECT_THAT(
+      out,
+      ::testing::HasSubstr(
+          std::string{kFirstWriterMarker} + "device reason=" +
+          std::to_string(static_cast<int>(AbortReason::IBRC_PROXY_TIMEOUT)) +
+          " context=AbortFlagTest callsite"))
+      << "captured: " << out;
+}
+
+TEST(AbortDeviceTest, flagSetAbortLoserIsSilent) {
+  Abort abort{/*enabled=*/true};
+  auto won = makeDeviceValue<int>();
+  ASSERT_NE(won, nullptr);
+
+  // The host takes the reason first, so the flag's CAS loses.
+  EXPECT_TRUE(abort.setAbort(AbortReason::ABORTED, "host got there first"));
+
+  FT_CAPTURE_DEVICE_STDOUT(out, [&] {
+    return launchFlagSetAbortWithContext(
+        abort.getDeviceHandle(),
+        AbortReason::NETWORK_ERROR,
+        /*useContext=*/true,
+        won.get(),
+        /*stream=*/nullptr);
+  });
+
+  EXPECT_EQ(readDeviceValue(won), 0);
+  EXPECT_EQ(abort.reason(), AbortReason::ABORTED);
+  EXPECT_EQ(countSubstr(out, kFirstWriterMarker), 0U) << "captured: " << out;
 }
 
 TEST(AbortDeviceTest, abortFlagPublishesEmptyContext) {
@@ -634,6 +768,105 @@ TEST(AbortDeviceTest, startAliasAndCheckExpiredRecordTimeout) {
   EXPECT_EQ(
       readDeviceValue(observedMode), static_cast<int>(AbortReason::TIMED_OUT));
   EXPECT_TRUE(abort.isTimedOut());
+}
+
+// The timeout path has two entry shapes and neither goes through a macro. These
+// are how production actually observes a deadline: `groupAborted()` in the IB
+// and NVL send/recv/forward loops and in Ring AllReduce calls `checkExpired()`,
+// and the IBGDA warp proxy calls `isAborted()` directly. Neither has a macro
+// above it to name a callsite, so unless the transition speaks for itself the
+// abort has no greppable origin -- and no later observer can supply one,
+// because they all take the `reason() != NONE` return without transitioning.
+// Routing the deadline CAS through `detail::deviceTrySetAbort` is what makes
+// these two identical to `setAbort()` in what they emit.
+
+TEST(AbortDeviceTest, directTimeoutViaIsAbortedEmitsTheMarker) {
+  Abort abort{/*enabled=*/true};
+  auto observedMode = makeDeviceValue<int>();
+  auto observedIsAborted = makeDeviceValue<int>();
+  ASSERT_NE(observedMode, nullptr);
+  ASSERT_NE(observedIsAborted, nullptr);
+
+  abort.setDefaultTimeout(std::chrono::milliseconds{1});
+
+  FT_CAPTURE_DEVICE_STDOUT(out, [&] {
+    return launchDeviceWaitForTimeout(
+        abort.getDeviceHandle(),
+        observedMode.get(),
+        observedIsAborted.get(),
+        kDeviceTimeoutPollIterations,
+        /*stream=*/nullptr);
+  });
+
+  ASSERT_TRUE(abort.isTimedOut());
+  EXPECT_THAT(
+      out,
+      ::testing::HasSubstr(
+          std::string{kFirstWriterMarker} + "device reason=" +
+          std::to_string(static_cast<int>(AbortReason::TIMED_OUT)) +
+          " context=" + kDeadlineExpiredContext))
+      << "captured: " << out;
+  // Exactly one, even though the kernel polls in a loop: the line is gated on
+  // the CAS, and only one iteration can perform the transition.
+  EXPECT_EQ(countSubstr(out, kFirstWriterMarker), 1U) << "captured: " << out;
+}
+
+TEST(AbortDeviceTest, directTimeoutViaCheckExpiredEmitsTheMarker) {
+  Abort abort{/*enabled=*/true};
+  auto observedMode = makeDeviceValue<int>();
+  auto observedCheckExpired = makeDeviceValue<int>();
+  ASSERT_NE(observedMode, nullptr);
+  ASSERT_NE(observedCheckExpired, nullptr);
+
+  abort.setDefaultTimeout(std::chrono::milliseconds{1});
+
+  FT_CAPTURE_DEVICE_STDOUT(out, [&] {
+    return launchDeviceWaitForTimeoutStartAlias(
+        abort.getDeviceHandle(),
+        observedMode.get(),
+        observedCheckExpired.get(),
+        kDeviceTimeoutPollIterations,
+        /*stream=*/nullptr);
+  });
+
+  ASSERT_TRUE(abort.isTimedOut());
+  EXPECT_THAT(
+      out,
+      ::testing::HasSubstr(
+          std::string{kFirstWriterMarker} + "device reason=" +
+          std::to_string(static_cast<int>(AbortReason::TIMED_OUT)) +
+          " context=" + kDeadlineExpiredContext))
+      << "captured: " << out;
+  EXPECT_EQ(countSubstr(out, kFirstWriterMarker), 1U) << "captured: " << out;
+}
+
+// A deadline that lapses after someone else already declared the reason is an
+// observation, not a transition, and must stay silent. Without the CAS gate
+// every thread that later notices the abort would emit its own line.
+TEST(AbortDeviceTest, directTimeoutNonWinnerIsSilent) {
+  Abort abort{/*enabled=*/true};
+  auto observedMode = makeDeviceValue<int>();
+  auto observedIsAborted = makeDeviceValue<int>();
+  ASSERT_NE(observedMode, nullptr);
+  ASSERT_NE(observedIsAborted, nullptr);
+
+  // Host wins first. Its own marker goes to stderr, so it cannot be mistaken
+  // for a device line in the stdout capture below.
+  ASSERT_TRUE(abort.setAbort(AbortReason::ABORTED, "host got there first"));
+  abort.setDefaultTimeout(std::chrono::milliseconds{1});
+
+  FT_CAPTURE_DEVICE_STDOUT(out, [&] {
+    return launchDeviceWaitForTimeout(
+        abort.getDeviceHandle(),
+        observedMode.get(),
+        observedIsAborted.get(),
+        kDeviceTimeoutPollIterations,
+        /*stream=*/nullptr);
+  });
+
+  EXPECT_EQ(readDeviceValue(observedIsAborted), 1);
+  EXPECT_EQ(abort.reason(), AbortReason::ABORTED);
+  EXPECT_EQ(countSubstr(out, kFirstWriterMarker), 0U) << "captured: " << out;
 }
 
 TEST(AbortDeviceTest, deviceTimeoutCanBeCancelledAndRestarted) {
@@ -1098,6 +1331,60 @@ TEST(AbortMacrosTest, TimeoutTerminatesTheLoop) {
   EXPECT_LT(observed, kMacroTimeoutLoopBound);
   EXPECT_GT(observed, kMacroTimeoutMinIterations);
   EXPECT_TRUE(abort.isTimedOut());
+}
+
+// The third way a device abort is declared: not `setAbort()` from either
+// handle, but a deadline lapsing inside `FT_ABORT_CHECK`.
+//
+// This is the case that produces both lines. The transition emits the
+// first-writer line from inside the CAS exactly as the direct-timeout kernels
+// above do, and the macro adds a site line naming the wait that noticed it.
+// Asserting both is what pins the split: a regression that folds the caller's
+// message back into the first-writer marker, or that drops the site line,
+// changes one of these without changing the other.
+//
+// Deliberately on the SKIP path. Under TRAP the markers are unassertable:
+// `__trap()` faults the context and the printf FIFO is not reliably drained.
+TEST(AbortMacrosTest, TimeoutFirstWriterEmitsTheMarker) {
+  Abort abort{/*enabled=*/true};
+  abort.setDefaultTimeout(kMacroTimeoutMs);
+  ASSERT_EQ(abort.getDeviceHandle().behavior(), AbortBehavior::SKIP);
+
+  auto iterations = makeDeviceValue<int>();
+  ASSERT_NE(iterations, nullptr);
+
+  FT_CAPTURE_DEVICE_STDOUT(out, [&] {
+    return launchMacroTimeoutLoop(
+        abort.getDeviceHandle(),
+        iterations.get(),
+        kMacroTimeoutLoopBound,
+        /*stream=*/nullptr);
+  });
+
+  ASSERT_TRUE(abort.isTimedOut());
+  // The transition. Same line the direct-timeout kernels produce, because it
+  // comes from the same place.
+  EXPECT_THAT(
+      out,
+      ::testing::HasSubstr(
+          std::string{kFirstWriterMarker} + "device reason=" +
+          std::to_string(static_cast<int>(AbortReason::TIMED_OUT)) +
+          " context=" + kDeadlineExpiredContext))
+      << "captured: " << out;
+  // The observation, carrying what only the callsite knows.
+  EXPECT_THAT(
+      out,
+      ::testing::HasSubstr(
+          std::string{kSiteMarker} + "macroTimeoutLoop iteration"))
+      << "captured: " << out;
+  // The source location the macro concatenates at compile time, which is what
+  // makes the site line attributable to a wait rather than to a communicator.
+  EXPECT_THAT(out, ::testing::HasSubstr("AbortDeviceTest.cu:"))
+      << "captured: " << out;
+  // One of each: every later observer of the same terminal reason stays silent,
+  // and the site line is gated on the same CAS win.
+  EXPECT_EQ(countSubstr(out, kFirstWriterMarker), 1U) << "captured: " << out;
+  EXPECT_EQ(countSubstr(out, kSiteMarker), 1U) << "captured: " << out;
 }
 
 } // namespace comms::fault_tolerance::testing

--- a/comms/common/fault_tolerance/tests/AbortLogMarkers.h
+++ b/comms/common/fault_tolerance/tests/AbortLogMarkers.h
@@ -1,0 +1,30 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+/*
+ * The greppable abort-log contract, spelled out for tests.
+ *
+ * Deliberately NOT derived from `FT_ABORT_FIRST_WRITER_` / `FT_ABORT_SITE_` in
+ * `Abort.h`. A test that built its expectation from the macro would follow it
+ * anywhere it went, including somewhere no existing log search would find it;
+ * these are the strings oncall greps for, so a change to either should fail a
+ * test rather than silently retarget it.
+ *
+ * Shared between `AbortDeviceUT.cc` and `AbortUT.cc` rather than spelled twice.
+ * Two independent copies keep the same property against the macro while adding
+ * a new way to drift: an edit to one file leaves the other asserting a stale
+ * string, and the stale one still passes.
+ */
+
+namespace comms::fault_tolerance::testing {
+
+// Prefixes the one line emitted by whichever writer won the reason CAS.
+constexpr const char* kFirstWriterMarker = "COMMS FT ABORT FIRST WRITER: ";
+
+// Prefixes the line an `FT_ABORT_*` macro adds naming where the abort was
+// observed. Separate from the marker above because an observation is not a
+// transition; counting first-writer markers must stay a count of transitions.
+constexpr const char* kSiteMarker = "COMMS FT ABORT SITE: ";
+
+} // namespace comms::fault_tolerance::testing

--- a/comms/common/fault_tolerance/tests/AbortUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortUT.cc
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <optional>
 #include <stdexcept>
+#include <string>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -13,6 +14,7 @@
 #include <gtest/gtest.h>
 
 #include "comms/common/fault_tolerance/Abort.h"
+#include "comms/common/fault_tolerance/tests/AbortLogMarkers.h"
 
 namespace comms::fault_tolerance::testing {
 
@@ -660,6 +662,42 @@ TEST(AbortTest, concurrentWritersLeaveOneStableReason) {
   for (int i = 0; i < 1000; ++i) {
     ASSERT_EQ(abort.reason(), reason);
   }
+}
+
+TEST(AbortTest, hostFirstWriterEmitsTheMarker) {
+  Abort abort{/*enabled=*/true};
+
+  ::testing::internal::CaptureStderr();
+  const bool won = abort.setAbort(AbortReason::NETWORK_ERROR, "host callsite");
+  const std::string out = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_TRUE(won);
+  // Both the numeric enum and the name: the number survives an enum rename and
+  // the name is what makes the line readable without a header lookup.
+  EXPECT_THAT(
+      out,
+      ::testing::HasSubstr(
+          std::string{kFirstWriterMarker} + "host reason=" +
+          std::to_string(static_cast<int>(AbortReason::NETWORK_ERROR)) + "(" +
+          std::string{abortReasonToString(AbortReason::NETWORK_ERROR)} +
+          ") context=host callsite"))
+      << "captured: " << out;
+}
+
+TEST(AbortTest, hostFirstWriterLoserIsSilent) {
+  Abort abort{/*enabled=*/true};
+  ASSERT_TRUE(abort.setAbort(AbortReason::TIMED_OUT, "the winner"));
+
+  ::testing::internal::CaptureStderr();
+  const bool won = abort.setAbort(AbortReason::NETWORK_ERROR, "the loser");
+  const std::string out = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_FALSE(won);
+  EXPECT_THAT(out, ::testing::Not(::testing::HasSubstr(kFirstWriterMarker)))
+      << "captured: " << out;
+  // And the losing context is not published either -- the line and the stored
+  // context have to agree about who won.
+  EXPECT_THAT(out, ::testing::Not(::testing::HasSubstr("the loser")));
 }
 
 TEST(AbortTest, abortReasonToString) {

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -1166,6 +1166,8 @@ P2pIbgdaTransportBuildParams MultipeerIbgdaTransport::buildPeerTransportParams(
   const int companionSlots = config_.fixedChannelCompanionQpsPerPeerPerNic();
   // Build the device-side send/recv layout from the shared base.
   P2pIbgdaTransportBuildParams params(channelLayoutForPeer(peerIndex));
+  params.myRank = myRank_;
+  params.peerRank = peerIndexToRank(peerIndex);
   params.maxChannels = config_.max_num_channels;
   params.qpDirectionCount = config_.fixedChannelDirectionCount();
   params.qpsPerConnection = config_.qpsPerConnection;

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cu
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cu
@@ -226,7 +226,9 @@ P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
             d_allLocalChannels + i * params[i].maxChannels,
             params[i].maxChannels),
         params[i].channelLayout,
-        params[i].collapsedCq);
+        params[i].collapsedCq,
+        params[i].myRank,
+        params[i].peerRank);
   }
 
   // 4. Allocate and copy transport objects to GPU.
@@ -377,7 +379,9 @@ void writeDeviceTransportSlot(
       params.qpDirectionCount,
       DeviceSpan<IbLocalChannel>(d_localChannels, params.maxChannels),
       params.channelLayout,
-      params.collapsedCq);
+      params.collapsedCq,
+      params.myRank,
+      params.peerRank);
 
   err = cudaMemcpy(
       deviceArray + peerIndex,

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cuh
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cuh
@@ -68,6 +68,10 @@ struct P2pIbgdaTransportBuildParams {
   IbgdaLocalBuffer localSignalBuf{};
   IbgdaLocalBuffer counterBuf{};
   IbgdaRemoteBuffer discardSignalSlot{};
+  // Diagnostic identity only. A device wait that aborts has no other way to
+  // name which pair of ranks stalled; nothing on the data path reads these.
+  int myRank{-1};
+  int peerRank{-1};
   int numSignalSlots{0};
   int numCounterSlots{0};
   int maxChannels{0};

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -275,6 +275,10 @@ class P2pIbgdaTransportDevice {
    * @param channelLayout         Optional pipelined send/recv channel layout.
    *                              When empty, send()/recv() are unavailable.
    * @param collapsedCq           Whether device-visible QPs use collapsed CQs.
+   * @param myRank                Diagnostic only: this rank, so an aborting
+   *                              wait can name itself. `-1` when unknown.
+   * @param peerRank              Diagnostic only: the rank on the other end of
+   *                              this transport. `-1` when unknown.
    */
   __host__ __device__ P2pIbgdaTransportDevice(
       DeviceSpan<NicDeviceIbgdaResources> nicDevices,
@@ -288,7 +292,9 @@ class P2pIbgdaTransportDevice {
       int qpDirectionCount = kIbDirections,
       DeviceSpan<IbLocalChannel> localChannels = {},
       IbChannelLayout channelLayout = {},
-      bool collapsedCq = false)
+      bool collapsedCq = false,
+      int myRank = -1,
+      int peerRank = -1)
       : nicDevices_(nicDevices),
         ownedRemoteSignalBuf_(ownedRemoteSignalBuf),
         ownedLocalSignalBuf_(ownedLocalSignalBuf),
@@ -300,7 +306,9 @@ class P2pIbgdaTransportDevice {
         qpDirectionCount_(qpDirectionCount),
         localChannels_(localChannels),
         channelLayout_(channelLayout),
-        collapsedCq_(collapsedCq) {}
+        collapsedCq_(collapsedCq),
+        myRank_(myRank),
+        peerRank_(peerRank) {}
 
   // IBGDA round-robins each send/recv chunk's RDMA_WRITE + DATA_READY atomic-FA
   // across per-lane single-writer DATA_READY slots (one per QP lane; see
@@ -801,8 +809,10 @@ class P2pIbgdaTransportDevice {
       return false;
     }
     printf(
-        "P2pIbgdaTransportDevice: local completion failed lane=%u "
-        "ticket=%llu status=%d\n",
+        "P2pIbgdaTransportDevice: local completion failed rank=%d peer=%d "
+        "lane=%u ticket=%llu status=%d\n",
+        myRank_,
+        peerRank_,
         ticket.completionId,
         static_cast<unsigned long long>(ticket.value),
         status);
@@ -1237,7 +1247,9 @@ class P2pIbgdaTransportDevice {
         if (status == EBUSY) {
           FT_ABORT_BREAK(
               abortDevice,
-              "wait_local_on_qp timed out (ticket=%llu)",
+              "wait_local_on_qp timed out: rank=%d peer=%d ticket=%llu",
+              myRank_,
+              peerRank_,
               static_cast<unsigned long long>(ticket));
         } else if (status != 0) {
           // Previously this fell straight out of the loop: the `while` only
@@ -1266,7 +1278,9 @@ class P2pIbgdaTransportDevice {
                   comms::fault_tolerance::AbortReason::NETWORK_ERROR)) {
             printf(
                 "P2pIbgdaTransportDevice: wait_local_on_qp completion failed "
-                "(ticket=%llu status=%d)\n",
+                "rank=%d peer=%d ticket=%llu status=%d\n",
+                myRank_,
+                peerRank_,
                 static_cast<unsigned long long>(ticket),
                 status);
           }
@@ -1441,7 +1455,11 @@ class P2pIbgdaTransportDevice {
       while (current < expected) {
         FT_ABORT_BREAK(
             abortDevice,
-            "wait_signal: expected>=%llu, current=%llu",
+            "wait_signal: rank=%d peer=%d channel=%u expected>=%llu "
+            "current=%llu",
+            myRank_,
+            peerRank_,
+            group.group_id,
             static_cast<unsigned long long>(expected),
             static_cast<unsigned long long>(current));
         current = load_acquire_system_u64(signalBuf.ptr);
@@ -1462,7 +1480,11 @@ class P2pIbgdaTransportDevice {
       while (current < expected) {
         FT_ABORT_BREAK(
             abortDevice,
-            "wait_counter: expected>=%llu, current=%llu",
+            "wait_counter: rank=%d peer=%d channel=%u expected>=%llu "
+            "current=%llu",
+            myRank_,
+            peerRank_,
+            group.group_id,
             static_cast<unsigned long long>(expected),
             static_cast<unsigned long long>(current));
         current = load_acquire_system_u64(counterBuf.ptr);
@@ -3165,6 +3187,12 @@ class P2pIbgdaTransportDevice {
 
   IbChannelLayout channelLayout_{};
   bool collapsedCq_{false};
+
+  // Diagnostic identity, read only from abort/error log paths. A stalled wait
+  // otherwise reports a signal value with nothing to attribute it to, and the
+  // rank is not recoverable from anything else the device transport holds.
+  int myRank_{-1};
+  int peerRank_{-1};
 };
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -1018,7 +1018,9 @@ void MultipeerIbrcTransport::updatePeerDeviceTransport(int peerIndex) noexcept {
       config_.numSignalSlots,
       config_.numCounterSlots,
       channelLayoutForPeer(peerIndex),
-      abortDevice_);
+      abortDevice_,
+      myRank_,
+      peerIndexToRank(peerIndex));
 }
 
 std::size_t MultipeerIbrcTransport::allocatedCmdQueueCount() const {

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cu
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cu
@@ -34,7 +34,9 @@ void writeIbrcDeviceSlot(
     int numSignalSlots,
     int numCounterSlots,
     IbChannelLayout channelLayout,
-    comms::fault_tolerance::AbortDevice abort) {
+    comms::fault_tolerance::AbortDevice abort,
+    int myRank,
+    int peerRank) {
   auto* slots = static_cast<P2pIbrcTransportDevice*>(slotsHost);
   new (&slots[peerIndex]) P2pIbrcTransportDevice(
       queues,
@@ -49,7 +51,9 @@ void writeIbrcDeviceSlot(
       numSignalSlots,
       numCounterSlots,
       channelLayout,
-      abort);
+      abort,
+      myRank,
+      peerRank);
 }
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cuh
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cuh
@@ -46,6 +46,8 @@ void writeIbrcDeviceSlot(
     int numSignalSlots,
     int numCounterSlots,
     IbChannelLayout channelLayout,
-    comms::fault_tolerance::AbortDevice abort);
+    comms::fault_tolerance::AbortDevice abort,
+    int myRank,
+    int peerRank);
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -89,7 +89,9 @@ class P2pIbrcTransportDevice {
       int numSignalSlots = 0,
       int numCounterSlots = 0,
       IbChannelLayout channelLayout = {},
-      AbortDevice abort = {})
+      AbortDevice abort = {},
+      int myRank = -1,
+      int peerRank = -1)
       : cmdQueues(queues),
         numNics(nics),
         maxChannels_(maxChannels),
@@ -102,7 +104,9 @@ class P2pIbrcTransportDevice {
         numSignalSlots_(numSignalSlots),
         numCounterSlots_(numCounterSlots),
         channelLayout_(channelLayout),
-        abort_(abort) {}
+        abort_(abort),
+        myRank_(myRank),
+        peerRank_(peerRank) {}
 
   // IBRC round-robins each send/recv chunk's RDMA_WRITE + DATA_READY fetch-add
   // across per-lane command queues / QPs when numLanes > 1 (select_put_queue_id
@@ -397,7 +401,11 @@ class P2pIbrcTransportDevice {
         check_status(queue);
         FT_ABORT_BREAK(
             abortDevice,
-            "P2pIbrcTransportDevice: wait_local lane=%u expected=%llu",
+            "P2pIbrcTransportDevice: wait_local rank=%d peer=%d channel=%u "
+            "lane=%u expected=%llu",
+            myRank_,
+            peerRank_,
+            group.group_id,
             ticket.completionId,
             static_cast<unsigned long long>(ticket.value));
       }
@@ -432,7 +440,11 @@ class P2pIbrcTransportDevice {
       check_status(queue);
       FT_ABORT_BREAK(
           abortDevice,
-          "P2pIbrcTransportDevice: local completion lane=%u expected=%llu",
+          "P2pIbrcTransportDevice: local completion rank=%d peer=%d "
+          "channel=%u lane=%u expected=%llu",
+          myRank_,
+          peerRank_,
+          channelId,
           ticket.completionId,
           static_cast<unsigned long long>(ticket.value));
     }
@@ -1056,13 +1068,24 @@ class P2pIbrcTransportDevice {
     }
     if (group.is_leader()) {
       validate_group_scope(group);
-      while (load_acquire_system_u64(ptr) < expected) {
+      // Carry the polled value in a register rather than reloading it for the
+      // message: the abort args are evaluated on every spin iteration, so an
+      // acquire load in the arg list would put a system-scope read back on the
+      // hot path that the throttled abort check exists to keep off it.
+      uint64_t current = load_acquire_system_u64(ptr);
+      while (current < expected) {
         check_channel_status(group.group_id);
         FT_ABORT_BREAK(
             abortDevice,
-            "P2pIbrcTransportDevice: wait_%s expected=%llu",
+            "P2pIbrcTransportDevice: wait_%s rank=%d peer=%d channel=%u "
+            "expected=%llu current=%llu",
             kind,
-            static_cast<unsigned long long>(expected));
+            myRank_,
+            peerRank_,
+            group.group_id,
+            static_cast<unsigned long long>(expected),
+            static_cast<unsigned long long>(current));
+        current = load_acquire_system_u64(ptr);
       }
     }
     group.sync();
@@ -1221,6 +1244,12 @@ class P2pIbrcTransportDevice {
   // FT is on, and *write* a terminal reason via a system-scope CAS. The waits
   // bound themselves on the device clock instead of on shared reads.
   AbortFlag abort_{};
+
+  // Diagnostic identity, read only from abort/error log paths. A stalled wait
+  // otherwise reports a ticket or signal value with nothing to attribute it to,
+  // and the rank is not recoverable from anything else this slot holds.
+  int myRank_{-1};
+  int peerRank_{-1};
 };
 
 static_assert(std::is_standard_layout_v<P2pIbrcTransportDevice>);

--- a/comms/prims/transport/nvl/MultimemNvlSignal.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlSignal.cuh
@@ -379,7 +379,8 @@ __device__ __forceinline__ void wait_per_peer_serial(
       if (!complete) {
         if (FT_ABORT_CHECK(
                 abortDevice,
-                "NVL serial per-peer wait for round=%llu",
+                "NVL serial per-peer wait: rank=%d round=%llu",
+                transport.nvlRank,
                 static_cast<unsigned long long>(round.value))) {
           FT_DEVICE_TRAP();
         }
@@ -421,7 +422,8 @@ __device__ __forceinline__ void wait_per_peer_tree(
     if (!complete && group.is_leader()) {
       if (FT_ABORT_CHECK(
               abortDevice,
-              "NVL tree per-peer wait for round=%llu",
+              "NVL tree per-peer wait: rank=%d round=%llu",
+              transport.nvlRank,
               static_cast<unsigned long long>(round.value))) {
         FT_DEVICE_TRAP();
       }
@@ -469,7 +471,8 @@ __device__ __forceinline__ void wait_per_peer_butterfly(
     if (!complete && group.is_leader()) {
       if (FT_ABORT_CHECK(
               abortDevice,
-              "NVL butterfly per-peer wait for round=%llu",
+              "NVL butterfly per-peer wait: rank=%d round=%llu",
+              transport.nvlRank,
               static_cast<unsigned long long>(round.value))) {
         FT_DEVICE_TRAP();
       }


### PR DESCRIPTION
Summary:
The device abort log names what stalled and, as of the previous diff, who. It
still cannot say **which operation** or **how long it waited** -- so a line
cannot be joined against colltrace, cannot be matched to the same collective on
another rank, and cannot distinguish "the deadline was 50ms and we blew it" from
"the deadline was 30 minutes and something else aborted us".

Those fields are properties of the abort, not per-call-site knowledge, so they
are formatted once in a fixed-signature helper rather than marshalled into the
varargs of each of the ~60 `FT_ABORT_*` call sites. Every abort now emits a
context line ahead of the caller's message:

```
COMMS FT ABORT CONTEXT: reason=timed_out op=0 timeout_ms=20 elapsed_ms=20
elapsed_cycles=39609941 deadline_cycles=329039440423362
now_cycles=329039440433303 cycles_per_ms=1980000 block=0 thread=0
```

Changes:
- `AbortDevice::setOpId()` / `opId()`, stamped per operation on the copied handle
- `AbortDevice::startCycles()`, stamped by `startTimeout()` -- this is what makes
  the elapsed time recoverable
- `deviceLogAbortContext()`, called from the reason-CAS winner in both
  `AbortDevice::setAbort()` and `abortCheckAndLog()`
- `detail::deviceAbortReasonName()`, so reasons print as names; the host
  `abortReasonToString()` returns `std::string_view` and cannot cross printf
- `applyOpTimeout()` -> `applyOpContext(timeout, opId, abort)` across all 6
  launchers, so a collective cannot arm a deadline without also stamping the
  operation it belongs to

**The log is out-of-lined from birth.** `COMMS_FT_ABORT_LOG_LINKAGE` makes
`deviceLogAbortContext()` `noinline` in the device pass, emitting one copy per
translation unit instead of one per call site: **5.8% less SASS** across the 50
fused AllReduce tree kernels. The abort *check* stays inline -- it is the
throttle gate on every spin iteration -- and only the *log* moves. All three
linkage parts are load-bearing: `inline` in the host pass (else duplicate
symbols at host link), `inline` in the device pass too (`comms/ctran`
device-links its objects, so external device linkage is `nvlink error : Multiple
definition`), and `noinline` in the device pass only (gcc rejects `inline` plus
`noinline` under `-Werror`). The ctran constraint fails only at CTRAN's device
link, which no whole-program consumer catches, so
`all_reduce_test_suite_IB_ONLY_1x8_binary` is the build to re-run for any future
change to this header.

`timeout_ms` is read live from `resolveTimeoutMs()` rather than cached at arm
time. Caching it would cost 8 bytes in a handle that travels in kernel
arguments and buy nothing: the host is not expected to move the communicator
timeout mid-operation. `elapsed_ms` is the one division on this path.

`elapsed_cycles` is guarded on `now >= startCycles` and not only on
`startCycles != 0`. The subtraction is unsigned and `deviceClock()` is per-SM,
so a handle armed on one SM and logged from another can read backwards; without
the guard a few cycles of skew print as an elapsed_ms near 10^13.

Nothing was added above the poll gate. The new fields travel by value in the
handle and are read only from the cold log path; `startTimeout()` reads the
device clock exactly as often as it did before. `AbortDevice` grows by 16 bytes,
now bounded by a `static_assert`.

Differential Revision: D117897252


