### PR TITLE
Avoid throwing from memCacheAllocator destructor

### DIFF
--- a/comms/ctran/memory/memCacheAllocator.cc
+++ b/comms/ctran/memory/memCacheAllocator.cc
@@ -5,6 +5,7 @@
 #include <fmt/format.h>
 #include <folly/Singleton.h>
 #include <cstdint>
+#include <exception>
 
 #include "comms/ctran/memory/Utils.h"
 #include "comms/ctran/utils/Alloc.h"
@@ -110,7 +111,30 @@ commResult_t memCacheAllocator::reset() {
 
 memCacheAllocator::~memCacheAllocator() {
   CTRAN_LOG_SUBSYS(INFO, INIT, "Shutting down NCCLX memory cache allocator");
-  FB_COMMCHECKTHROW_EX_NOCOMM(reset());
+  try {
+    const auto result = reset();
+    if (result != commSuccess) {
+      CTRAN_ERR(
+          result,
+          "Failed to reset NCCLX memory cache allocator during shutdown: {} ({})",
+          result,
+          ::meta::comms::commCodeToString(result));
+    }
+  } catch (const ctran::utils::Exception& e) {
+    CTRAN_ERR(
+        e.result(),
+        "Failed to reset NCCLX memory cache allocator during shutdown: {}",
+        e.what());
+  } catch (const std::exception& e) {
+    CTRAN_ERR(
+        commInternalError,
+        "Failed to reset NCCLX memory cache allocator during shutdown: {}",
+        e.what());
+  } catch (...) {
+    CTRAN_ERR(
+        commInternalError,
+        "Failed to reset NCCLX memory cache allocator during shutdown: unknown exception");
+  }
 }
 
 std::shared_ptr<memRegion> memCacheAllocator::getFreeMemReg(

--- a/comms/ctran/memory/tests/memoryUtilsTests.cc
+++ b/comms/ctran/memory/tests/memoryUtilsTests.cc
@@ -4,6 +4,7 @@
 #include <nccl.h>
 
 #include "comms/ctran/memory/Utils.h"
+#include "comms/ctran/memory/memCacheAllocator.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -100,6 +101,36 @@ TEST_F(memoryUtilsTest, cudaCallocAsyncSlab) {
   CUDACHECK_TEST(cudaMemGetInfo(&after, &total));
   EXPECT_EQ(before, after);
 }
+
+TEST_F(memoryUtilsTest, memCacheAllocatorDestructorHandlesResetFailure) {
+  EnvRAII<size_t> poolSizeGuard(NCCL_MEM_POOL_SIZE, 0);
+  size_t before, after, total;
+  CUDACHECK_TEST(cudaMemGetInfo(&before, &total));
+
+  auto allocator = std::make_unique<ncclx::memory::memCacheAllocator>();
+  ASSERT_EQ(allocator->init(), commSuccess);
+
+  void* ptr = nullptr;
+  constexpr size_t kSize = 1 << 21;
+  ASSERT_EQ(
+      allocator->getCachedCuMemById(
+          __func__,
+          &ptr,
+          /*cuHandle=*/nullptr,
+          kSize,
+          &dummyLogData,
+          __func__),
+      commSuccess);
+  ASSERT_NE(ptr, nullptr);
+
+  // Keep the region reserved so reset() reports an error during destruction.
+  allocator.reset();
+  EXPECT_EQ(allocator, nullptr);
+
+  CUDACHECK_TEST(cudaMemGetInfo(&after, &total));
+  EXPECT_EQ(before, after);
+}
+
 TEST_F(memoryUtilsTest, allocateShareableBuffer) {
   EnvRAII<size_t> poolSizeGuard(NCCL_MEM_POOL_SIZE, 0);
   auto allocator = ncclx::memory::memCacheAllocator::getInstance();


### PR DESCRIPTION
Summary: Make `memCacheAllocator::~memCacheAllocator()` contain both non-success `reset()` results and exceptions reachable through `reset()`, including CUDA failures from `printSnapshot()`. Preserve ERR-level logging and Scuba reporting through `CTRAN_ERR`, and add an active regression test that destroys an allocator with an outstanding region and verifies its memory is reclaimed.

Differential Revision: D118290075


