### PR TITLE
Log device abort first writer (#3936)

### DIFF
--- a/comms/common/fault_tolerance/Abort.cc
+++ b/comms/common/fault_tolerance/Abort.cc
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <cstdio>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -217,6 +218,14 @@ bool Abort::trySetAbort(AbortReason newReason, std::string context) {
   // The reason CAS gives this call exclusive ownership of context_. Publishing
   // happens afterwards on purpose: a racing reader may return the reason with
   // empty context, but it never reads context_ while this swap is in progress.
+  const auto reasonString = abortReasonToString(newReason);
+  std::fprintf(
+      stderr,
+      FT_ABORT_FIRST_WRITER_HOST_ "reason=%d(%.*s) context=%s\n",
+      static_cast<int>(newReason),
+      static_cast<int>(reasonString.size()),
+      reasonString.data(),
+      context.c_str());
   context_.swap(context);
   contextReady_.store(true, std::memory_order_release);
   return true;

--- a/comms/common/fault_tolerance/Abort.h
+++ b/comms/common/fault_tolerance/Abort.h
@@ -13,6 +13,24 @@
 
 #include "comms/common/fault_tolerance/AbortTypes.h"
 
+/*
+ * Marker prefixing every first-writer abort log line, on either side.
+ *
+ * The winner of the reason CAS logs once and every later observer stays silent,
+ * so exactly one of these lines exists per communicator and it names whatever
+ * declared the abort. Defined here rather than spelled out at the three
+ * emitting sites (`Abort::trySetAbort`, `AbortDevice::setAbort`,
+ * `FT_ABORT_CHECK`) so host and device cannot drift apart and stop answering to
+ * the same grep.
+ *
+ * Host and device print different fields after the tag -- the host has the
+ * reason name and a `std::string` context, the device has neither -- so this
+ * shares the marker, not the whole line.
+ */
+#define FT_ABORT_FIRST_WRITER_ "COMMS FT ABORT FIRST WRITER: "
+#define FT_ABORT_FIRST_WRITER_HOST_ FT_ABORT_FIRST_WRITER_ "host "
+#define FT_ABORT_FIRST_WRITER_DEVICE_ FT_ABORT_FIRST_WRITER_ "device "
+
 namespace comms::fault_tolerance {
 
 enum class AbortCheckResult : int {

--- a/comms/common/fault_tolerance/AbortDevice.cuh
+++ b/comms/common/fault_tolerance/AbortDevice.cuh
@@ -267,8 +267,8 @@ struct AbortDevice final {
    * performed by Prims helpers so common fault-tolerance code stays transport
    * agnostic.
    */
-  __device__ AbortCheckResult check() const {
-    if (!checkExpired()) {
+  __device__ AbortCheckResult check(bool* flippedHere = nullptr) const {
+    if (!checkExpired(flippedHere)) {
       return AbortCheckResult::CONTINUE;
     }
     return behavior_ == AbortBehavior::TRAP ? AbortCheckResult::TRAP
@@ -282,7 +282,10 @@ struct AbortDevice final {
    * timeout. If this handle's local deadline has expired, this records
    * `AbortReason::TIMED_OUT` in the shared state.
    */
-  __device__ bool checkExpired() const {
+  __device__ bool checkExpired(bool* flippedHere = nullptr) const {
+    if (flippedHere != nullptr) {
+      *flippedHere = false;
+    }
     if (!isEnabled()) {
       return false;
     }
@@ -310,7 +313,7 @@ struct AbortDevice final {
       sawTerminalReason_ = true;
       return true;
     }
-    if (deadlineDue && markTimedOutIfExpired()) {
+    if (deadlineDue && markTimedOutIfExpired(flippedHere)) {
       sawTerminalReason_ = true;
       return true;
     }
@@ -372,7 +375,6 @@ struct AbortDevice final {
     if (!isEnabled()) {
       return false;
     }
-    (void)context;
     const bool validReason = detail::deviceIsValidTerminalReason(newReason);
     assert(validReason);
     if (!validReason) {
@@ -380,8 +382,16 @@ struct AbortDevice final {
     }
 
     int expected = static_cast<int>(AbortReason::NONE);
-    return detail::deviceCompareExchangeSystem(
+    const bool won = detail::deviceCompareExchangeSystem(
         &state_->abort, &expected, static_cast<int>(newReason));
+    if (won) {
+      // NOLINTNEXTLINE(facebook-security-vulnerable-printf)
+      printf(
+          FT_ABORT_FIRST_WRITER_DEVICE_ "reason=%d context=%s\n",
+          static_cast<int>(newReason),
+          context == nullptr ? "" : context);
+    }
+    return won;
   }
 
  private:
@@ -440,7 +450,7 @@ struct AbortDevice final {
     return deadlineCycles_ != 0 && detail::deviceClock() >= deadlineCycles_;
   }
 
-  __device__ bool markTimedOutIfExpired() const {
+  __device__ bool markTimedOutIfExpired(bool* flippedHere = nullptr) const {
     if (!isEnabled() || !deadlineExpired()) {
       return false;
     }
@@ -450,6 +460,9 @@ struct AbortDevice final {
             &state_->abort,
             &expected,
             static_cast<int>(AbortReason::TIMED_OUT))) {
+      if (flippedHere != nullptr) {
+        *flippedHere = true;
+      }
       return true;
     }
     return expected == static_cast<int>(AbortReason::TIMED_OUT);

--- a/comms/common/fault_tolerance/AbortMacros.cuh
+++ b/comms/common/fault_tolerance/AbortMacros.cuh
@@ -16,10 +16,9 @@
  * Under `AbortBehavior::TRAP` all three log the *site* -- file, line and
  * function -- alongside the caller's message, so a log line says where the
  * abort or the timeout was observed rather than only that one happened. Under
- * the default `AbortBehavior::SKIP` they stay silent: a wait that aborts does
- * so on every thread that reached it, and one printf per thread per site would
- * bury the host-side diagnosis under device output. SKIP is the production
- * path; the reason is already recorded on the `Abort` for the host to report.
+ * the default `AbortBehavior::SKIP`, only the call that wins the shared reason
+ * CAS logs. Every later observer stays silent, avoiding one printf per thread
+ * while preserving the device callsite that first declared the abort.
  *
  * These live in the fault-tolerance module and deliberately depend on nothing
  * from Prims, so CTRAN and MCCL device code can use the same checks.
@@ -47,22 +46,34 @@ namespace comms::fault_tolerance::detail {
  * is consumed by the trailing `%s`.
  */
 template <typename... Args>
-__device__ __forceinline__ bool
-abortCheckAndLog(const AbortDevice& abort, const char* fmt, Args... args) {
+__device__ __forceinline__ bool abortCheckAndLog(
+    const AbortDevice& abort,
+    const char* fmt,
+    const char* firstWriterFmt,
+    Args... args) {
 #if FT_IS_DEVICE_COMPILE
-  const auto result = abort.check();
+  bool flippedHere = false;
+  const auto result = abort.check(&flippedHere);
   if (result == AbortCheckResult::CONTINUE) {
     return false;
   }
-  if (result == AbortCheckResult::TRAP) {
+  if (flippedHere) {
+    // The transition from NONE happens exactly once per communicator. Print
+    // regardless of behavior so the production SKIP path retains the winning
+    // device callsite. NOLINTNEXTLINE(facebook-security-vulnerable-printf)
+    printf(firstWriterFmt, args...);
+  } else if (result == AbortCheckResult::TRAP) {
     // NOLINTNEXTLINE(facebook-security-vulnerable-printf)
     printf(fmt, args...);
+  }
+  if (result == AbortCheckResult::TRAP) {
     FT_DEVICE_TRAP();
   }
   return true;
 #else
   (void)abort;
   (void)fmt;
+  (void)firstWriterFmt;
   ((void)args, ...);
   return false;
 #endif
@@ -85,9 +96,9 @@ abortCheckAndLog(const AbortDevice& abort, const char* fmt, Args... args) {
  * it at compile time. `__func__` is expanded here, at the call site, so it
  * names the function containing the wait.
  *
- * Under `AbortBehavior::TRAP` this prints the message and the site, traps, and
- * still reports true, so a caller that survives the trap still terminates.
- * Under the default `AbortBehavior::SKIP` it reports true without printing.
+ * A first-writer check prints the common first-writer marker in either
+ * behavior. Other TRAP observations print the legacy CUDA abort message before
+ * trapping; other SKIP observations stay silent.
  *
  * Use this where the exit needs more than a bare `break` or `return` -- for
  * example when the decision must be made warp-uniform before a barrier:
@@ -97,11 +108,12 @@ abortCheckAndLog(const AbortDevice& abort, const char* fmt, Args... args) {
  *       break;
  *     }
  */
-#define FT_ABORT_CHECK(abort, fmt, ...)               \
-  ::comms::fault_tolerance::detail::abortCheckAndLog( \
-      (abort),                                        \
-      "CUDA ABORT ERROR: " fmt FT_ABORT_SITE_SUFFIX_, \
-      ##__VA_ARGS__,                                  \
+#define FT_ABORT_CHECK(abort, fmt, ...)                        \
+  ::comms::fault_tolerance::detail::abortCheckAndLog(          \
+      (abort),                                                 \
+      "CUDA ABORT ERROR: " fmt FT_ABORT_SITE_SUFFIX_,          \
+      FT_ABORT_FIRST_WRITER_DEVICE_ fmt FT_ABORT_SITE_SUFFIX_, \
+      ##__VA_ARGS__,                                           \
       __func__)
 
 /*

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cu
@@ -17,6 +17,17 @@ __global__ void deviceSetAbortKernel(AbortDevice abort, AbortReason reason) {
   }
 }
 
+__global__ void deviceSetAbortWithContextKernel(
+    AbortDevice abort,
+    AbortReason reason,
+    bool useContext,
+    int* observedWinner) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    const char* context = useContext ? "AbortDeviceTest callsite" : nullptr;
+    *observedWinner = abort.setAbort(reason, context) ? 1 : 0;
+  }
+}
+
 __global__ void
 deviceReadAbortKernel(AbortDevice abort, int* observed, int* observedMode) {
   if (blockIdx.x == 0 && threadIdx.x == 0) {
@@ -171,6 +182,17 @@ cudaError_t launchDeviceSetAbort(
     AbortReason reason,
     cudaStream_t stream) {
   deviceSetAbortKernel<<<1, 1, 0, stream>>>(abort, reason);
+  return cudaGetLastError();
+}
+
+cudaError_t launchDeviceSetAbortWithContext(
+    AbortDevice abort,
+    AbortReason reason,
+    bool useContext,
+    int* observedWinner,
+    cudaStream_t stream) {
+  deviceSetAbortWithContextKernel<<<1, 1, 0, stream>>>(
+      abort, reason, useContext, observedWinner);
   return cudaGetLastError();
 }
 

--- a/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
+++ b/comms/common/fault_tolerance/tests/AbortDeviceTest.cuh
@@ -15,6 +15,13 @@ cudaError_t launchDeviceSetAbort(
     AbortReason reason,
     cudaStream_t stream);
 
+cudaError_t launchDeviceSetAbortWithContext(
+    AbortDevice abort,
+    AbortReason reason,
+    bool useContext,
+    int* observedWinner,
+    cudaStream_t stream);
+
 cudaError_t launchDeviceReadAbort(
     AbortDevice abort,
     int* observed,

--- a/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortDeviceUT.cc
@@ -237,6 +237,67 @@ TEST(AbortDeviceTest, deviceProducerSupportsDetailedTerminalReasons) {
   }
 }
 
+TEST(AbortDeviceTest, deviceContextLogsOnlyForReasonCasWinner) {
+  Abort abort{/*enabled=*/true};
+  auto firstWon = makeDeviceValue<int>();
+  auto secondWon = makeDeviceValue<int>();
+  ASSERT_NE(firstWon, nullptr);
+  ASSERT_NE(secondWon, nullptr);
+
+  EXPECT_EQ(
+      launchDeviceSetAbortWithContext(
+          abort.getDeviceHandle(),
+          AbortReason::NETWORK_ERROR,
+          /*useContext=*/true,
+          firstWon.get(),
+          /*stream=*/nullptr),
+      cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(
+      launchDeviceSetAbortWithContext(
+          abort.getDeviceHandle(),
+          AbortReason::INTERNAL_ERROR,
+          /*useContext=*/true,
+          secondWon.get(),
+          /*stream=*/nullptr),
+      cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(firstWon), 1);
+  EXPECT_EQ(readDeviceValue(secondWon), 0);
+  EXPECT_EQ(
+      abort.getAbortInfo(),
+      (AbortInfo{
+          .reason = AbortReason::NETWORK_ERROR,
+          .context = "",
+      }));
+}
+
+TEST(AbortDeviceTest, deviceNullContextCanLogForReasonCasWinner) {
+  Abort abort{/*enabled=*/true};
+  auto won = makeDeviceValue<int>();
+  ASSERT_NE(won, nullptr);
+
+  EXPECT_EQ(
+      launchDeviceSetAbortWithContext(
+          abort.getDeviceHandle(),
+          AbortReason::INTERNAL_ERROR,
+          /*useContext=*/false,
+          won.get(),
+          /*stream=*/nullptr),
+      cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readDeviceValue(won), 1);
+  EXPECT_EQ(
+      abort.getAbortInfo(),
+      (AbortInfo{
+          .reason = AbortReason::INTERNAL_ERROR,
+          .context = "",
+      }));
+}
+
 TEST(AbortDeviceTest, deviceWinnerDoesNotExposeLosingHostContext) {
   Abort abort{/*enabled=*/true};
 

--- a/comms/common/fault_tolerance/tests/AbortUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortUT.cc
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <optional>
@@ -607,6 +608,42 @@ TEST(AbortTest, firstTerminalReasonWins) {
   EXPECT_TRUE(abort.isAborted());
   EXPECT_TRUE(abort.isTimedOut());
   EXPECT_EQ(abort.reason(), AbortReason::TIMED_OUT);
+}
+
+// `firstTerminalReasonWins` covers the sequential case. This is the contended
+// one: many threads recording different reasons at once must still leave
+// exactly one terminal reason behind, and it must not move afterwards. A reason
+// that could be overwritten would make the first-writer log name a fault that
+// is no longer the one being reported.
+TEST(AbortTest, concurrentWritersLeaveOneStableReason) {
+  constexpr int kThreadsPerReason = 16;
+  Abort abort{/*enabled=*/true};
+
+  std::atomic<bool> go{false};
+  std::vector<std::thread> writers;
+  writers.reserve(kThreadsPerReason * 2);
+  for (int i = 0; i < kThreadsPerReason * 2; ++i) {
+    const auto reason =
+        (i % 2 == 0) ? AbortReason::ABORTED : AbortReason::TIMED_OUT;
+    writers.emplace_back([&abort, &go, reason] {
+      while (!go.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+      }
+      abort.setAbort(reason);
+    });
+  }
+  go.store(true, std::memory_order_release);
+  for (auto& t : writers) {
+    t.join();
+  }
+
+  const auto reason = abort.reason();
+  EXPECT_TRUE(
+      reason == AbortReason::ABORTED || reason == AbortReason::TIMED_OUT);
+  EXPECT_TRUE(abort.isAborted());
+  for (int i = 0; i < 1000; ++i) {
+    ASSERT_EQ(abort.reason(), reason);
+  }
 }
 
 TEST(AbortTest, abortReasonToString) {


### PR DESCRIPTION
Summary:

An abort has exactly one first writer -- the caller that wins the reason CAS.
Until now only the device side said so, and only when it happened to have been
given a `context` string. This makes the marker unconditional, gives the host
the matching line, and defines the marker once so the two cannot drift.

- `Abort::trySetAbort()` emits `COMMS FT ABORT FIRST WRITER: host reason=...`
  after it wins the CAS, using the local `context` before the swap. Both the
  numeric enum and `abortReasonToString()` are printed, so the line is readable
  without a header lookup and greppable by value.
- `AbortDevice::setAbort()` drops the `context != nullptr` guard. The log
  belongs to the CAS win, not to whether a diagnostic string was supplied; a
  winner without context prints an empty one rather than nothing at all.
- The marker moves to `FT_ABORT_FIRST_WRITER_` in `Abort.h`, with `_HOST_` and
  `_DEVICE_` tags built from it. Three sites emit this prefix --
  `Abort::trySetAbort`, `AbortDevice::setAbort` and `FT_ABORT_CHECK` -- across
  three files and two compilation passes, so spelling it once is what keeps them
  answering to the same grep. Host and device print different fields after the
  tag, so this shares the marker rather than the whole line.
- `FT_ABORT_CHECK` still logs only on the first transition. Later device
  observers stay silent under the production SKIP behavior, which is what keeps
  this from becoming one printf per thread.

Nothing is stored in mapped state and no host-device traffic is added. The
device `context` is a device address the host cannot dereference, and it is read
only at the winning callsite.

Reviewed By: Scusemua

Differential Revision: D116528783
