### PR TITLE
Lower NCCL_BUILD_JOBS to avoid runner OOM

### DIFF
--- a/scripts/_build_wheel.sh
+++ b/scripts/_build_wheel.sh
@@ -36,6 +36,9 @@ export CLEAN_BUILD=1
 export CXXSTD="-std=c++20"
 export NCCL_PATCH_FMT_NVCC_CXX20=1
 # NCCLX device compilation can exhaust memory at full host parallelism.
-export NCCL_BUILD_JOBS=16
+# Lower to 8 to avoid OOM on g5.12xlarge self-hosted runners for old CUDA
+# builders (cu126/cu130) that have been hitting "lost communication" during
+# device kernel compilation.
+export NCCL_BUILD_JOBS=8
 
 python setup.py bdist_wheel


### PR DESCRIPTION
Summary:
GitHub Actions wheel builds for py3.10 cu126 and cu130 have been consistently failing with 'The self-hosted runner lost communication with the server' during NCCLX device compilation (see D113661114, run 33423460197, jobs 99591505914 and 99591506413). The log shows 36 minutes of compiling .cu files then abrupt termination, typical of OOM on g5.12xlarge runners in group default-old.

Lower NCCL_BUILD_JOBS from 16 to 8 to reduce peak memory. This matches the mccl feedstock mitigation and should allow old CUDA builders (cu126/cu130) to complete. Newer CUDA builders (cu132/cu134) already pass but will also benefit from lower memory.

Differential Revision: D118310161


