### PR TITLE
Extract the shared Direct IB peer schedule

### DIFF
--- a/comms/prims/collectives/ReduceScatterDirectIb.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIb.cu
@@ -3,6 +3,7 @@
 #include <atomic>
 
 #include "comms/prims/collectives/ReduceScatterDirectIb.cuh"
+#include "comms/prims/collectives/ReduceScatterDirectIbCore.cuh"
 
 #include "comms/prims/core/Checks.h"
 #include "comms/prims/core/CopyOp.cuh"
@@ -91,9 +92,13 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
     }
 
     for (int step = 0; step < W - 1; ++step) {
-      const int peer_offset =
-          kStaggerChannels ? (step + channel) % (W - 1) : step;
-      const int peer = (my_rank + 1 + peer_offset) % W;
+      const int peer = direct_ib_reduce_scatter_peer_for_step(
+          my_rank,
+          W,
+          channel,
+          step,
+          DirectIbReduceScatterRole::RECEIVE,
+          kStaggerChannels);
       const char* local_input = !args.in_place && step == 0
           ? reinterpret_cast<const char*>(own_src)
           : output_bytes;
@@ -121,9 +126,13 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
     }
 
     for (int step = 0; step < W - 1; ++step) {
-      const int peer_offset =
-          kStaggerChannels ? (step + channel) % (W - 1) : step;
-      const int peer = (my_rank + W - 1 - peer_offset) % W;
+      const int peer = direct_ib_reduce_scatter_peer_for_step(
+          my_rank,
+          W,
+          channel,
+          step,
+          DirectIbReduceScatterRole::SEND,
+          kStaggerChannels);
       TiledBuffer<const T> send_tile(
           input_base + static_cast<std::size_t>(peer) * args.chunk_elements,
           args.chunk_elements,

--- a/comms/prims/collectives/ReduceScatterDirectIbCore.cuh
+++ b/comms/prims/collectives/ReduceScatterDirectIbCore.cuh
@@ -1,0 +1,55 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+#define PRIMS_DIRECT_IB_RS_HOST_DEVICE_INLINE \
+  __host__ __device__ __forceinline__
+#else
+#define PRIMS_DIRECT_IB_RS_HOST_DEVICE_INLINE inline
+#endif
+
+namespace comms::prims {
+
+/** Communication role assigned to a Direct IB ReduceScatter thread group. */
+enum class DirectIbReduceScatterRole : std::uint8_t {
+  RECEIVE,
+  SEND,
+};
+
+/**
+ * Return the peer for one step of the matched Direct IB ReduceScatter walk.
+ *
+ * A receiver visits peers in the positive direction while the matching sender
+ * visits them in the negative direction. Channel staggering rotates both walks
+ * by the same amount, preserving the one-to-one send/receive pairing while
+ * spreading channels across peers. The rank and step preconditions are
+ * `0 <= my_rank < num_ranks` and `0 <= step < num_ranks - 1`. For the
+ * single-rank identity, the function returns `my_rank` without performing
+ * modulo arithmetic.
+ */
+PRIMS_DIRECT_IB_RS_HOST_DEVICE_INLINE constexpr int
+direct_ib_reduce_scatter_peer_for_step(
+    int my_rank,
+    int num_ranks,
+    std::uint32_t channel,
+    int step,
+    DirectIbReduceScatterRole role,
+    bool stagger_channels = true) {
+  if (num_ranks <= 1) {
+    return my_rank;
+  }
+  const auto peer_count = static_cast<std::uint32_t>(num_ranks - 1);
+  const auto peer_offset = stagger_channels
+      ? (static_cast<std::uint32_t>(step) + channel) % peer_count
+      : static_cast<std::uint32_t>(step);
+  return role == DirectIbReduceScatterRole::RECEIVE
+      ? (my_rank + 1 + static_cast<int>(peer_offset)) % num_ranks
+      : (my_rank + num_ranks - 1 - static_cast<int>(peer_offset)) % num_ranks;
+}
+
+} // namespace comms::prims
+
+#undef PRIMS_DIRECT_IB_RS_HOST_DEVICE_INLINE

--- a/comms/prims/collectives/ReduceScatterDirectIbV2.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIbV2.cu
@@ -2,6 +2,8 @@
 
 #include "comms/prims/collectives/ReduceScatterDirectIbV2.cuh"
 
+#include "comms/prims/collectives/ReduceScatterDirectIbCore.cuh"
+
 #include "comms/prims/core/Checks.h"
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/TiledBuffer.cuh"
@@ -277,7 +279,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
       if (group.is_leader()) {
         for (int i = 0; i < count; ++i) {
           const int step = base + i;
-          rpeer_of[i] = (my_rank + 1 + (step + channel) % (W - 1)) % W;
+          rpeer_of[i] = direct_ib_reduce_scatter_peer_for_step(
+              my_rank, W, channel, step, DirectIbReduceScatterRole::RECEIVE);
           for (int sl = 0; sl < kSlots; ++sl) {
             rviews[sl][i] = detail::RecvChunkAcquisition{};
           }
@@ -434,7 +437,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
       bool posted[kMaxPeersInFlight];
       for (int i = 0; i < count; ++i) {
         const int step = base + i;
-        peer_of[i] = (my_rank + W - 1 - (step + channel) % (W - 1)) % W;
+        peer_of[i] = direct_ib_reduce_scatter_peer_for_step(
+            my_rank, W, channel, step, DirectIbReduceScatterRole::SEND);
         posted[i] = false;
         auto transport = args.peers[peer_of[i]];
         transport.init_registered_send_progress(

--- a/comms/prims/collectives/tests/DirectIbReduceScatterCoreTest.cpp
+++ b/comms/prims/collectives/tests/DirectIbReduceScatterCoreTest.cpp
@@ -1,0 +1,122 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "comms/prims/collectives/ReduceScatterDirectIbCore.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+int legacy_peer_for_step(
+    int rank,
+    int num_ranks,
+    std::uint32_t channel,
+    int step,
+    DirectIbReduceScatterRole role,
+    bool stagger_channels) {
+  const int peer_offset = stagger_channels
+      ? static_cast<int>(
+            (static_cast<std::uint32_t>(step) + channel) %
+            static_cast<std::uint32_t>(num_ranks - 1))
+      : step;
+  return role == DirectIbReduceScatterRole::RECEIVE
+      ? (rank + 1 + peer_offset) % num_ranks
+      : (rank + num_ranks - 1 - peer_offset) % num_ranks;
+}
+
+void expect_matched_peer_walk(int num_ranks, bool stagger_channels) {
+  const std::vector<std::uint32_t> channels{
+      0,
+      1,
+      static_cast<std::uint32_t>(num_ranks - 1),
+      static_cast<std::uint32_t>(num_ranks),
+      static_cast<std::uint32_t>(2 * num_ranks + 1),
+  };
+  for (const std::uint32_t channel : channels) {
+    for (int rank = 0; rank < num_ranks; ++rank) {
+      std::vector<bool> visited(num_ranks, false);
+      for (int step = 0; step < num_ranks - 1; ++step) {
+        const int peer = direct_ib_reduce_scatter_peer_for_step(
+            rank,
+            num_ranks,
+            channel,
+            step,
+            DirectIbReduceScatterRole::RECEIVE,
+            stagger_channels);
+        ASSERT_GE(peer, 0);
+        ASSERT_LT(peer, num_ranks);
+        EXPECT_NE(peer, rank);
+        EXPECT_FALSE(visited[peer]);
+        visited[peer] = true;
+
+        EXPECT_EQ(
+            direct_ib_reduce_scatter_peer_for_step(
+                peer,
+                num_ranks,
+                channel,
+                step,
+                DirectIbReduceScatterRole::SEND,
+                stagger_channels),
+            rank);
+      }
+
+      for (int peer = 0; peer < num_ranks; ++peer) {
+        EXPECT_EQ(visited[peer], peer != rank);
+      }
+    }
+  }
+}
+
+TEST(DirectIbReduceScatterCoreTest, PeerWalkMatchesLegacyOrdering) {
+  for (const int num_ranks : {2, 3, 4, 7, 8, 31, 32, 127, 128, 255, 256}) {
+    for (std::uint32_t channel = 0; channel < 256; ++channel) {
+      for (int rank = 0; rank < num_ranks; ++rank) {
+        for (int step = 0; step < num_ranks - 1; ++step) {
+          for (const auto role :
+               {DirectIbReduceScatterRole::RECEIVE,
+                DirectIbReduceScatterRole::SEND}) {
+            EXPECT_EQ(
+                direct_ib_reduce_scatter_peer_for_step(
+                    rank, num_ranks, channel, step, role, true),
+                legacy_peer_for_step(
+                    rank, num_ranks, channel, step, role, true));
+            EXPECT_EQ(
+                direct_ib_reduce_scatter_peer_for_step(
+                    rank, num_ranks, channel, step, role, false),
+                legacy_peer_for_step(
+                    rank, num_ranks, channel, step, role, false));
+          }
+        }
+      }
+    }
+  }
+}
+
+TEST(DirectIbReduceScatterCoreTest, StaggeredWalkIsMatchedPermutation) {
+  for (const int num_ranks : {2, 3, 4, 7, 8, 31, 32, 127, 128, 255, 256}) {
+    expect_matched_peer_walk(num_ranks, true);
+  }
+}
+
+TEST(DirectIbReduceScatterCoreTest, UnstaggeredWalkIsMatchedPermutation) {
+  for (const int num_ranks : {2, 3, 4, 7, 8, 31, 32, 127, 128, 255, 256}) {
+    expect_matched_peer_walk(num_ranks, false);
+  }
+}
+
+TEST(DirectIbReduceScatterCoreTest, SingleRankIdentityReturnsSelf) {
+  EXPECT_EQ(
+      direct_ib_reduce_scatter_peer_for_step(
+          0, 1, 0, 0, DirectIbReduceScatterRole::RECEIVE),
+      0);
+  EXPECT_EQ(
+      direct_ib_reduce_scatter_peer_for_step(
+          0, 1, 0, 0, DirectIbReduceScatterRole::SEND),
+      0);
+}
+
+} // namespace
+} // namespace comms::prims::test


### PR DESCRIPTION
Summary:
Move only the matched Direct IB ReduceScatter peer walk into a transport-neutral Prims helper. Reuse it from the existing V1 and V2 Direct kernels while preserving their thread-role partition, buffers, quantization, progress, barriers, and launch behavior. This is the narrow scheduling seam intended for reuse by fused AllReduce and the MCCL-owned fused ReduceScatter follow-up; it does not extract or replace the standalone kernel body.

Add host coverage for exact legacy ordering, peer pairing, channel staggering, non-power-of-two sizes, and the single-rank identity.

Differential Revision: D118174504


