### PR TITLE
Share Direct NVLink schedule and layouts

### DIFF
--- a/comms/prims/collectives/DirectCollectiveUtils.cuh
+++ b/comms/prims/collectives/DirectCollectiveUtils.cuh
@@ -27,10 +27,11 @@ struct MemcpyAndSelfCopy {
   }
 };
 
-__device__ __forceinline__ std::size_t direct_pipeline_window(
-    const P2pNvlTransportDevice* peers,
-    int my_rank,
-    int num_ranks) {
+// PeerArray may be a dense transport pointer or a lightweight view that maps a
+// phase-local rank into a global unified transport table.
+template <typename PeerArray>
+__device__ __forceinline__ std::size_t
+direct_pipeline_window(const PeerArray& peers, int my_rank, int num_ranks) {
   std::size_t window = 0;
   for (int peer = 0; peer < num_ranks; ++peer) {
     if (peer == my_rank) {

--- a/comms/prims/collectives/DirectNvlSchedule.cuh
+++ b/comms/prims/collectives/DirectNvlSchedule.cuh
@@ -1,0 +1,125 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+#define PRIMS_DIRECT_NVL_SCHEDULE_HOST_DEVICE __host__ __device__
+#else
+#define PRIMS_DIRECT_NVL_SCHEDULE_HOST_DEVICE
+#endif
+
+namespace comms::prims {
+
+/** Communication direction for one Direct NVLink peer walk. */
+enum class DirectNvlPeerRole : std::uint8_t {
+  SEND,
+  RECEIVE,
+};
+
+/**
+ * Iterate over every non-self local peer.
+ *
+ * With rotation disabled, both roles retain the legacy ascending-rank order.
+ * With rotation enabled, send and receive walks are complementary for a given
+ * channel and step, spreading simultaneous channels over different peers.
+ * Callers own the rotation policy because its threshold is algorithm tuning,
+ * not a property of the transport. `local_size` must be greater than one;
+ * collective entry points handle the single-rank identity before constructing
+ * an iterator.
+ */
+class DirectNvlPeerIterator {
+ public:
+  PRIMS_DIRECT_NVL_SCHEDULE_HOST_DEVICE constexpr DirectNvlPeerIterator(
+      int local_rank,
+      int local_size,
+      std::uint32_t channel,
+      DirectNvlPeerRole role,
+      bool rotate_peers)
+      : local_rank_(local_rank),
+        peer_count_(local_size - 1),
+        peer_index_(0),
+        peer_step_(1) {
+    if (rotate_peers) {
+      const std::uint32_t peer_count = static_cast<std::uint32_t>(peer_count_);
+      const int channel_offset = static_cast<int>(
+          channel < peer_count ? channel : channel % peer_count);
+      if (role == DirectNvlPeerRole::SEND) {
+        peer_index_ = local_rank - 1 - channel_offset;
+        if (peer_index_ < 0) {
+          peer_index_ += peer_count_;
+        }
+        peer_step_ = -1;
+      } else {
+        peer_index_ = local_rank + channel_offset;
+        if (peer_index_ >= peer_count_) {
+          peer_index_ -= peer_count_;
+        }
+      }
+    }
+  }
+
+  PRIMS_DIRECT_NVL_SCHEDULE_HOST_DEVICE constexpr int next() {
+    // Iterate in the dense local_size-1 index space, then insert self again.
+    const int peer = peer_index_ + (peer_index_ >= local_rank_);
+    peer_index_ += peer_step_;
+    if (peer_index_ < 0) {
+      peer_index_ += peer_count_;
+    } else if (peer_index_ >= peer_count_) {
+      peer_index_ -= peer_count_;
+    }
+    return peer;
+  }
+
+ private:
+  int local_rank_;
+  int peer_count_;
+  int peer_index_;
+  int peer_step_;
+};
+
+/** Owner-major source chunks: all destination-domain chunks for one owner. */
+struct DirectNvlContiguousOwnerLayout {
+  PRIMS_DIRECT_NVL_SCHEDULE_HOST_DEVICE static constexpr std::size_t
+  source_chunk(
+      std::size_t destination_domain,
+      std::size_t local_owner,
+      std::size_t /* local_size */,
+      std::size_t num_destination_domains) {
+    return local_owner * num_destination_domains + destination_domain;
+  }
+
+  PRIMS_DIRECT_NVL_SCHEDULE_HOST_DEVICE static constexpr std::size_t
+  packed_chunk(std::size_t destination_domain) {
+    return destination_domain;
+  }
+};
+
+/**
+ * Node-major source chunks with owner-strided packing.
+ *
+ * A local owner `l` collects global chunks `(d * local_size + l)` for every
+ * destination domain `d`, and packs them as consecutive chunks `[d]` for the
+ * following inter-domain ReduceScatter phase.
+ */
+struct DirectNvlNodeMajorOwnerStridedLayout {
+  PRIMS_DIRECT_NVL_SCHEDULE_HOST_DEVICE static constexpr std::size_t
+  source_chunk(
+      std::size_t destination_domain,
+      std::size_t local_owner,
+      std::size_t local_size,
+      std::size_t /* num_destination_domains */) {
+    return destination_domain * local_size + local_owner;
+  }
+
+  PRIMS_DIRECT_NVL_SCHEDULE_HOST_DEVICE static constexpr std::size_t
+  packed_chunk(std::size_t destination_domain) {
+    return destination_domain;
+  }
+};
+
+} // namespace comms::prims
+
+#undef PRIMS_DIRECT_NVL_SCHEDULE_HOST_DEVICE

--- a/comms/prims/collectives/ReduceScatterDirectIb.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIb.cu
@@ -3,6 +3,7 @@
 #include <atomic>
 
 #include "comms/prims/collectives/ReduceScatterDirectIb.cuh"
+#include "comms/prims/collectives/ReduceScatterDirectIbCore.cuh"
 
 #include "comms/prims/core/Checks.h"
 #include "comms/prims/core/CopyOp.cuh"
@@ -91,9 +92,13 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
     }
 
     for (int step = 0; step < W - 1; ++step) {
-      const int peer_offset =
-          kStaggerChannels ? (step + channel) % (W - 1) : step;
-      const int peer = (my_rank + 1 + peer_offset) % W;
+      const int peer = direct_ib_reduce_scatter_peer_for_step(
+          my_rank,
+          W,
+          channel,
+          step,
+          DirectIbReduceScatterRole::RECEIVE,
+          kStaggerChannels);
       const char* local_input = !args.in_place && step == 0
           ? reinterpret_cast<const char*>(own_src)
           : output_bytes;
@@ -121,9 +126,13 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
     }
 
     for (int step = 0; step < W - 1; ++step) {
-      const int peer_offset =
-          kStaggerChannels ? (step + channel) % (W - 1) : step;
-      const int peer = (my_rank + W - 1 - peer_offset) % W;
+      const int peer = direct_ib_reduce_scatter_peer_for_step(
+          my_rank,
+          W,
+          channel,
+          step,
+          DirectIbReduceScatterRole::SEND,
+          kStaggerChannels);
       TiledBuffer<const T> send_tile(
           input_base + static_cast<std::size_t>(peer) * args.chunk_elements,
           args.chunk_elements,

--- a/comms/prims/collectives/ReduceScatterDirectIbCore.cuh
+++ b/comms/prims/collectives/ReduceScatterDirectIbCore.cuh
@@ -1,0 +1,55 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+#define PRIMS_DIRECT_IB_RS_HOST_DEVICE_INLINE \
+  __host__ __device__ __forceinline__
+#else
+#define PRIMS_DIRECT_IB_RS_HOST_DEVICE_INLINE inline
+#endif
+
+namespace comms::prims {
+
+/** Communication role assigned to a Direct IB ReduceScatter thread group. */
+enum class DirectIbReduceScatterRole : std::uint8_t {
+  RECEIVE,
+  SEND,
+};
+
+/**
+ * Return the peer for one step of the matched Direct IB ReduceScatter walk.
+ *
+ * A receiver visits peers in the positive direction while the matching sender
+ * visits them in the negative direction. Channel staggering rotates both walks
+ * by the same amount, preserving the one-to-one send/receive pairing while
+ * spreading channels across peers. The rank and step preconditions are
+ * `0 <= my_rank < num_ranks` and `0 <= step < num_ranks - 1`. For the
+ * single-rank identity, the function returns `my_rank` without performing
+ * modulo arithmetic.
+ */
+PRIMS_DIRECT_IB_RS_HOST_DEVICE_INLINE constexpr int
+direct_ib_reduce_scatter_peer_for_step(
+    int my_rank,
+    int num_ranks,
+    std::uint32_t channel,
+    int step,
+    DirectIbReduceScatterRole role,
+    bool stagger_channels = true) {
+  if (num_ranks <= 1) {
+    return my_rank;
+  }
+  const auto peer_count = static_cast<std::uint32_t>(num_ranks - 1);
+  const auto peer_offset = stagger_channels
+      ? (static_cast<std::uint32_t>(step) + channel) % peer_count
+      : static_cast<std::uint32_t>(step);
+  return role == DirectIbReduceScatterRole::RECEIVE
+      ? (my_rank + 1 + static_cast<int>(peer_offset)) % num_ranks
+      : (my_rank + num_ranks - 1 - static_cast<int>(peer_offset)) % num_ranks;
+}
+
+} // namespace comms::prims
+
+#undef PRIMS_DIRECT_IB_RS_HOST_DEVICE_INLINE

--- a/comms/prims/collectives/ReduceScatterDirectIbV2.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIbV2.cu
@@ -2,6 +2,8 @@
 
 #include "comms/prims/collectives/ReduceScatterDirectIbV2.cuh"
 
+#include "comms/prims/collectives/ReduceScatterDirectIbCore.cuh"
+
 #include "comms/prims/core/Checks.h"
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/TiledBuffer.cuh"
@@ -277,7 +279,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
       if (group.is_leader()) {
         for (int i = 0; i < count; ++i) {
           const int step = base + i;
-          rpeer_of[i] = (my_rank + 1 + (step + channel) % (W - 1)) % W;
+          rpeer_of[i] = direct_ib_reduce_scatter_peer_for_step(
+              my_rank, W, channel, step, DirectIbReduceScatterRole::RECEIVE);
           for (int sl = 0; sl < kSlots; ++sl) {
             rviews[sl][i] = detail::RecvChunkAcquisition{};
           }
@@ -434,7 +437,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
       bool posted[kMaxPeersInFlight];
       for (int i = 0; i < count; ++i) {
         const int step = base + i;
-        peer_of[i] = (my_rank + W - 1 - (step + channel) % (W - 1)) % W;
+        peer_of[i] = direct_ib_reduce_scatter_peer_for_step(
+            my_rank, W, channel, step, DirectIbReduceScatterRole::SEND);
         posted[i] = false;
         auto transport = args.peers[peer_of[i]];
         transport.init_registered_send_progress(

--- a/comms/prims/collectives/tests/DirectIbReduceScatterCoreTest.cpp
+++ b/comms/prims/collectives/tests/DirectIbReduceScatterCoreTest.cpp
@@ -1,0 +1,122 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "comms/prims/collectives/ReduceScatterDirectIbCore.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+int legacy_peer_for_step(
+    int rank,
+    int num_ranks,
+    std::uint32_t channel,
+    int step,
+    DirectIbReduceScatterRole role,
+    bool stagger_channels) {
+  const int peer_offset = stagger_channels
+      ? static_cast<int>(
+            (static_cast<std::uint32_t>(step) + channel) %
+            static_cast<std::uint32_t>(num_ranks - 1))
+      : step;
+  return role == DirectIbReduceScatterRole::RECEIVE
+      ? (rank + 1 + peer_offset) % num_ranks
+      : (rank + num_ranks - 1 - peer_offset) % num_ranks;
+}
+
+void expect_matched_peer_walk(int num_ranks, bool stagger_channels) {
+  const std::vector<std::uint32_t> channels{
+      0,
+      1,
+      static_cast<std::uint32_t>(num_ranks - 1),
+      static_cast<std::uint32_t>(num_ranks),
+      static_cast<std::uint32_t>(2 * num_ranks + 1),
+  };
+  for (const std::uint32_t channel : channels) {
+    for (int rank = 0; rank < num_ranks; ++rank) {
+      std::vector<bool> visited(num_ranks, false);
+      for (int step = 0; step < num_ranks - 1; ++step) {
+        const int peer = direct_ib_reduce_scatter_peer_for_step(
+            rank,
+            num_ranks,
+            channel,
+            step,
+            DirectIbReduceScatterRole::RECEIVE,
+            stagger_channels);
+        ASSERT_GE(peer, 0);
+        ASSERT_LT(peer, num_ranks);
+        EXPECT_NE(peer, rank);
+        EXPECT_FALSE(visited[peer]);
+        visited[peer] = true;
+
+        EXPECT_EQ(
+            direct_ib_reduce_scatter_peer_for_step(
+                peer,
+                num_ranks,
+                channel,
+                step,
+                DirectIbReduceScatterRole::SEND,
+                stagger_channels),
+            rank);
+      }
+
+      for (int peer = 0; peer < num_ranks; ++peer) {
+        EXPECT_EQ(visited[peer], peer != rank);
+      }
+    }
+  }
+}
+
+TEST(DirectIbReduceScatterCoreTest, PeerWalkMatchesLegacyOrdering) {
+  for (const int num_ranks : {2, 3, 4, 7, 8, 31, 32, 127, 128, 255, 256}) {
+    for (std::uint32_t channel = 0; channel < 256; ++channel) {
+      for (int rank = 0; rank < num_ranks; ++rank) {
+        for (int step = 0; step < num_ranks - 1; ++step) {
+          for (const auto role :
+               {DirectIbReduceScatterRole::RECEIVE,
+                DirectIbReduceScatterRole::SEND}) {
+            EXPECT_EQ(
+                direct_ib_reduce_scatter_peer_for_step(
+                    rank, num_ranks, channel, step, role, true),
+                legacy_peer_for_step(
+                    rank, num_ranks, channel, step, role, true));
+            EXPECT_EQ(
+                direct_ib_reduce_scatter_peer_for_step(
+                    rank, num_ranks, channel, step, role, false),
+                legacy_peer_for_step(
+                    rank, num_ranks, channel, step, role, false));
+          }
+        }
+      }
+    }
+  }
+}
+
+TEST(DirectIbReduceScatterCoreTest, StaggeredWalkIsMatchedPermutation) {
+  for (const int num_ranks : {2, 3, 4, 7, 8, 31, 32, 127, 128, 255, 256}) {
+    expect_matched_peer_walk(num_ranks, true);
+  }
+}
+
+TEST(DirectIbReduceScatterCoreTest, UnstaggeredWalkIsMatchedPermutation) {
+  for (const int num_ranks : {2, 3, 4, 7, 8, 31, 32, 127, 128, 255, 256}) {
+    expect_matched_peer_walk(num_ranks, false);
+  }
+}
+
+TEST(DirectIbReduceScatterCoreTest, SingleRankIdentityReturnsSelf) {
+  EXPECT_EQ(
+      direct_ib_reduce_scatter_peer_for_step(
+          0, 1, 0, 0, DirectIbReduceScatterRole::RECEIVE),
+      0);
+  EXPECT_EQ(
+      direct_ib_reduce_scatter_peer_for_step(
+          0, 1, 0, 0, DirectIbReduceScatterRole::SEND),
+      0);
+}
+
+} // namespace
+} // namespace comms::prims::test

--- a/comms/prims/collectives/tests/DirectNvlScheduleTest.cc
+++ b/comms/prims/collectives/tests/DirectNvlScheduleTest.cc
@@ -1,0 +1,238 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "comms/prims/collectives/DirectNvlSchedule.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+// Preserve coverage through the largest peer table of the extracted callers
+// without coupling this transport-neutral schedule test back to MCCL.
+constexpr int kMaxCallerLocalSize = 72;
+
+constexpr int expected_rotated_peer(
+    int local_rank,
+    int local_size,
+    std::uint32_t channel,
+    std::uint32_t step,
+    DirectNvlPeerRole role) {
+  const int offset = static_cast<int>(
+      (static_cast<std::uint64_t>(channel) + step) %
+      static_cast<std::uint32_t>(local_size - 1));
+  return role == DirectNvlPeerRole::SEND
+      ? (local_rank + local_size - 1 - offset) % local_size
+      : (local_rank + 1 + offset) % local_size;
+}
+
+TEST(DirectNvlScheduleTest, RotatedWalksPairAndCoverEveryPeer) {
+  for (int local_size = 2; local_size <= kMaxCallerLocalSize; ++local_size) {
+    for (std::uint32_t channel_index = 0;
+         channel_index < static_cast<std::uint32_t>(local_size);
+         ++channel_index) {
+      const std::uint32_t channel =
+          channel_index == static_cast<std::uint32_t>(local_size - 1)
+          ? std::numeric_limits<std::uint32_t>::max()
+          : channel_index;
+      for (int local_rank = 0; local_rank < local_size; ++local_rank) {
+        SCOPED_TRACE(
+            ::testing::Message() << "local_size=" << local_size << " channel="
+                                 << channel << " local_rank=" << local_rank);
+        DirectNvlPeerIterator sends(
+            local_rank,
+            local_size,
+            channel,
+            DirectNvlPeerRole::SEND,
+            /*rotate_peers=*/true);
+        DirectNvlPeerIterator receives(
+            local_rank,
+            local_size,
+            channel,
+            DirectNvlPeerRole::RECEIVE,
+            /*rotate_peers=*/true);
+        std::vector<int> sent(local_size);
+        std::vector<int> received(local_size);
+        for (int step = 0; step < 2 * (local_size - 1); ++step) {
+          const int send_peer = sends.next();
+          const int receive_peer = receives.next();
+          EXPECT_EQ(
+              send_peer,
+              expected_rotated_peer(
+                  local_rank,
+                  local_size,
+                  channel,
+                  step,
+                  DirectNvlPeerRole::SEND));
+          EXPECT_EQ(
+              receive_peer,
+              expected_rotated_peer(
+                  local_rank,
+                  local_size,
+                  channel,
+                  step,
+                  DirectNvlPeerRole::RECEIVE));
+          sent.at(send_peer)++;
+          received.at(receive_peer)++;
+
+          EXPECT_EQ(
+              expected_rotated_peer(
+                  send_peer,
+                  local_size,
+                  channel,
+                  step,
+                  DirectNvlPeerRole::RECEIVE),
+              local_rank);
+        }
+        for (int peer = 0; peer < local_size; ++peer) {
+          const int expected_count = peer == local_rank ? 0 : 2;
+          EXPECT_EQ(sent.at(peer), expected_count);
+          EXPECT_EQ(received.at(peer), expected_count);
+        }
+      }
+    }
+  }
+}
+
+TEST(DirectNvlScheduleTest, RankOrderWalkPreservesLegacyOrder) {
+  for (int local_size = 2; local_size <= kMaxCallerLocalSize; ++local_size) {
+    for (const std::uint32_t channel :
+         {0U,
+          static_cast<std::uint32_t>(local_size - 2),
+          std::numeric_limits<std::uint32_t>::max()}) {
+      for (int local_rank = 0; local_rank < local_size; ++local_rank) {
+        DirectNvlPeerIterator sends(
+            local_rank,
+            local_size,
+            channel,
+            DirectNvlPeerRole::SEND,
+            /*rotate_peers=*/false);
+        DirectNvlPeerIterator receives(
+            local_rank,
+            local_size,
+            channel,
+            DirectNvlPeerRole::RECEIVE,
+            /*rotate_peers=*/false);
+        for (int cycle = 0; cycle < 2; ++cycle) {
+          for (int peer = 0; peer < local_size; ++peer) {
+            if (peer == local_rank) {
+              continue;
+            }
+            EXPECT_EQ(sends.next(), peer);
+            EXPECT_EQ(receives.next(), peer);
+          }
+        }
+      }
+    }
+  }
+}
+
+TEST(DirectNvlScheduleTest, OwnerFilteringKeepsEdgesPaired) {
+  for (const int local_size : {2, 3, 4, 7, 8, 16, kMaxCallerLocalSize}) {
+    for (int owner_count = 1; owner_count <= local_size; ++owner_count) {
+      for (const bool rotate_peers : {false, true}) {
+        for (std::uint32_t channel = 0;
+             channel < static_cast<std::uint32_t>(local_size - 1);
+             ++channel) {
+          std::vector<std::vector<int>> sends(
+              local_size, std::vector<int>(local_size));
+          std::vector<std::vector<int>> receives(
+              local_size, std::vector<int>(local_size));
+          for (int local_rank = 0; local_rank < local_size; ++local_rank) {
+            DirectNvlPeerIterator send_peers(
+                local_rank,
+                local_size,
+                channel,
+                DirectNvlPeerRole::SEND,
+                rotate_peers);
+            DirectNvlPeerIterator receive_peers(
+                local_rank,
+                local_size,
+                channel,
+                DirectNvlPeerRole::RECEIVE,
+                rotate_peers);
+            const int owner_steps = rotate_peers
+                ? local_size - 1
+                : owner_count - static_cast<int>(local_rank < owner_count);
+            for (int step = 0; step < owner_steps; ++step) {
+              const int owner = send_peers.next();
+              if (owner < owner_count) {
+                sends.at(local_rank).at(owner)++;
+              }
+            }
+            if (local_rank < owner_count) {
+              for (int step = 0; step < local_size - 1; ++step) {
+                receives.at(receive_peers.next()).at(local_rank)++;
+              }
+            }
+          }
+          EXPECT_EQ(sends, receives)
+              << "local_size=" << local_size << " owner_count=" << owner_count
+              << " channel=" << channel << " rotate_peers=" << rotate_peers;
+        }
+      }
+    }
+  }
+}
+
+template <std::size_t kDomains, std::size_t kLocalSize>
+void expect_node_major_owner_packing() {
+  std::vector<bool> source_chunks(kDomains * kLocalSize);
+  for (std::size_t domain = 0; domain < kDomains; ++domain) {
+    for (std::size_t owner = 0; owner < kLocalSize; ++owner) {
+      const std::size_t source =
+          DirectNvlNodeMajorOwnerStridedLayout::source_chunk(
+              domain, owner, kLocalSize, kDomains);
+      EXPECT_EQ(source, domain * kLocalSize + owner);
+      ASSERT_LT(source, source_chunks.size());
+      EXPECT_FALSE(source_chunks.at(source));
+      source_chunks.at(source) = true;
+      EXPECT_EQ(
+          DirectNvlNodeMajorOwnerStridedLayout::packed_chunk(domain), domain);
+    }
+  }
+  for (const bool visited : source_chunks) {
+    EXPECT_TRUE(visited);
+  }
+}
+
+TEST(DirectNvlScheduleTest, NodeMajorTwoByFourPacksByDomain) {
+  expect_node_major_owner_packing<2, 4>();
+}
+
+TEST(DirectNvlScheduleTest, NodeMajorFourByTwoPacksByDomain) {
+  expect_node_major_owner_packing<4, 2>();
+}
+
+TEST(DirectNvlScheduleTest, ContiguousOwnerLayoutGroupsOwnerBatches) {
+  constexpr std::size_t kDomains = 4;
+  constexpr std::size_t kLocalSize = 2;
+  for (std::size_t owner = 0; owner < kLocalSize; ++owner) {
+    for (std::size_t domain = 0; domain < kDomains; ++domain) {
+      EXPECT_EQ(
+          DirectNvlContiguousOwnerLayout::source_chunk(
+              domain, owner, kLocalSize, kDomains),
+          owner * kDomains + domain);
+      EXPECT_EQ(DirectNvlContiguousOwnerLayout::packed_chunk(domain), domain);
+    }
+  }
+}
+
+TEST(DirectNvlScheduleTest, LayoutUsesSizeTForLargeChunkIndices) {
+  constexpr std::size_t kLocalSize = std::size_t{1} << 20;
+  constexpr std::size_t kDomain = (std::size_t{1} << 20) + 3;
+  constexpr std::size_t kOwner = kLocalSize - 1;
+  constexpr std::size_t kExpected = kDomain * kLocalSize + kOwner;
+  static_assert(kExpected > std::numeric_limits<std::uint32_t>::max());
+  EXPECT_EQ(
+      DirectNvlNodeMajorOwnerStridedLayout::source_chunk(
+          kDomain, kOwner, kLocalSize, kDomain + 1),
+      kExpected);
+}
+
+} // namespace
+} // namespace comms::prims::test


### PR DESCRIPTION
Summary:
Move fused AllReduce's Direct NVLink peer walk into the neutral `DirectNvlSchedule` Prims helper with caller-owned rotation policy. Add contiguous-owner and node-major owner-strided chunk-layout policies for the MCCL fused ReduceScatter follow-up. Generalize the existing pipeline-window query over an indexable peer view so callers can project phase-local ranks from a unified global transport table without copying transport objects.

Preserve the standalone Direct NVLink kernel implementation and keep AllReduce's rotation threshold, reductions, synchronization, transports, and selection policy unchanged. Move exhaustive iterator and layout coverage to Prims, including the largest 72-peer caller shape, while retaining MCCL coverage for pMin rotation and matched ReduceScatter/AllGather owner filtering.

Differential Revision: D118219793


