### PR TITLE
comms/uniflow/benchmarks: add a cross-rank measurement barrier (#3941)

### DIFF
--- a/comms/uniflow/benchmarks/BenchmarkRunner.h
+++ b/comms/uniflow/benchmarks/BenchmarkRunner.h
@@ -49,6 +49,16 @@ struct BenchmarkConfig {
    * reports excellent throughput.
    */
   bool verify{true};
+  /*
+   * Cross-rank measurement barrier. A multi-GPU run launches N independent
+   * rank-pairs; nothing lines their timed loops up, so summing their
+   * bandwidths sums windows that do not coincide. barrierDir is a host-local
+   * directory shared by the active aggregate instances; when set, all N
+   * rendezvous after warmup, immediately before the clock starts.
+   */
+  std::string barrierDir;
+  int barrierRanks{0};
+  int barrierIndex{-1};
 };
 
 class Benchmark {

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
@@ -11,10 +11,13 @@
 #include <cstdlib>
 #include <cstring>
 #include <deque>
+#include <filesystem>
+#include <fstream>
 #include <future>
 #include <iostream>
 #include <random>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -127,13 +130,132 @@ struct TransferResult {
 
 // Warmup then a pipelined timed loop keeping up to txDepth put/get calls in
 // flight over the single TCP connection.
+
+/*
+ * Filesystem barrier across the N rank-pairs of an aggregate run, keyed by
+ * (direction, size) so every size re-synchronises. Fails closed: a barrier
+ * that timed out silently would restore the defect it exists to remove.
+ */
+constexpr std::string_view kMarkerPrefix = "inst";
+
+std::filesystem::path markerPath(
+    const std::filesystem::path& dir,
+    int barrierIndex) {
+  return dir / fmt::format("{}{}", kMarkerPrefix, barrierIndex);
+}
+
+bool measurementBarrier(
+    const BenchmarkConfig& config,
+    const std::string& tag,
+    int barrierIndex) {
+  const bool hasBarrierDir = !config.barrierDir.empty();
+  const bool hasBarrierRanks = config.barrierRanks > 0;
+  if (hasBarrierDir != hasBarrierRanks) {
+    UNIFLOW_LOG_ERROR(
+        "measurement barrier: --measurement-barrier-dir and "
+        "--measurement-barrier-ranks must be specified together");
+    return false;
+  }
+  if (config.barrierRanks <= 1) {
+    return true;
+  }
+  // Keep participant identity independent of the CUDA device: an aggregate
+  // may legitimately use a non-zero-based GPU subset such as devices 4-7.
+  if (barrierIndex < 0 || barrierIndex >= config.barrierRanks) {
+    UNIFLOW_LOG_ERROR(
+        "measurement barrier needs a unique per-instance key in [0, {}); got "
+        "{}. Pass --measurement-barrier-index for every instance",
+        config.barrierRanks,
+        barrierIndex);
+    return false;
+  }
+  namespace fs = std::filesystem;
+  std::error_code ec;
+  fs::path dir = fs::path(config.barrierDir) / tag;
+  fs::create_directories(dir, ec);
+  if (ec) {
+    UNIFLOW_LOG_ERROR(
+        "measurement barrier: cannot create {}: {}",
+        dir.string(),
+        ec.message());
+    return false;
+  }
+  // Nothing else writes this instance's marker, so finding it already there
+  // means the directory is being reused after an earlier run. Counting it
+  // would pre-satisfy the barrier and release early -- the same silent
+  // overstatement this change exists to remove -- so refuse instead.
+  const auto marker = markerPath(dir, barrierIndex);
+  const bool markerExists = fs::exists(marker, ec);
+  if (ec) {
+    UNIFLOW_LOG_ERROR(
+        "measurement barrier: cannot stat {}: {}",
+        marker.string(),
+        ec.message());
+    return false;
+  }
+  if (markerExists) {
+    UNIFLOW_LOG_ERROR(
+        "measurement barrier: {} already exists; pass a fresh "
+        "--measurement-barrier-dir per run",
+        marker.string());
+    return false;
+  }
+  {
+    std::ofstream f(marker);
+    if (!f) {
+      UNIFLOW_LOG_ERROR(
+          "measurement barrier: cannot write marker in {}", dir.string());
+      return false;
+    }
+  }
+
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(120);
+  while (std::chrono::steady_clock::now() < deadline) {
+    size_t arrived = 0;
+    // Enumerate the exact quorum instead of counting a filename prefix:
+    // instructions.txt, inst.tmp, and out-of-range markers must not release
+    // the barrier before every expected instance has arrived.
+    for (int expectedRank = 0; expectedRank < config.barrierRanks;
+         ++expectedRank) {
+      const auto expectedMarker = markerPath(dir, expectedRank);
+      if (fs::exists(expectedMarker, ec)) {
+        ++arrived;
+      }
+      if (ec) {
+        // A filesystem error is not "peers have not arrived yet"; spinning to
+        // the timeout would report it as one.
+        UNIFLOW_LOG_ERROR(
+            "measurement barrier: cannot stat {}: {}",
+            expectedMarker.string(),
+            ec.message());
+        return false;
+      }
+    }
+    if (arrived == static_cast<size_t>(config.barrierRanks)) {
+      return true;
+    }
+    // Cross-process filesystem rendezvous has no condition variable to wait
+    // on; bounded polling is intentional and remains outside the timed loop.
+    // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  UNIFLOW_LOG_ERROR(
+      "measurement barrier timed out at {} (index {}, need {})",
+      tag,
+      barrierIndex,
+      config.barrierRanks);
+  return false;
+}
+
 TransferResult runTransfer(
     Transport& transport,
     RegisteredSegment& localReg,
     RemoteRegisteredSegment& remoteReg,
     size_t size,
     const std::string& dir,
-    const BenchmarkConfig& config) {
+    const BenchmarkConfig& config,
+    int rank) {
   using Clock = std::chrono::steady_clock;
   const int batchSize = std::max(1, config.batchSize);
   const int txDepth = std::max(1, config.txDepth);
@@ -191,6 +313,13 @@ TransferResult runTransfer(
     inflight.pop_front();
     return true;
   };
+
+  // All N ranks line up here, after their own warmup, so that every rank's
+  // timed window covers the same wall-clock interval and the per-rank
+  // bandwidths are summable. Barrier cost is outside the clock below.
+  if (!measurementBarrier(config, fmt::format("{}_{}", dir, size), rank)) {
+    return out;
+  }
 
   auto start = Clock::now();
   for (int b = 0; b < numBatches; ++b) {
@@ -654,7 +783,14 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
       if (tcpTransport != nullptr) {
         tcpTransport->logAndResetPhaseStats("reset");
       }
-      auto r = runTransfer(*transport, localReg, remoteReg, size, dir, config);
+      auto r = runTransfer(
+          *transport,
+          localReg,
+          remoteReg,
+          size,
+          dir,
+          config,
+          config.barrierIndex);
       if (!r.ok) {
         // Latched rather than returned: every remaining size has a barrier the
         // peer is going to execute.

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -78,6 +78,9 @@ struct CliOptions {
   // --tcp-bind-dev. Names are per-host, so the two hosts may need different
   // lists for the same pair of physical ports.
   std::string tcpBindDevs;
+  std::string barrierDir;
+  int barrierRanks{0};
+  int barrierIndex{-1};
 };
 
 std::vector<int> parseIntList(const std::string& s) {
@@ -213,6 +216,12 @@ void printUsage(const char* prog) {
       << "  --cuda-devices <list>  Comma-separated GPU indices for single-process multi-GPU (overrides --cuda-device)\n"
       << "  --gpu-nics <groups>    Per-GPU NIC map for multi-GPU: ';'-separated groups of comma-separated NICs, one per --cuda-devices entry\n"
       << "  --data-direct          Register GPU memory over the mlx5 Data Direct path (default: off)\n"
+      << "  --measurement-barrier-dir <path>  Host-local dir shared by the active\n"
+      << "                         instances, used to line up their timed loops. Without\n"
+      << "                         it their windows stagger and summed bandwidth is\n"
+      << "                         overstated (measured overlap 1.0-2.1 of 8)\n"
+      << "  --measurement-barrier-ranks <n>   Number of instances to wait for\n"
+      << "  --measurement-barrier-index <i>   This instance's unique index in [0,n)\n"
       << "  --list                 List available benchmarks\n"
       << "  --help                 Show this help message\n"
       << "\n"
@@ -259,6 +268,9 @@ CliOptions parseArgs(int argc, char** argv) {
       {"tcp-sockets-per-nic", required_argument, nullptr, 270},
       {"tcp-bind-dev", no_argument, nullptr, 271},
       {"tcp-bind-devs", required_argument, nullptr, 272},
+      {"measurement-barrier-dir", required_argument, nullptr, 280},
+      {"measurement-barrier-ranks", required_argument, nullptr, 281},
+      {"measurement-barrier-index", required_argument, nullptr, 282},
       {"no-verify", no_argument, nullptr, 267},
       {"list", no_argument, nullptr, 'l'},
       {"help", no_argument, nullptr, 'h'},
@@ -358,6 +370,39 @@ CliOptions parseArgs(int argc, char** argv) {
         break;
       case 272:
         opts.tcpBindDevs = optarg;
+        break;
+      case 280:
+        opts.barrierDir = optarg;
+        break;
+      case 281:
+        try {
+          int parsed = std::stoi(optarg);
+          if (parsed < 1) {
+            std::cerr
+                << "Invalid value for --measurement-barrier-ranks: must be >= 1\n";
+            std::exit(1);
+          }
+          opts.barrierRanks = parsed;
+        } catch (const std::exception&) {
+          std::cerr << "Invalid value for --measurement-barrier-ranks: '"
+                    << optarg << "'\n";
+          std::exit(1);
+        }
+        break;
+      case 282:
+        try {
+          const int parsed = std::stoi(optarg);
+          if (parsed < 0) {
+            std::cerr
+                << "Invalid value for --measurement-barrier-index: must be >= 0\n";
+            std::exit(1);
+          }
+          opts.barrierIndex = parsed;
+        } catch (const std::exception&) {
+          std::cerr << "Invalid value for --measurement-barrier-index: '"
+                    << optarg << "'\n";
+          std::exit(1);
+        }
         break;
       case 'd':
         opts.direction = optarg;
@@ -490,6 +535,21 @@ CliOptions parseArgs(int argc, char** argv) {
     opts.benchmark = "__list__";
   }
 
+  const bool hasBarrierDir = !opts.barrierDir.empty();
+  const bool hasBarrierRanks = opts.barrierRanks > 0;
+  const bool hasBarrierIndex = opts.barrierIndex >= 0;
+  if ((hasBarrierDir || hasBarrierRanks || hasBarrierIndex) &&
+      !(hasBarrierDir && hasBarrierRanks && hasBarrierIndex)) {
+    std::cerr << "--measurement-barrier-dir, --measurement-barrier-ranks, and "
+                 "--measurement-barrier-index must be specified together\n";
+    std::exit(1);
+  }
+  if (hasBarrierIndex && opts.barrierIndex >= opts.barrierRanks) {
+    std::cerr << "Invalid value for --measurement-barrier-index: must be less "
+                 "than --measurement-barrier-ranks\n";
+    std::exit(1);
+  }
+
   return opts;
 }
 
@@ -554,6 +614,9 @@ int main(int argc, char** argv) {
   config.bidirectional = opts.bidirectional;
   config.dataDirect = opts.dataDirect;
   config.verify = !opts.noVerify;
+  config.barrierDir = opts.barrierDir;
+  config.barrierRanks = opts.barrierRanks;
+  config.barrierIndex = opts.barrierIndex;
   config.direction = opts.direction;
   config.batchSize = opts.batchSize;
   config.txDepth = opts.txDepth;


### PR DESCRIPTION
Summary:

A multi-GPU tcp_bandwidth run can report an aggregate above the link's physical
line rate: on a 2 x 200 Gb/s bind (ceiling 50 GB/s), 8 GPU at 4 MiB reported
98.24 GB/s. The aggregate is not a bandwidth.

The benchmark reports one bandwidth per process. runTransfer() brackets
start/end around that process's own loop, so each figure is correct for its own
window -- but nothing synchronises the windows: an aggregate run is N
independent rank-pairs, and barrier(peers, bootstrap) (Rendezvous.h:30-33)
couples rank 0 to rank 1 of its OWN pair only. Any caller that sums those N
figures is summing disjoint intervals. Every addend is correct; the premise
that they may be added is not.

Measured per-rank bandwidths for that 98.24 cell (8 GPU, 2 NIC, 4 MiB, PUT),
and for the same cell with the barrier applied. Bars are illustrative; the
per-rank values and the sums are measured.

  without barrier -- each rank starts its clock when its own warmup ends
    rank2  [==21.37==]                  short window, ran while few competed
    rank1  [==18.23==]
    rank4    [==15.93==]
    rank6      [==11.52==]
    rank3        [==9.96==]
    rank7          [==8.90==]
    rank0        [==8.26==]
    rank5            [=========4.07=========]   long window, fully contended
                                                sum = 98.24  <- ceiling is 50

  with barrier -- common start; ends still differ, so a tail remains
             | barrier |
    rank7    |-------->|[==6.42==]
    rank5    |-------->|[==5.58===]
    rank6    |-------->|[==5.58===]
    rank4    |-------->|[==5.38===]
    rank3    |-------->|[==4.81====]
    rank2    |-------->|[==4.66====]
    rank1    |-------->|[==4.26=====]
    rank0    |-------->|[==1.61=================================]
                        |<- 7 of 8 done ->|         tail: one rank, less
                                                    competition than the rest
                                                sum = 38.30  <- under ceiling

The ranks that finish quickest report the highest bandwidth precisely because
they overlapped the fewest others; summing them with the slow, fully-contended
ranks counts the same link more than once.

The barrier aligns starts, not ends: every rank runs the same iteration count
at a different rate, so the fast ones retire early and whatever is left runs
with less competition. That bounds the error rather than removing it -- here
7 of 8 finished within 0.03 s of each other and one straggler 0.20 s later
(logged completion times), so the overlap is good but not exact. It is also
the likely source of the residual 1.6% overshoot at 1 GiB in the Test Plan.
Measuring over a common window (stop all ranks together, or divide total bytes
by the union of the windows) would close it; this change does not attempt that.

Two things worth knowing:
- Keyed by an explicit zero-based measurement-barrier index, independent of
  both bootstrap rank and CUDA device. This keeps instance identity unique for
  arbitrary GPU subsets while retaining an exact expected marker set.
- Fails closed: times out loudly after 120 s rather than proceeding. A barrier
  that failed open would silently restore the defect it exists to remove.

No-op at 1 GPU, which is why 1-GPU columns in existing data were already sound.

Reviewed By: cppccppccppc

Differential Revision: D118308421


