### PR TITLE
Extract the blocking Direct IB phase

### DIFF
--- a/comms/prims/collectives/ReduceScatterDirectIb.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIb.cu
@@ -3,6 +3,7 @@
 #include <atomic>
 
 #include "comms/prims/collectives/ReduceScatterDirectIb.cuh"
+#include "comms/prims/collectives/ReduceScatterDirectIbCore.cuh"
 
 #include "comms/prims/core/Checks.h"
 #include "comms/prims/core/CopyOp.cuh"
@@ -31,31 +32,17 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
 #ifdef __CUDA_ARCH__
   abortDevice.start();
 
-  static_assert(kSendThreads % comms::device::kWarpSize == 0);
-  static_assert(kRecvThreads % comms::device::kWarpSize == 0);
-  static_assert(kSendThreads + kRecvThreads == kBlockSize);
-
   using QuantOp = QuantizedReduceScatterCopyOpT<kTmaRecv>;
 
   const ThreadGroup block = make_block_group();
-  const bool is_recv = block.thread_id_in_group < kRecvThreads;
-  ThreadGroup group = is_recv
-      ? ThreadGroup{
-            .thread_id_in_group = block.thread_id_in_group,
-            .group_size = kRecvThreads,
-            .group_id = block.group_id,
-            .block_id = block.block_id,
-            .total_groups = block.total_groups,
-            .scope = SyncScope::MULTIWARP,
-            .barrier_id = kQuantized ? 1 : ThreadGroup::kAutoBarrierId}
-      : ThreadGroup{
-            .thread_id_in_group = block.thread_id_in_group - kRecvThreads,
-            .group_size = kSendThreads,
-            .group_id = block.group_id,
-            .block_id = block.block_id,
-            .total_groups = block.total_groups,
-            .scope = SyncScope::MULTIWARP,
-            .barrier_id = kQuantized ? 2 : ThreadGroup::kAutoBarrierId};
+  auto role_group = make_direct_ib_reduce_scatter_role_group<
+      kSendThreads,
+      kRecvThreads,
+      kBlockSize,
+      kQuantized ? 1 : ThreadGroup::kAutoBarrierId,
+      kQuantized ? 2 : ThreadGroup::kAutoBarrierId>(block);
+  ThreadGroup& group = role_group.group;
+  const bool is_recv = role_group.role == DirectIbReduceScatterRole::RECEIVE;
 
   const int channels = static_cast<int>(group.total_groups);
   const int channel = static_cast<int>(group.group_id);
@@ -91,9 +78,13 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
     }
 
     for (int step = 0; step < W - 1; ++step) {
-      const int peer_offset =
-          kStaggerChannels ? (step + channel) % (W - 1) : step;
-      const int peer = (my_rank + 1 + peer_offset) % W;
+      const int peer = direct_ib_reduce_scatter_peer_for_step(
+          my_rank,
+          W,
+          channel,
+          step,
+          DirectIbReduceScatterRole::RECEIVE,
+          kStaggerChannels);
       const char* local_input = !args.in_place && step == 0
           ? reinterpret_cast<const char*>(own_src)
           : output_bytes;
@@ -121,9 +112,13 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
     }
 
     for (int step = 0; step < W - 1; ++step) {
-      const int peer_offset =
-          kStaggerChannels ? (step + channel) % (W - 1) : step;
-      const int peer = (my_rank + W - 1 - peer_offset) % W;
+      const int peer = direct_ib_reduce_scatter_peer_for_step(
+          my_rank,
+          W,
+          channel,
+          step,
+          DirectIbReduceScatterRole::SEND,
+          kStaggerChannels);
       TiledBuffer<const T> send_tile(
           input_base + static_cast<std::size_t>(peer) * args.chunk_elements,
           args.chunk_elements,

--- a/comms/prims/collectives/ReduceScatterDirectIb.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIb.cu
@@ -4,6 +4,7 @@
 
 #include "comms/prims/collectives/ReduceScatterDirectIb.cuh"
 #include "comms/prims/collectives/ReduceScatterDirectIbCore.cuh"
+#include "comms/prims/collectives/ReduceScatterDirectIbPhase.cuh"
 
 #include "comms/prims/core/Checks.h"
 #include "comms/prims/core/CopyOp.cuh"
@@ -31,6 +32,33 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
     AbortDevice abortDevice) {
 #ifdef __CUDA_ARCH__
   abortDevice.start();
+
+  if constexpr (!kQuantized) {
+    direct_ib_reduce_scatter_phase<
+        T,
+        ReduceOp,
+        kSendThreads,
+        kRecvThreads,
+        kBlockSize,
+        kStaggerChannels>(
+        args.my_rank,
+        args.num_ranks,
+        DirectIbPackedInputView<T>{
+            .data = args.input,
+            .chunk_elements = args.chunk_elements,
+            .chunk_stride_elements = args.chunk_elements,
+        },
+        DirectIbFinalOutputView<T>{
+            .data = args.output,
+            .seed = args.in_place ? DirectIbOutputSeed::OUTPUT_ALREADY_SEEDED
+                                  : DirectIbOutputSeed::PACKED_INPUT,
+        },
+        args.signaling_data_size,
+        args.peers,
+        make_block_group(),
+        abortDevice);
+    return;
+  }
 
   using QuantOp = QuantizedReduceScatterCopyOpT<kTmaRecv>;
 

--- a/comms/prims/collectives/ReduceScatterDirectIbCore.cuh
+++ b/comms/prims/collectives/ReduceScatterDirectIbCore.cuh
@@ -1,0 +1,153 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+#include "comms/prims/core/DeviceCheck.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+#define PRIMS_DIRECT_IB_RS_HOST_DEVICE_INLINE \
+  __host__ __device__ __forceinline__
+#else
+#define PRIMS_DIRECT_IB_RS_HOST_DEVICE_INLINE inline
+#endif
+
+namespace comms::prims {
+
+/** Communication role assigned to a Direct IB ReduceScatter thread group. */
+enum class DirectIbReduceScatterRole : std::uint8_t {
+  RECEIVE,
+  SEND,
+};
+
+/** A Direct IB role together with its cooperative thread group. */
+struct DirectIbReduceScatterRoleGroup {
+  ThreadGroup group;
+  DirectIbReduceScatterRole role;
+};
+
+/**
+ * Return the peer for one step of the matched Direct IB ReduceScatter walk.
+ *
+ * A receiver visits peers in the positive direction while the matching sender
+ * visits them in the negative direction. Channel staggering rotates both walks
+ * by the same amount, preserving the one-to-one send/receive pairing while
+ * spreading channels across peers. The rank and step preconditions are
+ * `0 <= my_rank < num_ranks` and `0 <= step < num_ranks - 1`. For the
+ * single-rank identity, the function returns `my_rank` without performing
+ * modulo arithmetic.
+ */
+PRIMS_DIRECT_IB_RS_HOST_DEVICE_INLINE constexpr int
+direct_ib_reduce_scatter_peer_for_step(
+    int my_rank,
+    int num_ranks,
+    std::uint32_t channel,
+    int step,
+    DirectIbReduceScatterRole role,
+    bool stagger_channels = true) {
+  if (num_ranks <= 1) {
+    return my_rank;
+  }
+  const int peer_count = num_ranks - 1;
+  const int peer_offset = stagger_channels
+      ? (step + static_cast<int>(channel % peer_count)) % peer_count
+      : step;
+  return role == DirectIbReduceScatterRole::RECEIVE
+      ? (my_rank + 1 + peer_offset) % num_ranks
+      : (my_rank + num_ranks - 1 - peer_offset) % num_ranks;
+}
+
+/** Return the communication role for a physical thread within the CTA. */
+PRIMS_DIRECT_IB_RS_HOST_DEVICE_INLINE constexpr DirectIbReduceScatterRole
+direct_ib_reduce_scatter_role_for_thread(
+    std::uint32_t thread_id,
+    std::uint32_t receive_threads) {
+  return thread_id < receive_threads ? DirectIbReduceScatterRole::RECEIVE
+                                     : DirectIbReduceScatterRole::SEND;
+}
+
+/**
+ * Split a block-wide logical channel into concurrent receive and send roles.
+ *
+ * The returned groups retain the parent's logical channel identity and
+ * physical block identity. This is required by IB transports, whose persistent
+ * cursors and QPs are indexed by those identities rather than by the role.
+ */
+template <
+    int kSendThreads,
+    int kRecvThreads,
+    int kBlockThreads,
+    std::uint32_t kRecvBarrierId = ThreadGroup::kAutoBarrierId,
+    std::uint32_t kSendBarrierId = ThreadGroup::kAutoBarrierId>
+PRIMS_DIRECT_IB_RS_HOST_DEVICE_INLINE DirectIbReduceScatterRoleGroup
+make_direct_ib_reduce_scatter_role_group(const ThreadGroup& block_group) {
+  static_assert(kSendThreads > 0);
+  static_assert(kRecvThreads > 0);
+  static_assert(kSendThreads % comms::device::kWarpSize == 0);
+  static_assert(kRecvThreads % comms::device::kWarpSize == 0);
+  static_assert(kSendThreads + kRecvThreads == kBlockThreads);
+  static_assert(
+      kSendBarrierId != ThreadGroup::kAutoBarrierId ||
+          kRecvThreads % kSendThreads == 0,
+      "automatic send barrier requires an aligned send-group start");
+
+  constexpr std::uint32_t kEffectiveRecvBarrierId =
+      kRecvBarrierId == ThreadGroup::kAutoBarrierId ? 0 : kRecvBarrierId;
+  constexpr std::uint32_t kEffectiveSendBarrierId =
+      kSendBarrierId == ThreadGroup::kAutoBarrierId
+      ? kRecvThreads / kSendThreads
+      : kSendBarrierId;
+  static_assert(
+      kEffectiveRecvBarrierId != kEffectiveSendBarrierId,
+      "Direct IB receive and send roles require distinct named barriers");
+  static_assert(
+      kEffectiveRecvBarrierId < kMaxMultiwarpsPerBlock &&
+          kEffectiveSendBarrierId < kMaxMultiwarpsPerBlock,
+      "Direct IB role barrier IDs exceed the hardware range");
+
+  PIPES_DEVICE_CHECK_MSG(
+      block_group.scope == SyncScope::BLOCK,
+      "Direct IB roles require a block-scoped parent group");
+  PIPES_DEVICE_CHECK_MSG(
+      block_group.group_size == kBlockThreads,
+      "Direct IB parent group size does not match its template geometry");
+  PIPES_DEVICE_CHECK_MSG(
+      block_group.thread_id_in_group < kBlockThreads,
+      "Direct IB parent thread ID is out of bounds");
+
+  const bool is_receive = direct_ib_reduce_scatter_role_for_thread(
+                              block_group.thread_id_in_group, kRecvThreads) ==
+      DirectIbReduceScatterRole::RECEIVE;
+  if (is_receive) {
+    return DirectIbReduceScatterRoleGroup{
+        .group =
+            ThreadGroup{
+                .thread_id_in_group = block_group.thread_id_in_group,
+                .group_size = kRecvThreads,
+                .group_id = block_group.group_id,
+                .block_id = block_group.block_id,
+                .total_groups = block_group.total_groups,
+                .scope = SyncScope::MULTIWARP,
+                .barrier_id = kRecvBarrierId},
+        .role = DirectIbReduceScatterRole::RECEIVE};
+  }
+
+  return DirectIbReduceScatterRoleGroup{
+      .group =
+          ThreadGroup{
+              .thread_id_in_group =
+                  block_group.thread_id_in_group - kRecvThreads,
+              .group_size = kSendThreads,
+              .group_id = block_group.group_id,
+              .block_id = block_group.block_id,
+              .total_groups = block_group.total_groups,
+              .scope = SyncScope::MULTIWARP,
+              .barrier_id = kSendBarrierId},
+      .role = DirectIbReduceScatterRole::SEND};
+}
+
+} // namespace comms::prims
+
+#undef PRIMS_DIRECT_IB_RS_HOST_DEVICE_INLINE

--- a/comms/prims/collectives/ReduceScatterDirectIbPhase.cuh
+++ b/comms/prims/collectives/ReduceScatterDirectIbPhase.cuh
@@ -1,0 +1,166 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/prims/collectives/ReduceScatterDirectIbCore.cuh"
+#include "comms/prims/core/AbortCheck.cuh"
+#include "comms/prims/core/CopyUtils.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/core/TiledBuffer.cuh"
+#include "comms/prims/transport/P2pIbTransportDevice.cuh"
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+#define PRIMS_DIRECT_IB_PHASE_HOST_DEVICE_INLINE \
+  __host__ __device__ __forceinline__
+#else
+#define PRIMS_DIRECT_IB_PHASE_HOST_DEVICE_INLINE inline
+#endif
+
+namespace comms::prims {
+
+/** The local operand source for a blocking Direct IB ReduceScatter phase. */
+enum class DirectIbOutputSeed : std::uint8_t {
+  PACKED_INPUT,
+  OUTPUT_ALREADY_SEEDED,
+};
+
+/** Equal logical chunks packed with an optional padded physical stride. */
+template <typename T>
+struct DirectIbPackedInputView {
+  const T* data{nullptr};
+  std::size_t chunk_elements{0};
+  std::size_t chunk_stride_elements{0};
+
+  PRIMS_DIRECT_IB_PHASE_HOST_DEVICE_INLINE constexpr const T* chunk_data(
+      int phase_rank) const {
+    return data + static_cast<std::size_t>(phase_rank) * chunk_stride_elements;
+  }
+};
+
+/** Final local output and whether a prior phase already seeded it. */
+template <typename T>
+struct DirectIbFinalOutputView {
+  T* data{nullptr};
+  DirectIbOutputSeed seed{DirectIbOutputSeed::PACKED_INPUT};
+};
+
+/**
+ * Run one blocking, non-quantized Direct IB ReduceScatter phase.
+ *
+ * The input contains one equal logical chunk per phase rank. The output is
+ * either disjoint from the packed input, in which case the first receive
+ * combines the local packed chunk with its peer, or it is already seeded by a
+ * prior phase. Callers validate buffer overlap, packed stride, and peer
+ * readiness before launch. Alignment is part of the selected ReduceOp's
+ * contract: callers using a 16-byte-only operation must pad the stride or
+ * select an unaligned-safe operation. Callers also own whole-block
+ * synchronization at phase boundaries; this helper synchronizes only its
+ * role-local groups. The peer table is indexed in the same phase-local rank
+ * space as `phase_rank` and `phase_size`; the self entry is unused.
+ */
+template <
+    typename T,
+    typename ReduceOp,
+    int kSendThreads,
+    int kRecvThreads,
+    int kBlockThreads,
+    bool kStaggerChannels = true,
+    std::uint32_t kRecvBarrierId = ThreadGroup::kAutoBarrierId,
+    std::uint32_t kSendBarrierId = ThreadGroup::kAutoBarrierId>
+__device__ __forceinline__ void direct_ib_reduce_scatter_phase(
+    int phase_rank,
+    int phase_size,
+    DirectIbPackedInputView<T> input,
+    DirectIbFinalOutputView<T> output,
+    std::size_t signaling_data_size,
+    const P2pIbTransportDevice* peers,
+    const ThreadGroup& block,
+    const AbortDevice& abort_device) {
+  auto role_group = make_direct_ib_reduce_scatter_role_group<
+      kSendThreads,
+      kRecvThreads,
+      kBlockThreads,
+      kRecvBarrierId,
+      kSendBarrierId>(block);
+  ThreadGroup& group = role_group.group;
+  const bool is_receive = role_group.role == DirectIbReduceScatterRole::RECEIVE;
+
+  const int channel = static_cast<int>(group.group_id);
+  TiledBuffer<T> output_tile(output.data, input.chunk_elements, group);
+  const std::size_t tile_bytes = output_tile.bytes();
+  if (tile_bytes == 0) {
+    return;
+  }
+
+  T* output_data = output_tile.data();
+  char* output_bytes = reinterpret_cast<char*>(output_data);
+
+  if (is_receive) {
+    const T* own_source = input.chunk_data(phase_rank) +
+        static_cast<std::size_t>(channel) * output_tile.tile_elements;
+
+    if (phase_size <= 1) {
+      if (output.seed == DirectIbOutputSeed::PACKED_INPUT) {
+        memcpy_vectorized(
+            output_bytes,
+            reinterpret_cast<const char*>(own_source),
+            tile_bytes,
+            group);
+      }
+      return;
+    }
+
+    for (int step = 0; step < phase_size - 1; ++step) {
+      const int peer = direct_ib_reduce_scatter_peer_for_step(
+          phase_rank,
+          phase_size,
+          channel,
+          step,
+          DirectIbReduceScatterRole::RECEIVE,
+          kStaggerChannels);
+      const char* local_input =
+          output.seed == DirectIbOutputSeed::PACKED_INPUT && step == 0
+          ? reinterpret_cast<const char*>(own_source)
+          : output_bytes;
+      auto transport = peers[peer];
+      transport.template recv<ReduceOp>(
+          group,
+          output_bytes,
+          tile_bytes,
+          signaling_data_size,
+          abort_device,
+          local_input);
+    }
+    return;
+  }
+
+  if (phase_size <= 1) {
+    return;
+  }
+
+  for (int step = 0; step < phase_size - 1; ++step) {
+    const int peer = direct_ib_reduce_scatter_peer_for_step(
+        phase_rank,
+        phase_size,
+        channel,
+        step,
+        DirectIbReduceScatterRole::SEND,
+        kStaggerChannels);
+    TiledBuffer<const T> send_tile(
+        input.chunk_data(peer), input.chunk_elements, group);
+    auto transport = peers[peer];
+    transport.send(
+        group,
+        reinterpret_cast<const char*>(send_tile.data()),
+        send_tile.bytes(),
+        signaling_data_size,
+        abort_device);
+  }
+}
+
+} // namespace comms::prims
+
+#undef PRIMS_DIRECT_IB_PHASE_HOST_DEVICE_INLINE

--- a/comms/prims/collectives/ReduceScatterDirectIbV2.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIbV2.cu
@@ -2,6 +2,8 @@
 
 #include "comms/prims/collectives/ReduceScatterDirectIbV2.cuh"
 
+#include "comms/prims/collectives/ReduceScatterDirectIbCore.cuh"
+
 #include "comms/prims/core/Checks.h"
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/TiledBuffer.cuh"
@@ -277,7 +279,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
       if (group.is_leader()) {
         for (int i = 0; i < count; ++i) {
           const int step = base + i;
-          rpeer_of[i] = (my_rank + 1 + (step + channel) % (W - 1)) % W;
+          rpeer_of[i] = direct_ib_reduce_scatter_peer_for_step(
+              my_rank, W, channel, step, DirectIbReduceScatterRole::RECEIVE);
           for (int sl = 0; sl < kSlots; ++sl) {
             rviews[sl][i] = detail::RecvChunkAcquisition{};
           }
@@ -431,7 +434,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
       bool posted[kMaxPeersInFlight];
       for (int i = 0; i < count; ++i) {
         const int step = base + i;
-        peer_of[i] = (my_rank + W - 1 - (step + channel) % (W - 1)) % W;
+        peer_of[i] = direct_ib_reduce_scatter_peer_for_step(
+            my_rank, W, channel, step, DirectIbReduceScatterRole::SEND);
         posted[i] = false;
         auto transport = args.peers[peer_of[i]];
         transport.init_registered_send_progress(solo, wire_bytes, max_sig);

--- a/comms/prims/collectives/ReduceScatterDirectNvlCore.cuh
+++ b/comms/prims/collectives/ReduceScatterDirectNvlCore.cuh
@@ -1,0 +1,123 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+#define PRIMS_DIRECT_NVL_RS_HOST_DEVICE __host__ __device__
+#else
+#define PRIMS_DIRECT_NVL_RS_HOST_DEVICE
+#endif
+
+namespace comms::prims {
+
+/** Communication direction for one Direct NVLink peer walk. */
+enum class DirectNvlPeerRole : std::uint8_t {
+  SEND,
+  RECEIVE,
+};
+
+/**
+ * Iterate over every non-self local peer.
+ *
+ * With rotation disabled, both roles retain the legacy ascending-rank order.
+ * With rotation enabled, send and receive walks are complementary for a given
+ * channel and step, spreading simultaneous channels over different peers.
+ * Callers own the rotation policy because its threshold is algorithm tuning,
+ * not a property of the transport. `local_size` must be greater than one;
+ * collective entry points handle the single-rank identity before constructing
+ * an iterator.
+ */
+class DirectNvlPeerIterator {
+ public:
+  PRIMS_DIRECT_NVL_RS_HOST_DEVICE constexpr DirectNvlPeerIterator(
+      int local_rank,
+      int local_size,
+      std::uint32_t channel,
+      DirectNvlPeerRole role,
+      bool rotate_peers)
+      : local_rank_(local_rank),
+        peer_count_(local_size - 1),
+        peer_index_(0),
+        peer_step_(1) {
+    if (rotate_peers) {
+      const std::uint32_t peer_count = static_cast<std::uint32_t>(peer_count_);
+      const int channel_offset = static_cast<int>(
+          channel < peer_count ? channel : channel % peer_count);
+      if (role == DirectNvlPeerRole::SEND) {
+        peer_index_ = local_rank - 1 - channel_offset;
+        if (peer_index_ < 0) {
+          peer_index_ += peer_count_;
+        }
+        peer_step_ = -1;
+      } else {
+        peer_index_ = local_rank + channel_offset;
+        if (peer_index_ >= peer_count_) {
+          peer_index_ -= peer_count_;
+        }
+      }
+    }
+  }
+
+  PRIMS_DIRECT_NVL_RS_HOST_DEVICE constexpr int next() {
+    // Iterate in the dense local_size-1 index space, then insert self again.
+    const int peer = peer_index_ + (peer_index_ >= local_rank_);
+    peer_index_ += peer_step_;
+    if (peer_index_ < 0) {
+      peer_index_ += peer_count_;
+    } else if (peer_index_ >= peer_count_) {
+      peer_index_ -= peer_count_;
+    }
+    return peer;
+  }
+
+ private:
+  int local_rank_;
+  int peer_count_;
+  int peer_index_;
+  int peer_step_;
+};
+
+/** Owner-major source chunks: all destination-domain chunks for one owner. */
+struct DirectNvlContiguousOwnerLayout {
+  PRIMS_DIRECT_NVL_RS_HOST_DEVICE static constexpr std::size_t source_chunk(
+      std::size_t destination_domain,
+      std::size_t local_owner,
+      std::size_t /* local_size */,
+      std::size_t num_destination_domains) {
+    return local_owner * num_destination_domains + destination_domain;
+  }
+
+  PRIMS_DIRECT_NVL_RS_HOST_DEVICE static constexpr std::size_t packed_chunk(
+      std::size_t destination_domain) {
+    return destination_domain;
+  }
+};
+
+/**
+ * Node-major source chunks with owner-strided packing.
+ *
+ * A local owner `l` collects global chunks `(d * local_size + l)` for every
+ * destination domain `d`, and packs them as consecutive chunks `[d]` for the
+ * following inter-domain ReduceScatter phase.
+ */
+struct DirectNvlNodeMajorOwnerStridedLayout {
+  PRIMS_DIRECT_NVL_RS_HOST_DEVICE static constexpr std::size_t source_chunk(
+      std::size_t destination_domain,
+      std::size_t local_owner,
+      std::size_t local_size,
+      std::size_t /* num_destination_domains */) {
+    return destination_domain * local_size + local_owner;
+  }
+
+  PRIMS_DIRECT_NVL_RS_HOST_DEVICE static constexpr std::size_t packed_chunk(
+      std::size_t destination_domain) {
+    return destination_domain;
+  }
+};
+
+} // namespace comms::prims
+
+#undef PRIMS_DIRECT_NVL_RS_HOST_DEVICE

--- a/comms/prims/collectives/tests/DirectIbReduceScatterCoreTest.cpp
+++ b/comms/prims/collectives/tests/DirectIbReduceScatterCoreTest.cpp
@@ -1,0 +1,145 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "comms/prims/collectives/ReduceScatterDirectIbCore.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+void expect_matched_peer_walk(int num_ranks, bool stagger_channels) {
+  const std::vector<std::uint32_t> channels{
+      0,
+      1,
+      static_cast<std::uint32_t>(num_ranks - 1),
+      static_cast<std::uint32_t>(num_ranks),
+      static_cast<std::uint32_t>(2 * num_ranks + 1),
+  };
+  for (const std::uint32_t channel : channels) {
+    for (int rank = 0; rank < num_ranks; ++rank) {
+      std::vector<bool> visited(num_ranks, false);
+      for (int step = 0; step < num_ranks - 1; ++step) {
+        const int peer = direct_ib_reduce_scatter_peer_for_step(
+            rank,
+            num_ranks,
+            channel,
+            step,
+            DirectIbReduceScatterRole::RECEIVE,
+            stagger_channels);
+        ASSERT_GE(peer, 0);
+        ASSERT_LT(peer, num_ranks);
+        EXPECT_NE(peer, rank);
+        EXPECT_FALSE(visited[peer]);
+        visited[peer] = true;
+
+        EXPECT_EQ(
+            direct_ib_reduce_scatter_peer_for_step(
+                peer,
+                num_ranks,
+                channel,
+                step,
+                DirectIbReduceScatterRole::SEND,
+                stagger_channels),
+            rank);
+      }
+
+      for (int peer = 0; peer < num_ranks; ++peer) {
+        EXPECT_EQ(visited[peer], peer != rank);
+      }
+    }
+  }
+}
+
+TEST(DirectIbReduceScatterCoreTest, StaggeredWalkIsMatchedPermutation) {
+  for (const int num_ranks : {2, 3, 4, 7, 8, 31, 32, 127, 128, 255, 256}) {
+    expect_matched_peer_walk(num_ranks, true);
+  }
+}
+
+TEST(DirectIbReduceScatterCoreTest, UnstaggeredWalkIsMatchedPermutation) {
+  for (const int num_ranks : {2, 3, 4, 7, 8, 31, 32, 127, 128, 255, 256}) {
+    expect_matched_peer_walk(num_ranks, false);
+  }
+}
+
+TEST(DirectIbReduceScatterCoreTest, SingleRankIdentityReturnsSelf) {
+  EXPECT_EQ(
+      direct_ib_reduce_scatter_peer_for_step(
+          0, 1, 0, 0, DirectIbReduceScatterRole::RECEIVE),
+      0);
+  EXPECT_EQ(
+      direct_ib_reduce_scatter_peer_for_step(
+          0, 1, 0, 0, DirectIbReduceScatterRole::SEND),
+      0);
+}
+
+TEST(DirectIbReduceScatterCoreTest, RoleBoundaryMatchesThreadSplit) {
+  EXPECT_EQ(
+      direct_ib_reduce_scatter_role_for_thread(0, 384),
+      DirectIbReduceScatterRole::RECEIVE);
+  EXPECT_EQ(
+      direct_ib_reduce_scatter_role_for_thread(383, 384),
+      DirectIbReduceScatterRole::RECEIVE);
+  EXPECT_EQ(
+      direct_ib_reduce_scatter_role_for_thread(384, 384),
+      DirectIbReduceScatterRole::SEND);
+  EXPECT_EQ(
+      direct_ib_reduce_scatter_role_for_thread(511, 384),
+      DirectIbReduceScatterRole::SEND);
+}
+
+TEST(DirectIbReduceScatterCoreTest, RoleGroupsPreserveLogicalIdentity) {
+  const auto make_parent = [](std::uint32_t thread_id) {
+    return ThreadGroup{
+        .thread_id_in_group = thread_id,
+        .group_size = 512,
+        .group_id = 7,
+        .block_id = 11,
+        .total_groups = 13,
+        .scope = SyncScope::BLOCK};
+  };
+
+  const auto receive =
+      make_direct_ib_reduce_scatter_role_group<128, 384, 512>(make_parent(383));
+  EXPECT_EQ(receive.role, DirectIbReduceScatterRole::RECEIVE);
+  EXPECT_EQ(receive.group.thread_id_in_group, 383);
+  EXPECT_EQ(receive.group.group_size, 384);
+  EXPECT_EQ(receive.group.group_id, 7);
+  EXPECT_EQ(receive.group.block_id, 11);
+  EXPECT_EQ(receive.group.total_groups, 13);
+  EXPECT_EQ(receive.group.scope, SyncScope::MULTIWARP);
+  EXPECT_EQ(receive.group.barrier_id, ThreadGroup::kAutoBarrierId);
+
+  const auto send =
+      make_direct_ib_reduce_scatter_role_group<128, 384, 512>(make_parent(384));
+  EXPECT_EQ(send.role, DirectIbReduceScatterRole::SEND);
+  EXPECT_EQ(send.group.thread_id_in_group, 0);
+  EXPECT_EQ(send.group.group_size, 128);
+  EXPECT_EQ(send.group.group_id, 7);
+  EXPECT_EQ(send.group.block_id, 11);
+  EXPECT_EQ(send.group.total_groups, 13);
+  EXPECT_EQ(send.group.scope, SyncScope::MULTIWARP);
+  EXPECT_EQ(send.group.barrier_id, ThreadGroup::kAutoBarrierId);
+}
+
+TEST(DirectIbReduceScatterCoreTest, ExplicitBarriersSupportReverseSplit) {
+  const ThreadGroup parent{
+      .thread_id_in_group = 128,
+      .group_size = 512,
+      .group_id = 3,
+      .block_id = 5,
+      .total_groups = 8,
+      .scope = SyncScope::BLOCK};
+  const auto send =
+      make_direct_ib_reduce_scatter_role_group<384, 128, 512, 1, 2>(parent);
+  EXPECT_EQ(send.role, DirectIbReduceScatterRole::SEND);
+  EXPECT_EQ(send.group.thread_id_in_group, 0);
+  EXPECT_EQ(send.group.group_size, 384);
+  EXPECT_EQ(send.group.barrier_id, 2);
+}
+
+} // namespace
+} // namespace comms::prims::test

--- a/comms/prims/collectives/tests/DirectIbReduceScatterTest.cc
+++ b/comms/prims/collectives/tests/DirectIbReduceScatterTest.cc
@@ -20,6 +20,7 @@ struct DirectIbReduceScatterTestParams {
   std::size_t chunk_elements;
   bool quantized;
   bool use_tma{true};
+  bool in_place{false};
   std::string name;
 };
 
@@ -72,6 +73,9 @@ TEST_P(DirectIbReduceScatterTest, Correctness) {
       cudaMemset(outputBuf.get(), 0, params.chunk_elements * sizeof(float)));
 
   fill_input(static_cast<float*>(inputBuf.get()), total_elements);
+  auto* outputPtr = params.in_place ? static_cast<float*>(inputBuf.get()) +
+          static_cast<std::size_t>(globalRank) * params.chunk_elements
+                                    : static_cast<float*>(outputBuf.get());
   const std::uint64_t seed = 0x123456789abcdef0ULL;
   CUDACHECK_TEST(
       cudaMemcpy(seedBuf.get(), &seed, sizeof(seed), cudaMemcpyHostToDevice));
@@ -82,8 +86,9 @@ TEST_P(DirectIbReduceScatterTest, Correctness) {
   launchParams.chunk_elements = params.chunk_elements;
   launchParams.signaling_data_size = 0;
   launchParams.input = static_cast<const float*>(inputBuf.get());
-  launchParams.output = static_cast<float*>(outputBuf.get());
+  launchParams.output = outputPtr;
   launchParams.quantized = params.quantized;
+  launchParams.in_place = params.in_place;
   launchParams.seed_ptr = params.quantized
       ? static_cast<const std::uint64_t*>(seedBuf.get())
       : nullptr;
@@ -125,9 +130,7 @@ TEST_P(DirectIbReduceScatterTest, Correctness) {
   }
 
   verify_reduce_scatter(
-      static_cast<const float*>(outputBuf.get()),
-      params.chunk_elements,
-      params.quantized ? 5e-2f : 1e-2f);
+      outputPtr, params.chunk_elements, params.quantized ? 5e-2f : 1e-2f);
 }
 
 std::vector<DirectIbReduceScatterTestParams> all_test_params() {
@@ -174,6 +177,11 @@ std::vector<DirectIbReduceScatterTestParams> all_test_params() {
       {.chunk_elements = 16384 * 8 + 4096,
        .quantized = true,
        .name = "RaggedTileQuantized"});
+  out.push_back(
+      {.chunk_elements = 8UL * 1024 * 1024 / sizeof(float) / kExpectedRanks,
+       .quantized = false,
+       .in_place = true,
+       .name = "8MBFp32InPlace"});
   return out;
 }
 

--- a/comms/prims/collectives/tests/DirectNvlReduceScatterCoreTest.cc
+++ b/comms/prims/collectives/tests/DirectNvlReduceScatterCoreTest.cc
@@ -1,0 +1,234 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "comms/prims/collectives/ReduceScatterDirectNvlCore.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+constexpr int expected_rotated_peer(
+    int local_rank,
+    int local_size,
+    std::uint32_t channel,
+    std::uint32_t step,
+    DirectNvlPeerRole role) {
+  const int offset = static_cast<int>(
+      (static_cast<std::uint64_t>(channel) + step) %
+      static_cast<std::uint32_t>(local_size - 1));
+  return role == DirectNvlPeerRole::SEND
+      ? (local_rank + local_size - 1 - offset) % local_size
+      : (local_rank + 1 + offset) % local_size;
+}
+
+TEST(DirectNvlReduceScatterCoreTest, RotatedWalksPairAndCoverEveryPeer) {
+  for (int local_size = 2; local_size <= 72; ++local_size) {
+    for (std::uint32_t channel_index = 0;
+         channel_index < static_cast<std::uint32_t>(local_size);
+         ++channel_index) {
+      const std::uint32_t channel =
+          channel_index == static_cast<std::uint32_t>(local_size - 1)
+          ? std::numeric_limits<std::uint32_t>::max()
+          : channel_index;
+      for (int local_rank = 0; local_rank < local_size; ++local_rank) {
+        SCOPED_TRACE(
+            ::testing::Message() << "local_size=" << local_size << " channel="
+                                 << channel << " local_rank=" << local_rank);
+        DirectNvlPeerIterator sends(
+            local_rank,
+            local_size,
+            channel,
+            DirectNvlPeerRole::SEND,
+            /*rotate_peers=*/true);
+        DirectNvlPeerIterator receives(
+            local_rank,
+            local_size,
+            channel,
+            DirectNvlPeerRole::RECEIVE,
+            /*rotate_peers=*/true);
+        std::vector<int> sent(local_size);
+        std::vector<int> received(local_size);
+        for (int step = 0; step < 2 * (local_size - 1); ++step) {
+          const int send_peer = sends.next();
+          const int receive_peer = receives.next();
+          EXPECT_EQ(
+              send_peer,
+              expected_rotated_peer(
+                  local_rank,
+                  local_size,
+                  channel,
+                  step,
+                  DirectNvlPeerRole::SEND));
+          EXPECT_EQ(
+              receive_peer,
+              expected_rotated_peer(
+                  local_rank,
+                  local_size,
+                  channel,
+                  step,
+                  DirectNvlPeerRole::RECEIVE));
+          sent.at(send_peer)++;
+          received.at(receive_peer)++;
+
+          EXPECT_EQ(
+              expected_rotated_peer(
+                  send_peer,
+                  local_size,
+                  channel,
+                  step,
+                  DirectNvlPeerRole::RECEIVE),
+              local_rank);
+        }
+        for (int peer = 0; peer < local_size; ++peer) {
+          const int expected_count = peer == local_rank ? 0 : 2;
+          EXPECT_EQ(sent.at(peer), expected_count);
+          EXPECT_EQ(received.at(peer), expected_count);
+        }
+      }
+    }
+  }
+}
+
+TEST(DirectNvlReduceScatterCoreTest, RankOrderWalkPreservesLegacyOrder) {
+  for (int local_size = 2; local_size <= 72; ++local_size) {
+    for (const std::uint32_t channel :
+         {0U,
+          static_cast<std::uint32_t>(local_size - 2),
+          std::numeric_limits<std::uint32_t>::max()}) {
+      for (int local_rank = 0; local_rank < local_size; ++local_rank) {
+        DirectNvlPeerIterator sends(
+            local_rank,
+            local_size,
+            channel,
+            DirectNvlPeerRole::SEND,
+            /*rotate_peers=*/false);
+        DirectNvlPeerIterator receives(
+            local_rank,
+            local_size,
+            channel,
+            DirectNvlPeerRole::RECEIVE,
+            /*rotate_peers=*/false);
+        for (int cycle = 0; cycle < 2; ++cycle) {
+          for (int peer = 0; peer < local_size; ++peer) {
+            if (peer == local_rank) {
+              continue;
+            }
+            EXPECT_EQ(sends.next(), peer);
+            EXPECT_EQ(receives.next(), peer);
+          }
+        }
+      }
+    }
+  }
+}
+
+TEST(DirectNvlReduceScatterCoreTest, OwnerFilteringKeepsEdgesPaired) {
+  for (const int local_size : {2, 3, 4, 7, 8, 16, 72}) {
+    for (int owner_count = 1; owner_count <= local_size; ++owner_count) {
+      for (const bool rotate_peers : {false, true}) {
+        for (std::uint32_t channel = 0;
+             channel < static_cast<std::uint32_t>(local_size - 1);
+             ++channel) {
+          std::vector<std::vector<int>> sends(
+              local_size, std::vector<int>(local_size));
+          std::vector<std::vector<int>> receives(
+              local_size, std::vector<int>(local_size));
+          for (int local_rank = 0; local_rank < local_size; ++local_rank) {
+            DirectNvlPeerIterator send_peers(
+                local_rank,
+                local_size,
+                channel,
+                DirectNvlPeerRole::SEND,
+                rotate_peers);
+            DirectNvlPeerIterator receive_peers(
+                local_rank,
+                local_size,
+                channel,
+                DirectNvlPeerRole::RECEIVE,
+                rotate_peers);
+            const int owner_steps = rotate_peers
+                ? local_size - 1
+                : owner_count - static_cast<int>(local_rank < owner_count);
+            for (int step = 0; step < owner_steps; ++step) {
+              const int owner = send_peers.next();
+              if (owner < owner_count) {
+                sends.at(local_rank).at(owner)++;
+              }
+            }
+            if (local_rank < owner_count) {
+              for (int step = 0; step < local_size - 1; ++step) {
+                receives.at(receive_peers.next()).at(local_rank)++;
+              }
+            }
+          }
+          EXPECT_EQ(sends, receives)
+              << "local_size=" << local_size << " owner_count=" << owner_count
+              << " channel=" << channel << " rotate_peers=" << rotate_peers;
+        }
+      }
+    }
+  }
+}
+
+template <std::size_t kDomains, std::size_t kLocalSize>
+void expect_node_major_owner_packing() {
+  std::vector<bool> source_chunks(kDomains * kLocalSize);
+  for (std::size_t domain = 0; domain < kDomains; ++domain) {
+    for (std::size_t owner = 0; owner < kLocalSize; ++owner) {
+      const std::size_t source =
+          DirectNvlNodeMajorOwnerStridedLayout::source_chunk(
+              domain, owner, kLocalSize, kDomains);
+      EXPECT_EQ(source, domain * kLocalSize + owner);
+      ASSERT_LT(source, source_chunks.size());
+      EXPECT_FALSE(source_chunks.at(source));
+      source_chunks.at(source) = true;
+      EXPECT_EQ(
+          DirectNvlNodeMajorOwnerStridedLayout::packed_chunk(domain), domain);
+    }
+  }
+  for (const bool visited : source_chunks) {
+    EXPECT_TRUE(visited);
+  }
+}
+
+TEST(DirectNvlReduceScatterCoreTest, NodeMajorTwoByFourPacksByDomain) {
+  expect_node_major_owner_packing<2, 4>();
+}
+
+TEST(DirectNvlReduceScatterCoreTest, NodeMajorFourByTwoPacksByDomain) {
+  expect_node_major_owner_packing<4, 2>();
+}
+
+TEST(DirectNvlReduceScatterCoreTest, ContiguousOwnerLayoutGroupsOwnerBatches) {
+  constexpr std::size_t kDomains = 4;
+  constexpr std::size_t kLocalSize = 2;
+  for (std::size_t owner = 0; owner < kLocalSize; ++owner) {
+    for (std::size_t domain = 0; domain < kDomains; ++domain) {
+      EXPECT_EQ(
+          DirectNvlContiguousOwnerLayout::source_chunk(
+              domain, owner, kLocalSize, kDomains),
+          owner * kDomains + domain);
+      EXPECT_EQ(DirectNvlContiguousOwnerLayout::packed_chunk(domain), domain);
+    }
+  }
+}
+
+TEST(DirectNvlReduceScatterCoreTest, LayoutUsesSizeTForLargeChunkIndices) {
+  constexpr std::size_t kLocalSize = std::size_t{1} << 20;
+  constexpr std::size_t kDomain = (std::size_t{1} << 20) + 3;
+  constexpr std::size_t kOwner = kLocalSize - 1;
+  constexpr std::size_t kExpected = kDomain * kLocalSize + kOwner;
+  static_assert(kExpected > std::numeric_limits<std::uint32_t>::max());
+  EXPECT_EQ(
+      DirectNvlNodeMajorOwnerStridedLayout::source_chunk(
+          kDomain, kOwner, kLocalSize, kDomain + 1),
+      kExpected);
+}
+
+} // namespace
+} // namespace comms::prims::test

--- a/comms/prims/collectives/tests/DirectNvlTest.cc
+++ b/comms/prims/collectives/tests/DirectNvlTest.cc
@@ -142,6 +142,9 @@ TEST_P(DirectReduceScatterNvlTest, Correctness) {
   CUDACHECK_TEST(cudaMemset(outputBuf.get(), 0, params.bytes));
 
   fill_input(static_cast<float*>(inputBuf.get()), total_elements);
+  auto* output = params.in_place ? static_cast<float*>(inputBuf.get()) +
+          static_cast<std::size_t>(globalRank) * chunk_elements
+                                 : static_cast<float*>(outputBuf.get());
 
   DirectReduceScatterNvlLaunchParams launchParams{};
   launchParams.my_rank = globalRank;
@@ -149,7 +152,7 @@ TEST_P(DirectReduceScatterNvlTest, Correctness) {
   launchParams.chunk_elements = chunk_elements;
   launchParams.signaling_data_size = 0;
   launchParams.input = static_cast<const float*>(inputBuf.get());
-  launchParams.output = static_cast<float*>(outputBuf.get());
+  launchParams.output = output;
   launchParams.num_blocks = params.num_blocks;
 
   for (int peer = 0; peer < worldSize; ++peer) {
@@ -165,8 +168,7 @@ TEST_P(DirectReduceScatterNvlTest, Correctness) {
   CUDACHECK_TEST(cudaDeviceSynchronize());
   bootstrap->barrierAll();
 
-  verify_reduce_scatter(
-      static_cast<const float*>(outputBuf.get()), chunk_elements);
+  verify_reduce_scatter(output, chunk_elements);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -199,7 +201,12 @@ INSTANTIATE_TEST_SUITE_P(
         DirectNvlTestParams{
             .bytes = 1024 * 1024,
             .num_blocks = 8,
-            .name = "1MB_8B"}),
+            .name = "1MB_8B"},
+        DirectNvlTestParams{
+            .bytes = 64 * 1024 + sizeof(float),
+            .num_blocks = 4,
+            .in_place = true,
+            .name = "64KBPlusOneFloat_4B_InPlace"}),
     param_name);
 
 } // namespace


### PR DESCRIPTION
Summary:
Extract the existing non-quantized V1 Direct IB ReduceScatter body into a force-inlined Prims phase helper. The helper takes phase-local rank/size, equal logical chunks with an optional physical stride, explicit output seed state, signaling size, a phase-local peer table, caller-selectable barrier IDs, and abort state. Migrate the standalone FP32/SUM V1 kernel as the first consumer while leaving both quantized specializations and Direct IB V2 unchanged.

This creates the reusable RDMA seam for the sequential NVLink-to-Direct-RDMA ReduceScatter follow-up without adding fused policy or topology to Prims. Add an exact in-place distributed case so both local-operand seed modes remain covered. The future fused consumer will provide end-to-end coverage for padded workspace stride and its single-domain identity path.

Differential Revision: D118224250


