### PR TITLE
MCCL: generalize bidirectional registered Ring (#3943)

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2063,6 +2063,16 @@ cvars:
      force - Require every rank and the exact Phase-2 source range to be
              eligible for IBGDA zero-copy; never fall back to the copy path.
 
+ - name        : MCCL_ALLREDUCE_RING_BIDIRECTIONAL_ENABLE
+   type        : bool
+   default     : true
+   description : |-
+     Enable bidirectional registered Ring reduce-scatter and all-gather for
+     in-place collectives with every supported virtual-stripe geometry.
+     Out-of-place collectives continue to use the unidirectional registered
+     Ring path. This value must be set identically on every rank. Set false to
+     use the unidirectional registered Ring path.
+
  - name        : NCCL_CTRAN_PIPES_TRACE_ENABLE
    type        : bool
    default     : false


### PR DESCRIPTION
Summary:

Remove the message-size and communicator-parity gates from the registered bidirectional Ring path. Split odd-ring reduce-scatter contributors asymmetrically between the two directions so each rank contributes exactly once, and make the zero-round direction safe for the two-node topology.

Replace the special 129-256 MiB staged all-gather path with the same concurrent bidirectional path used at other sizes. Add `MCCL_ALLREDUCE_RING_BIDIRECTIONAL_ENABLE` as a uniform rollback switch while retaining S10 as the required channel geometry.

Reviewed By: saifhhasan

Differential Revision: D118329688


