### PR TITLE
comms/uniflow/benchmarks: close the timed window on a peer ack (#3945)

### DIFF
--- a/comms/uniflow/benchmarks/BenchmarkRunner.h
+++ b/comms/uniflow/benchmarks/BenchmarkRunner.h
@@ -49,6 +49,16 @@ struct BenchmarkConfig {
    * reports excellent throughput.
    */
   bool verify{true};
+  /*
+   * Cross-rank measurement barrier. A multi-GPU run launches N independent
+   * rank-pairs; nothing lines their timed loops up, so summing their
+   * bandwidths sums windows that do not coincide. barrierDir is a host-local
+   * directory shared by the active aggregate instances; when set, all N
+   * rendezvous after warmup, immediately before the clock starts.
+   */
+  std::string barrierDir;
+  int barrierRanks{0};
+  int barrierIndex{-1};
 };
 
 class Benchmark {

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
@@ -13,6 +13,7 @@
 #include <deque>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <future>
 #include <iostream>
 #include <random>
@@ -255,7 +256,8 @@ TransferResult runTransfer(
     size_t size,
     const std::string& dir,
     const BenchmarkConfig& config,
-    int rank) {
+    int rank,
+    const std::function<bool()>& peerAck) {
   using Clock = std::chrono::steady_clock;
   const int batchSize = std::max(1, config.batchSize);
   const int txDepth = std::max(1, config.txDepth);
@@ -278,12 +280,14 @@ TransferResult runTransfer(
   };
 
   TransferResult out;
+  bool transferFailed = false;
 
   for (int i = 0; i < config.warmupIterations; ++i) {
     if (submit().get().hasError()) {
       UNIFLOW_LOG_ERROR(
           "TcpBandwidthBenchmark: warmup {} failed at size {}", dir, size);
-      return out;
+      transferFailed = true;
+      break;
     }
   }
 
@@ -317,31 +321,51 @@ TransferResult runTransfer(
   // All N ranks line up here, after their own warmup, so that every rank's
   // timed window covers the same wall-clock interval and the per-rank
   // bandwidths are summable. Barrier cost is outside the clock below.
-  if (!measurementBarrier(config, fmt::format("{}_{}", dir, size), rank)) {
-    return out;
+  if (!transferFailed &&
+      !measurementBarrier(config, fmt::format("{}_{}", dir, size), rank)) {
+    transferFailed = true;
   }
 
-  auto start = Clock::now();
-  for (int b = 0; b < numBatches; ++b) {
-    if (static_cast<int>(inflight.size()) >= txDepth) {
+  Clock::time_point start;
+  if (!transferFailed) {
+    start = Clock::now();
+    for (int b = 0; b < numBatches; ++b) {
+      if (static_cast<int>(inflight.size()) >= txDepth && !completeOne()) {
+        transferFailed = true;
+        break;
+      }
+      // Timestamp before submit(), not as a sibling argument to emplace_back:
+      // argument evaluation order is unspecified, so Clock::now() could be
+      // evaluated after submit() returns. That matters now that put() applies
+      // backpressure and blocks inside submit() while enqueueing chunks -- the
+      // blocked time would fall outside the measured interval and the reported
+      // latency would be a fraction of the real one (bandwidth, bracketed by
+      // start/end, stayed correct).
+      auto submitTime = Clock::now();
+      inflight.emplace_back(submit(), submitTime);
+    }
+    while (!transferFailed && !inflight.empty()) {
       if (!completeOne()) {
-        return out;
+        transferFailed = true;
       }
     }
-    // Timestamp before submit(), not as a sibling argument to emplace_back:
-    // argument evaluation order is unspecified, so Clock::now() could be
-    // evaluated after submit() returns. That matters now that put() applies
-    // backpressure and blocks inside submit() while enqueueing chunks -- the
-    // blocked time would fall outside the measured interval and the reported
-    // latency would be a fraction of the real one (bandwidth, bracketed by
-    // start/end, stayed correct).
-    auto submitTime = Clock::now();
-    inflight.emplace_back(submit(), submitTime);
   }
-  while (!inflight.empty()) {
-    if (!completeOne()) {
-      return out;
-    }
+  /*
+   * Always execute exactly one peer rendezvous for this size, including after
+   * warmup, measurement-barrier, or completion failure. The passive rank has
+   * already committed to its matching barrier; skipping this one shifts every
+   * later rendezvous by one and strands the peer at the end of the sweep.
+   *
+   * On success, stop the clock only after the peer confirms. A resolved local
+   * future means this side handed the transfer off, not that the peer has it.
+   */
+  if (peerAck && !peerAck()) {
+    UNIFLOW_LOG_ERROR(
+        "TcpBandwidthBenchmark: peer ack failed at {} size {}", dir, size);
+    return out;
+  }
+  if (transferFailed) {
+    return out;
   }
   auto end = Clock::now();
 
@@ -724,6 +748,17 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
   const bool isActiveRank = config.bidirectional || bootstrap.isRank0();
   auto sizes = generateSizes(config.minSize, config.maxSize);
 
+  auto abortBarrierSequence = [&]() {
+    // A barrier failure can be observed asymmetrically. Close the control
+    // connections so a peer that already returned success wakes with EOF at
+    // its next rendezvous instead of waiting through the retry budget.
+    for (auto& peer : peers) {
+      peer.ctrl->close();
+    }
+    peers.clear();
+    transport->shutdown();
+  };
+
   // Correctness before performance. Both ranks must reach the same barriers, so
   // the passive rank waits here while the active rank runs the sweep.
   //
@@ -736,7 +771,7 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
   if (config.verify) {
     if (!barrier(peers, bootstrap)) {
       UNIFLOW_LOG_ERROR("TcpBandwidthBenchmark: pre-verify barrier failed");
-      transport->shutdown();
+      abortBarrierSequence();
       return {};
     }
     if (isActiveRank &&
@@ -754,12 +789,12 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
     }
     if (!barrier(peers, bootstrap)) {
       UNIFLOW_LOG_ERROR("TcpBandwidthBenchmark: post-verify barrier failed");
-      transport->shutdown();
+      abortBarrierSequence();
       return {};
     }
   }
 
-  auto runDirection = [&](const std::string& dir) {
+  auto runDirection = [&](const std::string& dir) -> bool {
     // Seeded from the verify result: a failed correctness sweep still walks the
     // whole size sweep, meeting every barrier and reporting nothing.
     //
@@ -770,9 +805,15 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
     for (auto size : sizes) {
       if (!barrier(peers, bootstrap)) {
         UNIFLOW_LOG_ERROR("TcpBandwidthBenchmark: barrier failed");
-        return;
+        return false;
       }
       if (aborted || !isActiveRank) {
+        // Match the active rank's peer-ack barrier, or the two sides drift
+        // by one barrier per size and the final size hangs.
+        if (!barrier(peers, bootstrap)) {
+          UNIFLOW_LOG_ERROR("TcpBandwidthBenchmark: peer-ack barrier failed");
+          return false;
+        }
         continue;
       }
       // Bracket the timed loop so the phase split covers the same frames the
@@ -783,6 +824,7 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
       if (tcpTransport != nullptr) {
         tcpTransport->logAndResetPhaseStats("reset");
       }
+      bool peerAckFailed = false;
       auto r = runTransfer(
           *transport,
           localReg,
@@ -790,7 +832,15 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
           size,
           dir,
           config,
-          config.barrierIndex);
+          config.barrierIndex,
+          [&]() {
+            const bool ok = static_cast<bool>(barrier(peers, bootstrap));
+            peerAckFailed = !ok;
+            return ok;
+          });
+      if (peerAckFailed) {
+        return false;
+      }
       if (!r.ok) {
         // Latched rather than returned: every remaining size has a barrier the
         // peer is going to execute.
@@ -830,13 +880,20 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
           stats.avg,
           config.bidirectional ? "(bidirectional)" : "(unidirectional)");
     }
+    return true;
   };
 
   if (config.direction == "put" || config.direction == "both") {
-    runDirection("put");
+    if (!runDirection("put")) {
+      abortBarrierSequence();
+      return results;
+    }
   }
   if (config.direction == "get" || config.direction == "both") {
-    runDirection("get");
+    if (!runDirection("get")) {
+      abortBarrierSequence();
+      return results;
+    }
   }
 
   if (!barrier(peers, bootstrap)) {

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
@@ -11,10 +11,13 @@
 #include <cstdlib>
 #include <cstring>
 #include <deque>
+#include <filesystem>
+#include <fstream>
 #include <future>
 #include <iostream>
 #include <random>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -127,13 +130,132 @@ struct TransferResult {
 
 // Warmup then a pipelined timed loop keeping up to txDepth put/get calls in
 // flight over the single TCP connection.
+
+/*
+ * Filesystem barrier across the N rank-pairs of an aggregate run, keyed by
+ * (direction, size) so every size re-synchronises. Fails closed: a barrier
+ * that timed out silently would restore the defect it exists to remove.
+ */
+constexpr std::string_view kMarkerPrefix = "inst";
+
+std::filesystem::path markerPath(
+    const std::filesystem::path& dir,
+    int barrierIndex) {
+  return dir / fmt::format("{}{}", kMarkerPrefix, barrierIndex);
+}
+
+bool measurementBarrier(
+    const BenchmarkConfig& config,
+    const std::string& tag,
+    int barrierIndex) {
+  const bool hasBarrierDir = !config.barrierDir.empty();
+  const bool hasBarrierRanks = config.barrierRanks > 0;
+  if (hasBarrierDir != hasBarrierRanks) {
+    UNIFLOW_LOG_ERROR(
+        "measurement barrier: --measurement-barrier-dir and "
+        "--measurement-barrier-ranks must be specified together");
+    return false;
+  }
+  if (config.barrierRanks <= 1) {
+    return true;
+  }
+  // Keep participant identity independent of the CUDA device: an aggregate
+  // may legitimately use a non-zero-based GPU subset such as devices 4-7.
+  if (barrierIndex < 0 || barrierIndex >= config.barrierRanks) {
+    UNIFLOW_LOG_ERROR(
+        "measurement barrier needs a unique per-instance key in [0, {}); got "
+        "{}. Pass --measurement-barrier-index for every instance",
+        config.barrierRanks,
+        barrierIndex);
+    return false;
+  }
+  namespace fs = std::filesystem;
+  std::error_code ec;
+  fs::path dir = fs::path(config.barrierDir) / tag;
+  fs::create_directories(dir, ec);
+  if (ec) {
+    UNIFLOW_LOG_ERROR(
+        "measurement barrier: cannot create {}: {}",
+        dir.string(),
+        ec.message());
+    return false;
+  }
+  // Nothing else writes this instance's marker, so finding it already there
+  // means the directory is being reused after an earlier run. Counting it
+  // would pre-satisfy the barrier and release early -- the same silent
+  // overstatement this change exists to remove -- so refuse instead.
+  const auto marker = markerPath(dir, barrierIndex);
+  const bool markerExists = fs::exists(marker, ec);
+  if (ec) {
+    UNIFLOW_LOG_ERROR(
+        "measurement barrier: cannot stat {}: {}",
+        marker.string(),
+        ec.message());
+    return false;
+  }
+  if (markerExists) {
+    UNIFLOW_LOG_ERROR(
+        "measurement barrier: {} already exists; pass a fresh "
+        "--measurement-barrier-dir per run",
+        marker.string());
+    return false;
+  }
+  {
+    std::ofstream f(marker);
+    if (!f) {
+      UNIFLOW_LOG_ERROR(
+          "measurement barrier: cannot write marker in {}", dir.string());
+      return false;
+    }
+  }
+
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(120);
+  while (std::chrono::steady_clock::now() < deadline) {
+    size_t arrived = 0;
+    // Enumerate the exact quorum instead of counting a filename prefix:
+    // instructions.txt, inst.tmp, and out-of-range markers must not release
+    // the barrier before every expected instance has arrived.
+    for (int expectedRank = 0; expectedRank < config.barrierRanks;
+         ++expectedRank) {
+      const auto expectedMarker = markerPath(dir, expectedRank);
+      if (fs::exists(expectedMarker, ec)) {
+        ++arrived;
+      }
+      if (ec) {
+        // A filesystem error is not "peers have not arrived yet"; spinning to
+        // the timeout would report it as one.
+        UNIFLOW_LOG_ERROR(
+            "measurement barrier: cannot stat {}: {}",
+            expectedMarker.string(),
+            ec.message());
+        return false;
+      }
+    }
+    if (arrived == static_cast<size_t>(config.barrierRanks)) {
+      return true;
+    }
+    // Cross-process filesystem rendezvous has no condition variable to wait
+    // on; bounded polling is intentional and remains outside the timed loop.
+    // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  UNIFLOW_LOG_ERROR(
+      "measurement barrier timed out at {} (index {}, need {})",
+      tag,
+      barrierIndex,
+      config.barrierRanks);
+  return false;
+}
+
 TransferResult runTransfer(
     Transport& transport,
     RegisteredSegment& localReg,
     RemoteRegisteredSegment& remoteReg,
     size_t size,
     const std::string& dir,
-    const BenchmarkConfig& config) {
+    const BenchmarkConfig& config,
+    int rank) {
   using Clock = std::chrono::steady_clock;
   const int batchSize = std::max(1, config.batchSize);
   const int txDepth = std::max(1, config.txDepth);
@@ -191,6 +313,13 @@ TransferResult runTransfer(
     inflight.pop_front();
     return true;
   };
+
+  // All N ranks line up here, after their own warmup, so that every rank's
+  // timed window covers the same wall-clock interval and the per-rank
+  // bandwidths are summable. Barrier cost is outside the clock below.
+  if (!measurementBarrier(config, fmt::format("{}_{}", dir, size), rank)) {
+    return out;
+  }
 
   auto start = Clock::now();
   for (int b = 0; b < numBatches; ++b) {
@@ -654,7 +783,14 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
       if (tcpTransport != nullptr) {
         tcpTransport->logAndResetPhaseStats("reset");
       }
-      auto r = runTransfer(*transport, localReg, remoteReg, size, dir, config);
+      auto r = runTransfer(
+          *transport,
+          localReg,
+          remoteReg,
+          size,
+          dir,
+          config,
+          config.barrierIndex);
       if (!r.ok) {
         // Latched rather than returned: every remaining size has a barrier the
         // peer is going to execute.

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -78,6 +78,9 @@ struct CliOptions {
   // --tcp-bind-dev. Names are per-host, so the two hosts may need different
   // lists for the same pair of physical ports.
   std::string tcpBindDevs;
+  std::string barrierDir;
+  int barrierRanks{0};
+  int barrierIndex{-1};
 };
 
 std::vector<int> parseIntList(const std::string& s) {
@@ -213,6 +216,12 @@ void printUsage(const char* prog) {
       << "  --cuda-devices <list>  Comma-separated GPU indices for single-process multi-GPU (overrides --cuda-device)\n"
       << "  --gpu-nics <groups>    Per-GPU NIC map for multi-GPU: ';'-separated groups of comma-separated NICs, one per --cuda-devices entry\n"
       << "  --data-direct          Register GPU memory over the mlx5 Data Direct path (default: off)\n"
+      << "  --measurement-barrier-dir <path>  Host-local dir shared by the active\n"
+      << "                         instances, used to line up their timed loops. Without\n"
+      << "                         it their windows stagger and summed bandwidth is\n"
+      << "                         overstated (measured overlap 1.0-2.1 of 8)\n"
+      << "  --measurement-barrier-ranks <n>   Number of instances to wait for\n"
+      << "  --measurement-barrier-index <i>   This instance's unique index in [0,n)\n"
       << "  --list                 List available benchmarks\n"
       << "  --help                 Show this help message\n"
       << "\n"
@@ -259,6 +268,9 @@ CliOptions parseArgs(int argc, char** argv) {
       {"tcp-sockets-per-nic", required_argument, nullptr, 270},
       {"tcp-bind-dev", no_argument, nullptr, 271},
       {"tcp-bind-devs", required_argument, nullptr, 272},
+      {"measurement-barrier-dir", required_argument, nullptr, 280},
+      {"measurement-barrier-ranks", required_argument, nullptr, 281},
+      {"measurement-barrier-index", required_argument, nullptr, 282},
       {"no-verify", no_argument, nullptr, 267},
       {"list", no_argument, nullptr, 'l'},
       {"help", no_argument, nullptr, 'h'},
@@ -358,6 +370,39 @@ CliOptions parseArgs(int argc, char** argv) {
         break;
       case 272:
         opts.tcpBindDevs = optarg;
+        break;
+      case 280:
+        opts.barrierDir = optarg;
+        break;
+      case 281:
+        try {
+          int parsed = std::stoi(optarg);
+          if (parsed < 1) {
+            std::cerr
+                << "Invalid value for --measurement-barrier-ranks: must be >= 1\n";
+            std::exit(1);
+          }
+          opts.barrierRanks = parsed;
+        } catch (const std::exception&) {
+          std::cerr << "Invalid value for --measurement-barrier-ranks: '"
+                    << optarg << "'\n";
+          std::exit(1);
+        }
+        break;
+      case 282:
+        try {
+          const int parsed = std::stoi(optarg);
+          if (parsed < 0) {
+            std::cerr
+                << "Invalid value for --measurement-barrier-index: must be >= 0\n";
+            std::exit(1);
+          }
+          opts.barrierIndex = parsed;
+        } catch (const std::exception&) {
+          std::cerr << "Invalid value for --measurement-barrier-index: '"
+                    << optarg << "'\n";
+          std::exit(1);
+        }
         break;
       case 'd':
         opts.direction = optarg;
@@ -490,6 +535,21 @@ CliOptions parseArgs(int argc, char** argv) {
     opts.benchmark = "__list__";
   }
 
+  const bool hasBarrierDir = !opts.barrierDir.empty();
+  const bool hasBarrierRanks = opts.barrierRanks > 0;
+  const bool hasBarrierIndex = opts.barrierIndex >= 0;
+  if ((hasBarrierDir || hasBarrierRanks || hasBarrierIndex) &&
+      !(hasBarrierDir && hasBarrierRanks && hasBarrierIndex)) {
+    std::cerr << "--measurement-barrier-dir, --measurement-barrier-ranks, and "
+                 "--measurement-barrier-index must be specified together\n";
+    std::exit(1);
+  }
+  if (hasBarrierIndex && opts.barrierIndex >= opts.barrierRanks) {
+    std::cerr << "Invalid value for --measurement-barrier-index: must be less "
+                 "than --measurement-barrier-ranks\n";
+    std::exit(1);
+  }
+
   return opts;
 }
 
@@ -554,6 +614,9 @@ int main(int argc, char** argv) {
   config.bidirectional = opts.bidirectional;
   config.dataDirect = opts.dataDirect;
   config.verify = !opts.noVerify;
+  config.barrierDir = opts.barrierDir;
+  config.barrierRanks = opts.barrierRanks;
+  config.barrierIndex = opts.barrierIndex;
   config.direction = opts.direction;
   config.batchSize = opts.batchSize;
   config.txDepth = opts.txDepth;


### PR DESCRIPTION
Summary:

runTransfer() stops its clock when the last local future resolves:

    while (!inflight.empty()) { completeOne(); }
    auto end = Clock::now();

A resolved future means this side handed the transfer off, not that the peer
has it: for put the peer may still be draining queued frames, and for get the
async H2D copy is retired off the reader thread (D117155852). Dividing the full
byte count by that shorter interval reports a bandwidth the wire never carried.

Now, runTransfer() takes a peerAck callback and invokes it after
the last completion and before `end`. The callsite passes the existing per-pair
barrier(peers, bootstrap), so no wire-protocol change is involved.

The passive rank must match the extra barrier. It never calls runTransfer(), so
without a matching call the two sides drift by one barrier per size and the
final size hangs with no partner. If a barrier itself fails asymmetrically, the
failing side explicitly closes every control connection before returning; this
wakes a peer that already observed success instead of stranding it at the next
rendezvous.

Ordered after the cross-rank barrier: that one makes a multi-GPU aggregate
meaningful at all, this one corrects what a single window measures, at any rank
count.

Reviewed By: cppccppccppc

Differential Revision: D118308422


