### PR TITLE
Derive metrics on the host, off the copied-out bank (#3946)

### DIFF
--- a/comms/utils/collstats/CollStatsReadout.h
+++ b/comms/utils/collstats/CollStatsReadout.h
@@ -1,0 +1,70 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+// Host-side metric derivation from a copied-out bank value.
+// These run on the reader after the D2H copy, never on the device, so they are
+// plain host functions. They turn the raw per-window counters into the reported
+// numbers: the per-window average, the lower edge of a histogram bucket, and
+// tail percentiles from the histogram (at its ~9% relative error). The exact
+// minimum lives beside its encoding in CollStatsTypes.h (collStatDurMinNs) and
+// the maximum is a raw field, so neither is derived here.
+//
+// Bus bandwidth is deliberately absent: it needs the per-op traffic factor, and
+// the exported window carries the raw aggregates so the off-box consumer can
+// apply it -- see CollStatsJson.h. Keeping the latency and throughput numbers
+// distinct matters, because reporting one as the other is the main way this
+// class of tool misroutes an incident.
+
+namespace meta::comms::collstats {
+
+/* Lower edge (ns) of a histogram bucket, i.e. the inverse of logBucketNs under
+ * the same geometry. The underflow bucket starts at 0; the overflow bucket
+ * starts at tMaxNs. */
+inline double collStatBucketLowerNs(
+    const CollStatHistGeometry& geom,
+    uint32_t bucket) {
+  if (bucket == kHistUnderflowBucket) {
+    return 0.0;
+  }
+  if (bucket >= geom.numBuckets - 1) {
+    return static_cast<double>(geom.tMaxNs);
+  }
+  const double octavesAbove =
+      static_cast<double>(bucket - 1) / geom.subBucketsPerOctave;
+  return static_cast<double>(geom.tMinNs) * std::exp2(octavesAbove);
+}
+
+// Exact per-window average duration (ns); 0 when no observations.
+inline double collStatAvgDurationNs(const CollStatValue& v) {
+  return v.count == 0
+      ? 0.0
+      : static_cast<double>(v.durationSumNs) / static_cast<double>(v.count);
+}
+
+// Nearest-rank quantile read from the histogram, returned as the lower edge of
+// the containing bucket (ns). `p` is in (0, 1]. Adequate for ranking outliers;
+// paging keys off the exact threshold counters, not this.
+inline double collStatPercentileNs(
+    const CollStatHistGeometry& geom,
+    const CollStatValue& v,
+    double p) {
+  if (v.count == 0) {
+    return 0.0;
+  }
+  const double target = p * static_cast<double>(v.count);
+  uint64_t cum = 0;
+  for (uint32_t b = 0; b < geom.numBuckets; ++b) {
+    cum += v.histogram[b];
+    if (static_cast<double>(cum) >= target) {
+      return collStatBucketLowerNs(geom, b);
+    }
+  }
+  return collStatBucketLowerNs(geom, geom.numBuckets - 1);
+}
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/tests/CollStatsReadoutTest.cpp
+++ b/comms/utils/collstats/tests/CollStatsReadoutTest.cpp
@@ -1,0 +1,95 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/collstats/CollStatsReadout.h"
+
+#include <cmath>
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/collstats/CollStatsFinalize.h"
+#include "comms/utils/collstats/CollStatsHistogram.h"
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+namespace meta::comms::collstats {
+
+/* The tests assert against the cvar defaults explicitly, rather than against
+ * whatever the compiled-in constants happen to be. */
+const CollStatHistGeometry kTestGeom = collStatDefaultHistGeometry();
+namespace {
+
+constexpr uint64_t kSec = 1'000'000'000ull;
+
+TEST(CollStatsReadoutTest, BucketLowerIsInverseOfLogBucket) {
+  // A duration at an exact octave start must invert back to itself.
+  for (uint32_t k = 0; k < kDefaultHistOctaves; ++k) {
+    const uint64_t durNs = kDefaultHistTMinNs << k;
+    const uint32_t bucket = logBucketNs(kTestGeom, durNs);
+    EXPECT_NEAR(
+        collStatBucketLowerNs(kTestGeom, bucket),
+        static_cast<double>(durNs),
+        1.0)
+        << "octave k=" << k;
+  }
+}
+
+TEST(CollStatsReadoutTest, AverageIsSumOverCount) {
+  CollStatValue v{};
+  collStatAccumulate(&v, 2 * kSec, 0);
+  collStatAccumulate(&v, 4 * kSec, 0);
+  EXPECT_DOUBLE_EQ(collStatAvgDurationNs(v), 3.0 * kSec);
+}
+
+TEST(CollStatsReadoutTest, PercentileOfSingleBucketIsThatBucket) {
+  CollStatValue v{};
+  const uint64_t dur = 10 * kSec;
+  for (int i = 0; i < 100; ++i) {
+    collStatAccumulate(&v, dur, 0);
+  }
+  const double edge =
+      collStatBucketLowerNs(kTestGeom, logBucketNs(kTestGeom, dur));
+  EXPECT_DOUBLE_EQ(collStatPercentileNs(kTestGeom, v, 0.5), edge);
+  EXPECT_DOUBLE_EQ(collStatPercentileNs(kTestGeom, v, 0.99), edge);
+}
+
+TEST(CollStatsReadoutTest, PercentileSeparatesBulkFromTail) {
+  CollStatValue v{};
+  for (int i = 0; i < 99; ++i) {
+    collStatAccumulate(&v, 1 * kSec, 0);
+  }
+  collStatAccumulate(&v, 500 * kSec, 0); // one tail sample
+
+  // P50 sits in the bulk; P99.9 must reach the tail bucket.
+  EXPECT_LT(
+      collStatPercentileNs(kTestGeom, v, 0.5), static_cast<double>(100 * kSec));
+  EXPECT_GE(
+      collStatPercentileNs(kTestGeom, v, 0.999),
+      static_cast<double>(400 * kSec));
+}
+
+// The lower edge of the last interior bucket is the value a consumer needs to
+// place the tail correctly, and it is the one a naive reconstruction from the
+// octave count gets wrong: at the defaults it opens at 1us * 2^(239/8) =
+// 984.6s, not at a whole 2^30 octaves above tMinNs.
+TEST(CollStatsReadoutTest, LastInteriorBucketOpensBelowTMax) {
+  const uint32_t lastInterior = kTestGeom.numBuckets - 2;
+  const double edge = collStatBucketLowerNs(kTestGeom, lastInterior);
+  EXPECT_NEAR(edge, 984.6e9, 0.1e9);
+  EXPECT_LT(edge, static_cast<double>(kTestGeom.tMaxNs));
+}
+
+TEST(CollStatsReadoutTest, UnderflowAndOverflowEdgesAreExact) {
+  EXPECT_DOUBLE_EQ(collStatBucketLowerNs(kTestGeom, kHistUnderflowBucket), 0.0);
+  EXPECT_DOUBLE_EQ(
+      collStatBucketLowerNs(kTestGeom, kTestGeom.numBuckets - 1),
+      static_cast<double>(kTestGeom.tMaxNs));
+}
+
+TEST(CollStatsReadoutTest, NoObservationsReadsAsZero) {
+  const CollStatValue empty{};
+  EXPECT_DOUBLE_EQ(collStatAvgDurationNs(empty), 0.0);
+  EXPECT_DOUBLE_EQ(collStatPercentileNs(kTestGeom, empty, 0.5), 0.0);
+}
+
+} // namespace
+} // namespace meta::comms::collstats


### PR DESCRIPTION
Summary:

A copied-out stats window is raw counters -- sums, an atomicMax, a log histogram, threshold counts -- with nothing that turns them into numbers an operator reads. This adds `CollStatsReadout.h`: host-only pure functions over a `CollStatValue` snapshot, giving the per-window average, the lower edge of a histogram bucket, and a nearest-rank percentile.

Exact and approximate numbers are kept distinct, because reporting one as the other is how a tool like this misroutes an incident:

- Average is `durationSumNs / count` -- exact for the window.
- Percentiles are read off the log histogram and inherit its ~9% relative error (8 sub-buckets per octave), returned as the lower edge of the containing bucket. They are also censored: anything at or past the configured `geom.tMaxNs` (1024 s at the defaults) reports as that ceiling, so during a hang the percentile plateaus while the exact `durMaxNs` keeps climbing. Alerting should key off the exact threshold counters, not a percentile.
- The bucket lower edge is derived from the geometry's own bounds rather than reconstructed from an octave count, which is what keeps the tail placed correctly: at the defaults the last interior bucket opens at `1us * 2^(239/8)` = 984.6 s, not at a whole 30 octaves above `tMinNs`.

Bus bandwidth is deliberately absent. It needs the per-op traffic factor, and the exported window carries the raw aggregates so the off-box consumer can apply it -- the same split `CollStatsJson.h` records. Keeping it out of this header also keeps the one number that is a window throughput, not a per-occurrence distribution, from sitting next to the latency numbers as though a percentile of it existed.

Readers for `durMaxNs` and the threshold counters are not in this header, and neither is the minimum: `collStatDurMinNs` sits in `CollStatsTypes.h` beside the complemented field it decodes, since that encoding has exactly one reader and keeping them together is what stops it leaking.

Reviewed By: rmahidhar

Differential Revision: D113661125


