### PR TITLE
Add the device-resident block and the collective span (#3947)

### DIFF
--- a/comms/utils/collstats/CollStatsDeviceBlock.cc
+++ b/comms/utils/collstats/CollStatsDeviceBlock.cc
@@ -1,0 +1,196 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/collstats/CollStatsDeviceBlock.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "comms/utils/collstats/CollStatsHistogram.h"
+
+namespace meta::comms::collstats {
+
+namespace {
+
+/* Swallowing a CUDA failure hides it from us but not from the runtime: the
+ * error stays latched per-thread until the next cudaGetLastError(), which is
+ * usually a CUDACHECK in the collective library and would blame whatever ran
+ * after us.
+ *
+ * Called only when our own call failed, but cudaGetLastError() clears whatever
+ * is latched, not specifically ours -- an unrelated non-sticky error already
+ * pending is consumed too. The runtime offers no way to clear selectively, and
+ * between mis-attributing our failure to someone else's code and swallowing an
+ * error nobody has observed yet, the first is the worse outcome. Takes the
+ * status by value so a nodiscard call can be consumed by passing it in. */
+void clearLatchedError(cudaError_t e) {
+  if (e != cudaSuccess) {
+    // Consume the return value to satisfy HIP's nodiscard on hipGetLastError.
+    [[maybe_unused]] const cudaError_t cleared = cudaGetLastError();
+  }
+}
+
+// Allocate `bytes` of device memory into *out. Returns false on failure.
+bool alloc(void** out, std::size_t bytes) {
+  const cudaError_t e = cudaMalloc(out, bytes);
+  if (e != cudaSuccess) {
+    clearLatchedError(e);
+    *out = nullptr;
+    return false;
+  }
+  return true;
+}
+
+// Allocate `bytes` of zeroed device memory into *out. Returns false on failure.
+bool allocZeroed(void** out, std::size_t bytes) {
+  if (!alloc(out, bytes)) {
+    return false;
+  }
+  const cudaError_t e = cudaMemset(*out, 0, bytes);
+  if (e != cudaSuccess) {
+    clearLatchedError(e);
+    clearLatchedError(cudaFree(*out));
+    *out = nullptr;
+    return false;
+  }
+  return true;
+}
+
+} // namespace
+
+CollStatsDeviceBlockHandle collStatsAllocDeviceBlock(
+    uint32_t keyCapacity,
+    uint32_t numSlots,
+    const CollStatsBlockConfig& cfg) {
+  // Validate before building the handle, so every rejection returns an empty
+  // one and no partially-populated handle can escape.
+  if (keyCapacity == UINT32_MAX) {
+    return CollStatsDeviceBlockHandle{};
+  }
+  // The block's histogram and threshold arrays are fixed capacity, so an
+  // over-large configuration would write past them. Refuse rather than clamp:
+  // silently reshaping the geometry would make the exported buckets disagree
+  // with the geometry exported alongside them.
+  //
+  // Re-derive the bucket count instead of range-checking the one handed in.
+  // logBucketNs bounds its index by tMinNs/tMaxNs/subBucketsPerOctave, not by
+  // the declared numBuckets, so a geometry whose count is too small for its own
+  // bounds passes every range check and still indexes past histogram[].
+  // collStatMakeHistGeometry is the single source of truth the defaults are
+  // built through, and it also rejects tMinNs == 0 -- which would make
+  // log2(dur / tMinNs) infinite and the cast to a bucket index undefined.
+  const CollStatHistGeometry derived = collStatMakeHistGeometry(
+      cfg.hist.tMinNs, cfg.hist.tMaxNs, cfg.hist.subBucketsPerOctave);
+  if (derived.numBuckets == 0 || derived.numBuckets != cfg.hist.numBuckets ||
+      cfg.numThresholds > kMaxThresholds) {
+    return CollStatsDeviceBlockHandle{};
+  }
+  // A zero-slot block allocates nothing for the span scratch but still reports
+  // a valid handle, leaving every span entry pointing at unallocated memory.
+  if (numSlots == 0) {
+    return CollStatsDeviceBlockHandle{};
+  }
+
+  CollStatsDeviceBlockHandle handle{};
+  handle.numSlots = numSlots;
+  handle.keyCapacity = keyCapacity;
+  handle.cfg = cfg;
+  const uint32_t valueSlots = keyCapacity + 1; // trailing catch-all slot
+
+  // The span is allocated but not zeroed: the spanInit copy below overwrites
+  // every byte of it, so zeroing here would be discarded work and one more way
+  // to fail. The value banks do need it -- nothing else initializes them.
+  const std::size_t bankBytes =
+      static_cast<std::size_t>(valueSlots) * sizeof(CollStatValue);
+  const std::size_t spanBytes =
+      static_cast<std::size_t>(numSlots) * sizeof(CollStatSpanScratch);
+  const bool ok =
+      allocZeroed(reinterpret_cast<void**>(&handle.values[0]), bankBytes) &&
+      allocZeroed(reinterpret_cast<void**>(&handle.values[1]), bankBytes) &&
+      alloc(reinterpret_cast<void**>(&handle.span), spanBytes);
+  if (!ok) {
+    collStatsFreeDeviceBlock(handle);
+    return CollStatsDeviceBlockHandle{};
+  }
+
+  // Value-initialized; only start departs from zero, taking the atomicMin
+  // sentinel so the first entry timestamp wins the min rather than 0.
+  std::vector<CollStatSpanScratch> spanInit(numSlots);
+  for (auto& s : spanInit) {
+    s.start = kSpanStartInit;
+  }
+  const cudaError_t spanCopy = cudaMemcpy(
+      handle.span, spanInit.data(), spanBytes, cudaMemcpyHostToDevice);
+  if (spanCopy != cudaSuccess) {
+    clearLatchedError(spanCopy);
+    collStatsFreeDeviceBlock(handle);
+    return CollStatsDeviceBlockHandle{};
+  }
+
+  // Build the block on the host with device pointers, then publish it to
+  // device.
+  CollStatsDeviceBlock hostBlock{};
+  hostBlock.bank.numKeys = keyCapacity;
+  hostBlock.bank.epoch = 0;
+  hostBlock.bank.values[0] = handle.values[0];
+  hostBlock.bank.values[1] = handle.values[1];
+  hostBlock.span = handle.span;
+  hostBlock.numSlots = numSlots;
+  hostBlock.hist = cfg.hist;
+  hostBlock.numThresholds = cfg.numThresholds;
+  for (uint32_t i = 0; i < cfg.numThresholds; ++i) {
+    hostBlock.thresholdsNs[i] = cfg.thresholdsNs[i];
+  }
+
+  if (!alloc(
+          reinterpret_cast<void**>(&handle.dev),
+          sizeof(CollStatsDeviceBlock))) {
+    collStatsFreeDeviceBlock(handle);
+    return CollStatsDeviceBlockHandle{};
+  }
+  const cudaError_t blockCopy = cudaMemcpy(
+      handle.dev,
+      &hostBlock,
+      sizeof(CollStatsDeviceBlock),
+      cudaMemcpyHostToDevice);
+  if (blockCopy != cudaSuccess) {
+    clearLatchedError(blockCopy);
+    collStatsFreeDeviceBlock(handle);
+    return CollStatsDeviceBlockHandle{};
+  }
+  return handle;
+}
+
+void collStatsFreeDeviceBlock(const CollStatsDeviceBlockHandle& handle) {
+  // Fail-open: a failed free is ignored, but not left latched.
+  clearLatchedError(cudaFree(handle.dev));
+  clearLatchedError(cudaFree(handle.values[0]));
+  clearLatchedError(cudaFree(handle.values[1]));
+  clearLatchedError(cudaFree(handle.span));
+}
+
+void collStatsEnqueuePreReset(
+    const CollStatsDeviceBlockHandle& handle,
+    uint32_t slot,
+    cudaStream_t stream) {
+  if (handle.dev == nullptr || slot >= handle.numSlots) {
+    return;
+  }
+  // Compute device addresses without dereferencing a device pointer on the
+  // host.
+  // `&handle.span[slot].start` looks like a host dereference of device memory
+  // to sanitizers even though it is just offset arithmetic; use explicit byte
+  // offsets from the base pointer.
+  const char* slotBase = reinterpret_cast<const char*>(handle.span) +
+      static_cast<std::size_t>(slot) * sizeof(CollStatSpanScratch);
+  const char* startAddr = slotBase + offsetof(CollStatSpanScratch, start);
+  const char* arrivedAddr = slotBase + offsetof(CollStatSpanScratch, arrived);
+  // start = UINT64_MAX is all 0xFF bytes; arrived = 0 is all 0x00 bytes. Two
+  // async fills, stream-ordered before the collective's first entry.
+  clearLatchedError(cudaMemsetAsync(
+      const_cast<char*>(startAddr), 0xFF, sizeof(uint64_t), stream));
+  clearLatchedError(cudaMemsetAsync(
+      const_cast<char*>(arrivedAddr), 0, sizeof(uint32_t), stream));
+}
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsDeviceBlock.h
+++ b/comms/utils/collstats/CollStatsDeviceBlock.h
@@ -1,0 +1,180 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <cstdint>
+
+#include <cuda_runtime.h>
+
+#include "comms/utils/collstats/CollStatsBank.h"
+#include "comms/utils/collstats/CollStatsFinalize.h"
+#include "comms/utils/collstats/CollStatsHistogram.h"
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+// The globally-resident stats block for one communicator. A collective kernel
+// reaches it through a single pointer hung off the per-comm device state (which
+// is itself copied into shared memory per block), so everything the device
+// mutates atomically across blocks lives here in global memory, never in the
+// shared-mem copy. The double-buffered bank and the per-stream span scratch
+// both hang off this one block.
+
+namespace meta::comms::collstats {
+
+struct CollStatsDeviceBlock {
+  CollStatDoubleBank bank;
+  CollStatSpanScratch* span; // [numSlots]
+  uint32_t numSlots;
+  CollStatHistGeometry hist; // device-resident, per-comm config
+  uint32_t numThresholds;
+  uint64_t thresholdsNs[kMaxThresholds]; // device-resident, per-comm config
+};
+
+// The device finalizer's only entry point: fold one completed observation into
+// the current epoch's bank at `keyId`, using the block's device-resident
+// threshold vector. `keyId` comes from the host key registry, which resolved it
+// before the launch, so the device indexes rather than searching. Ids past the
+// key capacity land on the reserved trailing catch-all slot. Shared between
+// host and device so a GPU test drives the exact path.
+COLLSTATS_HD inline void collStatsRecordById(
+    CollStatsDeviceBlock* block,
+    uint32_t keyId,
+    uint64_t durNs,
+    uint64_t logicalBytes) {
+  const uint32_t valueSlot =
+      keyId > block->bank.numKeys ? block->bank.numKeys : keyId;
+  CollStatValue* values = collStatCurrentValues(&block->bank);
+  collStatAccumulate(
+      &values[valueSlot],
+      durNs,
+      logicalBytes,
+      block->hist,
+      block->thresholdsNs,
+      block->numThresholds);
+}
+
+/* Per-communicator bucketing configuration, resolved from cvars by the owner
+ * and copied into the block so the device finalizer reads it without a host
+ * round trip. Defaults reproduce the compiled-in behaviour, so a caller that
+ * does not configure anything gets 8 sub-buckets per octave over [1us, 1024s]
+ * and cut-points at 1s/10s/60s/600s. */
+struct CollStatsBlockConfig {
+  CollStatHistGeometry hist;
+  uint64_t thresholdsNs[kMaxThresholds];
+  uint32_t numThresholds;
+  /* Host-only, unlike the fields above: bucketing a message size happens on the
+   * enqueue thread, so the device never reads these and they are deliberately
+   * not copied into the device block. They live here because this struct is
+   * what a window's exported labels are resolved against. */
+  CollStatSizeClasses sizeClasses;
+};
+
+inline CollStatsBlockConfig collStatDefaultBlockConfig() {
+  CollStatsBlockConfig cfg{};
+  cfg.hist = collStatDefaultHistGeometry();
+  cfg.numThresholds = kMaxThresholds;
+  for (uint32_t i = 0; i < kMaxThresholds; ++i) {
+    cfg.thresholdsNs[i] = kDefaultThresholdsNs[i];
+  }
+  cfg.sizeClasses = collStatDefaultSizeClasses();
+  return cfg;
+}
+
+// Host-side handle retaining every device allocation backing a block, so it can
+// be freed without reading pointers back from the device. `dev` is the pointer
+// stored into the per-comm device state.
+//
+// Members are default-initialized so the "empty handle frees nothing" contract
+// holds for any handle, not only a brace-initialized one:
+// collStatsFreeDeviceBlock frees all four pointers unconditionally, and
+// cudaFree is a no-op on null but not on an indeterminate address.
+struct CollStatsDeviceBlockHandle {
+  CollStatsDeviceBlock* dev = nullptr;
+  CollStatValue* values[2] = {nullptr, nullptr};
+  CollStatSpanScratch* span = nullptr;
+  uint32_t numSlots = 0;
+  uint32_t keyCapacity = 0; // key-index capacity; banks hold keyCapacity + 1
+  /* The configuration the block was built with. Kept host-side so a readout can
+   * export the geometry its buckets were actually produced under, rather than
+   * whatever the defaults happen to be. */
+  CollStatsBlockConfig cfg;
+};
+
+/* Allocate a device-resident block: two zeroed value banks of keyCapacity + 1
+ * slots (the trailing slot is the catch-all) and numSlots span-scratch entries
+ * initialized to the atomicMin start sentinel rather than to zero.
+ *
+ * Returns a null `dev` on allocation failure, on numSlots == 0, or on a `cfg`
+ * whose geometry does not re-derive to itself -- the histogram and threshold
+ * arrays are fixed capacity, so a geometry that indexes past them would write
+ * past them rather than merely lose resolution. The check is a re-derivation
+ * through collStatMakeHistGeometry, not a range test on the declared bucket
+ * count, because the index logBucketNs produces follows from the bounds and
+ * not from that count. */
+CollStatsDeviceBlockHandle collStatsAllocDeviceBlock(
+    uint32_t keyCapacity,
+    uint32_t numSlots,
+    const CollStatsBlockConfig& cfg = collStatDefaultBlockConfig());
+
+/* Frees the four device allocations. Takes the handle by const reference and so
+ * cannot null it: the handle is a value type that readers and drivers copy
+ * freely, and nulling one copy would leave the others just as dangling. Exactly
+ * one CollStatsDeviceBlockOwner is therefore responsible for calling this, and
+ * every handle -- the owner's included -- is dead afterwards. Calling it twice
+ * on the same block double-frees. A no-op on the empty (all-null) handle. */
+void collStatsFreeDeviceBlock(const CollStatsDeviceBlockHandle& handle);
+
+// RAII owner of a device block: frees the allocations on destruction, so the
+// communicator holds one owner and lets destruction order handle teardown
+// instead of a manual free. Move-only, single-owner — the handle it hands out
+// is a non-owning view that readers/drivers copy freely.
+// `collStatsFreeDeviceBlock` is a no-op on the empty (all-null) handle, so a
+// default or moved-from owner destroys cleanly.
+class CollStatsDeviceBlockOwner {
+ public:
+  CollStatsDeviceBlockOwner() = default;
+  explicit CollStatsDeviceBlockOwner(CollStatsDeviceBlockHandle handle)
+      : handle_(handle) {}
+  ~CollStatsDeviceBlockOwner() {
+    collStatsFreeDeviceBlock(handle_);
+  }
+
+  CollStatsDeviceBlockOwner(CollStatsDeviceBlockOwner&& other) noexcept
+      : handle_(other.handle_) {
+    other.handle_ = {};
+  }
+  CollStatsDeviceBlockOwner& operator=(
+      CollStatsDeviceBlockOwner&& other) noexcept {
+    if (this != &other) {
+      collStatsFreeDeviceBlock(handle_);
+      handle_ = other.handle_;
+      other.handle_ = {};
+    }
+    return *this;
+  }
+  CollStatsDeviceBlockOwner(const CollStatsDeviceBlockOwner&) = delete;
+  CollStatsDeviceBlockOwner& operator=(const CollStatsDeviceBlockOwner&) =
+      delete;
+
+  const CollStatsDeviceBlockHandle& handle() const {
+    return handle_;
+  }
+  bool valid() const {
+    return handle_.dev != nullptr;
+  }
+
+ private:
+  CollStatsDeviceBlockHandle handle_{};
+};
+
+// Enqueue a stream-ordered pre-sequence reset of one span slot on `stream`:
+// start = UINT64_MAX, arrived = 0. It is the slot cleanup — it runs,
+// in stream order, after every prior kernel on the slot has completed and
+// before the next collective's first entry, so the slot is clean regardless of
+// whether the previous sequence finalized (an aborted sequence cannot poison
+// its successor). Two byte-fills, so it is graph-capturable and needs no
+// kernel. No-op when the handle is null (instrumentation off).
+void collStatsEnqueuePreReset(
+    const CollStatsDeviceBlockHandle& handle,
+    uint32_t slot,
+    cudaStream_t stream);
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsSpan.cuh
+++ b/comms/utils/collstats/CollStatsSpan.cuh
@@ -1,0 +1,153 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <cstdint>
+
+#include "comms/utils/collstats/CollStatsDeviceBlock.h"
+#include "comms/utils/collstats/CollStatsHistogram.h"
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+// Device-side collective span: the two touch points a collective kernel adds to
+// time itself. Entry records each block's start as a running minimum; the exit
+// finalizer (the last block to arrive) computes the duration and records one
+// observation. No block waits on another — the only barrier is the collective's
+// own block-wide __syncthreads(), which the caller already issues.
+//
+// Gated to Hopper and above; below it, and when instrumentation is disabled (a
+// null block), every entry point compiles to a no-op.
+//
+// Not implemented on AMD, and a green AMD build is not evidence otherwise:
+// hipcc never defines __CUDA_ARCH__ (it defines __HIP_DEVICE_COMPILE__), so the
+// gate below is false for every AMD arch and the whole file compiles away.
+// Not yet rather than not possible -- %globaltimer is PTX-only, and AMD's
+// nanosecond reference (__builtin_amdgcn_s_memrealtime) needs its own frequency
+// handling before end-minus-start means the same thing on both vendors.
+
+namespace meta::comms::collstats {
+
+// %globaltimer in nanoseconds. It is already an ns reference clock, so a
+// single-GPU end-minus-start needs no calibration.
+__device__ __forceinline__ uint64_t collStatsGlobaltimerNs() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  uint64_t t;
+  asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(t));
+  return t;
+#else
+  return 0;
+#endif
+}
+
+// Blocks in the launch grid. The span's arrival barrier counts one entry per
+// block, elected on threadIdx.{x,y,z} == 0, so it counts every block however
+// the grid is shaped. Comparing against gridDim.x alone would finalize a 2-D or
+// 3-D launch on its first gridDim.x arrivals, timing a span that is still
+// running.
+__device__ __forceinline__ unsigned int collStatsGridBlocks() {
+  return gridDim.x * gridDim.y * gridDim.z;
+}
+
+// Entry: the elected thread of each block folds its start time into the slot's
+// running minimum. Call from all threads; the election is internal.
+//
+// An out-of-range slot is dropped rather than indexed. The host path
+// (collStatsEnqueuePreReset) makes the same check, and the device is the only
+// side where getting it wrong writes past the span allocation instead of
+// merely losing an observation.
+__device__ __forceinline__ void collStatsSpanEntry(
+    CollStatsDeviceBlock* block,
+    uint32_t slot) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  if (block == nullptr) {
+    return;
+  }
+  // The slot bound is tested inside the election, so only the elected thread
+  // loads numSlots rather than every thread in the block.
+  if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0 &&
+      slot < block->numSlots) {
+    atomicMin(
+        reinterpret_cast<unsigned long long*>(&block->span[slot].start),
+        static_cast<unsigned long long>(collStatsGlobaltimerNs()));
+  }
+#else
+  (void)block;
+  (void)slot;
+#endif
+}
+
+// Exit finalizer taking a value slot resolved by the host key registry before
+// launch, so the device performs no key lookup at all.
+//
+// The finalizer emits only; it does not reset the slot. Slot cleanup is owned
+// by the stream-ordered pre-sequence reset (collStatsEnqueuePreReset), which
+// runs before the next collective's first entry and cleans the slot even when a
+// prior sequence aborted without finalizing.
+//
+// Election is internal and on all three thread indices, matching entry. The
+// caller must still issue the block-wide __syncthreads() first. Callers elect
+// too, but the common 1-D idiom (`if (threadIdx.x == 0)`) admits
+// blockDim.y * blockDim.z threads per block in a 2-D or 3-D launch, and the
+// extra arrivals mistime the span rather than losing it: the equality below
+// still fires exactly once, but on the gridDim'th of gridDim * blockDim.y *
+// blockDim.z increments -- while most blocks are still running -- so it reads
+// `end` early and records a plausible, far-too-short duration. That is the
+// failure this whole file is built to avoid, so the election is not left to
+// the caller.
+__device__ __forceinline__ void collStatsSpanFinalizeElectedById(
+    CollStatsDeviceBlock* block,
+    uint32_t slot,
+    uint32_t keyId,
+    uint64_t logicalBytes) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  if (block == nullptr || threadIdx.x != 0 || threadIdx.y != 0 ||
+      threadIdx.z != 0) {
+    return;
+  }
+  if (slot >= block->numSlots) {
+    return;
+  }
+  CollStatSpanScratch* s = &block->span[slot];
+  const uint64_t end = collStatsGlobaltimerNs();
+  // Release: publish this block's entry atomicMin before its arrival becomes
+  // visible. Acquire (below): the arrival count only orders the start
+  // timestamps if the read of them cannot be hoisted above the count.
+  __threadfence();
+  const unsigned int prev = atomicAdd(&s->arrived, 1u);
+  if (prev + 1u == collStatsGridBlocks()) {
+    __threadfence();
+    const uint64_t start =
+        *reinterpret_cast<volatile const unsigned long long*>(&s->start);
+    // Drop rather than record a duration that is not one. If no entry ever
+    // landed the sentinel survives, and end - UINT64_MAX wraps to end + 1 -- a
+    // sub-microsecond value that lands in the underflow bucket and reads as a
+    // real, very fast collective rather than as missing data. A start left over
+    // from an un-pre-reset predecessor fails the same way in the other
+    // direction, pinning durMaxNs.
+    if (start == kSpanStartInit || end < start) {
+      return;
+    }
+    collStatsRecordById(block, keyId, end - start, logicalBytes);
+  }
+#else
+  (void)block;
+  (void)slot;
+  (void)keyId;
+  (void)logicalBytes;
+#endif
+}
+
+// Derive the collective's logical message size from its launch args and
+// finalize the span in one call, so each instrumented kernel repeats neither.
+// `Args` is any collective's kernel-args type exposing `count` and
+// `collStatsKeyId`; the element size comes from the payload type `T`. Call
+// AFTER the block-wide __syncthreads(); the election is internal.
+template <typename T, typename Args>
+__device__ __forceinline__ void collStatsSpanFinalizeElectedColl(
+    CollStatsDeviceBlock* block,
+    uint32_t slot,
+    const Args& args) {
+  const uint64_t logicalBytes = static_cast<uint64_t>(args.count) * sizeof(T);
+  collStatsSpanFinalizeElectedById(
+      block, slot, args.collStatsKeyId, logicalBytes);
+}
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsTypes.h
+++ b/comms/utils/collstats/CollStatsTypes.h
@@ -157,12 +157,18 @@ inline uint64_t collStatDurMinNs(const CollStatValue& v) {
 
 struct CollStatSpanScratch {
   uint64_t start; // min entry %globaltimer over blocks; init UINT64_MAX
-  uint32_t
-      arrived; // exit-barrier arrival count; finalizer when == expectedBlocks
-  uint32_t expectedBlocks; // gridDim, from launch config
-  uint32_t kernelIndex; // multi-kernel collective: current kernel in sequence
-  uint32_t
-      kernelCount; // multi-kernel collective: total kernels; finalize on last
+  // Exit-barrier arrival count. The finalizer is the block that drives it to
+  // collStatsGridBlocks(), read from gridDim at exit -- not expectedBlocks.
+  uint32_t arrived;
+  /* Reserved, and none of the three is read today. A multi-kernel collective
+   * sharing one slot therefore records one observation per kernel rather than
+   * one per collective; sequencing on kernelIndex/kernelCount, and taking the
+   * block count from expectedBlocks instead of gridDim, are both future work.
+   * Stated here because the barrier condition a reader assumes is authoritative
+   * decides whether they trust a multi-kernel duration. */
+  uint32_t expectedBlocks;
+  uint32_t kernelIndex;
+  uint32_t kernelCount;
 };
 
 inline constexpr uint64_t kSpanStartInit = ~0ull; // UINT64_MAX

--- a/comms/utils/collstats/tests/CollStatsDeviceBlockGpuTest.cu
+++ b/comms/utils/collstats/tests/CollStatsDeviceBlockGpuTest.cu
@@ -1,0 +1,426 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include "comms/utils/collstats/CollStatsDeviceBlock.h"
+#include "comms/utils/collstats/CollStatsHistogram.h"
+#include "comms/utils/collstats/CollStatsSpan.cuh"
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+namespace meta::comms::collstats {
+namespace {
+
+// One elected thread per block records a single observation, mimicking the
+// collective finalizer: block b maps to key (b % numDistinctKeys) and a
+// duration that scales with the key, so the whole device claim + accumulate
+// path runs under real cross-block atomic contention.
+__global__ void recordKernel(
+    CollStatsDeviceBlock* block,
+    uint32_t numDistinctKeys,
+    uint64_t baseNs) {
+  if (threadIdx.x != 0) {
+    return;
+  }
+  // One value slot per distinct key, as the host registry would have handed
+  // them out.
+  const uint32_t keyId = blockIdx.x % numDistinctKeys;
+  const uint64_t dur = baseNs * (keyId + 1);
+  collStatsRecordById(block, keyId, dur, 100);
+}
+
+// The skip is the same in every test here, so it lives in SetUp rather than
+// being restated nine times.
+class CollStatsDeviceBlockGpuTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int deviceCount = 0;
+    if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount == 0) {
+      GTEST_SKIP() << "no CUDA device";
+    }
+  }
+
+  // The retired bank is always read back whole, so the copy and its sizing live
+  // in one place: values past the claimed keys are zero and cost nothing to
+  // compare.
+  static std::vector<CollStatValue> readValues(
+      const CollStatsDeviceBlockHandle& h,
+      uint32_t capacity) {
+    std::vector<CollStatValue> values(capacity + 1);
+    EXPECT_EQ(
+        cudaMemcpy(
+            values.data(),
+            h.values[0], // epoch started at 0
+            values.size() * sizeof(CollStatValue),
+            cudaMemcpyDeviceToHost),
+        cudaSuccess);
+    return values;
+  }
+};
+
+TEST_F(CollStatsDeviceBlockGpuTest, ConcurrentRecordAccumulatesOnDevice) {
+  const uint32_t capacity = 64;
+  const uint32_t numSlots = 4;
+  const uint32_t numDistinctKeys = 5;
+  const uint32_t numBlocks = 200;
+  const uint64_t baseNs = 1'000'000; // 1 ms
+
+  CollStatsDeviceBlockHandle h = collStatsAllocDeviceBlock(capacity, numSlots);
+  ASSERT_NE(h.dev, nullptr);
+
+  recordKernel<<<numBlocks, 32>>>(h.dev, numDistinctKeys, baseNs);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  CollStatsDeviceBlock hostBlock{};
+  ASSERT_EQ(
+      cudaMemcpy(
+          &hostBlock,
+          h.dev,
+          sizeof(CollStatsDeviceBlock),
+          cudaMemcpyDeviceToHost),
+      cudaSuccess);
+  // The readback is the only coverage the publish step has: the block the
+  // device actually sees must carry the capacity, slot count and device
+  // pointers the allocator was asked for, not just be copyable.
+  EXPECT_EQ(hostBlock.bank.numKeys, capacity);
+  EXPECT_EQ(hostBlock.numSlots, numSlots);
+  EXPECT_EQ(hostBlock.bank.values[0], h.values[0]);
+  EXPECT_EQ(hostBlock.bank.values[1], h.values[1]);
+  EXPECT_EQ(hostBlock.span, h.span);
+  EXPECT_EQ(
+      hostBlock.hist.numBuckets, collStatDefaultHistGeometry().numBuckets);
+  EXPECT_EQ(hostBlock.numThresholds, kMaxThresholds);
+
+  const std::vector<CollStatValue> values = readValues(h, capacity);
+
+  uint64_t totalCount = 0;
+  uint64_t totalHistogram = 0;
+  for (const auto& v : values) {
+    totalCount += v.count;
+    for (uint32_t b = 0; b < kHistMaxBuckets; ++b) {
+      totalHistogram += v.histogram[b];
+    }
+  }
+  EXPECT_EQ(totalCount, numBlocks);
+  EXPECT_EQ(totalHistogram, numBlocks);
+
+  collStatsFreeDeviceBlock(h);
+}
+
+// Mirrors the collective kernel's use of the span: every block records its
+// start on entry, then after a block-wide barrier the elected thread finalizes;
+// the last block to arrive records one observation.
+// `threadIdx.x == 0` is deliberately the caller's whole election: it is the
+// idiom every instrumented collective uses, so the span helpers must be correct
+// under it for any block shape.
+__global__ void spanKernel(
+    CollStatsDeviceBlock* block,
+    uint32_t slot,
+    uint32_t keyId,
+    uint64_t logicalBytes) {
+  collStatsSpanEntry(block, slot);
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    collStatsSpanFinalizeElectedById(block, slot, keyId, logicalBytes);
+  }
+}
+
+// Byte offsets rather than &h.span[slot].arrived: the latter is host code
+// forming an address inside a device allocation, which sanitizers flag even
+// though it never dereferences. collStatsEnqueuePreReset computes its addresses
+// the same way for the same reason.
+char* arrivedAddr(const CollStatsDeviceBlockHandle& h, uint32_t slot) {
+  return reinterpret_cast<char*>(h.span) +
+      static_cast<std::size_t>(slot) * sizeof(CollStatSpanScratch) +
+      offsetof(CollStatSpanScratch, arrived);
+}
+
+uint32_t readArrived(const CollStatsDeviceBlockHandle& h, uint32_t slot) {
+  uint32_t arrived = 0;
+  EXPECT_EQ(
+      cudaMemcpy(
+          &arrived,
+          arrivedAddr(h, slot),
+          sizeof(arrived),
+          cudaMemcpyDeviceToHost),
+      cudaSuccess);
+  return arrived;
+}
+
+void writeArrived(
+    const CollStatsDeviceBlockHandle& h,
+    uint32_t slot,
+    uint32_t value) {
+  EXPECT_EQ(
+      cudaMemcpy(
+          arrivedAddr(h, slot), &value, sizeof(value), cudaMemcpyHostToDevice),
+      cudaSuccess);
+}
+
+uint64_t totalCount(const std::vector<CollStatValue>& values) {
+  uint64_t total = 0;
+  for (const auto& v : values) {
+    total += v.count;
+  }
+  return total;
+}
+
+TEST_F(CollStatsDeviceBlockGpuTest, SpanRecordsOneObservationPerLaunch) {
+  const uint32_t capacity = 64;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/4);
+  ASSERT_NE(h.dev, nullptr);
+
+  // Value slot 0, as the host registry would have resolved it.
+  constexpr uint32_t kKeyId = 0;
+
+  // Mirror the launch path: a stream-ordered pre-reset before each collective.
+  // The finalizer emits only, so the pre-reset owns slot cleanup.
+  collStatsEnqueuePreReset(h, /*slot=*/0, /*stream=*/0);
+  spanKernel<<<16, 64>>>(h.dev, /*slot=*/0, kKeyId, 4096);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(totalCount(readValues(h, capacity)), 1u);
+
+  // A second collective, again pre-reset, records again.
+  collStatsEnqueuePreReset(h, /*slot=*/0, /*stream=*/0);
+  spanKernel<<<16, 64>>>(h.dev, /*slot=*/0, kKeyId, 4096);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  const std::vector<CollStatValue> values = readValues(h, capacity);
+  EXPECT_EQ(totalCount(values), 2u);
+
+  uint64_t maxDur = 0;
+  for (const auto& v : values) {
+    maxDur = v.durMaxNs > maxDur ? v.durMaxNs : maxDur;
+  }
+  EXPECT_GT(maxDur, 0u);
+  EXPECT_LT(maxDur, 1'000'000'000ull); // well under a second
+
+  collStatsFreeDeviceBlock(h);
+}
+
+// An aborted sequence — entry without a finalize (e.g. fewer blocks than
+// gridDim, or a kernel that returns early) — leaves the slot dirty. The
+// stream-ordered pre-reset must clean it so the next collective still records a
+// correct span. This is the property the old finalizer self-reset could not
+// give.
+__global__ void spanEntryOnlyKernel(CollStatsDeviceBlock* block) {
+  collStatsSpanEntry(block, /*slot=*/0);
+}
+
+TEST_F(CollStatsDeviceBlockGpuTest, PreResetRecoversFromAbortedSequence) {
+  const uint32_t capacity = 64;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/4);
+  ASSERT_NE(h.dev, nullptr);
+
+  constexpr uint32_t kKeyId = 0;
+
+  // Aborted sequence: blocks record entry but never finalize, so arrived is
+  // left nonzero and start holds a stale minimum.
+  spanEntryOnlyKernel<<<16, 64>>>(h.dev);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  // The successor's pre-reset cleans the slot; the full sequence then records
+  // exactly one observation with a plausible positive duration.
+  collStatsEnqueuePreReset(h, /*slot=*/0, /*stream=*/0);
+  spanKernel<<<16, 64>>>(h.dev, /*slot=*/0, kKeyId, 4096);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  const std::vector<CollStatValue> values = readValues(h, capacity);
+  EXPECT_EQ(totalCount(values), 1u);
+  uint64_t maxDur = 0;
+  for (const auto& v : values) {
+    maxDur = v.durMaxNs > maxDur ? v.durMaxNs : maxDur;
+  }
+  EXPECT_GT(maxDur, 0u);
+  EXPECT_LT(maxDur, 1'000'000'000ull);
+
+  collStatsFreeDeviceBlock(h);
+}
+
+// The comm allocates a single span slot, because OrderedWorkStreamGuard leaves
+// only one instrumented collective live at a time. Anything asking for a slot
+// past that must be a no-op rather than scribbling past the allocation.
+TEST_F(CollStatsDeviceBlockGpuTest, PreResetIgnoresOutOfRangeSlot) {
+  const uint32_t capacity = 8;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/1);
+  ASSERT_NE(h.dev, nullptr);
+
+  // Dirty the one real slot so an out-of-range reset landing there would show.
+  collStatsEnqueuePreReset(h, /*slot=*/0, /*stream=*/0);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  const uint32_t arrived = 7;
+  writeArrived(h, /*slot=*/0, arrived);
+
+  collStatsEnqueuePreReset(h, /*slot=*/1, /*stream=*/0);
+  collStatsEnqueuePreReset(h, /*slot=*/~0u, /*stream=*/0);
+  // A null handle is a no-op too (instrumentation off).
+  CollStatsDeviceBlockHandle none{};
+  collStatsEnqueuePreReset(none, /*slot=*/0, /*stream=*/0);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+
+  EXPECT_EQ(readArrived(h, /*slot=*/0), arrived)
+      << "slot 0 untouched by the out-of-range and null-handle resets";
+
+  collStatsFreeDeviceBlock(h);
+}
+
+// The finalizer elects internally, so a caller using the 1-D idiom in a 2-D
+// block still contributes exactly one arrival per block. Asserted on `arrived`
+// rather than on the duration because it is deterministic: without the internal
+// election this reads gridDim * blockDim.y, the equality fires while most
+// blocks are still running, and the recorded span is plausible but far too
+// short -- a wrong number rather than a missing one.
+TEST_F(CollStatsDeviceBlockGpuTest, SpanElectsInternallyInAMultiDimBlock) {
+  const uint32_t capacity = 64;
+  const uint32_t numBlocks = 16;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/4);
+  ASSERT_NE(h.dev, nullptr);
+
+  collStatsEnqueuePreReset(h, /*slot=*/0, /*stream=*/0);
+  // 64x2: the y dimension is what a caller electing on threadIdx.x alone
+  // misses.
+  spanKernel<<<numBlocks, dim3(64, 2, 1)>>>(
+      h.dev, /*slot=*/0, /*keyId=*/0, 4096);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readArrived(h, /*slot=*/0), numBlocks);
+
+  const std::vector<CollStatValue> values = readValues(h, capacity);
+  EXPECT_EQ(totalCount(values), 1u);
+
+  collStatsFreeDeviceBlock(h);
+}
+
+// The device span helpers bound the slot themselves. The host pre-reset already
+// does, but only the device side turns a bad slot into a write past the span
+// allocation rather than a lost observation.
+TEST_F(CollStatsDeviceBlockGpuTest, SpanIgnoresOutOfRangeSlotOnDevice) {
+  const uint32_t capacity = 64;
+  const uint32_t numSlots = 4;
+  CollStatsDeviceBlockHandle h = collStatsAllocDeviceBlock(capacity, numSlots);
+  ASSERT_NE(h.dev, nullptr);
+
+  spanKernel<<<16, 64>>>(h.dev, /*slot=*/numSlots, /*keyId=*/0, 4096);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+
+  const std::vector<CollStatValue> values = readValues(h, capacity);
+  EXPECT_EQ(totalCount(values), 0u) << "an out-of-range slot records nothing";
+  // The in-range slots are untouched, so the bad slot did not alias one.
+  for (uint32_t s = 0; s < numSlots; ++s) {
+    EXPECT_EQ(readArrived(h, s), 0u);
+  }
+
+  collStatsFreeDeviceBlock(h);
+}
+
+__global__ void recordAtKeyKernel(CollStatsDeviceBlock* block, uint32_t keyId) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    collStatsRecordById(block, keyId, /*durNs=*/5'000, /*logicalBytes=*/64);
+  }
+}
+
+// A key id past the registry's capacity is clamped onto the trailing catch-all
+// slot. This is the only branch in collStatsRecordById, and it is what keeps a
+// saturated registry losing attribution rather than indexing past the bank.
+TEST_F(CollStatsDeviceBlockGpuTest, RecordClampsIdsPastCapacityToCatchAll) {
+  const uint32_t capacity = 8;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/1);
+  ASSERT_NE(h.dev, nullptr);
+
+  recordAtKeyKernel<<<1, 32>>>(h.dev, /*keyId=*/capacity + 5);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  const std::vector<CollStatValue> values = readValues(h, capacity);
+
+  EXPECT_EQ(values[capacity].count, 1u) << "catch-all is the trailing slot";
+  for (uint32_t i = 0; i < capacity; ++i) {
+    EXPECT_EQ(values[i].count, 0u) << "no real key was charged, i=" << i;
+  }
+
+  collStatsFreeDeviceBlock(h);
+}
+
+// The owner is the only thing that frees a block, so its move paths decide
+// between a double free and a leak. A moved-from owner must be empty, and
+// self-assignment must not free the block it is about to keep.
+TEST_F(CollStatsDeviceBlockGpuTest, OwnerMovesWithoutDoubleFree) {
+  CollStatsDeviceBlockOwner a{
+      collStatsAllocDeviceBlock(/*keyCapacity=*/8, /*numSlots=*/1)};
+  ASSERT_TRUE(a.valid());
+  const CollStatsDeviceBlock* dev = a.handle().dev;
+
+  CollStatsDeviceBlockOwner b{std::move(a)};
+  EXPECT_TRUE(b.valid());
+  EXPECT_EQ(b.handle().dev, dev);
+  EXPECT_FALSE(a.valid()) << "moved-from owner must not free the block again";
+
+  // Through a reference, so this is a real self-assignment rather than one the
+  // compiler diagnoses and folds away.
+  CollStatsDeviceBlockOwner& alias = b;
+  b = std::move(alias);
+  EXPECT_TRUE(b.valid()) << "self-assignment kept the block";
+  EXPECT_EQ(b.handle().dev, dev);
+
+  {
+    CollStatsDeviceBlockOwner empty;
+  }
+  EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+}
+
+// Every rejection path guards a fixed-capacity device array against an
+// out-of-range index, so each must report a null handle -- leaving
+// instrumentation off -- rather than hand back a block that would be indexed
+// past its own allocation.
+TEST_F(CollStatsDeviceBlockGpuTest, AllocRejectsWhatItCannotBound) {
+  // keyCapacity + 1 is the value-slot count, so UINT32_MAX wraps it to zero.
+  EXPECT_EQ(collStatsAllocDeviceBlock(UINT32_MAX, /*numSlots=*/1).dev, nullptr);
+
+  // A zero-slot block would leave every span entry addressing nothing.
+  EXPECT_EQ(
+      collStatsAllocDeviceBlock(/*keyCapacity=*/8, /*numSlots=*/0).dev,
+      nullptr);
+
+  // A count too small for its own bounds: logBucketNs derives the index from
+  // the tMin/tMax/sub-bucket triple, not from numBuckets, so this passes a
+  // range check and still indexes past histogram[].
+  CollStatsBlockConfig understatedBuckets = collStatDefaultBlockConfig();
+  understatedBuckets.hist.numBuckets -= 1;
+  EXPECT_EQ(
+      collStatsAllocDeviceBlock(
+          /*keyCapacity=*/8, /*numSlots=*/1, understatedBuckets)
+          .dev,
+      nullptr);
+
+  // tMinNs == 0 makes log2(dur / tMinNs) infinite and the cast to an index
+  // undefined; the re-derivation reports zero buckets and the alloc refuses.
+  CollStatsBlockConfig zeroTMin = collStatDefaultBlockConfig();
+  zeroTMin.hist.tMinNs = 0;
+  EXPECT_EQ(
+      collStatsAllocDeviceBlock(/*keyCapacity=*/8, /*numSlots=*/1, zeroTMin)
+          .dev,
+      nullptr);
+
+  // More thresholds than the device-resident array holds.
+  CollStatsBlockConfig tooManyThresholds = collStatDefaultBlockConfig();
+  tooManyThresholds.numThresholds = kMaxThresholds + 1;
+  EXPECT_EQ(
+      collStatsAllocDeviceBlock(
+          /*keyCapacity=*/8, /*numSlots=*/1, tooManyThresholds)
+          .dev,
+      nullptr);
+}
+
+} // namespace
+} // namespace meta::comms::collstats


### PR DESCRIPTION
Summary:

A collective kernel has no device-resident state it can time itself against, and no way to turn per-block start and end times into a single observation. This adds both.

- `CollStatsDeviceBlock` is the per-comm global state a kernel reaches through one pointer: the double-buffered value banks, the span scratch, and the per-comm threshold cut-points. `collStatsRecordById` clamps the host-resolved key id onto the trailing catch-all, indexes the live bank, folds. No lookup, no allocation, no host round trip.
- `CollStatsBlockConfig` is how a comm is configured, not only what the device reads. The histogram geometry and threshold cut-points are copied into the block; the size-class edges are host-only and deliberately are not, because a message size is bucketed on the enqueue thread and the device never needs them. They travel here anyway so that one struct describes the configuration a window's exported labels are resolved against.
- A configuration that cannot be honoured is refused rather than clamped. The geometry is re-derived through `collStatMakeHistGeometry` and must reproduce the bucket count it was handed: the index `logBucketNs` produces follows from the bounds, not from the declared count, so a count that is too small for its own bounds would index past the fixed-capacity histogram while passing any range check. A zero-slot block is refused for the same reason -- it would publish a span pointer to nothing. Both return a null handle, which is the fail-open path.
- The span is two touch points. On entry each block's elected thread `atomicMin`s `%globaltimer` into the slot's start; on exit, after the kernel's own `__syncthreads()`, that thread bumps an arrival counter and the block completing the grid records one observation.
- The fences are load-bearing. CUDA atomics are relaxed, so the arrival counter orders nothing on its own: a release fence publishes each block's entry timestamp before its arrival is visible, and an acquire fence plus a `volatile` load stop the finalizer's read being hoisted or served from a non-coherent L1. The finalizer additionally refuses to record a duration that is not one: if the pre-launch sentinel survives, `end - UINT64_MAX` wraps to `end + 1`, a sub-microsecond value that lands in the underflow bucket and reads as a real, very fast collective rather than as missing data. Dropping it is what makes a fence bug show up as an absent observation instead of a plausible one.
- Cleanup belongs to `collStatsEnqueuePreReset`, never the finalizer. A self-resetting finalizer is unrecoverable: any launch where fewer blocks than the grid arrive leaves the arrival counter permanently offset, and every later collective on that slot then fires early and records a short duration forever. The reset is two stream-ordered byte-fills issued before the next collective, so it is graph-capturable and recovers from an aborted sequence.

Every CUDA call consumes its return value: hipify makes the HIP equivalents `[[nodiscard]]` and the AMD build compiles with `-Werror`.

Reviewed By: rmahidhar

Differential Revision: D113661130


