### PR TITLE
Default NCCL_CTRAN_GPE_HOST_NODE_SIDE_STREAM to false

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -193,7 +193,7 @@ cvars:
 
  - name        : NCCL_CTRAN_GPE_HOST_NODE_SIDE_STREAM
    type        : bool
-   default     : true
+   default     : false
    description : |-
      Record each captured GPE HOST node on a per-comm, per-graph side capture
      stream instead of inline on the user's stream, mirroring how NCCL records
@@ -219,15 +219,19 @@ cvars:
      relative win on small messages (+52% busbw at 8 MiB / 16 ranks) and
      negligible on large ones (+0.8% at 4 GiB).
 
-     On by default. It changes recorded graph topology (adds one join edge per
+     OFF by default: the spine has an unresolved correctness bug under CUDA
+     graph capture/replay. See
+     https://www.internalfb.com/collab-files/view/10EbU5GgVtvXzEGd4ndMf_4g3S9b3fQCl
+
+     When on, it changes recorded graph topology (adds one join edge per
      collective; the graph gains edges, it does not lose them). Only the
      mixing=0 in-capture path is affected: the mixing=1 side-stream fence and
      every eager path are unchanged.
 
      CAVEAT -- this reintroduces cross-collective serialization of the GPE host
-     callbacks, which is part of what mixing=0 removes for overlap. It is only
-     safe at mixing=0 because mixing=0 already declines to order a graph replay
-     ahead of a following eager CTRAN submission (see
+     callbacks, which is part of what mixing=0 removes for overlap. It is
+     restricted to mixing=0 because mixing=0 already declines to order a graph
+     replay ahead of a following eager CTRAN submission (see
      NCCL_CTRAN_GRAPH_MIXING_SUPPORT), so callers must already host-synchronize
      between replay and eager work. NCCL_CTRAN_GPE_DEVICE_RING removes the HOST
      nodes entirely instead of serializing them (~6% dispatch-latency cost);


### PR DESCRIPTION
Summary:
The side-stream GPE host-node spine has a correctness bug under CUDA graph
capture/replay, so turn it off by default until there is a root cause.

On `v17_tpp_535:DORA_PP_BENCH_NIGHTLY` (64 x gb300, 256 ranks, ctran DP
all-gather) the spine perturbs the DP-group all-gather: training loss leaves
trunk on the first replayed step and grows ~1.4x per step to 0.37% by step 113,
and three runs of one config produce three different trajectories. The knob is
honoured only at `NCCL_CTRAN_GRAPH_MIXING_SUPPORT=0`, which is why setting
mixing=1 also makes the problem disappear — it disables the spine as a side
effect.

Across 13 arms the knob separates the two clusters exactly: every arm with the
spine on diverged, every arm with it off or ignored was bitwise identical to
trunk over 120 steps. Forcing it off at mixing=0 is also the cheaper fix
(-0.24% throughput vs trunk, against -1.2 to -1.4% for the mixing=1 arms).

Flipping the default is the whole change; the flag still works when set
explicitly. The perf rationale in the cvar description (52-85 us saved per
captured replay) is left in place and the caveats updated to say why it is not
claimable today.

Investigation:
https://www.internalfb.com/collab-files/view/10EbU5GgVtvXzEGd4ndMf_4g3S9b3fQCl

Reviewed By: minsii

Differential Revision: D118373179


