### PR TITLE
registered Tree AllReduce optimization stack (#3949)

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3417,8 +3417,8 @@ cvars:
    default     : 1
    description : |-
      Number of independent Phase-2 IB progress groups per physical CUDA block
-     in MCCL fused AllReduce. Ring and Tree support 1, 2, 4, and 10. The
-     default preserves the existing full-block protocol.
+     in MCCL fused AllReduce. Ring supports 1, 2, 4, and 10; Tree supports 1
+     and 2. The default preserves the existing full-block protocol.
 
  - name        : MCCL_MAX_NCHANNELS
    type        : int


### PR DESCRIPTION
Summary:

This restores the registered Tree AllReduce implementation from before the striped-IB, overlapping child-receive, and pipelined reduce/broadcast optimizations while retaining later transport API and abort-status updates.

Reviewed By: function47

Differential Revision: D118392920


