### PR TITLE
MCCL: enable bidirectional Ring for staged copy (#3951)

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2067,13 +2067,14 @@ cvars:
 
  - name        : MCCL_ALLREDUCE_RING_BIDIRECTIONAL_ENABLE
    type        : bool
-   default     : true
+   default     : false
    description : |-
-     Enable bidirectional registered Ring reduce-scatter and all-gather for
-     in-place collectives with every supported virtual-stripe geometry.
-     Out-of-place collectives continue to use the unidirectional registered
-     Ring path. This value must be set identically on every rank. Set false to
-     use the unidirectional registered Ring path.
+     Enable bidirectional Ring reduce-scatter and all-gather for non-LL
+     collectives with more than two nodes on both staged-copy and registered
+     zero-copy paths. Out-of-place ranks stage their input before running the
+     same peer schedule. Fine-grained tracing is suppressed without changing
+     that schedule. A divergent value across ranks fails communicator
+     initialization.
 
  - name        : NCCL_CTRAN_PIPES_TRACE_ENABLE
    type        : bool


### PR DESCRIPTION
Summary:

Extend `MCCL_ALLREDUCE_RING_BIDIRECTIONAL_ENABLE` to control both registered zero-copy and staged-copy Ring AllReduce. Reuse the forward/reverse shard schedule with copy-path `send`, `recv`, and `forward` operations, retain the two-node and tracing fallbacks, and avoid the single-queue warp proxy while copy bidirectional mode is active.

Add enabled/disabled eager and CUDA Graph coverage plus a repeated two-node fallback case.

Reviewed By: rmahidhar, saifhhasan

Differential Revision: D118415885


