### PR TITLE
Document that partition() aliases channel ids across blocks

### DIFF
--- a/comms/prims/docs/Channels.md
+++ b/comms/prims/docs/Channels.md
@@ -168,3 +168,45 @@ Consequences for IBGDA:
 Adding a second poster to a QP is therefore not a configuration change; it would
 require revisiting the slot geometry, the cursor increment, and the fence
 placement together.
+
+### Partitioned groups alias channel ids
+
+The invariant above is per QP, not per channel, and a channel id is not unique
+across concurrently running groups. `ThreadGroup::partition` renumbers each
+subgroup relative to its partition start:
+
+```cpp
+.group_id = group_id - partition_start
+```
+
+so every partition hands out subgroup ids beginning at 0. Two blocks in
+different partitions carry the same `group_id`, select the same channel id, and
+reach the same QP slots.
+
+Direction is what keeps that safe today, not the channel id. The canonical
+partition splits a send role from a recv role — the example in `ThreadGroup.cuh`
+is `send_group` on partition 0 and `recv_group` on partition 1 — and the two
+roles post in opposite directions, which the slot index separates. Nothing
+enforces the split; it holds because of how the current callers are written.
+
+The sharp edge is the APIs that choose the direction themselves. `put` always
+posts Send, `signal` defaults to Send, the thread-scope `flush()` and `fence()`
+overloads pass Send unconditionally, and `wait_local` /
+`is_local_completion_ready` resolve their lane against Send. A recv-role group
+that calls one of these lands on the send-role group's QP, with two separate
+consequences:
+
+- Posting APIs give that QP a second poster. Under `EXCLUSIVE` the WQ-slot
+  reservation is a plain load and store, so both posters can be handed the same
+  WQE index and overwrite each other's WQE before the doorbell. That is silent
+  corruption rather than contention: the shared mode's `atomicAdd` would have
+  handed out distinct indices, so the same call was merely slow.
+- `flush` and `fence` share the direction's `IbQpState`. The drain exchanges
+  `pendingFlushLanesMask` to zero, so one group's flush consumes the other's
+  pending lanes and can return while those WQEs are still in flight.
+
+A group that may share a channel id with another concurrently running group
+must therefore pass an explicit direction that differs from the peer group's,
+and must not use the direction-defaulting overloads. Driving one
+`(channel_id, direction)` from two groups is the caller error named above; under
+`EXCLUSIVE` it now costs correctness on the posting path, not just performance.

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -596,6 +596,14 @@ class P2pIbgdaTransportDevice {
    * before signal(group, ...). A fused put(..., signal) remains self-ordered
    * because the put and signal are posted on the same QP.
    *
+   * `direction` selects more than a lane. Channel ids are not unique across
+   * concurrently running groups: `ThreadGroup::partition` renumbers each
+   * subgroup from 0, so two blocks in different partitions land on the same
+   * channel and are kept apart only by direction. Posting is `EXCLUSIVE`, so a
+   * recv-role group that takes the Send default shares a QP with the send-role
+   * group and both can reserve the same WQ slot. See "Partitioned groups alias
+   * channel ids" in comms/prims/docs/Channels.md.
+   *
    * @param group     Thread group; all threads must call. Leader posts WQE,
    *                  all sync.
    * @param signalBuf Pre-resolved remote signal slot (must point to the
@@ -616,7 +624,12 @@ class P2pIbgdaTransportDevice {
     group.sync();
   }
 
-  /** signal (thread-scope) - Single-thread variant. */
+  /**
+   * signal (thread-scope) - Single-thread variant.
+   *
+   * Posts Send unconditionally; a recv-role group sharing a channel id with a
+   * concurrent send-role group must use the direction-taking overload.
+   */
   __device__ void signal(
       const IbgdaRemoteBuffer& signalBuf,
       uint64_t signalVal = 1) {
@@ -672,6 +685,10 @@ class P2pIbgdaTransportDevice {
     wait_counter_impl(group, counterBuf, expected, abortDevice);
   }
 
+  // wait_local and is_local_completion_ready resolve their lane against Send
+  // unconditionally, so on a channel id shared with a concurrent recv-role
+  // group they poll the send-role group's CQ. See "Partitioned groups alias
+  // channel ids" in comms/prims/docs/Channels.md.
   __device__ void wait_local(
       ThreadGroup& group,
       const IbLocalCompletionTicket& ticket,
@@ -780,7 +797,15 @@ class P2pIbgdaTransportDevice {
     group.sync();
   }
 
-  /** flush (thread-scope) - Single-thread variant. */
+  /**
+   * flush (thread-scope) - Single-thread variant.
+   *
+   * Drains Send unconditionally. Two groups sharing a `(channel_id, direction)`
+   * share that direction's `IbQpState`, and the drain exchanges
+   * `pendingFlushLanesMask` to zero, so one group's flush consumes the other's
+   * pending lanes and can return with those WQEs still in flight. See
+   * "Partitioned groups alias channel ids" in comms/prims/docs/Channels.md.
+   */
   __device__ void flush(const AbortDevice& abortDevice = AbortDevice()) {
     ThreadGroup solo = make_thread_solo();
     flush(solo, IbDirection::Send, abortDevice);
@@ -801,7 +826,12 @@ class P2pIbgdaTransportDevice {
     flush(group, direction, abortDevice);
   }
 
-  /** fence (thread-scope) - Single-thread variant. */
+  /**
+   * fence (thread-scope) - Single-thread variant.
+   *
+   * Drains Send unconditionally; same shared-`IbQpState` caveat as the
+   * thread-scope flush() above.
+   */
   __device__ void fence(const AbortDevice& abortDevice = AbortDevice()) {
     flush(abortDevice);
   }


### PR DESCRIPTION
Summary:
Follow-up to D117934231, which switched IBGDA WQ posting to
`DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE` on the strength of "a QP
has exactly one poster". goelayu pointed out on that diff that the invariant
is easier to break than the slot-geometry argument suggests, and asked for it
to be written down -- in the transport code as well as the spec -- before a
future change walks into it.

The gap: `Channels.md` argued one-poster-per-QP from the slot index alone --
`((channel_id * directions + direction) * qpsPerConnection) + qp_index` has no
modulo, so a QP belongs to exactly one `(channel_id, direction)`. True, but it
reads as though a channel id identifies a group. It does not.
`ThreadGroup::partition` renumbers each subgroup relative to its partition
start (`group_id - partition_start`), so every partition hands out ids
beginning at 0 and two blocks in different partitions select the same channel.

What separates them today is direction, and only because the canonical
partition puts `send_group` on one side and `recv_group` on the other. Nothing
enforces it. The APIs that pick their own direction are where it goes wrong:
`put` always posts Send, `signal` defaults to Send, the thread-scope `flush()`
and `fence()` overloads pass Send unconditionally, and `wait_local` /
`is_local_completion_ready` resolve their lane against Send. A recv-role group
calling any of them lands on the send-role group's QP.

Two consequences, and only the first is new:

- **Duplicate WQE index**: under `EXCLUSIVE` the WQ-slot reservation is a plain
  load and store, so both posters can be handed the same index and overwrite
  each other's WQE before the doorbell. The shared mode's `atomicAdd` would
  have handed out distinct indices, so this call was previously just slow.
- **Stolen flush set**: `flush`/`fence` share the direction's `IbQpState` and
  exchange `pendingFlushLanesMask` to zero, so one group's drain consumes the
  other's pending lanes and can return with those WQEs still in flight. This
  one predates the sharing-mode change.

Changes:
- Add a "Partitioned groups alias channel ids" section to
  `comms/prims/docs/Channels.md`, next to "QP posting ownership". It states the
  rule for new callers: a group that may share a channel id with another
  concurrently running group must pass an explicit, differing direction and
  must not use the direction-defaulting overloads.
- Comment the four direction-defaulting entry points in
  `P2pIbgdaTransportDevice.cuh`, so the hazard is visible at the call site a
  future change would actually edit rather than only in the spec: the
  group-scope `signal` docblock carries the full explanation, and the
  thread-scope `signal`, `flush`, `fence`, and the `wait_local` /
  `is_local_completion_ready` pair carry short pointers to it.

Comments and documentation only -- no executable code, no behaviour change.

Differential Revision: D118430028


