### PR TITLE
Add the epoch-flip window readout (#3956)

### DIFF
--- a/comms/utils/collstats/CollStatsDeviceBlock.cc
+++ b/comms/utils/collstats/CollStatsDeviceBlock.cc
@@ -1,0 +1,196 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/collstats/CollStatsDeviceBlock.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "comms/utils/collstats/CollStatsHistogram.h"
+
+namespace meta::comms::collstats {
+
+namespace {
+
+/* Swallowing a CUDA failure hides it from us but not from the runtime: the
+ * error stays latched per-thread until the next cudaGetLastError(), which is
+ * usually a CUDACHECK in the collective library and would blame whatever ran
+ * after us.
+ *
+ * Called only when our own call failed, but cudaGetLastError() clears whatever
+ * is latched, not specifically ours -- an unrelated non-sticky error already
+ * pending is consumed too. The runtime offers no way to clear selectively, and
+ * between mis-attributing our failure to someone else's code and swallowing an
+ * error nobody has observed yet, the first is the worse outcome. Takes the
+ * status by value so a nodiscard call can be consumed by passing it in. */
+void clearLatchedError(cudaError_t e) {
+  if (e != cudaSuccess) {
+    // Consume the return value to satisfy HIP's nodiscard on hipGetLastError.
+    [[maybe_unused]] const cudaError_t cleared = cudaGetLastError();
+  }
+}
+
+// Allocate `bytes` of device memory into *out. Returns false on failure.
+bool alloc(void** out, std::size_t bytes) {
+  const cudaError_t e = cudaMalloc(out, bytes);
+  if (e != cudaSuccess) {
+    clearLatchedError(e);
+    *out = nullptr;
+    return false;
+  }
+  return true;
+}
+
+// Allocate `bytes` of zeroed device memory into *out. Returns false on failure.
+bool allocZeroed(void** out, std::size_t bytes) {
+  if (!alloc(out, bytes)) {
+    return false;
+  }
+  const cudaError_t e = cudaMemset(*out, 0, bytes);
+  if (e != cudaSuccess) {
+    clearLatchedError(e);
+    clearLatchedError(cudaFree(*out));
+    *out = nullptr;
+    return false;
+  }
+  return true;
+}
+
+} // namespace
+
+CollStatsDeviceBlockHandle collStatsAllocDeviceBlock(
+    uint32_t keyCapacity,
+    uint32_t numSlots,
+    const CollStatsBlockConfig& cfg) {
+  // Validate before building the handle, so every rejection returns an empty
+  // one and no partially-populated handle can escape.
+  if (keyCapacity == UINT32_MAX) {
+    return CollStatsDeviceBlockHandle{};
+  }
+  // The block's histogram and threshold arrays are fixed capacity, so an
+  // over-large configuration would write past them. Refuse rather than clamp:
+  // silently reshaping the geometry would make the exported buckets disagree
+  // with the geometry exported alongside them.
+  //
+  // Re-derive the bucket count instead of range-checking the one handed in.
+  // logBucketNs bounds its index by tMinNs/tMaxNs/subBucketsPerOctave, not by
+  // the declared numBuckets, so a geometry whose count is too small for its own
+  // bounds passes every range check and still indexes past histogram[].
+  // collStatMakeHistGeometry is the single source of truth the defaults are
+  // built through, and it also rejects tMinNs == 0 -- which would make
+  // log2(dur / tMinNs) infinite and the cast to a bucket index undefined.
+  const CollStatHistGeometry derived = collStatMakeHistGeometry(
+      cfg.hist.tMinNs, cfg.hist.tMaxNs, cfg.hist.subBucketsPerOctave);
+  if (derived.numBuckets == 0 || derived.numBuckets != cfg.hist.numBuckets ||
+      cfg.numThresholds > kMaxThresholds) {
+    return CollStatsDeviceBlockHandle{};
+  }
+  // A zero-slot block allocates nothing for the span scratch but still reports
+  // a valid handle, leaving every span entry pointing at unallocated memory.
+  if (numSlots == 0) {
+    return CollStatsDeviceBlockHandle{};
+  }
+
+  CollStatsDeviceBlockHandle handle{};
+  handle.numSlots = numSlots;
+  handle.keyCapacity = keyCapacity;
+  handle.cfg = cfg;
+  const uint32_t valueSlots = keyCapacity + 1; // trailing catch-all slot
+
+  // The span is allocated but not zeroed: the spanInit copy below overwrites
+  // every byte of it, so zeroing here would be discarded work and one more way
+  // to fail. The value banks do need it -- nothing else initializes them.
+  const std::size_t bankBytes =
+      static_cast<std::size_t>(valueSlots) * sizeof(CollStatValue);
+  const std::size_t spanBytes =
+      static_cast<std::size_t>(numSlots) * sizeof(CollStatSpanScratch);
+  const bool ok =
+      allocZeroed(reinterpret_cast<void**>(&handle.values[0]), bankBytes) &&
+      allocZeroed(reinterpret_cast<void**>(&handle.values[1]), bankBytes) &&
+      alloc(reinterpret_cast<void**>(&handle.span), spanBytes);
+  if (!ok) {
+    collStatsFreeDeviceBlock(handle);
+    return CollStatsDeviceBlockHandle{};
+  }
+
+  // Value-initialized; only start departs from zero, taking the atomicMin
+  // sentinel so the first entry timestamp wins the min rather than 0.
+  std::vector<CollStatSpanScratch> spanInit(numSlots);
+  for (auto& s : spanInit) {
+    s.start = kSpanStartInit;
+  }
+  const cudaError_t spanCopy = cudaMemcpy(
+      handle.span, spanInit.data(), spanBytes, cudaMemcpyHostToDevice);
+  if (spanCopy != cudaSuccess) {
+    clearLatchedError(spanCopy);
+    collStatsFreeDeviceBlock(handle);
+    return CollStatsDeviceBlockHandle{};
+  }
+
+  // Build the block on the host with device pointers, then publish it to
+  // device.
+  CollStatsDeviceBlock hostBlock{};
+  hostBlock.bank.numKeys = keyCapacity;
+  hostBlock.bank.epoch = 0;
+  hostBlock.bank.values[0] = handle.values[0];
+  hostBlock.bank.values[1] = handle.values[1];
+  hostBlock.span = handle.span;
+  hostBlock.numSlots = numSlots;
+  hostBlock.hist = cfg.hist;
+  hostBlock.numThresholds = cfg.numThresholds;
+  for (uint32_t i = 0; i < cfg.numThresholds; ++i) {
+    hostBlock.thresholdsNs[i] = cfg.thresholdsNs[i];
+  }
+
+  if (!alloc(
+          reinterpret_cast<void**>(&handle.dev),
+          sizeof(CollStatsDeviceBlock))) {
+    collStatsFreeDeviceBlock(handle);
+    return CollStatsDeviceBlockHandle{};
+  }
+  const cudaError_t blockCopy = cudaMemcpy(
+      handle.dev,
+      &hostBlock,
+      sizeof(CollStatsDeviceBlock),
+      cudaMemcpyHostToDevice);
+  if (blockCopy != cudaSuccess) {
+    clearLatchedError(blockCopy);
+    collStatsFreeDeviceBlock(handle);
+    return CollStatsDeviceBlockHandle{};
+  }
+  return handle;
+}
+
+void collStatsFreeDeviceBlock(const CollStatsDeviceBlockHandle& handle) {
+  // Fail-open: a failed free is ignored, but not left latched.
+  clearLatchedError(cudaFree(handle.dev));
+  clearLatchedError(cudaFree(handle.values[0]));
+  clearLatchedError(cudaFree(handle.values[1]));
+  clearLatchedError(cudaFree(handle.span));
+}
+
+void collStatsEnqueuePreReset(
+    const CollStatsDeviceBlockHandle& handle,
+    uint32_t slot,
+    cudaStream_t stream) {
+  if (handle.dev == nullptr || slot >= handle.numSlots) {
+    return;
+  }
+  // Compute device addresses without dereferencing a device pointer on the
+  // host.
+  // `&handle.span[slot].start` looks like a host dereference of device memory
+  // to sanitizers even though it is just offset arithmetic; use explicit byte
+  // offsets from the base pointer.
+  const char* slotBase = reinterpret_cast<const char*>(handle.span) +
+      static_cast<std::size_t>(slot) * sizeof(CollStatSpanScratch);
+  const char* startAddr = slotBase + offsetof(CollStatSpanScratch, start);
+  const char* arrivedAddr = slotBase + offsetof(CollStatSpanScratch, arrived);
+  // start = UINT64_MAX is all 0xFF bytes; arrived = 0 is all 0x00 bytes. Two
+  // async fills, stream-ordered before the collective's first entry.
+  clearLatchedError(cudaMemsetAsync(
+      const_cast<char*>(startAddr), 0xFF, sizeof(uint64_t), stream));
+  clearLatchedError(cudaMemsetAsync(
+      const_cast<char*>(arrivedAddr), 0, sizeof(uint32_t), stream));
+}
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsDeviceBlock.h
+++ b/comms/utils/collstats/CollStatsDeviceBlock.h
@@ -1,0 +1,180 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <cstdint>
+
+#include <cuda_runtime.h>
+
+#include "comms/utils/collstats/CollStatsBank.h"
+#include "comms/utils/collstats/CollStatsFinalize.h"
+#include "comms/utils/collstats/CollStatsHistogram.h"
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+// The globally-resident stats block for one communicator. A collective kernel
+// reaches it through a single pointer hung off the per-comm device state (which
+// is itself copied into shared memory per block), so everything the device
+// mutates atomically across blocks lives here in global memory, never in the
+// shared-mem copy. The double-buffered bank and the per-stream span scratch
+// both hang off this one block.
+
+namespace meta::comms::collstats {
+
+struct CollStatsDeviceBlock {
+  CollStatDoubleBank bank;
+  CollStatSpanScratch* span; // [numSlots]
+  uint32_t numSlots;
+  CollStatHistGeometry hist; // device-resident, per-comm config
+  uint32_t numThresholds;
+  uint64_t thresholdsNs[kMaxThresholds]; // device-resident, per-comm config
+};
+
+// The device finalizer's only entry point: fold one completed observation into
+// the current epoch's bank at `keyId`, using the block's device-resident
+// threshold vector. `keyId` comes from the host key registry, which resolved it
+// before the launch, so the device indexes rather than searching. Ids past the
+// key capacity land on the reserved trailing catch-all slot. Shared between
+// host and device so a GPU test drives the exact path.
+COLLSTATS_HD inline void collStatsRecordById(
+    CollStatsDeviceBlock* block,
+    uint32_t keyId,
+    uint64_t durNs,
+    uint64_t logicalBytes) {
+  const uint32_t valueSlot =
+      keyId > block->bank.numKeys ? block->bank.numKeys : keyId;
+  CollStatValue* values = collStatCurrentValues(&block->bank);
+  collStatAccumulate(
+      &values[valueSlot],
+      durNs,
+      logicalBytes,
+      block->hist,
+      block->thresholdsNs,
+      block->numThresholds);
+}
+
+/* Per-communicator bucketing configuration, resolved from cvars by the owner
+ * and copied into the block so the device finalizer reads it without a host
+ * round trip. Defaults reproduce the compiled-in behaviour, so a caller that
+ * does not configure anything gets 8 sub-buckets per octave over [1us, 1024s]
+ * and cut-points at 1s/10s/60s/600s. */
+struct CollStatsBlockConfig {
+  CollStatHistGeometry hist;
+  uint64_t thresholdsNs[kMaxThresholds];
+  uint32_t numThresholds;
+  /* Host-only, unlike the fields above: bucketing a message size happens on the
+   * enqueue thread, so the device never reads these and they are deliberately
+   * not copied into the device block. They live here because this struct is
+   * what a window's exported labels are resolved against. */
+  CollStatSizeClasses sizeClasses;
+};
+
+inline CollStatsBlockConfig collStatDefaultBlockConfig() {
+  CollStatsBlockConfig cfg{};
+  cfg.hist = collStatDefaultHistGeometry();
+  cfg.numThresholds = kMaxThresholds;
+  for (uint32_t i = 0; i < kMaxThresholds; ++i) {
+    cfg.thresholdsNs[i] = kDefaultThresholdsNs[i];
+  }
+  cfg.sizeClasses = collStatDefaultSizeClasses();
+  return cfg;
+}
+
+// Host-side handle retaining every device allocation backing a block, so it can
+// be freed without reading pointers back from the device. `dev` is the pointer
+// stored into the per-comm device state.
+//
+// Members are default-initialized so the "empty handle frees nothing" contract
+// holds for any handle, not only a brace-initialized one:
+// collStatsFreeDeviceBlock frees all four pointers unconditionally, and
+// cudaFree is a no-op on null but not on an indeterminate address.
+struct CollStatsDeviceBlockHandle {
+  CollStatsDeviceBlock* dev = nullptr;
+  CollStatValue* values[2] = {nullptr, nullptr};
+  CollStatSpanScratch* span = nullptr;
+  uint32_t numSlots = 0;
+  uint32_t keyCapacity = 0; // key-index capacity; banks hold keyCapacity + 1
+  /* The configuration the block was built with. Kept host-side so a readout can
+   * export the geometry its buckets were actually produced under, rather than
+   * whatever the defaults happen to be. */
+  CollStatsBlockConfig cfg;
+};
+
+/* Allocate a device-resident block: two zeroed value banks of keyCapacity + 1
+ * slots (the trailing slot is the catch-all) and numSlots span-scratch entries
+ * initialized to the atomicMin start sentinel rather than to zero.
+ *
+ * Returns a null `dev` on allocation failure, on numSlots == 0, or on a `cfg`
+ * whose geometry does not re-derive to itself -- the histogram and threshold
+ * arrays are fixed capacity, so a geometry that indexes past them would write
+ * past them rather than merely lose resolution. The check is a re-derivation
+ * through collStatMakeHistGeometry, not a range test on the declared bucket
+ * count, because the index logBucketNs produces follows from the bounds and
+ * not from that count. */
+CollStatsDeviceBlockHandle collStatsAllocDeviceBlock(
+    uint32_t keyCapacity,
+    uint32_t numSlots,
+    const CollStatsBlockConfig& cfg = collStatDefaultBlockConfig());
+
+/* Frees the four device allocations. Takes the handle by const reference and so
+ * cannot null it: the handle is a value type that readers and drivers copy
+ * freely, and nulling one copy would leave the others just as dangling. Exactly
+ * one CollStatsDeviceBlockOwner is therefore responsible for calling this, and
+ * every handle -- the owner's included -- is dead afterwards. Calling it twice
+ * on the same block double-frees. A no-op on the empty (all-null) handle. */
+void collStatsFreeDeviceBlock(const CollStatsDeviceBlockHandle& handle);
+
+// RAII owner of a device block: frees the allocations on destruction, so the
+// communicator holds one owner and lets destruction order handle teardown
+// instead of a manual free. Move-only, single-owner — the handle it hands out
+// is a non-owning view that readers/drivers copy freely.
+// `collStatsFreeDeviceBlock` is a no-op on the empty (all-null) handle, so a
+// default or moved-from owner destroys cleanly.
+class CollStatsDeviceBlockOwner {
+ public:
+  CollStatsDeviceBlockOwner() = default;
+  explicit CollStatsDeviceBlockOwner(CollStatsDeviceBlockHandle handle)
+      : handle_(handle) {}
+  ~CollStatsDeviceBlockOwner() {
+    collStatsFreeDeviceBlock(handle_);
+  }
+
+  CollStatsDeviceBlockOwner(CollStatsDeviceBlockOwner&& other) noexcept
+      : handle_(other.handle_) {
+    other.handle_ = {};
+  }
+  CollStatsDeviceBlockOwner& operator=(
+      CollStatsDeviceBlockOwner&& other) noexcept {
+    if (this != &other) {
+      collStatsFreeDeviceBlock(handle_);
+      handle_ = other.handle_;
+      other.handle_ = {};
+    }
+    return *this;
+  }
+  CollStatsDeviceBlockOwner(const CollStatsDeviceBlockOwner&) = delete;
+  CollStatsDeviceBlockOwner& operator=(const CollStatsDeviceBlockOwner&) =
+      delete;
+
+  const CollStatsDeviceBlockHandle& handle() const {
+    return handle_;
+  }
+  bool valid() const {
+    return handle_.dev != nullptr;
+  }
+
+ private:
+  CollStatsDeviceBlockHandle handle_{};
+};
+
+// Enqueue a stream-ordered pre-sequence reset of one span slot on `stream`:
+// start = UINT64_MAX, arrived = 0. It is the slot cleanup — it runs,
+// in stream order, after every prior kernel on the slot has completed and
+// before the next collective's first entry, so the slot is clean regardless of
+// whether the previous sequence finalized (an aborted sequence cannot poison
+// its successor). Two byte-fills, so it is graph-capturable and needs no
+// kernel. No-op when the handle is null (instrumentation off).
+void collStatsEnqueuePreReset(
+    const CollStatsDeviceBlockHandle& handle,
+    uint32_t slot,
+    cudaStream_t stream);
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsReader.cu
+++ b/comms/utils/collstats/CollStatsReader.cu
@@ -1,0 +1,337 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/collstats/CollStatsReader.h"
+
+#include <cstddef>
+
+namespace meta::comms::collstats {
+
+namespace {
+
+// Advance the epoch by one, publishing the flip to finalizers. A finalizer that
+// observes the new epoch also observes an initialized new bank because the
+// previous window's zeroing memset is stream-ordered ahead of this launch, not
+// because of the fence: the fence follows the increment, so it supplies
+// system-scope visibility of the epoch word, not release ordering.
+// One thread; the reader launches it on the reader stream.
+__global__ void flipEpochKernel(CollStatsDeviceBlock* block) {
+  atomicAdd(reinterpret_cast<unsigned long long*>(&block->bank.epoch), 1ull);
+  __threadfence_system();
+}
+
+// Step 1: make the reader stream wait until every old-epoch finalizer on each
+// instrumented stream has retired, so the retired bank is quiescent before the
+// copy. No-op when ungated.
+cudaError_t gateOldFinalizers(
+    cudaStream_t readerStream,
+    const CollStatsReadGating* gating) {
+  if (gating == nullptr) {
+    return cudaSuccess;
+  }
+  for (uint32_t i = 0; i < gating->numStreams; ++i) {
+    cudaError_t err = cudaEventRecord(
+        gating->streamEvents[i], gating->instrumentedStreams[i]);
+    if (err != cudaSuccess) {
+      return err;
+    }
+    err = cudaStreamWaitEvent(readerStream, gating->streamEvents[i], 0);
+    if (err != cudaSuccess) {
+      return err;
+    }
+  }
+  return cudaSuccess;
+}
+
+// Step 3: make each instrumented stream wait for the flip to be visible, so no
+// new-window collective launches before the epoch write and thus none writes
+// the retired bank. No-op when ungated.
+cudaError_t gateNewLaunches(
+    cudaStream_t readerStream,
+    const CollStatsReadGating* gating) {
+  if (gating == nullptr) {
+    return cudaSuccess;
+  }
+  cudaError_t err = cudaEventRecord(gating->flipEvent, readerStream);
+  if (err != cudaSuccess) {
+    return err;
+  }
+  for (uint32_t i = 0; i < gating->numStreams; ++i) {
+    err = cudaStreamWaitEvent(
+        gating->instrumentedStreams[i], gating->flipEvent, 0);
+    if (err != cudaSuccess) {
+      return err;
+    }
+  }
+  return cudaSuccess;
+}
+
+// Shared async sequence: wait old finalizers -> flip -> gate new launches ->
+// copy retired bank + key index + cumulative counters into `out` -> zero the
+// retired bank -> record copyDoneEvent (if non-null). No sync. `out` must be
+// pre-sized to numKeys. The retired bank is quiescent between the flip and the
+// copy, and new finalizers write the new bank, so the copy never races live
+// atomics.
+// `flipped`, when non-null, is set once the flip has been enqueued: past that
+// point the epoch has advanced whatever happens next, and a caller that bails
+// owns a retired bank nobody will copy or zero.
+cudaError_t issueGatedReadout(
+    const CollStatsDeviceBlockHandle& handle,
+    cudaStream_t readerStream,
+    const CollStatsReadGating* gating,
+    uint64_t currentEpoch,
+    const CollStatsKeyRegistry& keys,
+    cudaEvent_t copyDoneEvent,
+    CollStatsPinnedStaging& staging,
+    bool* flipped) {
+  const uint32_t retired = static_cast<uint32_t>(currentEpoch & 1u);
+  const uint32_t capacity = handle.keyCapacity;
+
+  cudaError_t e = gateOldFinalizers(readerStream, gating);
+  if (e != cudaSuccess) {
+    return e;
+  }
+  flipEpochKernel<<<1, 1, 0, readerStream>>>(handle.dev);
+  e = cudaGetLastError();
+  if (e != cudaSuccess) {
+    return e;
+  }
+  if (flipped != nullptr) {
+    *flipped = true;
+  }
+  e = gateNewLaunches(readerStream, gating);
+  if (e != cudaSuccess) {
+    return e;
+  }
+  // Sampled here, after the gate, and not by the caller before the flip. A
+  // collective enqueued between the old-finalizer event records and this gate
+  // is waited on by neither: the gate's wait lands at the stream's tail, behind
+  // that collective, so it can still execute against the retired bank. Its key
+  // was resolved before it was enqueued, so a count taken earlier would exclude
+  // it and its observation would be neither copied nor counted -- just zeroed
+  // by the memset below. Everything enqueued after the gate writes the new bank
+  // and is not our business.
+  //
+  // Clamped because the registry's capacity is its own; ids past the bank's
+  // capacity are folded onto the catch-all by collStatsRecordById and never
+  // occupy a slot of their own.
+  const uint32_t liveKeys = keys.size();
+  const uint32_t numKeys = liveKeys < capacity ? liveKeys : capacity;
+  staging.setStaged(numKeys);
+
+  // Occupied prefix only: ids are dense, so everything past numKeys has never
+  // been written.
+  if (numKeys > 0) {
+    e = cudaMemcpyAsync(
+        staging.values(),
+        handle.values[retired],
+        static_cast<std::size_t>(numKeys) * sizeof(CollStatValue),
+        cudaMemcpyDeviceToHost,
+        readerStream);
+    if (e != cudaSuccess) {
+      return e;
+    }
+  }
+  // The catch-all sits at the bank's capacity, not at numKeys, so it needs its
+  // own copy into the staging buffer's trailing slot.
+  e = cudaMemcpyAsync(
+      staging.values() + numKeys,
+      handle.values[retired] + capacity,
+      sizeof(CollStatValue),
+      cudaMemcpyDeviceToHost,
+      readerStream);
+  if (e != cudaSuccess) {
+    return e;
+  }
+  // Zero the whole bank rather than the copied prefix: a device-side memset
+  // costs no transfer, and it keeps the bank clean if the id space grows.
+  e = cudaMemsetAsync(
+      handle.values[retired],
+      0,
+      static_cast<std::size_t>(capacity + 1) * sizeof(CollStatValue),
+      readerStream);
+  if (e != cudaSuccess) {
+    return e;
+  }
+  if (copyDoneEvent != nullptr) {
+    e = cudaEventRecord(copyDoneEvent, readerStream);
+    if (e != cudaSuccess) {
+      return e;
+    }
+  }
+  return cudaSuccess;
+}
+
+} // namespace
+
+CollStatsPinnedStaging::~CollStatsPinnedStaging() {
+  release();
+}
+
+void CollStatsPinnedStaging::release() {
+  if (values_ != nullptr) {
+    // Consume the return value to satisfy HIP's nodiscard on hipHostFree.
+    [[maybe_unused]] const cudaError_t e = cudaFreeHost(values_);
+    values_ = nullptr;
+  }
+  capacity_ = 0;
+  staged_ = 0;
+}
+
+bool CollStatsPinnedStaging::allocate(uint32_t capacity) {
+  release();
+  if (cudaMallocHost(
+          reinterpret_cast<void**>(&values_),
+          static_cast<std::size_t>(capacity + 1) * sizeof(CollStatValue)) !=
+      cudaSuccess) {
+    values_ = nullptr;
+    return false;
+  }
+  capacity_ = capacity;
+  return true;
+}
+
+void CollStatsPinnedStaging::publish(
+    uint64_t windowEpoch,
+    const CollStatsKeyRegistry& keys,
+    const CollStatsBlockConfig& cfg,
+    CollStatSnapshot& out) const {
+  out.windowEpoch = windowEpoch;
+  out.hist = cfg.hist;
+  out.sizeClasses = cfg.sizeClasses;
+  // Clamped rather than trusted: the destination array is fixed capacity, and a
+  // config that reached here with a larger count would write past it. Callers
+  // reuse one snapshot across windows, so a partial overwrite would also leave
+  // the tail describing the previous window's bucketing.
+  out.numThresholds =
+      cfg.numThresholds < kMaxThresholds ? cfg.numThresholds : kMaxThresholds;
+  for (uint32_t i = 0; i < out.numThresholds; ++i) {
+    out.thresholdsNs[i] = cfg.thresholdsNs[i];
+  }
+  // Reset rather than leave: this snapshot is reused across publishes, and the
+  // window bounds are producer-stamped after publish returns. Carrying the
+  // previous window's timestamps into one that was never stamped would date the
+  // window to the wrong interval.
+  out.windowStartUnixNs = 0;
+  out.windowEndUnixNs = 0;
+  if (!valid()) {
+    out.numKeys = 0;
+    out.catchAllCount = 0;
+    out.keys.clear();
+    out.values.clear();
+    return;
+  }
+  out.numKeys = staged_;
+  out.catchAllCount = keys.catchAllCount();
+  // The registry may have grown since the copy was issued; only the slots that
+  // were actually transferred are described.
+  out.keys = keys.keys();
+  out.keys.resize(staged_);
+  out.values.assign(values_, values_ + staged_ + 1);
+}
+
+cudaError_t collStatsIssueReadWindow(
+    const CollStatsDeviceBlockHandle& handle,
+    cudaStream_t readerStream,
+    const CollStatsReadGating* gating,
+    uint64_t currentEpoch,
+    cudaEvent_t copyDoneEvent,
+    CollStatsPinnedStaging& staging,
+    const CollStatsKeyRegistry& keys) {
+  if (handle.dev == nullptr || !staging.valid() ||
+      staging.capacity() != handle.keyCapacity) {
+    return cudaErrorInvalidValue;
+  }
+  return issueGatedReadout(
+      handle,
+      readerStream,
+      gating,
+      currentEpoch,
+      keys,
+      copyDoneEvent,
+      staging,
+      /*flipped=*/nullptr);
+}
+
+CollStatSnapshot collStatsReadWindow(
+    const CollStatsDeviceBlockHandle& handle,
+    cudaStream_t readerStream,
+    const CollStatsKeyRegistry& keys,
+    const CollStatsReadGating* gating) {
+  CollStatSnapshot snapshot{};
+  if (handle.dev == nullptr) {
+    return snapshot;
+  }
+
+  // Read just the epoch word to pick the retired bank. Only the reader mutates
+  // the epoch, so this host read is race-free; the capacity comes from the
+  // handle, so no full-block read is needed.
+  //
+  // Async on the reader stream rather than a plain cudaMemcpy. A synchronous
+  // copy runs on the legacy default stream, which implicitly synchronizes with
+  // every blocking stream on the device -- so reading eight bytes of telemetry
+  // would wait on the training streams, which is exactly what this whole path
+  // promises not to do. The byte offset avoids forming &handle.dev->bank.epoch
+  // on the host, the same reason collStatsEnqueuePreReset uses offsets.
+  uint64_t currentEpoch = 0;
+  const char* epochAddr = reinterpret_cast<const char*>(handle.dev) +
+      offsetof(CollStatsDeviceBlock, bank) +
+      offsetof(CollStatDoubleBank, epoch);
+  if (cudaMemcpyAsync(
+          &currentEpoch,
+          epochAddr,
+          sizeof(currentEpoch),
+          cudaMemcpyDeviceToHost,
+          readerStream) != cudaSuccess ||
+      cudaStreamSynchronize(readerStream) != cudaSuccess) {
+    return snapshot;
+  }
+
+  // This path synchronizes anyway, so pinning buys nothing here; the staging
+  // buffer exists because issueGatedReadout writes through it.
+  CollStatsPinnedStaging staging;
+  if (!staging.allocate(handle.keyCapacity)) {
+    return snapshot;
+  }
+
+  bool flipped = false;
+  if (issueGatedReadout(
+          handle,
+          readerStream,
+          gating,
+          currentEpoch,
+          keys,
+          /*copyDoneEvent=*/nullptr,
+          staging,
+          &flipped) != cudaSuccess ||
+      cudaStreamSynchronize(readerStream) != cudaSuccess) {
+    if (flipped) {
+      // The epoch advanced but the retired bank was never copied or zeroed.
+      // Left resident, its counts become the next window's starting balance and
+      // inflate it. Best-effort: a stream wedged badly enough to fail above
+      // will fail here too, and then the counts are unrecoverable either way.
+      // Return values are consumed to satisfy HIP's nodiscard on
+      // hipMemsetAsync/hipStreamSynchronize; the recovery is best-effort, so
+      // there is nothing to do with a failure here.
+      [[maybe_unused]] const cudaError_t e0 = cudaMemsetAsync(
+          handle.values[currentEpoch & 1u],
+          0,
+          static_cast<std::size_t>(handle.keyCapacity + 1) *
+              sizeof(CollStatValue),
+          readerStream);
+      [[maybe_unused]] const cudaError_t e1 =
+          cudaStreamSynchronize(readerStream);
+    }
+    // `staging` is freed on the way out of this scope, and the failure may have
+    // been the synchronize above with both D2H copies already enqueued -- so
+    // drain before the pinned buffer they land in goes away. Best-effort, and
+    // deliberately not relying on cudaFreeHost's implicit synchronize, which is
+    // an implementation detail rather than a documented barrier.
+    [[maybe_unused]] const cudaError_t drained =
+        cudaStreamSynchronize(readerStream);
+    return CollStatSnapshot{};
+  }
+  staging.publish(currentEpoch, keys, handle.cfg, snapshot);
+  return snapshot;
+}
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsReader.h
+++ b/comms/utils/collstats/CollStatsReader.h
@@ -1,0 +1,197 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "comms/utils/collstats/CollStatsDeviceBlock.h"
+#include "comms/utils/collstats/CollStatsHistogram.h"
+#include "comms/utils/collstats/CollStatsKeyRegistry.h"
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+// Host-side readout of one window from a device-resident stats block. The
+// aggregate is double-buffered: finalizers write the current-epoch bank, and a
+// window is read by flipping the epoch (so new finalizers move to the other
+// bank), then copying and zeroing the now-retired bank. Because each bank holds
+// exactly one window, the snapshot needs no host delta subtraction.
+//
+// Cross-stream gating — recording events on the instrumented streams so
+// old-epoch finalizers have retired before the copy, and gating new-window
+// launches on the flip — is optional: pass a CollStatsReadGating to get it,
+// or a null one to leave the flip unordered against producers. Run on a
+// dedicated reader stream, never the training stream.
+
+namespace meta::comms::collstats {
+
+// One window's worth of per-key aggregates, copied to the host.
+//
+// `values` and `keys` are both indexed by the dense id the host key registry
+// assigned, so values[i] belongs to keys[i]. `values` carries one extra
+// trailing entry, values[numKeys], holding everything that resolved to the
+// catch-all; it has no entry in `keys` because it is not one key.
+//
+// Only the occupied prefix is transferred. Ids are handed out densely and never
+// recycled, so numKeys is the registry's size at the moment the window was
+// issued, not the bank's capacity.
+struct CollStatSnapshot {
+  uint32_t numKeys{0};
+  uint64_t windowEpoch{0}; // pre-flip epoch value; a monotonic window sequence
+  uint64_t catchAllCount{0}; // cumulative, from the host registry
+  // Wall-clock bounds of the window, unix nanoseconds, or 0 when the producer
+  // did not stamp them. Wall rather than monotonic because their purpose is
+  // lining a window up against events outside this process; durations come
+  // from the device clock and never from here, so a clock step can misplace a
+  // boundary but cannot corrupt a measurement.
+  //
+  // The span also makes the window's duty cycle computable: the per-key
+  // duration sums over this wall interval is the fraction of the period the
+  // rank spent inside collectives.
+  uint64_t windowStartUnixNs{0};
+  uint64_t windowEndUnixNs{0};
+  /* The bucketing this window was produced under. Exported alongside the
+   * buckets so a consumer never has to assume the defaults, and so a window
+   * recorded before a retune stays interpretable. Defaulted rather than
+   * zero-initialized: a zero geometry has numBuckets 0, and the readout's
+   * `numBuckets - 1` overflow index would wrap. */
+  CollStatHistGeometry hist{collStatDefaultHistGeometry()};
+  uint64_t thresholdsNs[kMaxThresholds]{
+      kDefaultThresholdsNs[0],
+      kDefaultThresholdsNs[1],
+      kDefaultThresholdsNs[2],
+      kDefaultThresholdsNs[3]};
+  uint32_t numThresholds{kMaxThresholds};
+  /* The size-class edges this window was produced under, carried for the same
+   * reason as `hist`: a key's sizeClass is an index into these, so without them
+   * an exported row cannot be turned back into byte bounds off-box. */
+  CollStatSizeClasses sizeClasses{collStatDefaultSizeClasses()};
+  std::vector<CollStatKey> keys; // [numKeys]
+  std::vector<CollStatValue> values; // [numKeys + 1]
+};
+
+// Cross-stream gating for the epoch flip. The caller (holding the per-comm
+// boundary lock, so no collective enqueues mid-flip) supplies the instrumented
+// streams the comm launched collectives on, plus reusable events: one per
+// stream and one flip event. The reader stream waits each instrumented stream's
+// event so every old-epoch finalizer has retired before the copy, and each
+// instrumented stream waits the flip event so no new-window collective launches
+// until the flip is visible and thus writes the new bank. Without gating a
+// concurrent producer could write the bank being copied.
+struct CollStatsReadGating {
+  const cudaStream_t* instrumentedStreams;
+  const cudaEvent_t* streamEvents; // [numStreams], reusable, caller-owned
+  uint32_t numStreams;
+  cudaEvent_t flipEvent; // reusable, caller-owned
+};
+
+// Flip the epoch on `readerStream`, then copy and zero the retired bank, all
+// stream-ordered on `readerStream`. `keys` supplies both how much of the bank
+// is occupied and the identity of each slot. When `gating` is non-null, the
+// cross-stream event sequence brackets the flip (wait old finalizers -> flip ->
+// gate new launches -> copy -> zero). Synchronizes `readerStream` and returns
+// the retired window's snapshot. On a null handle or a CUDA failure the
+// returned snapshot has numKeys == 0.
+CollStatSnapshot collStatsReadWindow(
+    const CollStatsDeviceBlockHandle& handle,
+    cudaStream_t readerStream,
+    const CollStatsKeyRegistry& keys,
+    const CollStatsReadGating* gating = nullptr);
+
+// Pinned host destination for one window's device-to-host copy.
+//
+// This is not an optimization. A device-to-host cudaMemcpyAsync whose
+// destination is pageable memory blocks the calling thread until the stream
+// drains, so copying straight into CollStatSnapshot's std::vectors would make
+// the "async" issue path stall the enqueue thread for as long as the GPU is
+// behind — exactly what the pipelined design exists to avoid. Page-locked
+// memory is what makes the copy genuinely asynchronous.
+//
+// Allocated once per driver and reused across windows; the snapshot handed to
+// the sink is filled by a plain host memcpy in publish() after the copy-done
+// event fires, so CollStatSnapshot stays cheap to copy and queue.
+class CollStatsPinnedStaging {
+ public:
+  CollStatsPinnedStaging() = default;
+  ~CollStatsPinnedStaging();
+
+  CollStatsPinnedStaging(const CollStatsPinnedStaging&) = delete;
+  CollStatsPinnedStaging& operator=(const CollStatsPinnedStaging&) = delete;
+  // Non-movable as well as non-copyable: the driver owns one staging buffer for
+  // its lifetime, and a moved-from buffer whose pinned allocation had already
+  // been handed to an in-flight copy would free it under the copy.
+  CollStatsPinnedStaging(CollStatsPinnedStaging&&) = delete;
+  CollStatsPinnedStaging& operator=(CollStatsPinnedStaging&&) = delete;
+
+  // Page-locks room for a bank of `capacity` key slots plus the catch-all.
+  // Returns false and leaves the object empty on failure, so the caller can
+  // fail open.
+  bool allocate(uint32_t capacity);
+
+  bool valid() const {
+    return values_ != nullptr;
+  }
+  uint32_t capacity() const {
+    return capacity_;
+  }
+
+  // Number of key slots the last issue actually copied. Recorded at issue time
+  // rather than read from the registry at publish time, because the registry
+  // may have handed out further ids while the copy was in flight.
+  uint32_t staged() const {
+    return staged_;
+  }
+  void setStaged(uint32_t n) {
+    staged_ = n;
+  }
+
+  // Copy the staged window into `out`, resizing it, and attribute each slot
+  // from `keys`. Host-to-host, so only call once the copy-done event has
+  // completed.
+  void publish(
+      uint64_t windowEpoch,
+      const CollStatsKeyRegistry& keys,
+      const CollStatsBlockConfig& cfg,
+      CollStatSnapshot& out) const;
+
+  // Device-to-host copy destination, for the reader only. Holds
+  // capacity + 1 slots; the reader fills [0, staged) plus the trailing
+  // catch-all at index staged.
+  CollStatValue* values() const {
+    return values_;
+  }
+
+ private:
+  void release();
+
+  uint32_t capacity_{0};
+  uint32_t staged_{0};
+  CollStatValue* values_{nullptr}; // [capacity + 1]
+};
+
+// Async issue of one window's readout, for the pipelined driver that must never
+// sync on the producer thread. Enqueues the gated flip and the copy of the
+// retired bank's occupied prefix plus its catch-all slot into `staging` on
+// `readerStream`, zeroes the retired bank, and records `copyDoneEvent` after
+// the copies. Does NOT synchronize. The
+// caller tracks `currentEpoch` (the device epoch before this flip; only this
+// path flips it, so a local counter stays in lockstep) and must not read
+// `staging` until `copyDoneEvent` has completed, at which point
+// CollStatsPinnedStaging::publish turns it into a snapshot. `staging` must
+// already be allocated for the handle's key capacity. Returns the first CUDA
+// error, else cudaSuccess.
+//
+// Takes the registry rather than a key count: how many slots are live has to be
+// sampled after the gate is installed, which only this function can do. A count
+// passed in from the caller is necessarily read before the flip and can miss a
+// collective that still lands in the retired bank.
+cudaError_t collStatsIssueReadWindow(
+    const CollStatsDeviceBlockHandle& handle,
+    cudaStream_t readerStream,
+    const CollStatsReadGating* gating,
+    uint64_t currentEpoch,
+    cudaEvent_t copyDoneEvent,
+    CollStatsPinnedStaging& staging,
+    const CollStatsKeyRegistry& keys);
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsSpan.cuh
+++ b/comms/utils/collstats/CollStatsSpan.cuh
@@ -1,0 +1,153 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <cstdint>
+
+#include "comms/utils/collstats/CollStatsDeviceBlock.h"
+#include "comms/utils/collstats/CollStatsHistogram.h"
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+// Device-side collective span: the two touch points a collective kernel adds to
+// time itself. Entry records each block's start as a running minimum; the exit
+// finalizer (the last block to arrive) computes the duration and records one
+// observation. No block waits on another — the only barrier is the collective's
+// own block-wide __syncthreads(), which the caller already issues.
+//
+// Gated to Hopper and above; below it, and when instrumentation is disabled (a
+// null block), every entry point compiles to a no-op.
+//
+// Not implemented on AMD, and a green AMD build is not evidence otherwise:
+// hipcc never defines __CUDA_ARCH__ (it defines __HIP_DEVICE_COMPILE__), so the
+// gate below is false for every AMD arch and the whole file compiles away.
+// Not yet rather than not possible -- %globaltimer is PTX-only, and AMD's
+// nanosecond reference (__builtin_amdgcn_s_memrealtime) needs its own frequency
+// handling before end-minus-start means the same thing on both vendors.
+
+namespace meta::comms::collstats {
+
+// %globaltimer in nanoseconds. It is already an ns reference clock, so a
+// single-GPU end-minus-start needs no calibration.
+__device__ __forceinline__ uint64_t collStatsGlobaltimerNs() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  uint64_t t;
+  asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(t));
+  return t;
+#else
+  return 0;
+#endif
+}
+
+// Blocks in the launch grid. The span's arrival barrier counts one entry per
+// block, elected on threadIdx.{x,y,z} == 0, so it counts every block however
+// the grid is shaped. Comparing against gridDim.x alone would finalize a 2-D or
+// 3-D launch on its first gridDim.x arrivals, timing a span that is still
+// running.
+__device__ __forceinline__ unsigned int collStatsGridBlocks() {
+  return gridDim.x * gridDim.y * gridDim.z;
+}
+
+// Entry: the elected thread of each block folds its start time into the slot's
+// running minimum. Call from all threads; the election is internal.
+//
+// An out-of-range slot is dropped rather than indexed. The host path
+// (collStatsEnqueuePreReset) makes the same check, and the device is the only
+// side where getting it wrong writes past the span allocation instead of
+// merely losing an observation.
+__device__ __forceinline__ void collStatsSpanEntry(
+    CollStatsDeviceBlock* block,
+    uint32_t slot) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  if (block == nullptr) {
+    return;
+  }
+  // The slot bound is tested inside the election, so only the elected thread
+  // loads numSlots rather than every thread in the block.
+  if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0 &&
+      slot < block->numSlots) {
+    atomicMin(
+        reinterpret_cast<unsigned long long*>(&block->span[slot].start),
+        static_cast<unsigned long long>(collStatsGlobaltimerNs()));
+  }
+#else
+  (void)block;
+  (void)slot;
+#endif
+}
+
+// Exit finalizer taking a value slot resolved by the host key registry before
+// launch, so the device performs no key lookup at all.
+//
+// The finalizer emits only; it does not reset the slot. Slot cleanup is owned
+// by the stream-ordered pre-sequence reset (collStatsEnqueuePreReset), which
+// runs before the next collective's first entry and cleans the slot even when a
+// prior sequence aborted without finalizing.
+//
+// Election is internal and on all three thread indices, matching entry. The
+// caller must still issue the block-wide __syncthreads() first. Callers elect
+// too, but the common 1-D idiom (`if (threadIdx.x == 0)`) admits
+// blockDim.y * blockDim.z threads per block in a 2-D or 3-D launch, and the
+// extra arrivals mistime the span rather than losing it: the equality below
+// still fires exactly once, but on the gridDim'th of gridDim * blockDim.y *
+// blockDim.z increments -- while most blocks are still running -- so it reads
+// `end` early and records a plausible, far-too-short duration. That is the
+// failure this whole file is built to avoid, so the election is not left to
+// the caller.
+__device__ __forceinline__ void collStatsSpanFinalizeElectedById(
+    CollStatsDeviceBlock* block,
+    uint32_t slot,
+    uint32_t keyId,
+    uint64_t logicalBytes) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  if (block == nullptr || threadIdx.x != 0 || threadIdx.y != 0 ||
+      threadIdx.z != 0) {
+    return;
+  }
+  if (slot >= block->numSlots) {
+    return;
+  }
+  CollStatSpanScratch* s = &block->span[slot];
+  const uint64_t end = collStatsGlobaltimerNs();
+  // Release: publish this block's entry atomicMin before its arrival becomes
+  // visible. Acquire (below): the arrival count only orders the start
+  // timestamps if the read of them cannot be hoisted above the count.
+  __threadfence();
+  const unsigned int prev = atomicAdd(&s->arrived, 1u);
+  if (prev + 1u == collStatsGridBlocks()) {
+    __threadfence();
+    const uint64_t start =
+        *reinterpret_cast<volatile const unsigned long long*>(&s->start);
+    // Drop rather than record a duration that is not one. If no entry ever
+    // landed the sentinel survives, and end - UINT64_MAX wraps to end + 1 -- a
+    // sub-microsecond value that lands in the underflow bucket and reads as a
+    // real, very fast collective rather than as missing data. A start left over
+    // from an un-pre-reset predecessor fails the same way in the other
+    // direction, pinning durMaxNs.
+    if (start == kSpanStartInit || end < start) {
+      return;
+    }
+    collStatsRecordById(block, keyId, end - start, logicalBytes);
+  }
+#else
+  (void)block;
+  (void)slot;
+  (void)keyId;
+  (void)logicalBytes;
+#endif
+}
+
+// Derive the collective's logical message size from its launch args and
+// finalize the span in one call, so each instrumented kernel repeats neither.
+// `Args` is any collective's kernel-args type exposing `count` and
+// `collStatsKeyId`; the element size comes from the payload type `T`. Call
+// AFTER the block-wide __syncthreads(); the election is internal.
+template <typename T, typename Args>
+__device__ __forceinline__ void collStatsSpanFinalizeElectedColl(
+    CollStatsDeviceBlock* block,
+    uint32_t slot,
+    const Args& args) {
+  const uint64_t logicalBytes = static_cast<uint64_t>(args.count) * sizeof(T);
+  collStatsSpanFinalizeElectedById(
+      block, slot, args.collStatsKeyId, logicalBytes);
+}
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsTypes.h
+++ b/comms/utils/collstats/CollStatsTypes.h
@@ -157,12 +157,18 @@ inline uint64_t collStatDurMinNs(const CollStatValue& v) {
 
 struct CollStatSpanScratch {
   uint64_t start; // min entry %globaltimer over blocks; init UINT64_MAX
-  uint32_t
-      arrived; // exit-barrier arrival count; finalizer when == expectedBlocks
-  uint32_t expectedBlocks; // gridDim, from launch config
-  uint32_t kernelIndex; // multi-kernel collective: current kernel in sequence
-  uint32_t
-      kernelCount; // multi-kernel collective: total kernels; finalize on last
+  // Exit-barrier arrival count. The finalizer is the block that drives it to
+  // collStatsGridBlocks(), read from gridDim at exit -- not expectedBlocks.
+  uint32_t arrived;
+  /* Reserved, and none of the three is read today. A multi-kernel collective
+   * sharing one slot therefore records one observation per kernel rather than
+   * one per collective; sequencing on kernelIndex/kernelCount, and taking the
+   * block count from expectedBlocks instead of gridDim, are both future work.
+   * Stated here because the barrier condition a reader assumes is authoritative
+   * decides whether they trust a multi-kernel duration. */
+  uint32_t expectedBlocks;
+  uint32_t kernelIndex;
+  uint32_t kernelCount;
 };
 
 inline constexpr uint64_t kSpanStartInit = ~0ull; // UINT64_MAX

--- a/comms/utils/collstats/tests/CollStatsDeviceBlockGpuTest.cu
+++ b/comms/utils/collstats/tests/CollStatsDeviceBlockGpuTest.cu
@@ -1,0 +1,426 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include "comms/utils/collstats/CollStatsDeviceBlock.h"
+#include "comms/utils/collstats/CollStatsHistogram.h"
+#include "comms/utils/collstats/CollStatsSpan.cuh"
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+namespace meta::comms::collstats {
+namespace {
+
+// One elected thread per block records a single observation, mimicking the
+// collective finalizer: block b maps to key (b % numDistinctKeys) and a
+// duration that scales with the key, so the whole device claim + accumulate
+// path runs under real cross-block atomic contention.
+__global__ void recordKernel(
+    CollStatsDeviceBlock* block,
+    uint32_t numDistinctKeys,
+    uint64_t baseNs) {
+  if (threadIdx.x != 0) {
+    return;
+  }
+  // One value slot per distinct key, as the host registry would have handed
+  // them out.
+  const uint32_t keyId = blockIdx.x % numDistinctKeys;
+  const uint64_t dur = baseNs * (keyId + 1);
+  collStatsRecordById(block, keyId, dur, 100);
+}
+
+// The skip is the same in every test here, so it lives in SetUp rather than
+// being restated nine times.
+class CollStatsDeviceBlockGpuTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int deviceCount = 0;
+    if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount == 0) {
+      GTEST_SKIP() << "no CUDA device";
+    }
+  }
+
+  // The retired bank is always read back whole, so the copy and its sizing live
+  // in one place: values past the claimed keys are zero and cost nothing to
+  // compare.
+  static std::vector<CollStatValue> readValues(
+      const CollStatsDeviceBlockHandle& h,
+      uint32_t capacity) {
+    std::vector<CollStatValue> values(capacity + 1);
+    EXPECT_EQ(
+        cudaMemcpy(
+            values.data(),
+            h.values[0], // epoch started at 0
+            values.size() * sizeof(CollStatValue),
+            cudaMemcpyDeviceToHost),
+        cudaSuccess);
+    return values;
+  }
+};
+
+TEST_F(CollStatsDeviceBlockGpuTest, ConcurrentRecordAccumulatesOnDevice) {
+  const uint32_t capacity = 64;
+  const uint32_t numSlots = 4;
+  const uint32_t numDistinctKeys = 5;
+  const uint32_t numBlocks = 200;
+  const uint64_t baseNs = 1'000'000; // 1 ms
+
+  CollStatsDeviceBlockHandle h = collStatsAllocDeviceBlock(capacity, numSlots);
+  ASSERT_NE(h.dev, nullptr);
+
+  recordKernel<<<numBlocks, 32>>>(h.dev, numDistinctKeys, baseNs);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  CollStatsDeviceBlock hostBlock{};
+  ASSERT_EQ(
+      cudaMemcpy(
+          &hostBlock,
+          h.dev,
+          sizeof(CollStatsDeviceBlock),
+          cudaMemcpyDeviceToHost),
+      cudaSuccess);
+  // The readback is the only coverage the publish step has: the block the
+  // device actually sees must carry the capacity, slot count and device
+  // pointers the allocator was asked for, not just be copyable.
+  EXPECT_EQ(hostBlock.bank.numKeys, capacity);
+  EXPECT_EQ(hostBlock.numSlots, numSlots);
+  EXPECT_EQ(hostBlock.bank.values[0], h.values[0]);
+  EXPECT_EQ(hostBlock.bank.values[1], h.values[1]);
+  EXPECT_EQ(hostBlock.span, h.span);
+  EXPECT_EQ(
+      hostBlock.hist.numBuckets, collStatDefaultHistGeometry().numBuckets);
+  EXPECT_EQ(hostBlock.numThresholds, kMaxThresholds);
+
+  const std::vector<CollStatValue> values = readValues(h, capacity);
+
+  uint64_t totalCount = 0;
+  uint64_t totalHistogram = 0;
+  for (const auto& v : values) {
+    totalCount += v.count;
+    for (uint32_t b = 0; b < kHistMaxBuckets; ++b) {
+      totalHistogram += v.histogram[b];
+    }
+  }
+  EXPECT_EQ(totalCount, numBlocks);
+  EXPECT_EQ(totalHistogram, numBlocks);
+
+  collStatsFreeDeviceBlock(h);
+}
+
+// Mirrors the collective kernel's use of the span: every block records its
+// start on entry, then after a block-wide barrier the elected thread finalizes;
+// the last block to arrive records one observation.
+// `threadIdx.x == 0` is deliberately the caller's whole election: it is the
+// idiom every instrumented collective uses, so the span helpers must be correct
+// under it for any block shape.
+__global__ void spanKernel(
+    CollStatsDeviceBlock* block,
+    uint32_t slot,
+    uint32_t keyId,
+    uint64_t logicalBytes) {
+  collStatsSpanEntry(block, slot);
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    collStatsSpanFinalizeElectedById(block, slot, keyId, logicalBytes);
+  }
+}
+
+// Byte offsets rather than &h.span[slot].arrived: the latter is host code
+// forming an address inside a device allocation, which sanitizers flag even
+// though it never dereferences. collStatsEnqueuePreReset computes its addresses
+// the same way for the same reason.
+char* arrivedAddr(const CollStatsDeviceBlockHandle& h, uint32_t slot) {
+  return reinterpret_cast<char*>(h.span) +
+      static_cast<std::size_t>(slot) * sizeof(CollStatSpanScratch) +
+      offsetof(CollStatSpanScratch, arrived);
+}
+
+uint32_t readArrived(const CollStatsDeviceBlockHandle& h, uint32_t slot) {
+  uint32_t arrived = 0;
+  EXPECT_EQ(
+      cudaMemcpy(
+          &arrived,
+          arrivedAddr(h, slot),
+          sizeof(arrived),
+          cudaMemcpyDeviceToHost),
+      cudaSuccess);
+  return arrived;
+}
+
+void writeArrived(
+    const CollStatsDeviceBlockHandle& h,
+    uint32_t slot,
+    uint32_t value) {
+  EXPECT_EQ(
+      cudaMemcpy(
+          arrivedAddr(h, slot), &value, sizeof(value), cudaMemcpyHostToDevice),
+      cudaSuccess);
+}
+
+uint64_t totalCount(const std::vector<CollStatValue>& values) {
+  uint64_t total = 0;
+  for (const auto& v : values) {
+    total += v.count;
+  }
+  return total;
+}
+
+TEST_F(CollStatsDeviceBlockGpuTest, SpanRecordsOneObservationPerLaunch) {
+  const uint32_t capacity = 64;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/4);
+  ASSERT_NE(h.dev, nullptr);
+
+  // Value slot 0, as the host registry would have resolved it.
+  constexpr uint32_t kKeyId = 0;
+
+  // Mirror the launch path: a stream-ordered pre-reset before each collective.
+  // The finalizer emits only, so the pre-reset owns slot cleanup.
+  collStatsEnqueuePreReset(h, /*slot=*/0, /*stream=*/0);
+  spanKernel<<<16, 64>>>(h.dev, /*slot=*/0, kKeyId, 4096);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(totalCount(readValues(h, capacity)), 1u);
+
+  // A second collective, again pre-reset, records again.
+  collStatsEnqueuePreReset(h, /*slot=*/0, /*stream=*/0);
+  spanKernel<<<16, 64>>>(h.dev, /*slot=*/0, kKeyId, 4096);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  const std::vector<CollStatValue> values = readValues(h, capacity);
+  EXPECT_EQ(totalCount(values), 2u);
+
+  uint64_t maxDur = 0;
+  for (const auto& v : values) {
+    maxDur = v.durMaxNs > maxDur ? v.durMaxNs : maxDur;
+  }
+  EXPECT_GT(maxDur, 0u);
+  EXPECT_LT(maxDur, 1'000'000'000ull); // well under a second
+
+  collStatsFreeDeviceBlock(h);
+}
+
+// An aborted sequence — entry without a finalize (e.g. fewer blocks than
+// gridDim, or a kernel that returns early) — leaves the slot dirty. The
+// stream-ordered pre-reset must clean it so the next collective still records a
+// correct span. This is the property the old finalizer self-reset could not
+// give.
+__global__ void spanEntryOnlyKernel(CollStatsDeviceBlock* block) {
+  collStatsSpanEntry(block, /*slot=*/0);
+}
+
+TEST_F(CollStatsDeviceBlockGpuTest, PreResetRecoversFromAbortedSequence) {
+  const uint32_t capacity = 64;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/4);
+  ASSERT_NE(h.dev, nullptr);
+
+  constexpr uint32_t kKeyId = 0;
+
+  // Aborted sequence: blocks record entry but never finalize, so arrived is
+  // left nonzero and start holds a stale minimum.
+  spanEntryOnlyKernel<<<16, 64>>>(h.dev);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  // The successor's pre-reset cleans the slot; the full sequence then records
+  // exactly one observation with a plausible positive duration.
+  collStatsEnqueuePreReset(h, /*slot=*/0, /*stream=*/0);
+  spanKernel<<<16, 64>>>(h.dev, /*slot=*/0, kKeyId, 4096);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  const std::vector<CollStatValue> values = readValues(h, capacity);
+  EXPECT_EQ(totalCount(values), 1u);
+  uint64_t maxDur = 0;
+  for (const auto& v : values) {
+    maxDur = v.durMaxNs > maxDur ? v.durMaxNs : maxDur;
+  }
+  EXPECT_GT(maxDur, 0u);
+  EXPECT_LT(maxDur, 1'000'000'000ull);
+
+  collStatsFreeDeviceBlock(h);
+}
+
+// The comm allocates a single span slot, because OrderedWorkStreamGuard leaves
+// only one instrumented collective live at a time. Anything asking for a slot
+// past that must be a no-op rather than scribbling past the allocation.
+TEST_F(CollStatsDeviceBlockGpuTest, PreResetIgnoresOutOfRangeSlot) {
+  const uint32_t capacity = 8;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/1);
+  ASSERT_NE(h.dev, nullptr);
+
+  // Dirty the one real slot so an out-of-range reset landing there would show.
+  collStatsEnqueuePreReset(h, /*slot=*/0, /*stream=*/0);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  const uint32_t arrived = 7;
+  writeArrived(h, /*slot=*/0, arrived);
+
+  collStatsEnqueuePreReset(h, /*slot=*/1, /*stream=*/0);
+  collStatsEnqueuePreReset(h, /*slot=*/~0u, /*stream=*/0);
+  // A null handle is a no-op too (instrumentation off).
+  CollStatsDeviceBlockHandle none{};
+  collStatsEnqueuePreReset(none, /*slot=*/0, /*stream=*/0);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+
+  EXPECT_EQ(readArrived(h, /*slot=*/0), arrived)
+      << "slot 0 untouched by the out-of-range and null-handle resets";
+
+  collStatsFreeDeviceBlock(h);
+}
+
+// The finalizer elects internally, so a caller using the 1-D idiom in a 2-D
+// block still contributes exactly one arrival per block. Asserted on `arrived`
+// rather than on the duration because it is deterministic: without the internal
+// election this reads gridDim * blockDim.y, the equality fires while most
+// blocks are still running, and the recorded span is plausible but far too
+// short -- a wrong number rather than a missing one.
+TEST_F(CollStatsDeviceBlockGpuTest, SpanElectsInternallyInAMultiDimBlock) {
+  const uint32_t capacity = 64;
+  const uint32_t numBlocks = 16;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/4);
+  ASSERT_NE(h.dev, nullptr);
+
+  collStatsEnqueuePreReset(h, /*slot=*/0, /*stream=*/0);
+  // 64x2: the y dimension is what a caller electing on threadIdx.x alone
+  // misses.
+  spanKernel<<<numBlocks, dim3(64, 2, 1)>>>(
+      h.dev, /*slot=*/0, /*keyId=*/0, 4096);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  EXPECT_EQ(readArrived(h, /*slot=*/0), numBlocks);
+
+  const std::vector<CollStatValue> values = readValues(h, capacity);
+  EXPECT_EQ(totalCount(values), 1u);
+
+  collStatsFreeDeviceBlock(h);
+}
+
+// The device span helpers bound the slot themselves. The host pre-reset already
+// does, but only the device side turns a bad slot into a write past the span
+// allocation rather than a lost observation.
+TEST_F(CollStatsDeviceBlockGpuTest, SpanIgnoresOutOfRangeSlotOnDevice) {
+  const uint32_t capacity = 64;
+  const uint32_t numSlots = 4;
+  CollStatsDeviceBlockHandle h = collStatsAllocDeviceBlock(capacity, numSlots);
+  ASSERT_NE(h.dev, nullptr);
+
+  spanKernel<<<16, 64>>>(h.dev, /*slot=*/numSlots, /*keyId=*/0, 4096);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+
+  const std::vector<CollStatValue> values = readValues(h, capacity);
+  EXPECT_EQ(totalCount(values), 0u) << "an out-of-range slot records nothing";
+  // The in-range slots are untouched, so the bad slot did not alias one.
+  for (uint32_t s = 0; s < numSlots; ++s) {
+    EXPECT_EQ(readArrived(h, s), 0u);
+  }
+
+  collStatsFreeDeviceBlock(h);
+}
+
+__global__ void recordAtKeyKernel(CollStatsDeviceBlock* block, uint32_t keyId) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    collStatsRecordById(block, keyId, /*durNs=*/5'000, /*logicalBytes=*/64);
+  }
+}
+
+// A key id past the registry's capacity is clamped onto the trailing catch-all
+// slot. This is the only branch in collStatsRecordById, and it is what keeps a
+// saturated registry losing attribution rather than indexing past the bank.
+TEST_F(CollStatsDeviceBlockGpuTest, RecordClampsIdsPastCapacityToCatchAll) {
+  const uint32_t capacity = 8;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/1);
+  ASSERT_NE(h.dev, nullptr);
+
+  recordAtKeyKernel<<<1, 32>>>(h.dev, /*keyId=*/capacity + 5);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  const std::vector<CollStatValue> values = readValues(h, capacity);
+
+  EXPECT_EQ(values[capacity].count, 1u) << "catch-all is the trailing slot";
+  for (uint32_t i = 0; i < capacity; ++i) {
+    EXPECT_EQ(values[i].count, 0u) << "no real key was charged, i=" << i;
+  }
+
+  collStatsFreeDeviceBlock(h);
+}
+
+// The owner is the only thing that frees a block, so its move paths decide
+// between a double free and a leak. A moved-from owner must be empty, and
+// self-assignment must not free the block it is about to keep.
+TEST_F(CollStatsDeviceBlockGpuTest, OwnerMovesWithoutDoubleFree) {
+  CollStatsDeviceBlockOwner a{
+      collStatsAllocDeviceBlock(/*keyCapacity=*/8, /*numSlots=*/1)};
+  ASSERT_TRUE(a.valid());
+  const CollStatsDeviceBlock* dev = a.handle().dev;
+
+  CollStatsDeviceBlockOwner b{std::move(a)};
+  EXPECT_TRUE(b.valid());
+  EXPECT_EQ(b.handle().dev, dev);
+  EXPECT_FALSE(a.valid()) << "moved-from owner must not free the block again";
+
+  // Through a reference, so this is a real self-assignment rather than one the
+  // compiler diagnoses and folds away.
+  CollStatsDeviceBlockOwner& alias = b;
+  b = std::move(alias);
+  EXPECT_TRUE(b.valid()) << "self-assignment kept the block";
+  EXPECT_EQ(b.handle().dev, dev);
+
+  {
+    CollStatsDeviceBlockOwner empty;
+  }
+  EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+}
+
+// Every rejection path guards a fixed-capacity device array against an
+// out-of-range index, so each must report a null handle -- leaving
+// instrumentation off -- rather than hand back a block that would be indexed
+// past its own allocation.
+TEST_F(CollStatsDeviceBlockGpuTest, AllocRejectsWhatItCannotBound) {
+  // keyCapacity + 1 is the value-slot count, so UINT32_MAX wraps it to zero.
+  EXPECT_EQ(collStatsAllocDeviceBlock(UINT32_MAX, /*numSlots=*/1).dev, nullptr);
+
+  // A zero-slot block would leave every span entry addressing nothing.
+  EXPECT_EQ(
+      collStatsAllocDeviceBlock(/*keyCapacity=*/8, /*numSlots=*/0).dev,
+      nullptr);
+
+  // A count too small for its own bounds: logBucketNs derives the index from
+  // the tMin/tMax/sub-bucket triple, not from numBuckets, so this passes a
+  // range check and still indexes past histogram[].
+  CollStatsBlockConfig understatedBuckets = collStatDefaultBlockConfig();
+  understatedBuckets.hist.numBuckets -= 1;
+  EXPECT_EQ(
+      collStatsAllocDeviceBlock(
+          /*keyCapacity=*/8, /*numSlots=*/1, understatedBuckets)
+          .dev,
+      nullptr);
+
+  // tMinNs == 0 makes log2(dur / tMinNs) infinite and the cast to an index
+  // undefined; the re-derivation reports zero buckets and the alloc refuses.
+  CollStatsBlockConfig zeroTMin = collStatDefaultBlockConfig();
+  zeroTMin.hist.tMinNs = 0;
+  EXPECT_EQ(
+      collStatsAllocDeviceBlock(/*keyCapacity=*/8, /*numSlots=*/1, zeroTMin)
+          .dev,
+      nullptr);
+
+  // More thresholds than the device-resident array holds.
+  CollStatsBlockConfig tooManyThresholds = collStatDefaultBlockConfig();
+  tooManyThresholds.numThresholds = kMaxThresholds + 1;
+  EXPECT_EQ(
+      collStatsAllocDeviceBlock(
+          /*keyCapacity=*/8, /*numSlots=*/1, tooManyThresholds)
+          .dev,
+      nullptr);
+}
+
+} // namespace
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/tests/CollStatsReaderGpuTest.cu
+++ b/comms/utils/collstats/tests/CollStatsReaderGpuTest.cu
@@ -1,0 +1,367 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cstdint>
+#include <vector>
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include "comms/utils/collstats/CollStatsDeviceBlock.h"
+#include "comms/utils/collstats/CollStatsKeyRegistry.h"
+#include "comms/utils/collstats/CollStatsReader.h"
+#include "comms/utils/collstats/CollStatsSpan.cuh"
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+namespace meta::comms::collstats {
+namespace {
+
+// Records one observation per launch through the span, exactly as the
+// instrumented collective kernel does: the value slot arrives as a kernel
+// argument, already resolved on the host.
+__global__ void
+spanKernel(CollStatsDeviceBlock* block, uint32_t keyId, uint64_t logicalBytes) {
+  collStatsSpanEntry(block, /*slot=*/0);
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    collStatsSpanFinalizeElectedById(block, /*slot=*/0, keyId, logicalBytes);
+  }
+}
+
+uint64_t totalCount(const std::vector<CollStatValue>& values) {
+  uint64_t total = 0;
+  for (const auto& v : values) {
+    total += v.count;
+  }
+  return total;
+}
+
+TEST(CollStatsReaderGpuTest, WindowReadoutIsPerWindowAndZeroesRetiredBank) {
+  int deviceCount = 0;
+  if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount == 0) {
+    GTEST_SKIP() << "no CUDA device";
+  }
+
+  const uint32_t capacity = 64;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/4);
+  ASSERT_NE(h.dev, nullptr);
+
+  cudaStream_t stream;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+  CollStatsKeyRegistry keys(capacity);
+  const uint32_t id = keys.resolve(
+      CollStatKey{
+          CollStatOp::AllReduce,
+          CollStatAlgo::Direct,
+          CollStatProto::Unknown,
+          7u,
+          3u});
+
+  // Window 0: three collectives, each preceded by its stream-ordered pre-reset
+  // (the finalizer emits only, so the pre-reset owns slot cleanup).
+  for (int i = 0; i < 3; ++i) {
+    collStatsEnqueuePreReset(h, /*slot=*/0, stream);
+    spanKernel<<<8, 64, 0, stream>>>(h.dev, id, 4096);
+  }
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+  const CollStatSnapshot w0 = collStatsReadWindow(h, stream, keys);
+  // Only the occupied prefix is transferred, not the bank's capacity.
+  EXPECT_EQ(w0.numKeys, 1u);
+  EXPECT_EQ(w0.values.size(), 2u); // one key plus the catch-all
+  EXPECT_EQ(totalCount(w0.values), 3u);
+  EXPECT_EQ(w0.catchAllCount, 0u);
+
+  // Window 1: two collectives land in the flipped-to bank. The retired bank was
+  // zeroed, so this window must report only the new two, not five.
+  for (int i = 0; i < 2; ++i) {
+    collStatsEnqueuePreReset(h, /*slot=*/0, stream);
+    spanKernel<<<8, 64, 0, stream>>>(h.dev, id, 4096);
+  }
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+  const CollStatSnapshot w1 = collStatsReadWindow(h, stream, keys);
+  EXPECT_EQ(totalCount(w1.values), 2u);
+  EXPECT_EQ(w1.windowEpoch, w0.windowEpoch + 1); // epoch advanced once per read
+
+  // An immediate re-read with no intervening collectives sees an empty window.
+  const CollStatSnapshot w2 = collStatsReadWindow(h, stream, keys);
+  EXPECT_EQ(totalCount(w2.values), 0u);
+
+  cudaStreamDestroy(stream);
+  collStatsFreeDeviceBlock(h);
+}
+
+TEST(CollStatsReaderGpuTest, SnapshotPairsValuesWithRecordedKey) {
+  int deviceCount = 0;
+  if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount == 0) {
+    GTEST_SKIP() << "no CUDA device";
+  }
+
+  const uint32_t capacity = 64;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/4);
+  ASSERT_NE(h.dev, nullptr);
+
+  cudaStream_t stream;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+  CollStatsKeyRegistry keys(capacity);
+  const uint32_t idA = keys.resolve(
+      CollStatKey{
+          CollStatOp::AllReduce,
+          CollStatAlgo::Direct,
+          CollStatProto::Unknown,
+          7u,
+          3u});
+  const uint32_t idB = keys.resolve(
+      CollStatKey{
+          CollStatOp::AllGather,
+          CollStatAlgo::Ring,
+          CollStatProto::Unknown,
+          2u,
+          9u});
+
+  collStatsEnqueuePreReset(h, /*slot=*/0, stream);
+  spanKernel<<<8, 64, 0, stream>>>(h.dev, idA, 4096);
+  collStatsEnqueuePreReset(h, /*slot=*/0, stream);
+  spanKernel<<<8, 64, 0, stream>>>(h.dev, idB, 8192);
+  collStatsEnqueuePreReset(h, /*slot=*/0, stream);
+  spanKernel<<<8, 64, 0, stream>>>(h.dev, idB, 8192);
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+  const CollStatSnapshot snap = collStatsReadWindow(h, stream, keys);
+
+  // values[i] and keys[i] describe the same key, and the counts follow the id
+  // each observation was launched with.
+  ASSERT_EQ(snap.numKeys, 2u);
+  ASSERT_EQ(snap.keys.size(), 2u);
+  EXPECT_EQ(snap.keys[idA].op, CollStatOp::AllReduce);
+  EXPECT_EQ(snap.keys[idA].dtype, 7u);
+  EXPECT_EQ(snap.keys[idA].sizeClass, 3u);
+  EXPECT_EQ(snap.values[idA].count, 1u);
+
+  EXPECT_EQ(snap.keys[idB].op, CollStatOp::AllGather);
+  EXPECT_EQ(snap.keys[idB].algorithm, CollStatAlgo::Ring);
+  EXPECT_EQ(snap.values[idB].count, 2u);
+
+  // Nothing saturated, so the trailing catch-all slot stayed empty.
+  EXPECT_EQ(snap.values[snap.numKeys].count, 0u);
+
+  cudaStreamDestroy(stream);
+  collStatsFreeDeviceBlock(h);
+}
+
+// Keys past capacity share the trailing slot, and their observations are still
+// recorded rather than dropped.
+TEST(CollStatsReaderGpuTest, SaturatedKeysLandInTheCatchAll) {
+  int deviceCount = 0;
+  if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount == 0) {
+    GTEST_SKIP() << "no CUDA device";
+  }
+
+  const uint32_t capacity = 2;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/4);
+  ASSERT_NE(h.dev, nullptr);
+
+  cudaStream_t stream;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+  CollStatsKeyRegistry keys(capacity);
+  keys.resolve(
+      CollStatKey{
+          CollStatOp::AllReduce,
+          CollStatAlgo::Direct,
+          CollStatProto::Unknown,
+          1u,
+          1u});
+  keys.resolve(
+      CollStatKey{
+          CollStatOp::AllReduce,
+          CollStatAlgo::Direct,
+          CollStatProto::Unknown,
+          2u,
+          2u});
+  const uint32_t overflow = keys.resolve(
+      CollStatKey{
+          CollStatOp::AllReduce,
+          CollStatAlgo::Direct,
+          CollStatProto::Unknown,
+          3u,
+          3u});
+  ASSERT_EQ(overflow, keys.catchAllId());
+
+  // No pre-reset, unlike the other cases here: this is the block's first
+  // collective, so the slot still holds the sentinel the allocation wrote. The
+  // pre-reset exists to clean a slot a predecessor left dirty, and there is no
+  // predecessor.
+  spanKernel<<<8, 64, 0, stream>>>(h.dev, overflow, 4096);
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+  const CollStatSnapshot snap = collStatsReadWindow(h, stream, keys);
+  EXPECT_EQ(snap.numKeys, capacity);
+  EXPECT_EQ(snap.values[snap.numKeys].count, 1u);
+  EXPECT_EQ(snap.catchAllCount, 1u);
+
+  cudaStreamDestroy(stream);
+  collStatsFreeDeviceBlock(h);
+}
+
+// The event-gated readout must order correctly across the instrumented stream
+// and the reader stream with no manual sync between phases: the reader waits
+// the instrumented stream's finalizers before copying, and post-flip
+// collectives are gated into the new bank. Running to completion also proves
+// the cross-stream waits do not deadlock.
+TEST(CollStatsReaderGpuTest, GatedReadoutOrdersAcrossStreamsWithoutManualSync) {
+  int deviceCount = 0;
+  if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount == 0) {
+    GTEST_SKIP() << "no CUDA device";
+  }
+
+  const uint32_t capacity = 64;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/4);
+  ASSERT_NE(h.dev, nullptr);
+
+  cudaStream_t instrumented;
+  cudaStream_t reader;
+  ASSERT_EQ(cudaStreamCreate(&instrumented), cudaSuccess);
+  ASSERT_EQ(cudaStreamCreate(&reader), cudaSuccess);
+  cudaEvent_t streamEvent;
+  cudaEvent_t flipEvent;
+  ASSERT_EQ(cudaEventCreate(&streamEvent), cudaSuccess);
+  ASSERT_EQ(cudaEventCreate(&flipEvent), cudaSuccess);
+
+  const cudaEvent_t streamEvents[1] = {streamEvent};
+  CollStatsReadGating gating{};
+  gating.instrumentedStreams = &instrumented;
+  gating.streamEvents = streamEvents;
+  gating.numStreams = 1;
+  gating.flipEvent = flipEvent;
+
+  CollStatsKeyRegistry keys(capacity);
+  const uint32_t id = keys.resolve(
+      CollStatKey{
+          CollStatOp::AllReduce,
+          CollStatAlgo::Direct,
+          CollStatProto::Unknown,
+          7u,
+          3u});
+
+  // Window 0: three collectives on the instrumented stream, left un-synced. The
+  // gated readout must itself order the copy after them.
+  for (int i = 0; i < 3; ++i) {
+    collStatsEnqueuePreReset(h, /*slot=*/0, instrumented);
+    spanKernel<<<8, 64, 0, instrumented>>>(h.dev, id, 4096);
+  }
+  const CollStatSnapshot w0 = collStatsReadWindow(h, reader, keys, &gating);
+  EXPECT_EQ(totalCount(w0.values), 3u);
+
+  // Window 1: two more collectives, gated into the new bank by the flip event.
+  for (int i = 0; i < 2; ++i) {
+    collStatsEnqueuePreReset(h, /*slot=*/0, instrumented);
+    spanKernel<<<8, 64, 0, instrumented>>>(h.dev, id, 4096);
+  }
+  const CollStatSnapshot w1 = collStatsReadWindow(h, reader, keys, &gating);
+  EXPECT_EQ(totalCount(w1.values), 2u);
+  EXPECT_EQ(w1.windowEpoch, w0.windowEpoch + 1);
+
+  ASSERT_EQ(cudaStreamSynchronize(instrumented), cudaSuccess);
+  cudaEventDestroy(streamEvent);
+  cudaEventDestroy(flipEvent);
+  cudaStreamDestroy(instrumented);
+  cudaStreamDestroy(reader);
+  collStatsFreeDeviceBlock(h);
+}
+
+// The async issue path must not synchronize: it records a copy-done event, and
+// the caller harvests the staging snapshot only after that event completes. The
+// caller-tracked epoch must select the correct retired bank each window.
+TEST(CollStatsReaderGpuTest, AsyncIssueHarvestsAfterCopyDoneEvent) {
+  int deviceCount = 0;
+  if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount == 0) {
+    GTEST_SKIP() << "no CUDA device";
+  }
+
+  const uint32_t capacity = 64;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/4);
+  ASSERT_NE(h.dev, nullptr);
+
+  cudaStream_t instrumented;
+  cudaStream_t reader;
+  ASSERT_EQ(cudaStreamCreate(&instrumented), cudaSuccess);
+  ASSERT_EQ(cudaStreamCreate(&reader), cudaSuccess);
+  cudaEvent_t streamEvent;
+  cudaEvent_t flipEvent;
+  cudaEvent_t copyDone;
+  ASSERT_EQ(cudaEventCreate(&streamEvent), cudaSuccess);
+  ASSERT_EQ(cudaEventCreate(&flipEvent), cudaSuccess);
+  ASSERT_EQ(cudaEventCreate(&copyDone), cudaSuccess);
+
+  const cudaEvent_t streamEvents[1] = {streamEvent};
+  CollStatsReadGating gating{};
+  gating.instrumentedStreams = &instrumented;
+  gating.streamEvents = streamEvents;
+  gating.numStreams = 1;
+  gating.flipEvent = flipEvent;
+
+  CollStatsKeyRegistry keys(capacity);
+  const uint32_t id = keys.resolve(
+      CollStatKey{
+          CollStatOp::AllReduce,
+          CollStatAlgo::Direct,
+          CollStatProto::Unknown,
+          7u,
+          3u});
+
+  CollStatsPinnedStaging staging; // reused across windows, like the driver's
+  ASSERT_TRUE(staging.allocate(capacity));
+  CollStatSnapshot snap;
+  uint64_t epoch = 0; // caller-tracked, in lockstep with the device flips
+
+  // Window 0: three collectives, then an async issue. Harvest after copyDone.
+  for (int i = 0; i < 3; ++i) {
+    collStatsEnqueuePreReset(h, /*slot=*/0, instrumented);
+    spanKernel<<<8, 64, 0, instrumented>>>(h.dev, id, 4096);
+  }
+  ASSERT_EQ(
+      collStatsIssueReadWindow(
+          h, reader, &gating, epoch, copyDone, staging, keys),
+      cudaSuccess);
+  ASSERT_EQ(cudaEventSynchronize(copyDone), cudaSuccess);
+  staging.publish(epoch, keys, h.cfg, snap);
+  ++epoch;
+  EXPECT_EQ(snap.numKeys, 1u);
+  EXPECT_EQ(snap.windowEpoch, 0u);
+  EXPECT_EQ(totalCount(snap.values), 3u);
+
+  // Window 1: two collectives; the tracked epoch selects the other retired
+  // bank.
+  for (int i = 0; i < 2; ++i) {
+    collStatsEnqueuePreReset(h, /*slot=*/0, instrumented);
+    spanKernel<<<8, 64, 0, instrumented>>>(h.dev, id, 4096);
+  }
+  ASSERT_EQ(
+      collStatsIssueReadWindow(
+          h, reader, &gating, epoch, copyDone, staging, keys),
+      cudaSuccess);
+  ASSERT_EQ(cudaEventSynchronize(copyDone), cudaSuccess);
+  staging.publish(epoch, keys, h.cfg, snap);
+  ++epoch;
+  EXPECT_EQ(snap.windowEpoch, 1u);
+  EXPECT_EQ(totalCount(snap.values), 2u);
+
+  ASSERT_EQ(cudaStreamSynchronize(instrumented), cudaSuccess);
+  cudaEventDestroy(streamEvent);
+  cudaEventDestroy(flipEvent);
+  cudaEventDestroy(copyDone);
+  cudaStreamDestroy(instrumented);
+  cudaStreamDestroy(reader);
+  collStatsFreeDeviceBlock(h);
+}
+
+} // namespace
+} // namespace meta::comms::collstats


### PR DESCRIPTION
Summary:

Nothing could pull a window of the device-resident collective stats to the host without synchronizing the training stream. This adds that readout.

On a dedicated reader stream: wait for the previous window's finalizers on each instrumented stream, flip the epoch, gate new launches behind the flip so they write the other bank, copy the retired bank device-to-host, then zero it. Each bank holds exactly one window, so the host never subtracts cumulative counters, and the retired bank is quiescent between flip and copy rather than merely ordered after it. Gating is optional -- with a null gating struct the flip is unordered against producers.

- `collStatsReadWindow` synchronizes and returns the snapshot; `collStatsIssueReadWindow` records a copy-done event instead, so a pipelined caller harvests on a later tick.
- A snapshot carries the configuration it was produced under -- histogram geometry, threshold cut-points, size-class edges -- and not just the counters. A key's `sizeClass` is an index into those edges and both they and the geometry are configurable, so a window that did not carry them could not be turned back into byte bounds or bucket edges once it left the process.
- Staging is page-locked out of necessity: a device-to-host `cudaMemcpyAsync` into pageable memory blocks the caller until the stream drains, which would make the async path not async.
- Only the claimed-key prefix plus the trailing catch-all is copied, not the full capacity; both entry points reject a key count above the block's capacity.
- After a failure past the flip, the synchronous path zeroes the retired bank best-effort, so its counts do not become the next window's opening balance. The async path has no such recovery.

Reviewed By: rmahidhar

Differential Revision: D113661117


