### PR TITLE
Close out review findings on the device block and reader (#3958)

### DIFF
--- a/comms/utils/collstats/CollStatsDeviceBlock.cc
+++ b/comms/utils/collstats/CollStatsDeviceBlock.cc
@@ -81,8 +81,11 @@ CollStatsDeviceBlockHandle collStatsAllocDeviceBlock(
   // log2(dur / tMinNs) infinite and the cast to a bucket index undefined.
   const CollStatHistGeometry derived = collStatMakeHistGeometry(
       cfg.hist.tMinNs, cfg.hist.tMaxNs, cfg.hist.subBucketsPerOctave);
+  // sizeClasses stays host-side, but sizeClassOf() still walks `i < sc.n` over
+  // a fixed-capacity edges[].
   if (derived.numBuckets == 0 || derived.numBuckets != cfg.hist.numBuckets ||
-      cfg.numThresholds > kMaxThresholds) {
+      cfg.numThresholds > kMaxThresholds ||
+      cfg.sizeClasses.n > kMaxSizeClasses) {
     return CollStatsDeviceBlockHandle{};
   }
   // A zero-slot block allocates nothing for the span scratch but still reports

--- a/comms/utils/collstats/CollStatsReader.cu
+++ b/comms/utils/collstats/CollStatsReader.cu
@@ -309,23 +309,16 @@ CollStatSnapshot collStatsReadWindow(
       // Left resident, its counts become the next window's starting balance and
       // inflate it. Best-effort: a stream wedged badly enough to fail above
       // will fail here too, and then the counts are unrecoverable either way.
-      // Return values are consumed to satisfy HIP's nodiscard on
-      // hipMemsetAsync/hipStreamSynchronize; the recovery is best-effort, so
-      // there is nothing to do with a failure here.
+      // Return value is consumed to satisfy HIP's nodiscard on hipMemsetAsync.
       [[maybe_unused]] const cudaError_t e0 = cudaMemsetAsync(
           handle.values[currentEpoch & 1u],
           0,
           static_cast<std::size_t>(handle.keyCapacity + 1) *
               sizeof(CollStatValue),
           readerStream);
-      [[maybe_unused]] const cudaError_t e1 =
-          cudaStreamSynchronize(readerStream);
     }
-    // `staging` is freed on the way out of this scope, and the failure may have
-    // been the synchronize above with both D2H copies already enqueued -- so
-    // drain before the pinned buffer they land in goes away. Best-effort, and
-    // deliberately not relying on cudaFreeHost's implicit synchronize, which is
-    // an implementation detail rather than a documented barrier.
+    // The failure can be the synchronize itself, leaving the D2H copies in
+    // flight into `staging`, which is freed on scope exit.
     [[maybe_unused]] const cudaError_t drained =
         cudaStreamSynchronize(readerStream);
     return CollStatSnapshot{};

--- a/comms/utils/collstats/tests/CollStatsDeviceBlockGpuTest.cu
+++ b/comms/utils/collstats/tests/CollStatsDeviceBlockGpuTest.cu
@@ -43,6 +43,19 @@ class CollStatsDeviceBlockGpuTest : public ::testing::Test {
     if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount == 0) {
       GTEST_SKIP() << "no CUDA device";
     }
+    // The span helpers are behind __CUDA_ARCH__ >= 900; below Hopper they are
+    // no-ops and every span assertion here passes vacuously.
+    int major = 0;
+    int device = 0;
+    if (cudaGetDevice(&device) != cudaSuccess ||
+        cudaDeviceGetAttribute(
+            &major, cudaDevAttrComputeCapabilityMajor, device) != cudaSuccess) {
+      GTEST_SKIP() << "cannot query compute capability";
+    }
+    if (major < 9) {
+      GTEST_SKIP() << "span helpers are compiled out below sm_90; device is sm_"
+                   << major << "x";
+    }
   }
 
   // The retired bank is always read back whole, so the copy and its sizing live
@@ -200,6 +213,40 @@ TEST_F(CollStatsDeviceBlockGpuTest, SpanRecordsOneObservationPerLaunch) {
   }
   EXPECT_GT(maxDur, 0u);
   EXPECT_LT(maxDur, 1'000'000'000ull); // well under a second
+
+  collStatsFreeDeviceBlock(h);
+}
+
+// Every block arrives, satisfying the barrier, but nothing ever sets `start`.
+__global__ void spanFinalizeOnlyKernel(
+    CollStatsDeviceBlock* block,
+    uint32_t keyId) {
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    collStatsSpanFinalizeElectedById(block, /*slot=*/0, keyId, 4096);
+  }
+}
+
+// `end - kSpanStartInit` wraps to `end + 1`: a sub-microsecond duration that
+// buckets as a real, very fast collective. The finalizer drops it instead.
+TEST_F(CollStatsDeviceBlockGpuTest, FinalizeWithoutEntryRecordsNothing) {
+  const uint32_t capacity = 64;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/4);
+  ASSERT_NE(h.dev, nullptr);
+
+  // No pre-reset, so `start` is still the allocator's sentinel.
+  spanFinalizeOnlyKernel<<<16, 64>>>(h.dev, /*keyId=*/0);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+
+  const std::vector<CollStatValue> values = readValues(h, capacity);
+  EXPECT_EQ(totalCount(values), 0u);
+  uint64_t maxDur = 0;
+  for (const auto& v : values) {
+    maxDur = v.durMaxNs > maxDur ? v.durMaxNs : maxDur;
+  }
+  EXPECT_EQ(maxDur, 0u);
 
   collStatsFreeDeviceBlock(h);
 }


### PR DESCRIPTION
Summary:

Follow-ups to the two base diffs, which had already been shipped when these came back from review. Four fixes and one test, all small and independent.

- `collStatsAllocDeviceBlock` bounded `numThresholds` against its array capacity but not `sizeClasses.n`. `sizeClassOf` walks `i < sc.n` over a fixed-capacity `edges[]`, so an oversized `n` reads past it on the host path that resolves a window's size-class labels. Checked in the same expression as its sibling.
- The span helpers are all behind `__CUDA_ARCH__ >= 900`, so on a pre-Hopper device they compile to no-ops and every span assertion in the GPU test holds vacuously -- a green run that tested nothing. The fixture now skips on compute capability, not just on the presence of a device.
- `-D__HIP_PLATFORM_AMD__` was set only in `preprocessor_flags`, which covers this target's own sources. `CollStatsDeviceBlock.h` and `CollStatsSpan.cuh` are exported and pull in `cuda_runtime.h`, so dependents compiled the same headers without the define; it is now propagated too, matching the pattern `nccl_build_config.bzl` uses for the same reason.
- `collStatsReadWindow`'s failure path synchronized the reader stream twice when the flip had happened and once when it had not, which was backwards -- the unconditional drain exists precisely for the case where the copies are already in flight. One drain now covers both reasons to need it.

The test is for the sentinel guard in the span finalizer, the one invariant in that file that had none. A finalize with no entry leaves `start` at `UINT64_MAX`, and `end - UINT64_MAX` wraps to `end + 1`: a sub-microsecond duration that lands in the underflow bucket and reads as a real, very fast collective. Dropping it is what makes a fence or pre-reset bug surface as a missing observation rather than a believable wrong one.

Reviewed By: Scusemua

Differential Revision: D118514769


