### PR TITLE
Stabilize CUDA wheel builds

### DIFF
--- a/scripts/_build_wheel.sh
+++ b/scripts/_build_wheel.sh
@@ -35,10 +35,11 @@ export CLEAN_BUILD=1
 # environment's dependency installation.
 export CXXSTD="-std=c++20"
 export NCCL_PATCH_FMT_NVCC_CXX20=1
-# NCCLX device compilation can exhaust memory at full host parallelism.
-# Lower to 8 to avoid OOM on g5.12xlarge self-hosted runners for old CUDA
-# builders (cu126/cu130) that have been hitting "lost communication" during
-# device kernel compilation.
+# CUDA device compilation can exhaust memory at full host parallelism. The
+# NCCLX build runs during CMake configuration, before the top-level build, so
+# cap both sequential phases independently. Four-way parallelism makes the
+# AArch64 wheel builds exceed their two-hour timeout.
+export CMAKE_BUILD_PARALLEL_LEVEL=8
 export NCCL_BUILD_JOBS=8
 
 python setup.py bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,21 @@ class build_ext(build_ext_orig):
             f"-DUSE_TRANSPORT_CCA_HOOK={flag_str(USE_TRANSPORT_CCA_HOOK)}",
             f"-DUSE_TRITON={flag_str(USE_TRITON)}",
         ]
-        build_args = ["--", "-j"]
+        parallel_level = os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", "").strip()
+        if parallel_level:
+            try:
+                parallel_jobs = int(parallel_level)
+            except ValueError as error:
+                raise ValueError(
+                    "CMAKE_BUILD_PARALLEL_LEVEL must be a positive integer"
+                ) from error
+            if parallel_jobs <= 0:
+                raise ValueError(
+                    "CMAKE_BUILD_PARALLEL_LEVEL must be a positive integer"
+                )
+            build_args = ["--parallel", str(parallel_jobs)]
+        else:
+            build_args = ["--", "-j"]
 
         os.chdir(str(build_temp))
         self.spawn(["cmake", str(cwd)] + cmake_args)


### PR DESCRIPTION
Summary:
TorchComms CUDA wheel builds used unbounded parallelism in the top-level CMake build, which could exhaust memory on self-hosted runners and surface as lost-runner failures.

Bound the sequential top-level CMake and nested NCCLX build phases to eight jobs. Normalize CMAKE_BUILD_PARALLEL_LEVEL and pass it explicitly to cmake --build; the historical unbounded behavior remains when the variable is unset. Four-way parallelism is intentionally avoided because all eight CUDA wheel builders reached the workflow timeout with that cap.

Reviewed By: shr, Scusemua

Differential Revision: D118530938


