### PR TITLE
Preserve runtime named logger routing

### DIFF
--- a/comms/ctran/utils/CtranLogUtils.h
+++ b/comms/ctran/utils/CtranLogUtils.h
@@ -35,7 +35,7 @@
       __VA_ARGS__)
 
 #define CTRAN_LOG_STREAM_EVERY_MS(level, ms) \
-  COMMS_LOG_NAMED_STREAM_EVERY_MS(::ctran::logging::kCtranLoggerName, level, ms)
+  COMMS_LOGGER_STREAM_EVERY_MS(::ctran::logging::getCtranLogger(), level, ms)
 
 #define CTRAN_LOG_TRACE(subsys, format, ...)                             \
   do {                                                                   \

--- a/comms/ctran/utils/CtranLogger.h
+++ b/comms/ctran/utils/CtranLogger.h
@@ -11,6 +11,12 @@ namespace ctran::logging {
 
 inline constexpr std::string_view kCtranLoggerName = "comms.ctran";
 
+inline meta::comms::logger::CommsSpdlogLogger& getCtranLogger() {
+  static auto& logger /* library-local */ =
+      meta::comms::logger::getSpdlogLogger(kCtranLoggerName);
+  return logger;
+}
+
 inline void configureStandaloneCtranLogging(
     spdlog::level::level_enum logLevel) {
   /*
@@ -53,10 +59,9 @@ inline void configureStandaloneCtranLogging(
   } while (false)
 #define CTRAN_LOG(level, ...) CTRAN_LOG_##level(__VA_ARGS__)
 #define CTRAN_LOG_STREAM_IF(level, condition) \
-  COMMS_LOG_NAMED_STREAM_IF(                  \
-      ::ctran::logging::kCtranLoggerName, level, condition)
+  COMMS_LOGGER_STREAM_IF(::ctran::logging::getCtranLogger(), level, condition)
 #define CTRAN_LOG_STREAM(level) \
-  COMMS_LOG_NAMED_STREAM(::ctran::logging::kCtranLoggerName, level)
+  COMMS_LOGGER_STREAM(::ctran::logging::getCtranLogger(), level)
 
 #define CTRAN_LOG_SYNC_ERR(...)                                          \
   do {                                                                   \

--- a/comms/ncclx/meta/NcclxLogUtils.h
+++ b/comms/ncclx/meta/NcclxLogUtils.h
@@ -19,7 +19,7 @@
       __VA_ARGS__)
 
 #define NCCLX_LOG_STREAM_EVERY_MS(level, ms) \
-  COMMS_LOG_NAMED_STREAM_EVERY_MS(::ncclx::logging::kNcclxLoggerName, level, ms)
+  COMMS_LOGGER_STREAM_EVERY_MS(::ncclx::logging::getNcclxLogger(), level, ms)
 
 #define NCCLX_ERR(code, ...)                                                  \
   do {                                                                        \

--- a/comms/ncclx/meta/NcclxLogger.h
+++ b/comms/ncclx/meta/NcclxLogger.h
@@ -11,6 +11,12 @@ namespace ncclx::logging {
 
 inline constexpr std::string_view kNcclxLoggerName = "comms.ncclx";
 
+inline meta::comms::logger::CommsSpdlogLogger& getNcclxLogger() {
+  static auto& logger /* library-local */ =
+      meta::comms::logger::getSpdlogLogger(kNcclxLoggerName);
+  return logger;
+}
+
 } // namespace ncclx::logging
 
 #define NCCLX_LOG_IMPL(spdlog_level, spdlog_macro, ...)                  \
@@ -40,10 +46,9 @@ inline constexpr std::string_view kNcclxLoggerName = "comms.ncclx";
   } while (false)
 #define NCCLX_LOG(level, ...) NCCLX_LOG_##level(__VA_ARGS__)
 #define NCCLX_LOG_STREAM_IF(level, condition) \
-  COMMS_LOG_NAMED_STREAM_IF(                  \
-      ::ncclx::logging::kNcclxLoggerName, level, condition)
+  COMMS_LOGGER_STREAM_IF(::ncclx::logging::getNcclxLogger(), level, condition)
 #define NCCLX_LOG_STREAM(level) \
-  COMMS_LOG_NAMED_STREAM(::ncclx::logging::kNcclxLoggerName, level)
+  COMMS_LOGGER_STREAM(::ncclx::logging::getNcclxLogger(), level)
 
 #define NCCLX_LOG_IF_IMPL(level, spdlog_level, condition, ...)           \
   do {                                                                   \

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -235,6 +235,19 @@ CommsSpdlogLogger& getSpdlogLogger(std::string_view loggerName);
 
 void reportCommsLoggingFailureToStderr(const char* level) noexcept;
 [[noreturn]] void abortAfterCommsLoggingFailure() noexcept;
+
+namespace detail {
+template <typename LoggerFactory>
+CommsSpdlogLogger& resolveLoggerForFatal(
+    LoggerFactory&& loggerFactory) noexcept {
+  try {
+    return std::forward<LoggerFactory>(loggerFactory)();
+  } catch (...) {
+    abortAfterCommsLoggingFailure();
+  }
+}
+} // namespace detail
+
 void shutdownSpdlogForFatal();
 /*
  * Terminal barrier for the comms logger state in this linkage image. It drains
@@ -416,7 +429,7 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
   COMMS_LOG_NAMED_##level(logger_name, __VA_ARGS__)
 
 #define COMMS_LOG_NAMED_STREAM_IMPL(logger_name, spdlog_level, condition) \
-  if (static auto& _comms_stream_logger =                                 \
+  if (auto& _comms_stream_logger =                                        \
           ::meta::comms::logger::getSpdlogLogger(logger_name);            \
       !_comms_stream_logger.should_log(spdlog_level) || !(condition)) {   \
   } else                                                                  \
@@ -427,7 +440,7 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
         .stream()
 
 #define COMMS_LOG_NAMED_FATAL_STREAM_IMPL(logger_name, condition)      \
-  if (static auto& _comms_stream_logger =                              \
+  if (auto& _comms_stream_logger =                                     \
           ::meta::comms::logger::getSpdlogLoggerForFatal(logger_name); \
       !(condition)) {                                                  \
   } else                                                               \
@@ -459,8 +472,9 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
   COMMS_LOG_NAMED_STREAM_IF_IMPL(logger_name, level, condition)
 #define COMMS_LOG_NAMED_STREAM(logger_name, level) \
   COMMS_LOG_NAMED_STREAM_IF(logger_name, level, true)
+
 #define COMMS_LOG_STREAM(level) \
-  COMMS_LOG_NAMED_STREAM(::meta::comms::logger::kCommsLoggerName, level)
+  COMMS_LOGGER_STREAM(::meta::comms::logger::getSpdlogLogger(), level)
 
 #define COMMS_LOG_RATE_LIMITABLE_DBG true
 #define COMMS_LOG_RATE_LIMITABLE_DBG5 true
@@ -487,8 +501,8 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
         return comms_log_stream_rate_limiter.check();                      \
       }())
 #define COMMS_LOG_STREAM_EVERY_MS(level, ms) \
-  COMMS_LOG_NAMED_STREAM_EVERY_MS(           \
-      ::meta::comms::logger::kCommsLoggerName, level, ms)
+  COMMS_LOGGER_STREAM_EVERY_MS(              \
+      ::meta::comms::logger::getSpdlogLogger(), level, ms)
 
 #define COMMS_LOGGER_STREAM_IMPL(logger_expression, spdlog_level, condition) \
   if (auto& _comms_stream_logger = (logger_expression);                      \
@@ -500,12 +514,17 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
         spdlog_level)                                                        \
         .stream()
 
-#define COMMS_LOGGER_FATAL_STREAM_IMPL(logger_expression, condition)    \
-  if (auto& _comms_stream_logger = (logger_expression); !(condition)) { \
-  } else                                                                \
-    ::meta::comms::logger::CommsFatalLogStream(                         \
-        _comms_stream_logger,                                           \
-        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION})      \
+#define COMMS_LOGGER_FATAL_STREAM_IMPL(logger_expression, condition) \
+  if (auto& _comms_stream_logger =                                   \
+          ::meta::comms::logger::detail::resolveLoggerForFatal(      \
+              [&]() -> ::meta::comms::logger::CommsSpdlogLogger& {   \
+                return (logger_expression);                          \
+              });                                                    \
+      !(condition)) {                                                \
+  } else                                                             \
+    ::meta::comms::logger::CommsFatalLogStream(                      \
+        _comms_stream_logger,                                        \
+        ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION})   \
         .stream()
 
 #define COMMS_LOGGER_STREAM_DBG_IF(logger_expression, condition) \

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -5,6 +5,7 @@
 
 #include "comms/utils/logger/SpdlogLogger.h"
 
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -141,6 +142,11 @@ std::string readFile(const std::filesystem::path& path) {
       std::istreambuf_iterator<char>{file}, std::istreambuf_iterator<char>{}};
 }
 
+[[noreturn]] meta::comms::logger::CommsSpdlogLogger&
+throwLoggerLookupFailure() {
+  throw std::runtime_error{"logger lookup failure"};
+}
+
 bool waitForFileToContain(
     const std::filesystem::path& path,
     std::string_view message) {
@@ -166,6 +172,8 @@ class LogLevelRestoringTest : public testing::Test {
     resetLogger(getSpdlogLogger(), "COMMS");
     resetLogger(getSpdlogLogger("comms.paired_test"), "PAIRED");
     resetLogger(getSpdlogLogger("comms.named_only_test"), "NAMED_ONLY");
+    resetLogger(getSpdlogLogger("comms.varying_macro_a"), "TEST");
+    resetLogger(getSpdlogLogger("comms.varying_macro_b"), "TEST");
   }
 };
 
@@ -179,6 +187,46 @@ TEST(SpdlogLoggerTest, ReturnsStableLoggerPerContext) {
   EXPECT_EQ(&ctranLogger, &getSpdlogLogger("comms.ctran"));
   EXPECT_NE(&ctranLogger, &getSpdlogLogger("comms.ncclx"));
   EXPECT_EQ(ctranLogger.name(), "comms.ctran");
+}
+
+TEST_F(LogLevelRestoringTest, NamedMacrosResolveVaryingNamesFromOneCallSite) {
+  constexpr std::array kNames{
+      std::string_view{"comms.varying_macro_a"},
+      std::string_view{"comms.varying_macro_b"}};
+  const auto messages =
+      std::make_shared<std::array<std::vector<std::string>, kNames.size()>>();
+
+  for (std::size_t index = 0; index < kNames.size(); ++index) {
+    auto& logger = getSpdlogLogger(kNames[index]);
+    logger.configure(
+        "TEST",
+        []() { return 0; },
+        [messages, index](std::string_view message) {
+          (*messages)[index].emplace_back(message);
+        },
+        false);
+    logger.set_level(spdlog::level::err);
+  }
+
+  const auto logFormatted = [](std::string_view name) {
+    COMMS_LOG_NAMED(name, ERR, "formatted {}", name);
+  };
+  const auto logStream = [](std::string_view name) {
+    COMMS_LOG_NAMED_STREAM(name, ERR) << "stream " << name;
+  };
+  for (const auto name : kNames) {
+    logFormatted(std::string{name});
+    logStream(std::string{name});
+  }
+
+  EXPECT_EQ(
+      (*messages)[0],
+      (std::vector<std::string>{
+          "formatted comms.varying_macro_a", "stream comms.varying_macro_a"}));
+  EXPECT_EQ(
+      (*messages)[1],
+      (std::vector<std::string>{
+          "formatted comms.varying_macro_b", "stream comms.varying_macro_b"}));
 }
 
 TEST(SpdlogLoggerTest, SupportsLoggerExpressionDbg5Stream) {
@@ -433,6 +481,14 @@ TEST(SpdlogLoggerTest, AbortDoesNotEvaluateDisabledArguments) {
       "");
 
   EXPECT_FALSE(std::filesystem::exists(evaluationMarker.path()));
+}
+
+TEST(SpdlogLoggerTest, FatalStreamAbortsWhenLoggerResolutionThrows) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_DEATH(
+      COMMS_LOGGER_STREAM(throwLoggerLookupFailure(), FATAL)
+          << "unreachable fatal record",
+      "FATAL: communications logging failed");
 }
 
 TEST(SpdlogLoggerTest, ShutdownDrainsEveryLoggerAndKeepsFallbackSynchronous) {


### PR DESCRIPTION
Summary:
Named logging APIs accept runtime `std::string_view` names, but `COMMS_LOG_NAMED_STREAM` and `MCCL_LOG_WITH_NAME` cached a function-local logger at the macro expansion site. Reusing one call site with different names therefore pinned the first logger and silently misrouted later records.

Resolve dynamic names on every invocation through the existing synchronized, process-lifetime named-logger registry. Fixed default, CTRAN, NCCLX, MCCL, and MCCL-adapter paths use library-local cached logger references, so established hot paths do not acquire the registry lock. No new cache or teardown state is introduced.

Preserve FATAL stream behavior when a cached logger is first initialized: generic logger-expression resolution now converts any lookup exception into the existing fallback diagnostic and `SIGABRT`, matching the named-stream path instead of allowing an exception to escape.

Add same-call-site tests for formatted, stream, and MCCL named logging, plus a death test that forces logger resolution to throw. The tests use caller-owned temporary name buffers and process-safe callback state.

Differential Revision: D117608839


