### PR TITLE
Registered Tree striped-IB optimization (#3961)

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3433,8 +3433,8 @@ cvars:
    default     : 1
    description : |-
      Number of independent Phase-2 IB progress groups per physical CUDA block
-     in MCCL fused AllReduce. Ring supports 1, 2, 4, and 10; Tree supports 1
-     and 2. The default preserves the existing full-block protocol.
+     in MCCL fused AllReduce. Ring and Tree support 1, 2, 4, and 10. The
+     default preserves the existing full-block protocol.
 
  - name        : MCCL_MAX_NCHANNELS
    type        : int


### PR DESCRIPTION
Summary:

Reintroduce the registered Tree striped-IB and direct-input foundation from D117295780. This restores requested S1/S2/S4/S10 virtual stripes, IB-group-aware block capping, and separately registered out-of-place input sends without adding a message-size, topology, hardware, or rollout gate.

Reviewed By: rmahidhar

Differential Revision: D118586110


