### PR TITLE
Fast conformance test for NCCLX/MCCL/CTRAN logging runtime behavior (#3964)

### DIFF
--- a/comms/ctran/utils/CtranLogUtils.h
+++ b/comms/ctran/utils/CtranLogUtils.h
@@ -6,8 +6,8 @@
 
 #include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/CommsLogging.h"
 #include "comms/utils/logger/LogTypes.h"
-#include "comms/utils/logger/LoggingFormat.h"
 
 #define CTRAN_LOG_SUBSYS(level, subsys, ...)            \
   CTRAN_LOG_IF(                                         \

--- a/comms/ctran/utils/Debug.h
+++ b/comms/ctran/utils/Debug.h
@@ -8,7 +8,7 @@
 #include <folly/system/ThreadName.h>
 
 #include "comms/ctran/utils/CtranLogUtils.h"
-#include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/CommsLogging.h"
 
 inline void commNamedThreadStart(
     const char* threadName,

--- a/comms/ctran/utils/LogInit.cc
+++ b/comms/ctran/utils/LogInit.cc
@@ -8,8 +8,8 @@
 
 #include "comms/ctran/utils/CtranLogger.h"
 #include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
+#include "comms/utils/logger/CommsLogging.h"
 #include "comms/utils/logger/LoggerRuntime.h"
-#include "comms/utils/logger/LoggingFormat.h"
 
 namespace ctran::logging {
 

--- a/comms/ctran/utils/tests/AvlTreeUT.cc
+++ b/comms/ctran/utils/tests/AvlTreeUT.cc
@@ -10,7 +10,7 @@
 #include "comms/ctran/utils/CtranAvlTree.h"
 #include "comms/ctran/utils/LogInit.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/CommsLogging.h"
 
 class Range {
  public:

--- a/comms/ncclx/meta/NcclxLogUtils.h
+++ b/comms/ncclx/meta/NcclxLogUtils.h
@@ -4,8 +4,8 @@
 
 #include <fmt/format.h>
 
+#include "comms/utils/logger/CommsLogging.h"
 #include "comms/utils/logger/LogTypes.h"
-#include "comms/utils/logger/LoggingFormat.h"
 #include "meta/NcclxLogger.h"
 
 #define NCCLX_LOG_SUBSYS(level, subsys, ...)            \

--- a/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -26,7 +26,7 @@
 #include "comms/utils/colltrace/CollTrace.h"
 #include "comms/utils/colltrace/tests/nvidia-only/CPUControlledKernel.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/CommsLogging.h"
 #include "meta/NcclxLogger.h"
 #include "meta/commDump.h"
 

--- a/comms/ncclx/meta/logger/DebugExt.cc
+++ b/comms/ncclx/meta/logger/DebugExt.cc
@@ -8,8 +8,8 @@
 #include "debug.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/CommsLogging.h"
 #include "comms/utils/logger/ErrorStackUtil.h"
-#include "comms/utils/logger/LoggingFormat.h"
 
 // These are Meta's logging implementations, kept out of the baseline debug.cc.
 // Guarded to v2_30+ since older versions keep their own copy in debug.cc.

--- a/comms/ncclx/meta/logger/tests/LoggingUT.cc
+++ b/comms/ncclx/meta/logger/tests/LoggingUT.cc
@@ -11,7 +11,7 @@
 
 #include "comms/testinfra/TestUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/CommsLogging.h"
 #include "comms/utils/logger/SpdlogLogger.h"
 #include "meta/NcclxChecks.h"
 

--- a/comms/ncclx/meta/tests/LoggingShutdownTest.cc
+++ b/comms/ncclx/meta/tests/LoggingShutdownTest.cc
@@ -1,0 +1,299 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Two rank processes initialize a communicator and tear it down in the mode
+// selected by the test target, logging a sentinel at each step. The driver
+// process outlives the ranks, so it observes what happens after each rank's
+// last gtest assertion: it checks the rank exit statuses and scans the
+// NCCL_DEBUG_FILE logs the ranks left behind.
+
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+#include <fmt/format.h>
+#include <folly/Random.h>
+#include <folly/testing/TestUtil.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "nccl.h" // @manual
+
+#include "comms/mccl/integration_tests/CollectiveIntegrationTestMixin.h"
+#include "comms/testinfra/ShutdownLogScan.h"
+#include "comms/utils/logger/SpdlogLogger.h"
+
+namespace {
+
+using meta::comms::testing::countLogsContaining;
+using meta::comms::testing::describeCrashMarkers;
+using meta::comms::testing::describeLogDir;
+using meta::comms::testing::findCrashMarkers;
+using meta::comms::testing::findTruncatedLogs;
+
+constexpr std::string_view kLoggerName{"comms.ncclx"};
+
+/*
+ * Sentinels are logged at WARN so NCCL_DEBUG=INFO cannot gate them away, and
+ * they are matched by the driver as plain substrings, so they must not appear
+ * anywhere else in a rank's log.
+ */
+constexpr std::string_view kAfterDestroy{"LoggingShutdown phase=after_destroy"};
+constexpr std::string_view kAfterAbort{"LoggingShutdown phase=after_abort"};
+constexpr std::string_view kBeforeLeak{
+    "LoggingShutdown phase=before_exit_without_destroy"};
+constexpr std::string_view kAtExit{"LoggingShutdown phase=atexit"};
+constexpr std::string_view kStaticDestruction{
+    "LoggingShutdown phase=static_destruction"};
+
+constexpr std::string_view kDestroyMode{"destroy"};
+constexpr std::string_view kAbortMode{"abort"};
+constexpr std::string_view kLeakMode{"leak"};
+
+bool& workerBodyCompleted() {
+  static bool completed = false;
+  return completed;
+}
+
+void logSentinel(std::string_view sentinel) {
+  auto& logger = ::meta::comms::logger::getSpdlogLogger(kLoggerName);
+  COMMS_LOG_NAMED(kLoggerName, WARN, "{}", sentinel);
+  // Without this an async sink could drop the record purely because the process
+  // is exiting, which would be indistinguishable from a shutdown bug.
+  logger.flush();
+}
+
+void logAtExitSentinel() {
+  if (workerBodyCompleted()) {
+    logSentinel(kAtExit);
+  }
+}
+
+/*
+ * Logging from a static destructor is the contract the comms spdlog facade is
+ * built for -- its logger objects are deliberately leaked so threads that were
+ * never joined can still log this late. This object is the last sentinel, so it
+ * runs after the atexit handler registered by the test body.
+ */
+struct StaticDestructionSentinel {
+  ~StaticDestructionSentinel() {
+    if (workerBodyCompleted()) {
+      logSentinel(kStaticDestruction);
+    }
+  }
+};
+
+const StaticDestructionSentinel staticDestructionSentinel{};
+
+void storeBarrier(
+    const std::shared_ptr<c10d::TCPStore>& store,
+    std::string_view tag,
+    int rank,
+    int worldSize) {
+  store->set(
+      fmt::format("barrier_{}_{}", tag, rank), std::vector<uint8_t>{'1'});
+  std::vector<std::string> keys;
+  keys.reserve(worldSize);
+  for (int peer = 0; peer < worldSize; ++peer) {
+    keys.push_back(fmt::format("barrier_{}_{}", tag, peer));
+  }
+  store->wait(keys);
+}
+
+// Rank 0 creates the id; every rank picks it up under a mode-tagged key.
+std::optional<ncclUniqueId> exchangeUniqueId(
+    const std::shared_ptr<c10d::TCPStore>& store,
+    std::string_view phase,
+    int rank) {
+  const auto key = fmt::format("nccl_unique_id_{}", phase);
+  ncclUniqueId id{};
+  std::vector<uint8_t> payload(sizeof(id) + 1, 0);
+  if (rank == 0) {
+    if (ncclGetUniqueId(&id) == ncclSuccess) {
+      payload[0] = 1;
+      std::memcpy(payload.data() + 1, &id, sizeof(id));
+    }
+    store->set(key, payload);
+  } else {
+    payload = store->get(key);
+  }
+  if (payload.size() != sizeof(id) + 1 || payload[0] != 1) {
+    return std::nullopt;
+  }
+  std::memcpy(&id, payload.data() + 1, sizeof(id));
+  return id;
+}
+
+// Tag the communicator so diagnostics identify the selected teardown mode.
+ncclComm_t initComm(
+    const ncclUniqueId& id,
+    const char* commDesc,
+    int rank,
+    int worldSize) {
+  ncclComm_t comm = nullptr;
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  config.commDesc = commDesc;
+  if (ncclCommInitRankConfig(&comm, worldSize, id, rank, &config) !=
+      ncclSuccess) {
+    return nullptr;
+  }
+  return comm;
+}
+
+} // namespace
+
+class LoggingShutdownTest : public mccl::CollectiveIntegrationTestMixin,
+                            public ::testing::Test {
+ public:
+  void SetUp() override {
+    mccl::CollectiveIntegrationTestMixin::SetUp(
+        mccl::CollectiveIntegrationTestMixin::Config{
+            .numRanks = kNumRanks,
+            // A rank that dies during shutdown must reach the driver's log scan
+            // rather than aborting the run inside the mixin.
+            .shouldExitOnFailure = false,
+            .env =
+                {
+                    "NCCL_HPC_JOB_IDS=",
+                    "NCCL_SOCKET_IFNAME=eth0",
+                    "NCCL_CLIENT_SOCKET_IFNAME=eth0",
+                    "NCCL_SOCKET_IPADDR_PREFIX=",
+                    "NCCL_FASTINIT_MODE=none",
+                    "NCCL_DEBUG=INFO",
+                    fmt::format(
+                        "NCCL_DEBUG_FILE={}",
+                        (tmpDir_.path() / "logfile%p").string()),
+                },
+        });
+  }
+
+  static constexpr int kNumRanks{2};
+
+  // The driver hands this path to the ranks via NCCL_DEBUG_FILE, so the ranks'
+  // own copies of this member are unused.
+  folly::test::TemporaryDirectory tmpDir_{
+      fmt::format("LoggingShutdown{}", folly::Random::rand64())};
+
+  // TemporaryDirectory hands back a boost path; the scanner takes a std one.
+  std::filesystem::path logDir() const {
+    return std::filesystem::path{tmpDir_.path().string()};
+  }
+
+  void checkRanksShutDownCleanly(std::string_view phaseSentinel) {
+    ASSERT_TRUE(
+        std::holds_alternative<
+            mccl::CollectiveIntegrationTestMixin::TestDriverState>(state_));
+    const auto& driverState =
+        std::get<mccl::CollectiveIntegrationTestMixin::TestDriverState>(state_);
+
+    std::vector<meta::comms::testing::LogCrashMarker> markers;
+    ASSERT_NO_THROW(markers = findCrashMarkers(logDir()))
+        << "failed to scan rank logs. " << describeLogDir(logDir());
+    EXPECT_THAT(markers, ::testing::IsEmpty())
+        << "crash markers in rank logs:" << describeCrashMarkers(markers);
+
+    /*
+     * Stop before sentinel checks when a rank failed in its test body. Those
+     * sentinels intentionally identify only a successfully completed body.
+     */
+    ASSERT_THAT(driverState.workerExitCodes, ::testing::Each(::testing::Eq(0)))
+        << "a rank did not exit cleanly. " << describeLogDir(logDir());
+
+    std::vector<std::string> truncatedLogs;
+    ASSERT_NO_THROW(truncatedLogs = findTruncatedLogs(logDir()))
+        << "failed to inspect rank log termination. "
+        << describeLogDir(logDir());
+    EXPECT_THAT(truncatedLogs, ::testing::IsEmpty())
+        << "rank log does not end in a newline, so the writer died mid-record "
+           "or the final flush never completed. "
+        << describeLogDir(logDir());
+
+    // Every sentinel must appear in every rank's log: that is the positive
+    // signal that logging still worked that late in the rank's life.
+    for (const auto sentinel : {phaseSentinel, kAtExit, kStaticDestruction}) {
+      int matchingLogCount{};
+      ASSERT_NO_THROW(
+          matchingLogCount = countLogsContaining(logDir(), sentinel))
+          << "failed to scan for sentinel \"" << sentinel << "\". "
+          << describeLogDir(logDir());
+      EXPECT_EQ(kNumRanks, matchingLogCount)
+          << "sentinel \"" << sentinel << "\" missing from a rank log. "
+          << describeLogDir(logDir());
+    }
+  }
+};
+
+/*
+ * One test only: the mixin spawns its ranks during the first test's SetUp, so a
+ * second test in this binary would never launch ranks of its own. BUCK creates
+ * one target per teardown mode so each mode receives fresh rank processes.
+ */
+TEST_F(LoggingShutdownTest, LogsSurviveSelectedTeardownPath) {
+  const char* modeValue = std::getenv("NCCLX_LOGGING_SHUTDOWN_MODE");
+  ASSERT_NE(nullptr, modeValue);
+  const std::string_view mode{modeValue};
+  ASSERT_THAT(
+      mode,
+      ::testing::AnyOf(
+          ::testing::Eq(kDestroyMode),
+          ::testing::Eq(kAbortMode),
+          ::testing::Eq(kLeakMode)));
+
+  const auto phaseSentinel = mode == kDestroyMode ? kAfterDestroy
+      : mode == kAbortMode                        ? kAfterAbort
+                                                  : kBeforeLeak;
+  if (isTestDriverProcess()) {
+    checkRanksShutDownCleanly(phaseSentinel);
+    return;
+  }
+
+  const auto rank = getRank();
+  const auto worldSize = getWorldSize();
+  const auto store = getTCPStore();
+  bool reachedBarrier = false;
+
+  /*
+   * A fatal assertion returns from this lambda, not the test, so a failed rank
+   * still reaches the peer barrier before the test process exits.
+   */
+  const auto runRankBody = [&] {
+    ASSERT_EQ(cudaSuccess, cudaSetDevice(rank));
+
+    const auto id = exchangeUniqueId(store, mode, rank);
+    ASSERT_TRUE(id.has_value());
+    const char* commDesc = mode == kDestroyMode ? "logging_shutdown_destroy"
+        : mode == kAbortMode                    ? "logging_shutdown_abort"
+                                                : "logging_shutdown_leak";
+    auto* comm = initComm(*id, commDesc, rank, worldSize);
+    ASSERT_NE(nullptr, comm);
+
+    if (mode == kDestroyMode) {
+      // ncclCommDestroy joins the communicator threads before logger teardown.
+      ASSERT_EQ(ncclSuccess, ncclCommDestroy(comm));
+      logSentinel(kAfterDestroy);
+    } else if (mode == kAbortMode) {
+      ASSERT_EQ(ncclSuccess, ncclCommAbort(comm));
+      logSentinel(kAfterAbort);
+    } else {
+      // Exit with a live communicator, as when a process terminates without a
+      // clean shutdown. The barrier keeps both ranks at the same point so
+      // neither observes the other's teardown as a peer failure.
+      logSentinel(kBeforeLeak);
+    }
+
+    storeBarrier(store, "before_exit", rank, worldSize);
+    reachedBarrier = true;
+
+    ASSERT_EQ(0, std::atexit(logAtExitSentinel));
+    workerBodyCompleted() = true;
+  };
+  runRankBody();
+  if (!reachedBarrier) {
+    storeBarrier(store, "before_exit", rank, worldSize);
+  }
+}

--- a/comms/ncclx/v2_29/src/debug.cc
+++ b/comms/ncclx/v2_29/src/debug.cc
@@ -27,7 +27,7 @@
 
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/ErrorStackUtil.h"
-#include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/CommsLogging.h"
 #include "meta/logger/NcclDebugLog.h"
 
 #define NCCL_DEBUG_RESET_TRIGGERED (-2)

--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -55,7 +55,7 @@
 
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/EventsScubaUtil.h"
-#include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/CommsLogging.h"
 #include "comms/ctran/memory/SlabAllocator.h"
 #include "comms/ctran/memory/Utils.h"
 #include "meta/wrapper/MetaFactory.h"

--- a/comms/ncclx/v2_29/src/misc/param.cc
+++ b/comms/ncclx/v2_29/src/misc/param.cc
@@ -24,7 +24,7 @@
 #include <unordered_set>
 #include "os.h"
 
-#include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/CommsLogging.h"
 #include "comms/utils/logger/LoggerRuntime.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/InitFolly.h"

--- a/comms/ncclx/v2_30/src/debug.cc
+++ b/comms/ncclx/v2_30/src/debug.cc
@@ -24,7 +24,7 @@
 #include <vector>
 #include <sstream>
 
-#include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/CommsLogging.h"
 #include "meta/logger/NcclDebugLog.h"
 
 #define NCCL_DEBUG_RESET_TRIGGERED (-2)

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -60,7 +60,7 @@
 
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/EventsScubaUtil.h"
-#include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/CommsLogging.h"
 #include "comms/ctran/memory/SlabAllocator.h"
 #include "comms/ctran/memory/Utils.h"
 #include "meta/wrapper/MetaFactory.h"

--- a/comms/ncclx/v2_30/src/misc/param.cc
+++ b/comms/ncclx/v2_30/src/misc/param.cc
@@ -21,7 +21,7 @@
 #include <unordered_set>
 #include "os.h"
 
-#include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/CommsLogging.h"
 #include "comms/utils/logger/LoggerRuntime.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/InitFolly.h"

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -1115,6 +1115,8 @@ set(COMMON_FILES
   comms/utils/logger/Logger.h
   comms/utils/logger/LoggerRuntime.cc
   comms/utils/logger/LoggerRuntime.h
+  comms/utils/logger/CommsLogging.cc
+  comms/utils/logger/CommsLogging.h
   comms/utils/logger/LoggingFormat.cc
   comms/utils/logger/LoggingFormat.h
   comms/utils/logger/LogTypes.cc

--- a/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/CMakeLists.txt
+++ b/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/CMakeLists.txt
@@ -757,6 +757,8 @@ set(COMMON_FILES
   comms/utils/logger/EventsScubaUtil.h
   comms/utils/logger/Logger.cc
   comms/utils/logger/Logger.h
+  comms/utils/logger/CommsLogging.cc
+  comms/utils/logger/CommsLogging.h
   comms/utils/logger/LoggingFormat.cc
   comms/utils/logger/LoggingFormat.h
   comms/utils/logger/LogUtils.cc

--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/CMakeLists.txt
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/CMakeLists.txt
@@ -757,6 +757,8 @@ set(COMMON_FILES
   comms/utils/logger/EventsScubaUtil.h
   comms/utils/logger/Logger.cc
   comms/utils/logger/Logger.h
+  comms/utils/logger/CommsLogging.cc
+  comms/utils/logger/CommsLogging.h
   comms/utils/logger/LoggingFormat.cc
   comms/utils/logger/LoggingFormat.h
   comms/utils/logger/LogUtils.cc

--- a/comms/utils/checks.h
+++ b/comms/utils/checks.h
@@ -10,7 +10,7 @@
 
 #include "comms/utils/Conversion.h"
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/CommsLogging.h"
 
 // Base case
 template <typename... ErrorCodes>

--- a/comms/utils/colltrace/NetworkPerfMonitor.cc
+++ b/comms/utils/colltrace/NetworkPerfMonitor.cc
@@ -12,7 +12,7 @@
 #include "comms/utils/StrUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
-#include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/CommsLogging.h"
 #include "comms/utils/logger/ScubaLogger.h"
 
 namespace ncclx::colltrace {

--- a/comms/utils/logger/CommsLogging.cc
+++ b/comms/utils/logger/CommsLogging.cc
@@ -1,0 +1,336 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/CommsLogging.h"
+
+#include <unistd.h>
+#include <array>
+#include <cstdio>
+#include <sstream>
+#include <utility>
+
+#include <folly/Synchronized.h>
+#include <folly/synchronization/CallOnce.h>
+
+#include "comms/utils/Conversion.h"
+#include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
+#include "comms/utils/logger/ErrorStackUtil.h"
+#include "comms/utils/logger/EventsScubaUtil.h"
+#include "comms/utils/logger/NcclScubaSample.h"
+
+namespace {
+
+std::string getHostName(const char delim) {
+  constexpr int maxlen = HOST_NAME_MAX + 1;
+  char hostname[maxlen];
+  if (gethostname(hostname, maxlen) != 0) {
+    return "unknown";
+  }
+  int i = 0;
+  while ((hostname[i] != delim) && (hostname[i] != '\0') && (i < maxlen - 1)) {
+    i++;
+  }
+  hostname[i] = '\0';
+  return std::string{hostname};
+}
+
+struct ProcMetaData {
+  ProcMetaData() : hostname(getHostName('.')), pid(getpid()) {}
+
+  std::string hostname;
+  int pid;
+};
+
+ProcMetaData& getProcMetaData() {
+  /*
+   * Retain process metadata for the process lifetime because formatting may
+   * run during static destruction.
+   */
+  static auto* metaData = new ProcMetaData{};
+  return *metaData;
+}
+
+struct LastErrorInfo {
+  std::string lastErrorMessage;
+  // Legacy per-frame error chain, still appended by v2_27/v2_29's debug.cc via
+  // appendErrorToStack(). Kept for backward compatibility.
+  // TODO: remove once ncclx v2_29 is retired -- only v2_29 populates this;
+  // v2_30 is native-stack-only (lastErrorNativeStack), so this field and the
+  // getLastCommsError() fallback that reads it become dead.
+  std::vector<std::string> lastErrorStack;
+  // Native symbolized stack captured at the error site by logErrorToScuba().
+  // Preferred by getLastCommsError() when present.
+  std::vector<std::string> lastErrorNativeStack;
+};
+
+folly::Synchronized<LastErrorInfo>& getLastCommsErrorStorage() {
+  /*
+   * Error callbacks remain reachable from logger threads during static
+   * destruction, so this storage must not register an exit-time destructor.
+   */
+  static auto* storage = new folly::Synchronized<LastErrorInfo>{};
+  return *storage;
+}
+
+constexpr char toAsciiUpper(char value) {
+  return value >= 'a' && value <= 'z' ? value - ('a' - 'A') : value;
+}
+
+bool asciiCaseInsensitiveEqual(std::string_view left, std::string_view right) {
+  if (left.size() != right.size()) {
+    return false;
+  }
+  for (std::size_t index = 0; index < left.size(); ++index) {
+    if (toAsciiUpper(left[index]) != toAsciiUpper(right[index])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+uint64_t getSubSystemMaskForName(std::string_view name) {
+  struct NamedMask {
+    std::string_view name;
+    uint64_t mask;
+  };
+  static constexpr std::array<NamedMask, 18> kNamedMasks{{
+      {"INIT", meta::comms::logger::INIT},
+      {"COLL", meta::comms::logger::COLL},
+      {"P2P", meta::comms::logger::P2P},
+      {"SHM", meta::comms::logger::SHM},
+      {"NET", meta::comms::logger::NET},
+      {"GRAPH", meta::comms::logger::GRAPH},
+      {"TUNING", meta::comms::logger::TUNING},
+      {"ENV", meta::comms::logger::ENV},
+      {"ALLOC", meta::comms::logger::ALLOC},
+      {"CALL", meta::comms::logger::CALL},
+      {"PROXY", meta::comms::logger::PROXY},
+      {"NVLS", meta::comms::logger::NVLS},
+      {"BOOTSTRAP", meta::comms::logger::BOOTSTRAP},
+      {"REG", meta::comms::logger::REG},
+      {"PROFILE", meta::comms::logger::PROFILE},
+      {"RAS", meta::comms::logger::RAS},
+      {"DESTROY", meta::comms::logger::DESTROY},
+      {"ALL", static_cast<uint64_t>(meta::comms::logger::ALL)},
+  }};
+  for (const auto& namedMask : kNamedMasks) {
+    if (asciiCaseInsensitiveEqual(name, namedMask.name)) {
+      return namedMask.mask;
+    }
+  }
+  return 0;
+}
+
+} // namespace
+
+namespace meta::comms::logger {
+
+void initProcMetaData() {
+  (void)getProcMetaData();
+}
+
+uint64_t parseDebugSubsysMask(const char* ncclDebugSubsysEnv) {
+  if (ncclDebugSubsysEnv == nullptr) {
+    return INIT | BOOTSTRAP | ENV;
+  }
+  std::string_view input{ncclDebugSubsysEnv};
+  const bool invert = !input.empty() && input.front() == '^';
+  if (invert) {
+    input.remove_prefix(1);
+  }
+  uint64_t maskResult = invert ? ~0ULL : 0ULL;
+  while (!input.empty()) {
+    const auto delimiter = input.find(',');
+    const auto token = input.substr(0, delimiter);
+    const auto mask = getSubSystemMaskForName(token);
+    if (mask) {
+      if (invert) {
+        maskResult &= ~mask;
+      } else {
+        maskResult |= mask;
+      }
+    }
+    if (delimiter == std::string_view::npos) {
+      break;
+    }
+    input.remove_prefix(delimiter + 1);
+  }
+  return maskResult;
+}
+
+std::string parseDebugFile(const char* ncclDebugFileEnv) {
+  if (ncclDebugFileEnv == nullptr) {
+    return {};
+  }
+  initProcMetaData();
+
+  int c = 0;
+  char debugFn[PATH_MAX + 1] = "";
+  char* dfn = debugFn;
+  while (ncclDebugFileEnv[c] != '\0' && (dfn - debugFn) < PATH_MAX) {
+    if (ncclDebugFileEnv[c++] != '%') {
+      *dfn++ = ncclDebugFileEnv[c - 1];
+      continue;
+    }
+    switch (ncclDebugFileEnv[c++]) {
+      case '%':
+        *dfn++ = '%';
+        break;
+      case 'h':
+        dfn += snprintf(
+            dfn,
+            PATH_MAX + 1 - (dfn - debugFn),
+            "%s",
+            getProcMetaData().hostname.c_str());
+        break;
+      case 'p':
+        dfn += snprintf(
+            dfn, PATH_MAX + 1 - (dfn - debugFn), "%d", getProcMetaData().pid);
+        break;
+      default:
+        *dfn++ = '%';
+        if ((dfn - debugFn) < PATH_MAX) {
+          *dfn++ = ncclDebugFileEnv[c - 1];
+        }
+        break;
+    }
+    if ((dfn - debugFn) > PATH_MAX) {
+      dfn = debugFn + PATH_MAX;
+    }
+  }
+  *dfn = '\0';
+  return std::string{debugFn};
+}
+
+LogLevel getLoggerDebugLevel(std::string_view level) {
+  if (level.empty()) {
+    return LogLevel::NONE;
+  }
+  if (level == "VERSION") {
+    return LogLevel::VERSION;
+  } else if (level == "ERROR") {
+    return LogLevel::ERROR;
+  } else if (level == "WARN") {
+    return LogLevel::WARN;
+  } else if (level == "INFO") {
+    return LogLevel::INFO;
+  } else if (level == "ABORT") {
+    return LogLevel::ABORT;
+  } else if (level == "TRACE") {
+    return LogLevel::TRACE;
+  } else if (level == "NONE") {
+    return LogLevel::NONE;
+  }
+  return LogLevel::NONE;
+}
+
+LogLevel getNcclLoggerDebugLevel(std::string_view level) {
+  if (asciiCaseInsensitiveEqual(level, "VERSION")) {
+    return LogLevel::VERSION;
+  } else if (asciiCaseInsensitiveEqual(level, "ERROR")) {
+    return LogLevel::ERROR;
+  } else if (asciiCaseInsensitiveEqual(level, "WARN")) {
+    return LogLevel::WARN;
+  } else if (asciiCaseInsensitiveEqual(level, "INFO")) {
+    return LogLevel::INFO;
+  } else if (asciiCaseInsensitiveEqual(level, "ABORT")) {
+    return LogLevel::ABORT;
+  } else if (asciiCaseInsensitiveEqual(level, "TRACE")) {
+    return LogLevel::TRACE;
+  }
+  return LogLevel::NONE;
+}
+
+bool parseDebugLoggingAsync(const char* value, bool valueWhenUnset) {
+  if (value == nullptr) {
+    return valueWhenUnset;
+  }
+  const std::string_view input{value};
+  if (asciiCaseInsensitiveEqual(input, "1") ||
+      asciiCaseInsensitiveEqual(input, "Y") ||
+      asciiCaseInsensitiveEqual(input, "YES") ||
+      asciiCaseInsensitiveEqual(input, "T") ||
+      asciiCaseInsensitiveEqual(input, "TRUE")) {
+    return true;
+  }
+  if (asciiCaseInsensitiveEqual(input, "0") ||
+      asciiCaseInsensitiveEqual(input, "N") ||
+      asciiCaseInsensitiveEqual(input, "NO") ||
+      asciiCaseInsensitiveEqual(input, "F") ||
+      asciiCaseInsensitiveEqual(input, "FALSE")) {
+    return false;
+  }
+  return true;
+}
+
+detail::ProcessMetadata detail::getLogProcessMetadata() {
+  const auto& metadata = getProcMetaData();
+  return {.hostname = metadata.hostname, .processId = metadata.pid};
+}
+
+void initThreadMetaData(std::string_view threadName) {
+  static thread_local folly::once_flag threadNameFlag;
+  folly::call_once(threadNameFlag, [&]() { setSpdlogThreadName(threadName); });
+}
+
+void detail::setLastErrorFromLegacyLog(std::string_view message) {
+  auto lockedError = getLastCommsErrorStorage().wlock();
+  lockedError->lastErrorMessage.assign(message);
+  lockedError->lastErrorNativeStack.clear();
+}
+
+void logErrorToScuba(
+    const std::string& message,
+    const int code,
+    const std::string& errorName,
+    const std::vector<std::string>& stack) {
+  auto sampleGuard = EVENTS_SCUBA_UTIL_SAMPLE_GUARD("ERROR");
+  auto& sample = sampleGuard.sample();
+  sample.setError(message, stack);
+  if (code != 0) {
+    sample.addNormal("error_code", fmt::format("{}:{}", code, errorName));
+  }
+}
+
+void setLastError(const std::string& message, std::vector<std::string> stack) {
+  auto w = getLastCommsErrorStorage().wlock();
+  w->lastErrorMessage = message;
+  w->lastErrorNativeStack = std::move(stack);
+}
+
+void logCommErrorToScuba(commResult_t code, const std::string& message) {
+  if (!NCCL_SCUBA_LOG_ERROR_ENABLED) {
+    return;
+  }
+  std::vector<std::string> stack;
+  if (NCCL_SCUBA_STACK_TRACE_ON_ERROR_ENABLED) {
+    stack = captureNativeErrorStack();
+  }
+  logErrorToScuba(
+      message,
+      static_cast<int>(code),
+      ::meta::comms::commCodeToString(code),
+      stack);
+}
+
+std::string getLastCommsError() {
+  std::ostringstream ss;
+  {
+    auto lastCommsErrorRLocked = getLastCommsErrorStorage().rlock();
+    ss << lastCommsErrorRLocked->lastErrorMessage << "\nNCCL Stack trace:";
+    const auto& stackTrace =
+        !lastCommsErrorRLocked->lastErrorNativeStack.empty()
+        ? lastCommsErrorRLocked->lastErrorNativeStack
+        : lastCommsErrorRLocked->lastErrorStack;
+    for (const auto& stack : stackTrace) {
+      ss << '\n' << stack;
+    }
+  }
+  return ss.str();
+}
+
+void appendErrorToStack(std::string error) {
+  getLastCommsErrorStorage().wlock()->lastErrorStack.push_back(
+      std::move(error));
+}
+
+} // namespace meta::comms::logger

--- a/comms/utils/logger/CommsLogging.h
+++ b/comms/utils/logger/CommsLogging.h
@@ -1,0 +1,105 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "comms/utils/commSpecs.h"
+#include "comms/utils/logger/LogTypes.h"
+#include "comms/utils/logger/SpdlogLogger.h"
+
+namespace meta::comms::logger {
+
+uint64_t parseDebugSubsysMask(const char* ncclDebugSubsysEnv);
+
+std::string parseDebugFile(const char* ncclDebugFileEnv);
+
+LogLevel getLoggerDebugLevel(std::string_view levelStr);
+LogLevel getNcclLoggerDebugLevel(std::string_view levelStr);
+
+/*
+ * The fallback applies only when value is absent. Any present value other
+ * than a recognized false token enables logging, matching NCCL cvar parsing.
+ */
+bool parseDebugLoggingAsync(const char* value, bool valueWhenUnset);
+
+void initProcMetaData();
+
+void initThreadMetaData(std::string_view threadName);
+
+std::string getLastCommsError();
+
+namespace detail {
+
+struct ProcessMetadata {
+  std::string_view hostname;
+  int processId;
+};
+
+ProcessMetadata getLogProcessMetadata();
+
+void setLastErrorFromLegacyLog(std::string_view message);
+
+} // namespace detail
+
+/*
+ * TODO: remove once ncclx v2_29 is retired. The only remaining producer is
+ * v2_29's ncclMetaDebugLogWithScuba (via ERR_WITH_SCUBA/WARN_WITH_SCUBA);
+ * v2_30 and ctran record the last-error stack via captureNativeErrorStack() +
+ * setLastError() instead (native-stack-only).
+ */
+void appendErrorToStack(std::string error);
+
+/*
+ * Record an ERROR-level log to the nccl_structured_logging Scuba table as a
+ * single error record (top-level message in the exception_message column,
+ * native stack in the stack_trace column). The caller is responsible for
+ * gating this on NCCL_SCUBA_LOG_ERROR_ENABLED and for capturing the native
+ * stack once so it can be shared across reporters.
+ */
+__attribute__((visibility("default"))) void logErrorToScuba(
+    const std::string& message,
+    int code,
+    const std::string& errorName,
+    const std::vector<std::string>& stack);
+
+/*
+ * Update the ncclGetLastError() state with the latest error message and its
+ * pre-captured native stack. Unconditional; independent of Scuba logging.
+ */
+void setLastError(const std::string& message, std::vector<std::string> stack);
+
+/*
+ * Record a CTRAN ERR-level error to Scuba, carrying the commResult_t code.
+ * Gated by NCCL_SCUBA_LOG_ERROR_ENABLED; a no-op when disabled.
+ */
+__attribute__((visibility("default"))) void logCommErrorToScuba(
+    commResult_t code,
+    const std::string& message);
+
+} // namespace meta::comms::logger
+
+#define COMMS_ERR(code, ...)                                                  \
+  do {                                                                        \
+    const auto _comms_error_message = fmt::format(__VA_ARGS__);               \
+    COMMS_LOG(ERR, "{}", _comms_error_message);                               \
+    ::meta::comms::logger::logCommErrorToScuba((code), _comms_error_message); \
+  } while (false)
+
+#define COMMS_NAMED_THREAD_START_EXT(threadName, rank, commHash, commDesc)                \
+  do {                                                                                    \
+    meta::comms::logger::initThreadMetaData(threadName);                                  \
+    COMMS_LOG(                                                                            \
+        INFO,                                                                             \
+        "[COMMS THREAD] Starting {} thread for rank {} commHash {:#x} commDesc {} at {}", \
+        threadName,                                                                       \
+        rank,                                                                             \
+        commHash,                                                                         \
+        commDesc,                                                                         \
+        __func__);                                                                        \
+  } while (0);

--- a/comms/utils/logger/LoggerRuntime.cc
+++ b/comms/utils/logger/LoggerRuntime.cc
@@ -5,8 +5,8 @@
 #include <mutex>
 
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/CommsLogging.h"
 #include "comms/utils/logger/DataTableWrapper.h"
-#include "comms/utils/logger/LoggingFormat.h"
 
 namespace meta::comms::logger {
 namespace {

--- a/comms/utils/logger/LoggingFormat.cc
+++ b/comms/utils/logger/LoggingFormat.cc
@@ -2,127 +2,14 @@
 
 #include "comms/utils/logger/LoggingFormat.h"
 
-#include <unistd.h>
-#include <array>
-#include <sstream>
 #include <string_view>
+#include <utility>
 
-#include <fmt/format.h>
-#include <folly/String.h>
-#include <folly/Synchronized.h>
 #include <folly/logging/LogCategory.h>
 #include <folly/logging/LogMessage.h>
 #include <folly/logging/LogName.h>
-#include <folly/synchronization/CallOnce.h>
 
-#include "comms/utils/Conversion.h"
-#include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
 #include "comms/utils/logger/CommsLogFormatter.h"
-#include "comms/utils/logger/ErrorStackUtil.h"
-#include "comms/utils/logger/EventsScubaUtil.h"
-#include "comms/utils/logger/NcclScubaSample.h"
-#include "comms/utils/logger/SpdlogLogger.h"
-
-namespace {
-std::string getHostName(const char delim) {
-  constexpr int maxlen = HOST_NAME_MAX + 1;
-  char hostname[maxlen];
-  if (gethostname(hostname, maxlen) != 0) {
-    return "unknown";
-  }
-  int i = 0;
-  while ((hostname[i] != delim) && (hostname[i] != '\0') && (i < maxlen - 1)) {
-    i++;
-  }
-  hostname[i] = '\0';
-  return std::string{hostname};
-}
-
-struct ProcMetaData {
-  std::string hostname;
-  int pid{};
-  folly::once_flag initFlag;
-};
-
-ProcMetaData& getProcMetaData() {
-  /*
-   * Retain process metadata for the process lifetime because formatting may run
-   * during static destruction. Keeping the initialization guard here also
-   * prevents its destruction from racing with initialization.
-   */
-  static auto* metaData = new ProcMetaData{};
-  return *metaData;
-}
-
-struct LastErrorInfo {
-  std::string lastErrorMessage;
-  // Legacy per-frame error chain, still appended by v2_27/v2_29's debug.cc via
-  // appendErrorToStack(). Kept for backward compatibility.
-  // TODO: remove once ncclx v2_29 is retired -- only v2_29 populates this;
-  // v2_30 is native-stack-only (lastErrorNativeStack), so this field and the
-  // getLastCommsError() fallback that reads it become dead.
-  std::vector<std::string> lastErrorStack;
-  // Native symbolized stack captured at the error site by logErrorToScuba().
-  // Preferred by getLastCommsError() when present.
-  std::vector<std::string> lastErrorNativeStack;
-};
-
-folly::Synchronized<LastErrorInfo>& getLastCommsErrorStorage() {
-  // Error callbacks remain reachable from logger threads during static
-  // destruction, so this storage must not register an exit-time destructor.
-  static auto* storage = new folly::Synchronized<LastErrorInfo>{};
-  return *storage;
-}
-
-constexpr char toAsciiUpper(char value) {
-  return value >= 'a' && value <= 'z' ? value - ('a' - 'A') : value;
-}
-
-bool asciiCaseInsensitiveEqual(std::string_view left, std::string_view right) {
-  if (left.size() != right.size()) {
-    return false;
-  }
-  for (std::size_t index = 0; index < left.size(); ++index) {
-    if (toAsciiUpper(left[index]) != toAsciiUpper(right[index])) {
-      return false;
-    }
-  }
-  return true;
-}
-
-uint64_t getSubSystemMaskForName(std::string_view name) {
-  struct NamedMask {
-    std::string_view name;
-    uint64_t mask;
-  };
-  static constexpr std::array<NamedMask, 18> kNamedMasks{{
-      {"INIT", meta::comms::logger::INIT},
-      {"COLL", meta::comms::logger::COLL},
-      {"P2P", meta::comms::logger::P2P},
-      {"SHM", meta::comms::logger::SHM},
-      {"NET", meta::comms::logger::NET},
-      {"GRAPH", meta::comms::logger::GRAPH},
-      {"TUNING", meta::comms::logger::TUNING},
-      {"ENV", meta::comms::logger::ENV},
-      {"ALLOC", meta::comms::logger::ALLOC},
-      {"CALL", meta::comms::logger::CALL},
-      {"PROXY", meta::comms::logger::PROXY},
-      {"NVLS", meta::comms::logger::NVLS},
-      {"BOOTSTRAP", meta::comms::logger::BOOTSTRAP},
-      {"REG", meta::comms::logger::REG},
-      {"PROFILE", meta::comms::logger::PROFILE},
-      {"RAS", meta::comms::logger::RAS},
-      {"DESTROY", meta::comms::logger::DESTROY},
-      {"ALL", static_cast<uint64_t>(meta::comms::logger::ALL)},
-  }};
-  for (const auto& namedMask : kNamedMasks) {
-    if (asciiCaseInsensitiveEqual(name, namedMask.name)) {
-      return namedMask.mask;
-    }
-  }
-  return 0;
-}
-} // Anonymous namespace
 
 namespace meta::comms::logger {
 
@@ -167,186 +54,19 @@ folly::StringPiece getCategoryNthParent(folly::StringPiece category, int n) {
   return category;
 }
 
-/* Parse the DEBUG_SUBSYS env var
- * This can be a comma separated list such as INIT,COLL
- * or ^INIT,COLL etc
- */
-uint64_t parseDebugSubsysMask(const char* ncclDebugSubsysEnv) {
-  if (ncclDebugSubsysEnv == nullptr) {
-    return INIT | BOOTSTRAP | ENV;
-  }
-  std::string_view input{ncclDebugSubsysEnv};
-  const bool invert = !input.empty() && input.front() == '^';
-  if (invert) {
-    input.remove_prefix(1);
-  }
-  uint64_t maskResult = invert ? ~0ULL : 0ULL;
-  while (!input.empty()) {
-    const auto delimiter = input.find(',');
-    const auto token = input.substr(0, delimiter);
-    const auto mask = getSubSystemMaskForName(token);
-    if (mask) {
-      if (invert) {
-        maskResult &= ~mask;
-      } else {
-        maskResult |= mask;
-      }
-    }
-    if (delimiter == std::string_view::npos) {
-      break;
-    }
-    input.remove_prefix(delimiter + 1);
-  }
-  return maskResult;
-}
-
-std::string parseDebugFile(const char* ncclDebugFileEnv) {
-  if (ncclDebugFileEnv == nullptr) {
-    return {};
-  }
-  initProcMetaData();
-
-  int c = 0;
-  char debugFn[PATH_MAX + 1] = "";
-  char* dfn = debugFn;
-  while (ncclDebugFileEnv[c] != '\0' && (dfn - debugFn) < PATH_MAX) {
-    if (ncclDebugFileEnv[c++] != '%') {
-      *dfn++ = ncclDebugFileEnv[c - 1];
-      continue;
-    }
-    switch (ncclDebugFileEnv[c++]) {
-      case '%': // Double %
-        *dfn++ = '%';
-        break;
-      case 'h': // %h = hostname
-        dfn += snprintf(
-            dfn,
-            PATH_MAX + 1 - (dfn - debugFn),
-            "%s",
-            getProcMetaData().hostname.c_str());
-        break;
-      case 'p': // %p = pid
-        dfn += snprintf(
-            dfn, PATH_MAX + 1 - (dfn - debugFn), "%d", getProcMetaData().pid);
-        break;
-      default: // Echo everything we don't understand
-        *dfn++ = '%';
-        if ((dfn - debugFn) < PATH_MAX) {
-          *dfn++ = ncclDebugFileEnv[c - 1];
-        }
-        break;
-    }
-    if ((dfn - debugFn) > PATH_MAX) {
-      // snprintf wanted to overfill the buffer: set dfn to the end
-      // of the buffer (for null char) and it will naturally exit
-      // the loop.
-      dfn = debugFn + PATH_MAX;
-    }
-  }
-  *dfn = '\0';
-  return std::string{debugFn};
-}
-
-LogLevel getLoggerDebugLevel(std::string_view level) {
-  // If the env var is empty, then we default to log nothing
-  if (level.empty()) {
-    return LogLevel::NONE;
-  }
-  if (level == "VERSION") {
-    return LogLevel::VERSION;
-  } else if (level == "ERROR") {
-    return LogLevel::ERROR;
-  } else if (level == "WARN") {
-    return LogLevel::WARN;
-  } else if (level == "INFO") {
-    return LogLevel::INFO;
-  } else if (level == "ABORT") {
-    return LogLevel::ABORT;
-  } else if (level == "TRACE") {
-    return LogLevel::TRACE;
-  } else if (level == "NONE") {
-    return LogLevel::NONE;
-  }
-  // TODO: Add a warning here
-  return LogLevel::NONE;
-}
-
-LogLevel getNcclLoggerDebugLevel(std::string_view level) {
-  if (asciiCaseInsensitiveEqual(level, "VERSION")) {
-    return LogLevel::VERSION;
-  } else if (asciiCaseInsensitiveEqual(level, "ERROR")) {
-    return LogLevel::ERROR;
-  } else if (asciiCaseInsensitiveEqual(level, "WARN")) {
-    return LogLevel::WARN;
-  } else if (asciiCaseInsensitiveEqual(level, "INFO")) {
-    return LogLevel::INFO;
-  } else if (asciiCaseInsensitiveEqual(level, "ABORT")) {
-    return LogLevel::ABORT;
-  } else if (asciiCaseInsensitiveEqual(level, "TRACE")) {
-    return LogLevel::TRACE;
-  }
-  return LogLevel::NONE;
-}
-
-bool parseDebugLoggingAsync(const char* value, bool valueWhenUnset) {
-  if (value == nullptr) {
-    return valueWhenUnset;
-  }
-  const std::string_view input{value};
-  if (asciiCaseInsensitiveEqual(input, "1") ||
-      asciiCaseInsensitiveEqual(input, "Y") ||
-      asciiCaseInsensitiveEqual(input, "YES") ||
-      asciiCaseInsensitiveEqual(input, "T") ||
-      asciiCaseInsensitiveEqual(input, "TRUE")) {
-    return true;
-  }
-  if (asciiCaseInsensitiveEqual(input, "0") ||
-      asciiCaseInsensitiveEqual(input, "N") ||
-      asciiCaseInsensitiveEqual(input, "NO") ||
-      asciiCaseInsensitiveEqual(input, "F") ||
-      asciiCaseInsensitiveEqual(input, "FALSE")) {
-    return false;
-  }
-  return true;
-}
-
-void initProcMetaData() {
-  auto& metaData = getProcMetaData();
-  folly::call_once(metaData.initFlag, [&metaData]() {
-    metaData.hostname = getHostName('.');
-    metaData.pid = getpid();
-  });
-}
-
-void initThreadMetaData(std::string_view threadName) {
-  static thread_local folly::once_flag threadNameFlag;
-  folly::call_once(threadNameFlag, [&]() { setSpdlogThreadName(threadName); });
-}
-
 std::string NcclLogFormatter::formatMessage(
     const folly::LogMessage& message,
     const folly::LogCategory* /* handlerCategory */) {
-  initProcMetaData();
-
-  bool isErrorMessage = message.getLevel() >= folly::LogLevel::ERR;
-  if (isErrorMessage) {
-    // Errors are recorded to Scuba at their call sites (ncclMetaDebugLogError
-    // for NCCL, CERR for CTRAN), each of which captures a fresh native stack
-    // via logErrorToScuba(). Clear any stale cached native stack here so
-    // getLastCommsError() does not pair this message with an unrelated stack;
-    // the call site's logErrorToScuba(), which runs after this formatter,
-    // re-sets it when present, and a bare XLOG(ERR) correctly falls back to the
-    // legacy per-frame chain.
-    auto lockedError = getLastCommsErrorStorage().wlock();
-    lockedError->lastErrorMessage = message.getMessage();
-    lockedError->lastErrorNativeStack.clear();
+  const auto processMetadata = detail::getLogProcessMetadata();
+  if (message.getLevel() >= folly::LogLevel::ERR) {
+    /*
+     * Errors are recorded to Scuba at their call sites. Clear any stale native
+     * stack here so a bare legacy XLOG(ERR) falls back to the per-frame chain.
+     */
+    detail::setLastErrorFromLegacyLog(message.getMessage());
   }
 
-  // At least for now, formatter is called in the same thread as the logging
-  // thread. So we don't need to worry about getting the information of another
-  // thread here.
-  int cudaDev = threadContextFn_();
-
+  const int cudaDev = threadContextFn_();
   const auto basename = message.getFileBaseName();
   return formatCommsLogMessage(
       getGlogLevelName(message.getLevel()),
@@ -355,81 +75,17 @@ std::string NcclLogFormatter::formatMessage(
        .threadId = message.getThreadID(),
        .filename = std::string_view{basename.data(), basename.size()},
        .lineNumber = message.getLineNumber(),
-       .hostname = getProcMetaData().hostname,
-       .processId = getProcMetaData().pid,
+       .hostname = processMetadata.hostname,
+       .processId = processMetadata.processId,
        .threadContext = cudaDev,
        .threadName = getLogThreadName(),
        .prefix = prefix_});
-}
-
-void logErrorToScuba(
-    const std::string& message,
-    const int code,
-    const std::string& errorName,
-    const std::vector<std::string>& stack) {
-  // Build one Scuba record for the whole error; the guard flushes it to
-  // nccl_structured_logging on scope exit and keeps the sticky-context columns.
-  auto sampleGuard = EVENTS_SCUBA_UTIL_SAMPLE_GUARD("ERROR");
-  auto& sample = sampleGuard.sample();
-  sample.setError(message, stack);
-  if (code != 0) {
-    sample.addNormal("error_code", fmt::format("{}:{}", code, errorName));
-  }
-}
-
-void setLastError(const std::string& message, std::vector<std::string> stack) {
-  auto w = getLastCommsErrorStorage().wlock();
-  w->lastErrorMessage = message;
-  w->lastErrorNativeStack = std::move(stack);
-}
-
-void logCommErrorToScuba(commResult_t code, const std::string& message) {
-  if (!NCCL_SCUBA_LOG_ERROR_ENABLED) {
-    return;
-  }
-  std::vector<std::string> stack;
-  if (NCCL_SCUBA_STACK_TRACE_ON_ERROR_ENABLED) {
-    stack = captureNativeErrorStack();
-  }
-  logErrorToScuba(
-      message,
-      static_cast<int>(code),
-      ::meta::comms::commCodeToString(code),
-      stack);
-}
-
-std::string getLastCommsError() {
-  std::ostringstream ss;
-  {
-    auto lastCommsErrorRLocked = getLastCommsErrorStorage().rlock();
-    ss << lastCommsErrorRLocked->lastErrorMessage << "\nNCCL Stack trace:";
-    // Prefer the native captured stack; fall back to the legacy per-frame
-    // chain (still populated by v2_27/v2_29) when no native stack is present.
-    // TODO: remove the lastErrorStack fallback once ncclx v2_29 is retired --
-    // v2_30 is native-only, so this can collapse to lastErrorNativeStack.
-    const auto& stackTrace =
-        !lastCommsErrorRLocked->lastErrorNativeStack.empty()
-        ? lastCommsErrorRLocked->lastErrorNativeStack
-        : lastCommsErrorRLocked->lastErrorStack;
-    for (const auto& stack : stackTrace) {
-      ss << '\n' << stack;
-    }
-  }
-  return ss.str();
-}
-
-// TODO: remove once ncclx v2_29 is retired (see appendErrorToStack decl in
-// LoggingFormat.h) -- v2_30/ctran use captureNativeErrorStack() +
-// setLastError().
-void appendErrorToStack(std::string error) {
-  getLastCommsErrorStorage().wlock()->lastErrorStack.push_back(
-      std::move(error));
 }
 
 NcclLogFormatter::NcclLogFormatter(
     std::string prefix,
     std::function<int(void)> threadContextFn)
     : prefix_(std::move(prefix)),
-      threadContextFn_(std::move(threadContextFn)) {};
+      threadContextFn_(std::move(threadContextFn)) {}
 
 } // namespace meta::comms::logger

--- a/comms/utils/logger/LoggingFormat.h
+++ b/comms/utils/logger/LoggingFormat.h
@@ -4,72 +4,21 @@
 
 #include <functional>
 #include <string>
-#include <vector>
 
 #include <fmt/format.h>
 #include <folly/Range.h>
 #include <folly/logging/LogFormatter.h>
 #include <folly/logging/LogLevel.h>
 
-#include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/LogTypes.h"
-#include "comms/utils/logger/SpdlogLogger.h"
+#include "comms/utils/logger/CommsLogging.h"
 
 namespace meta::comms::logger {
 
-// TODO: Properly clean this up so that we directly parse NCCL logs to folly
-// levels.
 folly::LogLevel loggerLevelToFollyLogLevel(LogLevel level);
 
 folly::StringPiece getCategoryNthParent(folly::StringPiece category, int n);
 
-uint64_t parseDebugSubsysMask(const char* ncclDebugSubsysEnv);
-
-std::string parseDebugFile(const char* ncclDebugFileEnv);
-
-LogLevel getLoggerDebugLevel(std::string_view levelStr);
-LogLevel getNcclLoggerDebugLevel(std::string_view levelStr);
-
-/*
- * The fallback applies only when value is absent. Any present value other
- * than a recognized false token enables logging, matching NCCL cvar parsing.
- */
-bool parseDebugLoggingAsync(const char* value, bool valueWhenUnset);
-
-void initProcMetaData();
-
-void initThreadMetaData(std::string_view threadName);
-
 fmt::memory_buffer getLogPrefix(LogLevel level);
-
-std::string getLastCommsError();
-
-// TODO: remove once ncclx v2_29 is retired. The only remaining producer is
-// v2_29's ncclMetaDebugLogWithScuba (via ERR_WITH_SCUBA/WARN_WITH_SCUBA);
-// v2_30 and ctran record the last-error stack via captureNativeErrorStack() +
-// setLastError() instead (native-stack-only).
-void appendErrorToStack(std::string error);
-
-// Record an ERROR-level log to the nccl_structured_logging Scuba table as a
-// single error record (top-level message in the exception_message column,
-// native stack in the stack_trace column). The caller is responsible for gating
-// this on NCCL_SCUBA_LOG_ERROR_ENABLED and for capturing the native `stack`
-// once (via captureNativeErrorStack()) so it can be shared across reporters.
-__attribute__((visibility("default"))) void logErrorToScuba(
-    const std::string& message,
-    int code,
-    const std::string& errorName,
-    const std::vector<std::string>& stack);
-
-// Update the ncclGetLastError() state with the latest error message and its
-// pre-captured native stack. Unconditional; independent of Scuba error logging.
-void setLastError(const std::string& message, std::vector<std::string> stack);
-
-// Record a CTRAN ERR-level error to Scuba, carrying the commResult_t code.
-// Gated by NCCL_SCUBA_LOG_ERROR_ENABLED; a no-op when disabled.
-__attribute__((visibility("default"))) void logCommErrorToScuba(
-    commResult_t code,
-    const std::string& message);
 
 class NcclLogFormatter : public folly::LogFormatter {
  public:
@@ -87,23 +36,3 @@ class NcclLogFormatter : public folly::LogFormatter {
 };
 
 } // namespace meta::comms::logger
-
-#define COMMS_ERR(code, ...)                                                  \
-  do {                                                                        \
-    const auto _comms_error_message = fmt::format(__VA_ARGS__);               \
-    COMMS_LOG(ERR, "{}", _comms_error_message);                               \
-    ::meta::comms::logger::logCommErrorToScuba((code), _comms_error_message); \
-  } while (false)
-
-#define COMMS_NAMED_THREAD_START_EXT(threadName, rank, commHash, commDesc)                \
-  do {                                                                                    \
-    meta::comms::logger::initThreadMetaData(threadName);                                  \
-    COMMS_LOG(                                                                            \
-        INFO,                                                                             \
-        "[COMMS THREAD] Starting {} thread for rank {} commHash {:#x} commDesc {} at {}", \
-        threadName,                                                                       \
-        rank,                                                                             \
-        commHash,                                                                         \
-        commDesc,                                                                         \
-        __func__);                                                                        \
-  } while (0);

--- a/comms/utils/logger/tests/LegacyLoggingContractTest.bxl
+++ b/comms/utils/logger/tests/LegacyLoggingContractTest.bxl
@@ -16,8 +16,12 @@ def _scope_source_fragment(scope: str) -> str:
     relative_path = scope[len(_SCOPE_LABEL_PREFIX) : -len(_SCOPE_LABEL_SUFFIX)]
     return "//{}/".format(relative_path)
 
-_SCOPES = [scope for scope, _ in _SCOPE_CONFIGS]
+_SCOPES = [scope for scope, _ in _SCOPE_CONFIGS] + [
+    "fbcode//comms/utils/logger:comms_logging",
+]
 _SCOPE_SOURCE_FRAGMENTS = [fragment for _, fragment in _SCOPE_CONFIGS]
+_EXCLUDED_TARGET_SCOPES = ("fbcode//comms/mccl/coordinator/zelos/...",)
+_EXCLUDED_SOURCE_FRAGMENTS = [_scope_source_fragment(scope) for scope in _EXCLUDED_TARGET_SCOPES]
 
 _SOURCE_EXTENSIONS = (
     ".c",
@@ -101,6 +105,12 @@ _FOLLY_LOGGING_SYMBOL = regex(
 )
 _FOLLY_LOGGING_INCLUDE = regex(
     '^[ \\t]*#[ \\t]*include[ \\t]*[<"]folly/logging/.*',
+)
+_LEGACY_COMPATIBILITY_TARGETS = (
+    "fbcode//comms/utils/logger:log_utils",
+    "fbcode//comms/utils/logger:logger",
+    "fbcode//comms/utils/logger:logging_format",
+    "fbcode//comms/utils/logger:nccl_writer_wrapper",
 )
 
 def _is_identifier_character(character: str) -> bool:
@@ -205,8 +215,8 @@ def _strip_non_code_line(line: str, in_block_comment: bool = False, raw_terminat
         escaped,
     )
 
-def _is_folly_logging_dependency(label: str) -> bool:
-    return "//folly/logging:" in label
+def _is_legacy_logging_dependency(label: str) -> bool:
+    return "//folly/logging:" in label or label in _LEGACY_COMPATIBILITY_TARGETS
 
 def _contains_folly_logging_include(line: str, starts_in_literal: bool) -> bool:
     return not starts_in_literal and _FOLLY_LOGGING_INCLUDE.match(line)
@@ -219,31 +229,38 @@ def _is_scoped_source(path: str) -> bool:
             break
     if not has_source_extension:
         return False
+    for excluded_fragment in _EXCLUDED_SOURCE_FRAGMENTS:
+        if excluded_fragment in path:
+            return False
     for source_fragment in _SCOPE_SOURCE_FRAGMENTS:
         if source_fragment in path:
             return True
-    return False
+    return path.endswith("/comms/utils/logger/CommsLogging.cc") or path.endswith("/comms/utils/logger/CommsLogging.h")
 
-def _check_direct_dependencies(ctx: bxl.Context) -> None:
+def _migrated_targets(ctx: bxl.Context):
+    targets = ctx.uquery().eval(" + ".join(_SCOPES))
+    for excluded_scope in _EXCLUDED_TARGET_SCOPES:
+        targets = targets - ctx.uquery().eval(excluded_scope)
+    return targets
+
+def _check_direct_dependencies(ctx: bxl.Context, migrated_targets) -> None:
     violations = {}
-    for scope in _SCOPES:
-        for dependency in ctx.uquery().deps(scope, 1):
-            dependency_label = str(dependency.label)
-            if _is_folly_logging_dependency(dependency_label):
-                violations[dependency_label] = True
+    for dependency in ctx.uquery().deps(migrated_targets, 1):
+        dependency_label = str(dependency.label)
+        if _is_legacy_logging_dependency(dependency_label):
+            violations[dependency_label] = True
 
     if violations:
         fail(
-            "Migrated comms targets must not depend directly on Folly logging:\n" + "\n".join(sorted(violations.keys())),
+            "Migrated comms targets must not depend directly on legacy logging:\n" + "\n".join(sorted(violations.keys())),
         )
 
-def _check_source_content(ctx: bxl.Context) -> None:
+def _check_source_content(ctx: bxl.Context, migrated_targets) -> None:
     source_by_path = {}
-    for scope in _SCOPES:
-        for source in ctx.uquery().inputs(scope):
-            path = str(source)
-            if _is_scoped_source(path):
-                source_by_path[path] = ctx.fs.source(source)
+    for source in ctx.uquery().inputs(migrated_targets):
+        path = str(source)
+        if _is_scoped_source(path):
+            source_by_path[path] = ctx.fs.source(source)
 
     actions = ctx.bxl_actions().actions
     result = actions.declare_output(
@@ -337,10 +354,13 @@ def _validate_detector() -> None:
     for source_path in (
         "//comms/utils/logger/Source.cc",
         "//comms/ctran/README.md",
+        "//comms/mccl/coordinator/zelos/Source.cc",
         "//comms/torchcomms/source.cc",
     ):
         if _is_scoped_source(source_path):
             fail("Migrated scope detector accepted: {}".format(source_path))
+    if not _is_scoped_source("//comms/mccl/utils/Source.cc"):
+        fail("Migrated scope detector missed MCCL runtime source")
 
     for source in (
         "XLOG(ERR)",
@@ -440,15 +460,20 @@ def _validate_detector() -> None:
     if _contains_folly_logging_include(include_string, False):
         fail("Folly include detector rejected a string literal")
 
-    if not _is_folly_logging_dependency("fbcode//folly/logging:logging"):
+    if not _is_legacy_logging_dependency("fbcode//folly/logging:logging"):
         fail("Folly dependency detector missed its positive control")
-    if _is_folly_logging_dependency("fbcode//folly:format"):
+    if not _is_legacy_logging_dependency("fbcode//comms/utils/logger:logging_format"):
+        fail("Compatibility dependency detector missed its positive control")
+    if _is_legacy_logging_dependency("fbcode//folly:format"):
         fail("Folly dependency detector rejected a non-logging target")
+    if _is_legacy_logging_dependency("fbcode//comms/utils/logger:comms_logging"):
+        fail("Compatibility dependency detector rejected the native target")
 
 def _audit_legacy_logging(ctx: bxl.Context) -> None:
     _validate_detector()
-    _check_direct_dependencies(ctx)
-    _check_source_content(ctx)
+    migrated_targets = _migrated_targets(ctx)
+    _check_direct_dependencies(ctx, migrated_targets)
+    _check_source_content(ctx, migrated_targets)
 
 test = bxl_main(
     cli_args = {},

--- a/comms/utils/logger/tests/LogErrorToScubaTest.cc
+++ b/comms/utils/logger/tests/LogErrorToScubaTest.cc
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-#include "comms/utils/logger/LoggingFormat.h"
+#include "comms/utils/logger/CommsLogging.h"
 
 #include <sstream>
 #include <string>

--- a/comms/utils/logger/tests/MultiLibraryLoggingUT.cc
+++ b/comms/utils/logger/tests/MultiLibraryLoggingUT.cc
@@ -1,0 +1,375 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/SpdlogLogger.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using meta::comms::logger::configureCommsAndNamedSpdlogLoggers;
+using meta::comms::logger::getSpdlogLogger;
+using meta::comms::logger::kCommsLoggerName;
+
+namespace {
+
+/*
+ * Mirrors the logger names and prefixes each library passes to
+ * configureCommsAndNamedSpdlogLoggers from its own initialization path:
+ * ncclx/src/misc/param.cc, ctran/utils/LogInit.cc and mccl/utils/Utils.cpp.
+ * They are duplicated here rather than included because the ncclx facade has no
+ * lightweight build target, and depending on ctran/mccl would invert the
+ * logger's layering.
+ */
+struct Library {
+  std::string_view loggerName;
+  std::string_view prefix;
+};
+
+constexpr Library kNcclx{"comms.ncclx", "NCCL"};
+constexpr Library kCtran{"comms.ctran", "CTRAN"};
+constexpr Library kMccl{"comms.mccl", "MCCL"};
+
+constexpr std::string_view kSharedPrefix{"COMM"};
+
+enum class CapturedStream { Stdout, Stderr };
+
+class ScopedStreamCapture {
+ public:
+  explicit ScopedStreamCapture(CapturedStream stream) : stream_{stream} {
+    if (stream_ == CapturedStream::Stdout) {
+      testing::internal::CaptureStdout();
+    } else {
+      testing::internal::CaptureStderr();
+    }
+  }
+
+  ~ScopedStreamCapture() {
+    if (!released_) {
+      (void)release();
+    }
+  }
+
+  ScopedStreamCapture(const ScopedStreamCapture&) = delete;
+  ScopedStreamCapture& operator=(const ScopedStreamCapture&) = delete;
+
+  std::string release() {
+    if (released_) {
+      return {};
+    }
+    auto output = stream_ == CapturedStream::Stdout
+        ? testing::internal::GetCapturedStdout()
+        : testing::internal::GetCapturedStderr();
+    released_ = true;
+    return output;
+  }
+
+ private:
+  CapturedStream stream_;
+  bool released_{false};
+};
+
+class ScopedTestFile {
+ public:
+  explicit ScopedTestFile(std::string filename)
+      : directory_{makeUniqueDirectory()},
+        path_{directory_ / std::move(filename)} {}
+
+  ~ScopedTestFile() {
+    cleanup();
+  }
+
+  void cleanup() noexcept {
+    std::error_code error;
+    std::filesystem::remove_all(directory_, error);
+  }
+
+  ScopedTestFile(const ScopedTestFile&) = delete;
+  ScopedTestFile& operator=(const ScopedTestFile&) = delete;
+
+  const std::filesystem::path& path() const {
+    return path_;
+  }
+
+  std::string read() const {
+    std::ifstream file{path_};
+    if (!file) {
+      throw std::runtime_error{"failed to open " + path_.string()};
+    }
+    return {
+        std::istreambuf_iterator<char>{file}, std::istreambuf_iterator<char>{}};
+  }
+
+ private:
+  static std::filesystem::path makeUniqueDirectory() {
+    const auto pattern = (std::filesystem::path{testing::TempDir()} /
+                          "comms_multi_library_ut_XXXXXX")
+                             .string();
+    std::vector<char> buffer{pattern.begin(), pattern.end()};
+    buffer.push_back('\0');
+    if (::mkdtemp(buffer.data()) == nullptr) {
+      throw std::runtime_error{
+          "failed to create a temporary directory under " +
+          std::string{testing::TempDir()}};
+    }
+    return std::filesystem::path{buffer.data()};
+  }
+
+  std::filesystem::path directory_;
+  std::filesystem::path path_;
+};
+
+class MultiLibraryLoggingTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    deathTestStyle_ = GTEST_FLAG_GET(death_test_style);
+    resetLoggers();
+  }
+
+  // Synchronous logging keeps every assertion below free of flush waits.
+  void initLibrary(
+      const Library& library,
+      std::string_view logFilePath,
+      spdlog::level::level_enum level,
+      std::function<void(std::string_view)> errorCallback = {}) {
+    configureCommsAndNamedSpdlogLoggers(
+        library.loggerName,
+        std::string{library.prefix},
+        logFilePath,
+        []() { return 0; },
+        std::move(errorCallback),
+        false,
+        level);
+  }
+
+  void TearDown() override {
+    GTEST_FLAG_SET(death_test_style, deathTestStyle_);
+    resetLoggers("");
+  }
+
+  void cleanupResetLogFile() {
+    resetLogFile_.cleanup();
+  }
+
+  void resetLoggers() {
+    resetLoggers(resetLogFile_.path().string());
+  }
+
+  void resetLoggers(std::string_view logFilePath) {
+    for (const auto name :
+         {kCommsLoggerName,
+          kNcclx.loggerName,
+          kCtran.loggerName,
+          kMccl.loggerName}) {
+      auto& logger = getSpdlogLogger(name);
+      logger.configureOutput(logFilePath);
+      logger.configure("COMMS", []() { return 0; }, {}, false);
+      logger.set_level(spdlog::level::info);
+    }
+  }
+
+ private:
+  ScopedTestFile resetLogFile_{"comms_multi_library_reset.log"};
+  std::string deathTestStyle_;
+};
+
+TEST_F(MultiLibraryLoggingTest, EachLibraryInitTagsItsOwnLoggerAndTheShared) {
+  for (const auto& library : {kNcclx, kCtran, kMccl}) {
+    SCOPED_TRACE(library.loggerName);
+    resetLoggers();
+    const ScopedTestFile logFile{"comms_multi_library_prefix.log"};
+    initLibrary(library, logFile.path().string(), spdlog::level::info);
+
+    ScopedStreamCapture stderrCapture{CapturedStream::Stderr};
+    COMMS_LOG_NAMED(library.loggerName, WARN, "library message");
+    COMMS_LOG(WARN, "shared message");
+    (void)stderrCapture.release();
+    resetLoggers();
+
+    const auto output = logFile.read();
+    EXPECT_NE(
+        output.find(std::string{library.prefix} + " WARN library message"),
+        std::string::npos)
+        << library.loggerName << " output: " << output;
+    EXPECT_NE(
+        output.find(std::string{kSharedPrefix} + " WARN shared message"),
+        std::string::npos)
+        << library.loggerName << " output: " << output;
+  }
+}
+
+/*
+ * Every library init also reconfigures the shared "comms" logger, so in a
+ * process that initializes more than one library the last init owns the shared
+ * logger's level, destination and error callback.
+ */
+TEST_F(MultiLibraryLoggingTest, LastLibraryInitOwnsTheSharedLogger) {
+  const ScopedTestFile ncclxLogFile{"comms_multi_library_ncclx.log"};
+  const ScopedTestFile mcclLogFile{"comms_multi_library_mccl.log"};
+  const auto ncclxErrors = std::make_shared<std::vector<std::string>>();
+  const auto mcclErrors = std::make_shared<std::vector<std::string>>();
+
+  initLibrary(
+      kNcclx,
+      ncclxLogFile.path().string(),
+      spdlog::level::err,
+      [ncclxErrors](std::string_view message) {
+        ncclxErrors->emplace_back(message);
+      });
+  initLibrary(
+      kMccl,
+      mcclLogFile.path().string(),
+      spdlog::level::info,
+      [mcclErrors](std::string_view message) {
+        mcclErrors->emplace_back(message);
+      });
+
+  ScopedStreamCapture stderrCapture{CapturedStream::Stderr};
+  COMMS_LOG(ERR, "shared error after both inits");
+  COMMS_LOG(INFO, "shared info after both inits");
+  (void)stderrCapture.release();
+  resetLoggers();
+
+  EXPECT_TRUE(ncclxErrors->empty());
+  EXPECT_EQ(
+      *mcclErrors, (std::vector<std::string>{"shared error after both inits"}));
+  EXPECT_EQ(ncclxLogFile.read().find("after both inits"), std::string::npos);
+  const auto mcclOutput = mcclLogFile.read();
+  EXPECT_NE(
+      mcclOutput.find("shared error after both inits"), std::string::npos);
+  EXPECT_NE(mcclOutput.find("shared info after both inits"), std::string::npos);
+}
+
+/*
+ * With NCCL_DEBUG_FILE unset, library init points the logger at stdout, which
+ * matches the `FILE* ncclDebugFile = stdout` default in ncclx's debug.cc and
+ * upstream NCCL.
+ */
+TEST_F(MultiLibraryLoggingTest, InitWithoutDebugFileWritesToStdout) {
+  constexpr std::string_view kMessage{"ncclx warn without debug file"};
+  ScopedStreamCapture stdoutCapture{CapturedStream::Stdout};
+  ScopedStreamCapture stderrCapture{CapturedStream::Stderr};
+  initLibrary(kNcclx, "", spdlog::level::info);
+  COMMS_LOG_NAMED(kNcclx.loggerName, WARN, "{}", kMessage);
+  const auto stdoutOutput = stdoutCapture.release();
+  const auto stderrOutput = stderrCapture.release();
+
+  EXPECT_NE(stdoutOutput.find(kMessage), std::string::npos)
+      << "captured stdout: " << stdoutOutput;
+  EXPECT_EQ(stderrOutput.find(kMessage), std::string::npos)
+      << "captured stderr: " << stderrOutput;
+}
+
+/*
+ * NCCL_DEBUG_FILE routing: every initialized library logger writes to the one
+ * file, and only warnings and errors are mirrored to stderr.
+ */
+TEST_F(MultiLibraryLoggingTest, InitializedLibraryLoggersShareTheDebugFile) {
+  const ScopedTestFile logFile{"comms_multi_library_shared_file.log"};
+  const auto logPath = logFile.path().string();
+  initLibrary(kNcclx, logPath, spdlog::level::info);
+  initLibrary(kCtran, logPath, spdlog::level::info);
+  initLibrary(kMccl, logPath, spdlog::level::info);
+
+  ScopedStreamCapture stderrCapture{CapturedStream::Stderr};
+  for (const auto& library : {kNcclx, kCtran, kMccl}) {
+    COMMS_LOG_NAMED(library.loggerName, INFO, "{} info line", library.prefix);
+    COMMS_LOG_NAMED(library.loggerName, WARN, "{} warn line", library.prefix);
+  }
+  const auto stderrOutput = stderrCapture.release();
+  resetLoggers();
+
+  const auto output = logFile.read();
+  for (const auto& library : {kNcclx, kCtran, kMccl}) {
+    std::string infoRecord{library.prefix};
+    infoRecord.append(" INFO ").append(library.prefix);
+    std::string warnRecord{library.prefix};
+    warnRecord.append(" WARN ").append(library.prefix);
+    std::string infoLine{library.prefix};
+    infoLine.append(" info line");
+    std::string warnLine{library.prefix};
+    warnLine.append(" warn line");
+
+    EXPECT_NE(output.find(infoRecord), std::string::npos)
+        << "log file: " << output;
+    EXPECT_NE(output.find(warnRecord), std::string::npos)
+        << "log file: " << output;
+    EXPECT_EQ(stderrOutput.find(infoLine), std::string::npos)
+        << "captured stderr: " << stderrOutput;
+    EXPECT_NE(stderrOutput.find(warnLine), std::string::npos)
+        << "captured stderr: " << stderrOutput;
+  }
+}
+
+/*
+ * A fatal in one library shuts the async thread pool down for the whole
+ * process. Every other library logger must keep delivering synchronously so
+ * that the messages explaining the abort are not lost.
+ */
+class MultiLibraryLoggingDeathTest : public MultiLibraryLoggingTest {};
+
+TEST_F(
+    MultiLibraryLoggingDeathTest,
+    AllLibraryLoggersDeliverAfterFatalShutdown) {
+  ScopedTestFile logFile{"comms_multi_library_fatal.log"};
+  const auto logPath = logFile.path().string();
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+  EXPECT_EXIT(
+      {
+        int exitCode = 0;
+        try {
+          // Asynchronous init is what shutdownSpdlogForFatal() has to undo.
+          for (const auto& library : {kNcclx, kCtran, kMccl}) {
+            configureCommsAndNamedSpdlogLoggers(
+                library.loggerName,
+                std::string{library.prefix},
+                logPath,
+                []() { return 0; },
+                {},
+                true,
+                spdlog::level::info);
+          }
+          meta::comms::logger::shutdownSpdlogForFatal();
+
+          COMMS_LOG_NAMED(kNcclx.loggerName, WARN, "ncclx after shutdown");
+          COMMS_LOG_NAMED(kCtran.loggerName, WARN, "ctran after shutdown");
+          COMMS_LOG_NAMED(kMccl.loggerName, WARN, "mccl after shutdown");
+          COMMS_LOG(WARN, "shared after shutdown");
+
+          const auto fileOutput = logFile.read();
+          if (fileOutput.find("ncclx after shutdown") == std::string::npos ||
+              fileOutput.find("ctran after shutdown") == std::string::npos ||
+              fileOutput.find("mccl after shutdown") == std::string::npos ||
+              fileOutput.find("shared after shutdown") == std::string::npos) {
+            std::fprintf(
+                stderr,
+                "debug file missing post-shutdown records:\n%s",
+                fileOutput.c_str());
+            exitCode = 1;
+          }
+        } catch (const std::exception& error) {
+          std::fprintf(
+              stderr,
+              "failed to inspect post-shutdown debug file: %s\n",
+              error.what());
+          exitCode = 1;
+        }
+        resetLoggers("");
+        logFile.cleanup();
+        cleanupResetLogFile();
+        std::exit(exitCode);
+      },
+      ::testing::ExitedWithCode(0),
+      "ncclx after shutdown(.|\\n)*ctran after shutdown(.|\\n)*mccl after "
+      "shutdown(.|\\n)*shared after shutdown");
+}
+
+} // namespace


### PR DESCRIPTION
Summary:

This adds a fast CPU-only conformance test for the shared logging configuration used by NCCLX, CTRAN, and MCCL. It exercises the real logger names and prefixes through `configureCommsAndNamedSpdlogLoggers()` and pins the cross-library contracts common to all three initialization paths:

- each named logger retains its library prefix while the shared logger uses `COMM`;
- the last library initialization owns the shared logger destination, level, and error callback;
- an empty debug-file path writes to stdout;
- initialized library loggers share one file while only warning/error records are mirrored to stderr; and
- after fatal shutdown, every configured logger continues delivering synchronously.

Each test starts from a private temporary sink so the stdout-routing assertion cannot pass because of prior fixture state. Test files use unique temporary directories so concurrently scheduled copies cannot unlink or reuse another test file. The re-exec death-test child explicitly removes its temporary files before `std::exit()` bypasses destructors. Error callback captures own their storage until logger configuration is reset, and the death-test style is restored during teardown. The fixture does not mutate the process-global subsystem mask because these tests do not change it.

A separate historical and live-path audit found that pre-initialization CTRAN logging must not inherit NCCLX configuration. Before migration, CTRAN source categories inherited the Folly root/base configuration until `initCtranLogging()`; they did not inherit the separately configured `comms.ncclx` category. The prior speculative assertion requiring NCCLX level/file inheritance was therefore removed rather than driving a behavior-changing production fix.

Reviewed By: shr

Differential Revision: D117570944


