### PR TITLE
Drive the readout on a cadence, and flush the tail

### DIFF
--- a/comms/utils/collstats/CollStatsDeviceBlock.cc
+++ b/comms/utils/collstats/CollStatsDeviceBlock.cc
@@ -81,8 +81,11 @@ CollStatsDeviceBlockHandle collStatsAllocDeviceBlock(
   // log2(dur / tMinNs) infinite and the cast to a bucket index undefined.
   const CollStatHistGeometry derived = collStatMakeHistGeometry(
       cfg.hist.tMinNs, cfg.hist.tMaxNs, cfg.hist.subBucketsPerOctave);
+  // sizeClasses stays host-side, but sizeClassOf() still walks `i < sc.n` over
+  // a fixed-capacity edges[].
   if (derived.numBuckets == 0 || derived.numBuckets != cfg.hist.numBuckets ||
-      cfg.numThresholds > kMaxThresholds) {
+      cfg.numThresholds > kMaxThresholds ||
+      cfg.sizeClasses.n > kMaxSizeClasses) {
     return CollStatsDeviceBlockHandle{};
   }
   // A zero-slot block allocates nothing for the span scratch but still reports

--- a/comms/utils/collstats/CollStatsReader.cu
+++ b/comms/utils/collstats/CollStatsReader.cu
@@ -309,23 +309,16 @@ CollStatSnapshot collStatsReadWindow(
       // Left resident, its counts become the next window's starting balance and
       // inflate it. Best-effort: a stream wedged badly enough to fail above
       // will fail here too, and then the counts are unrecoverable either way.
-      // Return values are consumed to satisfy HIP's nodiscard on
-      // hipMemsetAsync/hipStreamSynchronize; the recovery is best-effort, so
-      // there is nothing to do with a failure here.
+      // Return value is consumed to satisfy HIP's nodiscard on hipMemsetAsync.
       [[maybe_unused]] const cudaError_t e0 = cudaMemsetAsync(
           handle.values[currentEpoch & 1u],
           0,
           static_cast<std::size_t>(handle.keyCapacity + 1) *
               sizeof(CollStatValue),
           readerStream);
-      [[maybe_unused]] const cudaError_t e1 =
-          cudaStreamSynchronize(readerStream);
     }
-    // `staging` is freed on the way out of this scope, and the failure may have
-    // been the synchronize above with both D2H copies already enqueued -- so
-    // drain before the pinned buffer they land in goes away. Best-effort, and
-    // deliberately not relying on cudaFreeHost's implicit synchronize, which is
-    // an implementation detail rather than a documented barrier.
+    // The failure can be the synchronize itself, leaving the D2H copies in
+    // flight into `staging`, which is freed on scope exit.
     [[maybe_unused]] const cudaError_t drained =
         cudaStreamSynchronize(readerStream);
     return CollStatSnapshot{};

--- a/comms/utils/collstats/CollStatsReadoutDriver.cc
+++ b/comms/utils/collstats/CollStatsReadoutDriver.cc
@@ -1,0 +1,276 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/collstats/CollStatsReadoutDriver.h"
+#include <chrono>
+
+#include <algorithm>
+#include <cstdio>
+#include <exception>
+#include <utility>
+
+namespace meta::comms::collstats {
+
+namespace {
+
+uint64_t wallNowNs() {
+  return static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::system_clock::now().time_since_epoch())
+          .count());
+}
+
+// Create into `*out`, leaving it null on failure. CUDA does not promise to
+// leave an output parameter untouched when a create fails, and the destructor
+// destroys any non-null handle -- so a failed create must not be able to leave
+// an indeterminate one behind.
+bool createReaderStream(cudaStream_t* out) {
+  if (cudaStreamCreateWithFlags(out, cudaStreamNonBlocking) != cudaSuccess) {
+    *out = nullptr;
+    return false;
+  }
+  return true;
+}
+
+bool createTimingDisabledEvent(cudaEvent_t* out) {
+  if (cudaEventCreateWithFlags(out, cudaEventDisableTiming) != cudaSuccess) {
+    *out = nullptr;
+    return false;
+  }
+  return true;
+}
+
+// Puts the caller's CUDA device back on scope exit, or does nothing when
+// constructed with -1. The issue path launches the flip kernel on the reader
+// stream, which belongs to the driver's device, so that device has to stay
+// current across the whole of issue() and flush() -- not just the synchronize.
+class DeviceRestorer {
+ public:
+  explicit DeviceRestorer(int device) : device_(device) {}
+  ~DeviceRestorer() {
+    if (device_ >= 0) {
+      // Best-effort; the return value is consumed for HIP's nodiscard.
+      [[maybe_unused]] const cudaError_t e = cudaSetDevice(device_);
+    }
+  }
+  DeviceRestorer(const DeviceRestorer&) = delete;
+  DeviceRestorer& operator=(const DeviceRestorer&) = delete;
+  DeviceRestorer(DeviceRestorer&&) = delete;
+  DeviceRestorer& operator=(DeviceRestorer&&) = delete;
+
+ private:
+  int device_;
+};
+
+} // namespace
+
+CollStatsReadoutDriver::CollStatsReadoutDriver(
+    const CollStatsDeviceBlockHandle& handle,
+    uint32_t cadence,
+    Sink sink,
+    const CollStatsKeyRegistry& keys)
+    : handle_(handle),
+      cadence_(std::max<uint32_t>(1u, cadence)),
+      sink_(std::move(sink)),
+      keys_(&keys) {
+  // The registry's id space and the bank's value slots are sized
+  // independently, and only agree when the registry's catch-all sits exactly at
+  // the bank's key capacity. Mismatched, every readout past that point fails
+  // inside collStatsIssueReadWindow and is charged as a dropped window, which
+  // reads identically to a CUDA fault -- so refuse at construction instead of
+  // going dark mid-run.
+  if (handle_.dev == nullptr || keys.catchAllId() != handle_.keyCapacity ||
+      cudaGetDevice(&device_) != cudaSuccess || !createReaderStream(&reader_) ||
+      !createTimingDisabledEvent(&streamEvent_) ||
+      !createTimingDisabledEvent(&flipEvent_) ||
+      !createTimingDisabledEvent(&copyDone_) ||
+      !pinned_.allocate(handle_.keyCapacity)) {
+    disabled_ = true;
+  }
+  // The first window accumulates from here, not from epoch zero.
+  windowOpenNs_ = wallNowNs();
+}
+
+CollStatsReadoutDriver::~CollStatsReadoutDriver() {
+  // Harvest the last issued window and the collectives accumulated since,
+  // before the reader stream and the device bank go away.
+  flushFinal();
+  // A window can still be in flight here, and pending_ does not tell us:
+  // collStatsIssueReadWindow enqueues both D2H copies into pinned_ before its
+  // last few steps, so a failure at the memset or the event record returns
+  // non-success with those copies already on the stream, and issue() then
+  // leaves pending_ false. cudaStreamDestroy does not wait, and pinned_ is
+  // freed as soon as this body returns, so a gated sync would let the device
+  // DMA into a freed page-locked buffer. Unconditional, because the paths that
+  // clear pending_ on failure are exactly the ones that need it.
+  if (reader_ != nullptr) {
+    [[maybe_unused]] const cudaError_t e = cudaStreamSynchronize(reader_);
+  }
+  // Return values are consumed to satisfy HIP's nodiscard on the destroy
+  // entry points. Teardown is fail-open, so failures are ignored.
+  if (copyDone_ != nullptr) {
+    [[maybe_unused]] const cudaError_t e = cudaEventDestroy(copyDone_);
+  }
+  if (flipEvent_ != nullptr) {
+    [[maybe_unused]] const cudaError_t e = cudaEventDestroy(flipEvent_);
+  }
+  if (streamEvent_ != nullptr) {
+    [[maybe_unused]] const cudaError_t e = cudaEventDestroy(streamEvent_);
+  }
+  if (reader_ != nullptr) {
+    [[maybe_unused]] const cudaError_t e = cudaStreamDestroy(reader_);
+  }
+}
+
+void CollStatsReadoutDriver::harvestIfReady() {
+  if (!pending_) {
+    return;
+  }
+  const cudaError_t q = cudaEventQuery(copyDone_);
+  if (q == cudaSuccess) {
+    pinned_.publish(pendingEpoch_, *keys_, handle_.cfg, snapshot_);
+    // publish() fills the bank-derived fields; the wall bounds are the
+    // producer's and are stamped here.
+    snapshot_.windowStartUnixNs = pendingOpenNs_;
+    snapshot_.windowEndUnixNs = pendingCloseNs_;
+    if (sink_) {
+      // The sink is caller-supplied and this runs from the destructor's final
+      // flush, where an escaping exception would hit a noexcept boundary and
+      // std::terminate -- killing the job over telemetry. Swallow it, count it,
+      // and say so once so a silently throwing sink is still diagnosable.
+      try {
+        sink_(snapshot_);
+      } catch (const std::exception& e) {
+        if (sinkExceptions_ == 0) {
+          fprintf(
+              stderr,
+              "collstats: readout sink threw (%s); window dropped, "
+              "further occurrences counted only\n",
+              e.what());
+        }
+        ++sinkExceptions_;
+      } catch (...) {
+        if (sinkExceptions_ == 0) {
+          fprintf(
+              stderr,
+              "collstats: readout sink threw a non-std exception; window "
+              "dropped, further occurrences counted only\n");
+        }
+        ++sinkExceptions_;
+      }
+    }
+    ++windowsExported_;
+    pending_ = false;
+  } else if (q == cudaErrorNotReady) {
+    // The previous copy is still in flight; leave it pending and retry the
+    // harvest next cycle rather than overwrite an in-flight staging buffer.
+    // Deferred, not lost: the window still lands in exported or dropped later,
+    // so charging it here would double-count it and stop the two counters from
+    // partitioning windows.
+    ++harvestRetries_;
+  } else {
+    disabled_ = true;
+    ++windowsDropped_;
+  }
+}
+
+void CollStatsReadoutDriver::onCollective(cudaStream_t instrumentedStream) {
+  if (disabled_ || handle_.dev == nullptr) {
+    return;
+  }
+  // Not reset here: an issue that does not happen must not clear the count, or
+  // the collectives it covers become invisible to flushFinal. Left above
+  // cadence, the next tick retries instead of waiting a whole cadence again.
+  if (++sinceReadout_ < cadence_) {
+    return;
+  }
+
+  harvestIfReady();
+  if (disabled_ || pending_) {
+    // Either a real error, or the previous window's copy is not done yet; do
+    // not issue a new one until the staging buffer is free.
+    return;
+  }
+
+  const cudaEvent_t streamEvents[1] = {streamEvent_};
+  CollStatsReadGating gating{};
+  gating.instrumentedStreams = &instrumentedStream;
+  gating.streamEvents = streamEvents;
+  gating.numStreams = 1;
+  gating.flipEvent = flipEvent_;
+  issue(&gating);
+}
+
+void CollStatsReadoutDriver::issue(const CollStatsReadGating* gating) {
+  const cudaError_t e = collStatsIssueReadWindow(
+      handle_, reader_, gating, localEpoch_, copyDone_, pinned_, *keys_);
+  if (e == cudaSuccess) {
+    const uint64_t now = wallNowNs();
+    pendingEpoch_ = localEpoch_;
+    pendingOpenNs_ = windowOpenNs_;
+    pendingCloseNs_ = now;
+    windowOpenNs_ = now;
+    ++localEpoch_;
+    pending_ = true;
+    // The flip happened, so the bank this counts against is now the new one.
+    sinceReadout_ = 0;
+  } else {
+    disabled_ = true;
+    ++windowsDropped_;
+  }
+}
+
+void CollStatsReadoutDriver::flush() {
+  if (disabled_ || !pending_) {
+    return;
+  }
+  if (cudaStreamSynchronize(reader_) != cudaSuccess) {
+    disabled_ = true;
+    ++windowsDropped_;
+    return;
+  }
+  harvestIfReady();
+}
+
+void CollStatsReadoutDriver::flushFinal() {
+  flush();
+
+  // Nothing has accumulated since the last boundary, or the staging buffer is
+  // still occupied by a window flush() could not land: either way there is no
+  // extra window to issue.
+  if (disabled_ || pending_ || sinceReadout_ == 0 || handle_.dev == nullptr) {
+    return;
+  }
+  // Stands in for the gating an on-boundary issue would do, without needing a
+  // handle to the instrumented streams. The sync only covers the calling
+  // thread's current device, and teardown can run on a thread that never
+  // selected ours, so select the driver's device and put the caller's back —
+  // otherwise the wait is vacuous and the ungated issue races live finalizers.
+  int callerDev = -1;
+  if (cudaGetDevice(&callerDev) != cudaSuccess) {
+    disabled_ = true;
+    ++windowsDropped_;
+    return;
+  }
+  const bool swapDev = callerDev != device_;
+  if (swapDev && cudaSetDevice(device_) != cudaSuccess) {
+    disabled_ = true;
+    ++windowsDropped_;
+    return;
+  }
+  // Held until after issue() and flush(), not just the synchronize below.
+  // issue() launches the flip kernel on reader_, which belongs to device_, and
+  // a launch onto a stream of a non-current device fails with
+  // cudaErrorInvalidResourceHandle -- which would disable the driver and drop
+  // the very window this function exists to export.
+  const DeviceRestorer restore(swapDev ? callerDev : -1);
+
+  if (cudaDeviceSynchronize() != cudaSuccess) {
+    disabled_ = true;
+    ++windowsDropped_;
+    return;
+  }
+  issue(/*gating=*/nullptr);
+  flush();
+}
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsReadoutDriver.h
+++ b/comms/utils/collstats/CollStatsReadoutDriver.h
@@ -1,0 +1,167 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+#include <cuda_runtime.h>
+
+#include "comms/utils/collstats/CollStatsDeviceBlock.h"
+#include "comms/utils/collstats/CollStatsReader.h"
+
+// Per-communicator pipelined readout driver. Called from the producer thread
+// after each instrumented collective, it runs the window readout inline without
+// ever synchronizing: every `cadence` collectives it harvests the previous
+// window's already-completed copy (a non-blocking event query) and issues the
+// next window's copy on a dedicated reader stream. Because it is driven from
+// the same thread that enqueues collectives, the flip sequence needs no
+// boundary lock — no collective can enqueue mid-flip on that thread.
+//
+// It owns the reader stream, the reusable events, one page-locked staging
+// buffer, and one snapshot, all reused across windows. The staging buffer must
+// be page-locked for the non-blocking claim above to hold: a device-to-host
+// cudaMemcpyAsync into pageable memory blocks the calling thread until the
+// stream drains. Page-locking is necessary but has not proven sufficient
+// everywhere — one tick behind a spin kernel measures ~0ms on a devgpu H100 and
+// ~2005ms under remote execution, cause not yet identified (T282705070). A CUDA
+// failure disables the driver (telemetry stops) rather than risk the workload;
+// every dropped or lost window is counted.
+//
+// Not thread-safe: onCollective must be called from the comm's enqueue thread,
+// the same serialization the ctran launch path already assumes.
+
+namespace meta::comms::collstats {
+
+class CollStatsReadoutDriver {
+ public:
+  using Sink = std::function<void(const CollStatSnapshot&)>;
+
+  // Creates a dedicated non-blocking reader stream and reusable events. If any
+  // CUDA resource fails the driver is born disabled (a no-op). `handle.dev`
+  // must be non-null; `cadence` is the number of collectives between readouts
+  // (>= 1). `sink` receives each completed window synchronously and must
+  // consume it before returning (the staging buffer is reused). `keys` is the
+  // registry that assigned the value slots; it must outlive the driver, and it
+  // supplies both how much of the bank to read and the identity of each slot.
+  //
+  // `sink` should not throw. It is invoked from the destructor's final flush,
+  // where an escaping exception would call std::terminate and take the job down
+  // over telemetry. Exceptions are caught and counted (sinkExceptions()) rather
+  // than propagated, but a sink that throws still loses that window.
+  CollStatsReadoutDriver(
+      const CollStatsDeviceBlockHandle& handle,
+      uint32_t cadence,
+      Sink sink,
+      const CollStatsKeyRegistry& keys);
+  ~CollStatsReadoutDriver();
+
+  CollStatsReadoutDriver(const CollStatsReadoutDriver&) = delete;
+  CollStatsReadoutDriver& operator=(const CollStatsReadoutDriver&) = delete;
+  // Non-movable as well: the driver owns a reader stream, events and a pinned
+  // staging buffer that an in-flight copy is already addressed at, so a
+  // moved-from driver's destructor would tear them down under that copy.
+  CollStatsReadoutDriver(CollStatsReadoutDriver&&) = delete;
+  CollStatsReadoutDriver& operator=(CollStatsReadoutDriver&&) = delete;
+
+  // Called after each instrumented collective launch on `instrumentedStream`.
+  // Every `cadence` calls: harvest the previous window if its copy has
+  // completed (a non-blocking event query), then issue the next. Intended not
+  // to block the caller; see T282705070 for where that does not yet hold.
+  void onCollective(cudaStream_t instrumentedStream);
+
+  // Synchronize the reader stream and harvest an already-issued window.
+  //
+  // This recovers the last window that reached a cadence boundary, not the
+  // collectives accumulated since — those are still in the live device bank and
+  // were never staged. Use flushFinal() at teardown to get both.
+  void flush();
+
+  // flush(), then issue and harvest one extra window for the collectives
+  // accumulated since the last cadence boundary. Called from the destructor, so
+  // the up to `cadence - 1` collectives at the end of a run are reported rather
+  // than freed unread with the device bank.
+  //
+  // Blocks, unlike onCollective. The extra window is issued ungated, after a
+  // device synchronize: the usual cross-stream gating records an event on the
+  // instrumented stream, and a destructor cannot assume a stream it does not
+  // own still exists. The device sync gives the same guarantee — every
+  // finalizer has retired before the bank is copied — without touching a
+  // borrowed handle.
+  //
+  // The one ordering requirement is that the device block outlive the driver.
+  // CtranAlgo declares the driver last, so it is destroyed first.
+  void flushFinal();
+
+  uint64_t windowsExported() const {
+    return windowsExported_;
+  }
+  uint64_t windowsDropped() const {
+    return windowsDropped_;
+  }
+  // Harvest attempts that found the copy still in flight. Counts attempts, not
+  // windows: a deferred window stays pending and still lands in exactly one of
+  // exported/dropped, so one stalled copy can bump this many times.
+  uint64_t harvestRetries() const {
+    return harvestRetries_;
+  }
+  // Windows whose sink threw. Counted apart from windowsDropped_: the readout
+  // itself succeeded and the window was complete, so this attributes the loss
+  // to the consumer rather than to the device path.
+  uint64_t sinkExceptions() const {
+    return sinkExceptions_;
+  }
+  bool disabled() const {
+    return disabled_;
+  }
+
+ private:
+  void harvestIfReady();
+  // Enqueues one window's readout, gated when `gating` is non-null. Marks the
+  // driver disabled and counts a drop on failure.
+  void issue(const CollStatsReadGating* gating);
+
+  CollStatsDeviceBlockHandle handle_;
+  uint32_t cadence_;
+  Sink sink_;
+  const CollStatsKeyRegistry* keys_;
+
+  // The device current at construction, where reader_, the events and the
+  // bank live. flushFinal's device sync only covers the calling thread's
+  // current device, and teardown can run on a thread that never selected ours.
+  int device_{-1};
+
+  cudaStream_t reader_{nullptr};
+  cudaEvent_t streamEvent_{nullptr};
+  cudaEvent_t flipEvent_{nullptr};
+  cudaEvent_t copyDone_{nullptr};
+
+  // The device-to-host copy lands in page-locked memory (otherwise the copy
+  // would be synchronous and the issue path would block the producer thread);
+  // published into `snapshot_` by a host memcpy once copyDone_ fires.
+  CollStatsPinnedStaging pinned_;
+  CollStatSnapshot snapshot_;
+  uint64_t localEpoch_{0}; // in lockstep with the device epoch (only we flip)
+  uint64_t pendingEpoch_{0}; // epoch of the window currently in flight
+  // Wall-clock bounds, captured at the flip rather than at the harvest: the
+  // readout is pipelined, so the harvest happens an arbitrary time later and
+  // does not bound when the collectives it describes actually ran. Advanced
+  // only when an issue succeeds, so a dropped window leaves the next one
+  // correctly spanning the gap as well as its own period.
+  uint64_t windowOpenNs_{0};
+  uint64_t pendingOpenNs_{0};
+  uint64_t pendingCloseNs_{0};
+  // Collectives against the current bank. Cleared only when an issue succeeds
+  // and the epoch actually flips, so a skipped issue leaves them counted.
+  uint32_t sinceReadout_{0};
+  bool pending_{false}; // a copy into pinned_ is in flight
+  bool disabled_{false};
+
+  uint64_t windowsExported_{0};
+  // Windows genuinely lost: a CUDA error on the query, a failed stream sync, or
+  // a failed issue. With windowsExported_ this partitions windows.
+  uint64_t windowsDropped_{0};
+  uint64_t harvestRetries_{0};
+  uint64_t sinkExceptions_{0};
+};
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/tests/CollStatsDeviceBlockGpuTest.cu
+++ b/comms/utils/collstats/tests/CollStatsDeviceBlockGpuTest.cu
@@ -43,6 +43,19 @@ class CollStatsDeviceBlockGpuTest : public ::testing::Test {
     if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount == 0) {
       GTEST_SKIP() << "no CUDA device";
     }
+    // The span helpers are behind __CUDA_ARCH__ >= 900; below Hopper they are
+    // no-ops and every span assertion here passes vacuously.
+    int major = 0;
+    int device = 0;
+    if (cudaGetDevice(&device) != cudaSuccess ||
+        cudaDeviceGetAttribute(
+            &major, cudaDevAttrComputeCapabilityMajor, device) != cudaSuccess) {
+      GTEST_SKIP() << "cannot query compute capability";
+    }
+    if (major < 9) {
+      GTEST_SKIP() << "span helpers are compiled out below sm_90; device is sm_"
+                   << major << "x";
+    }
   }
 
   // The retired bank is always read back whole, so the copy and its sizing live
@@ -200,6 +213,40 @@ TEST_F(CollStatsDeviceBlockGpuTest, SpanRecordsOneObservationPerLaunch) {
   }
   EXPECT_GT(maxDur, 0u);
   EXPECT_LT(maxDur, 1'000'000'000ull); // well under a second
+
+  collStatsFreeDeviceBlock(h);
+}
+
+// Every block arrives, satisfying the barrier, but nothing ever sets `start`.
+__global__ void spanFinalizeOnlyKernel(
+    CollStatsDeviceBlock* block,
+    uint32_t keyId) {
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    collStatsSpanFinalizeElectedById(block, /*slot=*/0, keyId, 4096);
+  }
+}
+
+// `end - kSpanStartInit` wraps to `end + 1`: a sub-microsecond duration that
+// buckets as a real, very fast collective. The finalizer drops it instead.
+TEST_F(CollStatsDeviceBlockGpuTest, FinalizeWithoutEntryRecordsNothing) {
+  const uint32_t capacity = 64;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/4);
+  ASSERT_NE(h.dev, nullptr);
+
+  // No pre-reset, so `start` is still the allocator's sentinel.
+  spanFinalizeOnlyKernel<<<16, 64>>>(h.dev, /*keyId=*/0);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+
+  const std::vector<CollStatValue> values = readValues(h, capacity);
+  EXPECT_EQ(totalCount(values), 0u);
+  uint64_t maxDur = 0;
+  for (const auto& v : values) {
+    maxDur = v.durMaxNs > maxDur ? v.durMaxNs : maxDur;
+  }
+  EXPECT_EQ(maxDur, 0u);
 
   collStatsFreeDeviceBlock(h);
 }

--- a/comms/utils/collstats/tests/CollStatsReadoutDriverGpuTest.cu
+++ b/comms/utils/collstats/tests/CollStatsReadoutDriverGpuTest.cu
@@ -1,0 +1,313 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <atomic>
+#include <cstdint>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include "comms/utils/collstats/CollStatsDeviceBlock.h"
+#include "comms/utils/collstats/CollStatsKeyRegistry.h"
+#include "comms/utils/collstats/CollStatsReadoutDriver.h"
+#include "comms/utils/collstats/CollStatsSpan.cuh"
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+namespace meta::comms::collstats {
+namespace {
+
+__global__ void
+spanKernel(CollStatsDeviceBlock* block, uint32_t keyId, uint64_t logicalBytes) {
+  collStatsSpanEntry(block, /*slot=*/0);
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    collStatsSpanFinalizeElectedById(block, /*slot=*/0, keyId, logicalBytes);
+  }
+}
+
+uint64_t totalCount(const std::vector<CollStatValue>& values) {
+  uint64_t total = 0;
+  for (const auto& v : values) {
+    total += v.count;
+  }
+  return total;
+}
+
+// One instrumented collective: stream-ordered pre-reset, span kernel, then the
+// driver tick — exactly the sequence the launch path will run.
+void runCollective(
+    CollStatsReadoutDriver& driver,
+    const CollStatsDeviceBlockHandle& h,
+    cudaStream_t stream,
+    uint32_t keyId) {
+  collStatsEnqueuePreReset(h, /*slot=*/0, stream);
+  spanKernel<<<8, 64, 0, stream>>>(h.dev, keyId, 4096);
+  driver.onCollective(stream);
+}
+
+TEST(CollStatsReadoutDriverGpuTest, PipelinesWindowsWithoutBlocking) {
+  int deviceCount = 0;
+  if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount == 0) {
+    GTEST_SKIP() << "no CUDA device";
+  }
+
+  const uint32_t capacity = 64;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/4);
+  ASSERT_NE(h.dev, nullptr);
+
+  cudaStream_t stream;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+  CollStatsKeyRegistry keys(capacity);
+  const uint32_t key = keys.resolve(
+      CollStatKey{
+          CollStatOp::AllReduce,
+          CollStatAlgo::Direct,
+          CollStatProto::Unknown,
+          7u,
+          3u});
+
+  std::vector<uint64_t> exportedCounts;
+  const uint32_t cadence = 4;
+  // Scoped so the driver's own teardown runs before the block is freed.
+  {
+    CollStatsReadoutDriver driver(
+        h,
+        cadence,
+        [&](const CollStatSnapshot& snap) {
+          exportedCounts.push_back(totalCount(snap.values));
+        },
+        keys);
+    ASSERT_FALSE(driver.disabled());
+
+    // Batch A: cadence collectives. The cadence-th tick issues window 0's copy
+    // (pending), but harvests nothing yet.
+    for (uint32_t i = 0; i < cadence; ++i) {
+      runCollective(driver, h, stream, key);
+    }
+    EXPECT_TRUE(exportedCounts.empty());
+
+    // Ensure window 0's copy has completed so the next harvest query succeeds.
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    // Batch B: cadence more collectives. The cadence-th tick harvests window 0
+    // (the pipeline path, during onCollective) and issues window 1.
+    for (uint32_t i = 0; i < cadence; ++i) {
+      runCollective(driver, h, stream, key);
+    }
+    ASSERT_EQ(exportedCounts.size(), 1u);
+    EXPECT_EQ(exportedCounts[0], cadence); // window 0 = cadence observations
+
+    // Drain and harvest the last window via flush (teardown path).
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    driver.flush();
+    ASSERT_EQ(exportedCounts.size(), 2u);
+    EXPECT_EQ(exportedCounts[1], cadence); // window 1 = cadence observations
+
+    EXPECT_EQ(driver.windowsExported(), 2u);
+    EXPECT_EQ(driver.windowsDropped(), 0u);
+  }
+
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  cudaStreamDestroy(stream);
+  collStatsFreeDeviceBlock(h);
+}
+
+TEST(CollStatsReadoutDriverGpuTest, NoReadoutBeforeCadenceReached) {
+  int deviceCount = 0;
+  if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount == 0) {
+    GTEST_SKIP() << "no CUDA device";
+  }
+
+  const uint32_t capacity = 64;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/4);
+  ASSERT_NE(h.dev, nullptr);
+
+  cudaStream_t stream;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+  CollStatsKeyRegistry keys(capacity);
+  const uint32_t key = keys.resolve(
+      CollStatKey{
+          CollStatOp::AllReduce,
+          CollStatAlgo::Direct,
+          CollStatProto::Unknown,
+          7u,
+          3u});
+
+  int exports = 0;
+  // Scoped so the driver is destroyed while the block is still alive, the
+  // order CtranAlgo guarantees by declaring the driver last.
+  {
+    CollStatsReadoutDriver driver(
+        h, /*cadence=*/8, [&](const CollStatSnapshot&) { ++exports; }, keys);
+
+    for (int i = 0; i < 7; ++i) { // one short of cadence
+      runCollective(driver, h, stream, key);
+    }
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    driver.flush(); // no window was ever issued, so nothing to harvest
+    EXPECT_EQ(exports, 0);
+    EXPECT_EQ(driver.windowsExported(), 0u);
+  }
+  // The destructor's flushFinal does pick them up; flush alone never would.
+  EXPECT_EQ(exports, 1);
+
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  cudaStreamDestroy(stream);
+  collStatsFreeDeviceBlock(h);
+}
+
+// The collectives between the last cadence boundary and teardown are the tail
+// of every run, and at the default cadence of 128 they can be most of a short
+// one. flushFinal issues one extra window for them.
+TEST(CollStatsReadoutDriverGpuTest, FinalFlushExportsTheTrailingWindow) {
+  int deviceCount = 0;
+  if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount == 0) {
+    GTEST_SKIP() << "no CUDA device";
+  }
+
+  const uint32_t capacity = 64;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/4);
+  ASSERT_NE(h.dev, nullptr);
+
+  cudaStream_t stream;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+  CollStatsKeyRegistry keys(capacity);
+  const uint32_t key = keys.resolve(
+      CollStatKey{
+          CollStatOp::AllReduce,
+          CollStatAlgo::Direct,
+          CollStatProto::Unknown,
+          7u,
+          3u});
+
+  std::vector<uint64_t> exportedCounts;
+  const uint32_t cadence = 8;
+  // Scoped so the driver's own teardown runs before the block is freed.
+  {
+    CollStatsReadoutDriver driver(
+        h,
+        cadence,
+        [&](const CollStatSnapshot& snap) {
+          exportedCounts.push_back(totalCount(snap.values));
+        },
+        keys);
+    ASSERT_FALSE(driver.disabled());
+
+    // One full window, then a partial one that never reaches a boundary.
+    const int trailing = 3;
+    for (uint32_t i = 0; i < cadence + trailing; ++i) {
+      runCollective(driver, h, stream, key);
+    }
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    EXPECT_TRUE(exportedCounts.empty()); // window 0 issued, not yet harvested
+
+    driver.flushFinal();
+    ASSERT_EQ(exportedCounts.size(), 2u);
+    EXPECT_EQ(exportedCounts[0], cadence); // the window that hit the boundary
+    EXPECT_EQ(
+        exportedCounts[1], trailing); // the tail, which flush() would drop
+    EXPECT_EQ(driver.windowsExported(), 2u);
+    EXPECT_EQ(driver.windowsDropped(), 0u);
+
+    // Idempotent: the tail was consumed, so a second call has nothing to issue,
+    // and neither does the destructor below.
+    driver.flushFinal();
+    EXPECT_EQ(exportedCounts.size(), 2u);
+  }
+  EXPECT_EQ(exportedCounts.size(), 2u);
+
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  cudaStreamDestroy(stream);
+  collStatsFreeDeviceBlock(h);
+}
+
+// The sink is caller-supplied and is invoked from the destructor's final flush,
+// where an escaping exception would cross a noexcept boundary and call
+// std::terminate -- the job dying over telemetry. The catch is the only thing
+// preventing that, so it needs a test that actually throws.
+TEST(CollStatsReadoutDriverGpuTest, ThrowingSinkIsCountedNotPropagated) {
+  int deviceCount = 0;
+  if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount == 0) {
+    GTEST_SKIP() << "no CUDA device";
+  }
+
+  const uint32_t capacity = 64;
+  CollStatsDeviceBlockHandle h =
+      collStatsAllocDeviceBlock(capacity, /*numSlots=*/4);
+  ASSERT_NE(h.dev, nullptr);
+
+  cudaStream_t stream;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+  CollStatsKeyRegistry keys(capacity);
+  const uint32_t key = keys.resolve(
+      CollStatKey{
+          CollStatOp::AllReduce,
+          CollStatAlgo::Direct,
+          CollStatProto::Unknown,
+          7u,
+          3u});
+
+  uint32_t sinkCalls = 0;
+  uint32_t callsBeforeScopeExit = 0;
+  const uint32_t cadence = 4;
+  {
+    CollStatsReadoutDriver driver(
+        h,
+        cadence,
+        [&](const CollStatSnapshot&) {
+          ++sinkCalls;
+          throw std::runtime_error("sink failed");
+        },
+        keys);
+    ASSERT_FALSE(driver.disabled());
+
+    for (uint32_t i = 0; i < cadence * 2; ++i) {
+      runCollective(driver, h, stream, key);
+    }
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    // The throw is swallowed and counted; the window is still consumed, so the
+    // driver keeps running rather than wedging on a bad sink.
+    EXPECT_NO_THROW(driver.flushFinal());
+    EXPECT_GT(sinkCalls, 0u);
+    EXPECT_EQ(driver.sinkExceptions(), sinkCalls);
+    EXPECT_FALSE(driver.disabled()) << "a throwing sink is not a CUDA fault";
+
+    // Leave a tail unharvested so the destructor's own flushFinal also runs
+    // through the throwing sink. That call is the noexcept boundary the catch
+    // exists for, and the explicit flushFinal above would otherwise have
+    // consumed everything before it.
+    for (uint32_t i = 0; i < cadence - 1; ++i) {
+      runCollective(driver, h, stream, key);
+    }
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    callsBeforeScopeExit = sinkCalls;
+  }
+  // Reaching here at all is the assertion: the destructor exported the tail
+  // through a sink that throws, and did not call std::terminate.
+  EXPECT_GT(sinkCalls, callsBeforeScopeExit);
+
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  cudaStreamDestroy(stream);
+  collStatsFreeDeviceBlock(h);
+}
+
+// TODO(T282705070): "never blocks the enqueue thread" has no test, because it
+// does not hold everywhere. Parking the instrumented stream behind a 2s spin
+// kernel and timing one tick measures ~0ms on a devgpu H100 and ~2005ms under
+// remote execution, with the driver enabled and the pinned staging allocated in
+// both. Something in the issue path still serializes with the stream on some
+// hardware; identify it before asserting the invariant here.
+
+} // namespace
+
+} // namespace meta::comms::collstats


### PR DESCRIPTION
Summary:
Policy on top of the window readout mechanism: when to take a window, and how to get the last one.

`CollStatsReadoutDriver` ticks once per instrumented collective from the enqueue thread, so the epoch flip needs no boundary lock -- no collective can enqueue mid-flip on that thread. Every `cadence` ticks it harvests the previous window if its copy event has completed (a non-blocking query) and issues the next on a dedicated reader stream. Neither step is meant to synchronize the training thread, and neither does on a devgpu; under remote execution one tick still measures ~2005ms with the driver enabled and the pinned staging allocated, so something in the issue path serializes with the instrumented stream on some hardware. Tracked as T282705070 and not asserted anywhere until it is identified.

- Teardown exports the tail. A cadence boundary is only reached every N collectives, so up to `cadence - 1` collectives per communicator used to be freed unread. `flush()` cannot recover them -- it only harvests a window already issued -- so `flushFinal()` flushes and then issues one extra window for the remainder. Measured at cadence 32 across 8 ranks: 245 collectives per rank now report as seven windows of 32 plus a tail of 21, with uniform counts across all five size classes; previously the last two classes reported 48 and 40.
- That extra window is ungated and follows a device synchronize, because a destructor cannot assume a stream it does not own still exists. The sync covers only the calling thread's current device, so the driver records its device at construction and selects it for the wait.
- Exported and dropped partition the windows. A harvest that finds the copy in flight is a deferral, counted separately as a retry: the window still lands in exactly one of the two later, and charging it as a drop would double-count it and, since the collective counter is not cleared on a skipped issue, inflate once per collective for the length of a stall.
- Each window carries wall-clock bounds stamped at the flip, not at the harvest, so consecutive windows abut.

Reviewed By: rmahidhar

Differential Revision: D113661123
