### PR TITLE
Carry the low-precision wire format through the pipelined all-gather (#3987)

### DIFF
--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
@@ -9,8 +9,12 @@
 #include "sharded_relay_all_gather.h"
 #include "comm.h"
 #include "sharded_relay_graph_scratch.h"
+#include "sharded_relay_lp.h"
+#include "sharded_relay_lp_arena.h"
+#include "sharded_relay_lp_kernels.h"
 #include "sharded_relay_route.h"
 
+#include <hip/hip_bfloat16.h>
 #include <cstdint>
 #include <map>
 #include <mutex>
@@ -255,6 +259,236 @@ bool isSupportedRelayDataType(ncclDataType_t datatype) {
 
 } // namespace
 
+// =========================================================================
+// LOW-PRECISION DISPATCH
+// =========================================================================
+// Only bf16 and fp32 appear here, because lpDtypeSupported() admits only those
+// and the gate declines everything else back to full precision. The `default:`
+// arm is therefore unreachable rather than a silent fallthrough; it aborts the
+// call instead of returning ncclSuccess having quantized nothing.
+//
+// Only QUANTIZE and DEQUANTIZE, because all-gather has no reduction anywhere in
+// it -- no divisor, no fused reduce, and a helper that never interprets what it
+// carries. That is also why lpDequantize deliberately takes no divisor.
+#define DISPATCH_LP(datatype, CALL, ...)                                                                      \
+  do {                                                                                                        \
+    switch (datatype) {                                                                                       \
+      case ncclFloat32:                                                                                       \
+        CALL<float>(__VA_ARGS__);                                                                             \
+        break;                                                                                                \
+      case ncclBfloat16:                                                                                      \
+        CALL<__nv_bfloat16>(__VA_ARGS__);                                                                     \
+        break;                                                                                                \
+      default:                                                                                                \
+        WARN(                                                                                                 \
+            "Sharded relay: low precision reached an unsupported datatype %d; the eligibility gate is wrong", \
+            static_cast<int>(datatype));                                                                      \
+        return ncclInternalError;                                                                             \
+    }                                                                                                         \
+  } while (0)
+
+#define DISPATCH_LP_QUANTIZE(datatype, wireOut, in, count, stream) \
+  DISPATCH_LP(datatype, launchLpQuantizeKernel, wireOut, in, count, stream)
+
+#define DISPATCH_LP_DEQUANTIZE(datatype, out, wireIn, count, stream) \
+  DISPATCH_LP(datatype, launchLpDequantizeKernel, out, wireIn, count, stream)
+
+namespace {
+
+/**
+ * The wire buffers one 2-active all-gather call needs.
+ *
+ * Three regions, the same three the 2-active reduce-scatter uses, because the
+ * two schedules are duals: `sendShadow` for the one block every send reads, one
+ * arrival region, and the helper staging.
+ *
+ * The arrival region is where all-gather differs from every other collective.
+ * Its receives land STRAIGHT INTO recvBuff today -- there is no scratch at all,
+ * because there is nothing to reduce. Wire bytes cannot land in a
+ * full-precision recvBuff, so `gatherRecv` stages them, laid out to mirror the
+ * gather slot exactly, and ONE dequantize writes the whole slot out afterwards.
+ * The diagonal slot is not touched by any of this: it is this rank's own data,
+ * already final and already full precision, which is exactly the "skip the
+ * folded diagonal slot" the kernel header calls for.
+ *
+ * Carved unconditionally at the worst case over groups, so the partition is
+ * byte-identical on every rank and the capacity check is a pure function of the
+ * counts -- low precision has to be unanimous or the ranks disagree on wire
+ * byte counts and the call hangs instead of degrading.
+ */
+struct AgA2LpPlan {
+  char* sendShadow{nullptr}; // wire(sendCount): the whole send buffer
+  char* gatherRecv{nullptr}; // wire(sendCount): mirrors the gather slot
+  char* helper[SHARDED_RELAY_MAX_GROUPS]{};
+  bool valid{false};
+};
+
+// The size-and-dtype half of the gate, in one place so the dispatcher cannot
+// accidentally feed it a different size metric than the route selector uses.
+rcclx::relay::LpGateInputs allGatherLpGate(
+    ncclDataType_t datatype,
+    const size_t* sendCounts,
+    int nGroups,
+    int nActiveRanksPerGroup,
+    size_t elementSize,
+    bool relayRouteSelected,
+    size_t countAlignElems) {
+  rcclx::relay::LpGateInputs in;
+  in.coll = rcclx::relay::LpCollective::AllGather;
+  in.datatype = datatype;
+  in.counts = sendCounts;
+  in.nGroups = nGroups;
+  in.nActiveRanksPerGroup = nActiveRanksPerGroup;
+  // max(sendCounts) * elementSize is exactly selectAllGatherRoute()'s metric,
+  // so the low-precision threshold and the route threshold are directly
+  // comparable.
+  in.routeSizeBytes =
+      rcclx::relay::relayMaxCount(sendCounts, nGroups) * elementSize;
+  in.relayRouteSelected = relayRouteSelected;
+  in.countAlignElems = countAlignElems;
+  return in;
+}
+
+size_t agLpAlign(size_t bytes) {
+  return ((bytes + rcclx::relay::LpArenaCarver::kAlign - 1) /
+          rcclx::relay::LpArenaCarver::kAlign) *
+      rcclx::relay::LpArenaCarver::kAlign;
+}
+
+size_t agA2LpRequiredBytes(
+    const size_t* sendCounts,
+    const size_t* chunkSizes,
+    int nGroups,
+    int nActiveRanks) {
+  const size_t maxCount = rcclx::relay::relayMaxCount(sendCounts, nGroups);
+  const size_t maxChunk = rcclx::relay::relayMaxCount(chunkSizes, nGroups);
+  size_t total = 2 * agLpAlign(rcclx::relay::lpWireBytes(maxCount));
+  total += static_cast<size_t>(nGroups) *
+      agLpAlign(
+               static_cast<size_t>(nActiveRanks) *
+               rcclx::relay::lpWireBytes(maxChunk));
+  return total;
+}
+
+AgA2LpPlan agA2LpCarve(
+    const rcclx::relay::LpArenaLease& lease,
+    const size_t* sendCounts,
+    const size_t* chunkSizes,
+    int nGroups,
+    int nActiveRanks) {
+  const size_t maxCount = rcclx::relay::relayMaxCount(sendCounts, nGroups);
+  const size_t maxChunk = rcclx::relay::relayMaxCount(chunkSizes, nGroups);
+
+  AgA2LpPlan p{};
+  rcclx::relay::LpArenaCarver carver(lease);
+  p.sendShadow = carver.take(rcclx::relay::lpWireBytes(maxCount));
+  p.gatherRecv = carver.take(rcclx::relay::lpWireBytes(maxCount));
+  for (int g = 0; g < nGroups; g++) {
+    p.helper[g] = carver.take(
+        static_cast<size_t>(nActiveRanks) *
+        rcclx::relay::lpWireBytes(maxChunk));
+  }
+  p.valid = carver.ok();
+  return p;
+}
+
+/**
+ * The capture and arena preconditions every all-gather LP prepare shares.
+ *
+ * Creating the arena is not capturable: it runs a bootstrap all-gather. Using
+ * one that already exists is fine, so under capture take the path only if the
+ * arena is already up. Same precedent as the one-shot region.
+ *
+ * COLLECTIVE: lpArenaAcquire() runs a bootstrap unanimity vote on first use, so
+ * every rank must reach this whenever the dispatcher's size-only gate said yes
+ * -- including the helper ranks. Every reason it can return false is derived
+ * from the counts or is already agreed across the communicator, so all ranks
+ * decline together.
+ */
+bool agLpAcquireArena(
+    ncclComm_t comm,
+    cudaStream_t stream,
+    rcclx::relay::LpArenaLease* lease) {
+  struct ncclCudaGraph graph;
+  if (ncclCudaGetCapturingGraph(&graph, stream) != ncclSuccess) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::GraphCapture);
+    return false;
+  }
+  if (ncclCudaGraphValid(graph) && !rcclx::relay::lpArenaReady(comm)) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::GraphCapture);
+    return false;
+  }
+  if (!rcclx::relay::lpArenaAcquire(comm, lease)) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Every region boundary this schedule sends or receives at is a whole number of
+ * wire blocks.
+ *
+ * 128-aligned per-group counts make the slot offsets, the relay chunks and both
+ * direct chunks aligned -- but ONLY when the aligned chunk size is non-zero. In
+ * the chunkSize == 0 degenerate case the geometry falls back to splitting the
+ * buffer in half, and count / 2 is a multiple of 64, not of 128. Today's
+ * crossover keeps low precision far above that regime, so this never fires; it
+ * is checked rather than assumed so that lowering lpMinBytes() during tuning
+ * cannot silently produce unaligned wire offsets. Pure function of the counts,
+ * so every rank declines together.
+ */
+bool agA2LpGeometryOk(
+    const size_t* sendCounts,
+    const size_t* chunkSizes,
+    int nGroups) {
+  for (int g = 0; g < nGroups; g++) {
+    if (sendCounts[g] > 0 && chunkSizes[g] == 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool agA2LpPrepare(
+    bool wantLp,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const size_t* sendCounts,
+    const size_t* chunkSizes,
+    int nGroups,
+    int nActiveRanks,
+    AgA2LpPlan* out) {
+  if (!wantLp) {
+    return false;
+  }
+
+  if (!agA2LpGeometryOk(sendCounts, chunkSizes, nGroups)) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Alignment);
+    return false;
+  }
+
+  rcclx::relay::LpArenaLease lease{};
+  if (!agLpAcquireArena(comm, stream, &lease)) {
+    return false;
+  }
+  if (agA2LpRequiredBytes(sendCounts, chunkSizes, nGroups, nActiveRanks) >
+      lease.bytes) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+
+  *out = agA2LpCarve(lease, sendCounts, chunkSizes, nGroups, nActiveRanks);
+  if (!out->valid) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+  rcclx::relay::lpRecordEngage();
+  return true;
+}
+
+} // namespace
+
 /**
  * Two-active sharded relay all-gather (original path), the dual of the 2-active
  * reduce-scatter relay.
@@ -278,6 +512,13 @@ bool isSupportedRelayDataType(ncclDataType_t datatype) {
  * sendBuff == recvBuff + m x sendCount; in that case the diagonal copy is a
  * no-op. No scratch is needed in either mode because the gather destination
  * (slot o) never overlaps the send source (slot m).
+ *
+ * LOW PRECISION substitutes the wire format at the boundary-crossing transfers
+ * and adds exactly two kernels: one quantize of the send buffer before the
+ * first group, and one dequantize of the gather slot after the last. It cannot
+ * land arrivals in recvBuff directly the way full precision does -- wire bytes
+ * are not the caller's dtype -- so they stage in a region laid out to mirror
+ * the slot. The diagonal slot stays untouched and full precision throughout.
  */
 static ncclResult_t shardedRelayAllGather2Active(
     const void* const* sendBuffs,
@@ -290,7 +531,8 @@ static ncclResult_t shardedRelayAllGather2Active(
     int myActiveGroup,
     int numHelpers,
     int nGroups,
-    size_t elementSize) {
+    size_t elementSize,
+    bool wantLp) {
   // =========================================================================
   // CHUNK GEOMETRY: numHelpers relayed chunks + TWO direct chunks
   // =========================================================================
@@ -359,6 +601,57 @@ static ncclResult_t shardedRelayAllGather2Active(
   }
 
   // =========================================================================
+  // LOW PRECISION: decide, acquire the arena, and quantize the send buffer
+  // =========================================================================
+  // Collective: every rank reaches agA2LpPrepare() when the dispatcher's
+  // size-only gate said yes, and every way it can decline is agreed across the
+  // communicator, so all ranks run the same wire format or none do.
+  AgA2LpPlan lpPlan{};
+  const bool lp = agA2LpPrepare(
+      wantLp,
+      comm,
+      stream,
+      sendCounts,
+      chunkSizes,
+      nGroups,
+      configs[0].nActiveRanks,
+      &lpPlan);
+  const rcclx::relay::RelayWire wire =
+      rcclx::relay::lpWireFor(datatype, elementSize, lp);
+
+  // One quantize over the ENTIRE send buffer, before the first ncclGroupStart.
+  // Every byte of it crosses a rank boundary -- the relayed chunks cover
+  // [0, H*chunkSize) and the two direct chunks cover the rest -- so this is the
+  // whole buffer, and nothing produces a send source mid-call.
+  if (lp && myActiveGroup >= 0 && sendCounts[myActiveGroup] > 0) {
+    DISPATCH_LP_QUANTIZE(
+        datatype,
+        lpPlan.sendShadow,
+        sendBuffs[myActiveGroup],
+        sendCounts[myActiveGroup],
+        stream);
+  }
+
+  // Where a boundary-crossing send reads from, and where its counterpart lands.
+  // Offsets are in ELEMENTS of the caller's dtype -- relative to the send
+  // buffer and to the GATHER SLOT respectively -- on both paths, which is what
+  // keeps every call site below unchanged in shape.
+  auto sendFrom = [&](int g, size_t offsetElems) -> const char* {
+    if (lp) {
+      return lpPlan.sendShadow + wire.bytes(offsetElems);
+    }
+    return static_cast<const char*>(sendBuffs[g]) + offsetElems * elementSize;
+  };
+
+  auto gatherAt = [&](int g, size_t offsetElems) -> char* {
+    if (lp) {
+      return lpPlan.gatherRecv + wire.bytes(offsetElems);
+    }
+    return static_cast<char*>(recvBuffs[g]) +
+        (gatherSlotOffset + offsetElems) * elementSize;
+  };
+
+  // =========================================================================
   // DIAGONAL COPY: recvBuff[m x sendCount] = sendBuff
   // =========================================================================
   // Issued before the comm groups so it overlaps nothing that reads it.
@@ -380,6 +673,13 @@ static ncclResult_t shardedRelayAllGather2Active(
   for (int g = 0; g < nGroups; g++) {
     const ShardedRelayRankConfig& cfg = configs[g];
     if (!cfg.isActiveRank && sendCounts[g] > 0 && chunkSizes[g] > 0) {
+      if (lp) {
+        // Already carved, and in wire bytes: the helper forwards wire blocks
+        // without ever learning the caller's dtype. It never reduces in this
+        // collective, so it never has to interpret them either.
+        helperScratch[g] = lpPlan.helper[g];
+        continue;
+      }
       size_t needBytes =
           static_cast<size_t>(cfg.nActiveRanks) * chunkSizes[g] * elementSize;
       helperScratch[g] = ScratchBufferCache::getInstance().get(
@@ -403,15 +703,12 @@ static ncclResult_t shardedRelayAllGather2Active(
     size_t chunkSize = chunkSizes[g];
 
     if (cfg.isActiveRank) {
-      const char* sendbuff = static_cast<const char*>(sendBuffs[g]);
-      char* recvbuff = static_cast<char*>(recvBuffs[g]);
-
       // Scatter: chunk h of my sendBuff goes to helper h.
       for (int h = 0; h < cfg.numHelpers && chunkSize > 0; h++) {
         NCCLCHECK(ncclSend(
-            sendbuff + static_cast<size_t>(h) * chunkSize * elementSize,
-            chunkSize,
-            datatype,
+            sendFrom(g, static_cast<size_t>(h) * chunkSize),
+            wire.count(chunkSize),
+            wire.dtype,
             cfg.helperRanks[h],
             comm,
             stream));
@@ -421,16 +718,16 @@ static ncclResult_t shardedRelayAllGather2Active(
       // gather slot never overlaps the send source, so this is safe in-place.
       int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
       NCCLCHECK(ncclSend(
-          sendbuff + dirAOffsets[g] * elementSize,
-          dirASizes[g],
-          datatype,
+          sendFrom(g, dirAOffsets[g]),
+          wire.count(dirASizes[g]),
+          wire.dtype,
           partner,
           comm,
           stream));
       NCCLCHECK(ncclRecv(
-          recvbuff + (gatherSlotOffset + dirAOffsets[g]) * elementSize,
-          dirASizes[g],
-          datatype,
+          gatherAt(g, dirAOffsets[g]),
+          wire.count(dirASizes[g]),
+          wire.dtype,
           partner,
           comm,
           stream));
@@ -439,9 +736,9 @@ static ncclResult_t shardedRelayAllGather2Active(
       char* helperBuf = static_cast<char*>(helperScratch[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {
         NCCLCHECK(ncclRecv(
-            helperBuf + static_cast<size_t>(a) * chunkSize * elementSize,
-            chunkSize,
-            datatype,
+            helperBuf + wire.bytes(static_cast<size_t>(a) * chunkSize),
+            wire.count(chunkSize),
+            wire.dtype,
             cfg.activeRanks[a],
             comm,
             stream));
@@ -466,15 +763,11 @@ static ncclResult_t shardedRelayAllGather2Active(
     size_t chunkSize = chunkSizes[g];
 
     if (cfg.isActiveRank) {
-      char* recvbuff = static_cast<char*>(recvBuffs[g]);
-
       for (int h = 0; h < cfg.numHelpers && chunkSize > 0; h++) {
         NCCLCHECK(ncclRecv(
-            recvbuff +
-                (gatherSlotOffset + static_cast<size_t>(h) * chunkSize) *
-                    elementSize,
-            chunkSize,
-            datatype,
+            gatherAt(g, static_cast<size_t>(h) * chunkSize),
+            wire.count(chunkSize),
+            wire.dtype,
             cfg.helperRanks[h],
             comm,
             stream));
@@ -483,16 +776,16 @@ static ncclResult_t shardedRelayAllGather2Active(
       // Direct chunk B, again over the idle active<->active link.
       int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
       NCCLCHECK(ncclSend(
-          static_cast<const char*>(sendBuffs[g]) + dirBOffsets[g] * elementSize,
-          dirBSizes[g],
-          datatype,
+          sendFrom(g, dirBOffsets[g]),
+          wire.count(dirBSizes[g]),
+          wire.dtype,
           partner,
           comm,
           stream));
       NCCLCHECK(ncclRecv(
-          recvbuff + (gatherSlotOffset + dirBOffsets[g]) * elementSize,
-          dirBSizes[g],
-          datatype,
+          gatherAt(g, dirBOffsets[g]),
+          wire.count(dirBSizes[g]),
+          wire.dtype,
           partner,
           comm,
           stream));
@@ -500,9 +793,9 @@ static ncclResult_t shardedRelayAllGather2Active(
       const char* helperBuf = static_cast<const char*>(helperScratch[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {
         NCCLCHECK(ncclSend(
-            helperBuf + static_cast<size_t>(a) * chunkSize * elementSize,
-            chunkSize,
-            datatype,
+            helperBuf + wire.bytes(static_cast<size_t>(a) * chunkSize),
+            wire.count(chunkSize),
+            wire.dtype,
             cfg.activeRanks[1 - a],
             comm,
             stream));
@@ -511,6 +804,23 @@ static ncclResult_t shardedRelayAllGather2Active(
   }
 
   NCCLCHECK(ncclGroupEnd());
+
+  // =========================================================================
+  // LOW PRECISION: land the gather slot
+  // =========================================================================
+  // ONE launch for the whole slot. gatherRecv mirrors it exactly -- the relayed
+  // chunks and both direct chunks together cover [0, sendCount) -- and the
+  // diagonal slot is deliberately not in range: it holds this rank's own data,
+  // already final and already full precision.
+  if (lp && myActiveGroup >= 0 && sendCounts[myActiveGroup] > 0) {
+    DISPATCH_LP_DEQUANTIZE(
+        datatype,
+        static_cast<char*>(recvBuffs[myActiveGroup]) +
+            gatherSlotOffset * elementSize,
+        lpPlan.gatherRecv,
+        sendCounts[myActiveGroup],
+        stream);
+  }
 
   return ncclSuccess;
 }
@@ -1248,9 +1558,6 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
     int nActiveRanksPerGroup,
     int nGroups,
     int lowPrecision) {
-  // Accepted and ignored: the wire-format substitution lands in a later commit,
-  // so this commit cannot change behaviour.
-  (void)lowPrecision;
   int nRanks, rank;
   NCCLCHECK(ncclCommCount(comm, &nRanks));
   NCCLCHECK(ncclCommUserRank(comm, &rank));
@@ -1345,6 +1652,26 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
         rcclx::relay::relayShapeA2(numHelpers),
         rcclx::relay::relayMaxCount(sendCounts, nGroups),
         elementSize);
+
+    // The caller's request narrowed by the size-only gate, so every rank
+    // reaches the same answer without communicating. Only the non-pipelined
+    // 2-active schedule carries the wire format so far, so a pipelined call is
+    // reported as "no LP-capable route selected" and lands in the Route decline
+    // counter rather than declining silently. Safe because the tile count is a
+    // pure function of the counts -- a per-rank disagreement would be a hang,
+    // not a slowdown.
+    bool wantLp = false;
+    if (lowPrecision != 0) {
+      wantLp = rcclx::relay::lpEligible(allGatherLpGate(
+          datatype,
+          sendCounts,
+          nGroups,
+          nActiveRanksPerGroup,
+          elementSize,
+          nTiles == 1,
+          rcclx::relay::kLpBlockElems));
+    }
+
     r = (nTiles > 1) ? shardedRelayAllGather2ActivePipelined(
                            sendBuffs2,
                            recvBuffs2,
@@ -1368,7 +1695,8 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
                            myActiveGroup,
                            numHelpers,
                            nGroups,
-                           elementSize);
+                           elementSize,
+                           wantLp);
   } else {
     // A>2, or small A==2: flat scatter->forward relay (dual of reduce-scatter)
     // with a size-adaptive pure-direct small-size mode. A single-group call

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
@@ -1246,7 +1246,11 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
     cudaStream_t stream,
     const int* const* allActiveRanks,
     int nActiveRanksPerGroup,
-    int nGroups) {
+    int nGroups,
+    int lowPrecision) {
+  // Accepted and ignored: the wire-format substitution lands in a later commit,
+  // so this commit cannot change behaviour.
+  (void)lowPrecision;
   int nRanks, rank;
   NCCLCHECK(ncclCommCount(comm, &nRanks));
   NCCLCHECK(ncclCommUserRank(comm, &rank));

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.cc
@@ -487,6 +487,68 @@ bool agA2LpPrepare(
   return true;
 }
 
+// The same three regions as agA2LpCarve(), at the pipelined schedule's
+// geometry. Only the helper region differs in shape: the pipelined helper holds
+// two ping-pong units per active source rather than one chunk per source, and
+// nGroups is always 1 because that is the only shape that pipelines.
+//
+// No geometry predicate is needed. The schedule already rejects u == 0
+// outright, and u is a non-zero multiple of the chunk alignment, so every
+// offset it derives
+// -- tile, direct chunk, slot -- is a whole number of wire blocks once the
+// count is.
+size_t agA2PipeLpRequiredBytes(size_t sendCount, size_t u, int nActiveRanks) {
+  return 2 * agLpAlign(rcclx::relay::lpWireBytes(sendCount)) +
+      agLpAlign(
+             static_cast<size_t>(nActiveRanks) * 2 *
+             rcclx::relay::lpWireBytes(u));
+}
+
+AgA2LpPlan agA2PipeLpCarve(
+    const rcclx::relay::LpArenaLease& lease,
+    size_t sendCount,
+    size_t u,
+    int nActiveRanks) {
+  AgA2LpPlan p{};
+  rcclx::relay::LpArenaCarver carver(lease);
+  p.sendShadow = carver.take(rcclx::relay::lpWireBytes(sendCount));
+  p.gatherRecv = carver.take(rcclx::relay::lpWireBytes(sendCount));
+  p.helper[0] = carver.take(
+      static_cast<size_t>(nActiveRanks) * 2 * rcclx::relay::lpWireBytes(u));
+  p.valid = carver.ok();
+  return p;
+}
+
+bool agA2PipeLpPrepare(
+    bool wantLp,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    size_t sendCount,
+    size_t u,
+    int nActiveRanks,
+    AgA2LpPlan* out) {
+  if (!wantLp) {
+    return false;
+  }
+
+  rcclx::relay::LpArenaLease lease{};
+  if (!agLpAcquireArena(comm, stream, &lease)) {
+    return false;
+  }
+  if (agA2PipeLpRequiredBytes(sendCount, u, nActiveRanks) > lease.bytes) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+
+  *out = agA2PipeLpCarve(lease, sendCount, u, nActiveRanks);
+  if (!out->valid) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+  rcclx::relay::lpRecordEngage();
+  return true;
+}
+
 } // namespace
 
 /**
@@ -866,7 +928,8 @@ static ncclResult_t shardedRelayAllGather2ActivePipelined(
     int myActiveGroup,
     int numHelpers,
     int nTiles,
-    size_t elementSize) {
+    size_t elementSize,
+    bool wantLp) {
   const ShardedRelayRankConfig& cfg = configs[0];
   const size_t sc = sendCounts[0];
   const int H = numHelpers;
@@ -881,7 +944,19 @@ static ncclResult_t shardedRelayAllGather2ActivePipelined(
   const size_t directBase = static_cast<size_t>(H) * tileStride;
   const size_t lastDirect = sc - directBase - tileStride;
 
-  // Diagonal: recvBuff[m*sc] = sendBuff, a no-op when in-place.
+  // =========================================================================
+  // LOW PRECISION: decide, acquire the arena, and quantize the send buffer
+  // =========================================================================
+  // Reached by every rank -- the u == 0 rejection above is the only earlier
+  // exit and it is a pure function of the count, so the ranks agree on it.
+  AgA2LpPlan lpPlan{};
+  const bool lp =
+      agA2PipeLpPrepare(wantLp, comm, stream, sc, u, cfg.nActiveRanks, &lpPlan);
+  const rcclx::relay::RelayWire wire =
+      rcclx::relay::lpWireFor(datatype, elementSize, lp);
+
+  // Diagonal: recvBuff[m*sc] = sendBuff, a no-op when in-place. Full precision
+  // on both paths -- this is this rank's own data and never crosses a boundary.
   size_t gatherSlot = 0;
   if (myActiveGroup == 0) {
     const size_t diagSlot = static_cast<size_t>(cfg.myActiveIndex) * sc;
@@ -898,24 +973,58 @@ static ncclResult_t shardedRelayAllGather2ActivePipelined(
     }
   }
 
+  // One quantize over the whole send buffer, before the first group. Every send
+  // in the pipeline reads it and nothing produces a send source mid-call, so
+  // per-tile quantizes would cost T launches for nothing.
+  if (lp && myActiveGroup == 0) {
+    DISPATCH_LP_QUANTIZE(datatype, lpPlan.sendShadow, sendBuffs[0], sc, stream);
+  }
+
+  // Offsets stay in ELEMENTS -- relative to the send buffer and to the GATHER
+  // SLOT respectively -- on both paths.
+  auto sendFrom = [&](size_t offsetElems) -> const char* {
+    if (lp) {
+      return lpPlan.sendShadow + wire.bytes(offsetElems);
+    }
+    return static_cast<const char*>(sendBuffs[0]) + offsetElems * elementSize;
+  };
+
+  auto gatherAt = [&](size_t offsetElems) -> char* {
+    if (lp) {
+      return lpPlan.gatherRecv + wire.bytes(offsetElems);
+    }
+    return static_cast<char*>(recvBuffs[0]) +
+        (gatherSlot + offsetElems) * elementSize;
+  };
+
   // Helper staging: two ping-pong units per active source. Tiny by design, so a
-  // tile is forwarded out of cache rather than re-read from HBM.
+  // tile is forwarded out of cache rather than re-read from HBM. Under low
+  // precision it comes from the arena in wire bytes; the helper still only
+  // forwards bytes and needs no relayout, because nothing here reads two slots
+  // as one contiguous run.
   char* hbuff = nullptr;
   if (!cfg.isActiveRank) {
-    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
-        kHelperScratchKeyBase,
-        static_cast<size_t>(cfg.nActiveRanks) * 2 * u * elementSize,
-        stream));
-    if (hbuff == nullptr) {
-      return ncclInternalError;
+    if (lp) {
+      hbuff = lpPlan.helper[0];
+    } else {
+      hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+          kHelperScratchKeyBase,
+          static_cast<size_t>(cfg.nActiveRanks) * 2 * u * elementSize,
+          stream));
+      if (hbuff == nullptr) {
+        return ncclInternalError;
+      }
     }
   }
+  auto helperSlot = [&](int a, int k) -> char* {
+    return hbuff +
+        wire.bytes(
+            (static_cast<size_t>(a) * 2 + static_cast<size_t>(k % 2)) * u);
+  };
 
   for (int k = 0; k <= T; k++) {
     NCCLCHECK(ncclGroupStart());
     if (cfg.isActiveRank) {
-      const char* sendbuff = static_cast<const char*>(sendBuffs[0]);
-      char* recvbuff = static_cast<char*>(recvBuffs[0]);
       const int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
       const size_t directOffset = directBase + static_cast<size_t>(k) * u;
       const size_t directSize = (k < T) ? u : lastDirect;
@@ -923,42 +1032,40 @@ static ncclResult_t shardedRelayAllGather2ActivePipelined(
       if (k < T) {
         for (int h = 0; h < H; h++) {
           NCCLCHECK(ncclSend(
-              sendbuff +
-                  (static_cast<size_t>(h) * tileStride +
-                   static_cast<size_t>(k) * u) *
-                      elementSize,
-              u,
-              datatype,
+              sendFrom(
+                  static_cast<size_t>(h) * tileStride +
+                  static_cast<size_t>(k) * u),
+              wire.count(u),
+              wire.dtype,
               cfg.helperRanks[h],
               comm,
               stream));
         }
       }
       NCCLCHECK(ncclSend(
-          sendbuff + directOffset * elementSize,
-          directSize,
-          datatype,
+          sendFrom(directOffset),
+          wire.count(directSize),
+          wire.dtype,
           partner,
           comm,
           stream));
       if (k > 0) {
         for (int h = 0; h < H; h++) {
           NCCLCHECK(ncclRecv(
-              recvbuff +
-                  (gatherSlot + static_cast<size_t>(h) * tileStride +
-                   static_cast<size_t>(k - 1) * u) *
-                      elementSize,
-              u,
-              datatype,
+              gatherAt(
+                  static_cast<size_t>(h) * tileStride +
+                  static_cast<size_t>(k - 1) * u),
+              wire.count(u),
+              wire.dtype,
               cfg.helperRanks[h],
               comm,
               stream));
         }
       }
       NCCLCHECK(ncclRecv(
-          recvbuff + (gatherSlot + directOffset) * elementSize,
-          directSize,
-          datatype,
+          gatherAt(directOffset),
+          wire.count(directSize),
+          wire.dtype,
           partner,
           comm,
           stream));
@@ -966,11 +1073,9 @@ static ncclResult_t shardedRelayAllGather2ActivePipelined(
       if (k < T) {
         for (int a = 0; a < cfg.nActiveRanks; a++) {
           NCCLCHECK(ncclRecv(
-              hbuff +
-                  (static_cast<size_t>(a) * 2 + static_cast<size_t>(k % 2)) *
-                      u * elementSize,
-              u,
-              datatype,
+              helperSlot(a, k),
+              wire.count(u),
+              wire.dtype,
               cfg.activeRanks[a],
               comm,
               stream));
@@ -979,12 +1084,9 @@ static ncclResult_t shardedRelayAllGather2ActivePipelined(
       if (k > 0) {
         for (int a = 0; a < cfg.nActiveRanks; a++) {
           NCCLCHECK(ncclSend(
-              hbuff +
-                  (static_cast<size_t>(a) * 2 +
-                   static_cast<size_t>((k - 1) % 2)) *
-                      u * elementSize,
-              u,
-              datatype,
+              helperSlot(a, k - 1),
+              wire.count(u),
+              wire.dtype,
               cfg.activeRanks[1 - a],
               comm,
               stream));
@@ -992,6 +1094,22 @@ static ncclResult_t shardedRelayAllGather2ActivePipelined(
       }
     }
     NCCLCHECK(ncclGroupEnd());
+  }
+
+  // =========================================================================
+  // LOW PRECISION: land the gather slot
+  // =========================================================================
+  // ONE launch for the whole slot, after the last group rather than per tile:
+  // the regions are disjoint, so there is nothing to gain from T+1 launches.
+  // The diagonal slot is deliberately out of range -- already final, already
+  // full precision.
+  if (lp && myActiveGroup == 0) {
+    DISPATCH_LP_DEQUANTIZE(
+        datatype,
+        static_cast<char*>(recvBuffs[0]) + gatherSlot * elementSize,
+        lpPlan.gatherRecv,
+        sc,
+        stream);
   }
 
   return ncclSuccess;
@@ -1654,12 +1772,9 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
         elementSize);
 
     // The caller's request narrowed by the size-only gate, so every rank
-    // reaches the same answer without communicating. Only the non-pipelined
-    // 2-active schedule carries the wire format so far, so a pipelined call is
-    // reported as "no LP-capable route selected" and lands in the Route decline
-    // counter rather than declining silently. Safe because the tile count is a
-    // pure function of the counts -- a per-rank disagreement would be a hang,
-    // not a slowdown.
+    // reaches the same answer without communicating. Both 2-active schedules
+    // carry the wire format; the flat schedules still decline, identically on
+    // every rank since that condition is the selected route.
     bool wantLp = false;
     if (lowPrecision != 0) {
       wantLp = rcclx::relay::lpEligible(allGatherLpGate(
@@ -1668,7 +1783,7 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
           nGroups,
           nActiveRanksPerGroup,
           elementSize,
-          nTiles == 1,
+          /*relayRouteSelected=*/true,
           rcclx::relay::kLpBlockElems));
     }
 
@@ -1683,7 +1798,8 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
                            myActiveGroup,
                            numHelpers,
                            nTiles,
-                           elementSize)
+                           elementSize,
+                           wantLp)
                      : shardedRelayAllGather2Active(
                            sendBuffs2,
                            recvBuffs2,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_gather.h
@@ -126,6 +126,14 @@
  * [nGroups][nActiveRanksPerGroup]
  * @param nActiveRanksPerGroup Number of active ranks per group (2 or 4)
  * @param nGroups Number of groups (typically 4 for 8-GPU node)
+ * @param lowPrecision Non-zero to use the low-precision (fp8e4m3) wire format
+ *        where it pays; an internal size-only gate declines to full precision
+ *        silently otherwise (see sharded_relay_lp.h). COLLECTIVE -- it must be
+ *        identical on every rank of the call, like datatype and the counts.
+ *        Ranks that disagree disagree on how many bytes cross each link, so the
+ *        call hangs or corrupts rather than degrading. Documented rather than
+ *        validated, because a per-call check would cost an allreduce; datatype
+ *        is already treated the same way.
  * @return ncclResult_t Success or error code
  */
 ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
@@ -137,4 +145,5 @@ ncclResult_t ncclShardedRelayMultiGroupAllGatherImpl(
     cudaStream_t stream,
     const int* const* allActiveRanks,
     int nActiveRanksPerGroup,
-    int nGroups);
+    int nGroups,
+    int lowPrecision = 0);

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.cc
@@ -1277,7 +1277,11 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
     cudaStream_t stream,
     const int* const* allActiveRanks,
     int nActiveRanksPerGroup,
-    int nGroups) {
+    int nGroups,
+    int lowPrecision) {
+  // Accepted and ignored: the wire-format substitution lands in a later commit,
+  // so this commit cannot change behaviour.
+  (void)lowPrecision;
   int nRanks, rank;
   NCCLCHECK(ncclCommCount(comm, &nRanks));
   NCCLCHECK(ncclCommUserRank(comm, &rank));

--- a/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_all_to_all.h
@@ -119,6 +119,14 @@
  * [nGroups][nActiveRanksPerGroup]
  * @param nActiveRanksPerGroup Number of active ranks per group (2 or 4)
  * @param nGroups Number of groups (typically 4 for 8-GPU node)
+ * @param lowPrecision Non-zero to use the low-precision (fp8e4m3) wire format
+ *        where it pays; an internal size-only gate declines to full precision
+ *        silently otherwise (see sharded_relay_lp.h). COLLECTIVE -- it must be
+ *        identical on every rank of the call, like datatype and the counts.
+ *        Ranks that disagree disagree on how many bytes cross each link, so the
+ *        call hangs or corrupts rather than degrading. Documented rather than
+ *        validated, because a per-call check would cost an allreduce; datatype
+ *        is already treated the same way.
  * @return ncclResult_t Success or error code
  */
 ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
@@ -130,4 +138,5 @@ ncclResult_t ncclShardedRelayMultiGroupAllToAllImpl(
     cudaStream_t stream,
     const int* const* allActiveRanks,
     int nActiveRanksPerGroup,
-    int nGroups);
+    int nGroups,
+    int lowPrecision = 0);

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -1813,7 +1813,8 @@ static ncclResult_t shardedRelayAllReduce2ActivePipelined(
     int myActiveGroup,
     int numHelpers,
     int nTiles,
-    size_t elementSize) {
+    size_t elementSize,
+    bool wantLp) {
   const ShardedRelayRankConfig& cfg = configs[0];
   const size_t count = counts[0];
   const int H = numHelpers;
@@ -1829,12 +1830,52 @@ static ncclResult_t shardedRelayAllReduce2ActivePipelined(
   const size_t directTotal = count - directBase;
   const size_t lastDirect = directTotal - tileStride;
 
+  // =========================================================================
+  // LOW PRECISION: decide, acquire the arena, and quantize the send buffer
+  // =========================================================================
+  // The plan's region set fits this schedule exactly once the geometry is
+  // described in its terms: the relayed span is [0, directBase), and a helper
+  // needs nActiveRanks * 2 ping-pong slots of u, which is nActiveRanks slots of
+  // 2u. Both are 128-multiples, so wire.bytes() is additive across them and
+  // wire.bytes(2u) == 2 * wire.bytes(u).
+  const size_t lpRelayTotals[1] = {directBase};
+  const size_t lpChunkSizes[1] = {2 * u};
+  A2LpPlan lpPlan{};
+  const bool lp = a2LpPrepare(
+      wantLp,
+      comm,
+      stream,
+      counts,
+      lpRelayTotals,
+      lpChunkSizes,
+      /*nGroups=*/1,
+      cfg.nActiveRanks,
+      &lpPlan);
+  const rcclx::relay::RelayWire wire =
+      rcclx::relay::lpWireFor(datatype, elementSize, lp);
+
+  // One quantize over the whole send buffer, before the first group of the
+  // first stage. Hoisted out of the k-loop deliberately: per-tile would cost T
+  // launches, and worse, in the in-place case tile k's fold can still be in
+  // flight while tile k+1's send source is being read.
+  if (lp && cfg.isActiveRank && count > 0) {
+    DISPATCH_LP_QUANTIZE(
+        datatype, lpPlan.sendShadow, sendBuffs[0], count, stream);
+  }
+
+  auto sendFrom = [&](size_t offsetElems) -> const char* {
+    if (lp) {
+      return lpPlan.sendShadow + wire.bytes(offsetElems);
+    }
+    return static_cast<const char*>(sendBuffs[0]) + offsetElems * elementSize;
+  };
+
   // In-place must stage the received direct chunks so the local contribution is
   // still readable when the fused reduce runs; out-of-place lands them straight
   // in recvBuff and reduces against sendBuff.
   void* directScratch = nullptr;
   const bool isInPlace = (myActiveGroup == 0) && (sendBuffs[0] == recvBuffs[0]);
-  if (myActiveGroup == 0 && isInPlace) {
+  if (myActiveGroup == 0 && isInPlace && !lp) {
     directScratch = ScratchBufferCache::getInstance().get(
         0, directTotal * elementSize, stream);
     if (directScratch == nullptr) {
@@ -1842,6 +1883,10 @@ static ncclResult_t shardedRelayAllReduce2ActivePipelined(
     }
   }
   auto directDst = [&](size_t offsetWithinDirect) -> char* {
+    if (lp) {
+      // Wire bytes cannot land in recvBuff even out-of-place.
+      return lpPlan.directRecv + wire.bytes(offsetWithinDirect);
+    }
     if (isInPlace) {
       return static_cast<char*>(directScratch) +
           offsetWithinDirect * elementSize;
@@ -1854,19 +1899,33 @@ static ncclResult_t shardedRelayAllReduce2ActivePipelined(
   // flight. Small enough that a tile is reduced and forwarded out of cache.
   char* hbuff = nullptr;
   if (!cfg.isActiveRank) {
-    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
-        kHelperScratchKeyBase,
-        static_cast<size_t>(cfg.nActiveRanks) * 2 * u * elementSize,
-        stream));
-    if (hbuff == nullptr) {
-      return ncclInternalError;
+    if (lp) {
+      hbuff = lpPlan.helper[0];
+    } else {
+      hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+          kHelperScratchKeyBase,
+          static_cast<size_t>(cfg.nActiveRanks) * 2 * u * elementSize,
+          stream));
+      if (hbuff == nullptr) {
+        return ncclInternalError;
+      }
     }
   }
   // Slot for active source a of the buffer that stage k uses.
+  //
+  // STAGE-MAJOR: the slot index is (k%2)*nActiveRanks + a, so the sources of
+  // one stage are ADJACENT. Source-major -- (a*2 + k%2) -- put them two slots
+  // apart, which is equivalent while the reduce takes two explicit pointers,
+  // but not once it takes a base plus a contribution stride. Indices still
+  // cover 0..2A-1 exactly once, and the allocation is the same size, so this is
+  // behaviour-neutral.
   auto helperSlot = [&](int a, int k) -> char* {
     return hbuff +
-        (static_cast<size_t>(a) * 2 + static_cast<size_t>(k % 2)) * u *
-        elementSize;
+        wire.bytes(
+            (static_cast<size_t>(k % 2) *
+                 static_cast<size_t>(cfg.nActiveRanks) +
+             static_cast<size_t>(a)) *
+            u);
   };
 
   for (int k = 0; k <= T; k++) {
@@ -1881,34 +1940,38 @@ static ncclResult_t shardedRelayAllReduce2ActivePipelined(
       if (k < T) {
         for (int h = 0; h < H; h++) {
           NCCLCHECK(ncclSend(
-              sendbuff +
-                  (static_cast<size_t>(h) * tileStride +
-                   static_cast<size_t>(k) * u) *
-                      elementSize,
-              u,
-              datatype,
+              sendFrom(
+                  static_cast<size_t>(h) * tileStride +
+                  static_cast<size_t>(k) * u),
+              wire.count(u),
+              wire.dtype,
               cfg.helperRanks[h],
               comm,
               stream));
         }
       }
       NCCLCHECK(ncclSend(
-          sendbuff + (directBase + directOffset) * elementSize,
-          directSize,
-          datatype,
+          sendFrom(directBase + directOffset),
+          wire.count(directSize),
+          wire.dtype,
           partner,
           comm,
           stream));
       if (k > 0) {
-        // Already reduced by the helper, so this is its final value.
+        // Already reduced by the helper, so this is its final value. At full
+        // precision it lands where it belongs in recvBuff; under low precision
+        // it stages in lpPlan.relayRecv, laid out to mirror recvBuff's relayed
+        // span, and one dequantize after the loop writes [0, directBase) out at
+        // once.
         for (int h = 0; h < H; h++) {
+          const size_t offsetElems = static_cast<size_t>(h) * tileStride +
+              static_cast<size_t>(k - 1) * u;
+          char* dst = lp ? (lpPlan.relayRecv + wire.bytes(offsetElems))
+                         : (recvbuff + offsetElems * elementSize);
           NCCLCHECK(ncclRecv(
-              recvbuff +
-                  (static_cast<size_t>(h) * tileStride +
-                   static_cast<size_t>(k - 1) * u) *
-                      elementSize,
-              u,
-              datatype,
+              dst,
+              wire.count(u),
+              wire.dtype,
               cfg.helperRanks[h],
               comm,
               stream));
@@ -1916,8 +1979,8 @@ static ncclResult_t shardedRelayAllReduce2ActivePipelined(
       }
       NCCLCHECK(ncclRecv(
           directDst(directOffset),
-          directSize,
-          datatype,
+          wire.count(directSize),
+          wire.dtype,
           partner,
           comm,
           stream));
@@ -1925,15 +1988,20 @@ static ncclResult_t shardedRelayAllReduce2ActivePipelined(
       if (k < T) {
         for (int a = 0; a < cfg.nActiveRanks; a++) {
           NCCLCHECK(ncclRecv(
-              helperSlot(a, k), u, datatype, cfg.activeRanks[a], comm, stream));
+              helperSlot(a, k),
+              wire.count(u),
+              wire.dtype,
+              cfg.activeRanks[a],
+              comm,
+              stream));
         }
       }
       if (k > 0) {
         for (int a = 0; a < cfg.nActiveRanks; a++) {
           NCCLCHECK(ncclSend(
               helperSlot(0, k - 1),
-              u,
-              datatype,
+              wire.count(u),
+              wire.dtype,
               cfg.activeRanks[a],
               comm,
               stream));
@@ -1944,22 +2012,63 @@ static ncclResult_t shardedRelayAllReduce2ActivePipelined(
 
     // Reduce the tile this group received, before the next group forwards it.
     if (!cfg.isActiveRank && k < T) {
-      DISPATCH_FUSED_REDUCE(
-          datatype,
-          helperSlot(0, k),
-          helperSlot(0, k),
-          helperSlot(1, k),
-          u,
-          reductionDivisor,
-          stream);
+      if (lp) {
+        // The stage's sources are adjacent slots, which is what the stage-major
+        // layout above is for: this kernel reads nActiveRanks contributions
+        // from one base at wire.bytes(u) stride.
+        launchLpReduceRequantizeKernel(
+            helperSlot(0, k),
+            helperSlot(0, k),
+            cfg.nActiveRanks,
+            u,
+            reductionDivisor,
+            stream);
+      } else {
+        DISPATCH_FUSED_REDUCE(
+            datatype,
+            helperSlot(0, k),
+            helperSlot(0, k),
+            helperSlot(1, k),
+            u,
+            reductionDivisor,
+            stream);
+      }
     }
+  }
+
+  // Land the relayed span. One launch for [0, directBase), which the helpers
+  // already reduced and already divided.
+  if (lp && cfg.isActiveRank && directBase > 0) {
+    DISPATCH_LP_DEQUANTIZE(
+        datatype, recvBuffs[0], lpPlan.relayRecv, directBase, stream);
   }
 
   // Fold both received direct chunks in one fused pass; they are adjacent in
   // recvBuff and in the scratch.
   if (myActiveGroup == 0 && directTotal > 0) {
     char* dst = static_cast<char*>(recvBuffs[0]) + directBase * elementSize;
-    if (isInPlace) {
+    if (lp) {
+      if (isInPlace) {
+        DISPATCH_LP_MULTI_REDUCE(
+            datatype,
+            dst,
+            lpPlan.directRecv,
+            1,
+            directTotal,
+            reductionDivisor,
+            stream);
+      } else {
+        DISPATCH_LP_SEEDED_MULTI_REDUCE(
+            datatype,
+            dst,
+            static_cast<const char*>(sendBuffs[0]) + directBase * elementSize,
+            lpPlan.directRecv,
+            1,
+            directTotal,
+            reductionDivisor,
+            stream);
+      }
+    } else if (isInPlace) {
       if (reductionDivisor > 1) {
         DISPATCH_INCREMENTAL_ADD_AND_SCALE(
             datatype,
@@ -2816,13 +2925,12 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
         : 1;
 
     // The caller's request narrowed by the size-only gate, so every rank
-    // reaches the same answer without communicating. Only the non-pipelined
-    // 2-active schedule carries the wire format so far; the pipelined and flat
-    // schedules decline, which is safe precisely because this decision is
-    // identical on every rank -- a per-rank disagreement would be a hang, not a
-    // slowdown.
+    // reaches the same answer without communicating. Both 2-active schedules
+    // carry the wire format; the flat schedules still decline, which is safe
+    // precisely because this decision is identical on every rank -- a per-rank
+    // disagreement would be a hang, not a slowdown.
     bool wantLp = false;
-    if (lowPrecision != 0 && nTiles == 1) {
+    if (lowPrecision != 0) {
       wantLp = rcclx::relay::lpEligible(allReduceLpGate(
           datatype,
           counts,
@@ -2830,8 +2938,6 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
           nActiveRanksPerGroup,
           elementSize,
           route == rcclx::relay::AllReduceRoute::A2Relay));
-    } else if (lowPrecision != 0) {
-      rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Route);
     }
 
     r = (nTiles > 1) ? shardedRelayAllReduce2ActivePipelined(
@@ -2846,7 +2952,8 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
                            myActiveGroup,
                            numHelpers,
                            nTiles,
-                           elementSize)
+                           elementSize,
+                           wantLp)
                      : shardedRelayAllReduce2Active(
                            sendBuffs2,
                            recvBuffs2,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -2835,7 +2835,8 @@ static ncclResult_t shardedRelayAllReduceFlatPipelined(
     int numHelpers,
     int nActiveRanksPerGroup,
     int nTiles,
-    size_t elementSize) {
+    size_t elementSize,
+    bool wantLp) {
   const ShardedRelayRankConfig& cfg = configs[0];
   const size_t count = counts[0];
   const int A = nActiveRanksPerGroup;
@@ -2882,6 +2883,20 @@ static ncclResult_t shardedRelayAllReduceFlatPipelined(
         static_cast<size_t>(p) * tileSize(t);
   };
 
+  // Every offset below is a whole number of wire blocks: y is
+  // CHUNK_ALIGN-aligned, so oTile = 2y, oPiece = oTile/oN (oN in {1,2}), oChunk
+  // = T*oTile and pO = H*oChunk all are; pD = count - pO is because pO is;
+  // tileOffset(t) = t*y is, and so is the remainder tile dShard - (T-1)*y; and
+  // dSlot is a sum of the two. dShard = pD/A needs count to be a multiple of
+  // A*128, which is exactly what the gate requires -- pO is a multiple of
+  // A*128, so pD == count (mod A*128).
+  const size_t lpPO[1] = {pO};
+  FlatLpPlan lpPlan{};
+  const bool lp = flatLpPrepare(
+      wantLp, comm, stream, counts, lpPO, /*nGroups=*/1, A, &lpPlan);
+  const rcclx::relay::RelayWire wire =
+      rcclx::relay::lpWireFor(datatype, elementSize, lp);
+
   void* dScratch = nullptr;
   if (myActiveGroup == 0) {
     if (sendBuffs[0] != recvBuffs[0]) {
@@ -2892,31 +2907,57 @@ static ncclResult_t shardedRelayAllReduceFlatPipelined(
           cudaMemcpyDeviceToDevice,
           stream);
     }
-    dScratch = ScratchBufferCache::getInstance().get(
-        SHARDED_RELAY_MAX_GROUPS,
-        static_cast<size_t>(A - 1) * dShard * elementSize,
-        stream);
-    if (dScratch == nullptr) {
-      return ncclInternalError;
+    if (lp) {
+      dScratch = lpPlan.directRecv;
+    } else {
+      dScratch = ScratchBufferCache::getInstance().get(
+          SHARDED_RELAY_MAX_GROUPS,
+          static_cast<size_t>(A - 1) * dShard * elementSize,
+          stream);
+      if (dScratch == nullptr) {
+        return ncclInternalError;
+      }
     }
   }
+
+  // The reduce-scatter and offload sends read the caller's data, so one
+  // quantize covers them -- after the seeding above, and over recvBuff, because
+  // that is where this schedule reads its outbound data from. The all-gather's
+  // source is produced per stage and is quantized inside the loop instead.
+  if (lp && cfg.isActiveRank && count > 0) {
+    DISPATCH_LP_QUANTIZE(
+        datatype, lpPlan.sendShadow, recvBuffs[0], count, stream);
+  }
+  auto sendFrom = [&](size_t offsetElems) -> const char* {
+    if (lp) {
+      return lpPlan.sendShadow + wire.bytes(offsetElems);
+    }
+    return static_cast<const char*>(recvBuffs[0]) + offsetElems * elementSize;
+  };
 
   // Helper staging: A chunks per ping-pong buffer, buffer-major so the A inputs
   // of one stage are contiguous with stride oTile for the fused reduce.
   char* hbuff = nullptr;
   if (!cfg.isActiveRank) {
-    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
-        kHelperScratchKeyBase,
-        2 * static_cast<size_t>(A) * oTile * elementSize,
-        stream));
-    if (hbuff == nullptr) {
-      return ncclInternalError;
+    if (lp) {
+      hbuff = lpPlan.helper[0];
+    } else {
+      hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+          kHelperScratchKeyBase,
+          2 * static_cast<size_t>(A) * oTile * elementSize,
+          stream));
+      if (hbuff == nullptr) {
+        return ncclInternalError;
+      }
     }
   }
+  // Already stage-major -- the A inputs of one stage are contiguous with stride
+  // oTile -- which is exactly the layout launchLpReduceRequantizeKernel wants,
+  // so unlike the 2-active pipelined path this needs no relayout.
   auto helperSlot = [&](int a, int k) -> char* {
     return hbuff +
-        ((static_cast<size_t>(k % 2) * A + static_cast<size_t>(a)) * oTile) *
-        elementSize;
+        wire.bytes(
+            (static_cast<size_t>(k % 2) * A + static_cast<size_t>(a)) * oTile);
   };
 
   for (int k = 0; k <= T; k++) {
@@ -2934,11 +2975,9 @@ static ncclResult_t shardedRelayAllReduceFlatPipelined(
             continue;
           }
           NCCLCHECK(ncclSend(
-              recvbuff +
-                  (static_cast<size_t>(j) * dShard + tileOffset(k)) *
-                      elementSize,
-              tileSize(k),
-              datatype,
+              sendFrom(static_cast<size_t>(j) * dShard + tileOffset(k)),
+              wire.count(tileSize(k)),
+              wire.dtype,
               cfg.activeRanks[j],
               comm,
               stream));
@@ -2949,12 +2988,13 @@ static ncclResult_t shardedRelayAllReduceFlatPipelined(
           if (j == m) {
             continue;
           }
+          const size_t mineOff =
+              static_cast<size_t>(m) * dShard + tileOffset(k - 1);
           NCCLCHECK(ncclSend(
-              recvbuff +
-                  (static_cast<size_t>(m) * dShard + tileOffset(k - 1)) *
-                      elementSize,
-              tileSize(k - 1),
-              datatype,
+              lp ? (lpPlan.agStage + wire.bytes(mineOff))
+                 : (recvbuff + mineOff * elementSize),
+              wire.count(tileSize(k - 1)),
+              wire.dtype,
               cfg.activeRanks[j],
               comm,
               stream));
@@ -2970,13 +3010,12 @@ static ncclResult_t shardedRelayAllReduceFlatPipelined(
         for (int h = 0; h < H; h++) {
           for (int i = 0; i < oN; i++) {
             NCCLCHECK(ncclSend(
-                recvbuff +
-                    (pD + static_cast<size_t>(h) * oChunk +
-                     static_cast<size_t>(k) * oTile +
-                     static_cast<size_t>(i) * oPiece) *
-                        elementSize,
-                oPiece,
-                datatype,
+                sendFrom(
+                    pD + static_cast<size_t>(h) * oChunk +
+                    static_cast<size_t>(k) * oTile +
+                    static_cast<size_t>(i) * oPiece),
+                wire.count(oPiece),
+                wire.dtype,
                 cfg.helperRanks[h],
                 comm,
                 stream));
@@ -2991,9 +3030,9 @@ static ncclResult_t shardedRelayAllReduceFlatPipelined(
           }
           const int p = (s < m) ? s : s - 1;
           NCCLCHECK(ncclRecv(
-              static_cast<char*>(dScratch) + dSlot(k, p) * elementSize,
-              tileSize(k),
-              datatype,
+              static_cast<char*>(dScratch) + wire.bytes(dSlot(k, p)),
+              wire.count(tileSize(k)),
+              wire.dtype,
               cfg.activeRanks[s],
               comm,
               stream));
@@ -3004,12 +3043,13 @@ static ncclResult_t shardedRelayAllReduceFlatPipelined(
           if (j == m) {
             continue;
           }
+          const size_t theirsOff =
+              static_cast<size_t>(j) * dShard + tileOffset(k - 1);
           NCCLCHECK(ncclRecv(
-              recvbuff +
-                  (static_cast<size_t>(j) * dShard + tileOffset(k - 1)) *
-                      elementSize,
-              tileSize(k - 1),
-              datatype,
+              lp ? (lpPlan.agStage + wire.bytes(theirsOff))
+                 : (recvbuff + theirsOff * elementSize),
+              wire.count(tileSize(k - 1)),
+              wire.dtype,
               cfg.activeRanks[j],
               comm,
               stream));
@@ -3018,14 +3058,14 @@ static ncclResult_t shardedRelayAllReduceFlatPipelined(
         // match the scatter above.
         for (int h = 0; h < H; h++) {
           for (int i = 0; i < oN; i++) {
+            const size_t off = static_cast<size_t>(h) * oChunk +
+                static_cast<size_t>(k - 1) * oTile +
+                static_cast<size_t>(i) * oPiece;
             NCCLCHECK(ncclRecv(
-                recvbuff +
-                    (pD + static_cast<size_t>(h) * oChunk +
-                     static_cast<size_t>(k - 1) * oTile +
-                     static_cast<size_t>(i) * oPiece) *
-                        elementSize,
-                oPiece,
-                datatype,
+                lp ? (lpPlan.offloadRecv + wire.bytes(off))
+                   : (recvbuff + (pD + off) * elementSize),
+                wire.count(oPiece),
+                wire.dtype,
                 cfg.helperRanks[h],
                 comm,
                 stream));
@@ -3037,10 +3077,9 @@ static ncclResult_t shardedRelayAllReduceFlatPipelined(
         for (int a = 0; a < A; a++) {
           for (int i = 0; i < oN; i++) {
             NCCLCHECK(ncclRecv(
-                helperSlot(a, k) +
-                    static_cast<size_t>(i) * oPiece * elementSize,
-                oPiece,
-                datatype,
+                helperSlot(a, k) + wire.bytes(static_cast<size_t>(i) * oPiece),
+                wire.count(oPiece),
+                wire.dtype,
                 cfg.activeRanks[a],
                 comm,
                 stream));
@@ -3052,9 +3091,9 @@ static ncclResult_t shardedRelayAllReduceFlatPipelined(
           for (int i = 0; i < oN; i++) {
             NCCLCHECK(ncclSend(
                 helperSlot(0, k - 1) +
-                    static_cast<size_t>(i) * oPiece * elementSize,
-                oPiece,
-                datatype,
+                    wire.bytes(static_cast<size_t>(i) * oPiece),
+                wire.count(oPiece),
+                wire.dtype,
                 cfg.activeRanks[a],
                 comm,
                 stream));
@@ -3067,15 +3106,47 @@ static ncclResult_t shardedRelayAllReduceFlatPipelined(
     if (k < T) {
       if (cfg.isActiveRank) {
         // Fold this tile of my own shard, before the next group gathers it.
-        char* dst = static_cast<char*>(recvBuffs[0]) +
-            (static_cast<size_t>(cfg.myActiveIndex) * dShard + tileOffset(k)) *
-                elementSize;
-        DISPATCH_MULTI_REDUCE(
-            datatype,
-            dst,
-            static_cast<char*>(dScratch) + dSlot(k, 0) * elementSize,
-            A - 1,
-            tileSize(k),
+        const size_t mine =
+            static_cast<size_t>(cfg.myActiveIndex) * dShard + tileOffset(k);
+        char* dst = static_cast<char*>(recvBuffs[0]) + mine * elementSize;
+        if (lp) {
+          // dScratch is already tile-major, so this tile's A-1 contributions
+          // are contiguous at stride tileSize(k) -- what the kernel expects.
+          // The result is written FULL PRECISION, then quantized just below for
+          // the all-gather that carries it in the next group.
+          DISPATCH_LP_MULTI_REDUCE(
+              datatype,
+              dst,
+              static_cast<char*>(dScratch) + wire.bytes(dSlot(k, 0)),
+              A - 1,
+              tileSize(k),
+              reductionDivisor,
+              stream);
+          DISPATCH_LP_QUANTIZE(
+              datatype,
+              lpPlan.agStage + wire.bytes(mine),
+              dst,
+              tileSize(k),
+              stream);
+        } else {
+          DISPATCH_MULTI_REDUCE(
+              datatype,
+              dst,
+              static_cast<char*>(dScratch) + dSlot(k, 0) * elementSize,
+              A - 1,
+              tileSize(k),
+              reductionDivisor,
+              stream);
+        }
+      } else if (lp) {
+        // All A contributions from slot 0 at wire.bytes(oTile) stride. The
+        // divisor lands here: the broadcast delivers this straight to its final
+        // place, so there is no active-side reduce to defer it to.
+        launchLpReduceRequantizeKernel(
+            helperSlot(0, k),
+            helperSlot(0, k),
+            A,
+            oTile,
             reductionDivisor,
             stream);
       } else {
@@ -3089,6 +3160,37 @@ static ncclResult_t shardedRelayAllReduceFlatPipelined(
             reductionDivisor,
             stream);
       }
+    }
+  }
+
+  // ===== Low precision: land both regions, once, after every stage has
+  // arrived.
+  if (lp && cfg.isActiveRank) {
+    char* recvbuff = static_cast<char*>(recvBuffs[0]);
+    // The direct region in the at-most-two runs that EXCLUDE this rank's own
+    // shard, which the per-stage reduces already wrote at full precision.
+    const size_t mineBase = static_cast<size_t>(cfg.myActiveIndex) * dShard;
+    if (mineBase > 0) {
+      DISPATCH_LP_DEQUANTIZE(
+          datatype, recvbuff, lpPlan.agStage, mineBase, stream);
+    }
+    const size_t afterMine = mineBase + dShard;
+    if (afterMine < pD) {
+      DISPATCH_LP_DEQUANTIZE(
+          datatype,
+          recvbuff + afterMine * elementSize,
+          lpPlan.agStage + wire.bytes(afterMine),
+          pD - afterMine,
+          stream);
+    }
+    // The offload region is contiguous and arrives already reduced and divided.
+    if (pO > 0) {
+      DISPATCH_LP_DEQUANTIZE(
+          datatype,
+          recvbuff + pD * elementSize,
+          lpPlan.offloadRecv,
+          pO,
+          stream);
     }
   }
 
@@ -3279,7 +3381,7 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
         elementSize);
 
     bool wantLp = false;
-    if (lowPrecision != 0 && nTiles == 1) {
+    if (lowPrecision != 0) {
       wantLp = rcclx::relay::lpEligible(allReduceLpGate(
           datatype,
           counts,
@@ -3289,8 +3391,6 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
           /*relayRouteSelected=*/true,
           static_cast<size_t>(nActiveRanksPerGroup) *
               rcclx::relay::kLpBlockElems));
-    } else if (lowPrecision != 0) {
-      rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Route);
     }
 
     if (nTiles > 1) {
@@ -3307,7 +3407,8 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
           numHelpers,
           nActiveRanksPerGroup,
           nTiles,
-          elementSize);
+          elementSize,
+          wantLp);
     }
     r = shardedRelayAllReduceFlat(
         sendBuffs2,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -10,6 +10,9 @@
 #include "comm.h"
 #include "sharded_relay_allreduce_kernels.h"
 #include "sharded_relay_graph_scratch.h"
+#include "sharded_relay_lp.h"
+#include "sharded_relay_lp_arena.h"
+#include "sharded_relay_lp_kernels.h"
 #include "sharded_relay_oneshot.h"
 #include "sharded_relay_route.h"
 
@@ -590,6 +593,62 @@ class ScratchBufferCache {
     }                                                                      \
   } while (0)
 
+// =========================================================================
+// LOW-PRECISION DISPATCH
+// =========================================================================
+// Only bf16 and fp32 appear here, because lpDtypeSupported() admits only those
+// and the gate declines everything else back to full precision. The `default:`
+// arm is therefore unreachable rather than a silent fallthrough; it aborts the
+// call instead of returning ncclSuccess having quantized nothing, which is how
+// a gate bug surfaces as an error rather than as wrong numbers.
+#define DISPATCH_LP(datatype, CALL, ...)                                                                      \
+  do {                                                                                                        \
+    switch (datatype) {                                                                                       \
+      case ncclFloat32:                                                                                       \
+        CALL<float>(__VA_ARGS__);                                                                             \
+        break;                                                                                                \
+      case ncclBfloat16:                                                                                      \
+        CALL<__nv_bfloat16>(__VA_ARGS__);                                                                     \
+        break;                                                                                                \
+      default:                                                                                                \
+        WARN(                                                                                                 \
+            "Sharded relay: low precision reached an unsupported datatype %d; the eligibility gate is wrong", \
+            static_cast<int>(datatype));                                                                      \
+        return ncclInternalError;                                                                             \
+    }                                                                                                         \
+  } while (0)
+
+#define DISPATCH_LP_QUANTIZE(datatype, wireOut, in, count, stream) \
+  DISPATCH_LP(datatype, launchLpQuantizeKernel, wireOut, in, count, stream)
+
+#define DISPATCH_LP_DEQUANTIZE(datatype, out, wireIn, count, stream) \
+  DISPATCH_LP(datatype, launchLpDequantizeKernel, out, wireIn, count, stream)
+
+#define DISPATCH_LP_MULTI_REDUCE(                           \
+    datatype, dst, wireContribs, n, count, divisor, stream) \
+  DISPATCH_LP(                                              \
+      datatype,                                             \
+      launchLpMultiReduceKernel,                            \
+      dst,                                                  \
+      wireContribs,                                         \
+      n,                                                    \
+      count,                                                \
+      divisor,                                              \
+      stream)
+
+#define DISPATCH_LP_SEEDED_MULTI_REDUCE(                          \
+    datatype, dst, seed, wireContribs, n, count, divisor, stream) \
+  DISPATCH_LP(                                                    \
+      datatype,                                                   \
+      launchLpSeededMultiReduceKernel,                            \
+      dst,                                                        \
+      seed,                                                       \
+      wireContribs,                                               \
+      n,                                                          \
+      count,                                                      \
+      divisor,                                                    \
+      stream)
+
 namespace {
 
 // The DISPATCH_* macros above instantiate reduce kernels for exactly these
@@ -1016,6 +1075,209 @@ static bool tryOneShotAllReduce(
   return handled;
 }
 
+namespace {
+
+/**
+ * The wire buffers one 2-active relay call needs, carved from the
+ * communicator's low-precision arena.
+ *
+ * Every region is carved UNCONDITIONALLY and at the WORST CASE over all groups,
+ * even though a rank is active for exactly one group and a helper for the rest.
+ * That is deliberate on two counts. It makes the partition byte-identical on
+ * every rank and on every call with the same geometry, which is what lets a
+ * captured graph replay against the same addresses. And it makes the footprint
+ * a function of the counts alone, so the capacity check below is
+ * rank-independent -- a rank that sized its own roles would decline on a
+ * different set of calls than its peers, and low precision has to be unanimous
+ * or the two disagree on wire byte counts and the call hangs.
+ */
+struct A2LpPlan {
+  char* sendShadow{nullptr}; // wire(count): the whole active send buffer
+  char* relayRecv{
+      nullptr}; // wire(relayTotal): mirrors recvBuff's relayed region
+  char* directRecv{nullptr}; // wire(direct region)
+  char* helper[SHARDED_RELAY_MAX_GROUPS]{};
+  bool valid{false};
+};
+
+// The size-and-dtype half of the gate, in one place so the dispatcher cannot
+// accidentally feed it a different size metric than the route selector uses.
+rcclx::relay::LpGateInputs allReduceLpGate(
+    ncclDataType_t datatype,
+    const size_t* counts,
+    int nGroups,
+    int nActiveRanksPerGroup,
+    size_t elementSize,
+    bool relayRouteSelected) {
+  rcclx::relay::LpGateInputs in;
+  in.coll = rcclx::relay::LpCollective::AllReduce;
+  in.datatype = datatype;
+  in.counts = counts;
+  in.nGroups = nGroups;
+  in.nActiveRanksPerGroup = nActiveRanksPerGroup;
+  // max(counts) * elementSize is exactly selectAllReduceRoute()'s metric, so
+  // the low-precision threshold and the route threshold are directly
+  // comparable.
+  in.routeSizeBytes =
+      rcclx::relay::relayMaxCount(counts, nGroups) * elementSize;
+  in.relayRouteSelected = relayRouteSelected;
+  return in;
+}
+
+size_t a2LpAlign(size_t bytes) {
+  return ((bytes + rcclx::relay::LpArenaCarver::kAlign - 1) /
+          rcclx::relay::LpArenaCarver::kAlign) *
+      rcclx::relay::LpArenaCarver::kAlign;
+}
+
+// Bytes one call needs, derived only from the counts and the chunk geometry
+// (which is itself derived only from the counts), so every rank computes the
+// same number.
+size_t a2LpRequiredBytes(
+    const size_t* counts,
+    const size_t* relayTotals,
+    const size_t* chunkSizes,
+    int nGroups,
+    int nActiveRanks) {
+  const size_t maxCount = rcclx::relay::relayMaxCount(counts, nGroups);
+  const size_t maxRelay = rcclx::relay::relayMaxCount(relayTotals, nGroups);
+  const size_t maxChunk = rcclx::relay::relayMaxCount(chunkSizes, nGroups);
+  // directRecv is bounded by maxCount rather than max(count - relayTotal),
+  // which costs a little arena and removes a per-group subtraction from a
+  // number every rank has to agree on.
+  size_t total = a2LpAlign(rcclx::relay::lpWireBytes(maxCount)) +
+      a2LpAlign(rcclx::relay::lpWireBytes(maxRelay)) +
+      a2LpAlign(rcclx::relay::lpWireBytes(maxCount));
+  total += static_cast<size_t>(nGroups) *
+      a2LpAlign(
+               static_cast<size_t>(nActiveRanks) *
+               rcclx::relay::lpWireBytes(maxChunk));
+  return total;
+}
+
+A2LpPlan a2LpCarve(
+    const rcclx::relay::LpArenaLease& lease,
+    const size_t* counts,
+    const size_t* relayTotals,
+    const size_t* chunkSizes,
+    int nGroups,
+    int nActiveRanks) {
+  const size_t maxCount = rcclx::relay::relayMaxCount(counts, nGroups);
+  const size_t maxRelay = rcclx::relay::relayMaxCount(relayTotals, nGroups);
+  const size_t maxChunk = rcclx::relay::relayMaxCount(chunkSizes, nGroups);
+
+  A2LpPlan p{};
+  rcclx::relay::LpArenaCarver carver(lease);
+  p.sendShadow = carver.take(rcclx::relay::lpWireBytes(maxCount));
+  p.relayRecv = carver.take(rcclx::relay::lpWireBytes(maxRelay));
+  p.directRecv = carver.take(rcclx::relay::lpWireBytes(maxCount));
+  for (int g = 0; g < nGroups; g++) {
+    p.helper[g] = carver.take(
+        static_cast<size_t>(nActiveRanks) *
+        rcclx::relay::lpWireBytes(maxChunk));
+  }
+  p.valid = carver.ok();
+  return p;
+}
+
+/**
+ * Every region boundary this schedule sends or receives at is a whole number of
+ * wire blocks.
+ *
+ * 128-aligned per-group counts (what lpEligible() checks) make relayTotal, dirA
+ * and dirB aligned -- but ONLY when the aligned chunk size is non-zero. When
+ * count / numChunks floors to zero the geometry falls back to splitting the
+ * buffer in HALF, and count / 2 is a multiple of 64, not of 128. That is not a
+ * tail-only error: dirB starts at count/2, so under low precision the boundary
+ * lands mid-block and both directions of the exchange disagree about where the
+ * second chunk begins.
+ *
+ * The degenerate branch is easy to reach in a FUSED call, where one small group
+ * rides along with a large one: the gate only ever sees the largest group's
+ * size, so counts={2097152, 384} passes on the big sibling while the 384
+ * element group takes the halving branch. Its own size is a legal 128 multiple,
+ * which is why the count check cannot catch this.
+ *
+ * Pure function of the counts and the chunk geometry (itself a pure function of
+ * the counts), so every rank declines together.
+ */
+bool a2LpGeometryOk(
+    const size_t* counts,
+    const size_t* chunkSizes,
+    int nGroups) {
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] > 0 && chunkSizes[g] == 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Turn the caller's request into a decision, and carve the buffers if it holds.
+ *
+ * COLLECTIVE: lpArenaAcquire() runs a bootstrap unanimity vote on first use, so
+ * every rank must reach this whenever the dispatcher's size-only gate said yes
+ * -- including the helper ranks, which is why it is called before any role
+ * branch. Every reason it can return false is derived from the counts or is
+ * already agreed across the communicator, so all ranks decline together.
+ */
+bool a2LpPrepare(
+    bool wantLp,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const size_t* counts,
+    const size_t* relayTotals,
+    const size_t* chunkSizes,
+    int nGroups,
+    int nActiveRanks,
+    A2LpPlan* out) {
+  if (!wantLp) {
+    return false;
+  }
+
+  if (!a2LpGeometryOk(counts, chunkSizes, nGroups)) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Alignment);
+    return false;
+  }
+
+  // Creating the arena is not capturable: it runs a bootstrap all-gather. Using
+  // one that already exists is fine, so under capture take the path only if the
+  // arena is already up. Same precedent as the one-shot region.
+  struct ncclCudaGraph graph;
+  if (ncclCudaGetCapturingGraph(&graph, stream) != ncclSuccess) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::GraphCapture);
+    return false;
+  }
+  if (ncclCudaGraphValid(graph) && !rcclx::relay::lpArenaReady(comm)) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::GraphCapture);
+    return false;
+  }
+
+  rcclx::relay::LpArenaLease lease{};
+  if (!rcclx::relay::lpArenaAcquire(comm, &lease)) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+  if (a2LpRequiredBytes(
+          counts, relayTotals, chunkSizes, nGroups, nActiveRanks) >
+      lease.bytes) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+
+  *out =
+      a2LpCarve(lease, counts, relayTotals, chunkSizes, nGroups, nActiveRanks);
+  if (!out->valid) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+  rcclx::relay::lpRecordEngage();
+  return true;
+}
+
+} // namespace
+
 static ncclResult_t shardedRelayAllReduce2Active(
     const void* const* sendBuffs,
     void* const* recvBuffs,
@@ -1028,7 +1290,8 @@ static ncclResult_t shardedRelayAllReduce2Active(
     int myActiveGroup,
     int numHelpers,
     int nGroups,
-    size_t elementSize) {
+    size_t elementSize,
+    bool wantLp) {
   // ==========================================================================
   // SIZE-ADAPTIVE PURE-DIRECT FAST PATH (A==2)
   // ==========================================================================
@@ -1041,6 +1304,10 @@ static ncclResult_t shardedRelayAllReduce2Active(
   // selectAllReduceRoute() so the tests assert the same definition this
   // dispatch uses. This function is the A==2 path, so the selector is asked
   // about A==2.
+  // The pure-direct route is launch-bound, not bandwidth-bound: low precision
+  // would only add launches there, so the gate already excludes it and this
+  // branch never sees wantLp true. Asserted by construction rather than
+  // re-checked -- see the gate in the dispatcher.
   if (rcclx::relay::selectAllReduceRoute(2, nGroups, counts, elementSize) ==
       rcclx::relay::AllReduceRoute::PureDirect) {
     // One kernel instead of the group-plus-reduce pair below. See
@@ -1160,6 +1427,52 @@ static ncclResult_t shardedRelayAllReduce2Active(
   }
 
   // =========================================================================
+  // LOW PRECISION: decide, acquire the arena, and quantize the send buffer
+  // =========================================================================
+  // Collective: every rank reaches a2LpPrepare() when the dispatcher's
+  // size-only gate said yes, and every way it can decline is agreed across the
+  // communicator, so all ranks run the same wire format or none do.
+  A2LpPlan lpPlan{};
+  const bool lp = a2LpPrepare(
+      wantLp,
+      comm,
+      stream,
+      counts,
+      relayTotals,
+      chunkSizes,
+      nGroups,
+      configs[0].nActiveRanks,
+      &lpPlan);
+  const rcclx::relay::RelayWire wire =
+      rcclx::relay::lpWireFor(datatype, elementSize, lp);
+
+  // One quantize per group over the ENTIRE boundary-crossing send region,
+  // before the first ncclGroupStart. Every byte of the active buffer crosses a
+  // rank boundary here -- the relayed chunks cover [0, relayTotal) and the two
+  // direct chunks cover [relayTotal, count) -- so this is the whole buffer.
+  // Hoisted rather than done per chunk: per-chunk would cost numChunks launches
+  // instead of one for no benefit, since nothing between them reads the result.
+  if (lp && myActiveGroup >= 0 && counts[myActiveGroup] > 0) {
+    DISPATCH_LP_QUANTIZE(
+        datatype,
+        lpPlan.sendShadow,
+        sendBuffs[myActiveGroup],
+        counts[myActiveGroup],
+        stream);
+  }
+
+  // Where a boundary-crossing send reads from: the quantized shadow under low
+  // precision, the caller's buffer otherwise. Offsets are in ELEMENTS of the
+  // caller's dtype either way, which is what keeps every call site below
+  // unchanged in shape.
+  auto sendFrom = [&](int g, size_t offsetElems) -> const char* {
+    if (lp) {
+      return lpPlan.sendShadow + wire.bytes(offsetElems);
+    }
+    return static_cast<const char*>(sendBuffs[g]) + offsetElems * elementSize;
+  };
+
+  // =========================================================================
   // SCRATCH: the two received direct chunks, contiguous (in-place only)
   // =========================================================================
   // Out-of-place receives the direct chunks straight into recvBuff and reduces
@@ -1174,7 +1487,10 @@ static ncclResult_t shardedRelayAllReduce2Active(
     isInPlace = (sendBuffs[myActiveGroup] == recvBuffs[myActiveGroup]);
     myDirOffset = relayTotals[myActiveGroup];
     myDirTotal = counts[myActiveGroup] - myDirOffset;
-    if (isInPlace) {
+    // Under low precision the arrivals are wire bytes, so they cannot land in
+    // recvBuff even out-of-place: lpPlan.directRecv stages them in both cases
+    // and the closing fold reads them from there.
+    if (isInPlace && !lp) {
       directScratch = ScratchBufferCache::getInstance().get(
           myActiveGroup, myDirTotal * elementSize, stream);
       if (directScratch == nullptr) {
@@ -1185,6 +1501,9 @@ static ncclResult_t shardedRelayAllReduce2Active(
 
   // Destination for received direct chunk A / chunk B.
   auto directDst = [&](size_t offsetWithinDirect) -> char* {
+    if (lp) {
+      return lpPlan.directRecv + wire.bytes(offsetWithinDirect);
+    }
     if (isInPlace) {
       return static_cast<char*>(directScratch) +
           offsetWithinDirect * elementSize;
@@ -1200,6 +1519,12 @@ static ncclResult_t shardedRelayAllReduce2Active(
   for (int g = 0; g < nGroups; g++) {
     const ShardedRelayRankConfig& cfg = configs[g];
     if (!cfg.isActiveRank && counts[g] > 0 && chunkSizes[g] > 0) {
+      if (lp) {
+        // Already carved, and in wire bytes: the helper reduces and forwards
+        // wire blocks without ever learning the caller's dtype.
+        helperScratch[g] = lpPlan.helper[g];
+        continue;
+      }
       size_t needBytes =
           static_cast<size_t>(cfg.nActiveRanks) * chunkSizes[g] * elementSize;
       helperScratch[g] = ScratchBufferCache::getInstance().get(
@@ -1223,14 +1548,12 @@ static ncclResult_t shardedRelayAllReduce2Active(
     size_t chunkSize = chunkSizes[g];
 
     if (cfg.isActiveRank) {
-      const char* sendbuff = static_cast<const char*>(sendBuffs[g]);
-
       // Scatter: chunk h goes to helper h.
       for (int h = 0; h < cfg.numHelpers && chunkSize > 0; h++) {
         NCCLCHECK(ncclSend(
-            sendbuff + static_cast<size_t>(h) * chunkSize * elementSize,
-            chunkSize,
-            datatype,
+            sendFrom(g, static_cast<size_t>(h) * chunkSize),
+            wire.count(chunkSize),
+            wire.dtype,
             cfg.helperRanks[h],
             comm,
             stream));
@@ -1240,23 +1563,28 @@ static ncclResult_t shardedRelayAllReduce2Active(
       int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
       if (dirASizes[g] > 0) {
         NCCLCHECK(ncclSend(
-            sendbuff + relayTotals[g] * elementSize,
-            dirASizes[g],
-            datatype,
+            sendFrom(g, relayTotals[g]),
+            wire.count(dirASizes[g]),
+            wire.dtype,
             partner,
             comm,
             stream));
         NCCLCHECK(ncclRecv(
-            directDst(0), dirASizes[g], datatype, partner, comm, stream));
+            directDst(0),
+            wire.count(dirASizes[g]),
+            wire.dtype,
+            partner,
+            comm,
+            stream));
       }
     } else if (chunkSize > 0) {
       // Helper: receive active rank a's chunk into slot a.
       char* helperBuf = static_cast<char*>(helperScratch[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {
         NCCLCHECK(ncclRecv(
-            helperBuf + static_cast<size_t>(a) * chunkSize * elementSize,
-            chunkSize,
-            datatype,
+            helperBuf + wire.bytes(static_cast<size_t>(a) * chunkSize),
+            wire.count(chunkSize),
+            wire.dtype,
             cfg.activeRanks[a],
             comm,
             stream));
@@ -1280,6 +1608,21 @@ static ncclResult_t shardedRelayAllReduce2Active(
       continue;
     char* helperBuf = static_cast<char*>(helperScratch[g]);
     size_t chunkSize = chunkSizes[g];
+    if (lp) {
+      // Wire in, wire out, summed in fp32. The divisor lands HERE and not on
+      // the active rank because the reduced chunk below goes straight to its
+      // final place -- there is no active-side reduce for this region to defer
+      // it to. Exact: the divisor is a power of two. See
+      // sharded_relay_lp_kernels.h.
+      launchLpReduceRequantizeKernel(
+          helperBuf,
+          helperBuf,
+          configs[g].nActiveRanks,
+          chunkSize,
+          reductionDivisor,
+          stream);
+      continue;
+    }
     DISPATCH_FUSED_REDUCE(
         datatype,
         helperBuf,
@@ -1305,13 +1648,19 @@ static ncclResult_t shardedRelayAllReduce2Active(
     if (cfg.isActiveRank) {
       char* recvbuff = static_cast<char*>(recvBuffs[g]);
 
-      // The helper's chunk is already reduced, so it lands directly in its
-      // final place in recvBuff — no active-side reduction for this region.
+      // The helper's chunk is already reduced, so at full precision it lands
+      // directly in its final place in recvBuff. Under low precision it arrives
+      // as wire bytes, so it stages in lpPlan.relayRecv -- laid out to mirror
+      // recvBuff's relayed region -- and one dequantize below writes the whole
+      // region out at once.
       for (int h = 0; h < cfg.numHelpers && chunkSize > 0; h++) {
+        const size_t offsetElems = static_cast<size_t>(h) * chunkSize;
+        char* dst = lp ? (lpPlan.relayRecv + wire.bytes(offsetElems))
+                       : (recvbuff + offsetElems * elementSize);
         NCCLCHECK(ncclRecv(
-            recvbuff + static_cast<size_t>(h) * chunkSize * elementSize,
-            chunkSize,
-            datatype,
+            dst,
+            wire.count(chunkSize),
+            wire.dtype,
             cfg.helperRanks[h],
             comm,
             stream));
@@ -1320,16 +1669,16 @@ static ncclResult_t shardedRelayAllReduce2Active(
       // Direct chunk B, again over the idle active<->active link.
       int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
       NCCLCHECK(ncclSend(
-          static_cast<const char*>(sendBuffs[g]) + dirBOffsets[g] * elementSize,
-          dirBSizes[g],
-          datatype,
+          sendFrom(g, dirBOffsets[g]),
+          wire.count(dirBSizes[g]),
+          wire.dtype,
           partner,
           comm,
           stream));
       NCCLCHECK(ncclRecv(
           directDst(dirASizes[g]),
-          dirBSizes[g],
-          datatype,
+          wire.count(dirBSizes[g]),
+          wire.dtype,
           partner,
           comm,
           stream));
@@ -1338,12 +1687,31 @@ static ncclResult_t shardedRelayAllReduce2Active(
       const char* helperBuf = static_cast<const char*>(helperScratch[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {
         NCCLCHECK(ncclSend(
-            helperBuf, chunkSize, datatype, cfg.activeRanks[a], comm, stream));
+            helperBuf,
+            wire.count(chunkSize),
+            wire.dtype,
+            cfg.activeRanks[a],
+            comm,
+            stream));
       }
     }
   }
 
   NCCLCHECK(ncclGroupEnd());
+
+  // =========================================================================
+  // LOW PRECISION: land the relayed region
+  // =========================================================================
+  // One launch for the whole [0, relayTotal) region, which is already final --
+  // the helpers reduced it and applied the divisor. Nothing else touches it.
+  if (lp && myActiveGroup >= 0 && relayTotals[myActiveGroup] > 0) {
+    DISPATCH_LP_DEQUANTIZE(
+        datatype,
+        recvBuffs[myActiveGroup],
+        lpPlan.relayRecv,
+        relayTotals[myActiveGroup],
+        stream);
+  }
 
   // =========================================================================
   // DIRECT REDUCE: fold both received direct chunks in one fused pass
@@ -1353,7 +1721,32 @@ static ncclResult_t shardedRelayAllReduce2Active(
   if (myActiveGroup >= 0 && myDirTotal > 0) {
     char* dst = static_cast<char*>(recvBuffs[myActiveGroup]) +
         myDirOffset * elementSize;
-    if (isInPlace) {
+    if (lp) {
+      // One wire contribution (the partner's two direct chunks, contiguous)
+      // folded against this rank's own, accumulated in fp32. In-place reads its
+      // contribution from dst; out-of-place seeds from sendBuff.
+      if (isInPlace) {
+        DISPATCH_LP_MULTI_REDUCE(
+            datatype,
+            dst,
+            lpPlan.directRecv,
+            1,
+            myDirTotal,
+            reductionDivisor,
+            stream);
+      } else {
+        DISPATCH_LP_SEEDED_MULTI_REDUCE(
+            datatype,
+            dst,
+            static_cast<const char*>(sendBuffs[myActiveGroup]) +
+                myDirOffset * elementSize,
+            lpPlan.directRecv,
+            1,
+            myDirTotal,
+            reductionDivisor,
+            stream);
+      }
+    } else if (isInPlace) {
       if (reductionDivisor > 1) {
         DISPATCH_INCREMENTAL_ADD_AND_SCALE(
             datatype, dst, directScratch, myDirTotal, reductionDivisor, stream);
@@ -2332,9 +2725,6 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
     int nActiveRanksPerGroup,
     int nGroups,
     int lowPrecision) {
-  // Accepted and ignored: the wire-format substitution lands in a later commit,
-  // so this commit cannot change behaviour.
-  (void)lowPrecision;
   int nRanks, rank;
   NCCLCHECK(ncclCommCount(comm, &nRanks));
   NCCLCHECK(ncclCommUserRank(comm, &rank));
@@ -2415,15 +2805,35 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
     // be software-pipelined into one duplex stream. relayPipelineTiles()
     // returns 1 whenever that does not apply, and the small-message pure-direct
     // route (owned by shardedRelayAllReduce2Active) never pipelines.
-    const int nTiles =
-        (rcclx::relay::selectAllReduceRoute(2, nGroups, counts, elementSize) ==
-         rcclx::relay::AllReduceRoute::A2Relay)
+    const rcclx::relay::AllReduceRoute route =
+        rcclx::relay::selectAllReduceRoute(2, nGroups, counts, elementSize);
+    const int nTiles = (route == rcclx::relay::AllReduceRoute::A2Relay)
         ? rcclx::relay::relayPipelineTiles(
               nGroups,
               rcclx::relay::relayShapeA2(numHelpers),
               rcclx::relay::relayMaxCount(counts, nGroups),
               elementSize)
         : 1;
+
+    // The caller's request narrowed by the size-only gate, so every rank
+    // reaches the same answer without communicating. Only the non-pipelined
+    // 2-active schedule carries the wire format so far; the pipelined and flat
+    // schedules decline, which is safe precisely because this decision is
+    // identical on every rank -- a per-rank disagreement would be a hang, not a
+    // slowdown.
+    bool wantLp = false;
+    if (lowPrecision != 0 && nTiles == 1) {
+      wantLp = rcclx::relay::lpEligible(allReduceLpGate(
+          datatype,
+          counts,
+          nGroups,
+          nActiveRanksPerGroup,
+          elementSize,
+          route == rcclx::relay::AllReduceRoute::A2Relay));
+    } else if (lowPrecision != 0) {
+      rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Route);
+    }
+
     r = (nTiles > 1) ? shardedRelayAllReduce2ActivePipelined(
                            sendBuffs2,
                            recvBuffs2,
@@ -2449,12 +2859,19 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
                            myActiveGroup,
                            numHelpers,
                            nGroups,
-                           elementSize);
+                           elementSize,
+                           wantLp);
   } else {
     // A>2: flat helper-reduce-and-broadcast (direct RS+AG over intra woven with
-    // offload reduce+broadcast through the helpers). A single-group call can
-    // pipeline both dependencies so each cross link runs duplex; the selector
-    // returns 1 below the crossover, where the two-group schedule is better.
+    // offload reduce+broadcast through the helpers). Low precision is not
+    // carried here yet, so a request declines -- identically on every rank,
+    // since the condition is just the width.
+    if (lowPrecision != 0) {
+      rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Route);
+    }
+    // A single-group call can pipeline both dependencies so each cross link
+    // runs duplex; the selector returns 1 below the crossover, where the
+    // two-group schedule is better.
     const int nTiles = rcclx::relay::relayAllReducePipelineTiles(
         nGroups,
         nActiveRanksPerGroup,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -2330,7 +2330,11 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
     cudaStream_t stream,
     const int* const* allActiveRanks,
     int nActiveRanksPerGroup,
-    int nGroups) {
+    int nGroups,
+    int lowPrecision) {
+  // Accepted and ignored: the wire-format substitution lands in a later commit,
+  // so this commit cannot change behaviour.
+  (void)lowPrecision;
   int nRanks, rank;
   NCCLCHECK(ncclCommCount(comm, &nRanks));
   NCCLCHECK(ncclCommUserRank(comm, &rank));

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
@@ -1108,7 +1108,8 @@ rcclx::relay::LpGateInputs allReduceLpGate(
     int nGroups,
     int nActiveRanksPerGroup,
     size_t elementSize,
-    bool relayRouteSelected) {
+    bool relayRouteSelected,
+    size_t countAlignElems) {
   rcclx::relay::LpGateInputs in;
   in.coll = rcclx::relay::LpCollective::AllReduce;
   in.datatype = datatype;
@@ -1121,6 +1122,7 @@ rcclx::relay::LpGateInputs allReduceLpGate(
   in.routeSizeBytes =
       rcclx::relay::relayMaxCount(counts, nGroups) * elementSize;
   in.relayRouteSelected = relayRouteSelected;
+  in.countAlignElems = countAlignElems;
   return in;
 }
 
@@ -1268,6 +1270,154 @@ bool a2LpPrepare(
 
   *out =
       a2LpCarve(lease, counts, relayTotals, chunkSizes, nGroups, nActiveRanks);
+  if (!out->valid) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+  rcclx::relay::lpRecordEngage();
+  return true;
+}
+
+/**
+ * The wire buffers one flat (A>2) allreduce call needs.
+ *
+ * Five regions rather than the 2-active schedules' three, because this schedule
+ * sends from a region it produces MID-CALL: group 2's direct all-gather sends
+ * the shard the reduce wrote between the two groups, so that shard has to be
+ * quantized after the reduce and staged somewhere the peers' arrivals do not
+ * overwrite.
+ *
+ * Same discipline as A2LpPlan: carved unconditionally at the worst case over
+ * groups, so the partition is byte-identical on every rank and the capacity
+ * check is a pure function of the counts.
+ */
+struct FlatLpPlan {
+  char* sendShadow{nullptr}; // wire(count): quantized [0, count) for group 1
+  char* directRecv{
+      nullptr}; // wire(pD): the A-1 received direct shards (dScratch)
+  char* agStage{nullptr}; // wire(pD): reduced shards, mine out and theirs in
+  char* offloadRecv{
+      nullptr}; // wire(pO): the reduced offload region coming back
+  char* helper[SHARDED_RELAY_MAX_GROUPS]{};
+  bool valid{false};
+};
+
+size_t flatLpRequiredBytes(
+    const size_t* counts,
+    const size_t* pOArr,
+    int nGroups,
+    int nActiveRanks) {
+  const size_t maxCount = rcclx::relay::relayMaxCount(counts, nGroups);
+  const size_t maxOffload = rcclx::relay::relayMaxCount(pOArr, nGroups);
+  // pD and the AG stage are both bounded by maxCount, which costs a little
+  // arena and removes a per-group subtraction from a number every rank must
+  // agree on.
+  size_t total = a2LpAlign(rcclx::relay::lpWireBytes(maxCount)) +
+      2 * a2LpAlign(rcclx::relay::lpWireBytes(maxCount)) +
+      a2LpAlign(rcclx::relay::lpWireBytes(maxOffload));
+  total += static_cast<size_t>(nGroups) *
+      a2LpAlign(
+               static_cast<size_t>(nActiveRanks) *
+               rcclx::relay::lpWireBytes(maxOffload));
+  return total;
+}
+
+FlatLpPlan flatLpCarve(
+    const rcclx::relay::LpArenaLease& lease,
+    const size_t* counts,
+    const size_t* pOArr,
+    int nGroups,
+    int nActiveRanks) {
+  const size_t maxCount = rcclx::relay::relayMaxCount(counts, nGroups);
+  const size_t maxOffload = rcclx::relay::relayMaxCount(pOArr, nGroups);
+
+  FlatLpPlan p{};
+  rcclx::relay::LpArenaCarver carver(lease);
+  p.sendShadow = carver.take(rcclx::relay::lpWireBytes(maxCount));
+  p.directRecv = carver.take(rcclx::relay::lpWireBytes(maxCount));
+  p.agStage = carver.take(rcclx::relay::lpWireBytes(maxCount));
+  p.offloadRecv = carver.take(rcclx::relay::lpWireBytes(maxOffload));
+  for (int g = 0; g < nGroups; g++) {
+    p.helper[g] = carver.take(
+        static_cast<size_t>(nActiveRanks) *
+        rcclx::relay::lpWireBytes(maxOffload));
+  }
+  p.valid = carver.ok();
+  return p;
+}
+
+/**
+ * Every direct shard this schedule sends is a whole number of wire blocks.
+ *
+ * The gate makes count a multiple of A*128, so pD = count - pO leaves
+ * dShard = pD/A block-aligned exactly when pO is a multiple of A*128 too. pO is
+ * floored to H*CHUNK_ALIGN_ELEMENTS, which carries that only when
+ * A*128 divides H*CHUNK_ALIGN_ELEMENTS -- i.e. it rests on a relationship
+ * between A and H that nothing in buildShardedRelayRankConfig() enforces.
+ * numHelpers is nRanks - A, so A=4 with H=5..8 reaches this path as readily as
+ * the A == H the comments assume.
+ *
+ * When it does not hold the failure is silent and total: every
+ * wire.bytes(k * dShard) floors to a block boundary, so each shard's window
+ * shifts by up to 127 elements and recvBuff[0, pD) is wrong on every active
+ * rank while the same call in full precision is correct.
+ *
+ * Checked against the pO values themselves rather than against a divisibility
+ * rule, so it stays correct if either the chunk alignment or the offload share
+ * is retuned. Pure function of the counts and the geometry, so every rank
+ * declines together.
+ */
+bool flatLpGeometryOk(const size_t* pOArr, int nGroups, int nActiveRanks) {
+  if (nActiveRanks <= 0) {
+    return false;
+  }
+  const size_t shardAlign =
+      static_cast<size_t>(nActiveRanks) * rcclx::relay::kLpBlockElems;
+  for (int g = 0; g < nGroups; g++) {
+    if (pOArr[g] % shardAlign != 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// COLLECTIVE, for the same reason a2LpPrepare() is: lpArenaAcquire() votes on
+// first use, so every rank must reach this whenever the dispatcher said yes.
+bool flatLpPrepare(
+    bool wantLp,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const size_t* counts,
+    const size_t* pOArr,
+    int nGroups,
+    int nActiveRanks,
+    FlatLpPlan* out) {
+  if (!wantLp) {
+    return false;
+  }
+  if (!flatLpGeometryOk(pOArr, nGroups, nActiveRanks)) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Alignment);
+    return false;
+  }
+  struct ncclCudaGraph graph;
+  if (ncclCudaGetCapturingGraph(&graph, stream) != ncclSuccess) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::GraphCapture);
+    return false;
+  }
+  if (ncclCudaGraphValid(graph) && !rcclx::relay::lpArenaReady(comm)) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::GraphCapture);
+    return false;
+  }
+  rcclx::relay::LpArenaLease lease{};
+  if (!rcclx::relay::lpArenaAcquire(comm, &lease)) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+  if (flatLpRequiredBytes(counts, pOArr, nGroups, nActiveRanks) > lease.bytes) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+  *out = flatLpCarve(lease, counts, pOArr, nGroups, nActiveRanks);
   if (!out->valid) {
     rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
     return false;
@@ -2135,7 +2285,8 @@ static ncclResult_t shardedRelayAllReduceFlat(
     int numHelpers,
     int nActiveRanksPerGroup,
     int nGroups,
-    size_t elementSize) {
+    size_t elementSize,
+    bool wantLp) {
   const int A = nActiveRanksPerGroup;
   const int H = numHelpers;
 
@@ -2295,16 +2446,59 @@ static ncclResult_t shardedRelayAllReduceFlat(
         stream);
   }
 
+  // =========================================================================
+  // LOW PRECISION: decide, acquire the arena, and quantize the send region
+  // =========================================================================
+  FlatLpPlan lpPlan{};
+  const bool lp = flatLpPrepare(
+      wantLp,
+      comm,
+      stream,
+      counts,
+      pOArr,
+      nGroups,
+      nActiveRanksPerGroup,
+      &lpPlan);
+  const rcclx::relay::RelayWire wire =
+      rcclx::relay::lpWireFor(datatype, elementSize, lp);
+
+  // Note this quantizes recvBuff, not sendBuff, and only AFTER the seeding
+  // above: unlike the 2-active schedules, both regions of this one read their
+  // outbound data out of recvBuff. Covers all of [0, count) -- the direct
+  // reduce-scatter reads [0, pD) shard by shard and the offload scatter reads
+  // [pD, count).
+  if (lp && myActiveGroup >= 0 && counts[myActiveGroup] > 0) {
+    DISPATCH_LP_QUANTIZE(
+        datatype,
+        lpPlan.sendShadow,
+        recvBuffs[myActiveGroup],
+        counts[myActiveGroup],
+        stream);
+  }
+
+  // Where a group-1 send reads from. Offsets stay in ELEMENTS of the caller's
+  // dtype so the call sites keep their shape.
+  auto sendFrom = [&](int g, size_t offsetElems) -> const char* {
+    if (lp) {
+      return lpPlan.sendShadow + wire.bytes(offsetElems);
+    }
+    return static_cast<const char*>(recvBuffs[g]) + offsetElems * elementSize;
+  };
+
   // Direct reduce-scatter scratch: the A-1 received direct shards.
   void* dScratch = nullptr;
   if (myActiveGroup >= 0 && counts[myActiveGroup] > 0 &&
       pDArr[myActiveGroup] > 0) {
     size_t dShard = pDArr[myActiveGroup] / A;
-    size_t dBytes = static_cast<size_t>(A - 1) * dShard * elementSize;
-    dScratch = ScratchBufferCache::getInstance().get(
-        SHARDED_RELAY_MAX_GROUPS, dBytes, stream);
-    if (dScratch == nullptr) {
-      return ncclInternalError;
+    if (lp) {
+      dScratch = lpPlan.directRecv;
+    } else {
+      size_t dBytes = static_cast<size_t>(A - 1) * dShard * elementSize;
+      dScratch = ScratchBufferCache::getInstance().get(
+          SHARDED_RELAY_MAX_GROUPS, dBytes, stream);
+      if (dScratch == nullptr) {
+        return ncclInternalError;
+      }
     }
   }
 
@@ -2316,12 +2510,16 @@ static ncclResult_t shardedRelayAllReduceFlat(
     const ShardedRelayRankConfig& cfg = configs[g];
     size_t oChunkG = (pOArr[g] > 0) ? pOArr[g] / H : 0;
     if (!cfg.isActiveRank && counts[g] > 0 && oChunkG > 0) {
-      size_t needBytes =
-          static_cast<size_t>(cfg.nActiveRanks) * oChunkG * elementSize;
-      helperScratch[g] = ScratchBufferCache::getInstance().get(
-          kHelperScratchKeyBase + g, needBytes, stream);
-      if (helperScratch[g] == nullptr) {
-        return ncclInternalError;
+      if (lp) {
+        helperScratch[g] = lpPlan.helper[g];
+      } else {
+        size_t needBytes =
+            static_cast<size_t>(cfg.nActiveRanks) * oChunkG * elementSize;
+        helperScratch[g] = ScratchBufferCache::getInstance().get(
+            kHelperScratchKeyBase + g, needBytes, stream);
+        if (helperScratch[g] == nullptr) {
+          return ncclInternalError;
+        }
       }
     }
   }
@@ -2347,9 +2545,9 @@ static ncclResult_t shardedRelayAllReduceFlat(
           if (k == m)
             continue;
           NCCLCHECK(ncclSend(
-              recvbuff + static_cast<size_t>(k) * dShard * elementSize,
-              dShard,
-              datatype,
+              sendFrom(g, static_cast<size_t>(k) * dShard),
+              wire.count(dShard),
+              wire.dtype,
               cfg.activeRanks[k],
               comm,
               stream));
@@ -2360,9 +2558,9 @@ static ncclResult_t shardedRelayAllReduceFlat(
           int p = (s < m) ? s : s - 1;
           NCCLCHECK(ncclRecv(
               static_cast<char*>(dScratch) +
-                  static_cast<size_t>(p) * dShard * elementSize,
-              dShard,
-              datatype,
+                  wire.bytes(static_cast<size_t>(p) * dShard),
+              wire.count(dShard),
+              wire.dtype,
               cfg.activeRanks[s],
               comm,
               stream));
@@ -2372,9 +2570,9 @@ static ncclResult_t shardedRelayAllReduceFlat(
       if (oChunk > 0) {
         for (int h = 0; h < cfg.numHelpers; h++) {
           NCCLCHECK(ncclSend(
-              recvbuff + (pD + static_cast<size_t>(h) * oChunk) * elementSize,
-              oChunk,
-              datatype,
+              sendFrom(g, pD + static_cast<size_t>(h) * oChunk),
+              wire.count(oChunk),
+              wire.dtype,
               cfg.helperRanks[h],
               comm,
               stream));
@@ -2386,9 +2584,9 @@ static ncclResult_t shardedRelayAllReduceFlat(
       char* rawBuf = static_cast<char*>(helperScratch[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {
         NCCLCHECK(ncclRecv(
-            rawBuf + static_cast<size_t>(a) * oChunk * elementSize,
-            oChunk,
-            datatype,
+            rawBuf + wire.bytes(static_cast<size_t>(a) * oChunk),
+            wire.count(oChunk),
+            wire.dtype,
             cfg.activeRanks[a],
             comm,
             stream));
@@ -2413,8 +2611,16 @@ static ncclResult_t shardedRelayAllReduceFlat(
         char* dst = recvbuff + static_cast<size_t>(m) * dShard * elementSize;
         // Fused single-pass reduce: dst = (dst + A-1 direct contribs) / divisor
         // (AVG folded in), before the all-gather broadcasts the owned shard.
-        DISPATCH_MULTI_REDUCE(
-            datatype, dst, dScratch, A - 1, dShard, reductionDivisor, stream);
+        if (lp) {
+          // Writes FULL PRECISION: this shard's final value. It is re-quantized
+          // below for the all-gather, which is cheaper and clearer than
+          // teaching the reduce to emit wire.
+          DISPATCH_LP_MULTI_REDUCE(
+              datatype, dst, dScratch, A - 1, dShard, reductionDivisor, stream);
+        } else {
+          DISPATCH_MULTI_REDUCE(
+              datatype, dst, dScratch, A - 1, dShard, reductionDivisor, stream);
+        }
       }
     } else if (oChunk > 0) {
       // Helper: fused single-pass reduce of the A received chunks into
@@ -2422,15 +2628,42 @@ static ncclResult_t shardedRelayAllReduceFlat(
       // launch instead of memcpy + A-1 adds + scale. The broadcast below reads
       // rawBuf[0].
       char* rawBuf = static_cast<char*>(helperScratch[g]);
-      DISPATCH_MULTI_REDUCE(
-          datatype,
-          rawBuf,
-          rawBuf + oChunk * elementSize,
-          cfg.nActiveRanks - 1,
-          oChunk,
-          reductionDivisor,
-          stream);
+      if (lp) {
+        // All A contributions from one base at wire.bytes(oChunk) stride, which
+        // is exactly how group 1 laid them out. The divisor lands here because
+        // the broadcast below goes straight to its final place -- there is no
+        // active-side reduce for the offload region.
+        launchLpReduceRequantizeKernel(
+            rawBuf, rawBuf, cfg.nActiveRanks, oChunk, reductionDivisor, stream);
+      } else {
+        DISPATCH_MULTI_REDUCE(
+            datatype,
+            rawBuf,
+            rawBuf + oChunk * elementSize,
+            cfg.nActiveRanks - 1,
+            oChunk,
+            reductionDivisor,
+            stream);
+      }
     }
+  }
+
+  // ===== Low precision: the all-gather's send source is produced above, not by
+  // the caller, so it needs its own quantize here. This is the one place the
+  // flat schedule differs structurally from the 2-active ones, where a single
+  // hoisted pre-pass covers every outbound byte. It goes into the AG stage at
+  // this rank's own shard slot, so the peers' arrivals below land in the other
+  // slots and the whole direct region can be dequantized from one buffer.
+  if (lp && myActiveGroup >= 0 && pDArr[myActiveGroup] > 0) {
+    const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
+    const size_t dShard = pDArr[myActiveGroup] / A;
+    const size_t mine = static_cast<size_t>(cfg.myActiveIndex) * dShard;
+    DISPATCH_LP_QUANTIZE(
+        datatype,
+        lpPlan.agStage + wire.bytes(mine),
+        static_cast<const char*>(recvBuffs[myActiveGroup]) + mine * elementSize,
+        dShard,
+        stream);
   }
 
   // ===== Group 2: direct AG (active<->active) + offload broadcast
@@ -2453,17 +2686,21 @@ static ncclResult_t shardedRelayAllReduceFlat(
         for (int k = 0; k < A; k++) {
           if (k == m)
             continue;
+          const size_t mineOff = static_cast<size_t>(m) * dShard;
+          const size_t theirsOff = static_cast<size_t>(k) * dShard;
           NCCLCHECK(ncclSend(
-              recvbuff + static_cast<size_t>(m) * dShard * elementSize,
-              dShard,
-              datatype,
+              lp ? (lpPlan.agStage + wire.bytes(mineOff))
+                 : (recvbuff + mineOff * elementSize),
+              wire.count(dShard),
+              wire.dtype,
               cfg.activeRanks[k],
               comm,
               stream));
           NCCLCHECK(ncclRecv(
-              recvbuff + static_cast<size_t>(k) * dShard * elementSize,
-              dShard,
-              datatype,
+              lp ? (lpPlan.agStage + wire.bytes(theirsOff))
+                 : (recvbuff + theirsOff * elementSize),
+              wire.count(dShard),
+              wire.dtype,
               cfg.activeRanks[k],
               comm,
               stream));
@@ -2472,10 +2709,12 @@ static ncclResult_t shardedRelayAllReduceFlat(
       // Offload broadcast: recv reduced chunk h from helper h into recvBuff.
       if (oChunk > 0) {
         for (int h = 0; h < cfg.numHelpers; h++) {
+          const size_t off = static_cast<size_t>(h) * oChunk;
           NCCLCHECK(ncclRecv(
-              recvbuff + (pD + static_cast<size_t>(h) * oChunk) * elementSize,
-              oChunk,
-              datatype,
+              lp ? (lpPlan.offloadRecv + wire.bytes(off))
+                 : (recvbuff + (pD + off) * elementSize),
+              wire.count(oChunk),
+              wire.dtype,
               cfg.helperRanks[h],
               comm,
               stream));
@@ -2487,11 +2726,56 @@ static ncclResult_t shardedRelayAllReduceFlat(
       char* rawBuf = static_cast<char*>(helperScratch[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {
         NCCLCHECK(ncclSend(
-            rawBuf, oChunk, datatype, cfg.activeRanks[a], comm, stream));
+            rawBuf,
+            wire.count(oChunk),
+            wire.dtype,
+            cfg.activeRanks[a],
+            comm,
+            stream));
       }
     }
   }
   NCCLCHECK(ncclGroupEnd());
+
+  // ===== Low precision: land both regions.
+  if (lp && myActiveGroup >= 0 && counts[myActiveGroup] > 0) {
+    const ShardedRelayRankConfig& cfg = configs[myActiveGroup];
+    char* recvbuff = static_cast<char*>(recvBuffs[myActiveGroup]);
+    const size_t pD = pDArr[myActiveGroup];
+    const size_t pO = pOArr[myActiveGroup];
+
+    // The direct region, in the at-most-two contiguous runs that EXCLUDE this
+    // rank's own shard. The reduce above already wrote that shard at full
+    // precision, so dequantizing over it would round-trip a value that is
+    // already exact through fp8 for nothing.
+    if (pD > 0) {
+      const size_t dShard = pD / A;
+      const size_t mine = static_cast<size_t>(cfg.myActiveIndex) * dShard;
+      if (mine > 0) {
+        DISPATCH_LP_DEQUANTIZE(
+            datatype, recvbuff, lpPlan.agStage, mine, stream);
+      }
+      const size_t afterMine = mine + dShard;
+      if (afterMine < pD) {
+        DISPATCH_LP_DEQUANTIZE(
+            datatype,
+            recvbuff + afterMine * elementSize,
+            lpPlan.agStage + wire.bytes(afterMine),
+            pD - afterMine,
+            stream);
+      }
+    }
+
+    // The offload region is contiguous and arrives already reduced and divided.
+    if (pO > 0) {
+      DISPATCH_LP_DEQUANTIZE(
+          datatype,
+          recvbuff + pD * elementSize,
+          lpPlan.offloadRecv,
+          pO,
+          stream);
+    }
+  }
 
   // The AVG divisor was already folded into the per-shard direct reduce and the
   // per-chunk helper reduce above, so no separate whole-count scale is needed.
@@ -2937,7 +3221,8 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
           nGroups,
           nActiveRanksPerGroup,
           elementSize,
-          route == rcclx::relay::AllReduceRoute::A2Relay));
+          route == rcclx::relay::AllReduceRoute::A2Relay,
+          rcclx::relay::kLpBlockElems));
     }
 
     r = (nTiles > 1) ? shardedRelayAllReduce2ActivePipelined(
@@ -2971,20 +3256,43 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
   } else {
     // A>2: flat helper-reduce-and-broadcast (direct RS+AG over intra woven with
     // offload reduce+broadcast through the helpers). Low precision is not
-    // carried here yet, so a request declines -- identically on every rank,
-    // since the condition is just the width.
-    if (lowPrecision != 0) {
-      rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Route);
-    }
-    // A single-group call can pipeline both dependencies so each cross link
-    // runs duplex; the selector returns 1 below the crossover, where the
-    // two-group schedule is better.
+    // carried by the non-pipelined schedule below; the pipelined one still
+    // declines, identically on every rank since the condition is the tile
+    // count.
+    //
+    // The alignment requirement is STRICTER here than for the 2-active
+    // schedules. This one splits its direct region into A per-owner shards of
+    // pD/A, and pD being a whole number of wire blocks does not make pD/A one.
+    // So the gate asks for a multiple of A*128, which makes the shards
+    // block-aligned PROVIDED pO is a multiple of A*128 as well. That last part
+    // is a property of H, not of the count -- pO is floored to
+    // H*CHUNK_ALIGN_ELEMENTS -- so it is verified per call in
+    // flatLpGeometryOk() rather than assumed here. A single-group call can
+    // pipeline both dependencies so each cross link runs
+    // duplex; the selector returns 1 below the crossover, where the two-group
+    // schedule is better.
     const int nTiles = rcclx::relay::relayAllReducePipelineTiles(
         nGroups,
         nActiveRanksPerGroup,
         numHelpers,
         rcclx::relay::relayMaxCount(counts, nGroups),
         elementSize);
+
+    bool wantLp = false;
+    if (lowPrecision != 0 && nTiles == 1) {
+      wantLp = rcclx::relay::lpEligible(allReduceLpGate(
+          datatype,
+          counts,
+          nGroups,
+          nActiveRanksPerGroup,
+          elementSize,
+          /*relayRouteSelected=*/true,
+          static_cast<size_t>(nActiveRanksPerGroup) *
+              rcclx::relay::kLpBlockElems));
+    } else if (lowPrecision != 0) {
+      rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Route);
+    }
+
     if (nTiles > 1) {
       return shardedRelayAllReduceFlatPipelined(
           sendBuffs2,
@@ -3014,7 +3322,8 @@ HOT ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
         numHelpers,
         nActiveRanksPerGroup,
         nGroups,
-        elementSize);
+        elementSize,
+        wantLp);
   }
 
   return r;

--- a/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_allreduce.h
@@ -136,6 +136,14 @@
  * [nGroups][nActiveRanksPerGroup]
  * @param nActiveRanksPerGroup Number of active ranks per group (2 or 4)
  * @param nGroups Number of groups (typically 4 for 8-GPU node)
+ * @param lowPrecision Non-zero to use the low-precision (fp8e4m3) wire format
+ *        where it pays; an internal size-only gate declines to full precision
+ *        silently otherwise (see sharded_relay_lp.h). COLLECTIVE -- it must be
+ *        identical on every rank of the call, like datatype, op and the counts.
+ *        Ranks that disagree disagree on how many bytes cross each link, so the
+ *        call hangs or corrupts rather than degrading. Documented rather than
+ *        validated, because a per-call check would cost an allreduce; datatype
+ *        is already treated the same way.
  * @return ncclResult_t Success or error code
  */
 ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
@@ -148,4 +156,5 @@ ncclResult_t ncclShardedRelayMultiGroupAllReduceImpl(
     cudaStream_t stream,
     const int* const* allActiveRanks,
     int nActiveRanksPerGroup,
-    int nGroups);
+    int nGroups,
+    int lowPrecision = 0);

--- a/comms/rcclx/develop/meta/relay/sharded_relay_lp.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_lp.cc
@@ -91,12 +91,12 @@ bool lpDtypeSupported(ncclDataType_t datatype) {
   return datatype == ncclBfloat16 || datatype == ncclFloat32;
 }
 
-bool lpCountsAligned(const size_t* counts, int nGroups) {
-  if (counts == nullptr || nGroups <= 0) {
+bool lpCountsAligned(const size_t* counts, int nGroups, size_t alignElems) {
+  if (counts == nullptr || nGroups <= 0 || alignElems == 0) {
     return false;
   }
   for (int g = 0; g < nGroups; g++) {
-    if (counts[g] == 0 || counts[g] % kLpBlockElems != 0) {
+    if (counts[g] == 0 || counts[g] % alignElems != 0) {
       return false;
     }
   }
@@ -126,7 +126,7 @@ bool lpEligible(const LpGateInputs& in) {
     lpRecordDecline(LpDecline::Dtype);
     return false;
   }
-  if (!lpCountsAligned(in.counts, in.nGroups)) {
+  if (!lpCountsAligned(in.counts, in.nGroups, in.countAlignElems)) {
     lpRecordDecline(LpDecline::Alignment);
     return false;
   }

--- a/comms/rcclx/develop/meta/relay/sharded_relay_lp.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_lp.cc
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "meta/relay/sharded_relay_lp.h"
+
+#include <atomic>
+
+#include "debug.h"
+#include "param.h"
+
+namespace rcclx::relay {
+
+namespace {
+
+// Process-wide, because the question these answer is "did low precision engage
+// at all during this phase", which is asked by tests, the perf bench and the
+// examples -- none of which has a communicator handy at the point they ask.
+// Relaxed ordering: they are diagnostics, never read to make a decision, and a
+// count that lags a call by a few nanoseconds is not a wrong count by the time
+// anybody looks.
+std::atomic<uint64_t>& engageCounter() {
+  static std::atomic<uint64_t> c{0};
+  return c;
+}
+
+std::atomic<uint64_t>* declineCounters() {
+  static std::atomic<uint64_t> c[static_cast<int>(LpDecline::kNumReasons)]{};
+  return c;
+}
+
+const char* declineName(LpDecline reason) {
+  switch (reason) {
+    case LpDecline::Dtype:
+      return "unsupported dtype";
+    case LpDecline::Alignment:
+      return "a per-group count is not a multiple of 128";
+    case LpDecline::Size:
+      return "below the measured crossover";
+    case LpDecline::Route:
+      return "not a relay route";
+    case LpDecline::Arena:
+      return "does not fit the arena";
+    case LpDecline::GraphCapture:
+      return "no arena yet and the stream is capturing";
+    case LpDecline::kNumReasons:
+      break;
+  }
+  return "unknown";
+}
+
+} // namespace
+
+// Tuning and provisioning only. There is deliberately no
+// NCCL_SHARDED_RELAY_LP_MODE_ENABLE: low precision is requested per call, so a
+// process-wide switch would be a second, contradictory answer to the same
+// question.
+NCCL_PARAM(ShardedRelayLpHops, "SHARDED_RELAY_LP_HOPS", 2);
+NCCL_PARAM(ShardedRelayLpPrealloc, "SHARDED_RELAY_LP_PREALLOC", 0);
+NCCL_PARAM(ShardedRelayLpMaxMsgMb, "SHARDED_RELAY_LP_MAX_MSG_MB", 1024);
+
+int lpHops() {
+  const int64_t hops = ncclParamShardedRelayLpHops();
+  // Anything but 1 means "quantize both hops". Clamped rather than validated so
+  // a typo degrades to the default behaviour instead of disabling the feature.
+  return hops == 1 ? 1 : 2;
+}
+
+bool lpPrealloc() {
+  return ncclParamShardedRelayLpPrealloc() == 1;
+}
+
+size_t lpMaxMsgBytes() {
+  int64_t mb = ncclParamShardedRelayLpMaxMsgMb();
+  if (mb < 1) {
+    mb = 1;
+  }
+  return static_cast<size_t>(mb) << 20;
+}
+
+bool lpDtypeSupported(ncclDataType_t datatype) {
+  // bf16 and fp32 only. Both quantize to e4m3 through an fp32 intermediate, and
+  // both are what the relay actually carries in the workloads this targets.
+  // fp16 is deliberately absent: its 5-bit exponent already overlaps e4m3's
+  // range closely enough that the 1.94x is not obviously worth a second
+  // rounding, and adding it is a measurement away rather than a guess.
+  return datatype == ncclBfloat16 || datatype == ncclFloat32;
+}
+
+bool lpCountsAligned(const size_t* counts, int nGroups) {
+  if (counts == nullptr || nGroups <= 0) {
+    return false;
+  }
+  for (int g = 0; g < nGroups; g++) {
+    if (counts[g] == 0 || counts[g] % kLpBlockElems != 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+size_t lpMinBytes(LpCollective coll, int nActiveRanksPerGroup, int nGroups) {
+  (void)coll;
+  (void)nActiveRanksPerGroup;
+  (void)nGroups;
+  // PROVISIONAL, pending the LP sweep. 4 MiB is above the entire flat
+  // launch-bound band (measured flat across 4 KB..576 KB) and at or above every
+  // relay-route crossover in sharded_relay_route.h, so low precision is only
+  // ever considered where a relay route is already active and there is a real
+  // bandwidth term for it to shrink. The signature carries the collective and
+  // the geometry so the measured per-shape crossovers can be filled in here
+  // without touching a single call site.
+  return static_cast<size_t>(4) << 20;
+}
+
+bool lpEligible(const LpGateInputs& in) {
+  if (!in.relayRouteSelected) {
+    lpRecordDecline(LpDecline::Route);
+    return false;
+  }
+  if (!lpDtypeSupported(in.datatype)) {
+    lpRecordDecline(LpDecline::Dtype);
+    return false;
+  }
+  if (!lpCountsAligned(in.counts, in.nGroups)) {
+    lpRecordDecline(LpDecline::Alignment);
+    return false;
+  }
+  if (in.routeSizeBytes <
+      lpMinBytes(in.coll, in.nActiveRanksPerGroup, in.nGroups)) {
+    lpRecordDecline(LpDecline::Size);
+    return false;
+  }
+  return true;
+}
+
+void lpRecordDecline(LpDecline reason) {
+  const int idx = static_cast<int>(reason);
+  if (idx < 0 || idx >= static_cast<int>(LpDecline::kNumReasons)) {
+    return;
+  }
+  const uint64_t n =
+      declineCounters()[idx].fetch_add(1, std::memory_order_relaxed) + 1;
+  // Logged only the first few times per reason. The point is to learn whether
+  // real traffic misses the gate, which one line answers; a line per call would
+  // bury it.
+  if (n <= 4) {
+    INFO(
+        NCCL_COLL,
+        "Sharded relay: low precision declined (%s); running in full precision",
+        declineName(reason));
+  }
+}
+
+void lpRecordEngage() {
+  engageCounter().fetch_add(1, std::memory_order_relaxed);
+}
+
+uint64_t lpEngageCount() {
+  return engageCounter().load(std::memory_order_relaxed);
+}
+
+uint64_t lpDeclineCount(LpDecline reason) {
+  const int idx = static_cast<int>(reason);
+  if (idx < 0 || idx >= static_cast<int>(LpDecline::kNumReasons)) {
+    return 0;
+  }
+  return declineCounters()[idx].load(std::memory_order_relaxed);
+}
+
+uint64_t lpDeclineCount() {
+  uint64_t total = 0;
+  for (int i = 0; i < static_cast<int>(LpDecline::kNumReasons); i++) {
+    total += declineCounters()[i].load(std::memory_order_relaxed);
+  }
+  return total;
+}
+
+void lpResetCounters() {
+  engageCounter().store(0, std::memory_order_relaxed);
+  for (int i = 0; i < static_cast<int>(LpDecline::kNumReasons); i++) {
+    declineCounters()[i].store(0, std::memory_order_relaxed);
+  }
+}
+
+} // namespace rcclx::relay

--- a/comms/rcclx/develop/meta/relay/sharded_relay_lp.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_lp.h
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+#include "meta/relay/sharded_relay_route.h"
+#include "nccl.h"
+
+/**
+ * Low-precision (fp8e4m3) wire format for the sharded-relay collectives.
+ *
+ * WHY THIS EXISTS
+ *
+ * Every win the relay collectives have came from moving fewer bytes per XGMI
+ * link direction. This moves SMALLER bytes: data is quantized to fp8e4m3 before
+ * it crosses a rank boundary and dequantized after. For bf16 that is 1.94x less
+ * on the wire, for fp32 3.88x, on exactly the links the relay was built to keep
+ * busy.
+ *
+ * THE ONE IDEA
+ *
+ * The wire format of a transfer becomes a per-call VALUE, not a second set of
+ * collectives. Every boundary-crossing site in all four collectives has one
+ * shape today:
+ *
+ *     ncclSend(base + offsetElems * elementSize, nElems, datatype, peer, ...)
+ *
+ * A RelayWire answers `bytes(elems)`, `count(elems)` and `dtype`, so each site
+ * becomes
+ *
+ *     ncclSend(base + wire.bytes(offsetElems), wire.count(nElems), wire.dtype,
+ * ...)
+ *
+ * With LP off every one of those expressions evaluates to exactly what it does
+ * today, so the full-precision path is unchanged by construction rather than by
+ * testing. Routing, group structure, pipelining and op counts are untouched,
+ * and a helper that merely forwards bytes today keeps forwarding bytes and
+ * never becomes LP-aware. If review ever finds a passthrough helper being made
+ * LP-aware, this abstraction has leaked and the change is wrong.
+ *
+ * WHY 33/32
+ *
+ * The wire buffer is a sequence of 132-byte blocks: 128 fp8e4m3 payload bytes
+ * followed by one fp32 scale derived from that block's absmax. 132/128 = 33/32
+ * exactly, so bytes(n) = n * 33/32 is exact and -- critically -- ADDITIVE. The
+ * scales ride inline, so one ncclSend still moves one self-describing blob.
+ * Overhead is 3.1%: 1.031 effective bytes per element.
+ *
+ * ADDITIVITY NEEDS 128-ALIGNED COUNTS, SO THE GATE REQUIRES THEM
+ *
+ * bytes(a + b) == bytes(a) + bytes(b) only when both are multiples of 128, and
+ * the violations are not tail-only. `dirBSizes[g] = counts[g] - dirBOffsets[g]`
+ * inherits counts[g]'s alignment in all four collectives; all-gather and
+ * all-to-all slot strides and reduce-scatter's sendBlockOffset are raw
+ * per-group counts, which break in the MIDDLE of a buffer. Every one of them
+ * becomes aligned by construction the moment the per-group count is, so
+ * lpEligible() requires `counts[g] % kRelayChunkAlignElements == 0` for every
+ * group. That is a size-only predicate and therefore agreed across ranks
+ * without communication, the same discipline the one-shot gate follows. bytes()
+ * asserts the alignment under LP, which turns every substituted site into a
+ * self-test.
+ *
+ * NUMERICS: A POWER-OF-TWO NORMALIZATION TARGET
+ *
+ * A block's absmax m is normalized to kLpNormalizeMax = 128, NOT to the fp8
+ * format's own maximum (240 for the fnuz flavour, 448 for OCP). 128 is a power
+ * of two, which makes the whole scale chain exact:
+ *
+ *   scale  = m * 2^-7                   exact (power-of-two multiply)
+ *   code   = fp8(v / scale)             for v == m the true quotient is exactly
+ *                                       128, which fp8e4m3 represents exactly
+ *   value' = code * scale               exact for code == 128
+ *
+ * so a block whose elements are all equal round-trips BIT-EXACTLY, and so does
+ * a sum of such blocks. That is what lets the existing constant-fill tests keep
+ * their exact comparators and become genuine LP bug detectors for a wrong
+ * scale, a wrong block boundary or a dropped scale -- they must not be
+ * loosened. Normalizing to 240 or 448 instead would make `m / FP8_MAX` a
+ * rounded fp32 value and lose that property for no gain: relative precision
+ * inside a block is set by e4m3's 3 explicit mantissa bits (half-ULP 2^-4
+ * = 6.25%) either way, and 128 still leaves 17 binades of in-block dynamic
+ * range before subnormals.
+ *
+ * The BYTE PATTERNS are still arch-local -- rccl_float8 is __hip_fp8_e4m3_fnuz
+ * on gfx942 and OCP __hip_fp8_e4m3 elsewhere, and the two encode the same value
+ * differently. Fine today: the relay is intra-node and homogeneous. Latent if a
+ * relay ever spans a heterogeneous set of devices.
+ *
+ * THE SWITCH IS A PER-CALL ARGUMENT
+ *
+ * Low precision is requested per call by a trailing `low_precision` argument on
+ * each collective, not by a process-wide env var, because a job legitimately
+ * wants its gradient allreduce in fp8 while the optimizer-state collective
+ * stays full precision -- same process, same communicator, same step.
+ *
+ * `low_precision` is a COLLECTIVE argument. It must be identical on every rank
+ * of the call, exactly like datatype, op and the counts. Ranks that disagree
+ * disagree on wire byte counts, so the call hangs or corrupts rather than
+ * degrading. It is documented, not validated, because validating it would cost
+ * an allreduce per call -- the same treatment datatype already gets.
+ *
+ * Requesting LP means "use low precision where it pays", not "quantize
+ * unconditionally". On top of the caller's request the internal gate is
+ * size-only, so ranks agree on it without communication: supported dtype, 128
+ * aligned counts, a relay (not PureDirect, not one-shot) route, a size above
+ * the measured crossover, and a call that fits the arena. Measured relay time
+ * is flat across 4 KB..576 KB -- that regime is launch-bound with no bandwidth
+ * term, and LP ADDS launches -- so small messages stay full precision even when
+ * asked.
+ *
+ * The env vars here are tuning and provisioning only, never a feature switch.
+ */
+namespace rcclx::relay {
+
+// ---------------------------------------------------------------------------
+// Wire layout
+// ---------------------------------------------------------------------------
+
+// Payload elements per wire block. Tied to the relay's chunk alignment, not
+// chosen independently: the whole format rests on every LP region boundary
+// being a whole number of blocks, and kRelayChunkAlignElements is what the
+// collectives already align every chunk, offset and tile to.
+inline constexpr size_t kLpBlockElems = kRelayChunkAlignElements;
+
+// One fp32 scale per block, trailing its payload.
+inline constexpr size_t kLpScaleBytes = sizeof(float);
+
+// 128 payload bytes + 4 scale bytes.
+inline constexpr size_t kLpBlockBytes = kLpBlockElems + kLpScaleBytes;
+
+static_assert(kLpBlockElems == 128, "the 33/32 wire ratio assumes 128");
+static_assert(
+    kLpBlockBytes * 32 == kLpBlockElems * 33,
+    "wire bytes per element must be exactly 33/32");
+static_assert(
+    kLpBlockBytes % kLpScaleBytes == 0,
+    "block stride must keep the inline scale 4-byte aligned, so every LP "
+    "buffer offset -- always a whole number of blocks -- lands on an aligned "
+    "float");
+
+// Absmax normalization target. A power of two on purpose; see the file comment.
+inline constexpr float kLpNormalizeMax = 128.0f;
+inline constexpr float kLpInvNormalizeMax = 1.0f / kLpNormalizeMax;
+
+static_assert(
+    kLpNormalizeMax == 128.0f,
+    "kLpInvNormalizeMax must stay an exact power of two, or the scale "
+    "arithmetic stops being exact and constant blocks stop round-tripping");
+
+// Wire bytes for `elems` elements. Free function so host sizing code and device
+// kernels can share it without a RelayWire in hand.
+inline constexpr size_t lpWireBytes(size_t elems) {
+  return (elems / kLpBlockElems) * kLpBlockBytes;
+}
+
+// Wire bytes for `elems` elements, rounded up to a whole block. For SIZING
+// only (arena provisioning, capacity checks) -- never for an offset, because
+// rounding up is not additive and an offset computed this way would not agree
+// with the region sizes around it.
+inline constexpr size_t lpWireBytesRoundUp(size_t elems) {
+  return ((elems + kLpBlockElems - 1) / kLpBlockElems) * kLpBlockBytes;
+}
+
+/**
+ * The wire format of one transfer.
+ *
+ * Full precision is `{false, elementSize, datatype}` and reproduces today's
+ * arithmetic exactly. Low precision is `{true, elementSize, ncclUint8}`, where
+ * elementSize still describes the caller's FULL-PRECISION buffers -- the
+ * quantize source and the dequantize destination, which exist on both paths --
+ * and the wire itself is counted in bytes.
+ */
+struct RelayWire {
+  bool lp{false};
+  size_t elemSize{0};
+  ncclDataType_t dtype{ncclFloat32};
+
+  // Byte offset/length of `elems` elements on the wire. Additive in `elems` for
+  // 128-multiples, which is what every offset expression in the four
+  // collectives relies on.
+  size_t bytes(size_t elems) const {
+    if (!lp) {
+      return elems * elemSize;
+    }
+    // Guaranteed by lpEligible()'s alignment gate. Asserted rather than
+    // handled: there is no correct answer for an unaligned LP region, because
+    // the peer computing the matching offset would have to make the same wrong
+    // choice AND the surrounding regions would have to absorb the difference.
+    assert(elems % kLpBlockElems == 0);
+    return lpWireBytes(elems);
+  }
+
+  // What to pass as ncclSend/ncclRecv's `count`, given `elems` elements of the
+  // caller's data.
+  size_t count(size_t elems) const {
+    return lp ? bytes(elems) : elems;
+  }
+};
+
+// Full-precision wire for `datatype`. The identity case: this is what every
+// site sees when low precision is off or declined.
+inline RelayWire lpFullPrecisionWire(ncclDataType_t datatype, size_t elemSize) {
+  return RelayWire{false, elemSize, datatype};
+}
+
+// Low-precision wire for `datatype`. `elemSize` is still the caller's element
+// size, because the quantize source and dequantize destination are in the
+// caller's dtype.
+inline RelayWire lpWireFor(ncclDataType_t datatype, size_t elemSize, bool lp) {
+  return lp ? RelayWire{true, elemSize, ncclUint8}
+            : lpFullPrecisionWire(datatype, elemSize);
+}
+
+// ---------------------------------------------------------------------------
+// The gate
+// ---------------------------------------------------------------------------
+
+// Which relay collective is asking. Only used to pick a size threshold, so the
+// four crossovers can be tuned independently from one sweep.
+enum class LpCollective {
+  AllReduce,
+  ReduceScatter,
+  AllGather,
+  AllToAll,
+};
+
+/**
+ * True for the dtypes the LP wire supports: bf16 and fp32.
+ *
+ * Everything else falls through to full precision untouched even with
+ * `low_precision` set, which is why every existing ncclInt32 test keeps passing
+ * verbatim with the flag on and doubles as the regression test for clean
+ * fallback.
+ */
+bool lpDtypeSupported(ncclDataType_t datatype);
+
+// Every per-group count is a whole number of wire blocks. See the file comment
+// for why this is the gate rather than a tail-padding scheme.
+bool lpCountsAligned(const size_t* counts, int nGroups);
+
+/**
+ * Smallest message low precision is used for, in the same byte metric the
+ * collective's route selector uses (its per-rank input label).
+ *
+ * PROVISIONAL. Low precision starts where the relay routes start, which is the
+ * conservative choice: below ~576 KB the measured relay time is flat -- that
+ * band is pure launch cost with no bandwidth term -- and LP adds launches, so a
+ * gain there would mean the measurement is wrong. These get their measured
+ * values from the LP sweep, with the same "measured crossover, here is the
+ * provenance" convention sharded_relay_route.h uses for the route thresholds.
+ */
+size_t lpMinBytes(LpCollective coll, int nActiveRanksPerGroup, int nGroups);
+
+/**
+ * Everything the caller does not already know, in one place.
+ *
+ * `routeSizeBytes` is the metric the collective's own selector computed, passed
+ * in rather than recomputed here so the LP threshold and the route threshold
+ * are directly comparable and there is only one definition of each metric.
+ *
+ * `relayRouteSelected` is the caller's already-made decision: a relay route was
+ * chosen and this is not the one-shot path. LP has nothing to offer a schedule
+ * that does not cross a rank boundary through staging.
+ */
+struct LpGateInputs {
+  LpCollective coll{LpCollective::AllReduce};
+  ncclDataType_t datatype{ncclFloat32};
+  const size_t* counts{nullptr};
+  int nGroups{0};
+  int nActiveRanksPerGroup{0};
+  size_t routeSizeBytes{0};
+  bool relayRouteSelected{false};
+};
+
+// Why an LP request was declined. Recorded per reason because the gate declines
+// SILENTLY on four independent grounds, so an "LP" run that quietly fell back
+// looks exactly like a passing LP run -- every LP test, bench and demo asserts
+// engagement through these counters rather than trusting the flag.
+enum class LpDecline {
+  Dtype,
+  Alignment,
+  Size,
+  Route,
+  Arena,
+  GraphCapture,
+  kNumReasons,
+};
+
+/**
+ * The size-and-dtype half of the gate: true if low precision should be used for
+ * this call.
+ *
+ * Derived only from values that are collective-consistent, so every rank of the
+ * call reaches the same answer without communication. Callers AND this with the
+ * arena's capacity answer, which is also size-only.
+ *
+ * Records a decline reason and logs at INFO on false.
+ */
+bool lpEligible(const LpGateInputs& in);
+
+// Record a decline the caller detected itself -- arena capacity, or a first LP
+// call inside a graph capture. Keeps the counters a single source of truth for
+// "did LP engage".
+void lpRecordDecline(LpDecline reason);
+
+// Record that a call actually ran in low precision.
+void lpRecordEngage();
+
+// ---------------------------------------------------------------------------
+// Observability
+// ---------------------------------------------------------------------------
+
+// Calls that ran in low precision, process-wide.
+uint64_t lpEngageCount();
+
+// Calls that asked for low precision and did not get it, by reason.
+uint64_t lpDeclineCount(LpDecline reason);
+
+// All reasons summed.
+uint64_t lpDeclineCount();
+
+// For tests and benchmarks that measure engagement across a phase.
+void lpResetCounters();
+
+// ---------------------------------------------------------------------------
+// Tuning and provisioning parameters
+//
+// None of these is a feature switch -- low precision is requested per call. A
+// job that sets none of them gets the feature, lazily provisioned.
+// ---------------------------------------------------------------------------
+
+/**
+ * NCCL_SHARDED_RELAY_LP_HOPS, default 2. How many hops of a two-hop relay are
+ * quantized.
+ *
+ * 2 is what delivers the feature: in the A=2 relay the two hops are serialized
+ * groups, so quantizing only the up-hop yields about 1.3x instead of 1.94x. But
+ * it means the allreduce and reduce-scatter reduce path rounds to e4m3 twice,
+ * the second time on an already-summed value, and e4m3's half-ULP is 6.25%
+ * relative. 1 keeps the return hop in the caller's dtype, so an accuracy
+ * complaint can be bisected without a rebuild, at roughly a third of the gain.
+ *
+ * An env var rather than a second call argument because it is a debugging knob,
+ * not a per-call product decision. If a third knob ever has to be per-call,
+ * replace the trailing flag with an options struct (the ncclConfig_t pattern)
+ * rather than growing the parameter list again.
+ */
+int lpHops();
+
+// NCCL_SHARDED_RELAY_LP_PREALLOC, default 0. Build the arena during
+// ncclCommInitRank instead of on the first call that asks for low precision.
+// Off by default because a per-call flag means init cannot know whether LP will
+// ever be used, and provisioning the arena on every communicator whose caller
+// never asks is pure waste. Jobs that will use LP set it, and get zero
+// call-path allocation and graph-capture safety from their very first call.
+bool lpPrealloc();
+
+// NCCL_SHARDED_RELAY_LP_MAX_MSG_MB, default 1024. Largest full-precision
+// per-rank message the arena is provisioned for. See sharded_relay_lp_arena.h
+// for what that costs.
+size_t lpMaxMsgBytes();
+
+} // namespace rcclx::relay

--- a/comms/rcclx/develop/meta/relay/sharded_relay_lp.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_lp.h
@@ -243,9 +243,17 @@ enum class LpCollective {
  */
 bool lpDtypeSupported(ncclDataType_t datatype);
 
-// Every per-group count is a whole number of wire blocks. See the file comment
-// for why this is the gate rather than a tail-padding scheme.
-bool lpCountsAligned(const size_t* counts, int nGroups);
+// Every per-group count is a whole number of `alignElems` elements. 128 (one
+// wire block) is the floor, but a schedule whose geometry divides a region
+// further needs more: the flat A>2 allreduce splits its direct region into A
+// per-owner shards, and `pD / A` is only a whole number of blocks when the
+// count is a multiple of A * 128. Passing that requirement in keeps the check
+// size-only and therefore collective-consistent, which is what matters -- see
+// the file comment.
+bool lpCountsAligned(
+    const size_t* counts,
+    int nGroups,
+    size_t alignElems = kLpBlockElems);
 
 /**
  * Smallest message low precision is used for, in the same byte metric the
@@ -279,6 +287,10 @@ struct LpGateInputs {
   int nActiveRanksPerGroup{0};
   size_t routeSizeBytes{0};
   bool relayRouteSelected{false};
+  // Elements the per-group counts must be a whole multiple of. Defaults to one
+  // wire block; a schedule that subdivides a region further raises it. See
+  // lpCountsAligned().
+  size_t countAlignElems{kLpBlockElems};
 };
 
 // Why an LP request was declined. Recorded per reason because the gate declines

--- a/comms/rcclx/develop/meta/relay/sharded_relay_lp_arena.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_lp_arena.cc
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "meta/relay/sharded_relay_lp_arena.h"
+
+#include <hip/hip_runtime.h>
+#include <atomic>
+#include <map>
+#include <mutex>
+#include <vector>
+
+#include "bootstrap.h"
+#include "comm.h"
+#include "debug.h"
+#include "meta/relay/sharded_relay_lp.h"
+
+namespace rcclx::relay {
+
+namespace {
+
+struct Arena {
+  // Guards this arena's construction.
+  //
+  // Per-comm rather than process-global because createArena() runs a bootstrap
+  // all-gather. Holding one global lock across a collective deadlocks as soon
+  // as two communicators are set up concurrently and their peer processes reach
+  // the collectives in opposite order: each process would hold its own lock
+  // inside one comm's all-gather while the peer it is waiting for is blocked on
+  // that same lock. arenaMutex() therefore guards only the map.
+  std::mutex mu;
+  bool tried{false};
+  // ATOMIC, unlike the rest, because these two are the only fields read under a
+  // DIFFERENT lock than they are written under: createArena() writes them
+  // holding mu, and lpArenaReady() reads them holding only arenaMutex(). Two
+  // locks covering one location is a data race however careful each side is,
+  // and this one decides whether low precision is on -- a rank that answers
+  // differently from its peers is the mixed-format hang the whole design is
+  // built to avoid, so it cannot be left to chance.
+  //
+  // commHash is written BEFORE valid flips and the reader tests valid FIRST, so
+  // a reader that sees a valid arena can never pair it with a commHash that has
+  // not been published yet.
+  std::atomic<bool> valid{false};
+  void* base{nullptr};
+  size_t bytes{0};
+  // Identity of the communicator this arena belongs to. The map is keyed on the
+  // comm POINTER, which the allocator recycles; commHash distinguishes a
+  // recycled address from the comm that used to live there, so a missed release
+  // cannot be mistaken for a live arena.
+  std::atomic<uint64_t> commHash{0};
+};
+
+std::mutex& arenaMutex() {
+  static std::mutex m;
+  return m;
+}
+
+// One arena per COMMUNICATOR, for the same reasons the one-shot region is
+// per-comm: the create decision is then made from this comm's state alone,
+// which starts uniformly absent on every rank of it, so all of a comm's ranks
+// always agree on whether to enter createArena's collective bootstrap.
+std::map<const void*, Arena>& arenas() {
+  static std::map<const void*, Arena> a;
+  return a;
+}
+
+void destroyArena(Arena& arena) {
+  if (arena.base != nullptr) {
+    hipFree(arena.base);
+    arena.base = nullptr;
+  }
+  arena.bytes = 0;
+  arena.valid = false;
+}
+
+/**
+ * Build the arena. Returns false on any failure, but ALWAYS runs the bootstrap
+ * all-gather so every rank stays in lockstep -- an early return on one rank
+ * would desynchronize the vote for the others.
+ */
+bool createArena(ncclComm_t comm, Arena& arena) {
+  arena.commHash = comm->commHash;
+
+  const size_t wantBytes = lpArenaCapacityBytes();
+  bool ok = true;
+
+  // Plain device memory. Unlike the one-shot region this is never IPC-exported
+  // and never polled across processes, so it needs neither
+  // hipExtMallocWithFlags nor uncached pages -- it is written by this rank's
+  // quantize kernels and by RCCL's own transports servicing ncclRecv, both of
+  // which are fine with cached device memory.
+  //
+  // Not zeroed: every wire byte a call reads was written by that same call's
+  // quantize pass or by the ncclRecv that filled it, so a memset would only add
+  // a 2 GiB write to comm setup.
+  if (hipMalloc(&arena.base, wantBytes) != hipSuccess) {
+    arena.base = nullptr;
+    ok = false;
+    WARN(
+        "Sharded relay: could not allocate the %zu MiB low-precision arena; low precision will be unavailable on this communicator",
+        wantBytes >> 20);
+  } else {
+    arena.bytes = wantBytes;
+  }
+
+  // Agree on the outcome. An arena that only some ranks have is worse than no
+  // arena: the ranks that have it would quantize and send wire bytes while the
+  // others send their dtype, which hangs or corrupts instead of degrading.
+  std::vector<uint8_t> votes(comm->nRanks, 0);
+  votes[comm->rank] = ok ? 1 : 0;
+  if (bootstrapAllGather(comm->bootstrap, votes.data(), sizeof(uint8_t)) !=
+      ncclSuccess) {
+    ok = false;
+  } else {
+    for (int r = 0; r < comm->nRanks; r++) {
+      if (votes[r] == 0) {
+        ok = false;
+        break;
+      }
+    }
+  }
+
+  if (!ok) {
+    destroyArena(arena);
+    return false;
+  }
+  // LAST, and after commHash: this is what publishes the arena to
+  // lpArenaReady(), which reads valid before commHash.
+  arena.valid = true;
+  INFO(
+      NCCL_INIT,
+      "Sharded relay: low-precision arena ready, %zu MiB",
+      arena.bytes >> 20);
+  return true;
+}
+
+} // namespace
+
+size_t lpArenaCapacityBytes() {
+  // Elements, not bytes, is what the LP footprint scales with, and bf16 is the
+  // smallest supported element -- so a byte budget read as bf16 gives the
+  // worst case for that budget.
+  const size_t maxElems = lpMaxMsgBytes() / sizeof(uint16_t);
+  return kLpArenaShadowsPerMessage * lpWireBytesRoundUp(maxElems);
+}
+
+void lpArenaInit(ncclComm_t comm) {
+  if (comm == nullptr || !lpPrealloc()) {
+    return;
+  }
+  // Discard the lease: this is only here to force creation. The arena is kept
+  // on the comm, so the next real caller finds it ready.
+  LpArenaLease unused{};
+  (void)lpArenaAcquire(comm, &unused);
+}
+
+bool lpArenaReady(ncclComm_t comm) {
+  if (comm == nullptr) {
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(arenaMutex());
+  // find rather than operator[]: this must not create an entry, or a capturing
+  // caller would leave behind a tried=false shell keyed to this comm.
+  //
+  // arenaMutex() covers the MAP lookup only. valid and commHash are written by
+  // createArena() under Arena::mu instead, which is why they are atomic -- see
+  // the Arena declaration. Reading valid first is what makes the pair
+  // consistent.
+  auto it = arenas().find(static_cast<const void*>(comm));
+  return it != arenas().end() && it->second.valid &&
+      it->second.commHash == comm->commHash;
+}
+
+bool lpArenaAcquire(ncclComm_t comm, LpArenaLease* out) {
+  if (comm == nullptr || out == nullptr || comm->nRanks < 2) {
+    return false;
+  }
+
+  // arenaMutex() covers only the map -- the staleness sweep and the lookup. It
+  // is deliberately NOT held across createArena(), which runs a bootstrap
+  // all-gather: one global lock spanning a collective deadlocks as soon as two
+  // communicators are set up concurrently and their peer processes reach the
+  // collectives in opposite order.
+  Arena* arenap = nullptr;
+  {
+    std::lock_guard<std::mutex> mapLock(arenaMutex());
+
+    // A stale entry can only exist if this comm's release was missed and the
+    // allocator handed its address to a new comm. Drop the whole node rather
+    // than hand back a pointer into memory that went away with the old comm;
+    // every rank of the new comm sees the same mismatch, because commHash is
+    // agreed across it.
+    auto it = arenas().find(static_cast<const void*>(comm));
+    if (it != arenas().end() && it->second.tried &&
+        it->second.commHash != comm->commHash) {
+      destroyArena(it->second);
+      arenas().erase(it);
+    }
+
+    arenap = &arenas()[static_cast<const void*>(comm)];
+  }
+  // std::map is node based, so the reference stays valid once the map lock is
+  // dropped; only erasing this key invalidates it, and that happens either in
+  // the sweep above or in lpArenaRelease(), both only for a comm that is done.
+  Arena& arena = *arenap;
+
+  std::lock_guard<std::mutex> lock(arena.mu);
+
+  // Attempted once per comm. `tried` is sticky: a retry would have to be
+  // collectively agreed, and a rank retrying alone would enter a bootstrap
+  // all-gather the others are not in.
+  if (!arena.tried) {
+    arena.tried = true;
+    createArena(comm, arena);
+  }
+  if (!arena.valid) {
+    return false;
+  }
+
+  out->base = static_cast<char*>(arena.base);
+  out->bytes = arena.bytes;
+  return true;
+}
+
+void lpArenaRelease(ncclComm_t comm) {
+  if (comm == nullptr) {
+    return;
+  }
+  // Erasing the node destroys Arena::mu, so this must not run concurrently with
+  // an lpArenaAcquire() for the same comm -- it is called from comm teardown,
+  // after the last collective on that comm has been issued.
+  std::lock_guard<std::mutex> lock(arenaMutex());
+  auto it = arenas().find(static_cast<const void*>(comm));
+  if (it == arenas().end()) {
+    return;
+  }
+  destroyArena(it->second);
+  arenas().erase(it);
+}
+
+} // namespace rcclx::relay

--- a/comms/rcclx/develop/meta/relay/sharded_relay_lp_arena.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_lp_arena.h
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "nccl.h"
+
+/**
+ * Per-communicator scratch arena for the low-precision relay wire format.
+ *
+ * WHY NOT ScratchBufferCache
+ *
+ * The four collectives each keep a grow-only ScratchBufferCache backed by
+ * cudaMallocAsync on the caller's stream. That is the right tool for staging
+ * that only the owning translation unit sees, and it is deliberately left
+ * alone. It is the wrong tool for the LP buffers, for three reasons:
+ *
+ *   1. It allocates on the CALL PATH. sharded_relay_graph_scratch.h documents
+ *      three separate ways that breaks under HIP graph capture: an allocation
+ *      inside a capture records a graph allocation node whose address is only
+ *      valid while that graph runs; a growth inside a capture records a free
+ *      node, so the second replay double-frees; and a growth after a capture
+ *      returns a pointer the graph already baked in. A region allocated ONCE,
+ *      outside any capture, and never resized has none of those failure modes.
+ *   2. One arena is shared by all four collectives. LP buffers are the same
+ *      shape whichever collective asks, so per-TU pools would just be four
+ *      copies of the same high-water mark.
+ *   3. Its addresses move. A deterministic partition from a fixed base gives a
+ *      captured graph the same addresses on every replay for free.
+ *
+ * Lifecycle mirrors the one-shot region exactly: created either at
+ * ncclCommInitRank (NCCL_SHARDED_RELAY_LP_PREALLOC=1) or lazily on the first
+ * call that asks for low precision, kept for the communicator's life, and freed
+ * from RCCL's commFree().
+ *
+ * COLLECTIVE, AND WHY THAT MATTERS
+ *
+ * lpArenaAcquire() runs a bootstrap all-gather on first use, so EVERY rank of
+ * the communicator must call it on the same call -- including ranks that are
+ * pure passthrough helpers for this collective and need no bytes from the arena
+ * at all. Callers must therefore gate it on a predicate derived only from
+ * sizes, never on whether the calling rank happens to be active. That is the
+ * same contract sharded_relay_oneshot.h states, for the same reason.
+ *
+ * The all-gather is not decoration. Availability HAS to be agreed: a rank with
+ * an arena quantizes and sends wire bytes while a rank without one sends its
+ * dtype, the two disagree on how many bytes cross the link, and the call hangs
+ * or corrupts rather than degrading. A plain local hipMalloc failure on one
+ * rank would produce exactly that, which is why the outcome is voted on rather
+ * than decided locally.
+ *
+ * CAPACITY IS CHECKED BY THE CALLER, AGAINST A RANK-INDEPENDENT NUMBER
+ *
+ * The arena never grows, so a call whose footprint exceeds it declines. That
+ * check belongs in the caller's size-only gate and must use a WORST-CASE
+ * requirement across roles, compared against lpArenaCapacityBytes() -- both
+ * rank-independent, so every rank declines together. A rank comparing its own
+ * role's requirement would be back to per-rank divergence.
+ */
+namespace rcclx::relay {
+
+// Bytes provisioned per communicator, a pure function of
+// NCCL_SHARDED_RELAY_LP_MAX_MSG_MB and therefore identical on every rank.
+//
+// The budget is stated in FULL-PRECISION per-rank message bytes, because that
+// is the number a caller knows. bf16 sets the worst case at a given byte
+// budget: it is the smallest supported element, so a byte budget buys twice as
+// many elements as fp32 does, and the LP footprint scales with ELEMENTS.
+//
+// The widest shape is the A=4 all-gather, which needs one send shadow of the
+// rank's own shard plus A-1 foreign arrival slots of the same size, so the
+// budget is multiplied by kLpArenaShadowsPerMessage. At the 1024 MB default
+// that is 2112 MiB per communicator -- a real number, and the reason
+// NCCL_SHARDED_RELAY_LP_PREALLOC defaults off: nothing is provisioned until a
+// caller actually asks for low precision. A job whose messages are smaller
+// should say so; NCCL_SHARDED_RELAY_LP_MAX_MSG_MB=256 costs 528 MiB.
+size_t lpArenaCapacityBytes();
+
+// The multiplier above, named so the collectives in later commits can raise it
+// in one place if a shape turns out to need more than four shadows.
+inline constexpr size_t kLpArenaShadowsPerMessage = 4;
+
+/**
+ * The whole arena, handed to one call.
+ *
+ * Not a sub-allocation: the arena has one owner per call because the relay
+ * collectives on a given stream are serialized by that stream. Partition it
+ * with LpArenaCarver.
+ */
+struct LpArenaLease {
+  char* base{nullptr};
+  size_t bytes{0};
+
+  bool valid() const {
+    return base != nullptr && bytes > 0;
+  }
+};
+
+/**
+ * Deterministic bump partitioner over a lease.
+ *
+ * Every call partitions from the same base in the same order, so a captured
+ * graph sees the same addresses on every replay -- which is most of the reason
+ * the arena exists. Regions are 256-byte aligned, which keeps every LP buffer
+ * start comfortably above the 4-byte alignment the inline scales need.
+ *
+ * take() returns nullptr once the arena is exhausted and latches ok() false, so
+ * a caller can carve everything it needs and check once at the end instead of
+ * after every region.
+ */
+class LpArenaCarver {
+ public:
+  static constexpr size_t kAlign = 256;
+
+  explicit LpArenaCarver(const LpArenaLease& lease)
+      : base_(lease.base), capacity_(lease.bytes) {}
+
+  char* take(size_t bytes) {
+    if (base_ == nullptr) {
+      ok_ = false;
+      return nullptr;
+    }
+    const size_t aligned = ((bytes + kAlign - 1) / kAlign) * kAlign;
+    if (aligned > capacity_ - used_) {
+      ok_ = false;
+      return nullptr;
+    }
+    char* p = base_ + used_;
+    used_ += aligned;
+    return p;
+  }
+
+  bool ok() const {
+    return ok_;
+  }
+
+  size_t used() const {
+    return used_;
+  }
+
+ private:
+  char* base_{nullptr};
+  size_t capacity_{0};
+  size_t used_{0};
+  bool ok_{true};
+};
+
+/**
+ * Hand out this communicator's arena, creating it on first use.
+ *
+ * Returns false if the arena is unavailable -- allocation failed on any rank,
+ * or the communicator has none. A false return is identical on every rank, so
+ * callers can fall back to full precision without risking a mixed-format hang.
+ *
+ * COLLECTIVE on first call for a given communicator. See the file comment.
+ */
+bool lpArenaAcquire(ncclComm_t comm, LpArenaLease* out);
+
+/**
+ * Build this communicator's arena now, during ncclCommInitRank.
+ *
+ * Only acts when NCCL_SHARDED_RELAY_LP_PREALLOC=1. Creation is collective, so
+ * init is the one place it is free: every rank is already there, and doing it
+ * here means no later call -- including the first call of a graph capture --
+ * has to pay for it or refuse it.
+ *
+ * Like every NCCL parameter this assumes the variable is set identically on
+ * every rank. Setting it on some ranks only would leave those ranks in a
+ * bootstrap all-gather the others never join.
+ *
+ * Failure is not an error: low precision is optional and every caller has a
+ * fallback, so a comm that cannot build an arena behaves as if the variable
+ * were unset.
+ */
+void lpArenaInit(ncclComm_t comm);
+
+/**
+ * True if this communicator's arena already exists, without creating one.
+ *
+ * For callers under graph capture. Creation is not capturable -- it runs a
+ * bootstrap all-gather -- but an arena that already exists is perfectly usable
+ * from a captured kernel, so a caller consults this and declines to full
+ * precision rather than refusing every captured call outright. Whether an arena
+ * exists is agreed across the communicator, because it is only ever established
+ * by an all-gather every rank takes part in, so every rank gets the same
+ * answer.
+ */
+bool lpArenaReady(ncclComm_t comm);
+
+/**
+ * Free a communicator's arena. Called from RCCL's commFree(), the only point at
+ * which the relay learns a comm is going away. Purely local -- one hipFree --
+ * so it honours commFree()'s no-sync-among-ranks contract. A no-op for a comm
+ * that never asked for low precision.
+ */
+void lpArenaRelease(ncclComm_t comm);
+
+} // namespace rcclx::relay

--- a/comms/rcclx/develop/meta/relay/sharded_relay_lp_kernels.cu
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_lp_kernels.cu
@@ -1,0 +1,447 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Device bodies for the low-precision relay kernels. Separate from the header
+// for the same reason sharded_relay_allreduce_kernels.cu is: this TU is
+// compiled as a monolithic non-RDC HIP library WITHOUT `--offload-host-only`,
+// so the
+// `__global__` bodies survive into the archive, and the explicit instantiations
+// at the bottom give the host TUs' `<<<...>>>` stubs something to bind to.
+
+#include "meta/relay/sharded_relay_lp_kernels.h"
+
+#include <hip/hip_runtime.h>
+
+#include "meta/relay/sharded_relay_lp.h"
+#include "rccl_float8.h"
+
+namespace {
+
+using rcclx::relay::kLpBlockBytes;
+using rcclx::relay::kLpBlockElems;
+using rcclx::relay::kLpInvNormalizeMax;
+using rcclx::relay::lpWireBytes;
+
+static_assert(
+    sizeof(rccl_float8) == 1,
+    "the wire format stores one fp8 code per byte");
+
+// Two wire blocks per workgroup, one thread per payload element.
+//
+// The absmax reduction is done as a shared-memory BROADCAST loop rather than a
+// tree: every thread of a sub-block reads all 128 of its block's absolute
+// values and takes the max itself. That is 128x the LDS reads of a tree, but
+// LDS broadcast is one instruction per wavefront regardless of lane count, and
+// it costs ONE barrier per block instead of seven. Barriers, not LDS bandwidth,
+// are what a 256-byte-per-block kernel cannot afford.
+constexpr int kLpBlocksPerCta = 2;
+constexpr int kLpThreadsPerCta = kLpBlockElems * kLpBlocksPerCta;
+
+// Enough workgroups to fill the device several times over without making the
+// grid-stride loop pointless. The kernels are memory bound, so the exact value
+// is not delicate.
+constexpr int kLpMaxCtas = 8192;
+
+int ctaCount(size_t nBlocks) {
+  const size_t ctas = (nBlocks + kLpBlocksPerCta - 1) / kLpBlocksPerCta;
+  return static_cast<int>(
+      ctas < kLpMaxCtas ? (ctas == 0 ? 1 : ctas) : kLpMaxCtas);
+}
+
+int elementCtaCount(size_t count) {
+  const size_t ctas = (count + kLpThreadsPerCta - 1) / kLpThreadsPerCta;
+  return static_cast<int>(
+      ctas < kLpMaxCtas ? (ctas == 0 ? 1 : ctas) : kLpMaxCtas);
+}
+
+// Widening and narrowing in one place, so a dtype whose conversion needs an
+// intrinsic rather than a cast is a two-line change here.
+template <typename T>
+__device__ __forceinline__ float lpToFloat(T v) {
+  return static_cast<float>(v);
+}
+
+template <typename T>
+__device__ __forceinline__ T lpFromFloat(float v) {
+  return static_cast<T>(v);
+}
+
+// fp8e4m3 code <-> value, through rccl_float8 so the flavour question
+// (__hip_fp8_e4m3_fnuz on gfx942, OCP __hip_fp8_e4m3 elsewhere) is answered in
+// exactly one place in the tree. Encode and decode always run on the same
+// device, so they always agree; the BYTES are arch-local, which is fine for an
+// intra-node homogeneous relay and documented as latent otherwise.
+__device__ __forceinline__ uint8_t lpEncodeByte(float v) {
+  const rccl_float8 q(v);
+  uint8_t byte;
+  __builtin_memcpy(&byte, &q, 1);
+  return byte;
+}
+
+__device__ __forceinline__ float lpDecodeByte(uint8_t byte) {
+  rccl_float8 q{};
+  __builtin_memcpy(&q, &byte, 1);
+  return static_cast<float>(q);
+}
+
+// Where a block's inline scale lives. kLpBlockBytes is a multiple of 4 and
+// every LP buffer offset is a whole number of blocks, so this is always 4-byte
+// aligned.
+__device__ __forceinline__ float* scaleSlot(uint8_t* block) {
+  return reinterpret_cast<float*>(block + kLpBlockElems);
+}
+
+__device__ __forceinline__ float scaleOf(const uint8_t* block) {
+  return *reinterpret_cast<const float*>(block + kLpBlockElems);
+}
+
+/*
+ * Scale for a block whose absolute maximum is absMax.
+ *
+ * absMax * 2^-7 is EXACT (a power-of-two multiply), and the decode is
+ * code * scale, so a block whose elements are all equal round-trips
+ * bit-exactly: v / (v * 2^-7) has the exact quotient 128, fp8e4m3 represents
+ * 128 exactly, and 128 * (v * 2^-7) is v again. Normalizing to the format's own
+ * maximum (240 or 448) instead would make the scale a rounded fp32 value and
+ * throw that property away for no precision gain. See sharded_relay_lp.h.
+ *
+ * An all-zero block gets scale 0 and codes 0, which decodes back to 0. A block
+ * holding a NaN or an inf gets a non-finite scale and decodes non-finite; see
+ * lpAbsMaxFold().
+ */
+__device__ __forceinline__ float lpScaleFor(float absMax) {
+  return absMax * kLpInvNormalizeMax;
+}
+
+__device__ __forceinline__ uint8_t lpEncodeWithScale(float v, float scale) {
+  return lpEncodeByte(scale > 0.0f ? v / scale : 0.0f);
+}
+
+/*
+ * One step of the absmax fold, NaN-STICKY.
+ *
+ * Deliberately not fmaxf: fmaxf returns the NON-NaN operand, so an absmax
+ * folded with it reports the max of a block's FINITE elements and reports 0 for
+ * a block that is entirely NaN. Zero is the all-zero block's absmax, so a
+ * diverged block would be written as scale 0 with 128 zero codes and decode
+ * back to clean 0.0 -- silently erasing the divergence, and stopping a
+ * post-collective isfinite() check from firing on exactly the runs that need
+ * it.
+ *
+ * Sticky instead: once a NaN is in the accumulator it stays, because `v > acc`
+ * is false for a NaN acc. absMax then being non-finite makes lpScaleFor()
+ * non-finite, which makes every element of that block decode non-finite -- so
+ * the block is destroyed either way, but visibly. An inf absmax reaches the
+ * same place without help: the scale is inf, so every finite element encodes to
+ * 0 and decodes to 0 * inf == NaN.
+ *
+ * Still commutative and associative over the non-negative inputs the callers
+ * pass, so every lane of a block computes the identical value, bit for bit.
+ */
+__device__ __forceinline__ float lpAbsMaxFold(float acc, float v) {
+  return (v > acc || __builtin_isnan(v)) ? v : acc;
+}
+
+// Max of the 128 absolute values this thread's sub-block wrote into `shared`.
+__device__ __forceinline__ float subBlockAbsMax(const float* shared, int sub) {
+  const float* mine = shared + sub * kLpBlockElems;
+  float m = 0.0f;
+  for (int i = 0; i < kLpBlockElems; i++) {
+    m = lpAbsMaxFold(m, mine[i]);
+  }
+  return m;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Quantize
+// ---------------------------------------------------------------------------
+
+template <typename T>
+__global__ void lpQuantizeKernel(const T* in, uint8_t* wire, size_t nBlocks) {
+  __shared__ float sAbs[kLpThreadsPerCta];
+  const int sub = static_cast<int>(threadIdx.x) / kLpBlockElems;
+  const int lane = static_cast<int>(threadIdx.x) % kLpBlockElems;
+  const size_t ctaStride =
+      static_cast<size_t>(gridDim.x) * static_cast<size_t>(kLpBlocksPerCta);
+
+  for (size_t base = static_cast<size_t>(blockIdx.x) * kLpBlocksPerCta;
+       base < nBlocks;
+       base += ctaStride) {
+    const size_t b = base + sub;
+    const bool live = b < nBlocks;
+    const float v = live ? lpToFloat<T>(in[b * kLpBlockElems + lane]) : 0.0f;
+    sAbs[threadIdx.x] = fabsf(v);
+    __syncthreads();
+
+    if (live) {
+      const float scale = lpScaleFor(subBlockAbsMax(sAbs, sub));
+      uint8_t* block = wire + b * kLpBlockBytes;
+      block[lane] = lpEncodeWithScale(v, scale);
+      if (lane == 0) {
+        *scaleSlot(block) = scale;
+      }
+    }
+    // sAbs is reused by the next iteration, and the reads above are not done
+    // until every thread of the sub-block has finished them.
+    __syncthreads();
+  }
+}
+
+template <typename T>
+void launchLpQuantizeKernel(
+    void* wireOut,
+    const void* in,
+    size_t count,
+    cudaStream_t stream) {
+  const size_t nBlocks = count / kLpBlockElems;
+  if (nBlocks == 0) {
+    return;
+  }
+  lpQuantizeKernel<T><<<ctaCount(nBlocks), kLpThreadsPerCta, 0, stream>>>(
+      static_cast<const T*>(in), static_cast<uint8_t*>(wireOut), nBlocks);
+}
+
+// ---------------------------------------------------------------------------
+// Dequantize
+// ---------------------------------------------------------------------------
+
+template <typename T>
+__global__ void lpDequantizeKernel(T* out, const uint8_t* wire, size_t count) {
+  const size_t tid = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const size_t stride = static_cast<size_t>(blockDim.x) * gridDim.x;
+
+  for (size_t e = tid; e < count; e += stride) {
+    const uint8_t* block = wire + (e / kLpBlockElems) * kLpBlockBytes;
+    // Broadcast read: 128 consecutive threads share one scale.
+    const float scale = scaleOf(block);
+    out[e] = lpFromFloat<T>(lpDecodeByte(block[e % kLpBlockElems]) * scale);
+  }
+}
+
+template <typename T>
+void launchLpDequantizeKernel(
+    void* out,
+    const void* wireIn,
+    size_t count,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return;
+  }
+  lpDequantizeKernel<T>
+      <<<elementCtaCount(count), kLpThreadsPerCta, 0, stream>>>(
+          static_cast<T*>(out), static_cast<const uint8_t*>(wireIn), count);
+}
+
+// ---------------------------------------------------------------------------
+// Helper-side reduce and requantize (wire in, wire out)
+// ---------------------------------------------------------------------------
+
+__global__ void lpReduceRequantizeKernel(
+    uint8_t* wireOut,
+    const uint8_t* wireContribs,
+    int numContribs,
+    size_t nBlocks,
+    size_t contribStride,
+    int divisor) {
+  __shared__ float sAbs[kLpThreadsPerCta];
+  const int sub = static_cast<int>(threadIdx.x) / kLpBlockElems;
+  const int lane = static_cast<int>(threadIdx.x) % kLpBlockElems;
+  const size_t ctaStride =
+      static_cast<size_t>(gridDim.x) * static_cast<size_t>(kLpBlocksPerCta);
+
+  for (size_t base = static_cast<size_t>(blockIdx.x) * kLpBlocksPerCta;
+       base < nBlocks;
+       base += ctaStride) {
+    const size_t b = base + sub;
+    const bool live = b < nBlocks;
+
+    // fp32 accumulation, which is the whole reason the sum does not have to be
+    // range-limited the way an fp8 accumulation would.
+    float acc = 0.0f;
+    if (live) {
+      const size_t blockOffset = b * kLpBlockBytes;
+      for (int p = 0; p < numContribs; p++) {
+        const uint8_t* block =
+            wireContribs + static_cast<size_t>(p) * contribStride + blockOffset;
+        acc += lpDecodeByte(block[lane]) * scaleOf(block);
+      }
+      // Exact: the divisor is a power of two, so this rescales the block's
+      // absmax by the same factor and leaves every code below unchanged.
+      if (divisor > 1) {
+        acc /= static_cast<float>(divisor);
+      }
+    }
+    sAbs[threadIdx.x] = fabsf(acc);
+    __syncthreads();
+
+    if (live) {
+      const float scale = lpScaleFor(subBlockAbsMax(sAbs, sub));
+      uint8_t* block = wireOut + b * kLpBlockBytes;
+      block[lane] = lpEncodeWithScale(acc, scale);
+      if (lane == 0) {
+        *scaleSlot(block) = scale;
+      }
+    }
+    __syncthreads();
+  }
+}
+
+void launchLpReduceRequantizeKernel(
+    void* wireOut,
+    const void* wireContribs,
+    int numContribs,
+    size_t count,
+    int divisor,
+    cudaStream_t stream) {
+  const size_t nBlocks = count / kLpBlockElems;
+  if (nBlocks == 0 || numContribs <= 0) {
+    return;
+  }
+  lpReduceRequantizeKernel<<<ctaCount(nBlocks), kLpThreadsPerCta, 0, stream>>>(
+      static_cast<uint8_t*>(wireOut),
+      static_cast<const uint8_t*>(wireContribs),
+      numContribs,
+      nBlocks,
+      lpWireBytes(count),
+      divisor);
+}
+
+// ---------------------------------------------------------------------------
+// Active-rank closing reduce (wire contributions in, caller's dtype out)
+// ---------------------------------------------------------------------------
+
+template <typename T>
+__global__ void lpMultiReduceKernel(
+    T* dst,
+    const uint8_t* wireContribs,
+    int numContribs,
+    size_t count,
+    size_t contribStride,
+    int divisor) {
+  const size_t tid = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const size_t stride = static_cast<size_t>(blockDim.x) * gridDim.x;
+
+  for (size_t e = tid; e < count; e += stride) {
+    const size_t blockOffset = (e / kLpBlockElems) * kLpBlockBytes;
+    const size_t lane = e % kLpBlockElems;
+    float acc = lpToFloat<T>(dst[e]);
+    for (int p = 0; p < numContribs; p++) {
+      const uint8_t* block =
+          wireContribs + static_cast<size_t>(p) * contribStride + blockOffset;
+      acc += lpDecodeByte(block[lane]) * scaleOf(block);
+    }
+    if (divisor > 1) {
+      acc /= static_cast<float>(divisor);
+    }
+    dst[e] = lpFromFloat<T>(acc);
+  }
+}
+
+template <typename T>
+void launchLpMultiReduceKernel(
+    void* dst,
+    const void* wireContribs,
+    int numContribs,
+    size_t count,
+    int divisor,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return;
+  }
+  lpMultiReduceKernel<T>
+      <<<elementCtaCount(count), kLpThreadsPerCta, 0, stream>>>(
+          static_cast<T*>(dst),
+          static_cast<const uint8_t*>(wireContribs),
+          numContribs,
+          count,
+          lpWireBytes(count),
+          divisor);
+}
+
+template <typename T>
+__global__ void lpSeededMultiReduceKernel(
+    T* dst,
+    const T* seed,
+    const uint8_t* wireContribs,
+    int numContribs,
+    size_t count,
+    size_t contribStride,
+    int divisor) {
+#pragma clang fp reassociate(off)
+  const size_t tid = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const size_t stride = static_cast<size_t>(blockDim.x) * gridDim.x;
+
+#pragma clang loop vectorize(disable) interleave(disable)
+  for (size_t e = tid; e < count; e += stride) {
+    const size_t blockOffset = (e / kLpBlockElems) * kLpBlockBytes;
+    const size_t lane = e % kLpBlockElems;
+    float acc = lpToFloat<T>(seed[e]);
+#pragma clang loop unroll(disable) vectorize(disable) interleave(disable)
+    for (int p = 0; p < numContribs; p++) {
+      const uint8_t* block =
+          wireContribs + static_cast<size_t>(p) * contribStride + blockOffset;
+      acc = acc + lpDecodeByte(block[lane]) * scaleOf(block);
+    }
+    if (divisor > 1) {
+      acc = acc / static_cast<float>(divisor);
+    }
+    dst[e] = lpFromFloat<T>(acc);
+  }
+}
+
+template <typename T>
+void launchLpSeededMultiReduceKernel(
+    void* dst,
+    const void* seed,
+    const void* wireContribs,
+    int numContribs,
+    size_t count,
+    int divisor,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return;
+  }
+  lpSeededMultiReduceKernel<T>
+      <<<elementCtaCount(count), kLpThreadsPerCta, 0, stream>>>(
+          static_cast<T*>(dst),
+          static_cast<const T*>(seed),
+          static_cast<const uint8_t*>(wireContribs),
+          numContribs,
+          count,
+          lpWireBytes(count),
+          divisor);
+}
+
+// Explicit instantiations. bf16 and fp32 only -- see the header.
+#define RCCLX_INSTANTIATE_RELAY_LP_KERNELS(T)                            \
+  template void launchLpQuantizeKernel<T>(                               \
+      void* wireOut, const void* in, size_t count, cudaStream_t stream); \
+  template void launchLpDequantizeKernel<T>(                             \
+      void* out, const void* wireIn, size_t count, cudaStream_t stream); \
+  template void launchLpMultiReduceKernel<T>(                            \
+      void* dst,                                                         \
+      const void* wireContribs,                                          \
+      int numContribs,                                                   \
+      size_t count,                                                      \
+      int divisor,                                                       \
+      cudaStream_t stream);                                              \
+  template void launchLpSeededMultiReduceKernel<T>(                      \
+      void* dst,                                                         \
+      const void* seed,                                                  \
+      const void* wireContribs,                                          \
+      int numContribs,                                                   \
+      size_t count,                                                      \
+      int divisor,                                                       \
+      cudaStream_t stream);
+
+RCCLX_INSTANTIATE_RELAY_LP_KERNELS(float)
+RCCLX_INSTANTIATE_RELAY_LP_KERNELS(__nv_bfloat16)
+
+#undef RCCLX_INSTANTIATE_RELAY_LP_KERNELS

--- a/comms/rcclx/develop/meta/relay/sharded_relay_lp_kernels.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_lp_kernels.h
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <hip/hip_bf16.h>
+#include <hip/hip_bfloat16.h>
+#include <cstddef>
+#include <cstdint>
+
+#include "nccl.h"
+
+/*
+ * Host-callable launchers for the low-precision relay kernels.
+ *
+ * These are DEFINED in `sharded_relay_lp_kernels.cu`, which is compiled as a
+ * monolithic (non-RDC) HIP translation unit so the host stub for the
+ * `<<<...>>>` launch and the matching `__global__` body live in the same TU.
+ * Every instantiation the host TUs may reference is forward-declared here, so a
+ * host TU -- built with `--offload-host-only` -- never tries to instantiate one
+ * itself. Same arrangement as sharded_relay_allreduce_kernels.h; see its
+ * comment.
+ *
+ * ONLY bf16 AND fp32 ARE INSTANTIATED, because those are the only dtypes
+ * lpDtypeSupported() admits. A dispatch that reaches this header for any other
+ * dtype is a bug in the gate, and the missing instantiation makes it a link
+ * error rather than silent wrong output.
+ *
+ * WIRE FORMAT, restated because these signatures depend on it: a wire buffer is
+ * a sequence of 132-byte blocks, each 128 fp8e4m3 payload bytes followed by one
+ * fp32 scale. `count` is always in ELEMENTS of the caller's dtype and must be a
+ * multiple of 128 -- lpEligible()'s alignment gate is what guarantees that.
+ * Where a launcher takes several wire contributions they are contiguous, block
+ * p starting at `wireContribs + p * lpWireBytes(count)`, mirroring how the
+ * full-precision multi-reduce launchers already lay out their contributions.
+ *
+ * WHERE THE DIVISOR GOES. Two kernels can apply it, and which one does depends
+ * on whether the region has an active-side closing reduce at all. Regions the
+ * ACTIVE rank folds (a direct exchange, whose contributions it reduces itself)
+ * get it in `launchLpMultiReduceKernel`. Regions a HELPER reduces do not have
+ * an active-side reduce -- the helper's already-reduced chunk lands directly in
+ * its final place in the caller's receive buffer, so the only active-side step
+ * is a dequantize -- and those get it in `launchLpReduceRequantizeKernel`. A
+ * helper returning a pure sum would drop the ncclAvg divisor outright.
+ *
+ * `launchLpDequantizeKernel` deliberately has no divisor, so it stays a pure
+ * format conversion: all-gather and all-to-all have no divisor at all and would
+ * otherwise carry a dead parameter.
+ */
+
+/**
+ * Quantize `count` elements into the wire format.
+ *
+ * One launch per group covering the ENTIRE boundary-crossing send region,
+ * issued before the first ncclGroupStart(). Deliberately hoisted rather than
+ * done per-tile: per-tile would cost T launches instead of 1, and would create
+ * an ordering hazard in the in-place pipelined allreduce where tile t's fold
+ * can be in flight while tile t+1's send source is still being read.
+ */
+template <typename T>
+void launchLpQuantizeKernel(
+    void* wireOut,
+    const void* in,
+    size_t count,
+    cudaStream_t stream);
+
+/**
+ * Dequantize `count` elements from the wire format into the caller's dtype.
+ *
+ * Used by all-gather and all-to-all, whose receives land straight into recvBuff
+ * today: under low precision the FOREIGN slots arrive in wire form and one
+ * launch per group writes them out at the full-precision slot offsets. It must
+ * cover foreign slots only and skip the folded diagonal slot, which is already
+ * final and already full precision.
+ */
+template <typename T>
+void launchLpDequantizeKernel(
+    void* out,
+    const void* wireIn,
+    size_t count,
+    cudaStream_t stream);
+
+/**
+ * Wire in, wire out: sum `numContribs` wire contributions in fp32, apply
+ * `divisor`, and requantize, picking a fresh per-block absmax.
+ *
+ * The helper's reduce under low precision, replacing what DISPATCH_FUSED_REDUCE
+ * / DISPATCH_MULTI_REDUCE does at full precision. Not templated on the caller's
+ * dtype, because neither side of it is in the caller's dtype -- which is
+ * exactly why the helper stays ignorant of what it is carrying.
+ *
+ * Applying the divisor here costs nothing in accuracy. It is always
+ * `nActiveRanks`, which the dispatchers require to be a power of two, so
+ * scaling before the requantize moves the block absmax by the same exact power
+ * of two and leaves every fp8 code unchanged: dividing early and dividing late
+ * are bit-identical. See the file comment for why it cannot be deferred to the
+ * active rank instead.
+ */
+void launchLpReduceRequantizeKernel(
+    void* wireOut,
+    const void* wireContribs,
+    int numContribs,
+    size_t count,
+    int divisor,
+    cudaStream_t stream);
+
+/**
+ * Mixed reduce: dst (full precision) plus `numContribs` wire contributions,
+ * accumulated in fp32, written back in the caller's dtype with the divisor
+ * applied once.
+ *
+ * The active rank's closing fold under low precision. fp32 accumulation is the
+ * point -- it is what keeps a reduction of e4m3 values from overflowing or
+ * losing the sum's low bits.
+ */
+template <typename T>
+void launchLpMultiReduceKernel(
+    void* dst,
+    const void* wireContribs,
+    int numContribs,
+    size_t count,
+    int divisor,
+    cudaStream_t stream);
+
+/**
+ * As above, but seeded from a separate full-precision buffer instead of reading
+ * dst: result[i] = (seed[i] + sum_p wire_p[i]) / divisor, in that order.
+ */
+template <typename T>
+void launchLpSeededMultiReduceKernel(
+    void* dst,
+    const void* seed,
+    const void* wireContribs,
+    int numContribs,
+    size_t count,
+    int divisor,
+    cudaStream_t stream);
+
+// Suppress instantiation in the host TU; the actual instantiations live in
+// sharded_relay_lp_kernels.cu.
+#define RCCLX_DECLARE_RELAY_LP_KERNEL_INSTANTIATIONS(T)                  \
+  extern template void launchLpQuantizeKernel<T>(                        \
+      void* wireOut, const void* in, size_t count, cudaStream_t stream); \
+  extern template void launchLpDequantizeKernel<T>(                      \
+      void* out, const void* wireIn, size_t count, cudaStream_t stream); \
+  extern template void launchLpMultiReduceKernel<T>(                     \
+      void* dst,                                                         \
+      const void* wireContribs,                                          \
+      int numContribs,                                                   \
+      size_t count,                                                      \
+      int divisor,                                                       \
+      cudaStream_t stream);                                              \
+  extern template void launchLpSeededMultiReduceKernel<T>(               \
+      void* dst,                                                         \
+      const void* seed,                                                  \
+      const void* wireContribs,                                          \
+      int numContribs,                                                   \
+      size_t count,                                                      \
+      int divisor,                                                       \
+      cudaStream_t stream);
+
+RCCLX_DECLARE_RELAY_LP_KERNEL_INSTANTIATIONS(float)
+RCCLX_DECLARE_RELAY_LP_KERNEL_INSTANTIATIONS(__nv_bfloat16)
+
+#undef RCCLX_DECLARE_RELAY_LP_KERNEL_INSTANTIATIONS

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -2623,7 +2623,11 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
     cudaStream_t stream,
     const int* const* allActiveRanks,
     int nActiveRanksPerGroup,
-    int nGroups) {
+    int nGroups,
+    int lowPrecision) {
+  // Accepted and ignored: the wire-format substitution lands in a later commit,
+  // so this commit cannot change behaviour.
+  (void)lowPrecision;
   int nRanks, rank;
   NCCLCHECK(ncclCommCount(comm, &nRanks));
   NCCLCHECK(ncclCommUserRank(comm, &rank));

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -1650,6 +1650,83 @@ bool rsFlatLpPrepare(
   return true;
 }
 
+// The same four regions as rsFlatLpCarve(), at the pipelined schedule's
+// geometry. Only the helper region differs in shape: the pipelined helper holds
+// two ping-pong buffers of A*(A-1) slots of one tile each, rather than one
+// A*(A-1) set of full slices, and nGroups is always 1 because that is the only
+// shape that pipelines.
+//
+// No geometry predicate is needed. The schedule already rejects w == 0
+// outright, and w is a non-zero multiple of the chunk alignment, so every
+// offset it derives
+// -- direct piece, offload tile, helper slot -- is a whole number of wire
+// blocks once the count is.
+size_t rsFlatPipeLpRequiredBytes(
+    size_t recvcount,
+    size_t directSz,
+    size_t offloadTotal,
+    size_t w,
+    int nActiveRanks) {
+  const size_t A = static_cast<size_t>(nActiveRanks);
+  return rsLpAlign(rcclx::relay::lpWireBytes(A * recvcount)) +
+      rsLpAlign(rcclx::relay::lpWireBytes((A - 1) * directSz)) +
+      rsLpAlign(rcclx::relay::lpWireBytes(offloadTotal)) +
+      rsLpAlign(rcclx::relay::lpWireBytes(2 * A * (A - 1) * w));
+}
+
+RsFlatLpPlan rsFlatPipeLpCarve(
+    const rcclx::relay::LpArenaLease& lease,
+    size_t recvcount,
+    size_t directSz,
+    size_t offloadTotal,
+    size_t w,
+    int nActiveRanks) {
+  const size_t A = static_cast<size_t>(nActiveRanks);
+
+  RsFlatLpPlan p{};
+  rcclx::relay::LpArenaCarver carver(lease);
+  p.sendShadow = carver.take(rcclx::relay::lpWireBytes(A * recvcount));
+  p.directRecv = carver.take(rcclx::relay::lpWireBytes((A - 1) * directSz));
+  p.offloadRecv = carver.take(rcclx::relay::lpWireBytes(offloadTotal));
+  p.helper[0] = carver.take(rcclx::relay::lpWireBytes(2 * A * (A - 1) * w));
+  p.valid = carver.ok();
+  return p;
+}
+
+bool rsFlatPipeLpPrepare(
+    bool wantLp,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    size_t recvcount,
+    size_t directSz,
+    size_t offloadTotal,
+    size_t w,
+    int nActiveRanks,
+    RsFlatLpPlan* out) {
+  if (!wantLp) {
+    return false;
+  }
+
+  rcclx::relay::LpArenaLease lease{};
+  if (!rsLpAcquireArena(comm, stream, &lease)) {
+    return false;
+  }
+  if (rsFlatPipeLpRequiredBytes(
+          recvcount, directSz, offloadTotal, w, nActiveRanks) > lease.bytes) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+
+  *out = rsFlatPipeLpCarve(
+      lease, recvcount, directSz, offloadTotal, w, nActiveRanks);
+  if (!out->valid) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+  rcclx::relay::lpRecordEngage();
+  return true;
+}
+
 } // namespace
 
 /**
@@ -3124,7 +3201,8 @@ static ncclResult_t shardedRelayReduceScatterFlatPipelined(
     int numHelpers,
     int nActiveRanksPerGroup,
     int nTiles,
-    size_t elementSize) {
+    size_t elementSize,
+    bool wantLp) {
   const ShardedRelayRankConfig& cfg = configs[0];
   const size_t rc = recvCounts[0];
   const int A = nActiveRanksPerGroup;
@@ -3151,6 +3229,38 @@ static ncclResult_t shardedRelayReduceScatterFlatPipelined(
     return (k < T) ? heavy : (directSz - directOffset(T));
   };
 
+  // =========================================================================
+  // LOW PRECISION: decide, acquire the arena, and quantize the send buffer
+  // =========================================================================
+  // Reached by every rank -- the w == 0 rejection above is the only earlier
+  // exit and it is a pure function of the count, so the ranks agree on it.
+  RsFlatLpPlan lpPlan{};
+  const bool lp = rsFlatPipeLpPrepare(
+      wantLp, comm, stream, rc, directSz, offloadTotal, w, A, &lpPlan);
+  const rcclx::relay::RelayWire wire =
+      rcclx::relay::lpWireFor(datatype, elementSize, lp);
+
+  // One quantize over the whole send buffer, before the first group. Every send
+  // in the pipeline reads a foreign block of it and none is produced mid-call,
+  // so per-tile quantizes would cost T launches for nothing. The own block is
+  // included so a shadow offset is the same number as the caller-buffer offset;
+  // see RsFlatLpPlan.
+  if (lp && myActiveGroup == 0) {
+    DISPATCH_LP_QUANTIZE(
+        datatype,
+        lpPlan.sendShadow,
+        sendBuffs[0],
+        static_cast<size_t>(A) * rc,
+        stream);
+  }
+
+  auto sendFrom = [&](size_t offsetElems) -> const char* {
+    if (lp) {
+      return lpPlan.sendShadow + wire.bytes(offsetElems);
+    }
+    return static_cast<const char*>(sendBuffs[0]) + offsetElems * elementSize;
+  };
+
   // Active-rank scratch, both mirroring the flat path so the closing reduction
   // is identical: dScratch holds the A-1 peer contributions to my direct
   // region, one contiguous directSz block each; oScratch mirrors my output's
@@ -3164,42 +3274,64 @@ static ncclResult_t shardedRelayReduceScatterFlatPipelined(
     isInPlace =
         (static_cast<const void*>(recvBuffs[0]) ==
          static_cast<const void*>(ownBlock));
-    dScratch = ScratchBufferCache::getInstance().get(
-        SHARDED_RELAY_MAX_GROUPS,
-        static_cast<size_t>(A - 1) * directSz * elementSize,
-        stream);
-    oScratch = ScratchBufferCache::getInstance().get(
-        0, offloadTotal * elementSize, stream);
-    if (dScratch == nullptr || oScratch == nullptr) {
-      return ncclInternalError;
+    // Under low precision the arrivals are wire bytes, so lpPlan.directRecv and
+    // lpPlan.offloadRecv stage them instead, in the same two orderings.
+    if (!lp) {
+      dScratch = ScratchBufferCache::getInstance().get(
+          SHARDED_RELAY_MAX_GROUPS,
+          static_cast<size_t>(A - 1) * directSz * elementSize,
+          stream);
+      oScratch = ScratchBufferCache::getInstance().get(
+          0, offloadTotal * elementSize, stream);
+      if (dScratch == nullptr || oScratch == nullptr) {
+        return ncclInternalError;
+      }
     }
   }
+
+  auto directAt = [&](size_t offsetElems) -> char* {
+    if (lp) {
+      return lpPlan.directRecv + wire.bytes(offsetElems);
+    }
+    return static_cast<char*>(dScratch) + offsetElems * elementSize;
+  };
+
+  auto offloadAt = [&](size_t offsetElems) -> char* {
+    if (lp) {
+      return lpPlan.offloadRecv + wire.bytes(offsetElems);
+    }
+    return static_cast<char*>(oScratch) + offsetElems * elementSize;
+  };
 
   // Helper staging: one slot per (owner, contributing source) per ping-pong
   // buffer. Laid out buffer-major so that for a fixed buffer and owner the A-1
   // contributions are contiguous with stride w, which is what the fused
-  // multi-input reduce below requires.
+  // multi-input reduce below requires -- and, under low precision, what lets
+  // the reduce-and-requantize kernel read them from one base.
   char* hbuff = nullptr;
   const size_t slotsPerBuf = static_cast<size_t>(A) * (A - 1);
   if (!cfg.isActiveRank) {
-    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
-        kHelperScratchKeyBase, 2 * slotsPerBuf * w * elementSize, stream));
-    if (hbuff == nullptr) {
-      return ncclInternalError;
+    if (lp) {
+      hbuff = lpPlan.helper[0];
+    } else {
+      hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+          kHelperScratchKeyBase, 2 * slotsPerBuf * w * elementSize, stream));
+      if (hbuff == nullptr) {
+        return ncclInternalError;
+      }
     }
   }
   auto helperSlot = [&](int owner, int t, int k) -> char* {
     return hbuff +
-        ((static_cast<size_t>(k % 2) * slotsPerBuf +
-          static_cast<size_t>(owner) * (A - 1) + static_cast<size_t>(t)) *
-         w) *
-        elementSize;
+        wire.bytes(
+            (static_cast<size_t>(k % 2) * slotsPerBuf +
+             static_cast<size_t>(owner) * (A - 1) + static_cast<size_t>(t)) *
+            w);
   };
 
   for (int k = 0; k <= T; k++) {
     NCCLCHECK(ncclGroupStart());
     if (cfg.isActiveRank) {
-      const char* sendbuff = static_cast<const char*>(sendBuffs[0]);
       const int m = cfg.myActiveIndex;
       const size_t dOff = directOffset(k);
       const size_t dSz = directSize(k);
@@ -3235,10 +3367,9 @@ static ncclResult_t shardedRelayReduceScatterFlatPipelined(
         }
         for (int i = 0; i < dN; i++) {
           NCCLCHECK(ncclSend(
-              sendbuff +
-                  (static_cast<size_t>(j) * rc + dPieceOff(i)) * elementSize,
-              dPieceSz(i),
-              datatype,
+              sendFrom(static_cast<size_t>(j) * rc + dPieceOff(i)),
+              wire.count(dPieceSz(i)),
+              wire.dtype,
               cfg.activeRanks[j],
               comm,
               stream));
@@ -3252,13 +3383,12 @@ static ncclResult_t shardedRelayReduceScatterFlatPipelined(
               continue;
             }
             NCCLCHECK(ncclSend(
-                sendbuff +
-                    (static_cast<size_t>(j) * rc + directSz +
-                     static_cast<size_t>(h) * tileStride +
-                     static_cast<size_t>(k) * w) *
-                        elementSize,
-                w,
-                datatype,
+                sendFrom(
+                    static_cast<size_t>(j) * rc + directSz +
+                    static_cast<size_t>(h) * tileStride +
+                    static_cast<size_t>(k) * w),
+                wire.count(w),
+                wire.dtype,
                 cfg.helperRanks[h],
                 comm,
                 stream));
@@ -3272,11 +3402,9 @@ static ncclResult_t shardedRelayReduceScatterFlatPipelined(
         const int p = (s < m) ? s : s - 1;
         for (int i = 0; i < dN; i++) {
           NCCLCHECK(ncclRecv(
-              static_cast<char*>(dScratch) +
-                  (static_cast<size_t>(p) * directSz + dPieceOff(i)) *
-                      elementSize,
-              dPieceSz(i),
-              datatype,
+              directAt(static_cast<size_t>(p) * directSz + dPieceOff(i)),
+              wire.count(dPieceSz(i)),
+              wire.dtype,
               cfg.activeRanks[s],
               comm,
               stream));
@@ -3287,12 +3415,11 @@ static ncclResult_t shardedRelayReduceScatterFlatPipelined(
         // it.
         for (int h = 0; h < H; h++) {
           NCCLCHECK(ncclRecv(
-              static_cast<char*>(oScratch) +
-                  (static_cast<size_t>(h) * tileStride +
-                   static_cast<size_t>(k - 1) * w) *
-                      elementSize,
-              w,
-              datatype,
+              offloadAt(
+                  static_cast<size_t>(h) * tileStride +
+                  static_cast<size_t>(k - 1) * w),
+              wire.count(w),
+              wire.dtype,
               cfg.helperRanks[h],
               comm,
               stream));
@@ -3310,8 +3437,8 @@ static ncclResult_t shardedRelayReduceScatterFlatPipelined(
             const int t = (s < j) ? s : s - 1;
             NCCLCHECK(ncclRecv(
                 helperSlot(j, t, k),
-                w,
-                datatype,
+                wire.count(w),
+                wire.dtype,
                 cfg.activeRanks[s],
                 comm,
                 stream));
@@ -3322,8 +3449,8 @@ static ncclResult_t shardedRelayReduceScatterFlatPipelined(
         for (int j = 0; j < A; j++) {
           NCCLCHECK(ncclSend(
               helperSlot(j, 0, k - 1),
-              w,
-              datatype,
+              wire.count(w),
+              wire.dtype,
               cfg.activeRanks[j],
               comm,
               stream));
@@ -3333,10 +3460,20 @@ static ncclResult_t shardedRelayReduceScatterFlatPipelined(
     NCCLCHECK(ncclGroupEnd());
 
     // Sum this tile's A-1 contributions per owner, before the next group ships
-    // them. No divisor here: the owner applies it once at the end.
+    // them. No divisor here: the owner applies it once at the end, because this
+    // region does have an active-side closing reduce to defer it to. See
+    // sharded_relay_lp_kernels.h.
     if (!cfg.isActiveRank && k < T) {
       for (int j = 0; j < A; j++) {
         char* dst = helperSlot(j, 0, k);
+        if (lp) {
+          // Wire in, wire out, summed in fp32 and requantized against a fresh
+          // absmax. The A-1 contributions are contiguous from dst at
+          // wire.bytes(w) stride, which is what the buffer-major layout is for.
+          launchLpReduceRequantizeKernel(
+              dst, dst, A - 1, w, /*divisor=*/1, stream);
+          continue;
+        }
         DISPATCH_MULTI_REDUCE(
             datatype, dst, dst + w * elementSize, A - 2, w, 1, stream);
       }
@@ -3350,7 +3487,30 @@ static ncclResult_t shardedRelayReduceScatterFlatPipelined(
     const char* ownBlock = static_cast<const char*>(sendBuffs[0]) +
         static_cast<size_t>(cfg.myActiveIndex) * rc * elementSize;
 
-    if (A == 4 && !isInPlace) {
+    if (lp) {
+      // The divisor lands here for BOTH regions: this is the active-side
+      // closing reduce, and the helper deliberately returned a plain sum.
+      if (isInPlace) {
+        DISPATCH_LP_MULTI_REDUCE(
+            datatype,
+            out,
+            lpPlan.directRecv,
+            A - 1,
+            directSz,
+            reductionDivisor,
+            stream);
+      } else {
+        DISPATCH_LP_SEEDED_MULTI_REDUCE(
+            datatype,
+            out,
+            ownBlock,
+            lpPlan.directRecv,
+            A - 1,
+            directSz,
+            reductionDivisor,
+            stream);
+      }
+    } else if (A == 4 && !isInPlace) {
       DISPATCH_SEEDED_MULTI_REDUCE(
           datatype,
           out,
@@ -3374,7 +3534,30 @@ static ncclResult_t shardedRelayReduceScatterFlatPipelined(
     }
 
     char* oOut = out + directSz * elementSize;
-    if (isInPlace) {
+    if (lp) {
+      // ONE wire contribution: the H reduced tiles are contiguous and already
+      // mirror the output, so wire(offloadTotal) is exactly this span.
+      if (isInPlace) {
+        DISPATCH_LP_MULTI_REDUCE(
+            datatype,
+            oOut,
+            lpPlan.offloadRecv,
+            1,
+            offloadTotal,
+            reductionDivisor,
+            stream);
+      } else {
+        DISPATCH_LP_SEEDED_MULTI_REDUCE(
+            datatype,
+            oOut,
+            ownBlock + directSz * elementSize,
+            lpPlan.offloadRecv,
+            1,
+            offloadTotal,
+            reductionDivisor,
+            stream);
+      }
+    } else if (isInPlace) {
       if (reductionDivisor > 1) {
         DISPATCH_INCREMENTAL_ADD_AND_SCALE(
             datatype, oOut, oScratch, offloadTotal, reductionDivisor, stream);
@@ -3585,10 +3768,10 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
             elementSize)
       : 1;
 
-  // Only the non-pipelined flat schedule carries the wire format so far, so a
-  // pipelined call is reported to the gate as "no LP-capable route selected"
-  // and lands in the Route decline counter rather than declining silently. Safe
-  // because the tile count is a pure function of the counts.
+  // Both flat schedules carry the wire format. The alignment requirement is ONE
+  // wire block, unlike the flat allreduce's A*128: this schedule exchanges its
+  // direct region whole rather than splitting it into A per-owner shards, so
+  // there is no pD/A to keep block-aligned. See RsFlatLpPlan.
   bool wantLpFlat = false;
   if (lowPrecision != 0) {
     wantLpFlat = rcclx::relay::lpEligible(reduceScatterLpGate(
@@ -3597,7 +3780,7 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
         nGroups,
         nActiveRanksPerGroup,
         elementSize,
-        offload && nTiles == 1,
+        offload,
         rcclx::relay::kLpBlockElems));
   }
 
@@ -3615,7 +3798,8 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
         numHelpers,
         nActiveRanksPerGroup,
         nTiles,
-        elementSize);
+        elementSize,
+        wantLpFlat);
   }
   return shardedRelayReduceScatterFlat(
       sendBuffs,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -1360,13 +1360,42 @@ bool rsA2LpGeometryOk(
 }
 
 /**
- * Turn the caller's request into a decision, and carve the buffers if it holds.
+ * The capture and arena preconditions every reduce-scatter LP prepare shares.
+ *
+ * Creating the arena is not capturable: it runs a bootstrap all-gather. Using
+ * one that already exists is fine, so under capture take the path only if the
+ * arena is already up. Same precedent as the one-shot region.
  *
  * COLLECTIVE: lpArenaAcquire() runs a bootstrap unanimity vote on first use, so
  * every rank must reach this whenever the dispatcher's size-only gate said yes
- * -- including the helper ranks, which is why it is called before any role
- * branch. Every reason it can return false is derived from the counts or is
- * already agreed across the communicator, so all ranks decline together.
+ * -- including the helper ranks. Every reason it can return false is derived
+ * from the counts or is already agreed across the communicator, so all ranks
+ * decline together.
+ */
+bool rsLpAcquireArena(
+    ncclComm_t comm,
+    cudaStream_t stream,
+    rcclx::relay::LpArenaLease* lease) {
+  struct ncclCudaGraph graph;
+  if (ncclCudaGetCapturingGraph(&graph, stream) != ncclSuccess) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::GraphCapture);
+    return false;
+  }
+  if (ncclCudaGraphValid(graph) && !rcclx::relay::lpArenaReady(comm)) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::GraphCapture);
+    return false;
+  }
+  if (!rcclx::relay::lpArenaAcquire(comm, lease)) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Turn the caller's request into a decision, and carve the buffers if it holds.
+ *
+ * Called before any role branch, for the reason rsLpAcquireArena() documents.
  */
 bool rsA2LpPrepare(
     bool wantLp,
@@ -1386,22 +1415,8 @@ bool rsA2LpPrepare(
     return false;
   }
 
-  // Creating the arena is not capturable: it runs a bootstrap all-gather. Using
-  // one that already exists is fine, so under capture take the path only if the
-  // arena is already up. Same precedent as the one-shot region.
-  struct ncclCudaGraph graph;
-  if (ncclCudaGetCapturingGraph(&graph, stream) != ncclSuccess) {
-    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::GraphCapture);
-    return false;
-  }
-  if (ncclCudaGraphValid(graph) && !rcclx::relay::lpArenaReady(comm)) {
-    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::GraphCapture);
-    return false;
-  }
-
   rcclx::relay::LpArenaLease lease{};
-  if (!rcclx::relay::lpArenaAcquire(comm, &lease)) {
-    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+  if (!rsLpAcquireArena(comm, stream, &lease)) {
     return false;
   }
   if (rsA2LpRequiredBytes(recvCounts, chunkSizes, nGroups, nActiveRanks) >
@@ -1411,6 +1426,67 @@ bool rsA2LpPrepare(
   }
 
   *out = rsA2LpCarve(lease, recvCounts, chunkSizes, nGroups, nActiveRanks);
+  if (!out->valid) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+  rcclx::relay::lpRecordEngage();
+  return true;
+}
+
+// The same three regions as rsA2LpCarve(), at the pipelined schedule's
+// geometry. Only the helper region differs in shape: the pipelined helper holds
+// two ping-pong units per active source rather than one chunk per source, and
+// nGroups is always 1 here because that is the only shape that pipelines.
+//
+// No geometry predicate is needed. The pipelined schedule already rejects u ==
+// 0 outright, and u is a non-zero multiple of the chunk alignment, so every
+// offset it derives -- region, relay tile, direct chunk -- is a whole number of
+// wire blocks once the count is.
+size_t rsA2PipeLpRequiredBytes(size_t recvcount, size_t u, int nActiveRanks) {
+  return 2 * rsLpAlign(rcclx::relay::lpWireBytes(recvcount)) +
+      rsLpAlign(
+             static_cast<size_t>(nActiveRanks) * 2 *
+             rcclx::relay::lpWireBytes(u));
+}
+
+RsA2LpPlan rsA2PipeLpCarve(
+    const rcclx::relay::LpArenaLease& lease,
+    size_t recvcount,
+    size_t u,
+    int nActiveRanks) {
+  RsA2LpPlan p{};
+  rcclx::relay::LpArenaCarver carver(lease);
+  p.sendShadow = carver.take(rcclx::relay::lpWireBytes(recvcount));
+  p.foreignRecv = carver.take(rcclx::relay::lpWireBytes(recvcount));
+  p.helper[0] = carver.take(
+      static_cast<size_t>(nActiveRanks) * 2 * rcclx::relay::lpWireBytes(u));
+  p.valid = carver.ok();
+  return p;
+}
+
+bool rsA2PipeLpPrepare(
+    bool wantLp,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    size_t recvcount,
+    size_t u,
+    int nActiveRanks,
+    RsA2LpPlan* out) {
+  if (!wantLp) {
+    return false;
+  }
+
+  rcclx::relay::LpArenaLease lease{};
+  if (!rsLpAcquireArena(comm, stream, &lease)) {
+    return false;
+  }
+  if (rsA2PipeLpRequiredBytes(recvcount, u, nActiveRanks) > lease.bytes) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+
+  *out = rsA2PipeLpCarve(lease, recvcount, u, nActiveRanks);
   if (!out->valid) {
     rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
     return false;
@@ -1966,6 +2042,12 @@ static ncclResult_t shardedRelayReduceScatter2Active(
  * The owner's reduce is then issued per region on a side stream as each group
  * completes, rather than as one pass over the whole block at the end -- that
  * tail was 0.61 ms of a 2.64 ms call at 1 GB. See ReduceOverlapCache.
+ *
+ * LOW PRECISION substitutes the wire format at the six boundary-crossing
+ * transfers and changes nothing else. The quantize stays hoisted over the whole
+ * shipped block: per-tile quantizes would cost T launches and, worse, would
+ * race the in-place fold, since region k's reduce can be in flight on the side
+ * stream while region k+1's send source is still being read.
  */
 static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
     const void* const* sendBuffs,
@@ -1979,7 +2061,8 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
     int myActiveGroup,
     int numHelpers,
     int nTiles,
-    size_t elementSize) {
+    size_t elementSize,
+    bool wantLp) {
   const ShardedRelayRankConfig& cfg = configs[0];
   const size_t recvcount = recvCounts[0];
   const int H = numHelpers;
@@ -2013,6 +2096,17 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
     return (k < T) ? u : (recvcount - directOffset(T));
   };
 
+  // =========================================================================
+  // LOW PRECISION: decide and acquire the arena
+  // =========================================================================
+  // Reached by every rank -- the u == 0 rejection above is the only earlier
+  // exit and it is a pure function of the count, so the ranks agree on it.
+  RsA2LpPlan lpPlan{};
+  const bool lp = rsA2PipeLpPrepare(
+      wantLp, comm, stream, recvcount, u, cfg.nActiveRanks, &lpPlan);
+  const rcclx::relay::RelayWire wire =
+      rcclx::relay::lpWireFor(datatype, elementSize, lp);
+
   // Scratch mirroring the output block, so a region's reduce is one launch.
   void* foreignScratch = nullptr;
   size_t ownBlockOffset = 0;
@@ -2026,33 +2120,103 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
     isInPlace =
         (static_cast<const void*>(recvBuffs[0]) ==
          static_cast<const void*>(ownBlock));
-    foreignScratch = ScratchBufferCache::getInstance().get(
-        SHARDED_RELAY_MAX_GROUPS, recvcount * elementSize, stream);
-    if (foreignScratch == nullptr) {
-      return ncclInternalError;
+    // Under low precision the arrivals are wire bytes, so lpPlan.foreignRecv --
+    // laid out to mirror this same output-block ordering -- stages them and the
+    // per-region reduces read them from there.
+    if (!lp) {
+      foreignScratch = ScratchBufferCache::getInstance().get(
+          SHARDED_RELAY_MAX_GROUPS, recvcount * elementSize, stream);
+      if (foreignScratch == nullptr) {
+        return ncclInternalError;
+      }
     }
   }
 
-  // Helper staging: two ping-pong units per active source.
+  // One quantize over the whole shipped block, before the first group. Every
+  // send in the pipeline reads this one block, so per-tile quantizes would cost
+  // T launches for nothing -- and would race the in-place fold, since tile k's
+  // reduce can be in flight while tile k+1's send source is still being read.
+  if (lp && myActiveGroup == 0) {
+    DISPATCH_LP_QUANTIZE(
+        datatype,
+        lpPlan.sendShadow,
+        static_cast<const char*>(sendBuffs[0]) + sendBlockOffset * elementSize,
+        recvcount,
+        stream);
+  }
+
+  // Where a send reads from and where its counterpart lands. Offsets stay in
+  // ELEMENTS, relative to the shipped block and the output block, on both
+  // paths.
+  auto sendFrom = [&](size_t offsetElems) -> const char* {
+    if (lp) {
+      return lpPlan.sendShadow + wire.bytes(offsetElems);
+    }
+    return static_cast<const char*>(sendBuffs[0]) +
+        (sendBlockOffset + offsetElems) * elementSize;
+  };
+
+  auto foreignAt = [&](size_t offsetElems) -> char* {
+    if (lp) {
+      return lpPlan.foreignRecv + wire.bytes(offsetElems);
+    }
+    return static_cast<char*>(foreignScratch) + offsetElems * elementSize;
+  };
+
+  // Helper staging: two ping-pong units per active source. Under low precision
+  // this comes from the arena in wire bytes; the helper still only forwards
+  // bytes, so unlike allreduce's pipelined helper it needs no relayout -- there
+  // is nothing here that has to see two slots as one contiguous run.
   char* hbuff = nullptr;
   if (!cfg.isActiveRank) {
-    hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
-        kHelperScratchKeyBase,
-        static_cast<size_t>(cfg.nActiveRanks) * 2 * u * elementSize,
-        stream));
-    if (hbuff == nullptr) {
-      return ncclInternalError;
+    if (lp) {
+      hbuff = lpPlan.helper[0];
+    } else {
+      hbuff = static_cast<char*>(ScratchBufferCache::getInstance().get(
+          kHelperScratchKeyBase,
+          static_cast<size_t>(cfg.nActiveRanks) * 2 * u * elementSize,
+          stream));
+      if (hbuff == nullptr) {
+        return ncclInternalError;
+      }
     }
   }
   auto helperSlot = [&](int a, int k) -> char* {
     return hbuff +
-        (static_cast<size_t>(a) * 2 + static_cast<size_t>(k % 2)) * u *
-        elementSize;
+        wire.bytes(
+            (static_cast<size_t>(a) * 2 + static_cast<size_t>(k % 2)) * u);
   };
 
-  // out[span] = (own[span] + scratch[span]) / divisor.
-  auto reduceSpan = [&](size_t off, size_t sz, cudaStream_t s) {
+  // out[span] = (own[span] + foreign[span]) / divisor.
+  //
+  // Returns a result because the low-precision dispatch aborts an unsupported
+  // dtype rather than silently doing nothing, so both call sites check it.
+  auto reduceSpan = [&](size_t off, size_t sz, cudaStream_t s) -> ncclResult_t {
     char* out = static_cast<char*>(recvBuffs[0]) + off * elementSize;
+    if (lp) {
+      // ONE wire contribution: the partner's whole contribution to this span,
+      // relayed and direct pieces alike, accumulated in fp32. The divisor lands
+      // here and only here -- this collective's helper is a pure relay, so this
+      // is the schedule's only reduce. See the closing reduce in
+      // shardedRelayReduceScatter2Active for why that differs from allreduce.
+      const char* wireIn = lpPlan.foreignRecv + wire.bytes(off);
+      if (isInPlace) {
+        DISPATCH_LP_MULTI_REDUCE(
+            datatype, out, wireIn, 1, sz, reductionDivisor, s);
+      } else {
+        DISPATCH_LP_SEEDED_MULTI_REDUCE(
+            datatype,
+            out,
+            static_cast<const char*>(sendBuffs[0]) +
+                (ownBlockOffset + off) * elementSize,
+            wireIn,
+            1,
+            sz,
+            reductionDivisor,
+            s);
+      }
+      return ncclSuccess;
+    }
     const char* scratch =
         static_cast<const char*>(foreignScratch) + off * elementSize;
     if (isInPlace) {
@@ -2073,6 +2237,7 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
           reductionDivisor,
           s);
     }
+    return ncclSuccess;
   };
 
   // Per-region reduces run on a side stream so they overlap the transfers that
@@ -2111,9 +2276,6 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
     for (int k = 0; k <= T; k++) {
       NCCLCHECK(ncclGroupStart());
       if (cfg.isActiveRank) {
-        const char* sendBlock = static_cast<const char*>(sendBuffs[0]) +
-            sendBlockOffset * elementSize;
-        char* scratch = static_cast<char*>(foreignScratch);
         const int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
         const size_t dOff = directOffset(k);
         const size_t dSz = directSize(k);
@@ -2121,36 +2283,36 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
         if (k < T) {
           for (int h = 0; h < H; h++) {
             NCCLCHECK(ncclSend(
-                sendBlock + relayOffset(h, k) * elementSize,
-                u,
-                datatype,
+                sendFrom(relayOffset(h, k)),
+                wire.count(u),
+                wire.dtype,
                 cfg.helperRanks[h],
                 comm,
                 stream));
           }
         }
         NCCLCHECK(ncclSend(
-            sendBlock + dOff * elementSize,
-            dSz,
-            datatype,
+            sendFrom(dOff),
+            wire.count(dSz),
+            wire.dtype,
             partner,
             comm,
             stream));
         if (k > 0) {
           for (int h = 0; h < H; h++) {
             NCCLCHECK(ncclRecv(
-                scratch + relayOffset(h, k - 1) * elementSize,
-                u,
-                datatype,
+                foreignAt(relayOffset(h, k - 1)),
+                wire.count(u),
+                wire.dtype,
                 cfg.helperRanks[h],
                 comm,
                 stream));
           }
         }
         NCCLCHECK(ncclRecv(
-            scratch + dOff * elementSize,
-            dSz,
-            datatype,
+            foreignAt(dOff),
+            wire.count(dSz),
+            wire.dtype,
             partner,
             comm,
             stream));
@@ -2159,8 +2321,8 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
           for (int a = 0; a < cfg.nActiveRanks; a++) {
             NCCLCHECK(ncclRecv(
                 helperSlot(a, k),
-                u,
-                datatype,
+                wire.count(u),
+                wire.dtype,
                 cfg.activeRanks[a],
                 comm,
                 stream));
@@ -2170,8 +2332,8 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
           for (int a = 0; a < cfg.nActiveRanks; a++) {
             NCCLCHECK(ncclSend(
                 helperSlot(a, k - 1),
-                u,
-                datatype,
+                wire.count(u),
+                wire.dtype,
                 cfg.activeRanks[1 - a],
                 comm,
                 stream));
@@ -2188,7 +2350,7 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
         // The wait is what attaches the side stream, so the join is owed from
         // here on -- not from the record, which on its own leaves it detached.
         forked = true;
-        reduceSpan(regionOffset(k), regionSize(k), ovl->stream);
+        NCCLCHECK(reduceSpan(regionOffset(k), regionSize(k), ovl->stream));
       }
     }
     return ncclSuccess;
@@ -2212,7 +2374,7 @@ static ncclResult_t shardedRelayReduceScatter2ActivePipelined(
   }
   if (ovl == nullptr && ownerReduces) {
     // Fallback: one pass over the whole output block on the caller's stream.
-    reduceSpan(0, recvcount, stream);
+    NCCLCHECK(reduceSpan(0, recvcount, stream));
   }
 
   return ncclSuccess;
@@ -3073,12 +3235,9 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
         : 1;
 
     // The caller's request narrowed by the size-only gate, so every rank
-    // reaches the same answer without communicating. Only the non-pipelined
-    // 2-active schedule carries the wire format so far, so a pipelined call is
-    // reported to the gate as "no LP-capable route selected" and lands in the
-    // Route decline counter rather than declining silently. That is safe
-    // precisely because the tile count is a pure function of the counts -- a
-    // per-rank disagreement here would be a hang, not a slowdown.
+    // reaches the same answer without communicating. Both 2-active schedules
+    // carry the wire format; the flat schedules still decline, identically on
+    // every rank since that condition is nActiveRanksPerGroup.
     bool wantLp = false;
     if (lowPrecision != 0) {
       wantLp = rcclx::relay::lpEligible(reduceScatterLpGate(
@@ -3087,7 +3246,7 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
           nGroups,
           nActiveRanksPerGroup,
           elementSize,
-          route == rcclx::relay::ReduceScatterRoute::A2Relay && nTiles == 1,
+          route == rcclx::relay::ReduceScatterRoute::A2Relay,
           rcclx::relay::kLpBlockElems));
     }
     if (nTiles > 1) {
@@ -3103,7 +3262,8 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
           myActiveGroup,
           numHelpers,
           nTiles,
-          elementSize);
+          elementSize,
+          wantLp);
     }
     return shardedRelayReduceScatter2Active(
         sendBuffs2,

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -10,6 +10,9 @@
 #include "comm.h"
 #include "sharded_relay_allreduce_kernels.h"
 #include "sharded_relay_graph_scratch.h"
+#include "sharded_relay_lp.h"
+#include "sharded_relay_lp_arena.h"
+#include "sharded_relay_lp_kernels.h"
 #include "sharded_relay_oneshot.h"
 #include "sharded_relay_route.h"
 
@@ -1139,6 +1142,66 @@ static bool tryOneShotReduceScatter(
     }                                                                          \
   } while (0)
 
+// =========================================================================
+// LOW-PRECISION DISPATCH
+// =========================================================================
+// Only bf16 and fp32 appear here, because lpDtypeSupported() admits only those
+// and the gate declines everything else back to full precision. The `default:`
+// arm is therefore unreachable rather than a silent fallthrough; it aborts the
+// call instead of returning ncclSuccess having quantized nothing, which is how
+// a gate bug surfaces as an error rather than as wrong numbers.
+//
+// Deliberately a copy of the allreduce TU's macros, for the same reason the
+// rest of the infra in this file is: they are file-local there and cannot be
+// linked across translation units.
+#define DISPATCH_LP(datatype, CALL, ...)                                                                      \
+  do {                                                                                                        \
+    switch (datatype) {                                                                                       \
+      case ncclFloat32:                                                                                       \
+        CALL<float>(__VA_ARGS__);                                                                             \
+        break;                                                                                                \
+      case ncclBfloat16:                                                                                      \
+        CALL<__nv_bfloat16>(__VA_ARGS__);                                                                     \
+        break;                                                                                                \
+      default:                                                                                                \
+        WARN(                                                                                                 \
+            "Sharded relay: low precision reached an unsupported datatype %d; the eligibility gate is wrong", \
+            static_cast<int>(datatype));                                                                      \
+        return ncclInternalError;                                                                             \
+    }                                                                                                         \
+  } while (0)
+
+#define DISPATCH_LP_QUANTIZE(datatype, wireOut, in, count, stream) \
+  DISPATCH_LP(datatype, launchLpQuantizeKernel, wireOut, in, count, stream)
+
+#define DISPATCH_LP_DEQUANTIZE(datatype, out, wireIn, count, stream) \
+  DISPATCH_LP(datatype, launchLpDequantizeKernel, out, wireIn, count, stream)
+
+#define DISPATCH_LP_MULTI_REDUCE(                           \
+    datatype, dst, wireContribs, n, count, divisor, stream) \
+  DISPATCH_LP(                                              \
+      datatype,                                             \
+      launchLpMultiReduceKernel,                            \
+      dst,                                                  \
+      wireContribs,                                         \
+      n,                                                    \
+      count,                                                \
+      divisor,                                              \
+      stream)
+
+#define DISPATCH_LP_SEEDED_MULTI_REDUCE(                          \
+    datatype, dst, seed, wireContribs, n, count, divisor, stream) \
+  DISPATCH_LP(                                                    \
+      datatype,                                                   \
+      launchLpSeededMultiReduceKernel,                            \
+      dst,                                                        \
+      seed,                                                       \
+      wireContribs,                                               \
+      n,                                                          \
+      count,                                                      \
+      divisor,                                                    \
+      stream)
+
 namespace {
 
 // The DISPATCH_* macros above instantiate reduce kernels for exactly these
@@ -1168,6 +1231,194 @@ bool isSupportedRelayDataType(ncclDataType_t datatype) {
   }
 }
 
+/**
+ * The wire buffers one 2-active reduce-scatter call needs, carved from the
+ * communicator's low-precision arena.
+ *
+ * Only THREE regions, and no mid-call producer among them: unlike the flat
+ * allreduce, every reduce-scatter send reads the block this rank ships to its
+ * partner, which exists in full before the first ncclGroupStart(). So one
+ * hoisted quantize over that block covers the relayed chunks and both direct
+ * chunks, and nothing has to be re-quantized between groups.
+ *
+ * Every region is carved UNCONDITIONALLY and at the WORST CASE over all groups,
+ * even though a rank is active for exactly one group and a helper for the rest.
+ * That is deliberate on two counts. It makes the partition byte-identical on
+ * every rank and on every call with the same geometry, which is what lets a
+ * captured graph replay against the same addresses. And it makes the footprint
+ * a function of the counts alone, so the capacity check below is
+ * rank-independent -- a rank that sized its own roles would decline on a
+ * different set of calls than its peers, and low precision has to be unanimous
+ * or the two disagree on wire byte counts and the call hangs.
+ */
+struct RsA2LpPlan {
+  // wire(recvCount): the whole block shipped to the other active rank.
+  char* sendShadow{nullptr};
+  // wire(recvCount): mirrors foreignScratch, which mirrors the output block.
+  char* foreignRecv{nullptr};
+  char* helper[SHARDED_RELAY_MAX_GROUPS]{};
+  bool valid{false};
+};
+
+// The size-and-dtype half of the gate, in one place so the dispatcher cannot
+// accidentally feed it a different size metric than the route selector uses.
+rcclx::relay::LpGateInputs reduceScatterLpGate(
+    ncclDataType_t datatype,
+    const size_t* recvCounts,
+    int nGroups,
+    int nActiveRanksPerGroup,
+    size_t elementSize,
+    bool relayRouteSelected,
+    size_t countAlignElems) {
+  rcclx::relay::LpGateInputs in;
+  in.coll = rcclx::relay::LpCollective::ReduceScatter;
+  in.datatype = datatype;
+  in.counts = recvCounts;
+  in.nGroups = nGroups;
+  in.nActiveRanksPerGroup = nActiveRanksPerGroup;
+  // nActiveRanksPerGroup * max(recvCount) * elementSize is exactly
+  // selectReduceScatterRoute()'s metric (the bench's per-rank input label), so
+  // the low-precision threshold and the route threshold are directly
+  // comparable.
+  in.routeSizeBytes = static_cast<size_t>(nActiveRanksPerGroup) *
+      rcclx::relay::relayMaxCount(recvCounts, nGroups) * elementSize;
+  in.relayRouteSelected = relayRouteSelected;
+  in.countAlignElems = countAlignElems;
+  return in;
+}
+
+size_t rsLpAlign(size_t bytes) {
+  return ((bytes + rcclx::relay::LpArenaCarver::kAlign - 1) /
+          rcclx::relay::LpArenaCarver::kAlign) *
+      rcclx::relay::LpArenaCarver::kAlign;
+}
+
+// Bytes one call needs, derived only from the counts and the chunk geometry
+// (which is itself derived only from the counts), so every rank computes the
+// same number.
+size_t rsA2LpRequiredBytes(
+    const size_t* recvCounts,
+    const size_t* chunkSizes,
+    int nGroups,
+    int nActiveRanks) {
+  const size_t maxCount = rcclx::relay::relayMaxCount(recvCounts, nGroups);
+  const size_t maxChunk = rcclx::relay::relayMaxCount(chunkSizes, nGroups);
+  size_t total = rsLpAlign(rcclx::relay::lpWireBytes(maxCount)) +
+      rsLpAlign(rcclx::relay::lpWireBytes(maxCount));
+  total += static_cast<size_t>(nGroups) *
+      rsLpAlign(
+               static_cast<size_t>(nActiveRanks) *
+               rcclx::relay::lpWireBytes(maxChunk));
+  return total;
+}
+
+RsA2LpPlan rsA2LpCarve(
+    const rcclx::relay::LpArenaLease& lease,
+    const size_t* recvCounts,
+    const size_t* chunkSizes,
+    int nGroups,
+    int nActiveRanks) {
+  const size_t maxCount = rcclx::relay::relayMaxCount(recvCounts, nGroups);
+  const size_t maxChunk = rcclx::relay::relayMaxCount(chunkSizes, nGroups);
+
+  RsA2LpPlan p{};
+  rcclx::relay::LpArenaCarver carver(lease);
+  p.sendShadow = carver.take(rcclx::relay::lpWireBytes(maxCount));
+  p.foreignRecv = carver.take(rcclx::relay::lpWireBytes(maxCount));
+  for (int g = 0; g < nGroups; g++) {
+    p.helper[g] = carver.take(
+        static_cast<size_t>(nActiveRanks) *
+        rcclx::relay::lpWireBytes(maxChunk));
+  }
+  p.valid = carver.ok();
+  return p;
+}
+
+/**
+ * Every region boundary this schedule sends or receives at is a whole number of
+ * wire blocks.
+ *
+ * 128-aligned per-group counts (what lpEligible() checks) make ownBlockOffset,
+ * sendBlockOffset, relayTotal, dirA and dirB aligned -- but ONLY when the
+ * aligned chunk size is non-zero. In the chunkSize == 0 degenerate case the
+ * geometry falls back to splitting the block in half, and count / 2 is a
+ * multiple of 64, not of 128. Today's crossover keeps low precision far above
+ * that regime, so this never fires; it is checked rather than assumed so that
+ * lowering lpMinBytes() during tuning cannot silently produce unaligned wire
+ * offsets. Pure function of the counts, so every rank declines together.
+ */
+bool rsA2LpGeometryOk(
+    const size_t* recvCounts,
+    const size_t* chunkSizes,
+    int nGroups) {
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] > 0 && chunkSizes[g] == 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Turn the caller's request into a decision, and carve the buffers if it holds.
+ *
+ * COLLECTIVE: lpArenaAcquire() runs a bootstrap unanimity vote on first use, so
+ * every rank must reach this whenever the dispatcher's size-only gate said yes
+ * -- including the helper ranks, which is why it is called before any role
+ * branch. Every reason it can return false is derived from the counts or is
+ * already agreed across the communicator, so all ranks decline together.
+ */
+bool rsA2LpPrepare(
+    bool wantLp,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const size_t* recvCounts,
+    const size_t* chunkSizes,
+    int nGroups,
+    int nActiveRanks,
+    RsA2LpPlan* out) {
+  if (!wantLp) {
+    return false;
+  }
+
+  if (!rsA2LpGeometryOk(recvCounts, chunkSizes, nGroups)) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Alignment);
+    return false;
+  }
+
+  // Creating the arena is not capturable: it runs a bootstrap all-gather. Using
+  // one that already exists is fine, so under capture take the path only if the
+  // arena is already up. Same precedent as the one-shot region.
+  struct ncclCudaGraph graph;
+  if (ncclCudaGetCapturingGraph(&graph, stream) != ncclSuccess) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::GraphCapture);
+    return false;
+  }
+  if (ncclCudaGraphValid(graph) && !rcclx::relay::lpArenaReady(comm)) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::GraphCapture);
+    return false;
+  }
+
+  rcclx::relay::LpArenaLease lease{};
+  if (!rcclx::relay::lpArenaAcquire(comm, &lease)) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+  if (rsA2LpRequiredBytes(recvCounts, chunkSizes, nGroups, nActiveRanks) >
+      lease.bytes) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+
+  *out = rsA2LpCarve(lease, recvCounts, chunkSizes, nGroups, nActiveRanks);
+  if (!out->valid) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+  rcclx::relay::lpRecordEngage();
+  return true;
+}
+
 } // namespace
 
 /**
@@ -1194,6 +1445,14 @@ bool isSupportedRelayDataType(ncclDataType_t datatype) {
  * reduce-scatter in-place convention). In that case recvBuff already holds the
  * local contribution (no seeding copy) and the direct chunk is reduced via a
  * scratch buffer to avoid overwriting the local data before it is read.
+ *
+ * LOW PRECISION, when `wantLp` survives rsA2LpPrepare(), substitutes the wire
+ * format at each of the twelve boundary-crossing transfers and changes nothing
+ * else -- same groups, same chunk geometry, same op counts. It is the cheapest
+ * of the four collectives to carry, because every send reads the ONE block
+ * shipped to the partner (so a single hoisted quantize covers all of them) and
+ * every arrival lands in a buffer that already mirrors the output block (so the
+ * single fused closing reduce stays a single launch).
  */
 static constexpr int kHelperScratchKeyBase = SHARDED_RELAY_MAX_GROUPS + 1;
 
@@ -1209,7 +1468,8 @@ static ncclResult_t shardedRelayReduceScatter2Active(
     int myActiveGroup,
     int numHelpers,
     int nGroups,
-    size_t elementSize) {
+    size_t elementSize,
+    bool wantLp) {
   // ==========================================================================
   // SIZE-ADAPTIVE PURE-DIRECT FAST PATH (A==2)
   // ==========================================================================
@@ -1378,6 +1638,25 @@ static ncclResult_t shardedRelayReduceScatter2Active(
   }
 
   // =========================================================================
+  // LOW PRECISION: decide and acquire the arena
+  // =========================================================================
+  // Collective: every rank reaches rsA2LpPrepare() when the dispatcher's
+  // size-only gate said yes, and every way it can decline is agreed across the
+  // communicator, so all ranks run the same wire format or none do.
+  RsA2LpPlan lpPlan{};
+  const bool lp = rsA2LpPrepare(
+      wantLp,
+      comm,
+      stream,
+      recvCounts,
+      chunkSizes,
+      nGroups,
+      configs[0].nActiveRanks,
+      &lpPlan);
+  const rcclx::relay::RelayWire wire =
+      rcclx::relay::lpWireFor(datatype, elementSize, lp);
+
+  // =========================================================================
   // SCRATCH: the whole foreign contribution to my output block, contiguous
   // =========================================================================
   // One recvCount-element buffer laid out exactly like the output block: the
@@ -1401,12 +1680,52 @@ static ncclResult_t shardedRelayReduceScatter2Active(
         (static_cast<const void*>(recvBuffs[myActiveGroup]) ==
          static_cast<const void*>(ownBlock));
 
-    foreignScratch = ScratchBufferCache::getInstance().get(
-        SHARDED_RELAY_MAX_GROUPS, recvcount * elementSize, stream);
-    if (foreignScratch == nullptr) {
-      return ncclInternalError;
+    // Under low precision the arrivals are wire bytes, so lpPlan.foreignRecv --
+    // laid out to mirror this same output-block ordering -- stages them instead
+    // and the closing reduce reads them from there.
+    if (!lp) {
+      foreignScratch = ScratchBufferCache::getInstance().get(
+          SHARDED_RELAY_MAX_GROUPS, recvcount * elementSize, stream);
+      if (foreignScratch == nullptr) {
+        return ncclInternalError;
+      }
     }
   }
+
+  // One quantize over the ENTIRE boundary-crossing send region, before the
+  // first ncclGroupStart. That region is exactly the block shipped to the other
+  // active rank: the relayed chunks cover [0, relayTotal) of it and the two
+  // direct chunks cover [relayTotal, recvCount). Nothing produces a send source
+  // mid-call here -- every send reads this one block -- so a single launch
+  // suffices, unlike the flat allreduce.
+  if (lp && myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0) {
+    DISPATCH_LP_QUANTIZE(
+        datatype,
+        lpPlan.sendShadow,
+        static_cast<const char*>(sendBuffs[myActiveGroup]) +
+            sendBlockOffset * elementSize,
+        recvCounts[myActiveGroup],
+        stream);
+  }
+
+  // Where a boundary-crossing send reads from, and where its counterpart lands.
+  // Offsets are in ELEMENTS of the caller's dtype and relative to the shipped
+  // block / the output block on both paths, which is what keeps every call site
+  // below unchanged in shape.
+  auto sendFrom = [&](int g, size_t offsetElems) -> const char* {
+    if (lp) {
+      return lpPlan.sendShadow + wire.bytes(offsetElems);
+    }
+    return static_cast<const char*>(sendBuffs[g]) +
+        (sendBlockOffset + offsetElems) * elementSize;
+  };
+
+  auto foreignAt = [&](size_t offsetElems) -> char* {
+    if (lp) {
+      return lpPlan.foreignRecv + wire.bytes(offsetElems);
+    }
+    return static_cast<char*>(foreignScratch) + offsetElems * elementSize;
+  };
 
   // Helper staging is kernel-owned scratch: callers pass a placeholder buffer
   // for groups where they are a helper. Each helper group holds nActiveRanks
@@ -1415,6 +1734,13 @@ static ncclResult_t shardedRelayReduceScatter2Active(
   for (int g = 0; g < nGroups; g++) {
     const ShardedRelayRankConfig& cfg = configs[g];
     if (!cfg.isActiveRank && recvCounts[g] > 0 && chunkSizes[g] > 0) {
+      if (lp) {
+        // Already carved, and in wire bytes: the helper forwards wire blocks
+        // without ever learning the caller's dtype. It does not reduce them
+        // either -- see the schedule comment.
+        helperScratch[g] = lpPlan.helper[g];
+        continue;
+      }
       size_t needBytes =
           static_cast<size_t>(cfg.nActiveRanks) * chunkSizes[g] * elementSize;
       helperScratch[g] = ScratchBufferCache::getInstance().get(
@@ -1438,15 +1764,11 @@ static ncclResult_t shardedRelayReduceScatter2Active(
     size_t chunkSize = chunkSizes[g];
 
     if (cfg.isActiveRank) {
-      // The block shipped to the other active rank.
-      const char* sendBlock = static_cast<const char*>(sendBuffs[g]) +
-          sendBlockOffset * elementSize;
-
       for (int h = 0; h < cfg.numHelpers && chunkSize > 0; h++) {
         NCCLCHECK(ncclSend(
-            sendBlock + static_cast<size_t>(h) * chunkSize * elementSize,
-            chunkSize,
-            datatype,
+            sendFrom(g, static_cast<size_t>(h) * chunkSize),
+            wire.count(chunkSize),
+            wire.dtype,
             cfg.helperRanks[h],
             comm,
             stream));
@@ -1456,16 +1778,16 @@ static ncclResult_t shardedRelayReduceScatter2Active(
       int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
       if (dirASizes[g] > 0) {
         NCCLCHECK(ncclSend(
-            sendBlock + relayTotals[g] * elementSize,
-            dirASizes[g],
-            datatype,
+            sendFrom(g, relayTotals[g]),
+            wire.count(dirASizes[g]),
+            wire.dtype,
             partner,
             comm,
             stream));
         NCCLCHECK(ncclRecv(
-            static_cast<char*>(foreignScratch) + relayTotals[g] * elementSize,
-            dirASizes[g],
-            datatype,
+            foreignAt(relayTotals[g]),
+            wire.count(dirASizes[g]),
+            wire.dtype,
             partner,
             comm,
             stream));
@@ -1475,9 +1797,9 @@ static ncclResult_t shardedRelayReduceScatter2Active(
       char* helperBuf = static_cast<char*>(helperScratch[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {
         NCCLCHECK(ncclRecv(
-            helperBuf + static_cast<size_t>(a) * chunkSize * elementSize,
-            chunkSize,
-            datatype,
+            helperBuf + wire.bytes(static_cast<size_t>(a) * chunkSize),
+            wire.count(chunkSize),
+            wire.dtype,
             cfg.activeRanks[a],
             comm,
             stream));
@@ -1500,13 +1822,11 @@ static ncclResult_t shardedRelayReduceScatter2Active(
     size_t chunkSize = chunkSizes[g];
 
     if (cfg.isActiveRank) {
-      char* scratch = static_cast<char*>(foreignScratch);
-
       for (int h = 0; h < cfg.numHelpers && chunkSize > 0; h++) {
         NCCLCHECK(ncclRecv(
-            scratch + static_cast<size_t>(h) * chunkSize * elementSize,
-            chunkSize,
-            datatype,
+            foreignAt(static_cast<size_t>(h) * chunkSize),
+            wire.count(chunkSize),
+            wire.dtype,
             cfg.helperRanks[h],
             comm,
             stream));
@@ -1516,29 +1836,30 @@ static ncclResult_t shardedRelayReduceScatter2Active(
       int partner = cfg.activeRanks[1 - cfg.myActiveIndex];
       if (dirBSizes[g] > 0) {
         NCCLCHECK(ncclSend(
-            static_cast<const char*>(sendBuffs[g]) +
-                (sendBlockOffset + dirBOffsets[g]) * elementSize,
-            dirBSizes[g],
-            datatype,
+            sendFrom(g, dirBOffsets[g]),
+            wire.count(dirBSizes[g]),
+            wire.dtype,
             partner,
             comm,
             stream));
         NCCLCHECK(ncclRecv(
-            scratch + dirBOffsets[g] * elementSize,
-            dirBSizes[g],
-            datatype,
+            foreignAt(dirBOffsets[g]),
+            wire.count(dirBSizes[g]),
+            wire.dtype,
             partner,
             comm,
             stream));
       }
     } else if (chunkSize > 0) {
-      // Passthrough: slot a goes to the OTHER active rank, which owns it.
+      // Passthrough: slot a goes to the OTHER active rank, which owns it. Still
+      // a pure byte forward under low precision -- the helper never reduces
+      // here, so it never has to interpret what it is carrying.
       const char* helperBuf = static_cast<const char*>(helperScratch[g]);
       for (int a = 0; a < cfg.nActiveRanks; a++) {
         NCCLCHECK(ncclSend(
-            helperBuf + static_cast<size_t>(a) * chunkSize * elementSize,
-            chunkSize,
-            datatype,
+            helperBuf + wire.bytes(static_cast<size_t>(a) * chunkSize),
+            wire.count(chunkSize),
+            wire.dtype,
             cfg.activeRanks[1 - a],
             comm,
             stream));
@@ -1556,7 +1877,35 @@ static ncclResult_t shardedRelayReduceScatter2Active(
   if (myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0) {
     size_t recvcount = recvCounts[myActiveGroup];
     void* out = recvBuffs[myActiveGroup];
-    if (isInPlace) {
+    if (lp) {
+      // ONE wire contribution -- the partner's whole contribution to my output
+      // block, relayed and direct chunks together -- folded against my own,
+      // accumulated in fp32. The divisor lands HERE and nowhere else: the
+      // helper is a pure relay for this collective, so this is the only reduce
+      // in the schedule. Do NOT port the allreduce's divisor-at-the-helper
+      // reasoning across; there the helper reduces and this one does not.
+      if (isInPlace) {
+        DISPATCH_LP_MULTI_REDUCE(
+            datatype,
+            out,
+            lpPlan.foreignRecv,
+            1,
+            recvcount,
+            reductionDivisor,
+            stream);
+      } else {
+        DISPATCH_LP_SEEDED_MULTI_REDUCE(
+            datatype,
+            out,
+            static_cast<const char*>(sendBuffs[myActiveGroup]) +
+                ownBlockOffset * elementSize,
+            lpPlan.foreignRecv,
+            1,
+            recvcount,
+            reductionDivisor,
+            stream);
+      }
+    } else if (isInPlace) {
       if (reductionDivisor > 1) {
         DISPATCH_INCREMENTAL_ADD_AND_SCALE(
             datatype, out, foreignScratch, recvcount, reductionDivisor, stream);
@@ -2625,9 +2974,6 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
     int nActiveRanksPerGroup,
     int nGroups,
     int lowPrecision) {
-  // Accepted and ignored: the wire-format substitution lands in a later commit,
-  // so this commit cannot change behaviour.
-  (void)lowPrecision;
   int nRanks, rank;
   NCCLCHECK(ncclCommCount(comm, &nRanks));
   NCCLCHECK(ncclCommUserRank(comm, &rank));
@@ -2715,15 +3061,35 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
     // software-pipelined into one duplex stream. relayPipelineTiles() returns
     // 1 whenever that does not apply, and the small-message pure-direct route
     // (owned by shardedRelayReduceScatter2Active) never pipelines.
-    const int nTiles = (rcclx::relay::selectReduceScatterRoute(
-                            2, numHelpers, nGroups, recvCounts, elementSize) ==
-                        rcclx::relay::ReduceScatterRoute::A2Relay)
+    const rcclx::relay::ReduceScatterRoute route =
+        rcclx::relay::selectReduceScatterRoute(
+            2, numHelpers, nGroups, recvCounts, elementSize);
+    const int nTiles = (route == rcclx::relay::ReduceScatterRoute::A2Relay)
         ? rcclx::relay::relayPipelineTiles(
               nGroups,
               rcclx::relay::relayShapeA2(numHelpers),
               rcclx::relay::relayMaxCount(recvCounts, nGroups),
               elementSize)
         : 1;
+
+    // The caller's request narrowed by the size-only gate, so every rank
+    // reaches the same answer without communicating. Only the non-pipelined
+    // 2-active schedule carries the wire format so far, so a pipelined call is
+    // reported to the gate as "no LP-capable route selected" and lands in the
+    // Route decline counter rather than declining silently. That is safe
+    // precisely because the tile count is a pure function of the counts -- a
+    // per-rank disagreement here would be a hang, not a slowdown.
+    bool wantLp = false;
+    if (lowPrecision != 0) {
+      wantLp = rcclx::relay::lpEligible(reduceScatterLpGate(
+          datatype,
+          recvCounts,
+          nGroups,
+          nActiveRanksPerGroup,
+          elementSize,
+          route == rcclx::relay::ReduceScatterRoute::A2Relay && nTiles == 1,
+          rcclx::relay::kLpBlockElems));
+    }
     if (nTiles > 1) {
       return shardedRelayReduceScatter2ActivePipelined(
           sendBuffs2,
@@ -2751,12 +3117,17 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
         myActiveGroup,
         numHelpers,
         nGroups,
-        elementSize);
+        elementSize,
+        wantLp);
   }
   // A>2: two-group flat relay with reduce-at-helper woven with a direct
   // all-to-all reduce-scatter over the intra links. A single-group call with
   // the offload enabled can additionally be software-pipelined so the scatter
   // and the reduced return share each cross link's two directions.
+  //
+  // Neither flat schedule carries the wire format yet, so low precision is
+  // declined here -- identically on every rank, since the condition is
+  // nActiveRanksPerGroup.
   const bool offload =
       rcclx::relay::selectReduceScatterRoute(
           nActiveRanksPerGroup, numHelpers, nGroups, recvCounts, elementSize) ==

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc
@@ -1495,6 +1495,161 @@ bool rsA2PipeLpPrepare(
   return true;
 }
 
+/**
+ * The wire buffers one flat (A>2) reduce-scatter call needs.
+ *
+ * Four regions, because this schedule has two independent landing areas -- the
+ * direct region's A-1 peer blocks and the offload region's H helper-reduced
+ * slices -- where the 2-active schedules have one.
+ *
+ * `sendShadow` covers the WHOLE send buffer, all A blocks, not just the A-1
+ * foreign ones. The own block is never read from it, so that wastes 1/A of the
+ * quantize; in exchange an offset into the shadow is the same offset it is in
+ * the caller's buffer, and every send site keeps the `k * rc + ...` shape it
+ * already has. A shadow that skipped one block in the middle would make each of
+ * those offsets a different expression under low precision.
+ *
+ * THE ALIGNMENT REQUIREMENT IS ONLY ONE BLOCK, unlike the flat allreduce. That
+ * schedule splits its direct region into A per-owner shards of pD/A, and pD
+ * being a whole number of wire blocks does not make pD/A one, so it needs
+ * counts aligned to A*128. Here the direct region is exchanged WHOLE -- each
+ * source sends the entire d1 and d2 span of its foreign block, no per-owner
+ * subdivision -- so cs being chunk-aligned makes directSz, d1 and d2 aligned
+ * whenever the count is.
+ *
+ * Carved unconditionally at the worst case over groups, for the reasons
+ * RsA2LpPlan documents: a byte-identical partition on every rank, and a
+ * capacity check that is a pure function of the counts.
+ */
+struct RsFlatLpPlan {
+  char* sendShadow{nullptr}; // wire(A * recvCount): the whole send buffer
+  char* directRecv{nullptr}; // wire((A-1) * directSz): the peer blocks
+  char* offloadRecv{nullptr}; // wire(H * cs): reduced slices, mirroring output
+  char* helper[SHARDED_RELAY_MAX_GROUPS]{}; // A*(A-1) slices of wire(cs)
+  bool valid{false};
+};
+
+size_t rsFlatLpRequiredBytes(
+    const size_t* recvCounts,
+    const size_t* directSizes,
+    const size_t* chunkSizes,
+    int nGroups,
+    int nActiveRanks,
+    int numHelpers) {
+  const size_t maxCount = rcclx::relay::relayMaxCount(recvCounts, nGroups);
+  const size_t maxDirect = rcclx::relay::relayMaxCount(directSizes, nGroups);
+  const size_t maxCs = rcclx::relay::relayMaxCount(chunkSizes, nGroups);
+  const size_t A = static_cast<size_t>(nActiveRanks);
+  const size_t Hn = static_cast<size_t>(numHelpers);
+
+  size_t total = rsLpAlign(rcclx::relay::lpWireBytes(A * maxCount)) +
+      rsLpAlign(rcclx::relay::lpWireBytes((A - 1) * maxDirect)) +
+      rsLpAlign(rcclx::relay::lpWireBytes(Hn * maxCs));
+  total += static_cast<size_t>(nGroups) *
+      rsLpAlign(rcclx::relay::lpWireBytes(A * (A - 1) * maxCs));
+  return total;
+}
+
+RsFlatLpPlan rsFlatLpCarve(
+    const rcclx::relay::LpArenaLease& lease,
+    const size_t* recvCounts,
+    const size_t* directSizes,
+    const size_t* chunkSizes,
+    int nGroups,
+    int nActiveRanks,
+    int numHelpers) {
+  const size_t maxCount = rcclx::relay::relayMaxCount(recvCounts, nGroups);
+  const size_t maxDirect = rcclx::relay::relayMaxCount(directSizes, nGroups);
+  const size_t maxCs = rcclx::relay::relayMaxCount(chunkSizes, nGroups);
+  const size_t A = static_cast<size_t>(nActiveRanks);
+  const size_t Hn = static_cast<size_t>(numHelpers);
+
+  RsFlatLpPlan p{};
+  rcclx::relay::LpArenaCarver carver(lease);
+  p.sendShadow = carver.take(rcclx::relay::lpWireBytes(A * maxCount));
+  p.directRecv = carver.take(rcclx::relay::lpWireBytes((A - 1) * maxDirect));
+  p.offloadRecv = carver.take(rcclx::relay::lpWireBytes(Hn * maxCs));
+  for (int g = 0; g < nGroups; g++) {
+    p.helper[g] = carver.take(rcclx::relay::lpWireBytes(A * (A - 1) * maxCs));
+  }
+  p.valid = carver.ok();
+  return p;
+}
+
+/**
+ * The offload has to be ON for low precision to mean anything here.
+ *
+ * With cs == 0 this schedule degenerates to a single-group pure-direct
+ * all-to-all reduce-scatter with the helpers idle, which is the regime the
+ * one-shot kernel and the route gate already claim -- the dispatcher's
+ * relayRouteSelected excludes it. Checked again because the offload also
+ * carries the alignment argument: d1 = directSz - cs is a whole number of wire
+ * blocks only when cs is. Pure function of the counts, so all ranks decline
+ * together.
+ */
+bool rsFlatLpGeometryOk(
+    const size_t* recvCounts,
+    const size_t* chunkSizes,
+    int nGroups) {
+  for (int g = 0; g < nGroups; g++) {
+    if (recvCounts[g] > 0 && chunkSizes[g] == 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool rsFlatLpPrepare(
+    bool wantLp,
+    ncclComm_t comm,
+    cudaStream_t stream,
+    const size_t* recvCounts,
+    const size_t* directSizes,
+    const size_t* chunkSizes,
+    int nGroups,
+    int nActiveRanks,
+    int numHelpers,
+    RsFlatLpPlan* out) {
+  if (!wantLp) {
+    return false;
+  }
+
+  if (!rsFlatLpGeometryOk(recvCounts, chunkSizes, nGroups)) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Alignment);
+    return false;
+  }
+
+  rcclx::relay::LpArenaLease lease{};
+  if (!rsLpAcquireArena(comm, stream, &lease)) {
+    return false;
+  }
+  if (rsFlatLpRequiredBytes(
+          recvCounts,
+          directSizes,
+          chunkSizes,
+          nGroups,
+          nActiveRanks,
+          numHelpers) > lease.bytes) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+
+  *out = rsFlatLpCarve(
+      lease,
+      recvCounts,
+      directSizes,
+      chunkSizes,
+      nGroups,
+      nActiveRanks,
+      numHelpers);
+  if (!out->valid) {
+    rcclx::relay::lpRecordDecline(rcclx::relay::LpDecline::Arena);
+    return false;
+  }
+  rcclx::relay::lpRecordEngage();
+  return true;
+}
+
 } // namespace
 
 /**
@@ -2435,7 +2590,8 @@ static ncclResult_t shardedRelayReduceScatterFlat(
     int numHelpers,
     int nActiveRanksPerGroup,
     int nGroups,
-    size_t elementSize) {
+    size_t elementSize,
+    bool wantLp) {
   const int A = nActiveRanksPerGroup;
   const int H = numHelpers;
 
@@ -2489,6 +2645,52 @@ static ncclResult_t shardedRelayReduceScatterFlat(
     d1Arr[g] = (cs > 0) ? (directArr[g] - cs) : directArr[g];
   }
 
+  // =========================================================================
+  // LOW PRECISION: decide, acquire the arena, and quantize the send buffer
+  // =========================================================================
+  // Reached by every rank whenever the dispatcher's size-only gate said yes,
+  // helpers included, and every way it can decline is agreed across the
+  // communicator, so all ranks run the same wire format or none do.
+  RsFlatLpPlan lpPlan{};
+  const bool lp = rsFlatLpPrepare(
+      wantLp,
+      comm,
+      stream,
+      recvCounts,
+      directArr,
+      csArr,
+      nGroups,
+      A,
+      H,
+      &lpPlan);
+  const rcclx::relay::RelayWire wire =
+      rcclx::relay::lpWireFor(datatype, elementSize, lp);
+
+  // One quantize over the whole send buffer, before the first ncclGroupStart.
+  // Every send below reads a foreign block of it and none is produced mid-call,
+  // so one launch covers group 1's direct part, group 2's direct part and the
+  // offload scatter alike. The own block is included so that a shadow offset is
+  // the same number as the caller-buffer offset; see RsFlatLpPlan.
+  if (lp && myActiveGroup >= 0 && recvCounts[myActiveGroup] > 0) {
+    DISPATCH_LP_QUANTIZE(
+        datatype,
+        lpPlan.sendShadow,
+        sendBuffs[myActiveGroup],
+        static_cast<size_t>(A) * recvCounts[myActiveGroup],
+        stream);
+  }
+
+  // Where a boundary-crossing send reads from, and where each of the two
+  // landing areas puts its arrivals. Offsets stay in ELEMENTS of the caller's
+  // dtype on both paths, which is what keeps every call site unchanged in
+  // shape.
+  auto sendFrom = [&](int g, size_t offsetElems) -> const char* {
+    if (lp) {
+      return lpPlan.sendShadow + wire.bytes(offsetElems);
+    }
+    return static_cast<const char*>(sendBuffs[g]) + offsetElems * elementSize;
+  };
+
   // Active-rank scratch. dScratch holds the A-1 peer contributions to my direct
   // region, one contiguous directSz block each, so the whole direct region
   // reduces in a single multi-input pass. oScratch mirrors my output's offload
@@ -2505,23 +2707,44 @@ static ncclResult_t shardedRelayReduceScatterFlat(
         (static_cast<const void*>(recvBuffs[myActiveGroup]) ==
          static_cast<const void*>(ownBlock));
 
-    dScratch = ScratchBufferCache::getInstance().get(
-        SHARDED_RELAY_MAX_GROUPS,
-        static_cast<size_t>(A - 1) * directArr[myActiveGroup] * elementSize,
-        stream);
-    if (dScratch == nullptr) {
-      return ncclInternalError;
-    }
-    if (csArr[myActiveGroup] > 0) {
-      oScratch = ScratchBufferCache::getInstance().get(
-          myActiveGroup,
-          static_cast<size_t>(H) * csArr[myActiveGroup] * elementSize,
+    // Under low precision the arrivals are wire bytes, so lpPlan.directRecv and
+    // lpPlan.offloadRecv stage them -- laid out to mirror these same two
+    // orderings -- and the owner reduce below reads them from there.
+    if (!lp) {
+      dScratch = ScratchBufferCache::getInstance().get(
+          SHARDED_RELAY_MAX_GROUPS,
+          static_cast<size_t>(A - 1) * directArr[myActiveGroup] * elementSize,
           stream);
-      if (oScratch == nullptr) {
+      if (dScratch == nullptr) {
         return ncclInternalError;
+      }
+      if (csArr[myActiveGroup] > 0) {
+        oScratch = ScratchBufferCache::getInstance().get(
+            myActiveGroup,
+            static_cast<size_t>(H) * csArr[myActiveGroup] * elementSize,
+            stream);
+        if (oScratch == nullptr) {
+          return ncclInternalError;
+        }
       }
     }
   }
+
+  // Destination for a received peer block (offset within the A-1 packed blocks)
+  // and for a received reduced offload slice (offset within my offload region).
+  auto directAt = [&](size_t offsetElems) -> char* {
+    if (lp) {
+      return lpPlan.directRecv + wire.bytes(offsetElems);
+    }
+    return static_cast<char*>(dScratch) + offsetElems * elementSize;
+  };
+
+  auto offloadAt = [&](size_t offsetElems) -> char* {
+    if (lp) {
+      return lpPlan.offloadRecv + wire.bytes(offsetElems);
+    }
+    return static_cast<char*>(oScratch) + offsetElems * elementSize;
+  };
 
   // Helper staging is kernel-owned scratch: callers pass a placeholder buffer
   // for groups where they are a helper. Each helper group holds A*(A-1) offload
@@ -2530,6 +2753,13 @@ static ncclResult_t shardedRelayReduceScatterFlat(
   for (int g = 0; g < nGroups; g++) {
     const ShardedRelayRankConfig& cfg = configs[g];
     if (!cfg.isActiveRank && recvCounts[g] > 0 && csArr[g] > 0) {
+      if (lp) {
+        // Already carved, and in wire bytes. This helper DOES reduce, so unlike
+        // the 2-active schedules' it reads and writes the wire format -- but
+        // still never learns the caller's dtype.
+        helperScratch[g] = lpPlan.helper[g];
+        continue;
+      }
       size_t needBytes =
           static_cast<size_t>(A) * (A - 1) * csArr[g] * elementSize;
       helperScratch[g] = ScratchBufferCache::getInstance().get(
@@ -2555,7 +2785,6 @@ static ncclResult_t shardedRelayReduceScatterFlat(
     size_t d1 = d1Arr[g];
 
     if (cfg.isActiveRank) {
-      const char* sendbuff = static_cast<const char*>(sendBuffs[g]);
       int m = cfg.myActiveIndex;
 
       if (d1 > 0) {
@@ -2563,9 +2792,9 @@ static ncclResult_t shardedRelayReduceScatterFlat(
           if (k == m)
             continue;
           NCCLCHECK(ncclSend(
-              sendbuff + static_cast<size_t>(k) * rc * elementSize,
-              d1,
-              datatype,
+              sendFrom(g, static_cast<size_t>(k) * rc),
+              wire.count(d1),
+              wire.dtype,
               cfg.activeRanks[k],
               comm,
               stream));
@@ -2575,10 +2804,9 @@ static ncclResult_t shardedRelayReduceScatterFlat(
             continue;
           int p = (s < m) ? s : s - 1;
           NCCLCHECK(ncclRecv(
-              static_cast<char*>(dScratch) +
-                  static_cast<size_t>(p) * directSz * elementSize,
-              d1,
-              datatype,
+              directAt(static_cast<size_t>(p) * directSz),
+              wire.count(d1),
+              wire.dtype,
               cfg.activeRanks[s],
               comm,
               stream));
@@ -2591,12 +2819,12 @@ static ncclResult_t shardedRelayReduceScatterFlat(
           if (j == m)
             continue;
           NCCLCHECK(ncclSend(
-              sendbuff +
-                  (static_cast<size_t>(j) * rc + directSz +
-                   static_cast<size_t>(h) * cs) *
-                      elementSize,
-              cs,
-              datatype,
+              sendFrom(
+                  g,
+                  static_cast<size_t>(j) * rc + directSz +
+                      static_cast<size_t>(h) * cs),
+              wire.count(cs),
+              wire.dtype,
               cfg.helperRanks[h],
               comm,
               stream));
@@ -2612,9 +2840,9 @@ static ncclResult_t shardedRelayReduceScatterFlat(
           int t = (s < j) ? s : s - 1;
           size_t slot = static_cast<size_t>(j) * (A - 1) + t;
           NCCLCHECK(ncclRecv(
-              hbuff + slot * cs * elementSize,
-              cs,
-              datatype,
+              hbuff + wire.bytes(slot * cs),
+              wire.count(cs),
+              wire.dtype,
               cfg.activeRanks[s],
               comm,
               stream));
@@ -2636,7 +2864,10 @@ static ncclResult_t shardedRelayReduceScatterFlat(
   // HELPER REDUCE: sum each owner's A-1 contributions in place
   // =========================================================================
   // No divisor here: the owner applies the AVG divisor once when it folds in
-  // its own contribution.
+  // its own contribution. That is the SAME rule as the flat allreduce's offload
+  // region and the OPPOSITE of what the 2-active reduce-scatter does -- what
+  // decides it is whether the region has an active-side closing reduce to defer
+  // the divisor to, and this one does. See sharded_relay_lp_kernels.h.
   if (anyOffload) {
     for (int g = 0; g < nGroups; g++) {
       if (recvCounts[g] == 0 || csArr[g] == 0 || configs[g].isActiveRank)
@@ -2644,7 +2875,15 @@ static ncclResult_t shardedRelayReduceScatterFlat(
       char* hbuff = static_cast<char*>(helperScratch[g]);
       size_t cs = csArr[g];
       for (int j = 0; j < A; j++) {
-        char* dst = hbuff + static_cast<size_t>(j) * (A - 1) * cs * elementSize;
+        char* dst = hbuff + wire.bytes(static_cast<size_t>(j) * (A - 1) * cs);
+        if (lp) {
+          // Wire in, wire out, summed in fp32 and requantized against a fresh
+          // absmax. The A-1 contributions are contiguous from dst at
+          // wire.bytes(cs) stride, which is exactly how group 1 laid them out.
+          launchLpReduceRequantizeKernel(
+              dst, dst, A - 1, cs, /*divisor=*/1, stream);
+          continue;
+        }
         DISPATCH_MULTI_REDUCE(
             datatype, dst, dst + cs * elementSize, A - 2, cs, 1, stream);
       }
@@ -2668,7 +2907,6 @@ static ncclResult_t shardedRelayReduceScatterFlat(
       size_t d2 = directSz - d1;
 
       if (cfg.isActiveRank) {
-        const char* sendbuff = static_cast<const char*>(sendBuffs[g]);
         int m = cfg.myActiveIndex;
 
         if (d2 > 0) {
@@ -2676,9 +2914,9 @@ static ncclResult_t shardedRelayReduceScatterFlat(
             if (k == m)
               continue;
             NCCLCHECK(ncclSend(
-                sendbuff + (static_cast<size_t>(k) * rc + d1) * elementSize,
-                d2,
-                datatype,
+                sendFrom(g, static_cast<size_t>(k) * rc + d1),
+                wire.count(d2),
+                wire.dtype,
                 cfg.activeRanks[k],
                 comm,
                 stream));
@@ -2688,10 +2926,9 @@ static ncclResult_t shardedRelayReduceScatterFlat(
               continue;
             int p = (s < m) ? s : s - 1;
             NCCLCHECK(ncclRecv(
-                static_cast<char*>(dScratch) +
-                    (static_cast<size_t>(p) * directSz + d1) * elementSize,
-                d2,
-                datatype,
+                directAt(static_cast<size_t>(p) * directSz + d1),
+                wire.count(d2),
+                wire.dtype,
                 cfg.activeRanks[s],
                 comm,
                 stream));
@@ -2701,10 +2938,9 @@ static ncclResult_t shardedRelayReduceScatterFlat(
         // Reduced offload slices land contiguously, mirroring my output.
         for (int h = 0; h < cfg.numHelpers; h++) {
           NCCLCHECK(ncclRecv(
-              static_cast<char*>(oScratch) +
-                  static_cast<size_t>(h) * cs * elementSize,
-              cs,
-              datatype,
+              offloadAt(static_cast<size_t>(h) * cs),
+              wire.count(cs),
+              wire.dtype,
               cfg.helperRanks[h],
               comm,
               stream));
@@ -2714,9 +2950,9 @@ static ncclResult_t shardedRelayReduceScatterFlat(
         const char* hbuff = static_cast<const char*>(helperScratch[g]);
         for (int j = 0; j < A; j++) {
           NCCLCHECK(ncclSend(
-              hbuff + static_cast<size_t>(j) * (A - 1) * cs * elementSize,
-              cs,
-              datatype,
+              hbuff + wire.bytes(static_cast<size_t>(j) * (A - 1) * cs),
+              wire.count(cs),
+              wire.dtype,
               cfg.activeRanks[j],
               comm,
               stream));
@@ -2739,7 +2975,32 @@ static ncclResult_t shardedRelayReduceScatterFlat(
         static_cast<size_t>(cfg.myActiveIndex) * rc * elementSize;
 
     // Direct region: own + the A-1 peer blocks, one fused multi-input pass.
-    if (A == 4 && directSz > 0 && !isInPlace) {
+    if (lp) {
+      // The divisor lands here for BOTH regions: this is the active-side
+      // closing reduce, and the helper deliberately returned a plain sum.
+      if (directSz > 0) {
+        if (isInPlace) {
+          DISPATCH_LP_MULTI_REDUCE(
+              datatype,
+              out,
+              lpPlan.directRecv,
+              A - 1,
+              directSz,
+              reductionDivisor,
+              stream);
+        } else {
+          DISPATCH_LP_SEEDED_MULTI_REDUCE(
+              datatype,
+              out,
+              ownBlock,
+              lpPlan.directRecv,
+              A - 1,
+              directSz,
+              reductionDivisor,
+              stream);
+        }
+      }
+    } else if (A == 4 && directSz > 0 && !isInPlace) {
       DISPATCH_SEEDED_MULTI_REDUCE(
           datatype,
           out,
@@ -2767,7 +3028,30 @@ static ncclResult_t shardedRelayReduceScatterFlat(
     if (cs > 0) {
       char* oOut = out + directSz * elementSize;
       size_t oCount = rc - directSz;
-      if (isInPlace) {
+      if (lp) {
+        // ONE wire contribution: the H slices are contiguous and already mirror
+        // the output, so wire(H * cs) is exactly this span.
+        if (isInPlace) {
+          DISPATCH_LP_MULTI_REDUCE(
+              datatype,
+              oOut,
+              lpPlan.offloadRecv,
+              1,
+              oCount,
+              reductionDivisor,
+              stream);
+        } else {
+          DISPATCH_LP_SEEDED_MULTI_REDUCE(
+              datatype,
+              oOut,
+              ownBlock + directSz * elementSize,
+              lpPlan.offloadRecv,
+              1,
+              oCount,
+              reductionDivisor,
+              stream);
+        }
+      } else if (isInPlace) {
         if (reductionDivisor > 1) {
           DISPATCH_INCREMENTAL_ADD_AND_SCALE(
               datatype, oOut, oScratch, oCount, reductionDivisor, stream);
@@ -3285,9 +3569,10 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
   // the offload enabled can additionally be software-pipelined so the scatter
   // and the reduced return share each cross link's two directions.
   //
-  // Neither flat schedule carries the wire format yet, so low precision is
-  // declined here -- identically on every rank, since the condition is
-  // nActiveRanksPerGroup.
+  // The alignment requirement is ONE wire block, unlike the flat allreduce's
+  // A*128: this schedule exchanges its direct region whole rather than
+  // splitting it into A per-owner shards, so there is no pD/A to keep
+  // block-aligned. See RsFlatLpPlan.
   const bool offload =
       rcclx::relay::selectReduceScatterRoute(
           nActiveRanksPerGroup, numHelpers, nGroups, recvCounts, elementSize) ==
@@ -3299,6 +3584,23 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
             rcclx::relay::relayMaxCount(recvCounts, nGroups),
             elementSize)
       : 1;
+
+  // Only the non-pipelined flat schedule carries the wire format so far, so a
+  // pipelined call is reported to the gate as "no LP-capable route selected"
+  // and lands in the Route decline counter rather than declining silently. Safe
+  // because the tile count is a pure function of the counts.
+  bool wantLpFlat = false;
+  if (lowPrecision != 0) {
+    wantLpFlat = rcclx::relay::lpEligible(reduceScatterLpGate(
+        datatype,
+        recvCounts,
+        nGroups,
+        nActiveRanksPerGroup,
+        elementSize,
+        offload && nTiles == 1,
+        rcclx::relay::kLpBlockElems));
+  }
+
   if (nTiles > 1) {
     return shardedRelayReduceScatterFlatPipelined(
         sendBuffs,
@@ -3328,5 +3630,6 @@ HOT ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
       numHelpers,
       nActiveRanksPerGroup,
       nGroups,
-      elementSize);
+      elementSize,
+      wantLpFlat);
 }

--- a/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.h
+++ b/comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.h
@@ -136,6 +136,14 @@
  * [nGroups][nActiveRanksPerGroup]
  * @param nActiveRanksPerGroup Number of active ranks per group (2 or 4)
  * @param nGroups Number of groups (typically 4 for 8-GPU node)
+ * @param lowPrecision Non-zero to use the low-precision (fp8e4m3) wire format
+ *        where it pays; an internal size-only gate declines to full precision
+ *        silently otherwise (see sharded_relay_lp.h). COLLECTIVE -- it must be
+ *        identical on every rank of the call, like datatype, op and the counts.
+ *        Ranks that disagree disagree on how many bytes cross each link, so the
+ *        call hangs or corrupts rather than degrading. Documented rather than
+ *        validated, because a per-call check would cost an allreduce; datatype
+ *        is already treated the same way.
  * @return ncclResult_t Success or error code
  */
 ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
@@ -148,4 +156,5 @@ ncclResult_t ncclShardedRelayMultiGroupReduceScatterImpl(
     cudaStream_t stream,
     const int* const* allActiveRanks,
     int nActiveRanksPerGroup,
-    int nGroups);
+    int nGroups,
+    int lowPrecision = 0);

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
@@ -46,6 +46,7 @@
 #include "comm.h"
 #include "comms/rcclx/develop/meta/testinfra/TestUtils.h"
 #include "comms/rcclx/develop/meta/testinfra/TestsDistUtils.h"
+#include "meta/relay/sharded_relay_lp.h"
 #include "meta/relay/sharded_relay_route.h"
 #include "nccl.h"
 
@@ -2064,6 +2065,275 @@ TEST_F(
       HIPCHECK_TEST(hipFree(recvBuffs[g]));
     }
   }
+}
+
+// ===========================================================================
+// LOW PRECISION (fp8e4m3 wire format)
+// ===========================================================================
+//
+// Every case asserts that low precision actually ENGAGED or actually DECLINED,
+// via the counters, rather than trusting the flag. The gate declines silently
+// on several independent grounds, so an "LP" run that quietly fell back to full
+// precision produces exactly the numbers a passing LP run produces.
+//
+// The comparators stay EXACT. Each rank fills its shard with a single constant,
+// so every 128-element wire block has that constant as its absmax; the
+// power-of-two normalization target then makes quantize/dequantize an identity.
+// These cases are therefore a genuine detector for a wrong scale, a wrong block
+// boundary or a dropped scale. Do not loosen them.
+//
+// All-gather's own hazard, which none of the reduce-scatter cases can catch:
+// the DIAGONAL slot must come out full precision and untouched while the
+// foreign slot round-trips through fp8. Giving each rank a distinct constant
+// means a dequantize that covered the diagonal, or one that landed at the wrong
+// slot offset, changes a value that should not have moved.
+class ShardedRelayAllGatherLowPrecisionTest
+    : public ShardedRelayMultiGroupAllGatherTest {
+ protected:
+  static constexpr int kGroups = 4;
+  static constexpr int kActive = 2;
+
+  // 2 Mi elements per shard = 8 MiB in fp32, above the low-precision threshold
+  // and a whole number of 128-element blocks.
+  static constexpr size_t kLpCount = 2ULL * 1024 * 1024;
+
+  // Rank-distinct shard value, so a wrong slot is visible.
+  static float shardValue(int activeIndex) {
+    return static_cast<float>(activeIndex + 1) * 3.0f;
+  }
+
+  struct Buffers {
+    void* sendMem[kGroups]{};
+    void* recvMem[kGroups]{};
+    const void* sendPtrs[kGroups]{};
+    void* recvPtrs[kGroups]{};
+    size_t counts[kGroups]{};
+    int myActiveGroup{0};
+    int myActiveIndex{0};
+    int nGroups{kGroups};
+  };
+
+  // Out-of-place: a separate send buffer per group and an A*count output for
+  // the active group. Helper groups reuse their send allocation as the
+  // placeholder.
+  template <typename T>
+  void makeBuffers(size_t count, T value, int nGroups, Buffers& b) {
+    b = Buffers{};
+    b.nGroups = nGroups;
+    b.myActiveGroup = this->globalRank / kActive;
+    b.myActiveIndex = this->globalRank % kActive;
+    const size_t outCount = static_cast<size_t>(kActive) * count;
+
+    for (int g = 0; g < nGroups; g++) {
+      HIPCHECK_TEST(hipMalloc(&b.sendMem[g], count * sizeof(T)));
+      if (g == b.myActiveGroup) {
+        const std::vector<T> host(count, value);
+        HIPCHECK_TEST(hipMemcpy(
+            b.sendMem[g],
+            host.data(),
+            count * sizeof(T),
+            hipMemcpyHostToDevice));
+        HIPCHECK_TEST(hipMalloc(&b.recvMem[g], outCount * sizeof(T)));
+        // Poison the output so a slot the implementation never writes is a
+        // failure rather than an accidental pass.
+        HIPCHECK_TEST(hipMemset(b.recvMem[g], 0xff, outCount * sizeof(T)));
+      } else {
+        HIPCHECK_TEST(hipMemset(b.sendMem[g], 0, count * sizeof(T)));
+        b.recvMem[g] = b.sendMem[g];
+      }
+      b.sendPtrs[g] = b.sendMem[g];
+      b.recvPtrs[g] = b.recvMem[g];
+      b.counts[g] = count;
+    }
+  }
+
+  void freeBuffers(Buffers& b) {
+    for (int g = 0; g < b.nGroups; g++) {
+      HIPCHECK_TEST(hipFree(b.sendMem[g]));
+      if (g == b.myActiveGroup) {
+        HIPCHECK_TEST(hipFree(b.recvMem[g]));
+      }
+    }
+  }
+
+  // Slot i must hold shardValue(i), exactly, for every i -- diagonal included.
+  template <typename T>
+  void expectEverySlotIsItsOwner(const Buffers& b, size_t count) {
+    if (b.myActiveGroup >= b.nGroups) {
+      return;
+    }
+    const size_t outCount = static_cast<size_t>(kActive) * count;
+    std::vector<T> got(outCount);
+    HIPCHECK_TEST(hipMemcpy(
+        got.data(),
+        b.recvMem[b.myActiveGroup],
+        outCount * sizeof(T),
+        hipMemcpyDeviceToHost));
+    size_t reported = 0;
+    for (int slot = 0; slot < kActive && reported < 8; slot++) {
+      const T want = static_cast<T>(shardValue(slot));
+      for (size_t i = 0; i < count && reported < 8; i++) {
+        const T v = got[static_cast<size_t>(slot) * count + i];
+        if (v != want) {
+          reported++;
+          ADD_FAILURE() << "R" << this->globalRank << ": slot " << slot
+                        << " element " << i << ": got " << static_cast<float>(v)
+                        << ", want " << static_cast<float>(want)
+                        << (slot == b.myActiveIndex ? " (DIAGONAL -- must stay"
+                                                      " full precision)"
+                                                    : "");
+        }
+      }
+    }
+  }
+
+  ncclResult_t call(const Buffers& b, ncclDataType_t dt, int lowPrecision) {
+    Standard4GroupActiveRanks layout;
+    return callAllGatherCompat(
+        b.sendPtrs,
+        b.recvPtrs,
+        b.counts,
+        dt,
+        this->commFor(kActive),
+        this->stream,
+        layout.allActiveRanks,
+        kActive,
+        b.nGroups,
+        lowPrecision);
+  }
+};
+
+TEST_F(ShardedRelayAllGatherLowPrecisionTest, ConstantShardsAreBitExact) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  Buffers b;
+  makeBuffers<float>(
+      kLpCount, shardValue(this->globalRank % kActive), kGroups, b);
+  barrierSyncOn(nullptr);
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclFloat32, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  expectEverySlotIsItsOwner<float>(b, kLpCount);
+  EXPECT_GT(rcclx::relay::lpEngageCount(), 0u)
+      << "low precision never engaged, so this case proved nothing";
+  EXPECT_EQ(rcclx::relay::lpDeclineCount(), 0u);
+  freeBuffers(b);
+}
+
+TEST_F(ShardedRelayAllGatherLowPrecisionTest, DeclinesOnUnsupportedDtype) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // ncclInt32 is not a low-precision dtype, so the flag must fall through to
+  // full precision and the answer must be exactly the full-precision answer.
+  Buffers b;
+  makeBuffers<int32_t>(
+      kLpCount,
+      static_cast<int32_t>(shardValue(this->globalRank % kActive)),
+      kGroups,
+      b);
+  barrierSyncOn(nullptr);
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclInt32, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  expectEverySlotIsItsOwner<int32_t>(b, kLpCount);
+  EXPECT_EQ(rcclx::relay::lpEngageCount(), 0u);
+  EXPECT_GT(rcclx::relay::lpDeclineCount(rcclx::relay::LpDecline::Dtype), 0u);
+  freeBuffers(b);
+}
+
+TEST_F(
+    ShardedRelayAllGatherLowPrecisionTest,
+    DeclinesOnCountThatIsNotWholeBlocks) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // One element past a whole number of 128-element blocks. The slot stride is a
+  // raw per-group count here, so an unaligned count breaks additivity in the
+  // MIDDLE of the output buffer, not only in its tail -- the gate must refuse.
+  const size_t count = kLpCount + 1;
+  Buffers b;
+  makeBuffers<float>(count, shardValue(this->globalRank % kActive), kGroups, b);
+  barrierSyncOn(nullptr);
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclFloat32, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  expectEverySlotIsItsOwner<float>(b, count);
+  EXPECT_EQ(rcclx::relay::lpEngageCount(), 0u);
+  EXPECT_GT(
+      rcclx::relay::lpDeclineCount(rcclx::relay::LpDecline::Alignment), 0u);
+  freeBuffers(b);
+}
+
+TEST_F(ShardedRelayAllGatherLowPrecisionTest, InterleavesWithFullPrecision) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // The behaviour an env var could not express, and the whole point of making
+  // this a per-call argument: two calls on the SAME communicator, one low
+  // precision and one not, with no state leaking from the first into the
+  // second.
+  const float value = shardValue(this->globalRank % kActive);
+  Buffers b;
+  makeBuffers<float>(kLpCount, value, kGroups, b);
+  barrierSyncOn(nullptr);
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclFloat32, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+  expectEverySlotIsItsOwner<float>(b, kLpCount);
+  ASSERT_GT(rcclx::relay::lpEngageCount(), 0u);
+
+  const uint64_t engagedBefore = rcclx::relay::lpEngageCount();
+  freeBuffers(b);
+  makeBuffers<float>(kLpCount, value, kGroups, b);
+  barrierSyncOn(nullptr);
+  ASSERT_EQ(call(b, ncclFloat32, /*lowPrecision=*/0), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+  expectEverySlotIsItsOwner<float>(b, kLpCount);
+  EXPECT_EQ(rcclx::relay::lpEngageCount(), engagedBefore)
+      << "a full-precision call must not engage low precision";
+  freeBuffers(b);
+}
+
+TEST_F(
+    ShardedRelayAllGatherLowPrecisionTest,
+    DeclinesForTheSingleGroupPipelinedSchedule) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // A single-group call at this size pipelines, and the pipelined schedule does
+  // not carry the wire format yet. The decline must be unanimous, and it is,
+  // because the tile count is a pure function of the counts. The pipeline
+  // selection is asserted so this cannot quietly become a second test of the
+  // non-pipelined path.
+  const size_t count = 4ULL * 1024 * 1024;
+  ASSERT_GT(
+      rcclx::relay::relayPipelineTiles(
+          1, rcclx::relay::relayShapeA2(8 - kActive), count, sizeof(float)),
+      1);
+
+  Buffers b;
+  makeBuffers<float>(
+      count, shardValue(this->globalRank % kActive), /*nGroups=*/1, b);
+  barrierSyncOn(nullptr);
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclFloat32, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  expectEverySlotIsItsOwner<float>(b, count);
+  EXPECT_EQ(rcclx::relay::lpEngageCount(), 0u);
+  EXPECT_GT(rcclx::relay::lpDeclineCount(rcclx::relay::LpDecline::Route), 0u)
+      << "the decline must be recorded, not silent";
+  freeBuffers(b);
 }
 
 int main(int argc, char* argv[]) {

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
@@ -153,7 +153,8 @@ static ncclResult_t callAllGatherCompat(
     hipStream_t stream,
     const int* const* allActiveRanks,
     int nActiveRanksPerGroup,
-    int nGroups) {
+    int nGroups,
+    int lowPrecision = 0) {
   return ncclShardedRelayMultiGroupAllGather(
       sendPtrs,
       recvPtrs,
@@ -163,7 +164,8 @@ static ncclResult_t callAllGatherCompat(
       stream,
       allActiveRanks,
       nActiveRanksPerGroup,
-      nGroups);
+      nGroups,
+      lowPrecision);
 }
 
 class ShardedRelayMultiGroupAllGatherTest : public ::testing::Test {

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllGatherTest.cu
@@ -2303,17 +2303,14 @@ TEST_F(ShardedRelayAllGatherLowPrecisionTest, InterleavesWithFullPrecision) {
   freeBuffers(b);
 }
 
-TEST_F(
-    ShardedRelayAllGatherLowPrecisionTest,
-    DeclinesForTheSingleGroupPipelinedSchedule) {
+TEST_F(ShardedRelayAllGatherLowPrecisionTest, SingleGroupPipelinedIsBitExact) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks";
   }
-  // A single-group call at this size pipelines, and the pipelined schedule does
-  // not carry the wire format yet. The decline must be unanimous, and it is,
-  // because the tile count is a pure function of the counts. The pipeline
-  // selection is asserted so this cannot quietly become a second test of the
-  // non-pipelined path.
+  // relayPipelineTiles() returns 1 whenever nGroups != 1, so the 4-group cases
+  // above cannot reach the pipelined schedule. This one is single-group at a
+  // size the depth selector pipelines -- asserted, so a resize cannot quietly
+  // turn it into a second test of the non-pipelined path.
   const size_t count = 4ULL * 1024 * 1024;
   ASSERT_GT(
       rcclx::relay::relayPipelineTiles(
@@ -2330,9 +2327,9 @@ TEST_F(
   HIPCHECK_TEST(hipStreamSynchronize(this->stream));
 
   expectEverySlotIsItsOwner<float>(b, count);
-  EXPECT_EQ(rcclx::relay::lpEngageCount(), 0u);
-  EXPECT_GT(rcclx::relay::lpDeclineCount(rcclx::relay::LpDecline::Route), 0u)
-      << "the decline must be recorded, not silent";
+  EXPECT_GT(rcclx::relay::lpEngageCount(), 0u)
+      << "low precision never engaged, so this case proved nothing";
+  EXPECT_EQ(rcclx::relay::lpDeclineCount(), 0u);
   freeBuffers(b);
 }
 

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
@@ -2961,6 +2961,85 @@ TEST_F(
   freeAll(mem);
 }
 
+TEST_F(
+    ShardedRelayAllReduceFlatLowPrecisionTest,
+    SingleGroupPipelinedIsBitExact) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // The 2-group cases above cannot reach the pipelined flat schedule: its depth
+  // selector returns 1 unless nGroups == 1. Asserted rather than assumed, so a
+  // size that quietly stopped pipelining fails loudly instead of silently
+  // re-testing the non-pipelined schedule.
+  const int nGroups = 1;
+  const int kA = 4;
+  // 32 Mi elements = 128 MiB fp32: past the pipelining crossover, and a
+  // multiple of A*128 == 512 as the flat direct region's per-owner shards
+  // require.
+  const size_t count = 32ULL * 1024 * 1024;
+  ASSERT_EQ(count % (kA * 128u), 0u);
+  ASSERT_GT(
+      rcclx::relay::relayAllReducePipelineTiles(
+          nGroups, kA, this->numRanks - kA, count, sizeof(float)),
+      1)
+      << "chosen count does not pipeline, so this case would not exercise the "
+         "pipelined flat schedule";
+
+  static const int g0[] = {0, 1, 2, 3};
+  const int* allActiveRanks[] = {g0};
+  const bool isActive = (this->globalRank < kA);
+  const size_t elems = isActive ? count : static_cast<size_t>(kA) * count;
+
+  float* buff = nullptr;
+  HIPCHECK_TEST(hipMalloc(&buff, elems * sizeof(float)));
+  barrierSyncOn(reinterpret_cast<int32_t*>(buff));
+  if (isActive) {
+    const std::vector<float> host(
+        count, static_cast<float>(this->globalRank) + 1.0f);
+    HIPCHECK_TEST(hipMemcpy(
+        buff, host.data(), count * sizeof(float), hipMemcpyHostToDevice));
+  } else {
+    HIPCHECK_TEST(hipMemset(buff, 0, elems * sizeof(float)));
+  }
+
+  const void* sendPtrs[1] = {buff};
+  void* recvPtrs[1] = {buff};
+  size_t counts[1] = {count};
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(
+      callAllReduceCompat(
+          sendPtrs,
+          recvPtrs,
+          counts,
+          ncclFloat32,
+          ncclSum,
+          this->commFor(kA),
+          this->stream,
+          allActiveRanks,
+          kA,
+          nGroups,
+          /*lowPrecision=*/1),
+      ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  if (isActive) {
+    std::vector<float> got(count);
+    HIPCHECK_TEST(hipMemcpy(
+        got.data(), buff, count * sizeof(float), hipMemcpyDeviceToHost));
+    size_t reported = 0;
+    for (size_t i = 0; i < count && reported < 8; i++) {
+      if (got[i] != 10.0f) {
+        reported++;
+        ADD_FAILURE() << "element " << i << ": got " << got[i] << ", want 10";
+      }
+    }
+    EXPECT_GT(rcclx::relay::lpEngageCount(), 0u)
+        << "low precision never engaged, so this case proved nothing";
+  }
+  HIPCHECK_TEST(hipFree(buff));
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
@@ -182,7 +182,8 @@ static ncclResult_t callAllReduceCompat(
     hipStream_t stream,
     const int* const* allActiveRanks,
     int nActiveRanksPerGroup,
-    int nGroups) {
+    int nGroups,
+    int lowPrecision = 0) {
   return ncclShardedRelayMultiGroupAllReduce(
       sendPtrs,
       recvPtrs,
@@ -193,7 +194,8 @@ static ncclResult_t callAllReduceCompat(
       stream,
       allActiveRanks,
       nActiveRanksPerGroup,
-      nGroups);
+      nGroups,
+      lowPrecision);
 }
 
 class ShardedRelayMultiGroupAllReduceTest : public ::testing::Test {

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
@@ -55,6 +55,7 @@
 #include "comm.h"
 #include "comms/rcclx/develop/meta/testinfra/TestUtils.h"
 #include "comms/rcclx/develop/meta/testinfra/TestsDistUtils.h"
+#include "meta/relay/sharded_relay_lp.h"
 #include "meta/relay/sharded_relay_route.h"
 #include "nccl.h"
 
@@ -2542,6 +2543,206 @@ TEST_F(ShardedRelayMultiGroupAllReduceTest, Routing_SizeAdaptiveCrossovers) {
         sizeof(int32_t),
         crossover.atOrAbove);
   }
+}
+
+// ===========================================================================
+// LOW PRECISION (fp8e4m3 wire format)
+// ===========================================================================
+//
+// Every case here asserts that low precision actually ENGAGED or actually
+// DECLINED, via the counters, rather than trusting the flag. The gate declines
+// silently on four independent grounds, so an "LP" run that quietly fell back
+// to full precision produces exactly the numbers a passing LP run produces --
+// the counter is the only thing that tells them apart.
+//
+// The comparators stay EXACT. Each active rank fills its buffer with a single
+// constant, so every 128-element wire block has that constant as its absmax;
+// the power-of-two normalization target then makes quantize/dequantize an
+// identity, and a sum of equal values behaves the same way. These cases are
+// therefore a genuine detector for a wrong scale, a wrong block boundary or a
+// dropped scale. Do not loosen them.
+class ShardedRelayAllReduceLowPrecisionTest
+    : public ShardedRelayMultiGroupAllReduceTest {
+ protected:
+  static constexpr int kGroups = 4;
+  static constexpr int kActive = 2;
+
+  // 2 Mi elements = 8 MiB in fp32, comfortably above the low-precision size
+  // threshold and a whole number of 128-element blocks.
+  static constexpr size_t kLpCount = 2ULL * 1024 * 1024;
+
+  struct Buffers {
+    std::vector<void*> mem;
+    const void* sendPtrs[kGroups];
+    void* recvPtrs[kGroups];
+    size_t counts[kGroups];
+    int myActiveGroup{0};
+  };
+
+  // In-place buffers filled so the active group's contribution is a constant
+  // (activeIndex + 1), which makes the expected allreduce sum exact.
+  template <typename T>
+  void makeBuffers(size_t count, T contribution, Buffers& b) {
+    b = Buffers{};
+    b.myActiveGroup = this->globalRank / kActive;
+    b.mem.resize(kGroups);
+    for (int g = 0; g < kGroups; g++) {
+      const size_t elems =
+          (g == b.myActiveGroup) ? count : static_cast<size_t>(kActive) * count;
+      HIPCHECK_TEST(hipMalloc(&b.mem[g], elems * sizeof(T)));
+      if (g == b.myActiveGroup) {
+        const std::vector<T> host(count, contribution);
+        HIPCHECK_TEST(hipMemcpy(
+            b.mem[g], host.data(), count * sizeof(T), hipMemcpyHostToDevice));
+      } else {
+        HIPCHECK_TEST(hipMemset(b.mem[g], 0, elems * sizeof(T)));
+      }
+      b.sendPtrs[g] = b.mem[g];
+      b.recvPtrs[g] = b.mem[g];
+      b.counts[g] = count;
+    }
+  }
+
+  void freeBuffers(Buffers& b) {
+    for (void* p : b.mem) {
+      HIPCHECK_TEST(hipFree(p));
+    }
+  }
+
+  template <typename T>
+  void expectAllEqual(const Buffers& b, size_t count, T want) {
+    std::vector<T> got(count);
+    HIPCHECK_TEST(hipMemcpy(
+        got.data(),
+        b.mem[b.myActiveGroup],
+        count * sizeof(T),
+        hipMemcpyDeviceToHost));
+    size_t reported = 0;
+    for (size_t i = 0; i < count && reported < 8; i++) {
+      if (got[i] != want) {
+        reported++;
+        ADD_FAILURE() << "element " << i << ": got " << got[i] << ", want "
+                      << want;
+      }
+    }
+  }
+
+  ncclResult_t call(const Buffers& b, ncclDataType_t dt, int lowPrecision) {
+    return callAllReduceCompat(
+        b.sendPtrs,
+        b.recvPtrs,
+        b.counts,
+        dt,
+        ncclSum,
+        this->commFor(kActive),
+        this->stream,
+        Standard4GroupActiveRanks().allActiveRanks,
+        kActive,
+        kGroups,
+        lowPrecision);
+  }
+};
+
+TEST_F(ShardedRelayAllReduceLowPrecisionTest, ConstantBlocksAreBitExact) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  const float contribution =
+      static_cast<float>(this->globalRank % kActive) + 1.0f;
+  Buffers b;
+  makeBuffers<float>(kLpCount, contribution, b);
+  barrierSyncOn(static_cast<int32_t*>(b.mem[0]));
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclFloat32, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  // 1.0 + 2.0 across the two active ranks, identical in every element.
+  expectAllEqual<float>(b, kLpCount, 3.0f);
+  EXPECT_GT(rcclx::relay::lpEngageCount(), 0u)
+      << "low precision never engaged, so this case proved nothing";
+  EXPECT_EQ(rcclx::relay::lpDeclineCount(), 0u);
+  freeBuffers(b);
+}
+
+TEST_F(ShardedRelayAllReduceLowPrecisionTest, DeclinesOnUnsupportedDtype) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // ncclInt32 is not a low-precision dtype, so the flag must fall through to
+  // full precision and the answer must be exactly the full-precision answer.
+  Buffers b;
+  makeBuffers<int32_t>(kLpCount, 1, b);
+  barrierSyncOn(static_cast<int32_t*>(b.mem[0]));
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclInt32, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  expectAllEqual<int32_t>(b, kLpCount, kActive);
+  EXPECT_EQ(rcclx::relay::lpEngageCount(), 0u);
+  EXPECT_GT(rcclx::relay::lpDeclineCount(rcclx::relay::LpDecline::Dtype), 0u);
+  freeBuffers(b);
+}
+
+TEST_F(
+    ShardedRelayAllReduceLowPrecisionTest,
+    DeclinesOnCountThatIsNotWholeBlocks) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // One element past a whole number of 128-element blocks. bytes() is only
+  // additive on whole blocks, so the gate must refuse rather than produce
+  // offsets its peers compute differently.
+  const size_t count = kLpCount + 1;
+  const float contribution =
+      static_cast<float>(this->globalRank % kActive) + 1.0f;
+  Buffers b;
+  makeBuffers<float>(count, contribution, b);
+  barrierSyncOn(static_cast<int32_t*>(b.mem[0]));
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclFloat32, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  expectAllEqual<float>(b, count, 3.0f);
+  EXPECT_EQ(rcclx::relay::lpEngageCount(), 0u);
+  EXPECT_GT(
+      rcclx::relay::lpDeclineCount(rcclx::relay::LpDecline::Alignment), 0u);
+  freeBuffers(b);
+}
+
+TEST_F(ShardedRelayAllReduceLowPrecisionTest, InterleavesWithFullPrecision) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // The behaviour an env var could not express, and the whole point of making
+  // this a per-call argument: two calls on the SAME communicator, one low
+  // precision and one not, with no state leaking from the first into the
+  // second.
+  const float contribution =
+      static_cast<float>(this->globalRank % kActive) + 1.0f;
+  Buffers b;
+  makeBuffers<float>(kLpCount, contribution, b);
+  barrierSyncOn(static_cast<int32_t*>(b.mem[0]));
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclFloat32, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+  expectAllEqual<float>(b, kLpCount, 3.0f);
+  ASSERT_GT(rcclx::relay::lpEngageCount(), 0u);
+
+  // Re-seed and run the same shape at full precision.
+  freeBuffers(b);
+  makeBuffers<float>(kLpCount, contribution, b);
+  barrierSyncOn(static_cast<int32_t*>(b.mem[0]));
+  const uint64_t engagedBefore = rcclx::relay::lpEngageCount();
+  ASSERT_EQ(call(b, ncclFloat32, /*lowPrecision=*/0), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+  expectAllEqual<float>(b, kLpCount, 3.0f);
+  EXPECT_EQ(rcclx::relay::lpEngageCount(), engagedBefore)
+      << "a full-precision call must not engage low precision";
+  freeBuffers(b);
 }
 
 int main(int argc, char* argv[]) {

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
@@ -2745,6 +2745,85 @@ TEST_F(ShardedRelayAllReduceLowPrecisionTest, InterleavesWithFullPrecision) {
   freeBuffers(b);
 }
 
+TEST_F(ShardedRelayAllReduceLowPrecisionTest, SingleGroupPipelinedIsBitExact) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // The 4-group fixture above cannot reach the pipelined schedule:
+  // relayPipelineTiles() returns 1 whenever nGroups != 1. So this case is
+  // single-group, at a size large enough that the depth selector picks T > 1 --
+  // asserted below rather than assumed, because a size that quietly failed to
+  // pipeline would silently re-test the schedule the other cases already cover.
+  const int nGroups = 1;
+  const size_t count =
+      16ULL * 1024 * 1024; // 64 MiB fp32, a whole number of blocks
+
+  ASSERT_GT(
+      rcclx::relay::relayPipelineTiles(
+          nGroups,
+          rcclx::relay::relayShapeA2(this->numRanks - kActive),
+          count,
+          sizeof(float)),
+      1)
+      << "chosen count does not pipeline, so this case would not exercise the "
+         "pipelined schedule";
+
+  const int activeRanks[] = {0, 1};
+  const int* allActiveRanks[] = {activeRanks};
+  const bool isActive = (this->globalRank == 0 || this->globalRank == 1);
+  const float contribution =
+      isActive ? static_cast<float>(this->globalRank % kActive) + 1.0f : 0.0f;
+
+  const size_t elems = isActive ? count : static_cast<size_t>(kActive) * count;
+  float* buff = nullptr;
+  HIPCHECK_TEST(hipMalloc(&buff, elems * sizeof(float)));
+  barrierSyncOn(reinterpret_cast<int32_t*>(buff));
+  if (isActive) {
+    const std::vector<float> host(count, contribution);
+    HIPCHECK_TEST(hipMemcpy(
+        buff, host.data(), count * sizeof(float), hipMemcpyHostToDevice));
+  } else {
+    HIPCHECK_TEST(hipMemset(buff, 0, elems * sizeof(float)));
+  }
+
+  const void* sendPtrs[1] = {buff};
+  void* recvPtrs[1] = {buff};
+  size_t counts[1] = {count};
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(
+      callAllReduceCompat(
+          sendPtrs,
+          recvPtrs,
+          counts,
+          ncclFloat32,
+          ncclSum,
+          this->commFor(kActive),
+          this->stream,
+          allActiveRanks,
+          kActive,
+          nGroups,
+          /*lowPrecision=*/1),
+      ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  if (isActive) {
+    std::vector<float> got(count);
+    HIPCHECK_TEST(hipMemcpy(
+        got.data(), buff, count * sizeof(float), hipMemcpyDeviceToHost));
+    size_t reported = 0;
+    for (size_t i = 0; i < count && reported < 8; i++) {
+      if (got[i] != 3.0f) {
+        reported++;
+        ADD_FAILURE() << "element " << i << ": got " << got[i] << ", want 3";
+      }
+    }
+    EXPECT_GT(rcclx::relay::lpEngageCount(), 0u)
+        << "low precision never engaged, so this case proved nothing";
+  }
+  HIPCHECK_TEST(hipFree(buff));
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllReduceTest.cu
@@ -2824,6 +2824,143 @@ TEST_F(ShardedRelayAllReduceLowPrecisionTest, SingleGroupPipelinedIsBitExact) {
   HIPCHECK_TEST(hipFree(buff));
 }
 
+// ---------------------------------------------------------------------------
+// 4 active (flat offload schedule)
+// ---------------------------------------------------------------------------
+class ShardedRelayAllReduceFlatLowPrecisionTest
+    : public ShardedRelayMultiGroupAllReduceTest {
+ protected:
+  static constexpr int kGroups = 2;
+  static constexpr int kActive = 4;
+  // A multiple of A*128 == 512, which the flat schedule requires: it splits its
+  // direct region into A per-owner shards of pD/A, and pD being a whole number
+  // of wire blocks does not make pD/A one.
+  static constexpr size_t kCount = 2ULL * 1024 * 1024;
+
+  // Rank r is active for group r/4, helper for the other.
+  int myGroup() const {
+    return this->globalRank / kActive;
+  }
+
+  ncclResult_t
+  run(void** mem, size_t count, ncclDataType_t dt, int lowPrecision) {
+    static const int g0[] = {0, 1, 2, 3};
+    static const int g1[] = {4, 5, 6, 7};
+    const int* allActiveRanks[] = {g0, g1};
+    const void* sendPtrs[kGroups];
+    void* recvPtrs[kGroups];
+    size_t counts[kGroups];
+    for (int g = 0; g < kGroups; g++) {
+      sendPtrs[g] = mem[g];
+      recvPtrs[g] = mem[g];
+      counts[g] = count;
+    }
+    return callAllReduceCompat(
+        sendPtrs,
+        recvPtrs,
+        counts,
+        dt,
+        ncclSum,
+        this->commFor(kActive),
+        this->stream,
+        allActiveRanks,
+        kActive,
+        kGroups,
+        lowPrecision);
+  }
+
+  void alloc(void** mem, size_t count) {
+    for (int g = 0; g < kGroups; g++) {
+      const size_t elems =
+          (g == myGroup()) ? count : static_cast<size_t>(kActive) * count;
+      HIPCHECK_TEST(hipMalloc(&mem[g], elems * sizeof(float)));
+      if (g == myGroup()) {
+        // Contribution 1..4 by active index, so the sum is exactly 10.
+        const std::vector<float> host(
+            count, static_cast<float>(this->globalRank % kActive) + 1.0f);
+        HIPCHECK_TEST(hipMemcpy(
+            mem[g], host.data(), count * sizeof(float), hipMemcpyHostToDevice));
+      } else {
+        HIPCHECK_TEST(hipMemset(mem[g], 0, elems * sizeof(float)));
+      }
+    }
+  }
+
+  void expectSumIsTen(void** mem, size_t count) {
+    std::vector<float> got(count);
+    HIPCHECK_TEST(hipMemcpy(
+        got.data(),
+        mem[myGroup()],
+        count * sizeof(float),
+        hipMemcpyDeviceToHost));
+    size_t reported = 0;
+    for (size_t i = 0; i < count && reported < 8; i++) {
+      if (got[i] != 10.0f) {
+        reported++;
+        ADD_FAILURE() << "element " << i << ": got " << got[i] << ", want 10";
+      }
+    }
+  }
+
+  void freeAll(void** mem) {
+    for (int g = 0; g < kGroups; g++) {
+      HIPCHECK_TEST(hipFree(mem[g]));
+    }
+  }
+};
+
+TEST_F(ShardedRelayAllReduceFlatLowPrecisionTest, ConstantBlocksAreBitExact) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  void* mem[kGroups];
+  alloc(mem, kCount);
+  barrierSyncOn(static_cast<int32_t*>(mem[0]));
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(run(mem, kCount, ncclFloat32, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  // 1+2+3+4 == 10, exactly, in every element. This covers both of the flat
+  // schedule's regions at once: the direct reduce-scatter/all-gather over
+  // [0, pD) and the helper-reduced offload region over [pD, count).
+  expectSumIsTen(mem, kCount);
+  EXPECT_GT(rcclx::relay::lpEngageCount(), 0u)
+      << "low precision never engaged, so this case proved nothing";
+  freeAll(mem);
+}
+
+TEST_F(
+    ShardedRelayAllReduceFlatLowPrecisionTest,
+    DeclinesOnCountAlignedToBlocksButNotToShards) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // The regression test for the reason the gate needs a per-call alignment:
+  // this count IS a whole number of 128-element wire blocks, so the 2-active
+  // gate would admit it, but it is NOT a multiple of A*128, so pD/A would be a
+  // fractional block and every offset in the direct region would be wrong.
+  const size_t count =
+      kCount + rcclx::relay::kLpBlockElems; // + 128: still blocks, not shards
+  ASSERT_EQ(count % 128u, 0u);
+  ASSERT_NE(count % (kActive * 128u), 0u);
+
+  void* mem[kGroups];
+  alloc(mem, count);
+  barrierSyncOn(static_cast<int32_t*>(mem[0]));
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(run(mem, count, ncclFloat32, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  // Full precision, so still exactly 10.
+  expectSumIsTen(mem, count);
+  EXPECT_EQ(rcclx::relay::lpEngageCount(), 0u);
+  EXPECT_GT(
+      rcclx::relay::lpDeclineCount(rcclx::relay::LpDecline::Alignment), 0u);
+  freeAll(mem);
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayAllToAllTest.cu
@@ -150,7 +150,8 @@ static ncclResult_t callAllToAllCompat(
     hipStream_t stream,
     const int* const* allActiveRanks,
     int nActiveRanksPerGroup,
-    int nGroups) {
+    int nGroups,
+    int lowPrecision = 0) {
   return ncclShardedRelayMultiGroupAllToAll(
       sendPtrs,
       recvPtrs,
@@ -160,7 +161,8 @@ static ncclResult_t callAllToAllCompat(
       stream,
       allActiveRanks,
       nActiveRanksPerGroup,
-      nGroups);
+      nGroups,
+      lowPrecision);
 }
 
 class ShardedRelayMultiGroupAllToAllTest : public ::testing::Test {

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayControlPlaneGraphTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayControlPlaneGraphTest.cu
@@ -292,7 +292,8 @@ class ShardedRelayControlPlaneGraphTest : public ::testing::TestWithParam<int> {
         this->stream,
         allActiveRanks,
         nActive(),
-        1));
+        1,
+        /*lowPrecision=*/0));
   }
 
   // EndCapture always runs, so a failure inside `body` cannot leave the stream

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayControlPlaneTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayControlPlaneTest.cu
@@ -294,7 +294,8 @@ class ShardedRelayControlPlaneTest : public ::testing::TestWithParam<int> {
             this->stream,
             allActiveRanks,
             nActive,
-            1);
+            1,
+            /*lowPrecision=*/0);
       case rcclx::relay::kRelayOpReduceScatter:
         return ncclShardedRelayMultiGroupReduceScatter(
             sendPtrs,
@@ -306,7 +307,8 @@ class ShardedRelayControlPlaneTest : public ::testing::TestWithParam<int> {
             this->stream,
             allActiveRanks,
             nActive,
-            1);
+            1,
+            /*lowPrecision=*/0);
       case rcclx::relay::kRelayOpAllGather:
         return ncclShardedRelayMultiGroupAllGather(
             sendPtrs,
@@ -317,7 +319,8 @@ class ShardedRelayControlPlaneTest : public ::testing::TestWithParam<int> {
             this->stream,
             allActiveRanks,
             nActive,
-            1);
+            1,
+            /*lowPrecision=*/0);
       case rcclx::relay::kRelayOpAllToAll:
         return ncclShardedRelayMultiGroupAllToAll(
             sendPtrs,
@@ -328,7 +331,8 @@ class ShardedRelayControlPlaneTest : public ::testing::TestWithParam<int> {
             this->stream,
             allActiveRanks,
             nActive,
-            1);
+            1,
+            /*lowPrecision=*/0);
       default:
         return ncclInvalidArgument;
     }

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayGraphCaptureTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayGraphCaptureTest.cu
@@ -397,7 +397,8 @@ class ShardedRelayGraphCaptureReduceScatterTest
         this->stream,
         this->allActiveRanks,
         kActive,
-        kGroups);
+        kGroups,
+        /*lowPrecision=*/0);
   }
 
   // Run one uncaptured reduce-scatter and verify it, with a barrier either
@@ -664,7 +665,8 @@ TEST_F(ShardedRelayGraphCaptureOtherCollectivesTest, AllReduceMultiReplay) {
         this->stream,
         this->allActiveRanks,
         kActive,
-        kGroups);
+        kGroups,
+        /*lowPrecision=*/0);
   };
 
   if (this->isActive) {
@@ -725,7 +727,8 @@ TEST_F(ShardedRelayGraphCaptureOtherCollectivesTest, AllGatherMultiReplay) {
         this->stream,
         this->allActiveRanks,
         kActive,
-        kGroups);
+        kGroups,
+        /*lowPrecision=*/0);
   };
 
   if (this->isActive) {
@@ -798,7 +801,8 @@ TEST_F(ShardedRelayGraphCaptureOtherCollectivesTest, AllToAllMultiReplay) {
         this->stream,
         this->allActiveRanks,
         kActive,
-        kGroups);
+        kGroups,
+        /*lowPrecision=*/0);
   };
 
   if (this->isActive) {

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayLpTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayLpTest.cu
@@ -1,0 +1,188 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/**
+ * Unit-level properties of the low-precision relay path.
+ *
+ * WHY ppn=1 AND WHY THIS SUITE EXISTS SEPARATELY
+ *
+ * Nothing here needs a communicator. These are the properties the four
+ * collectives will BUILD ON, and they are much easier to pin down here than
+ * through an 8-rank collective: what a scale means, where a block ends, that
+ * bytes() is additive, that a reduction accumulates in fp32. If one of these is
+ * wrong, every collective is wrong in the same way, and a failure in this suite
+ * says which property broke instead of "the allreduce answer is off by 3%".
+ */
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "meta/relay/sharded_relay_lp.h"
+#include "nccl.h"
+
+using namespace rcclx::relay;
+
+namespace {
+
+constexpr size_t kBlock = kLpBlockElems;
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Wire layout. Host only -- these are the arithmetic identities every offset
+// expression in the four collectives is about to depend on.
+// ---------------------------------------------------------------------------
+
+TEST(ShardedRelayLpWire, BlockLayoutIsExactly33Over32) {
+  EXPECT_EQ(kLpBlockElems, 128u);
+  EXPECT_EQ(kLpBlockBytes, 132u);
+  EXPECT_EQ(lpWireBytes(kBlock), kLpBlockBytes);
+  for (size_t blocks = 1; blocks <= 4096; blocks *= 2) {
+    const size_t elems = blocks * kBlock;
+    EXPECT_EQ(lpWireBytes(elems) * 32, elems * 33) << "at " << elems;
+  }
+}
+
+TEST(ShardedRelayLpWire, BytesIsAdditiveOnAlignedCounts) {
+  // Exactly the shape every collective relies on: a region split into pieces
+  // whose wire bytes must sum to the whole, and an offset that must land where
+  // the previous piece ended.
+  const std::vector<size_t> counts = {
+      kBlock, 2 * kBlock, 8 * kBlock, 1000 * kBlock, 129024, 16777216};
+  for (size_t a : counts) {
+    for (size_t b : counts) {
+      EXPECT_EQ(lpWireBytes(a + b), lpWireBytes(a) + lpWireBytes(b))
+          << "a=" << a << " b=" << b;
+    }
+  }
+  // And the three-way split the pipelined paths produce.
+  const size_t total = 3 * 1024 * kBlock;
+  const size_t p0 = 1024 * kBlock;
+  const size_t p1 = 512 * kBlock;
+  EXPECT_EQ(
+      lpWireBytes(p0) + lpWireBytes(p1) + lpWireBytes(total - p0 - p1),
+      lpWireBytes(total));
+}
+
+TEST(ShardedRelayLpWire, FullPrecisionWireReproducesTodaysArithmetic) {
+  const RelayWire fp = lpFullPrecisionWire(ncclFloat32, sizeof(float));
+  EXPECT_FALSE(fp.lp);
+  EXPECT_EQ(fp.dtype, ncclFloat32);
+  for (size_t n : {size_t{1}, size_t{7}, size_t{128}, size_t{1000000}}) {
+    EXPECT_EQ(fp.bytes(n), n * sizeof(float));
+    EXPECT_EQ(fp.count(n), n);
+  }
+}
+
+TEST(ShardedRelayLpWire, LowPrecisionWireIsBytesOfUint8) {
+  const RelayWire lp = lpWireFor(ncclBfloat16, sizeof(uint16_t), true);
+  EXPECT_TRUE(lp.lp);
+  EXPECT_EQ(lp.dtype, ncclUint8);
+  // elemSize still describes the caller's buffers, not the wire.
+  EXPECT_EQ(lp.elemSize, sizeof(uint16_t));
+  for (size_t blocks : {size_t{1}, size_t{3}, size_t{1024}}) {
+    const size_t n = blocks * kBlock;
+    EXPECT_EQ(lp.bytes(n), lpWireBytes(n));
+    // count == bytes is what makes one ncclSend move one self-describing blob.
+    EXPECT_EQ(lp.count(n), lp.bytes(n));
+  }
+  // A bf16 message shrinks by 1.94x on the wire, an fp32 one by 3.88x.
+  const size_t n = 1024 * kBlock;
+  EXPECT_NEAR(
+      static_cast<double>(n * sizeof(uint16_t)) / lp.bytes(n), 1.939, 0.01);
+  EXPECT_NEAR(
+      static_cast<double>(n * sizeof(float)) / lp.bytes(n), 3.879, 0.01);
+}
+
+// ---------------------------------------------------------------------------
+// The gate
+// ---------------------------------------------------------------------------
+
+TEST(ShardedRelayLpGate, SupportsOnlyBf16AndFp32) {
+  EXPECT_TRUE(lpDtypeSupported(ncclBfloat16));
+  EXPECT_TRUE(lpDtypeSupported(ncclFloat32));
+  EXPECT_FALSE(lpDtypeSupported(ncclFloat16));
+  EXPECT_FALSE(lpDtypeSupported(ncclInt32));
+  EXPECT_FALSE(lpDtypeSupported(ncclFloat64));
+}
+
+TEST(ShardedRelayLpGate, RequiresEveryPerGroupCountToBeAWholeNumberOfBlocks) {
+  const size_t aligned[] = {kBlock, 4 * kBlock, 16777216};
+  const size_t oneOff[] = {kBlock, 4 * kBlock + 1, 16777216};
+  const size_t withZero[] = {kBlock, 0};
+  EXPECT_TRUE(lpCountsAligned(aligned, 3));
+  EXPECT_FALSE(lpCountsAligned(oneOff, 3));
+  EXPECT_FALSE(lpCountsAligned(withZero, 2));
+  EXPECT_FALSE(lpCountsAligned(nullptr, 1));
+  EXPECT_FALSE(lpCountsAligned(aligned, 0));
+}
+
+TEST(ShardedRelayLpGate, EachDeclineReasonIsCountedSeparately) {
+  // Engagement is asserted through these counters everywhere low precision is
+  // tested, because the gate declines SILENTLY -- an LP run that quietly fell
+  // back looks exactly like a passing one. So the counters themselves need to
+  // be trustworthy.
+  const size_t good[] = {4 * kBlock};
+  const size_t bad[] = {4 * kBlock + 3};
+  const size_t big = static_cast<size_t>(64) << 20;
+
+  LpGateInputs in;
+  in.coll = LpCollective::AllReduce;
+  in.datatype = ncclFloat32;
+  in.counts = good;
+  in.nGroups = 1;
+  in.nActiveRanksPerGroup = 2;
+  in.routeSizeBytes = big;
+  in.relayRouteSelected = true;
+
+  lpResetCounters();
+  EXPECT_TRUE(lpEligible(in));
+  EXPECT_EQ(lpDeclineCount(), 0u);
+
+  LpGateInputs notRelay = in;
+  notRelay.relayRouteSelected = false;
+  EXPECT_FALSE(lpEligible(notRelay));
+  EXPECT_EQ(lpDeclineCount(LpDecline::Route), 1u);
+
+  LpGateInputs wrongDtype = in;
+  wrongDtype.datatype = ncclInt32;
+  EXPECT_FALSE(lpEligible(wrongDtype));
+  EXPECT_EQ(lpDeclineCount(LpDecline::Dtype), 1u);
+
+  LpGateInputs unaligned = in;
+  unaligned.counts = bad;
+  EXPECT_FALSE(lpEligible(unaligned));
+  EXPECT_EQ(lpDeclineCount(LpDecline::Alignment), 1u);
+
+  LpGateInputs tooSmall = in;
+  tooSmall.routeSizeBytes = 4096;
+  EXPECT_FALSE(lpEligible(tooSmall));
+  EXPECT_EQ(lpDeclineCount(LpDecline::Size), 1u);
+
+  EXPECT_EQ(lpDeclineCount(), 4u);
+  lpRecordEngage();
+  EXPECT_EQ(lpEngageCount(), 1u);
+  lpResetCounters();
+  EXPECT_EQ(lpEngageCount(), 0u);
+  EXPECT_EQ(lpDeclineCount(), 0u);
+}
+
+TEST(ShardedRelayLpGate, SizeThresholdIsAboveTheLaunchBoundBand) {
+  // Below ~576 KB the measured relay time is flat: that band is pure launch
+  // cost, and low precision ADDS launches. A threshold inside it would make
+  // things slower.
+  for (int a : {2, 4}) {
+    for (int g : {1, 4}) {
+      EXPECT_GE(lpMinBytes(LpCollective::AllReduce, a, g), size_t{576} << 10);
+      EXPECT_GE(lpMinBytes(LpCollective::AllToAll, a, g), size_t{576} << 10);
+    }
+  }
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayLpTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayLpTest.cu
@@ -11,15 +11,38 @@
  * bytes() is additive, that a reduction accumulates in fp32. If one of these is
  * wrong, every collective is wrong in the same way, and a failure in this suite
  * says which property broke instead of "the allreduce answer is off by 3%".
+ *
+ * HOW CORRECTNESS IS ASSERTED WITHOUT A HOST fp8 MODEL
+ *
+ * rccl_float8 is __hip_fp8_e4m3_fnuz on gfx942 and OCP __hip_fp8_e4m3
+ * elsewhere, and the two encode the same value to different bytes. A host-side
+ * reference implementation would therefore have to know which device it is
+ * talking to, and would silently be testing itself on the arch it guessed
+ * wrong. So nothing here models fp8:
+ *
+ *  - Round-trip cases assert PROPERTIES that hold for both flavours: a block
+ *    whose elements are equal comes back bit-exact (the power-of-two
+ *    normalization target is what buys that, see sharded_relay_lp.h), and
+ *    anything else comes back inside e4m3's relative band.
+ *  - Reduce cases build their reference from the DEQUANTIZED inputs, read back
+ *    from the device. That takes input quantization out of the comparison
+ *    entirely, so what is left under test is the reduction arithmetic and the
+ * one rounding of its result -- which is the part these kernels actually own.
  */
 
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
 
+#include <algorithm>
+#include <cmath>
 #include <cstdint>
+#include <limits>
+#include <random>
 #include <vector>
 
 #include "meta/relay/sharded_relay_lp.h"
+#include "meta/relay/sharded_relay_lp_kernels.h"
 #include "nccl.h"
 
 using namespace rcclx::relay;
@@ -27,6 +50,178 @@ using namespace rcclx::relay;
 namespace {
 
 constexpr size_t kBlock = kLpBlockElems;
+
+// e4m3 has 3 explicit mantissa bits, so its half-ULP is 2^-4 = 6.25% relative.
+constexpr float kE4m3RelBand = 0.0625f;
+
+// RMS relative error of one e4m3 round-to-nearest, which is the floor the
+// global L2 check can possibly sit at. Within a binade the relative ULP runs
+// from 2^-3 at the bottom to 2^-4 at the top, and round-to-nearest error is
+// uniform on
+// +/- ULP/2, so the relative RMS is about 2^-4.5 / sqrt(3) = 0.026. Measured on
+// normal data this suite reads 0.0247-0.0257, i.e. exactly that -- which is
+// itself the strongest evidence the scale arithmetic is right, and the reason
+// an earlier 0.02 limit here was unsatisfiable rather than strict.
+//
+// 0.035 leaves ~35% headroom over the floor while still being nowhere near what
+// a real defect produces: a systematically wrong scale, a scale read from the
+// neighbouring block, or a dropped scale all land at 0.5 or above.
+constexpr float kL2LimitOneRounding = 0.035f;
+
+// Absolute floor for elements far below their block's maximum. With the absmax
+// normalized to 128, the smallest representable normalized magnitude is 2^-9
+// (OCP) or 2^-10 (fnuz) so the true floor is blockAbsMax * 2^-16 at worst;
+// /1024 leaves 64x of margin, which is the difference between a meaningful
+// bound and a flaky one.
+constexpr float kAbsBandFraction = 1.0f / 1024.0f;
+
+class DeviceBuf {
+ public:
+  explicit DeviceBuf(size_t bytes) {
+    if (bytes > 0 && hipMalloc(&p_, bytes) != hipSuccess) {
+      p_ = nullptr;
+    }
+  }
+  ~DeviceBuf() {
+    if (p_ != nullptr) {
+      hipFree(p_);
+    }
+  }
+  DeviceBuf(const DeviceBuf&) = delete;
+  DeviceBuf& operator=(const DeviceBuf&) = delete;
+
+  void* get() const {
+    return p_;
+  }
+
+ private:
+  void* p_{nullptr};
+};
+
+void toDevice(void* dst, const std::vector<float>& src) {
+  ASSERT_EQ(
+      hipMemcpy(
+          dst, src.data(), src.size() * sizeof(float), hipMemcpyHostToDevice),
+      hipSuccess);
+}
+
+std::vector<float> fromDevice(const void* src, size_t count) {
+  std::vector<float> out(count, 0.0f);
+  EXPECT_EQ(
+      hipMemcpy(out.data(), src, count * sizeof(float), hipMemcpyDeviceToHost),
+      hipSuccess);
+  return out;
+}
+
+// Quantize `in`, then dequantize it back. Returns what the wire round-trip
+// produced -- which is also, for every reduce test below, the ground truth for
+// what the wire actually holds.
+std::vector<float> roundTrip(const std::vector<float>& in) {
+  const size_t n = in.size();
+  DeviceBuf dIn(n * sizeof(float));
+  DeviceBuf dWire(lpWireBytes(n));
+  DeviceBuf dOut(n * sizeof(float));
+  toDevice(dIn.get(), in);
+  launchLpQuantizeKernel<float>(dWire.get(), dIn.get(), n, nullptr);
+  launchLpDequantizeKernel<float>(dOut.get(), dWire.get(), n, nullptr);
+  EXPECT_EQ(hipDeviceSynchronize(), hipSuccess);
+  return fromDevice(dOut.get(), n);
+}
+
+// Quantize `in` into an owned wire buffer, and report what that wire decodes
+// to.
+struct WireAndTruth {
+  std::vector<float> truth;
+};
+
+WireAndTruth quantizeInto(void* wire, const std::vector<float>& in) {
+  const size_t n = in.size();
+  DeviceBuf dIn(n * sizeof(float));
+  DeviceBuf dBack(n * sizeof(float));
+  toDevice(dIn.get(), in);
+  launchLpQuantizeKernel<float>(wire, dIn.get(), n, nullptr);
+  launchLpDequantizeKernel<float>(dBack.get(), wire, n, nullptr);
+  EXPECT_EQ(hipDeviceSynchronize(), hipSuccess);
+  return WireAndTruth{fromDevice(dBack.get(), n)};
+}
+
+std::vector<float> blockAbsMaxPerElement(const std::vector<float>& v) {
+  std::vector<float> out(v.size(), 0.0f);
+  for (size_t b = 0; b * kBlock < v.size(); b++) {
+    float m = 0.0f;
+    for (size_t i = 0; i < kBlock; i++) {
+      m = std::max(m, std::fabs(v[b * kBlock + i]));
+    }
+    for (size_t i = 0; i < kBlock; i++) {
+      out[b * kBlock + i] = m;
+    }
+  }
+  return out;
+}
+
+// |got - want| <= 6.25%*|want| + absMax/1024, plus a global relative L2 bound.
+// The L2 check is not redundant: a 6.25% per-element band would otherwise pass
+// a block whose scale is systematically wrong on smooth data.
+void expectWithinE4m3Band(
+    const std::vector<float>& got,
+    const std::vector<float>& want,
+    float l2Limit = kL2LimitOneRounding) {
+  ASSERT_EQ(got.size(), want.size());
+  const std::vector<float> absMax = blockAbsMaxPerElement(want);
+  double num = 0.0;
+  double den = 0.0;
+  size_t reported = 0;
+  for (size_t i = 0; i < want.size(); i++) {
+    const float tol =
+        kE4m3RelBand * std::fabs(want[i]) + kAbsBandFraction * absMax[i];
+    const float err = std::fabs(got[i] - want[i]);
+    if (err > tol && reported < 8) {
+      reported++;
+      ADD_FAILURE() << "element " << i << " (block " << i / kBlock << "): got "
+                    << got[i] << ", want " << want[i] << ", tolerance " << tol;
+    }
+    num += static_cast<double>(err) * err;
+    den += static_cast<double>(want[i]) * want[i];
+  }
+  if (den > 0.0) {
+    EXPECT_LT(std::sqrt(num / den), l2Limit);
+  }
+}
+
+void expectExact(
+    const std::vector<float>& got,
+    const std::vector<float>& want) {
+  ASSERT_EQ(got.size(), want.size());
+  for (size_t i = 0; i < want.size(); i++) {
+    ASSERT_FLOAT_EQ(got[i], want[i])
+        << "at element " << i << " (block " << i / kBlock << ")";
+  }
+}
+
+// A distinct constant per block, including a zero block and negatives. These
+// are the values that must survive BIT-EXACTLY, which is what lets the
+// collectives' existing constant-fill assertions stay exact under low
+// precision.
+std::vector<float> constantBlocks(size_t nBlocks) {
+  static const float kConstants[] = {
+      1.0f, -3.5f, 0.0f, 1024.0f, 7.25e-3f, -1.0f, 12345.0f, 0.125f};
+  std::vector<float> v(nBlocks * kBlock, 0.0f);
+  for (size_t b = 0; b < nBlocks; b++) {
+    const float c = kConstants[b % (sizeof(kConstants) / sizeof(float))];
+    std::fill(v.begin() + b * kBlock, v.begin() + (b + 1) * kBlock, c);
+  }
+  return v;
+}
+
+std::vector<float> randomValues(size_t n, uint32_t seed, float scale = 1.0f) {
+  std::mt19937 rng(seed);
+  std::normal_distribution<float> dist(0.0f, scale);
+  std::vector<float> v(n);
+  for (size_t i = 0; i < n; i++) {
+    v[i] = dist(rng);
+  }
+  return v;
+}
 
 } // namespace
 
@@ -178,6 +373,303 @@ TEST(ShardedRelayLpGate, SizeThresholdIsAboveTheLaunchBoundBand) {
       EXPECT_GE(lpMinBytes(LpCollective::AllReduce, a, g), size_t{576} << 10);
       EXPECT_GE(lpMinBytes(LpCollective::AllToAll, a, g), size_t{576} << 10);
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Quantize / dequantize
+// ---------------------------------------------------------------------------
+
+TEST(ShardedRelayLpKernels, ConstantBlocksRoundTripBitExactly) {
+  // The property the whole test story rests on: with the absmax normalized to a
+  // POWER OF TWO, a block of equal values comes back unchanged. That is why the
+  // collectives' existing constant-fill assertions stay exact under low
+  // precision and become detectors for a wrong scale, a wrong block boundary or
+  // a dropped scale. If this fails, do not loosen it.
+  const std::vector<float> in = constantBlocks(16);
+  expectExact(roundTrip(in), in);
+}
+
+TEST(ShardedRelayLpKernels, RandomValuesRoundTripInsideTheE4m3Band) {
+  const std::vector<float> in = randomValues(64 * kBlock, 12345);
+  expectWithinE4m3Band(roundTrip(in), in);
+}
+
+TEST(ShardedRelayLpKernels, ScalesArePerBlockNotPerBuffer) {
+  // Block 0 is enormous, block 1 is tiny. Under a single buffer-wide scale
+  // every element of block 1 would quantize to zero; under per-block scales
+  // block 1 is as accurate as if it were alone. This is the test that a scale
+  // is being read from the right block.
+  std::vector<float> in(2 * kBlock, 0.0f);
+  for (size_t i = 0; i < kBlock; i++) {
+    in[i] = 1.0e6f;
+    in[kBlock + i] = 1.0e-6f * static_cast<float>(i + 1);
+  }
+  const std::vector<float> got = roundTrip(in);
+  expectWithinE4m3Band(got, in);
+  for (size_t i = 0; i < kBlock; i++) {
+    EXPECT_GT(got[kBlock + i], 0.0f)
+        << "small block element " << i << " was flattened to zero";
+  }
+}
+
+TEST(ShardedRelayLpKernels, AllZeroBlockRoundTripsToZero) {
+  // scale == 0 is the one case the encode has to special-case, or it divides by
+  // zero and the block comes back NaN.
+  std::vector<float> in(4 * kBlock, 0.0f);
+  for (size_t i = 0; i < kBlock; i++) {
+    in[kBlock + i] = 2.0f; // a non-zero neighbour, so a shared scale would show
+  }
+  const std::vector<float> got = roundTrip(in);
+  expectExact(got, in);
+}
+
+TEST(ShardedRelayLpKernels, ANonFiniteElementDoesNotRoundTripToZero) {
+  // The counterpart of the case above, and the reason the absmax fold is not
+  // fmaxf: fmaxf returns the non-NaN operand, so a block holding a NaN would
+  // take the absmax of its FINITE elements and an all-NaN block would take 0 --
+  // which is the all-zero block's absmax, so the block would be written as 128
+  // zero codes and come back as clean 0.0. A diverged gradient must not arrive
+  // looking converged, or a post-collective isfinite() check stops firing on
+  // exactly the runs that need it.
+  std::vector<float> in = constantBlocks(4);
+  in[0 * kBlock + 5] = std::numeric_limits<float>::quiet_NaN();
+  in[2 * kBlock + 7] = std::numeric_limits<float>::infinity();
+  const std::vector<float> got = roundTrip(in);
+
+  // Asserted per BLOCK, not per element: a non-finite scale is a property of
+  // the whole block, so its 127 finite neighbours are lost too. That is not a
+  // regression -- an inf absmax already flattened them to zero -- and it is the
+  // conservative direction, because non-finite never decodes back to finite.
+  for (size_t i = 0; i < kBlock; i++) {
+    EXPECT_FALSE(std::isfinite(got[0 * kBlock + i]))
+        << "element " << i << " of the NaN-bearing block came back finite";
+    EXPECT_FALSE(std::isfinite(got[2 * kBlock + i]))
+        << "element " << i << " of the inf-bearing block came back finite";
+  }
+  // Blocks 1 and 3 are constant and untouched, so they still round-trip
+  // bit-exactly: the fold is per block and a bad neighbour does not leak in.
+  for (size_t i = 0; i < kBlock; i++) {
+    EXPECT_FLOAT_EQ(got[1 * kBlock + i], in[1 * kBlock + i]) << "at " << i;
+    EXPECT_FLOAT_EQ(got[3 * kBlock + i], in[3 * kBlock + i]) << "at " << i;
+  }
+}
+
+TEST(
+    ShardedRelayLpKernels,
+    ReduceRequantizeKeepsANonFiniteContributionVisible) {
+  // The path that matters most in practice: a region a HELPER reduces lands
+  // straight in the caller's receive buffer, so if the requantize swallowed a
+  // NaN there is no later kernel to notice. One contribution diverges; the sum
+  // must not come back finite.
+  constexpr int kContribs = 3;
+  const size_t n = 4 * kBlock;
+  DeviceBuf dContribs(kContribs * lpWireBytes(n));
+  DeviceBuf dOut(lpWireBytes(n));
+  DeviceBuf dBack(n * sizeof(float));
+
+  for (int p = 0; p < kContribs; p++) {
+    std::vector<float> in = constantBlocks(4);
+    if (p == 1) {
+      in[kBlock + 3] = std::numeric_limits<float>::quiet_NaN();
+    }
+    char* slot = static_cast<char*>(dContribs.get()) + p * lpWireBytes(n);
+    (void)quantizeInto(slot, in);
+  }
+
+  launchLpReduceRequantizeKernel(
+      dOut.get(), dContribs.get(), kContribs, n, /*divisor=*/1, nullptr);
+  launchLpDequantizeKernel<float>(dBack.get(), dOut.get(), n, nullptr);
+  ASSERT_EQ(hipDeviceSynchronize(), hipSuccess);
+
+  const std::vector<float> got = fromDevice(dBack.get(), n);
+  for (size_t i = 0; i < kBlock; i++) {
+    EXPECT_FALSE(std::isfinite(got[kBlock + i]))
+        << "element " << i << " of the diverged block survived the helper hop "
+        << "as a finite value";
+  }
+}
+
+TEST(ShardedRelayLpKernels, TailBlockIsQuantizedAndNeighboursAreUntouched) {
+  // A count that is a whole number of blocks but not a power of two, so the
+  // grid-stride loop's last iteration is partial.
+  const size_t nBlocks = 8191;
+  std::vector<float> in = randomValues(nBlocks * kBlock, 777);
+  // Make the very last block constant, so the tail is checked exactly.
+  std::fill(in.end() - kBlock, in.end(), -2.75f);
+  const std::vector<float> got = roundTrip(in);
+  for (size_t i = 0; i < kBlock; i++) {
+    ASSERT_FLOAT_EQ(got[in.size() - kBlock + i], -2.75f)
+        << "tail element " << i;
+  }
+  expectWithinE4m3Band(got, in);
+}
+
+// ---------------------------------------------------------------------------
+// Reductions
+// ---------------------------------------------------------------------------
+
+TEST(ShardedRelayLpKernels, ReduceRequantizeSumsWireContributionsInFp32) {
+  constexpr int kContribs = 4;
+  const size_t n = 32 * kBlock;
+  DeviceBuf dContribs(kContribs * lpWireBytes(n));
+  DeviceBuf dOut(lpWireBytes(n));
+  DeviceBuf dBack(n * sizeof(float));
+
+  std::vector<float> want(n, 0.0f);
+  for (int p = 0; p < kContribs; p++) {
+    const std::vector<float> in = randomValues(n, 100 + p);
+    char* slot = static_cast<char*>(dContribs.get()) + p * lpWireBytes(n);
+    // Reference is what the WIRE holds, not what we handed in, so input
+    // quantization is out of the comparison.
+    const WireAndTruth w = quantizeInto(slot, in);
+    for (size_t i = 0; i < n; i++) {
+      want[i] += w.truth[i];
+    }
+  }
+
+  launchLpReduceRequantizeKernel(
+      dOut.get(), dContribs.get(), kContribs, n, /*divisor=*/1, nullptr);
+  launchLpDequantizeKernel<float>(dBack.get(), dOut.get(), n, nullptr);
+  ASSERT_EQ(hipDeviceSynchronize(), hipSuccess);
+  expectWithinE4m3Band(fromDevice(dBack.get(), n), want);
+}
+
+TEST(ShardedRelayLpKernels, ReduceRequantizeIsExactForEqualConstantBlocks) {
+  // A sum of equal values has block absmax equal to that sum, so the
+  // power-of-two normalization makes the requantized result exact too. This is
+  // what keeps the collectives' constant-fill reduce assertions exact across
+  // the helper hop.
+  constexpr int kContribs = 3;
+  const size_t n = 8 * kBlock;
+  DeviceBuf dContribs(kContribs * lpWireBytes(n));
+  DeviceBuf dOut(lpWireBytes(n));
+  DeviceBuf dBack(n * sizeof(float));
+
+  const std::vector<float> in = constantBlocks(8);
+  for (int p = 0; p < kContribs; p++) {
+    char* slot = static_cast<char*>(dContribs.get()) + p * lpWireBytes(n);
+    const WireAndTruth w = quantizeInto(slot, in);
+    expectExact(w.truth, in);
+  }
+  std::vector<float> want(n);
+  for (size_t i = 0; i < n; i++) {
+    want[i] = static_cast<float>(kContribs) * in[i];
+  }
+
+  launchLpReduceRequantizeKernel(
+      dOut.get(), dContribs.get(), kContribs, n, /*divisor=*/1, nullptr);
+  launchLpDequantizeKernel<float>(dBack.get(), dOut.get(), n, nullptr);
+  ASSERT_EQ(hipDeviceSynchronize(), hipSuccess);
+  expectExact(fromDevice(dBack.get(), n), want);
+}
+
+TEST(ShardedRelayLpKernels, ReduceRequantizeDivisorIsExactAndAppliedOnce) {
+  // The divisor is always nActiveRanks, which the dispatchers require to be a
+  // power of two. Scaling before the requantize therefore moves the block
+  // absmax by the same exact power of two and leaves every fp8 code unchanged,
+  // so dividing here is bit-identical to dividing after the dequantize. Checked
+  // directly, because it is the reason the helper may own the divisor at all --
+  // the regions a helper reduces have no active-side closing kernel to defer it
+  // to.
+  constexpr int kContribs = 4;
+  constexpr int kDivisor = 4;
+  const size_t n = 8 * kBlock;
+  DeviceBuf dContribs(kContribs * lpWireBytes(n));
+  DeviceBuf dPlain(lpWireBytes(n));
+  DeviceBuf dDivided(lpWireBytes(n));
+  DeviceBuf dPlainBack(n * sizeof(float));
+  DeviceBuf dDividedBack(n * sizeof(float));
+
+  for (int p = 0; p < kContribs; p++) {
+    char* slot = static_cast<char*>(dContribs.get()) + p * lpWireBytes(n);
+    (void)quantizeInto(slot, randomValues(n, 900 + p));
+  }
+
+  launchLpReduceRequantizeKernel(
+      dPlain.get(), dContribs.get(), kContribs, n, /*divisor=*/1, nullptr);
+  launchLpReduceRequantizeKernel(
+      dDivided.get(), dContribs.get(), kContribs, n, kDivisor, nullptr);
+  launchLpDequantizeKernel<float>(dPlainBack.get(), dPlain.get(), n, nullptr);
+  launchLpDequantizeKernel<float>(
+      dDividedBack.get(), dDivided.get(), n, nullptr);
+  ASSERT_EQ(hipDeviceSynchronize(), hipSuccess);
+
+  const std::vector<float> plain = fromDevice(dPlainBack.get(), n);
+  const std::vector<float> divided = fromDevice(dDividedBack.get(), n);
+  for (size_t i = 0; i < n; i++) {
+    // Bit-exact, not approximate: no extra rounding may creep in.
+    ASSERT_FLOAT_EQ(divided[i], plain[i] / static_cast<float>(kDivisor))
+        << "at element " << i;
+  }
+}
+
+TEST(ShardedRelayLpKernels, MultiReduceAccumulatesIntoDstAndDividesOnce) {
+  constexpr int kContribs = 3;
+  constexpr int kDivisor = 4; // == 1 seed + 3 contributions, i.e. ncclAvg
+  const size_t n = 16 * kBlock;
+  DeviceBuf dContribs(kContribs * lpWireBytes(n));
+  DeviceBuf dDst(n * sizeof(float));
+
+  const std::vector<float> dstIn = randomValues(n, 42);
+  std::vector<float> want = dstIn;
+  for (int p = 0; p < kContribs; p++) {
+    const std::vector<float> in = randomValues(n, 200 + p);
+    char* slot = static_cast<char*>(dContribs.get()) + p * lpWireBytes(n);
+    const WireAndTruth w = quantizeInto(slot, in);
+    for (size_t i = 0; i < n; i++) {
+      want[i] += w.truth[i];
+    }
+  }
+  for (size_t i = 0; i < n; i++) {
+    want[i] /= static_cast<float>(kDivisor);
+  }
+
+  toDevice(dDst.get(), dstIn);
+  launchLpMultiReduceKernel<float>(
+      dDst.get(), dContribs.get(), kContribs, n, kDivisor, nullptr);
+  ASSERT_EQ(hipDeviceSynchronize(), hipSuccess);
+  // dst and the contributions are exact here (dst is never quantized, the
+  // contributions were read back from the wire), so the only slack is fp32
+  // summation order.
+  const std::vector<float> got = fromDevice(dDst.get(), n);
+  for (size_t i = 0; i < n; i++) {
+    ASSERT_NEAR(got[i], want[i], 1e-4f * std::fabs(want[i]) + 1e-6f)
+        << "at element " << i;
+  }
+}
+
+TEST(ShardedRelayLpKernels, SeededMultiReduceReadsSeedNotDst) {
+  constexpr int kContribs = 2;
+  const size_t n = 8 * kBlock;
+  DeviceBuf dContribs(kContribs * lpWireBytes(n));
+  DeviceBuf dSeed(n * sizeof(float));
+  DeviceBuf dDst(n * sizeof(float));
+
+  const std::vector<float> seed = randomValues(n, 7);
+  // Poison dst: if the kernel reads it instead of the seed, the answer is wrong
+  // by a large, obvious amount rather than subtly.
+  const std::vector<float> poison(n, 1.0e9f);
+
+  std::vector<float> want = seed;
+  for (int p = 0; p < kContribs; p++) {
+    const std::vector<float> in = randomValues(n, 300 + p);
+    char* slot = static_cast<char*>(dContribs.get()) + p * lpWireBytes(n);
+    const WireAndTruth w = quantizeInto(slot, in);
+    for (size_t i = 0; i < n; i++) {
+      want[i] += w.truth[i];
+    }
+  }
+
+  toDevice(dSeed.get(), seed);
+  toDevice(dDst.get(), poison);
+  launchLpSeededMultiReduceKernel<float>(
+      dDst.get(), dSeed.get(), dContribs.get(), kContribs, n, 1, nullptr);
+  ASSERT_EQ(hipDeviceSynchronize(), hipSuccess);
+  const std::vector<float> got = fromDevice(dDst.get(), n);
+  for (size_t i = 0; i < n; i++) {
+    ASSERT_NEAR(got[i], want[i], 1e-4f * std::fabs(want[i]) + 1e-6f)
+        << "at element " << i;
   }
 }
 

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayLpTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayLpTest.cu
@@ -315,6 +315,36 @@ TEST(ShardedRelayLpGate, RequiresEveryPerGroupCountToBeAWholeNumberOfBlocks) {
   EXPECT_FALSE(lpCountsAligned(aligned, 0));
 }
 
+TEST(ShardedRelayLpGate, CountAlignmentRequirementIsPerCall) {
+  // 128 elements is the floor, but a schedule that subdivides a region needs
+  // more. The flat A>2 allreduce splits its direct region into A per-owner
+  // shards, and pD / A is only a whole number of wire blocks when the count is
+  // a multiple of A * 128 -- so a count that satisfies the floor can still be
+  // wrong for that schedule, and the gate has to be told which it is.
+  const size_t blockAligned[] = {4 * kBlock}; // 512 elements
+  EXPECT_TRUE(lpCountsAligned(blockAligned, 1));
+  EXPECT_TRUE(lpCountsAligned(blockAligned, 1, 4 * kBlock));
+  // A whole number of blocks, but not of 4 blocks: fine at A=2, not at A=4.
+  const size_t threeBlocks[] = {3 * kBlock};
+  EXPECT_TRUE(lpCountsAligned(threeBlocks, 1));
+  EXPECT_FALSE(lpCountsAligned(threeBlocks, 1, 4 * kBlock));
+  EXPECT_FALSE(lpCountsAligned(blockAligned, 1, 0));
+
+  // And it reaches lpEligible through LpGateInputs.
+  LpGateInputs in;
+  in.datatype = ncclFloat32;
+  in.counts = threeBlocks;
+  in.nGroups = 1;
+  in.nActiveRanksPerGroup = 4;
+  in.routeSizeBytes = static_cast<size_t>(64) << 20;
+  in.relayRouteSelected = true;
+  lpResetCounters();
+  EXPECT_TRUE(lpEligible(in));
+  in.countAlignElems = 4 * kBlock;
+  EXPECT_FALSE(lpEligible(in));
+  EXPECT_EQ(lpDeclineCount(LpDecline::Alignment), 1u);
+}
+
 TEST(ShardedRelayLpGate, EachDeclineReasonIsCountedSeparately) {
   // Engagement is asserted through these counters everywhere low precision is
   // tested, because the gate declines SILENTLY -- an LP run that quietly fell

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayLpTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayLpTest.cu
@@ -42,6 +42,7 @@
 #include <vector>
 
 #include "meta/relay/sharded_relay_lp.h"
+#include "meta/relay/sharded_relay_lp_arena.h"
 #include "meta/relay/sharded_relay_lp_kernels.h"
 #include "nccl.h"
 
@@ -374,6 +375,43 @@ TEST(ShardedRelayLpGate, SizeThresholdIsAboveTheLaunchBoundBand) {
       EXPECT_GE(lpMinBytes(LpCollective::AllToAll, a, g), size_t{576} << 10);
     }
   }
+}
+
+TEST(ShardedRelayLpArena, CapacityFollowsTheMessageProvisioning) {
+  // A pure function of NCCL_SHARDED_RELAY_LP_MAX_MSG_MB, which is what makes it
+  // safe for every rank to compare its footprint against independently.
+  const size_t maxElems = lpMaxMsgBytes() / sizeof(uint16_t);
+  EXPECT_EQ(
+      lpArenaCapacityBytes(),
+      kLpArenaShadowsPerMessage * lpWireBytesRoundUp(maxElems));
+  EXPECT_GT(lpArenaCapacityBytes(), lpMaxMsgBytes());
+}
+
+TEST(ShardedRelayLpArena, CarverPartitionsDeterministicallyAndRefusesOverrun) {
+  std::vector<char> backing(1 << 20);
+  LpArenaLease lease{backing.data(), backing.size()};
+
+  LpArenaCarver first(lease);
+  char* a1 = first.take(1000);
+  char* b1 = first.take(4096);
+  ASSERT_NE(a1, nullptr);
+  ASSERT_NE(b1, nullptr);
+
+  // Same order, same addresses -- which is what lets a captured graph replay.
+  LpArenaCarver second(lease);
+  EXPECT_EQ(second.take(1000), a1);
+  EXPECT_EQ(second.take(4096), b1);
+
+  // 256-byte aligned, so the inline fp32 scales are always aligned too.
+  EXPECT_EQ(reinterpret_cast<uintptr_t>(a1) % LpArenaCarver::kAlign, 0u);
+  EXPECT_EQ(reinterpret_cast<uintptr_t>(b1) % LpArenaCarver::kAlign, 0u);
+  EXPECT_GE(b1 - a1, 1000);
+
+  LpArenaCarver small(LpArenaLease{backing.data(), 512});
+  EXPECT_NE(small.take(256), nullptr);
+  EXPECT_TRUE(small.ok());
+  EXPECT_EQ(small.take(1024), nullptr);
+  EXPECT_FALSE(small.ok());
 }
 
 // ---------------------------------------------------------------------------

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
@@ -172,7 +172,8 @@ static ncclResult_t callReduceScatterCompat(
     hipStream_t stream,
     const int* const* allActiveRanks,
     int nActiveRanksPerGroup,
-    int nGroups) {
+    int nGroups,
+    int lowPrecision = 0) {
   return ncclShardedRelayMultiGroupReduceScatter(
       sendPtrs,
       recvPtrs,
@@ -183,7 +184,8 @@ static ncclResult_t callReduceScatterCompat(
       stream,
       allActiveRanks,
       nActiveRanksPerGroup,
-      nGroups);
+      nGroups,
+      lowPrecision);
 }
 
 class ShardedRelayMultiGroupReduceScatterTest : public ::testing::Test {

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
@@ -3485,6 +3485,102 @@ TEST_F(
   freeBuffers(b);
 }
 
+TEST_F(
+    ShardedRelayReduceScatterFlatLowPrecisionTest,
+    SingleGroupPipelinedIsBitExact) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // relayPipelineTiles() returns 1 whenever nGroups != 1, so the two-group
+  // cases above cannot reach the pipelined flat schedule. This one is
+  // single-group, at a size the depth selector pipelines -- asserted, so a
+  // resize cannot quietly turn this into a third test of the non-pipelined
+  // path.
+  const size_t count = 8ULL * 1024 * 1024;
+  size_t counts[1] = {count};
+  ASSERT_EQ(
+      rcclx::relay::selectReduceScatterRoute(
+          kActive, 8 - kActive, 1, counts, sizeof(float)),
+      rcclx::relay::ReduceScatterRoute::FlatOffload);
+  ASSERT_GT(
+      rcclx::relay::relayPipelineTiles(
+          1,
+          rcclx::relay::relayShapeFanout(kActive, 8 - kActive),
+          count,
+          sizeof(float)),
+      1);
+
+  // Group 0's active ranks are {0, 1, 2, 3}; ranks 4-7 are its helpers.
+  const int myActiveIndex = this->globalRank % kActive;
+  const bool owner = this->globalRank < kActive;
+  const size_t inputCount = static_cast<size_t>(kActive) * count;
+
+  void* sendMem = nullptr;
+  void* recvMem = nullptr;
+  HIPCHECK_TEST(hipMalloc(&sendMem, inputCount * sizeof(float)));
+  HIPCHECK_TEST(hipMalloc(&recvMem, count * sizeof(float)));
+  HIPCHECK_TEST(hipMemset(recvMem, 0, count * sizeof(float)));
+  if (owner) {
+    std::vector<float> host(inputCount);
+    for (int j = 0; j < kActive; j++) {
+      std::fill(
+          host.begin() + static_cast<ptrdiff_t>(j * count),
+          host.begin() + static_cast<ptrdiff_t>((j + 1) * count),
+          blockValue(myActiveIndex, j));
+    }
+    HIPCHECK_TEST(hipMemcpy(
+        sendMem,
+        host.data(),
+        inputCount * sizeof(float),
+        hipMemcpyHostToDevice));
+  } else {
+    HIPCHECK_TEST(hipMemset(sendMem, 0, inputCount * sizeof(float)));
+  }
+
+  const void* sendPtrs[1] = {sendMem};
+  void* recvPtrs[1] = {owner ? recvMem : sendMem};
+  barrierSyncOn(nullptr);
+
+  TwoGroupFourActiveRanks layout;
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(
+      callReduceScatterCompat(
+          sendPtrs,
+          recvPtrs,
+          counts,
+          ncclFloat32,
+          ncclSum,
+          this->commFor(kActive),
+          this->stream,
+          layout.allActiveRanks,
+          kActive,
+          1,
+          /*lowPrecision=*/1),
+      ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  if (owner) {
+    const float want = expectedOwnerValue(myActiveIndex);
+    std::vector<float> got(count);
+    HIPCHECK_TEST(hipMemcpy(
+        got.data(), recvMem, count * sizeof(float), hipMemcpyDeviceToHost));
+    size_t reported = 0;
+    for (size_t i = 0; i < count && reported < 8; i++) {
+      if (got[i] != want) {
+        reported++;
+        ADD_FAILURE() << "R" << this->globalRank << ": element " << i
+                      << ": got " << got[i] << ", want " << want;
+      }
+    }
+  }
+  EXPECT_GT(rcclx::relay::lpEngageCount(), 0u)
+      << "low precision never engaged, so this case proved nothing";
+  EXPECT_EQ(rcclx::relay::lpDeclineCount(), 0u);
+
+  HIPCHECK_TEST(hipFree(sendMem));
+  HIPCHECK_TEST(hipFree(recvMem));
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
@@ -3201,15 +3201,15 @@ TEST_F(
 
 TEST_F(
     ShardedRelayReduceScatterLowPrecisionTest,
-    DeclinesForTheSingleGroupPipelinedSchedule) {
+    SingleGroupPipelinedIsBitExact) {
   if (this->numRanks != 8) {
     GTEST_SKIP() << "Test requires exactly 8 ranks";
   }
-  // A single-group call at this size pipelines, and the pipelined schedule does
-  // not carry the wire format yet. The decline has to be unanimous, and it is
-  // because the tile count is a pure function of the counts. The pipeline
-  // selection is asserted rather than assumed, so this case cannot quietly
-  // become a second test of the non-pipelined path.
+  // The 4-group fixture above cannot reach the pipelined schedule:
+  // relayPipelineTiles() returns 1 whenever nGroups != 1. So this case is
+  // single-group, at a size the depth selector pipelines -- asserted rather
+  // than assumed, because a size that quietly failed to pipeline would silently
+  // re-test the schedule the other cases already cover.
   const size_t count = 4ULL * 1024 * 1024;
   const int numHelpers = 8 - kActive;
   ASSERT_GT(
@@ -3226,9 +3226,37 @@ TEST_F(
   HIPCHECK_TEST(hipStreamSynchronize(this->stream));
 
   expectOutputEquals<float>(b, count, expectedOwnerValue(b.myActiveIndex));
-  EXPECT_EQ(rcclx::relay::lpEngageCount(), 0u);
-  EXPECT_GT(rcclx::relay::lpDeclineCount(rcclx::relay::LpDecline::Route), 0u)
-      << "the decline must be recorded, not silent";
+  EXPECT_GT(rcclx::relay::lpEngageCount(), 0u)
+      << "low precision never engaged, so this case proved nothing";
+  EXPECT_EQ(rcclx::relay::lpDeclineCount(), 0u);
+  freeBuffers(b);
+}
+
+TEST_F(
+    ShardedRelayReduceScatterLowPrecisionTest,
+    SingleGroupPipelinedAvgIsBitExact) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // The pipelined schedule reduces PER REGION on a side stream rather than once
+  // at the end, so the divisor is applied T + 1 times over disjoint spans. This
+  // pins that it is applied exactly once per element: a divisor that also
+  // landed at the helper, or one applied twice to an overlapping span, breaks
+  // the exact comparator.
+  const size_t count = 4ULL * 1024 * 1024;
+  Buffers b;
+  makeBuffers<float>(count, /*nGroups=*/1, b);
+  barrierSyncOn(nullptr);
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclFloat32, ncclAvg, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  expectOutputEquals<float>(
+      b,
+      count,
+      expectedOwnerValue(b.myActiveIndex) / static_cast<float>(kActive));
+  EXPECT_GT(rcclx::relay::lpEngageCount(), 0u);
   freeBuffers(b);
 }
 

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
@@ -64,6 +64,7 @@
 #include "comm.h"
 #include "comms/rcclx/develop/meta/testinfra/TestUtils.h"
 #include "comms/rcclx/develop/meta/testinfra/TestsDistUtils.h"
+#include "meta/relay/sharded_relay_lp.h"
 #include "meta/relay/sharded_relay_route.h"
 #include "nccl.h"
 
@@ -2884,6 +2885,351 @@ TEST_F(
   for (int g = 0; g < nGroups; g++) {
     HIPCHECK_TEST(hipFree(sendBuffs[g]));
   }
+}
+
+// ===========================================================================
+// LOW PRECISION (fp8e4m3 wire format)
+// ===========================================================================
+//
+// Every case here asserts that low precision actually ENGAGED or actually
+// DECLINED, via the counters, rather than trusting the flag. The gate declines
+// silently on several independent grounds, so an "LP" run that quietly fell
+// back to full precision produces exactly the numbers a passing LP run
+// produces -- the counter is the only thing that tells them apart.
+//
+// The comparators stay EXACT. Each active rank fills every block it contributes
+// with a single constant, so every 128-element wire block has that constant as
+// its absmax; the power-of-two normalization target then makes
+// quantize/dequantize an identity, and a sum of equal values behaves the same
+// way. These cases are therefore a genuine detector for a wrong scale, a wrong
+// block boundary or a dropped scale. Do not loosen them.
+//
+// Reduce-scatter's own hazard, which no allreduce case can catch: the halves of
+// the send buffer are DIFFERENT blocks bound for different places, and
+// sendBlockOffset selects the one shipped to the partner. Filling each block
+// with a different constant means a wire offset computed against the wrong
+// block, or a quantize hoisted over the wrong span, changes the answer instead
+// of cancelling out.
+class ShardedRelayReduceScatterLowPrecisionTest
+    : public ShardedRelayMultiGroupReduceScatterTest {
+ protected:
+  static constexpr int kActive = 2;
+  static constexpr int kGroups = 4;
+
+  // 2 Mi elements per output block = 16 MiB of fp32 input per active rank,
+  // comfortably above the low-precision size threshold and a whole number of
+  // 128-element blocks.
+  static constexpr size_t kLpCount = 2ULL * 1024 * 1024;
+
+  // bf16 is carried as raw bits, the convention the rest of this file uses, so
+  // that no host-side bf16 arithmetic or comparison is involved. These
+  // overloads are selected by a value-initialized tag of the storage type.
+  static float encodeAs(float v, float) {
+    return v;
+  }
+  static int32_t encodeAs(float v, int32_t) {
+    return static_cast<int32_t>(v);
+  }
+  static uint16_t encodeAs(float v, uint16_t) {
+    return bfloat16Bits(v);
+  }
+
+  template <typename T>
+  static T encode(float v) {
+    return encodeAs(v, T{});
+  }
+
+  // Active rank r's input block b holds this value, so the expected output for
+  // whichever rank owns block b is the sum over r -- a different constant per
+  // owner, which is what makes a swapped block detectable. All four values
+  // (5, 6, 9, 10) and both sums (14, 16) are exactly representable in fp32,
+  // bf16 and, after the power-of-two normalization, e4m3.
+  static float blockValue(int activeIndex, int blockIndex) {
+    return static_cast<float>((activeIndex + 1) * 4 + (blockIndex + 1));
+  }
+
+  static float expectedOwnerValue(int blockIndex) {
+    float sum = 0.0f;
+    for (int r = 0; r < kActive; r++) {
+      sum += blockValue(r, blockIndex);
+    }
+    return sum;
+  }
+
+  struct Buffers {
+    std::vector<void*> sendMem;
+    void* recvMem{nullptr};
+    const void* sendPtrs[kGroups];
+    void* recvPtrs[kGroups];
+    size_t counts[kGroups];
+    int nGroups{kGroups};
+    int myActiveGroup{0};
+    int myActiveIndex{0};
+  };
+
+  // Out-of-place buffers, one contiguous send/recv pair per group. Helper
+  // groups pass their send allocation as the output placeholder, as the rest of
+  // this suite does; only the active group's output is read.
+  template <typename T>
+  void makeBuffers(size_t count, int nGroups, Buffers& b) {
+    b = Buffers{};
+    b.nGroups = nGroups;
+    b.myActiveGroup = this->globalRank / kActive;
+    b.myActiveIndex = this->globalRank % kActive;
+    b.sendMem.resize(nGroups);
+    const size_t elems = static_cast<size_t>(kActive) * count;
+    for (int g = 0; g < nGroups; g++) {
+      HIPCHECK_TEST(hipMalloc(&b.sendMem[g], elems * sizeof(T)));
+      if (g == b.myActiveGroup) {
+        std::vector<T> host(elems);
+        for (int blk = 0; blk < kActive; blk++) {
+          std::fill(
+              host.begin() + static_cast<ptrdiff_t>(blk * count),
+              host.begin() + static_cast<ptrdiff_t>((blk + 1) * count),
+              encode<T>(blockValue(b.myActiveIndex, blk)));
+        }
+        HIPCHECK_TEST(hipMemcpy(
+            b.sendMem[g],
+            host.data(),
+            elems * sizeof(T),
+            hipMemcpyHostToDevice));
+      } else {
+        HIPCHECK_TEST(hipMemset(b.sendMem[g], 0, elems * sizeof(T)));
+      }
+      b.sendPtrs[g] = b.sendMem[g];
+      b.counts[g] = count;
+    }
+    HIPCHECK_TEST(hipMalloc(&b.recvMem, count * sizeof(T)));
+    HIPCHECK_TEST(hipMemset(b.recvMem, 0, count * sizeof(T)));
+    for (int g = 0; g < nGroups; g++) {
+      b.recvPtrs[g] = (g == b.myActiveGroup) ? b.recvMem : b.sendMem[g];
+    }
+  }
+
+  void freeBuffers(Buffers& b) {
+    for (void* p : b.sendMem) {
+      HIPCHECK_TEST(hipFree(p));
+    }
+    HIPCHECK_TEST(hipFree(b.recvMem));
+    b.sendMem.clear();
+    b.recvMem = nullptr;
+  }
+
+  // Exact, element by element. Only the ranks that own an output block check
+  // it; for a single-group call the rest are helpers with no output of their
+  // own.
+  template <typename T>
+  void expectOutputEquals(const Buffers& b, size_t count, float wantValue) {
+    if (b.myActiveGroup >= b.nGroups) {
+      return;
+    }
+    const T want = encode<T>(wantValue);
+    std::vector<T> got(count);
+    HIPCHECK_TEST(hipMemcpy(
+        got.data(), b.recvMem, count * sizeof(T), hipMemcpyDeviceToHost));
+    size_t reported = 0;
+    for (size_t i = 0; i < count && reported < 8; i++) {
+      if (got[i] != want) {
+        reported++;
+        ADD_FAILURE() << "R" << this->globalRank << ": element " << i
+                      << " differs (raw comparison against the encoding of "
+                      << wantValue << ")";
+      }
+    }
+  }
+
+  ncclResult_t
+  call(const Buffers& b, ncclDataType_t dt, ncclRedOp_t op, int lowPrecision) {
+    Standard4GroupActiveRanks layout;
+    return callReduceScatterCompat(
+        b.sendPtrs,
+        b.recvPtrs,
+        b.counts,
+        dt,
+        op,
+        this->commFor(kActive),
+        this->stream,
+        layout.allActiveRanks,
+        kActive,
+        b.nGroups,
+        lowPrecision);
+  }
+};
+
+TEST_F(ShardedRelayReduceScatterLowPrecisionTest, ConstantBlocksAreBitExact) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  Buffers b;
+  makeBuffers<float>(kLpCount, kGroups, b);
+  barrierSyncOn(nullptr);
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclFloat32, ncclSum, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  expectOutputEquals<float>(b, kLpCount, expectedOwnerValue(b.myActiveIndex));
+  EXPECT_GT(rcclx::relay::lpEngageCount(), 0u)
+      << "low precision never engaged, so this case proved nothing";
+  EXPECT_EQ(rcclx::relay::lpDeclineCount(), 0u);
+  freeBuffers(b);
+}
+
+TEST_F(ShardedRelayReduceScatterLowPrecisionTest, Bfloat16IsBitExact) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // The other supported dtype, and the one the wire format was built for: bf16
+  // in, fp8 on the wire, bf16 out, with a single rounding on the whole path
+  // because reduce-scatter's helper never requantizes.
+  Buffers b;
+  makeBuffers<uint16_t>(kLpCount, kGroups, b);
+  barrierSyncOn(nullptr);
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclBfloat16, ncclSum, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  expectOutputEquals<uint16_t>(
+      b, kLpCount, expectedOwnerValue(b.myActiveIndex));
+  EXPECT_GT(rcclx::relay::lpEngageCount(), 0u);
+  EXPECT_EQ(rcclx::relay::lpDeclineCount(), 0u);
+  freeBuffers(b);
+}
+
+TEST_F(ShardedRelayReduceScatterLowPrecisionTest, AvgAppliesTheDivisorOnce) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // ncclAvg is where reduce-scatter parts company with allreduce. Its helper is
+  // a PURE RELAY, so the divisor belongs solely to the active rank's closing
+  // reduce. A divisor also applied at the helper -- which is correct for
+  // allreduce and wrong here -- would halve the relayed chunks and leave the
+  // two direct chunks right, and the exact comparator catches that at the first
+  // relayed element. 14 / 2 and 16 / 2 are both exact.
+  Buffers b;
+  makeBuffers<float>(kLpCount, kGroups, b);
+  barrierSyncOn(nullptr);
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclFloat32, ncclAvg, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  expectOutputEquals<float>(
+      b,
+      kLpCount,
+      expectedOwnerValue(b.myActiveIndex) / static_cast<float>(kActive));
+  EXPECT_GT(rcclx::relay::lpEngageCount(), 0u);
+  freeBuffers(b);
+}
+
+TEST_F(ShardedRelayReduceScatterLowPrecisionTest, DeclinesOnUnsupportedDtype) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // ncclInt32 is not a low-precision dtype, so the flag must fall through to
+  // full precision and the answer must be exactly the full-precision answer.
+  Buffers b;
+  makeBuffers<int32_t>(kLpCount, kGroups, b);
+  barrierSyncOn(nullptr);
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclInt32, ncclSum, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  expectOutputEquals<int32_t>(b, kLpCount, expectedOwnerValue(b.myActiveIndex));
+  EXPECT_EQ(rcclx::relay::lpEngageCount(), 0u);
+  EXPECT_GT(rcclx::relay::lpDeclineCount(rcclx::relay::LpDecline::Dtype), 0u);
+  freeBuffers(b);
+}
+
+TEST_F(
+    ShardedRelayReduceScatterLowPrecisionTest,
+    DeclinesOnCountThatIsNotWholeBlocks) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // One element past a whole number of 128-element blocks. sendBlockOffset is a
+  // raw per-group count here, so an unaligned count breaks additivity in the
+  // MIDDLE of the send buffer, not only in its tail -- the gate must refuse.
+  const size_t count = kLpCount + 1;
+  Buffers b;
+  makeBuffers<float>(count, kGroups, b);
+  barrierSyncOn(nullptr);
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclFloat32, ncclSum, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  expectOutputEquals<float>(b, count, expectedOwnerValue(b.myActiveIndex));
+  EXPECT_EQ(rcclx::relay::lpEngageCount(), 0u);
+  EXPECT_GT(
+      rcclx::relay::lpDeclineCount(rcclx::relay::LpDecline::Alignment), 0u);
+  freeBuffers(b);
+}
+
+TEST_F(
+    ShardedRelayReduceScatterLowPrecisionTest,
+    InterleavesWithFullPrecision) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // The behaviour an env var could not express, and the whole point of making
+  // this a per-call argument: two calls on the SAME communicator, one low
+  // precision and one not, with no state leaking from the first into the
+  // second.
+  Buffers b;
+  makeBuffers<float>(kLpCount, kGroups, b);
+  barrierSyncOn(nullptr);
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclFloat32, ncclSum, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+  expectOutputEquals<float>(b, kLpCount, expectedOwnerValue(b.myActiveIndex));
+  ASSERT_GT(rcclx::relay::lpEngageCount(), 0u);
+
+  const uint64_t engagedBefore = rcclx::relay::lpEngageCount();
+  HIPCHECK_TEST(hipMemset(b.recvMem, 0, kLpCount * sizeof(float)));
+  barrierSyncOn(nullptr);
+  ASSERT_EQ(call(b, ncclFloat32, ncclSum, /*lowPrecision=*/0), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+  expectOutputEquals<float>(b, kLpCount, expectedOwnerValue(b.myActiveIndex));
+  EXPECT_EQ(rcclx::relay::lpEngageCount(), engagedBefore)
+      << "a full-precision call must not engage low precision";
+  freeBuffers(b);
+}
+
+TEST_F(
+    ShardedRelayReduceScatterLowPrecisionTest,
+    DeclinesForTheSingleGroupPipelinedSchedule) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // A single-group call at this size pipelines, and the pipelined schedule does
+  // not carry the wire format yet. The decline has to be unanimous, and it is
+  // because the tile count is a pure function of the counts. The pipeline
+  // selection is asserted rather than assumed, so this case cannot quietly
+  // become a second test of the non-pipelined path.
+  const size_t count = 4ULL * 1024 * 1024;
+  const int numHelpers = 8 - kActive;
+  ASSERT_GT(
+      rcclx::relay::relayPipelineTiles(
+          1, rcclx::relay::relayShapeA2(numHelpers), count, sizeof(float)),
+      1);
+
+  Buffers b;
+  makeBuffers<float>(count, /*nGroups=*/1, b);
+  barrierSyncOn(nullptr);
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclFloat32, ncclSum, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  expectOutputEquals<float>(b, count, expectedOwnerValue(b.myActiveIndex));
+  EXPECT_EQ(rcclx::relay::lpEngageCount(), 0u);
+  EXPECT_GT(rcclx::relay::lpDeclineCount(rcclx::relay::LpDecline::Route), 0u)
+      << "the decline must be recorded, not silent";
+  freeBuffers(b);
 }
 
 int main(int argc, char* argv[]) {

--- a/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
+++ b/comms/rcclx/develop/meta/relay/tests/ShardedRelayReduceScatterTest.cu
@@ -3260,6 +3260,231 @@ TEST_F(
   freeBuffers(b);
 }
 
+// ===========================================================================
+// LOW PRECISION, FLAT A>2 PATH
+// ===========================================================================
+//
+// Same exactness discipline as the 2-active fixture above, at the 2-group
+// 4-active geometry, which is what reaches shardedRelayReduceScatterFlat.
+//
+// Every value here is a distinct per-(source, owner) constant, so a wrong block
+// index, a wrong helper slot or a wrong owner changes the answer. Exactness
+// survives even though the offload region rounds TWICE -- once on the way up
+// and again when the helper requantizes its sum -- because each 128-element
+// wire block is constant, and a constant block's absmax normalization makes the
+// code exactly 128 and the round trip exact for ANY value. That is the property
+// kLpNormalizeMax being a power of two buys, and it is what makes these exact
+// comparators legitimate rather than lucky.
+class ShardedRelayReduceScatterFlatLowPrecisionTest
+    : public ShardedRelayMultiGroupReduceScatterTest {
+ protected:
+  static constexpr int kActive = 4;
+  static constexpr int kGroups = 2;
+
+  // 4 Mi elements per output block = 64 MiB of fp32 input per rank. The flat
+  // route's own metric is A * recvCount * elementSize = 64 MiB, which is above
+  // both the offload crossover (~48 MB) and the low-precision threshold; the
+  // test asserts the offload route rather than assuming it.
+  static constexpr size_t kLpCount = 4ULL * 1024 * 1024;
+
+  // Source s's contribution to owner j. Distinct in both indices.
+  static float blockValue(int sourceIndex, int ownerIndex) {
+    return static_cast<float>((sourceIndex + 1) * 10 + (ownerIndex + 1));
+  }
+
+  static float expectedOwnerValue(int ownerIndex) {
+    float sum = 0.0f;
+    for (int s = 0; s < kActive; s++) {
+      sum += blockValue(s, ownerIndex);
+    }
+    return sum;
+  }
+
+  struct Buffers {
+    void* sendMem[kGroups]{};
+    void* recvMem{nullptr};
+    const void* sendPtrs[kGroups]{};
+    void* recvPtrs[kGroups]{};
+    size_t counts[kGroups]{};
+    int myActiveGroup{0};
+    int myActiveIndex{0};
+  };
+
+  void makeBuffers(size_t count, Buffers& b) {
+    b = Buffers{};
+    b.myActiveGroup = this->globalRank / kActive;
+    b.myActiveIndex = this->globalRank % kActive;
+    const size_t inputCount = static_cast<size_t>(kActive) * count;
+
+    for (int g = 0; g < kGroups; g++) {
+      HIPCHECK_TEST(hipMalloc(&b.sendMem[g], inputCount * sizeof(float)));
+      if (g == b.myActiveGroup) {
+        std::vector<float> host(inputCount);
+        for (int owner = 0; owner < kActive; owner++) {
+          std::fill(
+              host.begin() + static_cast<ptrdiff_t>(owner * count),
+              host.begin() + static_cast<ptrdiff_t>((owner + 1) * count),
+              blockValue(b.myActiveIndex, owner));
+        }
+        HIPCHECK_TEST(hipMemcpy(
+            b.sendMem[g],
+            host.data(),
+            inputCount * sizeof(float),
+            hipMemcpyHostToDevice));
+      } else {
+        HIPCHECK_TEST(hipMemset(b.sendMem[g], 0, inputCount * sizeof(float)));
+      }
+      b.sendPtrs[g] = b.sendMem[g];
+      b.counts[g] = count;
+    }
+
+    HIPCHECK_TEST(hipMalloc(&b.recvMem, count * sizeof(float)));
+    HIPCHECK_TEST(hipMemset(b.recvMem, 0, count * sizeof(float)));
+    for (int g = 0; g < kGroups; g++) {
+      b.recvPtrs[g] = (g == b.myActiveGroup) ? b.recvMem : b.sendMem[g];
+    }
+  }
+
+  void freeBuffers(Buffers& b) {
+    for (int g = 0; g < kGroups; g++) {
+      HIPCHECK_TEST(hipFree(b.sendMem[g]));
+    }
+    HIPCHECK_TEST(hipFree(b.recvMem));
+  }
+
+  void expectOutputEquals(const Buffers& b, size_t count, float wantValue) {
+    std::vector<float> got(count);
+    HIPCHECK_TEST(hipMemcpy(
+        got.data(), b.recvMem, count * sizeof(float), hipMemcpyDeviceToHost));
+    size_t reported = 0;
+    for (size_t i = 0; i < count && reported < 8; i++) {
+      if (got[i] != wantValue) {
+        reported++;
+        ADD_FAILURE() << "R" << this->globalRank << ": element " << i
+                      << ": got " << got[i] << ", want " << wantValue;
+      }
+    }
+  }
+
+  ncclResult_t call(const Buffers& b, ncclRedOp_t op, int lowPrecision) {
+    TwoGroupFourActiveRanks layout;
+    return callReduceScatterCompat(
+        b.sendPtrs,
+        b.recvPtrs,
+        b.counts,
+        ncclFloat32,
+        op,
+        this->commFor(kActive),
+        this->stream,
+        layout.allActiveRanks,
+        kActive,
+        kGroups,
+        lowPrecision);
+  }
+
+  // The flat schedule only routes through the helpers above the offload
+  // crossover; below it the call degenerates to a pure-direct all-to-all with
+  // the helpers idle, which low precision declines. Asserting the route keeps a
+  // resized test from silently covering the wrong schedule.
+  void assertOffloadRouteSelected(size_t count) {
+    size_t counts[kGroups];
+    for (int g = 0; g < kGroups; g++) {
+      counts[g] = count;
+    }
+    ASSERT_EQ(
+        rcclx::relay::selectReduceScatterRoute(
+            kActive, 8 - kActive, kGroups, counts, sizeof(float)),
+        rcclx::relay::ReduceScatterRoute::FlatOffload);
+  }
+};
+
+TEST_F(
+    ShardedRelayReduceScatterFlatLowPrecisionTest,
+    ConstantBlocksAreBitExact) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  assertOffloadRouteSelected(kLpCount);
+
+  Buffers b;
+  makeBuffers(kLpCount, b);
+  barrierSyncOn(nullptr);
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclSum, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  // Covers both regions of the schedule at once: the direct all-to-all over the
+  // intra links and the reduce-at-helper offload over the cross links. Their
+  // boundary is interior to the output block, so a wire offset that disagrees
+  // with a peer's shows up as a mismatch partway through rather than
+  // everywhere.
+  expectOutputEquals(b, kLpCount, expectedOwnerValue(b.myActiveIndex));
+  EXPECT_GT(rcclx::relay::lpEngageCount(), 0u)
+      << "low precision never engaged, so this case proved nothing";
+  EXPECT_EQ(rcclx::relay::lpDeclineCount(), 0u);
+  freeBuffers(b);
+}
+
+TEST_F(
+    ShardedRelayReduceScatterFlatLowPrecisionTest,
+    AvgAppliesTheDivisorOnce) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  // The divisor placement differs BETWEEN THE TWO REGIONS of this one schedule.
+  // The offload region's helper reduces and returns a plain sum, so the divisor
+  // waits for the owner's fold; the direct region has no helper at all and gets
+  // it in the same owner-side reduce. A divisor applied at the helper as well
+  // would scale only the offload region, which the exact comparator catches at
+  // the region boundary rather than everywhere.
+  assertOffloadRouteSelected(kLpCount);
+
+  Buffers b;
+  makeBuffers(kLpCount, b);
+  barrierSyncOn(nullptr);
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclAvg, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+
+  expectOutputEquals(
+      b,
+      kLpCount,
+      expectedOwnerValue(b.myActiveIndex) / static_cast<float>(kActive));
+  EXPECT_GT(rcclx::relay::lpEngageCount(), 0u);
+  freeBuffers(b);
+}
+
+TEST_F(
+    ShardedRelayReduceScatterFlatLowPrecisionTest,
+    InterleavesWithFullPrecision) {
+  if (this->numRanks != 8) {
+    GTEST_SKIP() << "Test requires exactly 8 ranks";
+  }
+  assertOffloadRouteSelected(kLpCount);
+
+  Buffers b;
+  makeBuffers(kLpCount, b);
+  barrierSyncOn(nullptr);
+
+  rcclx::relay::lpResetCounters();
+  ASSERT_EQ(call(b, ncclSum, /*lowPrecision=*/1), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+  expectOutputEquals(b, kLpCount, expectedOwnerValue(b.myActiveIndex));
+  ASSERT_GT(rcclx::relay::lpEngageCount(), 0u);
+
+  const uint64_t engagedBefore = rcclx::relay::lpEngageCount();
+  HIPCHECK_TEST(hipMemset(b.recvMem, 0, kLpCount * sizeof(float)));
+  barrierSyncOn(nullptr);
+  ASSERT_EQ(call(b, ncclSum, /*lowPrecision=*/0), ncclSuccess);
+  HIPCHECK_TEST(hipStreamSynchronize(this->stream));
+  expectOutputEquals(b, kLpCount, expectedOwnerValue(b.myActiveIndex));
+  EXPECT_EQ(rcclx::relay::lpEngageCount(), engagedBefore)
+      << "a full-precision call must not engage low precision";
+  freeBuffers(b);
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -971,6 +971,8 @@ set(RCCLX_LIB_FILES
   comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.h
   comms/rcclx/develop/meta/relay/sharded_relay_graph_scratch.cc
   comms/rcclx/develop/meta/relay/sharded_relay_graph_scratch.h
+  comms/rcclx/develop/meta/relay/sharded_relay_lp.cc
+  comms/rcclx/develop/meta/relay/sharded_relay_lp.h
   comms/rcclx/develop/meta/relay/sharded_relay_oneshot.cc
   comms/rcclx/develop/meta/relay/sharded_relay_oneshot.h
   comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -973,6 +973,8 @@ set(RCCLX_LIB_FILES
   comms/rcclx/develop/meta/relay/sharded_relay_graph_scratch.h
   comms/rcclx/develop/meta/relay/sharded_relay_lp.cc
   comms/rcclx/develop/meta/relay/sharded_relay_lp.h
+  comms/rcclx/develop/meta/relay/sharded_relay_lp_kernels.cu
+  comms/rcclx/develop/meta/relay/sharded_relay_lp_kernels.h
   comms/rcclx/develop/meta/relay/sharded_relay_oneshot.cc
   comms/rcclx/develop/meta/relay/sharded_relay_oneshot.h
   comms/rcclx/develop/meta/relay/sharded_relay_reduce_scatter.cc

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -973,6 +973,8 @@ set(RCCLX_LIB_FILES
   comms/rcclx/develop/meta/relay/sharded_relay_graph_scratch.h
   comms/rcclx/develop/meta/relay/sharded_relay_lp.cc
   comms/rcclx/develop/meta/relay/sharded_relay_lp.h
+  comms/rcclx/develop/meta/relay/sharded_relay_lp_arena.cc
+  comms/rcclx/develop/meta/relay/sharded_relay_lp_arena.h
   comms/rcclx/develop/meta/relay/sharded_relay_lp_kernels.cu
   comms/rcclx/develop/meta/relay/sharded_relay_lp_kernels.h
   comms/rcclx/develop/meta/relay/sharded_relay_oneshot.cc

--- a/comms/rcclx/develop/projects/rccl/src/collectives.cc
+++ b/comms/rcclx/develop/projects/rccl/src/collectives.cc
@@ -452,12 +452,14 @@ ncclResult_t ncclAllReduceWithBias_impl(const void* sendbuff, void* recvbuff, si
 NCCL_API(ncclResult_t, ncclShardedRelayMultiGroupAllReduce, 
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* counts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 
 ncclResult_t ncclShardedRelayMultiGroupAllReduce_impl(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* counts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision) {
   // Validate operation - only SUM and AVG are supported
   if (op != ncclSum && op != ncclAvg) {
     WARN("ncclShardedRelayMultiGroupAllReduce: only ncclSum and ncclAvg operations are supported");
@@ -497,27 +499,32 @@ ncclResult_t ncclShardedRelayMultiGroupAllReduce_impl(
         nRanks, nActiveRanksPerGroup, nGroups);
   return ncclShardedRelayMultiGroupAllReduceImpl(
       sendBuffs, recvBuffs, counts,
-      datatype, op, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
+      datatype, op, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups,
+      lowPrecision);
 }
 
 ncclResult_t ncclShardedRelayMultiGroupAllReduce(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* counts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision) {
   return ncclShardedRelayMultiGroupAllReduce_impl(
       sendBuffs, recvBuffs, counts,
-      datatype, op, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
+      datatype, op, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups,
+      lowPrecision);
 }
 
 NCCL_API(ncclResult_t, ncclShardedRelayMultiGroupReduceScatter,
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* recvCounts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 
 ncclResult_t ncclShardedRelayMultiGroupReduceScatter_impl(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* recvCounts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision) {
   // Validate operation - only SUM and AVG are supported
   if (op != ncclSum && op != ncclAvg) {
     WARN("ncclShardedRelayMultiGroupReduceScatter: only ncclSum and ncclAvg operations are supported");
@@ -557,27 +564,32 @@ ncclResult_t ncclShardedRelayMultiGroupReduceScatter_impl(
         nRanks, nActiveRanksPerGroup, nGroups);
   return ncclShardedRelayMultiGroupReduceScatterImpl(
       sendBuffs, recvBuffs, recvCounts,
-      datatype, op, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
+      datatype, op, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups,
+      lowPrecision);
 }
 
 ncclResult_t ncclShardedRelayMultiGroupReduceScatter(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* recvCounts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, cudaStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision) {
   return ncclShardedRelayMultiGroupReduceScatter_impl(
       sendBuffs, recvBuffs, recvCounts,
-      datatype, op, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
+      datatype, op, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups,
+      lowPrecision);
 }
 
 NCCL_API(ncclResult_t, ncclShardedRelayMultiGroupAllToAll,
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
     ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 
 ncclResult_t ncclShardedRelayMultiGroupAllToAll_impl(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
     ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision) {
   // Validate buffer pointers
   if (recvBuffs == nullptr || allActiveRanks == nullptr || segmentCounts == nullptr ||
       sendBuffs == nullptr) {
@@ -611,27 +623,32 @@ ncclResult_t ncclShardedRelayMultiGroupAllToAll_impl(
         nRanks, nActiveRanksPerGroup, nGroups);
   return ncclShardedRelayMultiGroupAllToAllImpl(
       sendBuffs, recvBuffs, segmentCounts,
-      datatype, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
+      datatype, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups,
+      lowPrecision);
 }
 
 ncclResult_t ncclShardedRelayMultiGroupAllToAll(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
     ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision) {
   return ncclShardedRelayMultiGroupAllToAll_impl(
       sendBuffs, recvBuffs, segmentCounts,
-      datatype, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
+      datatype, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups,
+      lowPrecision);
 }
 
 NCCL_API(ncclResult_t, ncclShardedRelayMultiGroupAllGather,
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* sendCounts,
     ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 
 ncclResult_t ncclShardedRelayMultiGroupAllGather_impl(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* sendCounts,
     ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision) {
   // Validate buffer pointers
   if (recvBuffs == nullptr || allActiveRanks == nullptr || sendCounts == nullptr ||
       sendBuffs == nullptr) {
@@ -665,16 +682,32 @@ ncclResult_t ncclShardedRelayMultiGroupAllGather_impl(
         nRanks, nActiveRanksPerGroup, nGroups);
   return ncclShardedRelayMultiGroupAllGatherImpl(
       sendBuffs, recvBuffs, sendCounts,
-      datatype, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
+      datatype, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups,
+      lowPrecision);
 }
 
 ncclResult_t ncclShardedRelayMultiGroupAllGather(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* sendCounts,
     ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups) {
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision) {
   return ncclShardedRelayMultiGroupAllGather_impl(
       sendBuffs, recvBuffs, sendCounts,
-      datatype, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups);
+      datatype, comm, stream, allActiveRanks, nActiveRanksPerGroup, nGroups,
+      lowPrecision);
+}
+
+// The ABI probe for consumers that bind the four entry points above through
+// ctypes, with no compiler and no linker in the chain to notice that their
+// signatures changed. See nccl.h.in for why one exists at all.
+NCCL_API(int, ncclShardedRelayAbiVersion, void);
+
+int ncclShardedRelayAbiVersion_impl(void) {
+  return NCCL_SHARDED_RELAY_ABI_VERSION;
+}
+
+int ncclShardedRelayAbiVersion(void) {
+  return ncclShardedRelayAbiVersion_impl();
 }
 
 // Host control plane for the relay collectives. Two functions and one struct is

--- a/comms/rcclx/develop/projects/rccl/src/init.cc
+++ b/comms/rcclx/develop/projects/rccl/src/init.cc
@@ -73,6 +73,7 @@
 #include "meta/lpcoll/low_precision_buffer_pool.h"
 #include "meta/relay/sharded_relay_oneshot.h"
 #include "meta/relay/relay_control.h"
+#include "meta/relay/sharded_relay_lp_arena.h"
 // [/RCCL]
 
 #ifdef ENABLE_ROCSHMEM
@@ -538,6 +539,11 @@ static ncclResult_t commFree(ncclComm_t comm) {
   // creating rank, an shm_unlink -- so it respects commFree()'s
   // no-sync-among-ranks contract, and a no-op for a comm that never built one.
   rcclx::relay::relayControlRelease(comm);
+
+  // And the low-precision arena, which is the largest of the three by far (over
+  // a GiB at the default message provisioning). One hipFree, purely local, a
+  // no-op for a comm no caller ever asked for low precision on.
+  rcclx::relay::lpArenaRelease(comm);
 
   if (comm->symmetricSupport) {
     NCCLCHECK(ncclSymkFinalize(comm));
@@ -2501,6 +2507,14 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   // every rank is in init already, and no later call has to run a bootstrap
   // all-gather it cannot capture.
   rcclx::relay::oneShotInit(comm);
+
+  // And the low-precision arena, if NCCL_SHARDED_RELAY_LP_PREALLOC asked for it.
+  // Off by default: low precision is requested per call, so init cannot know
+  // whether this comm will ever use it, and the arena is too large to provision
+  // speculatively. A job that will use it sets the variable and gets zero
+  // call-path allocation -- and therefore graph-capture safety -- from its first
+  // call onwards.
+  rcclx::relay::lpArenaInit(comm);
 
   // And the control plane segment, for the same reason: setup is collective (two
   // bootstrap all-gathers, enabled only on unanimity), so init is the one place

--- a/comms/rcclx/develop/projects/rccl/src/nccl.h
+++ b/comms/rcclx/develop/projects/rccl/src/nccl.h
@@ -681,16 +681,24 @@ ncclResult_t pncclAllReduceWithBias(const void* sendbuff, void* recvbuff, size_t
     @param[in]  stream              HIP stream to execute collective on
     @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
     @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
-    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node)
+    @param[in]  lowPrecision        Non-zero to use the low-precision (fp8e4m3) wire format where
+                                    it pays; an internal size-only gate declines to full precision
+                                    silently otherwise. COLLECTIVE -- it must be identical on every
+                                    rank of the call, like datatype, op and the counts. Ranks that
+                                    disagree disagree on how many bytes cross each link, so the
+                                    call hangs or corrupts rather than degrading. */
 ncclResult_t  ncclShardedRelayMultiGroupAllReduce(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* counts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @cond       include_hidden */
 ncclResult_t pncclShardedRelayMultiGroupAllReduce(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* counts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @endcond */
 
 /*! @brief      Fused Multi-Group Sharded Relay Reduce-Scatter for 2D Sparse Parallelism
@@ -729,16 +737,21 @@ ncclResult_t pncclShardedRelayMultiGroupAllReduce(
     @param[in]  stream              HIP stream to execute collective on
     @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
     @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
-    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node)
+    @param[in]  lowPrecision        Non-zero to use the low-precision (fp8e4m3) wire format where
+                                    it pays. COLLECTIVE; see
+                                    @ref ncclShardedRelayMultiGroupAllReduce. */
 ncclResult_t  ncclShardedRelayMultiGroupReduceScatter(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* recvCounts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @cond       include_hidden */
 ncclResult_t pncclShardedRelayMultiGroupReduceScatter(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* recvCounts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @endcond */
 
 /*! @brief      Fused Multi-Group Sharded Relay All-to-All for 2D Sparse Parallelism
@@ -780,16 +793,21 @@ ncclResult_t pncclShardedRelayMultiGroupReduceScatter(
     @param[in]  stream              HIP stream to execute collective on
     @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
     @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
-    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node)
+    @param[in]  lowPrecision        Non-zero to use the low-precision (fp8e4m3) wire format where
+                                    it pays. COLLECTIVE; see
+                                    @ref ncclShardedRelayMultiGroupAllReduce. */
 ncclResult_t  ncclShardedRelayMultiGroupAllToAll(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
     ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @cond       include_hidden */
 ncclResult_t pncclShardedRelayMultiGroupAllToAll(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
     ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @endcond */
 
 /*! @brief      Relay operation codes used by @ref ncclRelayPlanInfo */
@@ -954,16 +972,47 @@ ncclResult_t pncclRelayControlConsume(
     @param[in]  stream              HIP stream to execute collective on
     @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
     @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
-    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node)
+    @param[in]  lowPrecision        Non-zero to use the low-precision (fp8e4m3) wire format where
+                                    it pays. COLLECTIVE; see
+                                    @ref ncclShardedRelayMultiGroupAllReduce. */
 ncclResult_t  ncclShardedRelayMultiGroupAllGather(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* sendCounts,
     ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @cond       include_hidden */
 ncclResult_t pncclShardedRelayMultiGroupAllGather(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* sendCounts,
     ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
+/*! @endcond */
+
+/*! @brief ABI revision of the four sharded-relay entry points. 2 = they carry lowPrecision. */
+#define NCCL_SHARDED_RELAY_ABI_VERSION 2
+
+/*! @brief      ABI revision of the sharded-relay entry points, as built into this library.
+    @details    Exists for consumers that bind those symbols with NO compiler and NO linker in the
+                chain -- notably the pynccl / sglang path, where `install_rcclx_libs.sh` points a
+                serving venv's `torch/lib` at an rcclx `librccl.so` and a hand-transcribed
+                `ctypes` `argtypes` table supplies the signature.
+
+                C has no name mangling, so a signature change there is undetectable at link time:
+                a venv still carrying a ten-argument table against an eleven-parameter function
+                would pass ten arguments and let the callee read register or stack garbage for
+                `lowPrecision`, so low precision would switch itself on or off at random,
+                silently, in a serving path. `hasattr` probing cannot see an argument-count change.
+                It CAN see this symbol, precisely because the symbol itself is new -- which turns
+                one silent failure into three distinguishable states: ABSENT means a librccl
+                predating low precision, i.e. the old ten-parameter signature; PRESENT AND EQUAL to
+                @ref NCCL_SHARDED_RELAY_ABI_VERSION means safe to bind; PRESENT AND DIFFERENT means
+                a future incompatible change. The macro is the single source of truth, so a C++
+                consumer can compare against it too, though the compiled paths do not need to.
+    @return     The value of @ref NCCL_SHARDED_RELAY_ABI_VERSION this library was built with. */
+int  ncclShardedRelayAbiVersion(void);
+/*! @cond       include_hidden */
+int pncclShardedRelayAbiVersion(void);
 /*! @endcond */
 
 /*! @brief      Reduce-Scatter

--- a/comms/rcclx/develop/projects/rccl/src/nccl.h.in
+++ b/comms/rcclx/develop/projects/rccl/src/nccl.h.in
@@ -681,16 +681,24 @@ ncclResult_t pncclAllReduceWithBias(const void* sendbuff, void* recvbuff, size_t
     @param[in]  stream              HIP stream to execute collective on
     @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
     @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
-    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node)
+    @param[in]  lowPrecision        Non-zero to use the low-precision (fp8e4m3) wire format where
+                                    it pays; an internal size-only gate declines to full precision
+                                    silently otherwise. COLLECTIVE -- it must be identical on every
+                                    rank of the call, like datatype, op and the counts. Ranks that
+                                    disagree disagree on how many bytes cross each link, so the
+                                    call hangs or corrupts rather than degrading. */
 ncclResult_t  ncclShardedRelayMultiGroupAllReduce(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* counts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @cond       include_hidden */
 ncclResult_t pncclShardedRelayMultiGroupAllReduce(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* counts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @endcond */
 
 /*! @brief      Fused Multi-Group Sharded Relay Reduce-Scatter for 2D Sparse Parallelism
@@ -729,16 +737,21 @@ ncclResult_t pncclShardedRelayMultiGroupAllReduce(
     @param[in]  stream              HIP stream to execute collective on
     @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
     @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
-    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node)
+    @param[in]  lowPrecision        Non-zero to use the low-precision (fp8e4m3) wire format where
+                                    it pays. COLLECTIVE; see
+                                    @ref ncclShardedRelayMultiGroupAllReduce. */
 ncclResult_t  ncclShardedRelayMultiGroupReduceScatter(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* recvCounts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @cond       include_hidden */
 ncclResult_t pncclShardedRelayMultiGroupReduceScatter(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* recvCounts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @endcond */
 
 /*! @brief      Fused Multi-Group Sharded Relay All-to-All for 2D Sparse Parallelism
@@ -780,16 +793,21 @@ ncclResult_t pncclShardedRelayMultiGroupReduceScatter(
     @param[in]  stream              HIP stream to execute collective on
     @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
     @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
-    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node)
+    @param[in]  lowPrecision        Non-zero to use the low-precision (fp8e4m3) wire format where
+                                    it pays. COLLECTIVE; see
+                                    @ref ncclShardedRelayMultiGroupAllReduce. */
 ncclResult_t  ncclShardedRelayMultiGroupAllToAll(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
     ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @cond       include_hidden */
 ncclResult_t pncclShardedRelayMultiGroupAllToAll(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
     ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @endcond */
 
 /*! @brief      Relay operation codes used by @ref ncclRelayPlanInfo */
@@ -954,16 +972,47 @@ ncclResult_t pncclRelayControlConsume(
     @param[in]  stream              HIP stream to execute collective on
     @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
     @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
-    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node)
+    @param[in]  lowPrecision        Non-zero to use the low-precision (fp8e4m3) wire format where
+                                    it pays. COLLECTIVE; see
+                                    @ref ncclShardedRelayMultiGroupAllReduce. */
 ncclResult_t  ncclShardedRelayMultiGroupAllGather(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* sendCounts,
     ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @cond       include_hidden */
 ncclResult_t pncclShardedRelayMultiGroupAllGather(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* sendCounts,
     ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
+/*! @endcond */
+
+/*! @brief ABI revision of the four sharded-relay entry points. 2 = they carry lowPrecision. */
+#define NCCL_SHARDED_RELAY_ABI_VERSION 2
+
+/*! @brief      ABI revision of the sharded-relay entry points, as built into this library.
+    @details    Exists for consumers that bind those symbols with NO compiler and NO linker in the
+                chain -- notably the pynccl / sglang path, where `install_rcclx_libs.sh` points a
+                serving venv's `torch/lib` at an rcclx `librccl.so` and a hand-transcribed
+                `ctypes` `argtypes` table supplies the signature.
+
+                C has no name mangling, so a signature change there is undetectable at link time:
+                a venv still carrying a ten-argument table against an eleven-parameter function
+                would pass ten arguments and let the callee read register or stack garbage for
+                `lowPrecision`, so low precision would switch itself on or off at random,
+                silently, in a serving path. `hasattr` probing cannot see an argument-count change.
+                It CAN see this symbol, precisely because the symbol itself is new -- which turns
+                one silent failure into three distinguishable states: ABSENT means a librccl
+                predating low precision, i.e. the old ten-parameter signature; PRESENT AND EQUAL to
+                @ref NCCL_SHARDED_RELAY_ABI_VERSION means safe to bind; PRESENT AND DIFFERENT means
+                a future incompatible change. The macro is the single source of truth, so a C++
+                consumer can compare against it too, though the compiled paths do not need to.
+    @return     The value of @ref NCCL_SHARDED_RELAY_ABI_VERSION this library was built with. */
+int  ncclShardedRelayAbiVersion(void);
+/*! @cond       include_hidden */
+int pncclShardedRelayAbiVersion(void);
 /*! @endcond */
 
 /*! @brief      Reduce-Scatter

--- a/comms/rcclx/develop/projects/rccl/src/rccl.h
+++ b/comms/rcclx/develop/projects/rccl/src/rccl.h
@@ -681,16 +681,24 @@ ncclResult_t pncclAllReduceWithBias(const void* sendbuff, void* recvbuff, size_t
     @param[in]  stream              HIP stream to execute collective on
     @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
     @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
-    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node)
+    @param[in]  lowPrecision        Non-zero to use the low-precision (fp8e4m3) wire format where
+                                    it pays; an internal size-only gate declines to full precision
+                                    silently otherwise. COLLECTIVE -- it must be identical on every
+                                    rank of the call, like datatype, op and the counts. Ranks that
+                                    disagree disagree on how many bytes cross each link, so the
+                                    call hangs or corrupts rather than degrading. */
 ncclResult_t  ncclShardedRelayMultiGroupAllReduce(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* counts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @cond       include_hidden */
 ncclResult_t pncclShardedRelayMultiGroupAllReduce(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* counts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @endcond */
 
 /*! @brief      Fused Multi-Group Sharded Relay Reduce-Scatter for 2D Sparse Parallelism
@@ -729,16 +737,21 @@ ncclResult_t pncclShardedRelayMultiGroupAllReduce(
     @param[in]  stream              HIP stream to execute collective on
     @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
     @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
-    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node)
+    @param[in]  lowPrecision        Non-zero to use the low-precision (fp8e4m3) wire format where
+                                    it pays. COLLECTIVE; see
+                                    @ref ncclShardedRelayMultiGroupAllReduce. */
 ncclResult_t  ncclShardedRelayMultiGroupReduceScatter(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* recvCounts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @cond       include_hidden */
 ncclResult_t pncclShardedRelayMultiGroupReduceScatter(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* recvCounts,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @endcond */
 
 /*! @brief      Fused Multi-Group Sharded Relay All-to-All for 2D Sparse Parallelism
@@ -780,16 +793,21 @@ ncclResult_t pncclShardedRelayMultiGroupReduceScatter(
     @param[in]  stream              HIP stream to execute collective on
     @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
     @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
-    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node)
+    @param[in]  lowPrecision        Non-zero to use the low-precision (fp8e4m3) wire format where
+                                    it pays. COLLECTIVE; see
+                                    @ref ncclShardedRelayMultiGroupAllReduce. */
 ncclResult_t  ncclShardedRelayMultiGroupAllToAll(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
     ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @cond       include_hidden */
 ncclResult_t pncclShardedRelayMultiGroupAllToAll(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* segmentCounts,
     ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @endcond */
 
 /*! @brief      Relay operation codes used by @ref ncclRelayPlanInfo */
@@ -954,16 +972,47 @@ ncclResult_t pncclRelayControlConsume(
     @param[in]  stream              HIP stream to execute collective on
     @param[in]  allActiveRanks      2D array of active ranks [nGroups][nActiveRanksPerGroup]
     @param[in]  nActiveRanksPerGroup Number of active ranks per group (typically 2)
-    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node) */
+    @param[in]  nGroups             Number of groups (typically 4 for 8-GPU node)
+    @param[in]  lowPrecision        Non-zero to use the low-precision (fp8e4m3) wire format where
+                                    it pays. COLLECTIVE; see
+                                    @ref ncclShardedRelayMultiGroupAllReduce. */
 ncclResult_t  ncclShardedRelayMultiGroupAllGather(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* sendCounts,
     ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
 /*! @cond       include_hidden */
 ncclResult_t pncclShardedRelayMultiGroupAllGather(
     const void* const* sendBuffs, void* const* recvBuffs, const size_t* sendCounts,
     ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream,
-    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups);
+    const int* const* allActiveRanks, int nActiveRanksPerGroup, int nGroups,
+    int lowPrecision);
+/*! @endcond */
+
+/*! @brief ABI revision of the four sharded-relay entry points. 2 = they carry lowPrecision. */
+#define NCCL_SHARDED_RELAY_ABI_VERSION 2
+
+/*! @brief      ABI revision of the sharded-relay entry points, as built into this library.
+    @details    Exists for consumers that bind those symbols with NO compiler and NO linker in the
+                chain -- notably the pynccl / sglang path, where `install_rcclx_libs.sh` points a
+                serving venv's `torch/lib` at an rcclx `librccl.so` and a hand-transcribed
+                `ctypes` `argtypes` table supplies the signature.
+
+                C has no name mangling, so a signature change there is undetectable at link time:
+                a venv still carrying a ten-argument table against an eleven-parameter function
+                would pass ten arguments and let the callee read register or stack garbage for
+                `lowPrecision`, so low precision would switch itself on or off at random,
+                silently, in a serving path. `hasattr` probing cannot see an argument-count change.
+                It CAN see this symbol, precisely because the symbol itself is new -- which turns
+                one silent failure into three distinguishable states: ABSENT means a librccl
+                predating low precision, i.e. the old ten-parameter signature; PRESENT AND EQUAL to
+                @ref NCCL_SHARDED_RELAY_ABI_VERSION means safe to bind; PRESENT AND DIFFERENT means
+                a future incompatible change. The macro is the single source of truth, so a C++
+                consumer can compare against it too, though the compiled paths do not need to.
+    @return     The value of @ref NCCL_SHARDED_RELAY_ABI_VERSION this library was built with. */
+int  ncclShardedRelayAbiVersion(void);
+/*! @cond       include_hidden */
+int pncclShardedRelayAbiVersion(void);
 /*! @endcond */
 
 /*! @brief      Reduce-Scatter

--- a/comms/torchcomms/rcclx/RcclxApi.hpp
+++ b/comms/torchcomms/rcclx/RcclxApi.hpp
@@ -277,7 +277,13 @@ class RcclxApi {
   virtual ncclResult_t memAlloc(void** ptr, size_t size) = 0;
   virtual ncclResult_t memFree(void* ptr) = 0;
 
-  // Fused multi-group sharded relay allreduce for 2D sparse parallelism
+  // Fused multi-group sharded relay allreduce for 2D sparse parallelism.
+  //
+  // `lowPrecision` selects the fp8e4m3 wire format where it pays. It is a
+  // COLLECTIVE argument -- identical on every rank of the call, like datatype,
+  // op and the counts -- because ranks that disagree disagree on how many bytes
+  // cross each link, so the call hangs or corrupts rather than degrading. The
+  // same contract applies to all four collectives below.
   virtual ncclResult_t shardedRelayMultiGroupAllReduce(
       const void* const* sendBuffs,
       void* const* recvBuffs,
@@ -288,7 +294,8 @@ class RcclxApi {
       hipStream_t stream,
       const int* const* allActiveRanks,
       int nActiveRanksPerGroup,
-      int nGroups) = 0;
+      int nGroups,
+      int lowPrecision) = 0;
 
   // Fused multi-group sharded relay reduce-scatter for 2D sparse parallelism
   virtual ncclResult_t shardedRelayMultiGroupReduceScatter(
@@ -301,7 +308,8 @@ class RcclxApi {
       hipStream_t stream,
       const int* const* allActiveRanks,
       int nActiveRanksPerGroup,
-      int nGroups) = 0;
+      int nGroups,
+      int lowPrecision) = 0;
 
   // Fused multi-group sharded relay all-to-all for 2D sparse parallelism.
   // No reduction op (pure data movement); out-of-place only.
@@ -314,7 +322,8 @@ class RcclxApi {
       hipStream_t stream,
       const int* const* allActiveRanks,
       int nActiveRanksPerGroup,
-      int nGroups) = 0;
+      int nGroups,
+      int lowPrecision) = 0;
 
   // Fused multi-group sharded relay all-gather for 2D sparse parallelism.
   // No reduction op (pure data movement); supports in-place and out-of-place.
@@ -327,7 +336,8 @@ class RcclxApi {
       hipStream_t stream,
       const int* const* allActiveRanks,
       int nActiveRanksPerGroup,
-      int nGroups) = 0;
+      int nGroups,
+      int lowPrecision) = 0;
 
   // Relay control plane. Host-only: publishes/consumes the plan for one forward
   // through the communicator's shared-memory segment, choosing nothing about
@@ -598,7 +608,8 @@ class DefaultRcclxApi : public RcclxApi {
       hipStream_t stream,
       const int* const* allActiveRanks,
       int nActiveRanksPerGroup,
-      int nGroups) override;
+      int nGroups,
+      int lowPrecision) override;
 
   // Fused multi-group sharded relay reduce-scatter for 2D sparse parallelism
   ncclResult_t shardedRelayMultiGroupReduceScatter(
@@ -611,7 +622,8 @@ class DefaultRcclxApi : public RcclxApi {
       hipStream_t stream,
       const int* const* allActiveRanks,
       int nActiveRanksPerGroup,
-      int nGroups) override;
+      int nGroups,
+      int lowPrecision) override;
 
   // Fused multi-group sharded relay all-to-all for 2D sparse parallelism.
   // No reduction op (pure data movement); out-of-place only.
@@ -624,7 +636,8 @@ class DefaultRcclxApi : public RcclxApi {
       hipStream_t stream,
       const int* const* allActiveRanks,
       int nActiveRanksPerGroup,
-      int nGroups) override;
+      int nGroups,
+      int lowPrecision) override;
 
   // Fused multi-group sharded relay all-gather for 2D sparse parallelism.
   // No reduction op (pure data movement); supports in-place and out-of-place.
@@ -637,7 +650,8 @@ class DefaultRcclxApi : public RcclxApi {
       hipStream_t stream,
       const int* const* allActiveRanks,
       int nActiveRanksPerGroup,
-      int nGroups) override;
+      int nGroups,
+      int lowPrecision) override;
 
   ncclResult_t relayControlPublish(
       ncclComm_t comm,

--- a/comms/torchcomms/rcclx/RcclxApiShardedRelay.cpp
+++ b/comms/torchcomms/rcclx/RcclxApiShardedRelay.cpp
@@ -59,7 +59,8 @@ ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllReduce(
     hipStream_t stream,
     const int* const* allActiveRanks,
     int nActiveRanksPerGroup,
-    int nGroups) {
+    int nGroups,
+    int lowPrecision) {
   return ncclShardedRelayMultiGroupAllReduce(
       sendBuffs,
       recvBuffs,
@@ -70,7 +71,8 @@ ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllReduce(
       stream,
       allActiveRanks,
       nActiveRanksPerGroup,
-      nGroups);
+      nGroups,
+      lowPrecision);
 }
 
 ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupReduceScatter(
@@ -83,7 +85,8 @@ ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupReduceScatter(
     hipStream_t stream,
     const int* const* allActiveRanks,
     int nActiveRanksPerGroup,
-    int nGroups) {
+    int nGroups,
+    int lowPrecision) {
   return ncclShardedRelayMultiGroupReduceScatter(
       sendBuffs,
       recvBuffs,
@@ -94,7 +97,8 @@ ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupReduceScatter(
       stream,
       allActiveRanks,
       nActiveRanksPerGroup,
-      nGroups);
+      nGroups,
+      lowPrecision);
 }
 
 ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllToAll(
@@ -106,7 +110,8 @@ ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllToAll(
     hipStream_t stream,
     const int* const* allActiveRanks,
     int nActiveRanksPerGroup,
-    int nGroups) {
+    int nGroups,
+    int lowPrecision) {
   return ncclShardedRelayMultiGroupAllToAll(
       sendBuffs,
       recvBuffs,
@@ -116,7 +121,8 @@ ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllToAll(
       stream,
       allActiveRanks,
       nActiveRanksPerGroup,
-      nGroups);
+      nGroups,
+      lowPrecision);
 }
 
 ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllGather(
@@ -128,7 +134,8 @@ ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllGather(
     hipStream_t stream,
     const int* const* allActiveRanks,
     int nActiveRanksPerGroup,
-    int nGroups) {
+    int nGroups,
+    int lowPrecision) {
   return ncclShardedRelayMultiGroupAllGather(
       sendBuffs,
       recvBuffs,
@@ -138,7 +145,8 @@ ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllGather(
       stream,
       allActiveRanks,
       nActiveRanksPerGroup,
-      nGroups);
+      nGroups,
+      lowPrecision);
 }
 
 // Hop three of the plan's wire path: RcclxRelayPlan -> ncclRelayPlanInfo -> the

--- a/comms/torchcomms/rcclx/RcclxApiShardedRelayStub.cpp
+++ b/comms/torchcomms/rcclx/RcclxApiShardedRelayStub.cpp
@@ -52,7 +52,8 @@ ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllReduce(
     hipStream_t /*stream*/,
     const int* const* /*allActiveRanks*/,
     int /*nActiveRanksPerGroup*/,
-    int /*nGroups*/) {
+    int /*nGroups*/,
+    int /*lowPrecision*/) {
   return ncclInternalError;
 }
 
@@ -66,7 +67,8 @@ ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupReduceScatter(
     hipStream_t /*stream*/,
     const int* const* /*allActiveRanks*/,
     int /*nActiveRanksPerGroup*/,
-    int /*nGroups*/) {
+    int /*nGroups*/,
+    int /*lowPrecision*/) {
   return ncclInternalError;
 }
 
@@ -79,7 +81,8 @@ ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllToAll(
     hipStream_t /*stream*/,
     const int* const* /*allActiveRanks*/,
     int /*nActiveRanksPerGroup*/,
-    int /*nGroups*/) {
+    int /*nGroups*/,
+    int /*lowPrecision*/) {
   return ncclInternalError;
 }
 
@@ -92,7 +95,8 @@ ncclResult_t DefaultRcclxApi::shardedRelayMultiGroupAllGather(
     hipStream_t /*stream*/,
     const int* const* /*allActiveRanks*/,
     int /*nActiveRanksPerGroup*/,
-    int /*nGroups*/) {
+    int /*nGroups*/,
+    int /*lowPrecision*/) {
   return ncclInternalError;
 }
 

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
@@ -730,7 +730,8 @@ TorchCommRCCLX::sharded_relay_multi_group_all_reduce(
     const std::vector<std::vector<int64_t>>& all_active_ranks,
     const std::vector<int64_t>& per_group_counts,
     bool async_op,
-    std::optional<std::vector<at::Tensor>> output_tensors) {
+    std::optional<std::vector<at::Tensor>> output_tensors,
+    bool low_precision) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
 
@@ -902,7 +903,7 @@ TorchCommRCCLX::sharded_relay_multi_group_all_reduce(
       allActiveRanksPtr.data(),
       nActiveRanksPerGroup,
       nGroups,
-      /*lowPrecision=*/0);
+      low_precision ? 1 : 0);
 
   if (result != ncclSuccess) {
     throw RCCLXException(
@@ -926,7 +927,8 @@ TorchCommRCCLX::sharded_relay_multi_group_reduce_scatter(
     const ReduceOp& op,
     const std::vector<std::vector<int64_t>>& all_active_ranks,
     const std::vector<int64_t>& per_group_recv_counts,
-    bool async_op) {
+    bool async_op,
+    bool low_precision) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
 
@@ -1081,7 +1083,7 @@ TorchCommRCCLX::sharded_relay_multi_group_reduce_scatter(
       allActiveRanksPtr.data(),
       nActiveRanksPerGroup,
       nGroups,
-      /*lowPrecision=*/0);
+      low_precision ? 1 : 0);
 
   if (result != ncclSuccess) {
     throw RCCLXException(
@@ -1104,7 +1106,8 @@ TorchCommRCCLX::sharded_relay_multi_group_all_to_all(
     std::vector<at::Tensor>& output_tensors,
     const std::vector<std::vector<int64_t>>& all_active_ranks,
     const std::vector<int64_t>& per_group_segment_counts,
-    bool async_op) {
+    bool async_op,
+    bool low_precision) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
 
@@ -1253,7 +1256,7 @@ TorchCommRCCLX::sharded_relay_multi_group_all_to_all(
       allActiveRanksPtr.data(),
       nActiveRanksPerGroup,
       nGroups,
-      /*lowPrecision=*/0);
+      low_precision ? 1 : 0);
 
   if (result != ncclSuccess) {
     throw RCCLXException(
@@ -1276,7 +1279,8 @@ TorchCommRCCLX::sharded_relay_multi_group_all_gather(
     std::vector<at::Tensor>& output_tensors,
     const std::vector<std::vector<int64_t>>& all_active_ranks,
     const std::vector<int64_t>& per_group_send_counts,
-    bool async_op) {
+    bool async_op,
+    bool low_precision) {
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
 
@@ -1426,7 +1430,7 @@ TorchCommRCCLX::sharded_relay_multi_group_all_gather(
       allActiveRanksPtr.data(),
       nActiveRanksPerGroup,
       nGroups,
-      /*lowPrecision=*/0);
+      low_precision ? 1 : 0);
 
   if (result != ncclSuccess) {
     throw RCCLXException(

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
@@ -901,7 +901,8 @@ TorchCommRCCLX::sharded_relay_multi_group_all_reduce(
       stream,
       allActiveRanksPtr.data(),
       nActiveRanksPerGroup,
-      nGroups);
+      nGroups,
+      /*lowPrecision=*/0);
 
   if (result != ncclSuccess) {
     throw RCCLXException(
@@ -1079,7 +1080,8 @@ TorchCommRCCLX::sharded_relay_multi_group_reduce_scatter(
       stream,
       allActiveRanksPtr.data(),
       nActiveRanksPerGroup,
-      nGroups);
+      nGroups,
+      /*lowPrecision=*/0);
 
   if (result != ncclSuccess) {
     throw RCCLXException(
@@ -1250,7 +1252,8 @@ TorchCommRCCLX::sharded_relay_multi_group_all_to_all(
       stream,
       allActiveRanksPtr.data(),
       nActiveRanksPerGroup,
-      nGroups);
+      nGroups,
+      /*lowPrecision=*/0);
 
   if (result != ncclSuccess) {
     throw RCCLXException(
@@ -1422,7 +1425,8 @@ TorchCommRCCLX::sharded_relay_multi_group_all_gather(
       stream,
       allActiveRanksPtr.data(),
       nActiveRanksPerGroup,
-      nGroups);
+      nGroups,
+      /*lowPrecision=*/0);
 
   if (result != ncclSuccess) {
     throw RCCLXException(

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
@@ -193,13 +193,21 @@ class TorchCommRCCLX : public TorchCommBackend,
   // Fused multi-group sharded relay allreduce for 2D sparse parallelism
   // Executes multiple allreduce groups in lockstep phases to eliminate XGMI
   // contention
+  //
+  // `low_precision` asks for the fp8e4m3 wire format where it pays; an internal
+  // size-only gate declines to full precision silently otherwise. It is a
+  // COLLECTIVE argument -- identical on every rank of the call, like the dtype,
+  // the op and the counts -- because ranks that disagree disagree on how many
+  // bytes cross each link, so the call hangs or corrupts rather than degrading.
+  // The same contract applies to the three collectives below.
   c10::intrusive_ptr<TorchWork> sharded_relay_multi_group_all_reduce(
       std::vector<at::Tensor>& tensors,
       const ReduceOp& op,
       const std::vector<std::vector<int64_t>>& all_active_ranks,
       const std::vector<int64_t>& per_group_counts,
       bool async_op,
-      std::optional<std::vector<at::Tensor>> output_tensors = std::nullopt);
+      std::optional<std::vector<at::Tensor>> output_tensors = std::nullopt,
+      bool low_precision = false);
 
   // Fused multi-group sharded relay reduce-scatter for 2D sparse parallelism.
   // input_tensors[g] / output_tensors[g] are the contiguous send / recv buffer
@@ -210,7 +218,8 @@ class TorchCommRCCLX : public TorchCommBackend,
       const ReduceOp& op,
       const std::vector<std::vector<int64_t>>& all_active_ranks,
       const std::vector<int64_t>& per_group_recv_counts,
-      bool async_op);
+      bool async_op,
+      bool low_precision = false);
 
   // Fused multi-group sharded relay all-to-all for 2D sparse parallelism.
   // Each active rank's input/output hold nActiveRanks x
@@ -223,7 +232,8 @@ class TorchCommRCCLX : public TorchCommBackend,
       std::vector<at::Tensor>& output_tensors,
       const std::vector<std::vector<int64_t>>& all_active_ranks,
       const std::vector<int64_t>& per_group_segment_counts,
-      bool async_op);
+      bool async_op,
+      bool low_precision = false);
 
   // Fused multi-group sharded relay all-gather for 2D sparse parallelism.
   // Each active rank's input holds per_group_send_counts[g] elements (its
@@ -237,7 +247,8 @@ class TorchCommRCCLX : public TorchCommBackend,
       std::vector<at::Tensor>& output_tensors,
       const std::vector<std::vector<int64_t>>& all_active_ranks,
       const std::vector<int64_t>& per_group_send_counts,
-      bool async_op);
+      bool async_op,
+      bool low_precision = false);
 
   // Relay control plane: how a helper rank learns what collectives to call.
   //

--- a/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXPy.cpp
@@ -24,14 +24,16 @@ PYBIND11_MODULE(_comms_rcclx, m, py::mod_gil_not_used()) {
              const std::vector<std::vector<int64_t>>& all_active_ranks,
              const std::vector<int64_t>& per_group_counts,
              bool async_op,
-             std::optional<std::vector<at::Tensor>> output_tensors) {
+             std::optional<std::vector<at::Tensor>> output_tensors,
+             bool low_precision) {
             return self.sharded_relay_multi_group_all_reduce(
                 tensors,
                 op,
                 all_active_ranks,
                 per_group_counts,
                 async_op,
-                output_tensors);
+                output_tensors,
+                low_precision);
           },
           R"(
 Fused multi-group sharded relay allreduce for 2D sparse parallelism.
@@ -63,6 +65,14 @@ Args:
         out-of-place into these output tensors while the inputs are preserved;
         the active group's output segments must mirror its input segments in
         count and per-segment numel().
+    low_precision: If True, use the low-precision (fp8e4m3) wire format where
+        it pays. An internal size-only gate decides -- unsupported dtype,
+        counts that are not a multiple of 128, or a message below the measured
+        crossover all decline to full precision SILENTLY, so assert engagement
+        rather than assuming it. COLLECTIVE: pass the same value on every rank
+        of the call, exactly like the dtype and the counts. Ranks that disagree
+        disagree on how many bytes cross each link, so the call hangs or
+        corrupts rather than degrading.
 
 Returns:
     TorchWork object for operation completion if async_op=True
@@ -81,6 +91,7 @@ Example:
           py::arg("per_group_counts"),
           py::arg("async_op") = false,
           py::arg("output_tensors") = py::none(),
+          py::arg("low_precision") = false,
           py::call_guard<py::gil_scoped_release>())
       .def(
           "sharded_relay_multi_group_reduce_scatter",
@@ -90,14 +101,16 @@ Example:
              const ReduceOp& op,
              const std::vector<std::vector<int64_t>>& all_active_ranks,
              const std::vector<int64_t>& per_group_recv_counts,
-             bool async_op) {
+             bool async_op,
+             bool low_precision) {
             return self.sharded_relay_multi_group_reduce_scatter(
                 input_tensors,
                 output_tensors,
                 op,
                 all_active_ranks,
                 per_group_recv_counts,
-                async_op);
+                async_op,
+                low_precision);
           },
           R"(
 Fused multi-group sharded relay reduce-scatter for 2D sparse parallelism.
@@ -126,6 +139,9 @@ Args:
         active ranks.
     per_group_recv_counts: List of OUTPUT element counts (one per group).
     async_op: If True, returns a TorchWork handle for async operation
+    low_precision: If True, use the fp8e4m3 wire format where it pays. See
+        sharded_relay_multi_group_all_reduce -- same gate, same COLLECTIVE
+        contract.
 
 Returns:
     TorchWork object for operation completion if async_op=True
@@ -146,6 +162,7 @@ Example:
           py::arg("all_active_ranks"),
           py::arg("per_group_recv_counts"),
           py::arg("async_op") = false,
+          py::arg("low_precision") = false,
           py::call_guard<py::gil_scoped_release>())
       .def(
           "sharded_relay_multi_group_all_to_all",
@@ -154,13 +171,15 @@ Example:
              std::vector<at::Tensor>& output_tensors,
              const std::vector<std::vector<int64_t>>& all_active_ranks,
              const std::vector<int64_t>& per_group_segment_counts,
-             bool async_op) {
+             bool async_op,
+             bool low_precision) {
             return self.sharded_relay_multi_group_all_to_all(
                 input_tensors,
                 output_tensors,
                 all_active_ranks,
                 per_group_segment_counts,
-                async_op);
+                async_op,
+                low_precision);
           },
           R"(
 Fused multi-group sharded relay all-to-all for 2D sparse parallelism.
@@ -190,6 +209,9 @@ Args:
     all_active_ranks: List of lists of active rank IDs per sparse group.
     per_group_segment_counts: List of per-segment element counts (one per group).
     async_op: If True, returns a TorchWork handle for async operation
+    low_precision: If True, use the fp8e4m3 wire format where it pays. See
+        sharded_relay_multi_group_all_reduce -- same gate, same COLLECTIVE
+        contract.
 
 Returns:
     TorchWork object for operation completion if async_op=True
@@ -199,6 +221,7 @@ Returns:
           py::arg("all_active_ranks"),
           py::arg("per_group_segment_counts"),
           py::arg("async_op") = false,
+          py::arg("low_precision") = false,
           py::call_guard<py::gil_scoped_release>())
       .def(
           "sharded_relay_multi_group_all_gather",
@@ -207,13 +230,15 @@ Returns:
              std::vector<at::Tensor>& output_tensors,
              const std::vector<std::vector<int64_t>>& all_active_ranks,
              const std::vector<int64_t>& per_group_send_counts,
-             bool async_op) {
+             bool async_op,
+             bool low_precision) {
             return self.sharded_relay_multi_group_all_gather(
                 input_tensors,
                 output_tensors,
                 all_active_ranks,
                 per_group_send_counts,
-                async_op);
+                async_op,
+                low_precision);
           },
           R"(
 Fused multi-group sharded relay all-gather for 2D sparse parallelism.
@@ -246,6 +271,9 @@ Args:
     all_active_ranks: List of lists of active rank IDs per sparse group.
     per_group_send_counts: List of per-rank contribution counts (one per group).
     async_op: If True, returns a TorchWork handle for async operation
+    low_precision: If True, use the fp8e4m3 wire format where it pays. See
+        sharded_relay_multi_group_all_reduce -- same gate, same COLLECTIVE
+        contract.
 
 Returns:
     TorchWork object for operation completion if async_op=True
@@ -255,6 +283,7 @@ Returns:
           py::arg("all_active_ranks"),
           py::arg("per_group_send_counts"),
           py::arg("async_op") = false,
+          py::arg("low_precision") = false,
           py::call_guard<py::gil_scoped_release>())
       .def(
           "relay_control_publish",

--- a/comms/torchcomms/rcclx/_comms_rcclx.pyi
+++ b/comms/torchcomms/rcclx/_comms_rcclx.pyi
@@ -17,6 +17,7 @@ class TorchCommRCCLX:
         per_group_counts: list[int],
         async_op: bool = False,
         output_tensors: list[torch.Tensor] | None = None,
+        low_precision: bool = False,
     ) -> TorchWork | None:
         """
         Fused multi-group sharded relay allreduce for 2D sparse parallelism.
@@ -37,6 +38,15 @@ class TorchCommRCCLX:
                 allreduce is in-place. When provided, the active group's
                 reduced result is written out-of-place into these tensors
                 while the inputs are preserved.
+            low_precision: If True, use the low-precision (fp8e4m3) wire format
+                where it pays. An internal size-only gate decides -- an
+                unsupported dtype, counts that are not a multiple of 128, or a
+                message below the measured crossover all decline to full
+                precision SILENTLY, so assert engagement rather than assuming
+                it. COLLECTIVE: pass the same value on every rank of the call,
+                exactly like the dtype and the counts. Ranks that disagree
+                disagree on how many bytes cross each link, so the call hangs or
+                corrupts rather than degrading.
 
         Returns:
             TorchWork handle if async_op=True, else None
@@ -51,6 +61,7 @@ class TorchCommRCCLX:
         all_active_ranks: list[list[int]],
         per_group_recv_counts: list[int],
         async_op: bool = False,
+        low_precision: bool = False,
     ) -> TorchWork | None:
         """
         Fused multi-group sharded relay reduce-scatter for 2D sparse parallelism.
@@ -72,6 +83,9 @@ class TorchCommRCCLX:
                 active rank IDs for one sparse group
             per_group_recv_counts: List of OUTPUT element counts (one per group)
             async_op: If True, returns a TorchWork handle for async operation
+            low_precision: If True, use the fp8e4m3 wire format where it pays.
+                See sharded_relay_multi_group_all_reduce -- same gate, same
+                COLLECTIVE contract.
 
         Returns:
             TorchWork handle if async_op=True, else None
@@ -85,6 +99,7 @@ class TorchCommRCCLX:
         all_active_ranks: list[list[int]],
         per_group_segment_counts: list[int],
         async_op: bool = False,
+        low_precision: bool = False,
     ) -> TorchWork | None:
         """
         Fused multi-group sharded relay all-to-all for 2D sparse parallelism.
@@ -109,6 +124,9 @@ class TorchCommRCCLX:
             all_active_ranks: List of lists of active rank IDs per sparse group
             per_group_segment_counts: List of per-segment element counts
             async_op: If True, returns a TorchWork handle for async operation
+            low_precision: If True, use the fp8e4m3 wire format where it pays.
+                See sharded_relay_multi_group_all_reduce -- same gate, same
+                COLLECTIVE contract.
 
         Returns:
             TorchWork handle if async_op=True, else None
@@ -122,6 +140,7 @@ class TorchCommRCCLX:
         all_active_ranks: list[list[int]],
         per_group_send_counts: list[int],
         async_op: bool = False,
+        low_precision: bool = False,
     ) -> TorchWork | None:
         """
         Fused multi-group sharded relay all-gather for 2D sparse parallelism.
@@ -148,6 +167,9 @@ class TorchCommRCCLX:
             all_active_ranks: List of lists of active rank IDs per sparse group
             per_group_send_counts: List of per-rank contribution counts
             async_op: If True, returns a TorchWork handle for async operation
+            low_precision: If True, use the fp8e4m3 wire format where it pays.
+                See sharded_relay_multi_group_all_reduce -- same gate, same
+                COLLECTIVE contract.
 
         Returns:
             TorchWork handle if async_op=True, else None

--- a/comms/torchcomms/rcclx/tests/unit/cpp/mocks/RcclxMock.hpp
+++ b/comms/torchcomms/rcclx/tests/unit/cpp/mocks/RcclxMock.hpp
@@ -310,7 +310,8 @@ class RcclxMock : public RcclxApi {
        hipStream_t stream,
        const int* const* allActiveRanks,
        int nActiveRanksPerGroup,
-       int nGroups),
+       int nGroups,
+       int lowPrecision),
       (override));
   MOCK_METHOD(
       ncclResult_t,
@@ -324,7 +325,8 @@ class RcclxMock : public RcclxApi {
        hipStream_t stream,
        const int* const* allActiveRanks,
        int nActiveRanksPerGroup,
-       int nGroups),
+       int nGroups,
+       int lowPrecision),
       (override));
   MOCK_METHOD(
       ncclResult_t,
@@ -337,7 +339,8 @@ class RcclxMock : public RcclxApi {
        hipStream_t stream,
        const int* const* allActiveRanks,
        int nActiveRanksPerGroup,
-       int nGroups),
+       int nGroups,
+       int lowPrecision),
       (override));
   MOCK_METHOD(
       ncclResult_t,
@@ -350,7 +353,8 @@ class RcclxMock : public RcclxApi {
        hipStream_t stream,
        const int* const* allActiveRanks,
        int nActiveRanksPerGroup,
-       int nGroups),
+       int nGroups,
+       int lowPrecision),
       (override));
   MOCK_METHOD(
       ncclResult_t,


### PR DESCRIPTION
Summary:

Substitutes the wire format at the six boundary-crossing transfers of
`shardedRelayAllGather2ActivePipelined`, so both 2-active all-gather schedules now
carry it and the collective's low-precision behaviour no longer depends on whether
the size happens to pipeline.

Three arena regions, the same three the non-pipelined path uses, with the helper
region reshaped to the pipelined geometry: two ping-pong units per active source
instead of one chunk per source. No relayout of the existing ping-pong indexing
was needed -- this helper is a pure forwarder, so nothing reads two slots as one
contiguous run, unlike the pipelined allreduce's helper which reduces across them.

The quantize stays hoisted over the whole send buffer and the dequantize stays a
single launch after the last group. Neither is done per tile: the regions a
pipeline lands are disjoint, so T+1 launches would buy nothing, and a per-tile
quantize would additionally race nothing useful since every send reads the one
buffer that exists in full before the first group.

The diagonal slot keeps its full-precision memcpy (a no-op in-place) on both
paths, and stays deliberately outside the dequantize's range: it is this rank's own
data, already final.

Both the active side's four transfers and the helper's two are converted. That
pairing is called out because the pipelined flat allreduce shipped with the
helper's pair left in caller-dtype counts, and the symptom was one region of
garbage with everything else perfect.

The flat (A>2) schedules still decline and follow next.

Reviewed By: JinghanHuang

Differential Revision: D118652794
