### PR TITLE
Add the export identity and placement join key (#4008)

### DIFF
--- a/comms/utils/collstats/CollStatsIdentity.h
+++ b/comms/utils/collstats/CollStatsIdentity.h
@@ -1,0 +1,38 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+// Stable identity + physical-placement join key for an exported readout window.
+// Folly-free plain data, so the launch/comm layer can populate it without
+// pulling the JSON serializer's dependencies. A process-local communicator
+// value is not enough for fleet aggregation; the backend aggregates and dedups
+// across restarts and ranks on this tuple, and joins the placement key (host,
+// GPU, NIC/rail) against the topology inventory at `topologyVersion`.
+
+namespace meta::comms::collstats {
+
+// Every field must be able to say "not reported" distinguishably from a real
+// value, because a producer sets only the ones it has a source for and the
+// backend joins on what it receives. Strings use empty, the two rank/device
+// ordinals use -1, and the counters below are optional: unlike an ordinal,
+// 0 is a perfectly good generation or topology version, so a zero default
+// would be indistinguishable from a field nobody filled in.
+struct CollStatsExportIdentity {
+  std::string job;
+  std::string tenant;
+  std::string processGroup;
+  uint64_t commHash{0};
+  std::optional<uint64_t> commGeneration;
+  int32_t rank{-1};
+  std::string softwareVersion;
+  // Physical-placement join key, as seen at the rank.
+  std::string host;
+  int32_t gpu{-1};
+  std::string nicRail;
+  std::optional<uint64_t> topologyVersion;
+};
+
+} // namespace meta::comms::collstats


### PR DESCRIPTION
Summary:

A process-local communicator handle means nothing to an export backend: rows have to be grouped and deduplicated across ranks and restarts, and placed against the fleet. `CollStatsExportIdentity` gives every exported readout window a stable identity, in two groups of fields:

- Identity -- job, tenant, process group, comm hash, comm generation, rank, software version. This is what lets a consumer group the rows belonging to one collective across ranks, and tell a restarted job's rows from the previous incarnation's.
- Placement join key -- host, GPU ordinal, NIC/rail, plus `topologyVersion`. Cluster, region and rack are deliberately not duplicated on every row; they are joined off-box from this key against the topology inventory at that version. That indirection is what lets a consumer separate a job-level regression from a shared-infrastructure fault such as a bad rack or a degraded rail, and it only works if the version the row resolves against is part of the contract rather than assumed.

The struct is folly-free plain data (`<cstdint>`, `<string>` only) so the launch and comm layers can populate it without pulling in the serializer's dependencies.

Reviewed By: rmahidhar

Differential Revision: D113661121


