### PR TITLE
Export windows out of band, losing them loudly if at all (#4009)

### DIFF
--- a/comms/utils/collstats/CollStatsExporter.cc
+++ b/comms/utils/collstats/CollStatsExporter.cc
@@ -1,0 +1,133 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/collstats/CollStatsExporter.h"
+
+#include <fstream>
+#include <ios>
+#include <memory>
+#include <utility>
+
+namespace meta::comms::collstats {
+
+CollStatsExporter::CollStatsExporter(
+    CollStatsExportIdentity identity,
+    Serializer serializer,
+    JsonSink sink,
+    std::size_t queueCapacity)
+    : identity_(std::move(identity)),
+      serializer_(std::move(serializer)),
+      sink_(std::move(sink)),
+      capacity_(queueCapacity < 1 ? 1 : queueCapacity) {
+  thread_ = std::thread([this]() { run(); });
+}
+
+CollStatsExporter::~CollStatsExporter() {
+  shutdown();
+}
+
+void CollStatsExporter::shutdown(std::chrono::steady_clock::duration budget) {
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    stop_ = true;
+    drainDeadline_ = std::chrono::steady_clock::now() + budget;
+  }
+  cv_.notify_all();
+  if (thread_.joinable()) {
+    thread_.join();
+  }
+}
+
+void CollStatsExporter::submit(CollStatSnapshot snapshot) {
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    if (stop_ || queue_.size() >= capacity_) {
+      dropped_.fetch_add(1, std::memory_order_relaxed);
+      return;
+    }
+    queue_.push(std::move(snapshot));
+  }
+  cv_.notify_one();
+}
+
+void CollStatsExporter::run() {
+  for (;;) {
+    CollStatSnapshot snapshot;
+    {
+      std::unique_lock<std::mutex> lk(mu_);
+      cv_.wait(lk, [this]() { return stop_ || !queue_.empty(); });
+      if (queue_.empty()) {
+        // Only woken for stop with nothing left to drain.
+        return;
+      }
+      if (stop_ && std::chrono::steady_clock::now() > drainDeadline_) {
+        // The teardown drain is time-boxed: the destroying thread reaches this
+        // queue through join(), so a slow sink would otherwise stall comm
+        // teardown for as long as it likes.
+        //
+        // The bound is on the queue, not on one call: the deadline is only
+        // consulted here, between items, so a single wedged sink call still
+        // blocks join() for as long as it runs. Bounding that would need the
+        // sink on its own abandonable thread, which is a bigger contract than
+        // the queue's -- so the budget caps how many slow calls teardown waits
+        // through, not how long any one of them may take.
+        dropped_.fetch_add(queue_.size(), std::memory_order_relaxed);
+        // Popped rather than swapped against a fresh queue: constructing one
+        // allocates, and this runs outside the try below, so a throw here would
+        // escape the thread body -- the std::terminate route this function
+        // exists to close.
+        while (!queue_.empty()) {
+          queue_.pop();
+        }
+        return;
+      }
+      snapshot = std::move(queue_.front());
+      queue_.pop();
+    }
+    // Serialize and hand off outside the lock so submit() never blocks on I/O.
+    // Telemetry must never take the job down: without the catch, a throw from
+    // a caller-supplied serializer or sink escapes the thread body and calls
+    // std::terminate.
+    if (!serializer_ || !sink_) {
+      failed_.fetch_add(1, std::memory_order_relaxed);
+      continue;
+    }
+    try {
+      sink_(serializer_(identity_, snapshot));
+      exported_.fetch_add(1, std::memory_order_relaxed);
+    } catch (...) {
+      failed_.fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+}
+
+CollStatsExporter::JsonSink collStatsMakeFileSink(const std::string& path) {
+  auto file = std::make_shared<std::ofstream>(path, std::ios::app);
+  if (!file->is_open()) {
+    // Empty sink, so the caller can tell the open failed. Returning a
+    // silently-discarding sink instead would make a bad output path
+    // indistinguishable from a working one that produced no windows.
+    return {};
+  }
+  return [file](const std::string& json) {
+    (*file) << json << '\n';
+    file->flush();
+    // std::ofstream does not throw on a failed write by default: it sets
+    // fail/bad and every subsequent write silently no-ops. Unchecked, a disk
+    // that fills after the open turns every remaining window into a counted
+    // export that reached nothing. Throwing hands it to the exporter's catch,
+    // which counts it under failed() -- a visible loss rather than a silent
+    // one. No is_open() guard: the factory returns an empty sink when the open
+    // failed, and this lambda's shared_ptr is the only owner, so the stream
+    // cannot be closed underneath it.
+    if (!file->good()) {
+      // Cleared before throwing: the fail/bad bits latch, so leaving them set
+      // would make every later window throw on this stream's state rather than
+      // on its own write, turning one transient failure into a whole run of
+      // failed() windows.
+      file->clear();
+      throw std::ios_base::failure("collstats file sink write failed");
+    }
+  };
+}
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsExporter.h
+++ b/comms/utils/collstats/CollStatsExporter.h
@@ -1,0 +1,130 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <thread>
+
+#include "comms/utils/collstats/CollStatsIdentity.h"
+#include "comms/utils/collstats/CollStatsSnapshot.h"
+
+// Out-of-band, asynchronous exporter for readout windows. The producer thread
+// hands a snapshot to submit() — a cheap bounded-queue enqueue that never
+// blocks — and a background thread serializes it (tagging it with the export
+// identity) and passes the blob to a pluggable sink. Serialization and I/O
+// therefore never touch the producer/training thread. The background thread
+// does no CUDA, so it carries none of the poll-thread CUDA hazards.
+//
+// The queue is bounded and lossy: if the sink cannot keep up, snapshots are
+// dropped and counted rather than stalling training — every export hop is async
+// and droppable, and every drop is counted.
+//
+// Both what a window turns into and where it goes are the caller's choice: this
+// class owns the thread, the bounded queue and the loss accounting, and knows
+// nothing about the wire format. That is what lets a second reporting backend
+// reuse the transport instead of reimplementing it.
+
+namespace meta::comms::collstats {
+
+class CollStatsExporter {
+ public:
+  // Receives one window's serialized blob. Called only on the background
+  // thread.
+  using JsonSink = std::function<void(const std::string&)>;
+
+  // Turns one window plus its identity into the blob handed to the sink.
+  // Called only on the background thread, so it may be as expensive as the
+  // format requires. A throw is caught and counted as a failed window.
+  using Serializer = std::function<
+      std::string(const CollStatsExportIdentity&, const CollStatSnapshot&)>;
+
+  CollStatsExporter(
+      CollStatsExportIdentity identity,
+      Serializer serializer,
+      JsonSink sink,
+      std::size_t queueCapacity = 16);
+  ~CollStatsExporter();
+
+  CollStatsExporter(const CollStatsExporter&) = delete;
+  CollStatsExporter& operator=(const CollStatsExporter&) = delete;
+  // Non-movable as well: the background thread captures `this`, so moving the
+  // object would leave that thread reading a moved-from queue and mutex.
+  CollStatsExporter(CollStatsExporter&&) = delete;
+  CollStatsExporter& operator=(CollStatsExporter&&) = delete;
+
+  // Enqueue a window for export. Non-blocking; drops and counts if the queue is
+  // full. The snapshot is moved in.
+  //
+  // Throws only if the enqueue itself cannot allocate, which is deliberate: the
+  // caller is the training thread, and a telemetry path that swallows
+  // std::bad_alloc there would be hiding an out-of-memory condition the job
+  // cannot continue through anyway. Every other loss is counted, not thrown.
+  void submit(CollStatSnapshot snapshot);
+
+  // Stop accepting windows, drain what is queued within `budget`, and join the
+  // background thread. Idempotent.
+  //
+  // Call this before reading the counters. Windows abandoned at the deadline
+  // are charged to dropped() here, so only a caller that shuts down explicitly
+  // can observe the teardown loss -- the destructor's own call runs after the
+  // last chance to read, which is where a teardown drop would go unreported.
+  //
+  // `budget` bounds how many slow sink calls teardown waits through, not how
+  // long any one of them may take; see kDrainBudget.
+  void shutdown(std::chrono::steady_clock::duration budget = kDrainBudget);
+
+  uint64_t exported() const {
+    return exported_.load(std::memory_order_relaxed);
+  }
+  uint64_t dropped() const {
+    return dropped_.load(std::memory_order_relaxed);
+  }
+  // Windows that reached the exporter thread but produced no output: the sink
+  // or the serializer threw, or either is absent. Distinct from dropped(),
+  // which counts windows that never got that far.
+  uint64_t failed() const {
+    return failed_.load(std::memory_order_relaxed);
+  }
+
+ private:
+  void run();
+
+  CollStatsExportIdentity identity_;
+  Serializer serializer_;
+  JsonSink sink_;
+  const std::size_t capacity_;
+
+  std::mutex mu_;
+  std::condition_variable cv_;
+  std::queue<CollStatSnapshot> queue_; // guarded by mu_
+  bool stop_{false}; // guarded by mu_
+
+  std::atomic<uint64_t> exported_{0};
+  std::atomic<uint64_t> dropped_{0};
+  std::atomic<uint64_t> failed_{0};
+
+  // How long the destructor lets the background thread keep pushing queued
+  // windows through the sink before abandoning the rest. The destructor joins
+  // that thread, so an unbounded drain would let a wedged sink stall teardown.
+  static constexpr std::chrono::seconds kDrainBudget{2};
+  std::chrono::steady_clock::time_point drainDeadline_{}; // guarded by mu_
+
+  std::thread thread_;
+};
+
+// A JSON sink that appends each blob as one line (JSON Lines) to `path`. The
+// file is opened once and shared with the returned callable. Returns an empty
+// (falsy) std::function if the open fails — the caller must test it and report
+// the failure, because an exporter built on an empty sink writes nothing and
+// would otherwise be indistinguishable from one that had no windows to write.
+// Intended default sink for file-per-rank export.
+CollStatsExporter::JsonSink collStatsMakeFileSink(const std::string& path);
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsIdentity.h
+++ b/comms/utils/collstats/CollStatsIdentity.h
@@ -1,0 +1,38 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+// Stable identity + physical-placement join key for an exported readout window.
+// Folly-free plain data, so the launch/comm layer can populate it without
+// pulling the JSON serializer's dependencies. A process-local communicator
+// value is not enough for fleet aggregation; the backend aggregates and dedups
+// across restarts and ranks on this tuple, and joins the placement key (host,
+// GPU, NIC/rail) against the topology inventory at `topologyVersion`.
+
+namespace meta::comms::collstats {
+
+// Every field must be able to say "not reported" distinguishably from a real
+// value, because a producer sets only the ones it has a source for and the
+// backend joins on what it receives. Strings use empty, the two rank/device
+// ordinals use -1, and the counters below are optional: unlike an ordinal,
+// 0 is a perfectly good generation or topology version, so a zero default
+// would be indistinguishable from a field nobody filled in.
+struct CollStatsExportIdentity {
+  std::string job;
+  std::string tenant;
+  std::string processGroup;
+  uint64_t commHash{0};
+  std::optional<uint64_t> commGeneration;
+  int32_t rank{-1};
+  std::string softwareVersion;
+  // Physical-placement join key, as seen at the rank.
+  std::string host;
+  int32_t gpu{-1};
+  std::string nicRail;
+  std::optional<uint64_t> topologyVersion;
+};
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsReader.h
+++ b/comms/utils/collstats/CollStatsReader.h
@@ -9,6 +9,7 @@
 #include "comms/utils/collstats/CollStatsDeviceBlock.h"
 #include "comms/utils/collstats/CollStatsHistogram.h"
 #include "comms/utils/collstats/CollStatsKeyRegistry.h"
+#include "comms/utils/collstats/CollStatsSnapshot.h"
 #include "comms/utils/collstats/CollStatsTypes.h"
 
 // Host-side readout of one window from a device-resident stats block. The
@@ -24,51 +25,6 @@
 // dedicated reader stream, never the training stream.
 
 namespace meta::comms::collstats {
-
-// One window's worth of per-key aggregates, copied to the host.
-//
-// `values` and `keys` are both indexed by the dense id the host key registry
-// assigned, so values[i] belongs to keys[i]. `values` carries one extra
-// trailing entry, values[numKeys], holding everything that resolved to the
-// catch-all; it has no entry in `keys` because it is not one key.
-//
-// Only the occupied prefix is transferred. Ids are handed out densely and never
-// recycled, so numKeys is the registry's size at the moment the window was
-// issued, not the bank's capacity.
-struct CollStatSnapshot {
-  uint32_t numKeys{0};
-  uint64_t windowEpoch{0}; // pre-flip epoch value; a monotonic window sequence
-  uint64_t catchAllCount{0}; // cumulative, from the host registry
-  // Wall-clock bounds of the window, unix nanoseconds, or 0 when the producer
-  // did not stamp them. Wall rather than monotonic because their purpose is
-  // lining a window up against events outside this process; durations come
-  // from the device clock and never from here, so a clock step can misplace a
-  // boundary but cannot corrupt a measurement.
-  //
-  // The span also makes the window's duty cycle computable: the per-key
-  // duration sums over this wall interval is the fraction of the period the
-  // rank spent inside collectives.
-  uint64_t windowStartUnixNs{0};
-  uint64_t windowEndUnixNs{0};
-  /* The bucketing this window was produced under. Exported alongside the
-   * buckets so a consumer never has to assume the defaults, and so a window
-   * recorded before a retune stays interpretable. Defaulted rather than
-   * zero-initialized: a zero geometry has numBuckets 0, and the readout's
-   * `numBuckets - 1` overflow index would wrap. */
-  CollStatHistGeometry hist{collStatDefaultHistGeometry()};
-  uint64_t thresholdsNs[kMaxThresholds]{
-      kDefaultThresholdsNs[0],
-      kDefaultThresholdsNs[1],
-      kDefaultThresholdsNs[2],
-      kDefaultThresholdsNs[3]};
-  uint32_t numThresholds{kMaxThresholds};
-  /* The size-class edges this window was produced under, carried for the same
-   * reason as `hist`: a key's sizeClass is an index into these, so without them
-   * an exported row cannot be turned back into byte bounds off-box. */
-  CollStatSizeClasses sizeClasses{collStatDefaultSizeClasses()};
-  std::vector<CollStatKey> keys; // [numKeys]
-  std::vector<CollStatValue> values; // [numKeys + 1]
-};
 
 // Cross-stream gating for the epoch flip. The caller (holding the per-comm
 // boundary lock, so no collective enqueues mid-flip) supplies the instrumented

--- a/comms/utils/collstats/CollStatsSnapshot.h
+++ b/comms/utils/collstats/CollStatsSnapshot.h
@@ -1,0 +1,63 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "comms/utils/collstats/CollStatsHistogram.h"
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+// A readout window after it has left the device. Deliberately its own header,
+// and free of the CUDA runtime: the reader produces one of these, but the
+// consumers -- the exporter's queue, the serializers -- are plain host code,
+// and pulling them through CollStatsReader.h would make every one of them a
+// GPU target for a struct of integers and vectors.
+
+namespace meta::comms::collstats {
+
+// One window's worth of per-key aggregates, copied to the host.
+//
+// `values` and `keys` are both indexed by the dense id the host key registry
+// assigned, so values[i] belongs to keys[i]. `values` carries one extra
+// trailing entry, values[numKeys], holding everything that resolved to the
+// catch-all; it has no entry in `keys` because it is not one key.
+//
+// Only the occupied prefix is transferred. Ids are handed out densely and never
+// recycled, so numKeys is the registry's size at the moment the window was
+// issued, not the bank's capacity.
+struct CollStatSnapshot {
+  uint32_t numKeys{0};
+  uint64_t windowEpoch{0}; // pre-flip epoch value; a monotonic window sequence
+  uint64_t catchAllCount{0}; // cumulative, from the host registry
+  // Wall-clock bounds of the window, unix nanoseconds, or 0 when the producer
+  // did not stamp them. Wall rather than monotonic because their purpose is
+  // lining a window up against events outside this process; durations come
+  // from the device clock and never from here, so a clock step can misplace a
+  // boundary but cannot corrupt a measurement.
+  //
+  // The span also makes the window's duty cycle computable: the per-key
+  // duration sums over this wall interval is the fraction of the period the
+  // rank spent inside collectives.
+  uint64_t windowStartUnixNs{0};
+  uint64_t windowEndUnixNs{0};
+  /* The bucketing this window was produced under. Exported alongside the
+   * buckets so a consumer never has to assume the defaults, and so a window
+   * recorded before a retune stays interpretable. Defaulted rather than
+   * zero-initialized: a zero geometry has numBuckets 0, and the readout's
+   * `numBuckets - 1` overflow index would wrap. */
+  CollStatHistGeometry hist{collStatDefaultHistGeometry()};
+  uint64_t thresholdsNs[kMaxThresholds]{
+      kDefaultThresholdsNs[0],
+      kDefaultThresholdsNs[1],
+      kDefaultThresholdsNs[2],
+      kDefaultThresholdsNs[3]};
+  uint32_t numThresholds{kMaxThresholds};
+  /* The size-class edges this window was produced under, carried for the same
+   * reason as `hist`: a key's sizeClass is an index into these, so without them
+   * an exported row cannot be turned back into byte bounds off-box. */
+  CollStatSizeClasses sizeClasses{collStatDefaultSizeClasses()};
+  std::vector<CollStatKey> keys; // [numKeys]
+  std::vector<CollStatValue> values; // [numKeys + 1]
+};
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/tests/CollStatsExporterTest.cpp
+++ b/comms/utils/collstats/tests/CollStatsExporterTest.cpp
@@ -1,0 +1,325 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/collstats/CollStatsExporter.h"
+
+#include <unistd.h>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <functional>
+#include <future>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/collstats/CollStatsIdentity.h"
+#include "comms/utils/collstats/CollStatsSnapshot.h"
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+// Covers the transport only: the queue bound, the loss accounting and the
+// drain. What a window turns into is the serializer's business and is covered
+// by CollStatsJsonTest, so these tests pass a stub that makes each window
+// identifiable without pulling in a wire format.
+
+namespace meta::comms::collstats {
+namespace {
+
+// Upper bound on any wait for the background thread. Long enough that a loaded
+// CI host never trips it, short enough that a genuine hang fails the test
+// rather than the suite's own timeout.
+constexpr std::chrono::seconds kTestWait{30};
+
+CollStatsExportIdentity makeIdentity() {
+  CollStatsExportIdentity id;
+  id.processGroup = "dp";
+  id.commHash = 0xabc;
+  id.rank = 3;
+  id.host = "host-1";
+  id.gpu = 5;
+  return id;
+}
+
+// Renders both halves of the serializer's input, so a test can tell which
+// window it is looking at and that the identity reached the background thread.
+std::string stubSerialize(
+    const CollStatsExportIdentity& id,
+    const CollStatSnapshot& snap) {
+  return "rank=" + std::to_string(id.rank) +
+      " epoch=" + std::to_string(snap.windowEpoch);
+}
+
+// Blocks until `read` reports at least `want`, so a test can assert on the
+// background thread's counters without racing it. Bounded so a regression
+// fails the test instead of hanging the suite.
+bool waitForCount(const std::function<uint64_t()>& read, uint64_t want) {
+  for (int i = 0; i < 2000; ++i) {
+    if (read() >= want) {
+      return true;
+    }
+    // The bounded poll the guidance asks for, not a sleep standing in for
+    // synchronization. The counters are atomics the exporter thread bumps with
+    // nothing to wait on; the loop is capped so a regression fails rather than
+    // hangs.
+    // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  return false;
+}
+
+// A snapshot with `windowEpoch` set and one occupied key, so each window is
+// distinguishable.
+CollStatSnapshot makeSnapshot(uint64_t epoch) {
+  CollStatSnapshot snap;
+  snap.numKeys = 1;
+  snap.windowEpoch = epoch;
+  snap.keys.assign(
+      1,
+      CollStatKey{
+          CollStatOp::AllReduce,
+          CollStatAlgo::Direct,
+          CollStatProto::Unknown,
+          7u,
+          3u});
+  snap.values.assign(2, CollStatValue{});
+  snap.values[0].count = 1;
+  return snap;
+}
+
+TEST(CollStatsExporterTest, ExportsEverySubmittedWindowToSink) {
+  std::vector<std::string> captured; // written only on the bg thread
+  uint64_t exported = 0;
+  uint64_t dropped = 0;
+  uint64_t failed = 0;
+  {
+    CollStatsExporter exporter(
+        makeIdentity(), stubSerialize, [&captured](const std::string& blob) {
+          captured.push_back(blob);
+        });
+    for (uint64_t e = 0; e < 5; ++e) {
+      exporter.submit(makeSnapshot(e));
+    }
+    // Drains and joins, so the counters are final and the sink is done writing.
+    exporter.shutdown();
+    exported = exporter.exported();
+    dropped = exporter.dropped();
+    failed = exporter.failed();
+  }
+  const std::vector<std::string> expected = {
+      "rank=3 epoch=0",
+      "rank=3 epoch=1",
+      "rank=3 epoch=2",
+      "rank=3 epoch=3",
+      "rank=3 epoch=4"};
+  EXPECT_EQ(captured, expected);
+  // Asserted, not incidental: without this the exported_ increment can be
+  // deleted with every test still green.
+  EXPECT_EQ(exported, 5u);
+  EXPECT_EQ(dropped, 0u);
+  EXPECT_EQ(failed, 0u);
+}
+
+TEST(CollStatsExporterTest, DropsAndCountsWhenQueueFull) {
+  std::promise<void> entered;
+  std::promise<void> release;
+  // Shared, so the sink can wait on it without consuming the promise's single
+  // future, and bounded, so a regression in submit/run fails this test instead
+  // of hanging the suite on a thread that never reaches the sink.
+  std::shared_future<void> enteredFuture = entered.get_future().share();
+  std::shared_future<void> releaseFuture = release.get_future().share();
+  std::atomic<bool> firstDone{false};
+
+  uint64_t exportedAtCheck = 0;
+  {
+    CollStatsExporter exporter(
+        makeIdentity(),
+        stubSerialize,
+        [&](const std::string&) {
+          // Block the background thread inside the first sink call so the queue
+          // cannot drain, making the overflow deterministic.
+          if (!firstDone.exchange(true)) {
+            entered.set_value();
+            releaseFuture.wait_for(kTestWait);
+          }
+        },
+        /*queueCapacity=*/2);
+
+    exporter.submit(makeSnapshot(0)); // popped by bg thread, blocks in sink
+    ASSERT_EQ(enteredFuture.wait_for(kTestWait), std::future_status::ready)
+        << "background thread never reached the sink";
+
+    exporter.submit(makeSnapshot(1)); // queue: [1]
+    exporter.submit(makeSnapshot(2)); // queue: [1,2] -> full
+    exporter.submit(makeSnapshot(3)); // dropped
+    exporter.submit(makeSnapshot(4)); // dropped
+    exporter.submit(makeSnapshot(5)); // dropped
+
+    EXPECT_EQ(exporter.dropped(), 3u);
+    exportedAtCheck = exporter.exported(); // s0 still in sink, not yet counted
+
+    release.set_value(); // let the bg thread finish and drain 1 and 2
+  }
+  EXPECT_EQ(exportedAtCheck, 0u);
+}
+
+// A serializer that throws must cost one window, not the process: the throw
+// happens on the background thread, where an escape calls std::terminate.
+TEST(CollStatsExporterTest, CountsFailedWhenSerializerThrows) {
+  std::atomic<int> sinkCalls{0};
+  CollStatsExporter exporter(
+      makeIdentity(),
+      // The lambda must match the Serializer signature and return std::string;
+      // [[noreturn]] is not spellable on a lambda, and throwing is the whole
+      // point here.
+      // NOLINTNEXTLINE(clang-diagnostic-missing-noreturn)
+      [](const CollStatsExportIdentity&, const CollStatSnapshot&)
+          -> std::string { throw std::runtime_error("serializer failed"); },
+      [&sinkCalls](const std::string&) { ++sinkCalls; });
+  exporter.submit(makeSnapshot(0));
+  exporter.submit(makeSnapshot(1));
+
+  ASSERT_TRUE(waitForCount([&] { return exporter.failed(); }, 2));
+  EXPECT_EQ(exporter.exported(), 0u);
+  EXPECT_EQ(exporter.dropped(), 0u);
+  EXPECT_EQ(sinkCalls.load(), 0);
+}
+
+// An exporter with no serializer writes nothing and says so, rather than
+// looking like a run that had no windows.
+TEST(CollStatsExporterTest, CountsFailedWithNoSerializer) {
+  std::atomic<int> sinkCalls{0};
+  CollStatsExporter exporter(
+      makeIdentity(),
+      CollStatsExporter::Serializer{},
+      [&sinkCalls](const std::string&) { ++sinkCalls; });
+  exporter.submit(makeSnapshot(0));
+
+  ASSERT_TRUE(waitForCount([&] { return exporter.failed(); }, 1));
+  EXPECT_EQ(exporter.exported(), 0u);
+  EXPECT_EQ(sinkCalls.load(), 0);
+}
+
+TEST(CollStatsExporterTest, FileSinkWritesOneLinePerWindow) {
+  const std::string path =
+      "/tmp/collstats_exporter_test_" + std::to_string(::getpid()) + ".jsonl";
+  std::remove(path.c_str());
+  {
+    CollStatsExporter exporter(
+        makeIdentity(), stubSerialize, collStatsMakeFileSink(path));
+    exporter.submit(makeSnapshot(0));
+    exporter.submit(makeSnapshot(1));
+  }
+  std::ifstream in(path);
+  ASSERT_TRUE(in.is_open());
+  std::vector<std::string> lines;
+  std::string line;
+  while (std::getline(in, line)) {
+    if (!line.empty()) {
+      lines.push_back(line);
+    }
+  }
+  in.close();
+  std::remove(path.c_str());
+
+  const std::vector<std::string> expected = {
+      "rank=3 epoch=0", "rank=3 epoch=1"};
+  EXPECT_EQ(lines, expected);
+}
+
+// A write that fails after a successful open must be counted, not swallowed.
+// std::ofstream reports write errors through the stream state rather than by
+// throwing, so an unchecked sink would keep "succeeding" on a full disk and the
+// windows would be counted as exported while reaching nothing.
+//
+// /dev/full opens cleanly and fails every write with ENOSPC, which is the
+// failure mode being guarded without needing to actually fill a disk.
+TEST(CollStatsExporterTest, FileSinkCountsFailedWhenWriteFails) {
+  std::ifstream probe("/dev/full");
+  if (!probe.is_open()) {
+    GTEST_SKIP() << "/dev/full not available";
+  }
+  probe.close();
+
+  CollStatsExporter::JsonSink sink = collStatsMakeFileSink("/dev/full");
+  ASSERT_TRUE(static_cast<bool>(sink)) << "/dev/full should open";
+
+  CollStatsExporter exporter(makeIdentity(), stubSerialize, std::move(sink));
+  exporter.submit(makeSnapshot(0));
+
+  ASSERT_TRUE(waitForCount([&] { return exporter.failed(); }, 1));
+  EXPECT_EQ(exporter.exported(), 0u);
+}
+
+// An exporter with no sink is the other half of the "produced no output" pair:
+// the serializer runs or not, but nothing receives the blob either way.
+TEST(CollStatsExporterTest, CountsFailedWithNoSink) {
+  std::atomic<int> serializerCalls{0};
+  CollStatsExporter exporter(
+      makeIdentity(),
+      [&serializerCalls](
+          const CollStatsExportIdentity&, const CollStatSnapshot&) {
+        ++serializerCalls;
+        return std::string{};
+      },
+      CollStatsExporter::JsonSink{});
+  exporter.submit(makeSnapshot(0));
+
+  ASSERT_TRUE(waitForCount([&] { return exporter.failed(); }, 1));
+  EXPECT_EQ(exporter.exported(), 0u);
+  // The absent sink is detected before the serializer runs, so a window costs
+  // nothing to discover it cannot be written.
+  EXPECT_EQ(serializerCalls.load(), 0);
+}
+
+// A path that cannot be opened yields a falsy sink rather than one that
+// silently discards, so the owner can report the bad path instead of shipping a
+// run whose zero windows look like a quiet one.
+TEST(CollStatsExporterTest, FileSinkIsEmptyWhenOpenFails) {
+  const CollStatsExporter::JsonSink sink =
+      collStatsMakeFileSink("/nonexistent-dir-for-collstats-test/out.jsonl");
+  EXPECT_FALSE(static_cast<bool>(sink));
+}
+
+// Teardown is time-boxed, and what it abandons is counted rather than lost
+// quietly. The first sink call outlasts the budget by construction, so by the
+// time the background thread looks at the deadline it has already passed and
+// every remaining window is abandoned in one go.
+TEST(CollStatsExporterTest, ShutdownAbandonsAndCountsPastTheDrainBudget) {
+  std::promise<void> entered;
+  std::shared_future<void> enteredFuture = entered.get_future().share();
+  std::atomic<bool> firstDone{false};
+
+  CollStatsExporter exporter(
+      makeIdentity(),
+      stubSerialize,
+      [&](const std::string&) {
+        if (!firstDone.exchange(true)) {
+          entered.set_value();
+          // Outlasts the budget passed to shutdown() below. The deadline is
+          // only consulted between windows, so this call is not interrupted --
+          // it is what pushes the clock past the deadline.
+          // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+          std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        }
+      },
+      /*queueCapacity=*/8);
+
+  exporter.submit(makeSnapshot(0)); // popped, blocks in the slow sink
+  ASSERT_EQ(enteredFuture.wait_for(kTestWait), std::future_status::ready);
+  for (uint64_t e = 1; e < 5; ++e) {
+    exporter.submit(makeSnapshot(e)); // queued behind it
+  }
+
+  exporter.shutdown(std::chrono::milliseconds(20));
+
+  EXPECT_EQ(exporter.exported(), 1u); // only the in-flight window got through
+  EXPECT_EQ(exporter.dropped(), 4u); // the queued remainder, counted
+  EXPECT_EQ(exporter.failed(), 0u);
+}
+
+} // namespace
+} // namespace meta::comms::collstats


### PR DESCRIPTION
Summary:

Readout windows are produced on the training thread, where JSON serialization and file I/O do not belong, and telemetry must never backpressure training. `CollStatsExporter` takes a completed window through a non-blocking `submit()` onto a bounded queue; a background thread serializes it with the export identity and hands the blob to a pluggable sink. No CUDA on that thread. Nothing calls `submit()` yet -- this adds the mechanism and a file sink that appends JSON Lines to a caller-supplied path.

The queue is lossy by design, so the two ways of losing a window are counted apart: `dropped()` never reached the exporter thread (queue full, or shutdown started), `failed()` reached it and produced no output (serializer or sink threw, or there is no sink). Slow sink versus broken sink.

Three silent-failure modes closed:

- The thread body catches. A throw out of folly JSON or a caller-supplied sink would escape the thread and call `std::terminate`, taking the job down for a telemetry fault. The teardown path pops the abandoned queue rather than swapping a fresh one over it, because constructing that temporary allocates outside the `try` and would reopen the same route.
- The drain is time-boxed at 2s and lives in `shutdown()`, which the destructor calls. It joins the background thread, so an unbounded drain lets a wedged sink stall communicator teardown; the remainder is abandoned and counted as dropped. `shutdown()` is public and idempotent because that count is only observable to a caller that shuts down *before* reading the counters -- when the destructor is the only caller, the abandoned windows are charged after the last read, and the one loss teardown introduces is the silent one. Wiring the owner to call it arrives with `CollStatsComm`.
- `collStatsMakeFileSink` returns an empty function when the open fails, so a bad output path is distinguishable from a run with no windows. On a failed write it clears the stream before throwing: the fail bits latch, so leaving them set would turn one transient failure into a whole run of `failed()` windows.

The exporter is transport only, and knows nothing about the wire format:

* `Serializer` is a caller-supplied `(identity, snapshot) -> string` callback,
  invoked on the background thread. The exporter no longer calls the JSON
  serializer directly, so a second reporting backend reuses the thread, the
  bounded queue and the loss accounting instead of reimplementing them.
* A throwing or absent serializer costs one window and is counted as failed,
  never the process: the call runs on the background thread, where an escaping
  exception reaches `std::terminate`.
* `CollStatsExporter.{cc,h}` owns the `collstats_export` target alone. It
  previously shared one target with `CollStatsJson.{cc,h}`, which is what made
  the transport look inseparable from the format.
* `CollStatsExporterTest` asserts transport behaviour -- queue bound, drop and
  failure accounting, one line per blob -- against a stub serializer. What a
  window turns into is covered by `collstats_json_test`, so this test no longer
  parses JSON to check its own dependency.

Reviewed By: rmahidhar

Differential Revision: D113661120


