### PR TITLE
Hold one communicator's stats state in one object (#4010)

### DIFF
--- a/comms/utils/collstats/CollStatsComm.cc
+++ b/comms/utils/collstats/CollStatsComm.cc
@@ -1,0 +1,68 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/collstats/CollStatsComm.h"
+
+#include <utility>
+
+namespace meta::comms::collstats {
+
+CollStatsComm::CollStatsComm(
+    CollStatsDeviceBlockOwner block,
+    std::unique_ptr<CollStatsKeyRegistry> keys,
+    CollStatsExportIdentity identity,
+    std::unique_ptr<CollStatsExporter> exporter,
+    std::unique_ptr<CollStatsReadoutDriver> driver,
+    CollStatSizeClasses sizeClasses)
+    : block_(std::move(block)),
+      keys_(std::move(keys)),
+      identity_(std::move(identity)),
+      exporter_(std::move(exporter)),
+      driver_(std::move(driver)),
+      sizeClasses_(sizeClasses) {}
+
+CollStatsComm::~CollStatsComm() {
+  shutdown();
+}
+
+CollStatsComm::Totals CollStatsComm::shutdown() {
+  Totals t;
+  if (shutdownDone_) {
+    return t;
+  }
+  shutdownDone_ = true;
+
+  t.uninstrumented = uninstrumented_.load(std::memory_order_relaxed);
+  // Release the driver first: its teardown flush issues and harvests the
+  // trailing window, submitting it to the exporter. Then drain the exporter and
+  // read its counters, so the totals describe every window it was handed --
+  // including the ones the drain deadline abandoned. The block owner outlives
+  // both and frees last.
+  driver_.reset();
+  if (exporter_) {
+    t.hasExporter = true;
+    // Explicitly, before the read: shutdown() charges abandoned windows to
+    // dropped(), and leaving that to ~CollStatsExporter would bill them after
+    // the only read of the counter, reporting every teardown loss as zero.
+    exporter_->shutdown();
+    t.exported = exporter_->exported();
+    t.dropped = exporter_->dropped();
+    t.failed = exporter_->failed();
+    exporter_.reset();
+  }
+  return t;
+}
+
+uint32_t CollStatsComm::resolveKeyId(const CollStatKey& key) {
+  if (!keys_) {
+    return 0;
+  }
+  return keys_->resolve(key);
+}
+
+void CollStatsComm::onCollective(cudaStream_t stream) {
+  if (driver_) {
+    driver_->onCollective(stream);
+  }
+}
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsComm.h
+++ b/comms/utils/collstats/CollStatsComm.h
@@ -1,0 +1,136 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+
+#include "comms/utils/collstats/CollStatsDeviceBlock.h"
+#include "comms/utils/collstats/CollStatsExporter.h"
+#include "comms/utils/collstats/CollStatsHistogram.h"
+#include "comms/utils/collstats/CollStatsIdentity.h"
+#include "comms/utils/collstats/CollStatsKeyRegistry.h"
+#include "comms/utils/collstats/CollStatsReadoutDriver.h"
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+// Everything one communicator's collective-stats instrumentation owns: the
+// device block, the key registry that indexes it, the export identity, the
+// out-of-band exporter and the readout driver.
+//
+// There is exactly one instance per *logical* communicator, not one per
+// collective implementation. Two would mean two device blocks, two epochs and
+// two readout cadences reported under a single commHash, which no backend join
+// could untangle -- so ownership sits on the communicator rather than on any
+// object that runs collectives.
+//
+// Deliberately free of the cvars and of the logger: the owner reads
+// configuration, chooses the sink and does the reporting, then hands the
+// assembled pieces here. That keeps this directory light enough for a consumer
+// that has neither to hold one.
+
+namespace meta::comms::collstats {
+
+class CollStatsComm {
+ public:
+  // Totals worth surfacing once at teardown, returned by shutdown(). A run that
+  // dropped or failed every window otherwise looks exactly like one that had
+  // nothing to write.
+  struct Totals {
+    uint64_t exported{0};
+    uint64_t dropped{0};
+    uint64_t failed{0};
+    // Collectives that ran on a path instrumentation does not cover, so a run
+    // with missing collectives can be explained rather than silently short.
+    uint64_t uninstrumented{0};
+    bool hasExporter{false};
+  };
+
+  // `block` must be non-empty and `keys` non-null. `exporter` is null when no
+  // output directory is configured, in which case `driver`'s sink does its own
+  // reporting. `driver` must already be wired to whichever sink the owner
+  // chose.
+  CollStatsComm(
+      CollStatsDeviceBlockOwner block,
+      std::unique_ptr<CollStatsKeyRegistry> keys,
+      CollStatsExportIdentity identity,
+      std::unique_ptr<CollStatsExporter> exporter,
+      std::unique_ptr<CollStatsReadoutDriver> driver,
+      CollStatSizeClasses sizeClasses = collStatDefaultSizeClasses());
+
+  // Calls shutdown() if the owner did not.
+  ~CollStatsComm();
+
+  // Tears down in dependency order and returns the totals to report.
+  //
+  // The order is load-bearing, and is why this is not a plain accessor plus
+  // member destruction: the driver's final flush submits the trailing window
+  // into the exporter, so the counters must be read *after* the driver is gone
+  // and *after* the exporter has drained and joined.
+  //
+  // Reading before the driver is released undercounts by the trailing window.
+  // Reading before the drain undercounts by everything still queued -- which
+  // includes that same trailing window, since the flush only just submitted it
+  // -- and reports any window the drain deadline abandoned as zero.
+  //
+  // Idempotent; a second call returns zeroed totals.
+  Totals shutdown();
+
+  CollStatsComm(const CollStatsComm&) = delete;
+  CollStatsComm& operator=(const CollStatsComm&) = delete;
+  CollStatsComm(CollStatsComm&&) = delete;
+  CollStatsComm& operator=(CollStatsComm&&) = delete;
+
+  // The device-side handle the kernels reach through the per-comm device state.
+  const CollStatsDeviceBlockHandle& handle() const {
+    return block_.handle();
+  }
+
+  // A driver that failed to acquire its CUDA resources is born disabled: it
+  // exists, but it will never flip an epoch, so every window accumulates into a
+  // bank nobody reads. Reporting that as enabled makes the launch path
+  // instrument collectives whose numbers can never be exported, and the only
+  // surviving symptom is a zero export count at teardown.
+  bool enabled() const {
+    return driver_ != nullptr && !driver_->disabled();
+  }
+
+  const CollStatsExportIdentity& identity() const {
+    return identity_;
+  }
+
+  // Resolve a collective's key to the dense value slot its kernel accumulates
+  // into. Called on the enqueue thread before the launch, so the device
+  // performs no lookup of its own.
+  uint32_t resolveKeyId(const CollStatKey& key);
+
+  /* The configured size-class edges, so the launch path buckets a message size
+   * the same way the exported rows are labelled. */
+  const CollStatSizeClasses& sizeClasses() const {
+    return sizeClasses_;
+  }
+
+  // Tick the pipelined readout after an instrumented collective was launched on
+  // `stream`. Never blocks.
+  void onCollective(cudaStream_t stream);
+
+  void noteUninstrumentedLaunch() {
+    uninstrumented_.fetch_add(1, std::memory_order_relaxed);
+  }
+
+ private:
+  CollStatsDeviceBlockOwner block_;
+  std::unique_ptr<CollStatsKeyRegistry> keys_;
+  CollStatsExportIdentity identity_;
+
+  // Bumped from the launch path, which may be more than one thread, and read
+  // once at teardown.
+  std::atomic<uint64_t> uninstrumented_{0};
+
+  std::unique_ptr<CollStatsExporter> exporter_;
+  std::unique_ptr<CollStatsReadoutDriver> driver_;
+  CollStatSizeClasses sizeClasses_;
+
+  bool shutdownDone_{false};
+};
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsExporter.cc
+++ b/comms/utils/collstats/CollStatsExporter.cc
@@ -1,0 +1,133 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/collstats/CollStatsExporter.h"
+
+#include <fstream>
+#include <ios>
+#include <memory>
+#include <utility>
+
+namespace meta::comms::collstats {
+
+CollStatsExporter::CollStatsExporter(
+    CollStatsExportIdentity identity,
+    Serializer serializer,
+    JsonSink sink,
+    std::size_t queueCapacity)
+    : identity_(std::move(identity)),
+      serializer_(std::move(serializer)),
+      sink_(std::move(sink)),
+      capacity_(queueCapacity < 1 ? 1 : queueCapacity) {
+  thread_ = std::thread([this]() { run(); });
+}
+
+CollStatsExporter::~CollStatsExporter() {
+  shutdown();
+}
+
+void CollStatsExporter::shutdown() {
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    stop_ = true;
+    drainDeadline_ = std::chrono::steady_clock::now() + kDrainBudget;
+  }
+  cv_.notify_all();
+  if (thread_.joinable()) {
+    thread_.join();
+  }
+}
+
+void CollStatsExporter::submit(CollStatSnapshot snapshot) {
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    if (stop_ || queue_.size() >= capacity_) {
+      dropped_.fetch_add(1, std::memory_order_relaxed);
+      return;
+    }
+    queue_.push(std::move(snapshot));
+  }
+  cv_.notify_one();
+}
+
+void CollStatsExporter::run() {
+  for (;;) {
+    CollStatSnapshot snapshot;
+    {
+      std::unique_lock<std::mutex> lk(mu_);
+      cv_.wait(lk, [this]() { return stop_ || !queue_.empty(); });
+      if (queue_.empty()) {
+        // Only woken for stop with nothing left to drain.
+        return;
+      }
+      if (stop_ && std::chrono::steady_clock::now() > drainDeadline_) {
+        // The teardown drain is time-boxed: the destroying thread reaches this
+        // queue through join(), so a slow sink would otherwise stall comm
+        // teardown for as long as it likes.
+        //
+        // The bound is on the queue, not on one call: the deadline is only
+        // consulted here, between items, so a single wedged sink call still
+        // blocks join() for as long as it runs. Bounding that would need the
+        // sink on its own abandonable thread, which is a bigger contract than
+        // the queue's -- so the budget caps how many slow calls teardown waits
+        // through, not how long any one of them may take.
+        dropped_.fetch_add(queue_.size(), std::memory_order_relaxed);
+        // Popped rather than swapped against a fresh queue: constructing one
+        // allocates, and this runs outside the try below, so a throw here would
+        // escape the thread body -- the std::terminate route this function
+        // exists to close.
+        while (!queue_.empty()) {
+          queue_.pop();
+        }
+        return;
+      }
+      snapshot = std::move(queue_.front());
+      queue_.pop();
+    }
+    // Serialize and hand off outside the lock so submit() never blocks on I/O.
+    // Telemetry must never take the job down: without the catch, a throw from
+    // a caller-supplied serializer or sink escapes the thread body and calls
+    // std::terminate.
+    if (!serializer_ || !sink_) {
+      failed_.fetch_add(1, std::memory_order_relaxed);
+      continue;
+    }
+    try {
+      sink_(serializer_(identity_, snapshot));
+      exported_.fetch_add(1, std::memory_order_relaxed);
+    } catch (...) {
+      failed_.fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+}
+
+CollStatsExporter::JsonSink collStatsMakeFileSink(const std::string& path) {
+  auto file = std::make_shared<std::ofstream>(path, std::ios::app);
+  if (!file->is_open()) {
+    // Empty sink, so the caller can tell the open failed. Returning a
+    // silently-discarding sink instead would make a bad output path
+    // indistinguishable from a working one that produced no windows.
+    return {};
+  }
+  return [file](const std::string& json) {
+    (*file) << json << '\n';
+    file->flush();
+    // std::ofstream does not throw on a failed write by default: it sets
+    // fail/bad and every subsequent write silently no-ops. Unchecked, a disk
+    // that fills after the open turns every remaining window into a counted
+    // export that reached nothing. Throwing hands it to the exporter's catch,
+    // which counts it under failed() -- a visible loss rather than a silent
+    // one. No is_open() guard: the factory returns an empty sink when the open
+    // failed, and this lambda's shared_ptr is the only owner, so the stream
+    // cannot be closed underneath it.
+    if (!file->good()) {
+      // Cleared before throwing: the fail/bad bits latch, so leaving them set
+      // would make every later window throw on this stream's state rather than
+      // on its own write, turning one transient failure into a whole run of
+      // failed() windows.
+      file->clear();
+      throw std::ios_base::failure("collstats file sink write failed");
+    }
+  };
+}
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsExporter.h
+++ b/comms/utils/collstats/CollStatsExporter.h
@@ -1,0 +1,122 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <thread>
+
+#include "comms/utils/collstats/CollStatsIdentity.h"
+#include "comms/utils/collstats/CollStatsReader.h"
+
+// Out-of-band, asynchronous exporter for readout windows. The producer thread
+// hands a snapshot to submit() — a cheap bounded-queue enqueue that never
+// blocks — and a background thread serializes it (tagging it with the export
+// identity) and passes the blob to a pluggable sink. Serialization and I/O
+// therefore never touch the producer/training thread. The background thread
+// does no CUDA, so it carries none of the poll-thread CUDA hazards.
+//
+// The queue is bounded and lossy: if the sink cannot keep up, snapshots are
+// dropped and counted rather than stalling training — every export hop is async
+// and droppable, and every drop is counted.
+//
+// Both what a window turns into and where it goes are the caller's choice: this
+// class owns the thread, the bounded queue and the loss accounting, and knows
+// nothing about the wire format. That is what lets a second reporting backend
+// reuse the transport instead of reimplementing it.
+
+namespace meta::comms::collstats {
+
+class CollStatsExporter {
+ public:
+  // Receives one window's serialized blob. Called only on the background
+  // thread.
+  using JsonSink = std::function<void(const std::string&)>;
+
+  // Turns one window plus its identity into the blob handed to the sink.
+  // Called only on the background thread, so it may be as expensive as the
+  // format requires. A throw is caught and counted as a failed window.
+  using Serializer = std::function<
+      std::string(const CollStatsExportIdentity&, const CollStatSnapshot&)>;
+
+  CollStatsExporter(
+      CollStatsExportIdentity identity,
+      Serializer serializer,
+      JsonSink sink,
+      std::size_t queueCapacity = 16);
+  ~CollStatsExporter();
+
+  CollStatsExporter(const CollStatsExporter&) = delete;
+  CollStatsExporter& operator=(const CollStatsExporter&) = delete;
+  // Non-movable as well: the background thread captures `this`, so moving the
+  // object would leave that thread reading a moved-from queue and mutex.
+  CollStatsExporter(CollStatsExporter&&) = delete;
+  CollStatsExporter& operator=(CollStatsExporter&&) = delete;
+
+  // Enqueue a window for export. Non-blocking; drops and counts if the queue is
+  // full. The snapshot is moved in.
+  void submit(CollStatSnapshot snapshot);
+
+  // Stop accepting windows, drain what is queued within kDrainBudget, and join
+  // the background thread. Idempotent.
+  //
+  // Call this before reading the counters. Windows abandoned at the deadline
+  // are charged to dropped() here, so only a caller that shuts down explicitly
+  // can observe the teardown loss -- the destructor's own call runs after the
+  // last chance to read, which is where a teardown drop would go unreported.
+  void shutdown();
+
+  uint64_t exported() const {
+    return exported_.load(std::memory_order_relaxed);
+  }
+  uint64_t dropped() const {
+    return dropped_.load(std::memory_order_relaxed);
+  }
+  // Windows that reached the exporter thread but produced no output: the sink
+  // or the serializer threw, or either is absent. Distinct from dropped(),
+  // which counts windows that never got that far.
+  uint64_t failed() const {
+    return failed_.load(std::memory_order_relaxed);
+  }
+
+ private:
+  void run();
+
+  CollStatsExportIdentity identity_;
+  Serializer serializer_;
+  JsonSink sink_;
+  const std::size_t capacity_;
+
+  std::mutex mu_;
+  std::condition_variable cv_;
+  std::queue<CollStatSnapshot> queue_; // guarded by mu_
+  bool stop_{false}; // guarded by mu_
+
+  std::atomic<uint64_t> exported_{0};
+  std::atomic<uint64_t> dropped_{0};
+  std::atomic<uint64_t> failed_{0};
+
+  // How long the destructor lets the background thread keep pushing queued
+  // windows through the sink before abandoning the rest. The destructor joins
+  // that thread, so an unbounded drain would let a wedged sink stall teardown.
+  static constexpr std::chrono::seconds kDrainBudget{2};
+  std::chrono::steady_clock::time_point drainDeadline_{}; // guarded by mu_
+
+  std::thread thread_;
+};
+
+// A JSON sink that appends each blob as one line (JSON Lines) to `path`. The
+// file is opened once and shared with the returned callable. Returns an empty
+// (falsy) std::function if the open fails — the caller must test it and report
+// the failure, because an exporter built on an empty sink writes nothing and
+// would otherwise be indistinguishable from one that had no windows to write.
+// Intended default sink for file-per-rank export.
+CollStatsExporter::JsonSink collStatsMakeFileSink(const std::string& path);
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/CollStatsIdentity.h
+++ b/comms/utils/collstats/CollStatsIdentity.h
@@ -1,0 +1,31 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+// Stable identity + physical-placement join key for an exported readout window.
+// Folly-free plain data, so the launch/comm layer can populate it without
+// pulling the JSON serializer's dependencies. A process-local communicator
+// value is not enough for fleet aggregation; the backend aggregates and dedups
+// across restarts and ranks on this tuple, and joins the placement key (host,
+// GPU, NIC/rail) against the topology inventory at `topologyVersion`.
+
+namespace meta::comms::collstats {
+
+struct CollStatsExportIdentity {
+  std::string job;
+  std::string tenant;
+  std::string processGroup;
+  uint64_t commHash{0};
+  uint64_t commGeneration{0};
+  int32_t rank{-1};
+  std::string softwareVersion;
+  // Physical-placement join key, as seen at the rank.
+  std::string host;
+  int32_t gpu{-1};
+  std::string nicRail;
+  uint64_t topologyVersion{0};
+};
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/tests/CollStatsCommTest.cpp
+++ b/comms/utils/collstats/tests/CollStatsCommTest.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <future>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/collstats/CollStatsComm.h"
+#include "comms/utils/collstats/CollStatsExporter.h"
+#include "comms/utils/collstats/CollStatsIdentity.h"
+#include "comms/utils/collstats/CollStatsKeyRegistry.h"
+
+namespace meta::comms::collstats {
+namespace {
+
+CollStatsExportIdentity makeIdentity() {
+  CollStatsExportIdentity id;
+  id.rank = 3;
+  return id;
+}
+
+std::string stubSerialize(
+    const CollStatsExportIdentity& id,
+    const CollStatSnapshot& snap) {
+  return "rank=" + std::to_string(id.rank) +
+      " epoch=" + std::to_string(snap.windowEpoch);
+}
+
+CollStatSnapshot makeSnapshot(uint64_t epoch) {
+  CollStatSnapshot snap;
+  snap.windowEpoch = epoch;
+  return snap;
+}
+
+// No device block and no driver: shutdown() touches neither, and an empty
+// owner frees nothing. This keeps the teardown accounting testable on a host
+// without a GPU, which is where the ordering bug lived.
+std::unique_ptr<CollStatsComm> makeComm(
+    std::unique_ptr<CollStatsExporter> exporter) {
+  return std::make_unique<CollStatsComm>(
+      CollStatsDeviceBlockOwner{},
+      std::make_unique<CollStatsKeyRegistry>(/*capacity=*/8),
+      makeIdentity(),
+      std::move(exporter),
+      /*driver=*/nullptr);
+}
+
+} // namespace
+
+// The exporter is drained before its counters are read, so the totals cover
+// windows still queued at teardown. Reading first reports them as never
+// exported -- and the driver's final flush makes the trailing window exactly
+// such a window on every real teardown.
+TEST(CollStatsCommTest, ShutdownDrainsTheExporterBeforeReadingCounters) {
+  std::promise<void> release;
+  std::shared_future<void> gate = release.get_future().share();
+
+  auto exporter = std::make_unique<CollStatsExporter>(
+      makeIdentity(), stubSerialize, [gate](const std::string&) {
+        // Hold the background thread until the test lets go, so every window
+        // is still queued when shutdown() is entered.
+        gate.wait();
+      });
+  CollStatsExporter* raw = exporter.get();
+  auto comm = makeComm(std::move(exporter));
+
+  for (uint64_t e = 0; e < 4; ++e) {
+    raw->submit(makeSnapshot(e));
+  }
+  release.set_value();
+
+  const CollStatsComm::Totals totals = comm->shutdown();
+  EXPECT_TRUE(totals.hasExporter);
+  EXPECT_EQ(totals.exported, 4u);
+  EXPECT_EQ(totals.dropped, 0u);
+  EXPECT_EQ(totals.failed, 0u);
+}
+
+TEST(CollStatsCommTest, SecondShutdownReturnsZeroedTotals) {
+  auto exporter = std::make_unique<CollStatsExporter>(
+      makeIdentity(), stubSerialize, [](const std::string&) {});
+  CollStatsExporter* raw = exporter.get();
+  auto comm = makeComm(std::move(exporter));
+  raw->submit(makeSnapshot(0));
+
+  const CollStatsComm::Totals first = comm->shutdown();
+  EXPECT_TRUE(first.hasExporter);
+  EXPECT_EQ(first.exported, 1u);
+
+  const CollStatsComm::Totals second = comm->shutdown();
+  EXPECT_FALSE(second.hasExporter);
+  EXPECT_EQ(second.exported, 0u);
+}
+
+// Uninstrumented launches are reported even with no exporter attached: a run
+// that instrumented nothing must be distinguishable from one that exported
+// nothing.
+TEST(CollStatsCommTest, ReportsUninstrumentedLaunchesWithoutAnExporter) {
+  auto comm = makeComm(/*exporter=*/nullptr);
+  comm->noteUninstrumentedLaunch();
+  comm->noteUninstrumentedLaunch();
+
+  const CollStatsComm::Totals totals = comm->shutdown();
+  EXPECT_FALSE(totals.hasExporter);
+  EXPECT_EQ(totals.uninstrumented, 2u);
+}
+
+} // namespace meta::comms::collstats

--- a/comms/utils/collstats/tests/CollStatsExporterTest.cpp
+++ b/comms/utils/collstats/tests/CollStatsExporterTest.cpp
@@ -1,0 +1,247 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/collstats/CollStatsExporter.h"
+
+#include <unistd.h>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <functional>
+#include <future>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/collstats/CollStatsIdentity.h"
+#include "comms/utils/collstats/CollStatsReader.h"
+#include "comms/utils/collstats/CollStatsTypes.h"
+
+// Covers the transport only: the queue bound, the loss accounting and the
+// drain. What a window turns into is the serializer's business and is covered
+// by CollStatsJsonTest, so these tests pass a stub that makes each window
+// identifiable without pulling in a wire format.
+
+namespace meta::comms::collstats {
+namespace {
+
+CollStatsExportIdentity makeIdentity() {
+  CollStatsExportIdentity id;
+  id.processGroup = "dp";
+  id.commHash = 0xabc;
+  id.rank = 3;
+  id.host = "host-1";
+  id.gpu = 5;
+  return id;
+}
+
+// Renders both halves of the serializer's input, so a test can tell which
+// window it is looking at and that the identity reached the background thread.
+std::string stubSerialize(
+    const CollStatsExportIdentity& id,
+    const CollStatSnapshot& snap) {
+  return "rank=" + std::to_string(id.rank) +
+      " epoch=" + std::to_string(snap.windowEpoch);
+}
+
+// Blocks until `read` reports at least `want`, so a test can assert on the
+// background thread's counters without racing it. Bounded so a regression
+// fails the test instead of hanging the suite.
+bool waitForCount(const std::function<uint64_t()>& read, uint64_t want) {
+  for (int i = 0; i < 2000; ++i) {
+    if (read() >= want) {
+      return true;
+    }
+    // The bounded poll the guidance asks for, not a sleep standing in for
+    // synchronization. The counters are atomics the exporter thread bumps with
+    // nothing to wait on; the loop is capped so a regression fails rather than
+    // hangs.
+    // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  return false;
+}
+
+// A snapshot with `windowEpoch` set and one occupied key, so each window is
+// distinguishable.
+CollStatSnapshot makeSnapshot(uint64_t epoch) {
+  CollStatSnapshot snap;
+  snap.numKeys = 1;
+  snap.windowEpoch = epoch;
+  snap.keys.assign(
+      1,
+      CollStatKey{
+          CollStatOp::AllReduce,
+          CollStatAlgo::Direct,
+          CollStatProto::Unknown,
+          7u,
+          3u});
+  snap.values.assign(2, CollStatValue{});
+  snap.values[0].count = 1;
+  return snap;
+}
+
+TEST(CollStatsExporterTest, ExportsEverySubmittedWindowToSink) {
+  std::vector<std::string> captured; // written only on the bg thread
+  uint64_t exported = 0;
+  uint64_t dropped = 0;
+  uint64_t failed = 0;
+  {
+    CollStatsExporter exporter(
+        makeIdentity(), stubSerialize, [&captured](const std::string& blob) {
+          captured.push_back(blob);
+        });
+    for (uint64_t e = 0; e < 5; ++e) {
+      exporter.submit(makeSnapshot(e));
+    }
+    // Drains and joins, so the counters are final and the sink is done writing.
+    exporter.shutdown();
+    exported = exporter.exported();
+    dropped = exporter.dropped();
+    failed = exporter.failed();
+  }
+  const std::vector<std::string> expected = {
+      "rank=3 epoch=0",
+      "rank=3 epoch=1",
+      "rank=3 epoch=2",
+      "rank=3 epoch=3",
+      "rank=3 epoch=4"};
+  EXPECT_EQ(captured, expected);
+  // Asserted, not incidental: without this the exported_ increment can be
+  // deleted with every test still green.
+  EXPECT_EQ(exported, 5u);
+  EXPECT_EQ(dropped, 0u);
+  EXPECT_EQ(failed, 0u);
+}
+
+TEST(CollStatsExporterTest, DropsAndCountsWhenQueueFull) {
+  std::promise<void> entered;
+  std::promise<void> release;
+  std::atomic<bool> firstDone{false};
+
+  uint64_t exportedAtCheck = 0;
+  {
+    CollStatsExporter exporter(
+        makeIdentity(),
+        stubSerialize,
+        [&](const std::string&) {
+          // Block the background thread inside the first sink call so the queue
+          // cannot drain, making the overflow deterministic.
+          if (!firstDone.exchange(true)) {
+            entered.set_value();
+            release.get_future().wait();
+          }
+        },
+        /*queueCapacity=*/2);
+
+    exporter.submit(makeSnapshot(0)); // popped by bg thread, blocks in sink
+    entered.get_future().wait(); // bg thread is now blocked
+
+    exporter.submit(makeSnapshot(1)); // queue: [1]
+    exporter.submit(makeSnapshot(2)); // queue: [1,2] -> full
+    exporter.submit(makeSnapshot(3)); // dropped
+    exporter.submit(makeSnapshot(4)); // dropped
+    exporter.submit(makeSnapshot(5)); // dropped
+
+    EXPECT_EQ(exporter.dropped(), 3u);
+    exportedAtCheck = exporter.exported(); // s0 still in sink, not yet counted
+
+    release.set_value(); // let the bg thread finish and drain 1 and 2
+  }
+  EXPECT_EQ(exportedAtCheck, 0u);
+}
+
+// A serializer that throws must cost one window, not the process: the throw
+// happens on the background thread, where an escape calls std::terminate.
+TEST(CollStatsExporterTest, CountsFailedWhenSerializerThrows) {
+  std::atomic<int> sinkCalls{0};
+  CollStatsExporter exporter(
+      makeIdentity(),
+      // The lambda must match the Serializer signature and return std::string;
+      // [[noreturn]] is not spellable on a lambda, and throwing is the whole
+      // point here.
+      // NOLINTNEXTLINE(clang-diagnostic-missing-noreturn)
+      [](const CollStatsExportIdentity&, const CollStatSnapshot&)
+          -> std::string { throw std::runtime_error("serializer failed"); },
+      [&sinkCalls](const std::string&) { ++sinkCalls; });
+  exporter.submit(makeSnapshot(0));
+  exporter.submit(makeSnapshot(1));
+
+  ASSERT_TRUE(waitForCount([&] { return exporter.failed(); }, 2));
+  EXPECT_EQ(exporter.exported(), 0u);
+  EXPECT_EQ(exporter.dropped(), 0u);
+  EXPECT_EQ(sinkCalls.load(), 0);
+}
+
+// An exporter with no serializer writes nothing and says so, rather than
+// looking like a run that had no windows.
+TEST(CollStatsExporterTest, CountsFailedWithNoSerializer) {
+  std::atomic<int> sinkCalls{0};
+  CollStatsExporter exporter(
+      makeIdentity(),
+      CollStatsExporter::Serializer{},
+      [&sinkCalls](const std::string&) { ++sinkCalls; });
+  exporter.submit(makeSnapshot(0));
+
+  ASSERT_TRUE(waitForCount([&] { return exporter.failed(); }, 1));
+  EXPECT_EQ(exporter.exported(), 0u);
+  EXPECT_EQ(sinkCalls.load(), 0);
+}
+
+TEST(CollStatsExporterTest, FileSinkWritesOneLinePerWindow) {
+  const std::string path =
+      "/tmp/collstats_exporter_test_" + std::to_string(::getpid()) + ".jsonl";
+  std::remove(path.c_str());
+  {
+    CollStatsExporter exporter(
+        makeIdentity(), stubSerialize, collStatsMakeFileSink(path));
+    exporter.submit(makeSnapshot(0));
+    exporter.submit(makeSnapshot(1));
+  }
+  std::ifstream in(path);
+  ASSERT_TRUE(in.is_open());
+  std::vector<std::string> lines;
+  std::string line;
+  while (std::getline(in, line)) {
+    if (!line.empty()) {
+      lines.push_back(line);
+    }
+  }
+  in.close();
+  std::remove(path.c_str());
+
+  const std::vector<std::string> expected = {
+      "rank=3 epoch=0", "rank=3 epoch=1"};
+  EXPECT_EQ(lines, expected);
+}
+
+// A write that fails after a successful open must be counted, not swallowed.
+// std::ofstream reports write errors through the stream state rather than by
+// throwing, so an unchecked sink would keep "succeeding" on a full disk and the
+// windows would be counted as exported while reaching nothing.
+//
+// /dev/full opens cleanly and fails every write with ENOSPC, which is the
+// failure mode being guarded without needing to actually fill a disk.
+TEST(CollStatsExporterTest, FileSinkCountsFailedWhenWriteFails) {
+  std::ifstream probe("/dev/full");
+  if (!probe.is_open()) {
+    GTEST_SKIP() << "/dev/full not available";
+  }
+  probe.close();
+
+  CollStatsExporter::JsonSink sink = collStatsMakeFileSink("/dev/full");
+  ASSERT_TRUE(static_cast<bool>(sink)) << "/dev/full should open";
+
+  CollStatsExporter exporter(makeIdentity(), stubSerialize, std::move(sink));
+  exporter.submit(makeSnapshot(0));
+
+  ASSERT_TRUE(waitForCount([&] { return exporter.failed(); }, 1));
+  EXPECT_EQ(exporter.exported(), 0u);
+}
+
+} // namespace
+} // namespace meta::comms::collstats


### PR DESCRIPTION
Summary:

Collective-stats state for a communicator is five separate pieces -- device block, key registry, export identity, exporter, readout driver -- with one lifetime and no single owner. `CollStatsComm` holds them together.

- The state is per *logical* communicator, not per collective implementation. Two instances under one commHash would produce two epochs, two readout cadences and two window streams that no backend join could separate, so ownership sits on the comm rather than on whatever object runs collectives.
- `shutdown()` returns the totals instead of exposing an accessor because the teardown order is load-bearing: the driver's final flush submits the trailing window into the exporter, so the counters must be read after the driver is released and before the exporter drains and joins. Reading earlier undercounts by exactly that window. Idempotent, and the destructor calls it.
- `Totals` also carries `uninstrumented`, bumped by `noteUninstrumentedLaunch()`, so a run with missing collectives can be explained rather than looking silently short.
- Depends on neither the cvars nor the logger, matching the rest of this directory: the owner reads configuration and does the reporting, then hands the assembled pieces over.

New target `//comms/utils/collstats:collstats_comm`.

Reviewed By: rmahidhar

Differential Revision: D113661118


