### PR TITLE
Add wheel build diagnostics

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -81,8 +81,10 @@ jobs:
     with:
       repository: meta-pytorch/torchcomms
       ref: ""
-      pre-script: ""
-      post-script: ""
+      pre-script: |
+        free -g; df -h .; ulimit -a
+      post-script: |
+        du -sh build/ncclx/obj build/ncclx/lib 2>/dev/null; free -g; df -h .
       build-platform: "python-build-package"
       build-command: "scripts/_build_wheel.sh"
       smoke-test-script: "scripts/smoke_test.py"


### PR DESCRIPTION
Summary: - TorchComms wheel CI lacked resource diagnostics, leaving build failures ambiguous between memory and disk pressure; capture host capacity before the build and output sizes afterward so each run carries its own diagnosis.

Differential Revision: D118657227


