### PR TITLE
Keep wheel diagnostics running

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -84,7 +84,7 @@ jobs:
       pre-script: |
         free -g; df -h .; ulimit -a
       post-script: |
-        du -sh build/ncclx/obj build/ncclx/lib 2>/dev/null; free -g; df -h .
+        du -sh build/ncclx/obj build/ncclx/lib 2>/dev/null || true; free -g; df -h .
       build-platform: "python-build-package"
       build-command: "scripts/_build_wheel.sh"
       smoke-test-script: "scripts/smoke_test.py"


### PR DESCRIPTION
Summary: - TorchComms wheel diagnostics could stop before reporting memory and disk usage when optional NCCLX output directories were absent; tolerate a failed size probe so the remaining diagnostics always run.

Differential Revision: D118660549


