### PR TITLE
Fix wheel build pre/post scripts

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -81,10 +81,8 @@ jobs:
     with:
       repository: meta-pytorch/torchcomms
       ref: ""
-      pre-script: |
-        free -g; df -h .; ulimit -a
-      post-script: |
-        du -sh build/ncclx/obj build/ncclx/lib 2>/dev/null || true; free -g; df -h .
+      pre-script: "scripts/ci_log_resources_pre.sh"
+      post-script: "scripts/ci_log_resources_post.sh"
       build-platform: "python-build-package"
       build-command: "scripts/_build_wheel.sh"
       smoke-test-script: "scripts/smoke_test.py"

--- a/scripts/ci_log_resources_post.sh
+++ b/scripts/ci_log_resources_post.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# CI instrumentation only. Must never fail the build.
+du -sh build/ncclx/obj build/ncclx/lib 2>/dev/null || true
+free -g || true
+df -h . || true
+exit 0

--- a/scripts/ci_log_resources_pre.sh
+++ b/scripts/ci_log_resources_pre.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# CI instrumentation only. Must never fail the build.
+free -g || true
+df -h . || true
+ulimit -a || true
+exit 0


### PR DESCRIPTION
Summary:
- Linux wheel builds were failing in seconds on every leg before reaching the build: the pre/post hooks in build_wheels_linux.yml carried inline shell text, but the test-infra driver executes them as script file paths and hard-errors when the file is missing, so no leg could ever reach the build.
- Adds scripts/ci_log_resources_pre.sh and scripts/ci_log_resources_post.sh (memory, disk, limits, and build-output sizes, every command guarded so the observability hook can never fail the build) and points the workflow at those paths.

Differential Revision: D118697844


