### PR TITLE
CTA-scope CQ acquire fence for prims: -4.6% small-message sendrecv latency

### DIFF
--- a/comms/prims/DocaAcquireScopeCapabilityCheck.cu
+++ b/comms/prims/DocaAcquireScopeCapabilityCheck.cu
@@ -1,0 +1,43 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Fails the build if the vendored DOCA headers lose the capability macro that
+// P2pIbgdaTransportDevice.cuh feature-detects on.
+//
+// Patch 0002 adds both DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE and the
+// acquire_scope template parameter. Re-applying it after a resync without the
+// macro hunk leaves a green build, a passing test suite and correct results,
+// with every fence silently back on SYS and the whole saving gone.
+//
+// This lives in its own target, which depends only on :doca_gpunetio_dl, so it
+// always sees the vendored headers. The equivalent check cannot go in
+// P2pIbgdaTransportDevice.cuh: that file is also compiled in builds where ncclx
+// shadows these headers and the macro is legitimately absent, which is exactly
+// what the feature-detect exists to tolerate.
+
+#include <device/doca_gpunetio_dev_verbs_cq.cuh>
+
+#ifndef DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE
+#error \
+    "The vendored DOCA headers no longer define DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE. prims silently falls back to the SYS-scope fence and the CQ-fence optimization is inert. This is what an incomplete re-apply of third-party/nvidia-doca/patches/0002-gpunetio-cq-fence-cta.patch looks like."
+#endif
+
+static_assert(
+    DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE == 1,
+    "DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE must be 1 where it is defined.");
+
+// The macro and the parameter must travel together: instantiating with an
+// explicit acquire_scope fails to compile if the parameter hunk was dropped.
+template <enum doca_gpu_dev_verbs_sync_scope scope>
+__device__ int doca_acquire_scope_capability_probe(
+    struct doca_gpu_dev_verbs_cq* cq,
+    uint64_t ticket) {
+  return doca_gpu_dev_verbs_poll_one_cq_at<
+      DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+      DOCA_GPUNETIO_VERBS_QP_SQ,
+      scope>(cq, ticket);
+}
+
+template __device__ int
+doca_acquire_scope_capability_probe<DOCA_GPUNETIO_VERBS_SYNC_SCOPE_CTA>(
+    struct doca_gpu_dev_verbs_cq*,
+    uint64_t);

--- a/comms/prims/P2pIbTransportBuildContractTest.py
+++ b/comms/prims/P2pIbTransportBuildContractTest.py
@@ -29,6 +29,24 @@ _PROGRESS_ONLY_FUNCTIONS = (
 
 _PROGRESS_ONLY_TYPES = ("ProgressChunk", "ProgressGeometry")
 
+# Markers for "this transport reads NIC-written memory after a completion".
+#
+# Regexes, not substrings. `doca_gpu_dev_verbs_get` is a real RDMA READ -- the
+# generic entry point in `device/doca_gpunetio_dev_verbs_onesided.cuh`, of which
+# `_get_thread`/`_get_warp` are the exec-scope implementations, and the one
+# ncclx GIN calls -- so it has to trip this. But `doca_gpu_dev_verbs_get_wqe_ptr`
+# (used at every WQE build site), `_get_lane_id` and `_get_counter` are
+# unrelated and must not. A plain substring cannot separate them, so require a
+# call or template-argument list immediately after the generic name.
+_NIC_READ_MARKERS = (
+    r"DOCA_GPUNETIO_IB_MLX5_OPCODE_RDMA_READ",
+    r"doca_gpu_dev_verbs_get\s*[<(]",
+    r"doca_gpu_dev_verbs_get_wait",
+    r"doca_gpu_dev_verbs_get_thread",
+    r"doca_gpu_dev_verbs_get_warp",
+    r"wqe_prepare_read",
+)
+
 
 class P2pIbTransportBuildContractTest(unittest.TestCase):
     def setUp(self) -> None:
@@ -81,6 +99,47 @@ class P2pIbTransportBuildContractTest(unittest.TestCase):
             1,
         )
         self.assertIn('":p2p_ib_transport_device_impl"', progress_target)
+
+    def test_cta_cq_acquire_scope_implies_no_rdma_read(self) -> None:
+        """Guards the CTA-scope CQ acquire fence.
+
+        On Blackwell the SYS-scope acquire DOCA runs after a completion lowers
+        to CCTL.IVALL, a whole-L1 invalidate; CTA lowers to a NOP. Dropping it
+        is only sound while this transport never reads NIC-written memory
+        through L1 after a completion -- today it issues no RDMA READ, atomic
+        results go to a discard sink, and the signal is read via a system-scope
+        atomic load that carries its own invalidate.
+
+        Adding an RDMA READ breaks that silently: no crash, no wrong return
+        code, just stale data under a timing window a short test will not hit.
+        So fail loudly here instead.
+        """
+        ibgda = (self.transport / "ibgda/P2pIbgdaTransportDevice.cuh").read_text()
+        scope = re.search(
+            r"kCqAcquireScope\s*=\s*(DOCA_GPUNETIO_VERBS_SYNC_SCOPE_\w+)", ibgda
+        )
+        self.assertIsNotNone(
+            scope,
+            "kCqAcquireScope is not declared in P2pIbgdaTransportDevice.cuh. It was "
+            "renamed, moved or deleted; this guard cannot tell whether the CTA fence "
+            "is live, so it must not pass by default. Re-point the guard at wherever "
+            "the acquire scope is now decided.",
+        )
+        assert scope is not None  # for the type checker
+        if scope.group(1) != "DOCA_GPUNETIO_VERBS_SYNC_SCOPE_CTA":
+            self.skipTest(
+                f"CQ acquire scope is {scope.group(1)}; invariant not required"
+            )
+        for marker in _NIC_READ_MARKERS:
+            self.assertIsNone(
+                re.search(marker, ibgda),
+                f"{marker} matches an RDMA-read path here. Reading NIC-written "
+                "memory is incompatible with kCqAcquireScope == "
+                "DOCA_GPUNETIO_VERBS_SYNC_SCOPE_CTA. Either set kCqAcquireScope "
+                "back to DOCA_GPUNETIO_VERBS_SYNC_SCOPE_SYS or give the new read "
+                "path its own system-scope acquire. See "
+                "third-party/nvidia-doca/patches/README.md.",
+            )
 
 
 if __name__ == "__main__":

--- a/comms/prims/transport/amd/DocaCompat.h
+++ b/comms/prims/transport/amd/DocaCompat.h
@@ -51,6 +51,13 @@ using doca_gpu_dev_verbs_cq = ::prims_amd_gda_gpu_dev_verbs_cq;
 using doca_gpu_dev_verbs_ticket_t = uint64_t;
 using doca_gpu_dev_verbs_wqe_ctrl_flags = uint8_t;
 
+// The shims below all carry the `ACQ` acquire-scope template parameter, so
+// declare the same capability the vendored DOCA header declares. Without this
+// the AMD build silently takes the fallback arm of the feature-detect in
+// `P2pIbgdaTransportDevice.cuh` -- harmless, since ACQ is inert here, but it
+// would mean the two platforms compile different call shapes for no reason.
+#define DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE 1
+
 // =============================================================================
 // Constant aliases
 // =============================================================================
@@ -70,6 +77,11 @@ constexpr int DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE = 0;
 constexpr int DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO = 0;
 constexpr int DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU = 0;
 constexpr int DOCA_GPUNETIO_VERBS_SYNC_SCOPE_THREAD = 0;
+// Inert like the rest: the CQ-poll acquire scope is an NVIDIA/Blackwell
+// concern (there it selects CCTL.IVALL vs NOP). Spelled here because
+// `kCqAcquireScope` names it and is compiled on both platforms.
+constexpr int DOCA_GPUNETIO_VERBS_SYNC_SCOPE_CTA = 0;
+constexpr int DOCA_GPUNETIO_VERBS_QP_SQ = 0;
 constexpr int DOCA_GPUNETIO_VERBS_EXEC_SCOPE_THREAD = 0;
 constexpr int DOCA_GPUNETIO_VERBS_SIGNAL_OP_ADD = 0;
 
@@ -86,7 +98,9 @@ constexpr uint8_t DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_FENCE =
 // Function shims — pure name-prefix forwarders
 // =============================================================================
 
-template <int MODE = 0>
+// QPT and ACQ mirror the NVIDIA qp_type / acquire-scope parameters and are
+// ignored here.
+template <int MODE = 0, int QPT = 0, int ACQ = 0>
 __device__ __forceinline__ uint64_t doca_gpu_dev_verbs_reserve_wq_slots(
     doca_gpu_dev_verbs_qp* qp,
     uint32_t numSlots) {
@@ -179,7 +193,8 @@ __device__ __forceinline__ void doca_gpu_dev_verbs_submit(
       qp, nextWqeIdx);
 }
 
-template <int MODE = 0, int HANDLER = 0>
+// ACQ mirrors the NVIDIA acquire-scope parameter and is ignored here.
+template <int MODE = 0, int HANDLER = 0, int ACQ = 0>
 __device__ __forceinline__ void doca_gpu_dev_verbs_wait(
     doca_gpu_dev_verbs_qp* qp,
     uint64_t ticket) {
@@ -223,7 +238,9 @@ doca_gpu_dev_verbs_qp_get_cq_sq(doca_gpu_dev_verbs_qp* qp) {
   return prims_amd_gda::prims_amd_gda_gpu_dev_verbs_qp_get_cq_sq(qp);
 }
 
-template <int MODE = 0>
+// QPT and ACQ mirror the NVIDIA qp_type / acquire-scope parameters and are
+// ignored here.
+template <int MODE = 0, int QPT = 0, int ACQ = 0>
 __device__ __forceinline__ int doca_gpu_dev_verbs_poll_one_cq_at(
     doca_gpu_dev_verbs_cq* cq,
     uint64_t consIndex) {

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -707,9 +707,8 @@ class P2pIbgdaTransportDevice {
       const AbortDevice& abortDevice = AbortDevice()) {
     IbgdaLane lane =
         lane_from_ordinal(channelId, IbDirection::Send, ticket.completionId);
-    const int status = doca_gpu_dev_verbs_poll_one_cq_at<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
-        doca_gpu_dev_verbs_qp_get_cq_sq(lane.qp), ticket.value);
+    const int status =
+        poll_cq_once(doca_gpu_dev_verbs_qp_get_cq_sq(lane.qp), ticket.value);
     if (status == 0) {
       return true;
     }
@@ -1137,15 +1136,11 @@ class P2pIbgdaTransportDevice {
       // this once per QP lane.
       const AbortDevice& abortDevice = AbortDevice()) {
     if (!abortDevice.isEnabled()) {
-      doca_gpu_dev_verbs_wait<
-          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
-          DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp, ticket);
+      wait_cq(qp, ticket);
     } else {
       int status;
       do {
-        status = doca_gpu_dev_verbs_poll_one_cq_at<
-            DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
-            doca_gpu_dev_verbs_qp_get_cq_sq(qp), ticket);
+        status = poll_cq_once(doca_gpu_dev_verbs_qp_get_cq_sq(qp), ticket);
         if (status == EBUSY) {
           FT_ABORT_BREAK(
               abortDevice,
@@ -1529,9 +1524,82 @@ class P2pIbgdaTransportDevice {
   static constexpr auto kQpSharingMode =
       DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE;
 
+  // Scope of the acquire fence DOCA runs after observing a completion. On
+  // Blackwell the SYS form is `CCTL.IVALL`, a whole-L1 invalidate, worth ~1.6us
+  // per op; CTA is a NOP.
+  //
+  // CTA is correct here only because no path in this transport reads
+  // NIC-written data through L1 after a completion: we issue no RDMA READ,
+  // atomic results go to a discard sink, staging and SQ-ring reuse are writes,
+  // and wait_signal_impl() reads the signal via a system-scope atomic load that
+  // carries its own invalidate. Adding an RDMA READ, or any post-completion
+  // load of remotely-written memory that is not a system-scope atomic, means
+  // this must go back to SYS. Nothing enforces that; see
+  // third-party/nvidia-doca/patches/README.md.
+  //
+  // Scoped here rather than via a macro on purpose: the DOCA headers are shared
+  // with ncclx GIN, which does issue RDMA READ.
+  static constexpr auto kCqAcquireScope = DOCA_GPUNETIO_VERBS_SYNC_SCOPE_CTA;
+
+  // The DOCA calls that opt into `acquire_scope` go through the three wrappers
+  // below, because the parameter is not always there. The counter and
+  // cooperative-put paths still call DOCA directly and keep SYS.
+  //
+  // ncclx bundles its own copy of the DOCA device headers at the SAME include
+  // path this file uses (`device/doca_gpunetio_dev_verbs_*.cuh`; see
+  // ncclx/v2_3x/src/transport/net_ib/gdaki/doca-gpunetio/include, exported
+  // publicly with `header_namespace = ""`). In a target that links both prims
+  // and ncclx -- the torchcomms integration tests, for instance -- `-I` order
+  // decides which copy we compile against, and it is not necessarily ours.
+  // Passing the extra template argument unconditionally fails there with
+  // "no instance of function template ... matches the argument list".
+  //
+  // So feature-detect on the macro our vendored header defines. Where our copy
+  // wins we get the CTA scope; where ncclx's wins we make the stock call and
+  // keep the SYS-scope fence -- slower, never wrong. The fallback is the
+  // *strong* fence, so a shadowed build is correct by construction.
   __device__ __forceinline__ uint64_t
   reserve_wqes(doca_gpu_dev_verbs_qp* qp, uint32_t count) const {
+    // Same acquire scope as the completion path: the SQ-slot wait polls the
+    // same CQ, so without this it keeps the SYS-scope L1 invalidate once per
+    // posting operation. Only fires once the SQ has wrapped.
+#ifdef DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE
+    return doca_gpu_dev_verbs_reserve_wq_slots<
+        kQpSharingMode,
+        DOCA_GPUNETIO_VERBS_QP_SQ,
+        kCqAcquireScope>(qp, count);
+#else
     return doca_gpu_dev_verbs_reserve_wq_slots<kQpSharingMode>(qp, count);
+#endif
+  }
+
+  __device__ __forceinline__ int poll_cq_once(
+      doca_gpu_dev_verbs_cq* cq,
+      doca_gpu_dev_verbs_ticket_t ticket) const {
+#ifdef DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE
+    return doca_gpu_dev_verbs_poll_one_cq_at<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_QP_SQ,
+        kCqAcquireScope>(cq, ticket);
+#else
+    return doca_gpu_dev_verbs_poll_one_cq_at<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(cq, ticket);
+#endif
+  }
+
+  __device__ __forceinline__ void wait_cq(
+      doca_gpu_dev_verbs_qp* qp,
+      doca_gpu_dev_verbs_ticket_t ticket) const {
+#ifdef DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE
+    doca_gpu_dev_verbs_wait<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO,
+        kCqAcquireScope>(qp, ticket);
+#else
+    doca_gpu_dev_verbs_wait<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp, ticket);
+#endif
   }
 
   __device__ __forceinline__ void mark_wqes_ready_mode(


### PR DESCRIPTION
Summary:
On Blackwell, the acquire fence DOCA runs after observing a completion lowers
to `CCTL.IVALL` -- a whole-L1 invalidate -- when its scope is SYS, and to a
`NOP` when it is CTA. prims fires the SYS form on every retired completion,
discarding the entire L1 each time.

prims hits that fence on **two** paths, not one: after observing a completion,
and again inside `reserve_wq_slots` -> `wait_until_slot_available`, which polls
the same CQ on every posting operation once the SQ has wrapped. The posting
path turns out to be the larger of the two (-3.1% of the -4.6%).

This adds an `acquire_scope` template parameter to
`doca_gpu_dev_verbs_poll_one_cq_at`, `doca_gpu_dev_verbs_poll_cq_at`,
`doca_gpu_dev_verbs_wait`, `doca_gpu_dev_verbs_wait_until_slot_available` and
`doca_gpu_dev_verbs_reserve_wq_slots`, defaulting to `SYNC_SCOPE_SYS`. prims
passes `SYNC_SCOPE_CTA` via `kCqAcquireScope`. **Every other caller is
unchanged.**

Note `reserve_wq_slots` also accepts `GPU_CODE_OPT_SKIP_AVAILABILITY_CHECK`,
which would skip the poll outright. Deliberately not used: that check exists to
stop us overrunning the SQ, and removing a safety check is a different risk
class from narrowing a fence scope. Scoping gets the same saving.

WHY NOT UPSTREAM'S MACRO -- upstream solves this with
`DOCA_GPUNETIO_VERBS_EXP_NIC_FENCE_ACQUIRE_CTA`, defined to 1 in GPUNetIO
v3.0.0+, closed SDK 3.4.0112 and NCCL 4.1.0. Adopting it here would be a
silent stale-data bug in `stable` ncclx:

  - `ncclx/v2_30/def_build.bzl:224,514` depend on `:doca_gpunetio_dl`, which
    propagates `-DDOCA_VERBS_USE_META_THIRD_PARTY=1`.
  - That macro makes `gin_gdaki.h:28` include *this* vendored tree rather than
    ncclx's own bundled DOCA copy.
  - v2_30 GIN issues `doca_gpu_dev_verbs_get` (RDMA READ) at `gin_gdaki.h:266`
    and waits via `poll_one_cq_at`/`doca_gpu_dev_verbs_wait` (`:305,308`), NOT
    `get_wait` -- so upstream's compensating `get_wait` fence never fires for
    it, and the caller then reads the READ destination with ordinary loads.

A template parameter with a SYS default cannot be mis-scoped: any call site
that does not opt in keeps the strong fence, even inside a TU that also uses
prims. An earlier revision of this diff used the macro and was exactly the bug
described above; it was caught in review before submission.

Reviewed By: zhiyongww, snarayankh

Differential Revision: D118532592
