### PR TITLE
Fix CLOGF_SUBSYS include in CtranIb (#4020)

### DIFF
--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -34,6 +34,7 @@
 #include "comms/utils/StrUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/LogUtils.h"
 #include "folly/synchronization/CallOnce.h"
 
 using namespace ctran::ib;


### PR DESCRIPTION
Summary:

- The IB backend's per-communicator traffic-class logging uses `CLOGF_SUBSYS`, which is declared in the comms logger utilities header that the IB source file never included, so builds whose include closure does not pull that header in transitively fail to compile `CtranIb.cc`.
- Include the logger header at the use site so the dependency is explicit instead of relying on include order.

Reviewed By: rmahidhar

Differential Revision: D118719689


