### PR TITLE
Use CTRAN logger in traffic-class path

### DIFF
--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -1140,7 +1140,7 @@ commResult_t CtranIb::resolveTrafficClass() {
     const int hint = comm->config_.trafficClass;
     if (hint >= 0 && hint <= kMaxTrafficClass) {
       trafficClass_ = static_cast<uint32_t>(hint);
-      CLOGF_SUBSYS(
+      CTRAN_LOG_SUBSYS(
           INFO,
           INIT,
           "CTRAN-IB: commHash {:x}, commDesc {} trafficClass={} (from per-comm hint)",
@@ -1150,7 +1150,7 @@ commResult_t CtranIb::resolveTrafficClass() {
       return commSuccess;
     }
     if (hint > kMaxTrafficClass) {
-      CLOGF(
+      CTRAN_LOG(
           WARN,
           "CTRAN-IB: commHash {:x}, commDesc {} ignoring out-of-range per-comm trafficClass hint {} (valid range [0, {}]); falling back to env settings.",
           commHash,
@@ -1211,7 +1211,7 @@ commResult_t CtranIb::resolveTrafficClass() {
 
   if (matchedTc.has_value()) {
     trafficClass_ = *matchedTc;
-    CLOGF_SUBSYS(
+    CTRAN_LOG_SUBSYS(
         INFO,
         INIT,
         "CTRAN-IB: commHash {:x}, commDesc {} trafficClass={} (from NCCL_CTRAN_IB_PG_TRAFFIC_CLASS env-map)",
@@ -1223,7 +1223,7 @@ commResult_t CtranIb::resolveTrafficClass() {
 
   // 3. Global fallback.
   trafficClass_ = static_cast<uint32_t>(NCCL_IB_TC);
-  CLOGF_SUBSYS(
+  CTRAN_LOG_SUBSYS(
       INFO,
       INIT,
       "CTRAN-IB: commHash {:x}, commDesc {} trafficClass={} (from NCCL_IB_TC global fallback)",


### PR DESCRIPTION
Summary:
D113875097 added traffic-class resolution logs using the retired `CLOGF` and `CLOGF_SUBSYS` macros. After the CTRAN logging migration, those names are unavailable and break NCCLX feedstock and wheel compilation.

Replace the four legacy calls with the equivalent `CTRAN_LOG` and `CTRAN_LOG_SUBSYS` APIs. This preserves the existing messages, levels, and INIT subsystem filtering.

Differential Revision: D118721491


