### PR TITLE
Enable collapsed CQs for Prims IBGDA (#4022)

### DIFF
--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -42,6 +42,10 @@ endif
 ifeq ($(ENABLE_PRIMS),1)
 CXXFLAGS += -DENABLE_PRIMS
 NVCUFLAGS += -DENABLE_PRIMS
+# v2.29's bundled host GPUNetIO always creates ring CQs, even when Prims sees
+# the newer CONDA_INCLUDE_DIR header. Keep host creation and device polling ring.
+CXXFLAGS += -DPRIMS_IBGDA_DISABLE_COLLAPSED_CQ
+NVCUFLAGS += -DPRIMS_IBGDA_DISABLE_COLLAPSED_CQ
 endif
 
 ##### src files
@@ -324,7 +328,10 @@ staticlib : $(LIBDIR)/$(STATICLIBTARGET)
 binary : $(BINDIR)/$(BINNAME)
 
 $(DEVMANIFEST): ALWAYS_REBUILD $(INCTARGETS)
-	$(MAKE) -C ./device BASE_DIR=$(BASE_DIR) CONDA_INCLUDE_DIR=$(CONDA_INCLUDE_DIR)
+	$(MAKE) -C ./device \
+		BASE_DIR=$(BASE_DIR) \
+		CONDA_INCLUDE_DIR=$(CONDA_INCLUDE_DIR) \
+		ENABLE_PRIMS=$(ENABLE_PRIMS)
 
 # Empty target to force rebuild
 .PHONY: ALWAYS_REBUILD

--- a/comms/ncclx/v2_29/src/device/Makefile
+++ b/comms/ncclx/v2_29/src/device/Makefile
@@ -42,6 +42,9 @@ endif
 ifeq ($(ENABLE_PRIMS),1)
 NVCUFLAGS += --compiler-options "-DENABLE_PRIMS"
 NVCUFLAGS_SYM += --compiler-options "-DENABLE_PRIMS"
+# Match the host Makefile: its bundled GPUNetIO can create only ring CQs.
+NVCUFLAGS += -DPRIMS_IBGDA_DISABLE_COLLAPSED_CQ
+NVCUFLAGS_SYM += -DPRIMS_IBGDA_DISABLE_COLLAPSED_CQ
 endif
 
 SAY = @bash -c 'path="$$2"; [[ "$$(realpath "$$2")" =~ ^$(subst .,\.,$(abspath $(NCCLDIR)))/(.*)$$ ]] && path="$${BASH_REMATCH[1]}"; printf "%-15s %s\n" "$$1" "$$path"' SAY

--- a/comms/prims/DocaAcquireScopeCapabilityCheck.cu
+++ b/comms/prims/DocaAcquireScopeCapabilityCheck.cu
@@ -1,0 +1,43 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Fails the build if the vendored DOCA headers lose the capability macro that
+// P2pIbgdaTransportDevice.cuh feature-detects on.
+//
+// Patch 0002 adds both DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE and the
+// acquire_scope template parameter. Re-applying it after a resync without the
+// macro hunk leaves a green build, a passing test suite and correct results,
+// with every fence silently back on SYS and the whole saving gone.
+//
+// This lives in its own target, which depends only on :doca_gpunetio_dl, so it
+// always sees the vendored headers. The equivalent check cannot go in
+// P2pIbgdaTransportDevice.cuh: that file is also compiled in builds where ncclx
+// shadows these headers and the macro is legitimately absent, which is exactly
+// what the feature-detect exists to tolerate.
+
+#include <device/doca_gpunetio_dev_verbs_cq.cuh>
+
+#ifndef DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE
+#error \
+    "The vendored DOCA headers no longer define DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE. prims silently falls back to the SYS-scope fence and the CQ-fence optimization is inert. This is what an incomplete re-apply of third-party/nvidia-doca/patches/0002-gpunetio-cq-fence-cta.patch looks like."
+#endif
+
+static_assert(
+    DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE == 1,
+    "DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE must be 1 where it is defined.");
+
+// The macro and the parameter must travel together: instantiating with an
+// explicit acquire_scope fails to compile if the parameter hunk was dropped.
+template <enum doca_gpu_dev_verbs_sync_scope scope>
+__device__ int doca_acquire_scope_capability_probe(
+    struct doca_gpu_dev_verbs_cq* cq,
+    uint64_t ticket) {
+  return doca_gpu_dev_verbs_poll_one_cq_at<
+      DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+      DOCA_GPUNETIO_VERBS_QP_SQ,
+      scope>(cq, ticket);
+}
+
+template __device__ int
+doca_acquire_scope_capability_probe<DOCA_GPUNETIO_VERBS_SYNC_SCOPE_CTA>(
+    struct doca_gpu_dev_verbs_cq*,
+    uint64_t);

--- a/comms/prims/P2pIbTransportBuildContractTest.py
+++ b/comms/prims/P2pIbTransportBuildContractTest.py
@@ -29,6 +29,24 @@ _PROGRESS_ONLY_FUNCTIONS = (
 
 _PROGRESS_ONLY_TYPES = ("ProgressChunk", "ProgressGeometry")
 
+# Markers for "this transport reads NIC-written memory after a completion".
+#
+# Regexes, not substrings. `doca_gpu_dev_verbs_get` is a real RDMA READ -- the
+# generic entry point in `device/doca_gpunetio_dev_verbs_onesided.cuh`, of which
+# `_get_thread`/`_get_warp` are the exec-scope implementations, and the one
+# ncclx GIN calls -- so it has to trip this. But `doca_gpu_dev_verbs_get_wqe_ptr`
+# (used at every WQE build site), `_get_lane_id` and `_get_counter` are
+# unrelated and must not. A plain substring cannot separate them, so require a
+# call or template-argument list immediately after the generic name.
+_NIC_READ_MARKERS = (
+    r"DOCA_GPUNETIO_IB_MLX5_OPCODE_RDMA_READ",
+    r"doca_gpu_dev_verbs_get\s*[<(]",
+    r"doca_gpu_dev_verbs_get_wait",
+    r"doca_gpu_dev_verbs_get_thread",
+    r"doca_gpu_dev_verbs_get_warp",
+    r"wqe_prepare_read",
+)
+
 
 class P2pIbTransportBuildContractTest(unittest.TestCase):
     def setUp(self) -> None:
@@ -81,6 +99,47 @@ class P2pIbTransportBuildContractTest(unittest.TestCase):
             1,
         )
         self.assertIn('":p2p_ib_transport_device_impl"', progress_target)
+
+    def test_cta_cq_acquire_scope_implies_no_rdma_read(self) -> None:
+        """Guards the CTA-scope CQ acquire fence.
+
+        On Blackwell the SYS-scope acquire DOCA runs after a completion lowers
+        to CCTL.IVALL, a whole-L1 invalidate; CTA lowers to a NOP. Dropping it
+        is only sound while this transport never reads NIC-written memory
+        through L1 after a completion -- today it issues no RDMA READ, atomic
+        results go to a discard sink, and the signal is read via a system-scope
+        atomic load that carries its own invalidate.
+
+        Adding an RDMA READ breaks that silently: no crash, no wrong return
+        code, just stale data under a timing window a short test will not hit.
+        So fail loudly here instead.
+        """
+        ibgda = (self.transport / "ibgda/P2pIbgdaTransportDevice.cuh").read_text()
+        scope = re.search(
+            r"kCqAcquireScope\s*=\s*(DOCA_GPUNETIO_VERBS_SYNC_SCOPE_\w+)", ibgda
+        )
+        self.assertIsNotNone(
+            scope,
+            "kCqAcquireScope is not declared in P2pIbgdaTransportDevice.cuh. It was "
+            "renamed, moved or deleted; this guard cannot tell whether the CTA fence "
+            "is live, so it must not pass by default. Re-point the guard at wherever "
+            "the acquire scope is now decided.",
+        )
+        assert scope is not None  # for the type checker
+        if scope.group(1) != "DOCA_GPUNETIO_VERBS_SYNC_SCOPE_CTA":
+            self.skipTest(
+                f"CQ acquire scope is {scope.group(1)}; invariant not required"
+            )
+        for marker in _NIC_READ_MARKERS:
+            self.assertIsNone(
+                re.search(marker, ibgda),
+                f"{marker} matches an RDMA-read path here. Reading NIC-written "
+                "memory is incompatible with kCqAcquireScope == "
+                "DOCA_GPUNETIO_VERBS_SYNC_SCOPE_CTA. Either set kCqAcquireScope "
+                "back to DOCA_GPUNETIO_VERBS_SYNC_SCOPE_SYS or give the new read "
+                "path its own system-scope acquire. See "
+                "third-party/nvidia-doca/patches/README.md.",
+            )
 
 
 if __name__ == "__main__":

--- a/comms/prims/benchmarks/IbgdaBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cc
@@ -685,6 +685,123 @@ TEST_P(IbgdaBenchmarkFixture, PutSignalFlush) {
   printResultsTable(backendTitle("Put+Signal+Flush (RDMA Write)"), results);
 }
 
+TEST_P(IbgdaBenchmarkFixture, PutSignalWaitLocalFlush) {
+  if (numRanks != 2) {
+    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  const int peerRank = globalRank == 0 ? 1 : 0;
+  constexpr int kSignalId = 0;
+  constexpr uint8_t kDataPattern = 0xA7;
+  auto configs = getFullConfigs();
+  std::size_t maxBufferSize = 0;
+  for (const auto& config : configs) {
+    maxBufferSize = std::max(maxBufferSize, config.nBytes);
+  }
+
+  std::vector<IbgdaBenchmarkResult> results;
+  try {
+    MultipeerIbgdaTransportConfig transportConfig{
+        .cudaDevice = localRank,
+    };
+    transportConfig.ibHca = benchIbHca();
+    transportConfig.enableDataDirect = benchDataDirect();
+    transportConfig.qpOrderingPolicy = benchQpOrderingPolicy();
+
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    BenchIbTransport transport(
+        backend(), globalRank, numRanks, bootstrap, transportConfig);
+    transport.exchange();
+
+    DeviceBuffer dataBuffer(maxBufferSize);
+    CUDA_CHECK_VOID(cudaMemset(
+        dataBuffer.get(), globalRank == 0 ? kDataPattern : 0, maxBufferSize));
+    auto localDataBuf =
+        transport.registerBuffer(dataBuffer.get(), maxBufferSize);
+    auto remoteDataBufs = transport.exchangeBuffer(localDataBuf);
+    const int peerIndex = peerRank < globalRank ? peerRank : peerRank - 1;
+    auto remoteDataBuf = remoteDataBufs.at(peerIndex);
+
+    DeviceBuffer signalBuffer(sizeof(uint64_t));
+    CUDA_CHECK_VOID(cudaMemset(signalBuffer.get(), 0, sizeof(uint64_t)));
+    auto localSignalBuf =
+        transport.registerBuffer(signalBuffer.get(), sizeof(uint64_t));
+    auto remoteSignalBufs = transport.exchangeBuffer(localSignalBuf);
+    auto remoteSignalBuf = remoteSignalBufs.at(peerIndex);
+    auto deviceTransport = transport.getP2pTransportDevice(peerRank);
+
+    unsigned long long* d_totalCycles;
+    CUDA_CHECK_VOID(cudaMalloc(&d_totalCycles, sizeof(unsigned long long)));
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    if (globalRank == 0) {
+      launchIbgdaPutSignalWaitLocalFlushBatch(
+          deviceTransport,
+          localDataBuf,
+          remoteDataBuf,
+          remoteSignalBuf,
+          maxBufferSize,
+          kSignalId,
+          1,
+          d_totalCycles,
+          stream_);
+      CUDA_CHECK_VOID(cudaStreamSynchronize(stream_));
+    }
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    if (globalRank == 1) {
+      std::vector<uint8_t> actual(maxBufferSize);
+      CUDA_CHECK_VOID(cudaMemcpy(
+          actual.data(),
+          dataBuffer.get(),
+          actual.size(),
+          cudaMemcpyDeviceToHost));
+      EXPECT_TRUE(std::all_of(actual.begin(), actual.end(), [](uint8_t value) {
+        return value == kDataPattern;
+      }));
+    }
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    for (const auto& config : configs) {
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+      if (globalRank == 0) {
+        launchIbgdaPutSignalWaitLocalFlushBatch(
+            deviceTransport,
+            localDataBuf,
+            remoteDataBuf,
+            remoteSignalBuf,
+            config.nBytes,
+            kSignalId,
+            kIbgdaBatchIters,
+            d_totalCycles,
+            stream_);
+        CUDA_CHECK_VOID(cudaStreamSynchronize(stream_));
+
+        unsigned long long totalCycles;
+        CUDA_CHECK_VOID(cudaMemcpy(
+            &totalCycles,
+            d_totalCycles,
+            sizeof(totalCycles),
+            cudaMemcpyDeviceToHost));
+        IbgdaBenchmarkResult result;
+        result.testName = config.name;
+        result.messageSize = config.nBytes;
+        result.latency = cyclesToUs(totalCycles) / kIbgdaBatchIters;
+        result.bandwidth = (config.nBytes / 1e9f) / (result.latency / 1e6f);
+        results.push_back(result);
+      }
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    }
+
+    CUDA_CHECK_VOID(cudaFree(d_totalCycles));
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IB transport not available: " << e.what();
+  }
+
+  printResultsTable(
+      backendTitle("Put+Signal+WaitLocal+Flush (RDMA Write)"), results);
+}
+
 TEST_P(IbgdaBenchmarkFixture, ThreadScopeMultiBlockPutFlush) {
   // One thread per block uses the no-ThreadGroup put()+flush() API on a
   // block-private slice. This checks that thread-scope wrappers inherit the

--- a/comms/prims/benchmarks/IbgdaBenchmark.cu
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cu
@@ -145,6 +145,40 @@ __global__ void ibgdaPutSignalFlushBatchKernel(
   }
 }
 
+__global__ void ibgdaPutSignalWaitLocalFlushBatchKernel(
+    P2pIbTransportDevice transport,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    std::size_t nbytes,
+    int signalId,
+    int numIters,
+    unsigned long long* totalCycles) {
+  auto group = make_block_group();
+  if (group.is_global_leader()) {
+    auto solo = make_thread_solo();
+    const auto resolvedSignalBuf =
+        remoteSignalBuf.subBuffer(signalId * sizeof(uint64_t));
+
+    for (int i = 0; i < 10; ++i) {
+      const auto ticket =
+          transport.put(localBuf, remoteBuf, nbytes, resolvedSignalBuf, 1);
+      transport.wait_local(solo, ticket);
+      transport.flush();
+    }
+
+    const unsigned long long startCycle = BENCHMARK_CLOCK64();
+    for (int i = 0; i < numIters; ++i) {
+      const auto ticket =
+          transport.put(localBuf, remoteBuf, nbytes, resolvedSignalBuf, 1);
+      transport.wait_local(solo, ticket);
+      transport.flush();
+    }
+    const unsigned long long endCycle = BENCHMARK_CLOCK64();
+    *totalCycles = endCycle - startCycle;
+  }
+}
+
 __global__ void ibgdaPutFlushBatchKernel(
     P2pIbTransportDevice transport,
     IbgdaLocalBuffer localBuf,
@@ -471,6 +505,32 @@ void launchIbgdaPutSignalFlushBatch(
     unsigned long long* totalCycles,
     cudaStream_t stream) {
   ibgdaPutSignalFlushBatchKernel<<<1, 32, 0, stream>>>(
+      transport,
+      localBuf,
+      remoteBuf,
+      remoteSignalBuf,
+      nbytes,
+      signalId,
+      numIters,
+      totalCycles);
+  const cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
+void launchIbgdaPutSignalWaitLocalFlushBatch(
+    P2pIbTransportDevice transport,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    const IbgdaRemoteBuffer& remoteSignalBuf,
+    std::size_t nbytes,
+    int signalId,
+    int numIters,
+    unsigned long long* totalCycles,
+    cudaStream_t stream) {
+  ibgdaPutSignalWaitLocalFlushBatchKernel<<<1, 32, 0, stream>>>(
       transport,
       localBuf,
       remoteBuf,

--- a/comms/prims/benchmarks/IbgdaBenchmark.cuh
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cuh
@@ -76,6 +76,16 @@ __global__ void ibgdaPutSignalWaitCounterBatchKernel(
     int numIters,
     unsigned long long* totalCycles);
 
+__global__ void ibgdaPutSignalWaitLocalFlushBatchKernel(
+    P2pIbTransportDevice transport,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    std::size_t nbytes,
+    int signalId,
+    int numIters,
+    unsigned long long* totalCycles);
+
 __global__ void ibgdaSignalOnlyBatchKernel(
     P2pIbTransportDevice transport,
     IbgdaRemoteBuffer remoteSignalBuf,

--- a/comms/prims/benchmarks/IbgdaBenchmark.h
+++ b/comms/prims/benchmarks/IbgdaBenchmark.h
@@ -103,6 +103,22 @@ void launchIbgdaPutSignalFlushBatch(
     cudaStream_t stream);
 
 /**
+ * Launch batched kernel: put + signal, wait for the WRITE ticket, then flush
+ * the trailing signal. A collapsed CQ can satisfy the second poll from the
+ * frontier advanced by the first.
+ */
+void launchIbgdaPutSignalWaitLocalFlushBatch(
+    P2pIbTransportDevice transport,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    const IbgdaRemoteBuffer& remoteSignalBuf,
+    std::size_t nbytes,
+    int signalId,
+    int numIters,
+    unsigned long long* totalCycles,
+    cudaStream_t stream);
+
+/**
  * Launch batched kernel: one thread per block uses the thread-scope put +
  * flush API on a block-private buffer slice.
  *

--- a/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
+++ b/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
@@ -167,6 +167,37 @@ TEST(MultiPeerIbTransportConfigTest, ReliableDoorbellDisableForcesValidDbr) {
       config, /*nicReliableDoorbellCapable=*/false));
 }
 
+TEST(MultiPeerIbTransportConfigTest, CollapsedCqAutoUsesAllNicResult) {
+  const MultipeerIbTransportConfig config;
+  EXPECT_FALSE(config.enableCollapsedCq.has_value());
+  EXPECT_TRUE(collapsedCqNeedsCapabilityProbe(config));
+  EXPECT_TRUE(
+      collapsedCqActiveForTransport(config, /*allNicsAcceptCollapsedCq=*/true));
+  EXPECT_FALSE(collapsedCqActiveForTransport(
+      config, /*allNicsAcceptCollapsedCq=*/false));
+}
+
+TEST(MultiPeerIbTransportConfigTest, CollapsedCqOnRequiresEveryNic) {
+  MultipeerIbTransportConfig config;
+  config.enableCollapsedCq = true;
+  EXPECT_TRUE(collapsedCqNeedsCapabilityProbe(config));
+  EXPECT_TRUE(
+      collapsedCqActiveForTransport(config, /*allNicsAcceptCollapsedCq=*/true));
+  EXPECT_THROW(
+      collapsedCqActiveForTransport(config, /*allNicsAcceptCollapsedCq=*/false),
+      std::invalid_argument);
+}
+
+TEST(MultiPeerIbTransportConfigTest, CollapsedCqOffForcesRingAndSkipsProbe) {
+  MultipeerIbTransportConfig config;
+  config.enableCollapsedCq = false;
+  EXPECT_FALSE(collapsedCqNeedsCapabilityProbe(config));
+  EXPECT_FALSE(
+      collapsedCqActiveForTransport(config, /*allNicsAcceptCollapsedCq=*/true));
+  EXPECT_FALSE(collapsedCqActiveForTransport(
+      config, /*allNicsAcceptCollapsedCq=*/false));
+}
+
 // -----------------------------------------------------------------------------
 // max_rd_atomic (MCCL_IBGDA_MAX_RD_ATOMIC / config.maxRdAtomic)
 // -----------------------------------------------------------------------------

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -8,6 +8,7 @@
 #include "comms/utils/logger/SpdlogLogger.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 #include <tuple>
@@ -175,6 +176,10 @@ class TestIbTransport {
                   : ibrc_->isPeerMaterialized(peerRank);
   }
 
+  bool collapsedCqActive() const {
+    return ibgda_ != nullptr && ibgda_->collapsedCqActive();
+  }
+
  private:
   int firstPeerRank() const {
     return myRank() == 0 ? 1 : 0;
@@ -194,7 +199,8 @@ std::unique_ptr<TestIbTransport> createTestTransport(
     int numSignalSlots = 1,
     int numCounterSlots = 1,
     int maxGroups = 64,
-    int qpsPerBlockPerNic = 1) {
+    int qpsPerBlockPerNic = 1,
+    std::optional<bool> enableCollapsedCq = std::nullopt) {
   MultipeerIbTransportConfig config{
       .cudaDevice = localRank,
       .numSignalSlots = numSignalSlots,
@@ -202,7 +208,7 @@ std::unique_ptr<TestIbTransport> createTestTransport(
       .maxGroups = maxGroups,
       .qpsPerBlockPerNic = qpsPerBlockPerNic,
   };
-
+  config.enableCollapsedCq = enableCollapsedCq;
   auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
   return std::make_unique<TestIbTransport>(
       backend, globalRank, numRanks, std::move(bootstrap), config);
@@ -225,7 +231,8 @@ class MultipeerIbTransportTestFixture
       int numSignalSlots = 1,
       int numCounterSlots = 1,
       int maxGroups = 64,
-      int qpsPerBlockPerNic = 1) {
+      int qpsPerBlockPerNic = 1,
+      std::optional<bool> enableCollapsedCq = std::nullopt) {
     return createTestTransport(
         backend(),
         globalRank,
@@ -234,7 +241,8 @@ class MultipeerIbTransportTestFixture
         numSignalSlots,
         numCounterSlots,
         maxGroups,
-        qpsPerBlockPerNic);
+        qpsPerBlockPerNic,
+        enableCollapsedCq);
   }
 };
 
@@ -462,10 +470,12 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalBasic) {
 /*
  * The completion-error path, reached deterministically.
  *
- * Rank 0 posts an RDMA write with the peer's rkey corrupted. The NIC answers
- * `REM_ACCESS_ERR`, and `flush()` picks it up inside `wait_local_on_qp`'s CQ
- * poll -- the branch that used to fall straight out of the
- * `while (status == EBUSY)` loop and report success from a `void` function.
+ * Rank 0 posts an RDMA write with the peer's rkey variant corrupted, queues
+ * four valid writes behind it, and only then polls. The preserved mkey index
+ * lets the responder attribute the request and return `REM_ACCESS_ERR`;
+ * `flush()` picks it up inside `wait_local_on_qp`'s CQ poll -- the branch that
+ * used to fall straight out of the `while (status == EBUSY)` loop and report
+ * success from a `void` function.
  *
  * **Why a bad rkey and not a dead peer.** The AllReduce-level
  * `DeadPeerCompletionErrorUnwinds` cannot reach this branch, and the
@@ -476,9 +486,9 @@ TEST_P(MultipeerIbTransportTestFixture, PutSignalBasic) {
  * and immediate, so it is the only way to make the CQE the *cause*.
  *
  * **What discriminates the two paths, with no timing assumption.** The reason.
- * The deadline records `TIMED_OUT`; this branch records `ABORTED`. The op
- * deadline is 30 s, far longer than the test can take, so `ABORTED` is only
- * reachable through the CQE.
+ * The deadline records `TIMED_OUT`; this branch records `NETWORK_ERROR`. The
+ * op deadline is 30 s, far longer than the test can take, so `NETWORK_ERROR`
+ * is only reachable through the CQE.
  *
  * Built on `createTransport()` rather than a raw `MultipeerIbgdaTransport`:
  * the wrapper materialises and connects peers, and an earlier revision of this
@@ -500,86 +510,115 @@ TEST_P(MultipeerIbTransportTestFixture, BadRkeyCompletionErrorUnwinds) {
   constexpr std::chrono::milliseconds kDeadline{30000};
   constexpr std::chrono::milliseconds kMaxElapsed{5000};
 
-  // Local outcome, reduced across ranks after the try so the skip decision is
-  // uniform. See the MPI_Allreduce below.
-  int localSetupOk = 0;
-  std::string skipReason;
-  try {
-    auto transport = createTransport();
-    DeviceBuffer dataBuffer(nbytes);
-    auto localDataBuf = transport->registerBuffer(dataBuffer.get(), nbytes);
-    auto remoteDataBufs = transport->exchangeBuffer(localDataBuf);
+  for (const bool collapsed : {false, true}) {
+#ifdef __HIP_PLATFORM_AMD__
+    if (collapsed) {
+      continue;
+    }
+#endif
+    SCOPED_TRACE(collapsed ? "collapsed" : "ring");
+    std::unique_ptr<TestIbTransport> transport;
+    std::unique_ptr<DeviceBuffer> dataBuffer;
+    IbgdaLocalBuffer localDataBuf{};
+    std::vector<IbgdaRemoteBuffer> remoteDataBufs;
+    P2pIbTransportDevice peerTransport;
     const int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
-    auto peerTransport = transport->getP2pTransportDevice(peerRank);
 
+    int localSetupOk = 0;
+    std::string skipReason;
+    try {
+      transport = createTransport(
+          /*numSignalSlots=*/1,
+          /*numCounterSlots=*/1,
+          /*maxGroups=*/64,
+          /*qpsPerBlockPerNic=*/1,
+          collapsed);
+      EXPECT_EQ(transport->collapsedCqActive(), collapsed);
+      dataBuffer = std::make_unique<DeviceBuffer>(nbytes);
+      localDataBuf = transport->registerBuffer(dataBuffer->get(), nbytes);
+      remoteDataBufs = transport->exchangeBuffer(localDataBuf);
+      peerTransport = transport->getP2pTransportDevice(peerRank);
+      localSetupOk = 1;
+    } catch (const std::exception& e) {
+      skipReason = e.what();
+    }
+    int allSetupOk = 0;
+    MPI_CHECK(MPI_Allreduce(
+        &localSetupOk, &allSetupOk, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD));
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
-
-    if (globalRank == 0) {
-      // Flip the high bits rather than zeroing: zero is a plausible "unset"
-      // value that a future host-side guard might reject before the WQE is
-      // posted, which would silently stop this test exercising the NIC.
-      auto badRemoteBuf = remoteDataBufs[peerIndex];
-      // Every populated device key, not just [0]. QP lanes index this array by
-      // their own `nic_id`, so on a 2-NIC part (GB200/GB300) poisoning only
-      // slot 0 leaves NIC 1 perfectly valid and any put that lands on such a
-      // lane completes normally -- the test would pass while exercising
-      // nothing. `size` is the populated count; indexing past it traps.
-      ASSERT_GT(badRemoteBuf.rkey_per_device.size, 0);
-      for (int nic = 0; nic < badRemoteBuf.rkey_per_device.size; ++nic) {
-        badRemoteBuf.rkey_per_device[nic].value ^= 0xDEAD0000U;
-      }
-
-      comms::fault_tolerance::Abort abort(/*enabled=*/true);
-      // The budget belongs on the *device* handle. `startTimeout()` arms a
-      // host-side deadline only; the device resolves its own from
-      // `opTimeoutMs_`, and a bare `Abort` has none, leaving `deadlineCycles_`
-      // at 0 -- "no deadline". An earlier revision hung for exactly that.
-      auto deviceAbort = abort.getDeviceHandle();
-      deviceAbort.setOpTimeoutMs(kDeadline.count());
-
-      const auto start = std::chrono::steady_clock::now();
-      test::testPutAndFlushWithAbort(
-          peerTransport,
-          localDataBuf,
-          badRemoteBuf,
-          nbytes,
-          deviceAbort,
-          numBlocks,
-          blockSize);
-      // Deliberately not CUDACHECK_TEST: a trap surfaces here, and reporting it
-      // is the point rather than aborting the process on it.
-      const cudaError_t syncStatus = cudaDeviceSynchronize();
-      const auto elapsed =
-          std::chrono::duration_cast<std::chrono::milliseconds>(
-              std::chrono::steady_clock::now() - start);
-
-      EXPECT_EQ(cudaSuccess, syncStatus)
-          << "the completion error must unwind, not trap: "
-          << cudaGetErrorString(syncStatus);
-      EXPECT_LT(elapsed.count(), kMaxElapsed.count())
-          << "an error CQE is reported immediately; this long suggests the wait "
-             "ended on something other than the completion error";
-      EXPECT_EQ(
-          comms::fault_tolerance::AbortReason::NETWORK_ERROR, abort.reason())
-          << "expected the completion error to latch NETWORK_ERROR; TIMED_OUT "
-             "would mean the deadline won and the CQE branch was never reached";
+    if (allSetupOk == 0) {
+      GTEST_SKIP() << "IB transport not available on some rank: " << skipReason;
     }
 
-    localSetupOk = 1;
-  } catch (const std::exception& e) {
-    skipReason = e.what();
-  }
-  // Agreed across ranks BEFORE anyone skips. Only rank 0 runs the injection and
-  // the CUDA sync, so a rank-local launch failure used to send it through
-  // GTEST_SKIP() without ever entering the barrier below, leaving its peer
-  // blocked until the harness timeout. Reaching the barrier unconditionally and
-  // reducing the verdict makes both ranks skip or continue together.
-  int allSetupOk = 0;
-  MPI_CHECK(MPI_Allreduce(
-      &localSetupOk, &allSetupOk, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD));
-  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
-  if (allSetupOk == 0) {
-    GTEST_SKIP() << "IB transport not available on some rank: " << skipReason;
+    int localRunOk = 1;
+    std::string runFailure;
+    if (globalRank == 0) {
+      try {
+        // The low byte is the mlx5 mkey variant. Preserve the index so the peer
+        // can resolve the MR and return an immediate remote-access-error NAK;
+        // changing index bits can instead trigger transport retries for ~34 s.
+        auto badRemoteBuf = remoteDataBufs[peerIndex];
+        // Every populated device key, not just [0]. QP lanes index this array
+        // by their own `nic_id`, so on a 2-NIC part (GB200/GB300) poisoning
+        // only slot 0 leaves NIC 1 perfectly valid and any put that lands on
+        // such a lane completes normally -- the test would pass while
+        // exercising nothing. `size` is the populated count; indexing past it
+        // traps.
+        if (badRemoteBuf.rkey_per_device.size <= 0) {
+          throw std::runtime_error("remote buffer has no populated device key");
+        }
+        for (int nic = 0; nic < badRemoteBuf.rkey_per_device.size; ++nic) {
+          badRemoteBuf.rkey_per_device[nic].value ^=
+              comms::prims::detail::ibgdaNetworkByteOrderKey(0xFFU);
+        }
+
+        comms::fault_tolerance::Abort abort(/*enabled=*/true);
+        // The budget belongs on the *device* handle. `startTimeout()` arms a
+        // host-side deadline only; the device resolves its own from
+        // `opTimeoutMs_`, and a bare `Abort` has none, leaving
+        // `deadlineCycles_` at 0 -- "no deadline". An earlier revision hung for
+        // exactly that.
+        auto deviceAbort = abort.getDeviceHandle();
+        deviceAbort.setOpTimeoutMs(kDeadline.count());
+
+        const auto start = std::chrono::steady_clock::now();
+        test::testPutAndFlushWithAbort(
+            peerTransport,
+            localDataBuf,
+            badRemoteBuf,
+            remoteDataBufs[peerIndex],
+            nbytes,
+            deviceAbort,
+            numBlocks,
+            blockSize);
+        // Deliberately not CUDACHECK_TEST: a trap surfaces here, and reporting
+        // it is the point rather than aborting the process on it.
+        const cudaError_t syncStatus = cudaDeviceSynchronize();
+        const auto elapsed =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - start);
+
+        EXPECT_EQ(cudaSuccess, syncStatus)
+            << "the completion error must unwind, not trap: "
+            << cudaGetErrorString(syncStatus);
+        EXPECT_LT(elapsed.count(), kMaxElapsed.count())
+            << "an error CQE is reported immediately; this long suggests the wait "
+               "ended on something other than the completion error";
+        EXPECT_EQ(
+            comms::fault_tolerance::AbortReason::NETWORK_ERROR, abort.reason())
+            << "expected the completion error to latch NETWORK_ERROR; TIMED_OUT "
+               "would mean the deadline won and the CQE branch was never reached";
+      } catch (const std::exception& e) {
+        localRunOk = 0;
+        runFailure = e.what();
+      }
+    }
+    int allRunOk = 0;
+    MPI_CHECK(MPI_Allreduce(
+        &localRunOk, &allRunOk, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD));
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    ASSERT_EQ(allRunOk, 1) << "bad-rkey exercise failed on one rank: "
+                           << runFailure;
   }
 }
 
@@ -595,9 +634,10 @@ TEST_P(MultipeerIbTransportTestFixture, BadRkeyCompletionErrorUnwinds) {
  * `ReduceScatterDirectIbV2.cu`'s `while (... != Drained)` spun for the life of
  * the kernel.
  *
- * A bad rkey is what makes the completions genuinely never land: the NIC
- * answers `REM_ACCESS_ERR`, `is_local_completion_ready()` stays false and
- * latches `ABORTED`. A pre-abort would be vacuous (nothing ever posts) and
+ * A bad-rkey variant is what makes the completions fail: the peer can resolve
+ * the mkey index and immediately answers `REM_ACCESS_ERR`, after which
+ * `is_local_completion_ready()` latches `NETWORK_ERROR`. A pre-abort would be
+ * vacuous (nothing ever posts) and
  * racing a healthy CQE would be flaky, so this is the only deterministic
  * construction.
  *
@@ -657,13 +697,14 @@ TEST_P(MultipeerIbTransportTestFixture, RegisteredSendDrainTerminatesOnAbort) {
 
     if (globalRank == 0) {
       const int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
-      // Same poisoning as BadRkeyCompletionErrorUnwinds: flip the high bits of
-      // an exchanged peer buffer's rkey. Those keys are known-valid, unlike the
-      // channel layout's staging keys.
+      // Same poisoning as BadRkeyCompletionErrorUnwinds: change only the mkey
+      // variant of an exchanged peer buffer. Those keys are known-valid, unlike
+      // the channel layout's staging keys.
       auto poisonedRemote = remoteDataBufs[peerIndex];
       ASSERT_GT(poisonedRemote.rkey_per_device.size, 0);
       for (int nic = 0; nic < poisonedRemote.rkey_per_device.size; ++nic) {
-        poisonedRemote.rkey_per_device[nic].value ^= 0xDEAD0000U;
+        poisonedRemote.rkey_per_device[nic].value ^=
+            comms::prims::detail::ibgdaNetworkByteOrderKey(0xFFU);
       }
 
       DeviceBuffer observationBuf(sizeof(test::RegisteredSendObservation));
@@ -1428,6 +1469,142 @@ TEST_P(MultipeerIbTransportTestFixture, StressTest) {
       numIterations);
 }
 
+TEST_F(MultipeerIbgdaTransportTestFixture, CollapsedCqAndRingSurviveSqWrap) {
+#ifdef __HIP_PLATFORM_AMD__
+  GTEST_SKIP() << "collapsed CQ is NVIDIA-only";
+#endif
+  if (numRanks != 2) {
+    GTEST_SKIP() << "requires exactly 2 ranks, got " << numRanks;
+  }
+
+  constexpr uint32_t kQpDepth = 32;
+  constexpr int kWqesPerLane = 65568;
+  constexpr std::size_t kBytesPerPut = 64;
+  constexpr int kSignalId = 0;
+  constexpr int kCounterId = 0;
+  const int peerRank = globalRank == 0 ? 1 : 0;
+
+  for (const bool collapsed : {false, true}) {
+    SCOPED_TRACE(collapsed ? "collapsed" : "ring");
+    std::unique_ptr<TestIbTransport> transport;
+    std::unique_ptr<DeviceBuffer> dataBuffer;
+    IbgdaLocalBuffer localDataBuf{};
+    std::vector<IbgdaRemoteBuffer> remoteDataBufs;
+    std::vector<uint8_t> expected;
+    int numBurstPuts = 0;
+    int numCompanionOps = 0;
+    int localSetupOk = 0;
+    std::string skipReason;
+    try {
+      MultipeerIbTransportConfig config{
+          .cudaDevice = localRank,
+          .numSignalSlots = 1,
+          .numCounterSlots = 1,
+          .maxGroups = 1,
+          .qpDepth = kQpDepth,
+      };
+      config.max_num_channels = 1;
+      config.enableCollapsedCq = collapsed;
+      auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+      transport = std::make_unique<TestIbTransport>(
+          IbTestBackend::Ibgda,
+          globalRank,
+          numRanks,
+          std::move(bootstrap),
+          config);
+      EXPECT_EQ(transport->collapsedCqActive(), collapsed);
+
+      const int laneCount = transport->numNics() * config.qpsPerConnection;
+      numBurstPuts = kWqesPerLane * laneCount;
+      // Each put+signal+counter operation posts two companion-QP WQEs.
+      numCompanionOps = (kWqesPerLane / 2) * laneCount;
+      const std::size_t totalBytes =
+          static_cast<std::size_t>(numBurstPuts) * kBytesPerPut;
+      expected.resize(totalBytes);
+      for (int put = 0; put < numBurstPuts; ++put) {
+        for (std::size_t byte = 0; byte < kBytesPerPut; ++byte) {
+          expected[put * kBytesPerPut + byte] = static_cast<uint8_t>(
+              (static_cast<uint32_t>(put) >> (8 * (byte % 4))) ^ byte);
+        }
+      }
+
+      dataBuffer = std::make_unique<DeviceBuffer>(totalBytes);
+      localDataBuf = transport->registerBuffer(dataBuffer->get(), totalBytes);
+      remoteDataBufs = transport->exchangeBuffer(localDataBuf);
+      localSetupOk = 1;
+    } catch (const std::exception& e) {
+      skipReason = e.what();
+    }
+    int allSetupOk = 0;
+    MPI_CHECK(MPI_Allreduce(
+        &localSetupOk, &allSetupOk, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD));
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    if (allSetupOk == 0) {
+      GTEST_SKIP() << "IBGDA transport not available on some rank: "
+                   << skipReason;
+    }
+
+    const int peerIndex = peerRank < globalRank ? peerRank : peerRank - 1;
+    const auto remoteDataBuf = remoteDataBufs[peerIndex];
+    const auto peerTransport = transport->getP2pTransportDevice(peerRank);
+
+    if (globalRank == 0) {
+      CUDACHECK_TEST(cudaMemcpy(
+          localDataBuf.ptr,
+          expected.data(),
+          expected.size(),
+          cudaMemcpyHostToDevice));
+    } else {
+      CUDACHECK_TEST(cudaMemset(localDataBuf.ptr, 0, expected.size()));
+    }
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    if (globalRank == 0) {
+      test::testBurstPutAndFlush(
+          peerTransport,
+          localDataBuf,
+          remoteDataBuf,
+          kBytesPerPut,
+          numBurstPuts,
+          1,
+          32);
+    }
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    if (globalRank == 1) {
+      std::vector<uint8_t> actual(expected.size());
+      CUDACHECK_TEST(cudaMemcpy(
+          actual.data(),
+          localDataBuf.ptr,
+          actual.size(),
+          cudaMemcpyDeviceToHost));
+      EXPECT_EQ(actual, expected);
+    }
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    if (globalRank == 0) {
+      test::testPutSignalCounter(
+          peerTransport,
+          localDataBuf,
+          remoteDataBuf,
+          kBytesPerPut,
+          kSignalId,
+          1,
+          kCounterId,
+          1,
+          1,
+          32,
+          numCompanionOps);
+      test::testWaitCounter(peerTransport, kCounterId, numCompanionOps, 1, 32);
+    } else {
+      test::testWaitSignal(peerTransport, kSignalId, numCompanionOps, 1, 32);
+    }
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  }
+}
+
 // =============================================================================
 // Signal Only Test - Tests sending signals without data
 // =============================================================================
@@ -1777,7 +1954,7 @@ TEST_F(
 }
 
 // ANS (nvcompdx) is NVIDIA-only; the compressed CopyOp is not built on AMD/HIP.
-#ifndef __HIP_PLATFORM_AMD__
+#if !defined(__HIP_PLATFORM_AMD__) && defined(PIPES_ENABLE_ANS_COMPRESSION)
 // Round-trips a payload through the variable-size (ANS-compressed) CopyOp over
 // the blocking send()/recv() path added in D111967119: rank 0 compresses+sends,
 // rank 1 recvs+decompresses, and the received bytes must match the sent
@@ -1899,7 +2076,7 @@ TEST_F(
   runIbgdaAnsBlockingRoundTrip(
       localRank, globalRank, numRanks, /*maxSignalBytes=*/256 * 1024);
 }
-#endif // __HIP_PLATFORM_AMD__
+#endif // !__HIP_PLATFORM_AMD__ && PIPES_ENABLE_ANS_COMPRESSION
 
 TEST_F(
     MultipeerIbgdaTransportTestFixture,

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -256,6 +256,43 @@ void testMultiplePutAndSignal(
   }
 }
 
+__global__ void burstPutAndFlushKernel(
+    P2pIbTransportDevice transport,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    std::size_t bytesPerPut,
+    int numPuts) {
+  auto group = make_block_group();
+  if (group.is_global_leader()) {
+    for (int i = 0; i < numPuts; ++i) {
+      transport.put(
+          localBuf.subBuffer(i * bytesPerPut),
+          remoteBuf.subBuffer(i * bytesPerPut),
+          bytesPerPut,
+          /*signalId=*/-1,
+          /*signalVal=*/0);
+    }
+    transport.flush();
+  }
+}
+
+void testBurstPutAndFlush(
+    P2pIbTransportDevice deviceTransportPtr,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t bytesPerPut,
+    int numPuts,
+    int numBlocks,
+    int blockSize) {
+  burstPutAndFlushKernel<<<numBlocks, blockSize>>>(
+      deviceTransportPtr, localBuf, remoteBuf, bytesPerPut, numPuts);
+  const cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
 // =============================================================================
 // Kernel: Signal only (no data)
 // =============================================================================
@@ -1246,18 +1283,21 @@ __global__ void putSignalCounterKernel(
     int signalId,
     uint64_t signalVal,
     int counterId,
-    uint64_t counterVal) {
+    uint64_t counterVal,
+    int numIterations) {
   auto group = make_block_group();
   if (group.is_global_leader()) {
-    transport.put(
-        localDataBuf,
-        remoteDataBuf,
-        nbytes,
-        signalId,
-        signalVal,
-        counterId,
-        counterVal);
-    transport.wait_counter(counterId, counterVal);
+    for (int i = 0; i < numIterations; ++i) {
+      transport.put(
+          localDataBuf,
+          remoteDataBuf,
+          nbytes,
+          signalId,
+          signalVal,
+          counterId,
+          counterVal);
+    }
+    transport.wait_counter(counterId, counterVal * numIterations);
   }
 }
 
@@ -1271,7 +1311,8 @@ void testPutSignalCounter(
     int counterId,
     uint64_t counterVal,
     int numBlocks,
-    int blockSize) {
+    int blockSize,
+    int numIterations) {
   putSignalCounterKernel<<<numBlocks, blockSize>>>(
       deviceTransportPtr,
       localDataBuf,
@@ -1280,7 +1321,8 @@ void testPutSignalCounter(
       signalId,
       signalVal,
       counterId,
-      counterVal);
+      counterVal,
+      numIterations);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(
@@ -1372,21 +1414,35 @@ void testMultiQpPutAndSignal(
 // =============================================================================
 // Kernel: put + flush against a caller-supplied abort handle
 //
-// No signal is posted -- the point is to reach the completion drain, and a
-// signal would only add a second WQE that fails the same way.
+// The first bad-rkey WQE puts the RC QP into error; the later valid-rkey WQEs
+// become flush errors. Posting them before one drain verifies that a collapsed
+// CQ still reports an error after later completions overwrite its single slot.
 // =============================================================================
 
 __global__ void putAndFlushWithAbortKernel(
     P2pIbTransportDevice transport,
     IbgdaLocalBuffer localBuf,
-    IbgdaRemoteBuffer remoteBuf,
+    IbgdaRemoteBuffer poisonedRemoteBuf,
+    IbgdaRemoteBuffer validRemoteBuf,
     std::size_t nbytes,
     comms::fault_tolerance::AbortDevice abort) {
   auto group = make_block_group();
   if (group.is_global_leader()) {
     abort.start();
     transport.put(
-        localBuf, remoteBuf, nbytes, /*signalId=*/-1, /*signalVal=*/0);
+        localBuf,
+        poisonedRemoteBuf,
+        nbytes,
+        /*signalId=*/-1,
+        /*signalVal=*/0);
+    for (int i = 0; i < 4; ++i) {
+      transport.put(
+          localBuf,
+          validRemoteBuf,
+          nbytes,
+          /*signalId=*/-1,
+          /*signalVal=*/0);
+    }
     transport.flush(abort);
   }
 }
@@ -1508,13 +1564,14 @@ void testRegisteredSendDrainWithAbort(
 void testPutAndFlushWithAbort(
     P2pIbTransportDevice transport,
     const IbgdaLocalBuffer& localBuf,
-    const IbgdaRemoteBuffer& remoteBuf,
+    const IbgdaRemoteBuffer& poisonedRemoteBuf,
+    const IbgdaRemoteBuffer& validRemoteBuf,
     std::size_t nbytes,
     comms::fault_tolerance::AbortDevice abort,
     int numBlocks,
     int blockSize) {
   putAndFlushWithAbortKernel<<<numBlocks, blockSize>>>(
-      transport, localBuf, remoteBuf, nbytes, abort);
+      transport, localBuf, poisonedRemoteBuf, validRemoteBuf, nbytes, abort);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -98,6 +98,19 @@ void testMultiplePutAndSignal(
     int blockSize);
 
 /**
+ * Test kernel: post a burst larger than the SQ, then flush once. Slot reuse
+ * must therefore make progress through reserve_wq_slots' internal CQ poll.
+ */
+void testBurstPutAndFlush(
+    P2pIbTransportDevice deviceTransportPtr,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t bytesPerPut,
+    int numPuts,
+    int numBlocks,
+    int blockSize);
+
+/**
  * Test kernel: Send signal only (no data, slot-index)
  */
 void testSignalOnly(
@@ -405,7 +418,8 @@ void testPutSignalCounter(
     int counterId,
     uint64_t counterVal,
     int numBlocks,
-    int blockSize);
+    int blockSize,
+    int numIterations = 1);
 
 /**
  * Test kernel: Wait for local counter to reach expected value (slot-index)
@@ -489,7 +503,8 @@ void testRegisteredSendDrainWithAbort(
 void testPutAndFlushWithAbort(
     P2pIbTransportDevice transport,
     const IbgdaLocalBuffer& localBuf,
-    const IbgdaRemoteBuffer& remoteBuf,
+    const IbgdaRemoteBuffer& poisonedRemoteBuf,
+    const IbgdaRemoteBuffer& validRemoteBuf,
     std::size_t nbytes,
     comms::fault_tolerance::AbortDevice abort,
     int numBlocks,

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTest.cu
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTest.cu
@@ -492,4 +492,89 @@ void runTestWaitSignalNoTimeout(
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
+#ifndef __HIP_PLATFORM_AMD__
+__global__ void testCollapsedCqPoll(
+    doca_gpu_dev_verbs_cq* cq,
+    uint64_t ticket,
+    bool blocking,
+    CollapsedCqPollResult* result) {
+  if (blocking) {
+    result->status = prims_ibgda_wait_collapsed_cq<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_CTA>(cq, ticket);
+  } else {
+    result->status = prims_ibgda_poll_collapsed_cq_once<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_CTA>(cq, ticket);
+  }
+  result->finalConsumerIndex = cq->cqe_ci;
+}
+
+cudaError_t runTestCollapsedCqPoll(
+    const CollapsedCqPollCase& testCase,
+    CollapsedCqPollResult* result) {
+  doca_gpunetio_ib_mlx5_cqe64 hostCqe{};
+  hostCqe.wqe_counter = static_cast<__be16>(
+      (testCase.wqeCounter >> 8) | (testCase.wqeCounter << 8));
+  hostCqe.op_own = static_cast<uint8_t>(
+      testCase.opcode << DOCA_GPUNETIO_VERBS_MLX5_CQE_OPCODE_SHIFT);
+
+  doca_gpunetio_ib_mlx5_cqe64* deviceCqe = nullptr;
+  doca_gpu_dev_verbs_cq* deviceCq = nullptr;
+  CollapsedCqPollResult* deviceResult = nullptr;
+  cudaError_t status = cudaMalloc(&deviceCqe, sizeof(hostCqe));
+  if (status != cudaSuccess) {
+    return status;
+  }
+  status = cudaMalloc(&deviceCq, sizeof(doca_gpu_dev_verbs_cq));
+  if (status != cudaSuccess) {
+    cudaFree(deviceCqe);
+    return status;
+  }
+  status = cudaMalloc(&deviceResult, sizeof(CollapsedCqPollResult));
+  if (status != cudaSuccess) {
+    cudaFree(deviceCq);
+    cudaFree(deviceCqe);
+    return status;
+  }
+
+  doca_gpu_dev_verbs_cq hostCq{};
+  hostCq.cqe_daddr = reinterpret_cast<uint8_t*>(deviceCqe);
+  hostCq.cqe_num = testCase.cqeCount;
+  hostCq.cqe_ci = testCase.initialConsumerIndex;
+  status =
+      cudaMemcpy(deviceCqe, &hostCqe, sizeof(hostCqe), cudaMemcpyHostToDevice);
+  if (status == cudaSuccess) {
+    status =
+        cudaMemcpy(deviceCq, &hostCq, sizeof(hostCq), cudaMemcpyHostToDevice);
+  }
+  if (status == cudaSuccess) {
+    testCollapsedCqPoll<<<1, 1>>>(
+        deviceCq, testCase.ticket, testCase.blocking, deviceResult);
+    status = cudaDeviceSynchronize();
+  }
+  if (status == cudaSuccess) {
+    status = cudaMemcpy(
+        result,
+        deviceResult,
+        sizeof(CollapsedCqPollResult),
+        cudaMemcpyDeviceToHost);
+  }
+
+  const cudaError_t resultFreeStatus = cudaFree(deviceResult);
+  const cudaError_t cqFreeStatus = cudaFree(deviceCq);
+  const cudaError_t cqeFreeStatus = cudaFree(deviceCqe);
+  if (status != cudaSuccess) {
+    return status;
+  }
+  if (resultFreeStatus != cudaSuccess) {
+    return resultFreeStatus;
+  }
+  if (cqFreeStatus != cudaSuccess) {
+    return cqFreeStatus;
+  }
+  return cqeFreeStatus;
+}
+#endif
+
 } // namespace comms::prims::tests

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh
@@ -92,6 +92,26 @@ void runTestPutCooperativePartitioningBlock(bool* d_success);
 // Test trace_ibgda_event writes the expected trace payload.
 void runTestTraceIbgdaEvent(PipesTraceHandle trace);
 
+#ifndef __HIP_PLATFORM_AMD__
+struct CollapsedCqPollCase {
+  uint64_t initialConsumerIndex;
+  uint64_t ticket;
+  uint32_t cqeCount;
+  uint16_t wqeCounter;
+  uint8_t opcode;
+  bool blocking;
+};
+
+struct CollapsedCqPollResult {
+  int status;
+  uint64_t finalConsumerIndex;
+};
+
+cudaError_t runTestCollapsedCqPoll(
+    const CollapsedCqPollCase& testCase,
+    CollapsedCqPollResult* result);
+#endif
+
 // =============================================================================
 // wait_signal timeout tests
 // =============================================================================

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTestMain.cc
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTestMain.cc
@@ -8,6 +8,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cerrno>
 #include <chrono>
 #include <cstdint>
 #include <functional>
@@ -84,6 +85,78 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, DefaultConstruction) {
     runTestP2pTransportDefaultConstruction(d_success);
   });
 }
+
+#ifndef __HIP_PLATFORM_AMD__
+TEST_F(P2pIbgdaTransportDeviceTestFixture, CollapsedCqPollerAdvancesFrontier) {
+  constexpr uint8_t kRequestCompletion = 0;
+  const std::vector<std::pair<CollapsedCqPollCase, uint64_t>> cases{
+      {{0, 0, 32, 0, kRequestCompletion, true}, 1},
+      {{0, 1, 32, 1, kRequestCompletion, false}, 2},
+      {{0, 0, 32, 5, kRequestCompletion, false}, 6},
+      {{65534, 65535, 32, 65535, kRequestCompletion, false}, 65536},
+      {{65534, 65535, 32, 1, kRequestCompletion, false}, 65538},
+      {{65535, 65536, 32, 0, kRequestCompletion, false}, 65537},
+      {{65536, 65536, 32, 1, kRequestCompletion, false}, 65538},
+  };
+
+  for (const auto& [testCase, expectedConsumerIndex] : cases) {
+    SCOPED_TRACE(testCase.ticket);
+    CollapsedCqPollResult result{};
+    CUDACHECK_TEST(runTestCollapsedCqPoll(testCase, &result));
+    EXPECT_EQ(result.status, 0);
+    EXPECT_EQ(result.finalConsumerIndex, expectedConsumerIndex);
+  }
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, CollapsedCqPollerStaysBusy) {
+  constexpr uint8_t kRequestCompletion = 0;
+  constexpr uint8_t kInvalidCompletion = 15;
+  const std::vector<CollapsedCqPollCase> cases{
+      {0, 1, 32, 0, kRequestCompletion, false},
+      {0, 32, 32, 31, kRequestCompletion, false},
+      {0, 32, 32, 100, kRequestCompletion, false},
+      {0, 0, 32, 0, kInvalidCompletion, false},
+      {65535, 65536, 32, 65535, kRequestCompletion, false},
+      {65535, 65541, 32, 65535, kRequestCompletion, false},
+  };
+
+  for (const auto& testCase : cases) {
+    SCOPED_TRACE(testCase.ticket);
+    CollapsedCqPollResult result{};
+    CUDACHECK_TEST(runTestCollapsedCqPoll(testCase, &result));
+    EXPECT_EQ(result.status, EBUSY);
+    EXPECT_EQ(result.finalConsumerIndex, testCase.initialConsumerIndex);
+  }
+}
+
+TEST_F(
+    P2pIbgdaTransportDeviceTestFixture,
+    CollapsedCqPollerAcceptsRetiredTicket) {
+  constexpr uint8_t kInvalidCompletion = 15;
+  const CollapsedCqPollCase testCase{6, 3, 32, 0, kInvalidCompletion, false};
+  CollapsedCqPollResult result{};
+  CUDACHECK_TEST(runTestCollapsedCqPoll(testCase, &result));
+  EXPECT_EQ(result.status, 0);
+  EXPECT_EQ(result.finalConsumerIndex, 6);
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, CollapsedCqWaitReturnsError) {
+  constexpr uint8_t kRequestErrorCompletion = 13;
+  const std::vector<CollapsedCqPollCase> cases{
+      {0, 0, 32, 0, kRequestErrorCompletion, true},
+      // A sticky error must win over the bounded-window EBUSY check. Otherwise
+      // SQ reclamation can spin forever after the QP enters error state.
+      {0, 32, 32, 0, kRequestErrorCompletion, false},
+  };
+  for (const auto& testCase : cases) {
+    SCOPED_TRACE(testCase.ticket);
+    CollapsedCqPollResult result{};
+    CUDACHECK_TEST(runTestCollapsedCqPoll(testCase, &result));
+    EXPECT_EQ(result.status, -EIO);
+    EXPECT_EQ(result.finalConsumerIndex, 0);
+  }
+}
+#endif
 
 TEST_F(P2pIbgdaTransportDeviceTestFixture, ReadSignal) {
   // Test that read_signal returns correct values for each signal slot

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -333,6 +333,11 @@ struct MultipeerIbTransportConfig {
   // auto-detects NIC support, true requires support, and false disables it.
   std::optional<bool> enableReliableDoorbell;
 
+  // IBGDA-only collapsed-CQ policy; ignored by IBRC and AMD. nullopt probes
+  // every selected NIC and enables the format only when all accept it, true
+  // requires every NIC to accept it, and false forces ordinary ring CQs.
+  std::optional<bool> enableCollapsedCq;
+
   int numQpsPerPeerPerNic() const {
     if (maxGroups < 0 || qpsPerBlockPerNic < 0) {
       throw std::invalid_argument(
@@ -596,6 +601,21 @@ inline bool reliableDoorbellActiveForNic(
 inline bool reliableDoorbellNeedsCapabilityQuery(
     const MultipeerIbTransportConfig& config) {
   return config.enableReliableDoorbell.value_or(true);
+}
+
+inline bool collapsedCqActiveForTransport(
+    const MultipeerIbTransportConfig& config,
+    bool allNicsAcceptCollapsedCq) {
+  if (config.enableCollapsedCq.value_or(false) && !allNicsAcceptCollapsedCq) {
+    throw std::invalid_argument(
+        "enableCollapsedCq requires collapsed-CQ support on every selected NIC");
+  }
+  return config.enableCollapsedCq.value_or(allNicsAcceptCollapsedCq);
+}
+
+inline bool collapsedCqNeedsCapabilityProbe(
+    const MultipeerIbTransportConfig& config) {
+  return config.enableCollapsedCq.value_or(true);
 }
 
 // Whether MultipeerIbTransportConfig::maxRdAtomic is programmable as-is.

--- a/comms/prims/transport/amd/DocaCompat.h
+++ b/comms/prims/transport/amd/DocaCompat.h
@@ -50,6 +50,7 @@ using doca_gpu_dev_verbs_wqe = ::prims_amd_gda_gpu_dev_verbs_wqe;
 using doca_gpu_dev_verbs_cq = ::prims_amd_gda_gpu_dev_verbs_cq;
 using doca_gpu_dev_verbs_ticket_t = uint64_t;
 using doca_gpu_dev_verbs_wqe_ctrl_flags = uint8_t;
+using doca_gpu_dev_verbs_resource_sharing_mode = int;
 
 // The shims below all carry the `ACQ` acquire-scope template parameter, so
 // declare the same capability the vendored DOCA header declares. Without this

--- a/comms/prims/transport/amd/DocaCompat.h
+++ b/comms/prims/transport/amd/DocaCompat.h
@@ -51,6 +51,13 @@ using doca_gpu_dev_verbs_cq = ::prims_amd_gda_gpu_dev_verbs_cq;
 using doca_gpu_dev_verbs_ticket_t = uint64_t;
 using doca_gpu_dev_verbs_wqe_ctrl_flags = uint8_t;
 
+// The shims below all carry the `ACQ` acquire-scope template parameter, so
+// declare the same capability the vendored DOCA header declares. Without this
+// the AMD build silently takes the fallback arm of the feature-detect in
+// `P2pIbgdaTransportDevice.cuh` -- harmless, since ACQ is inert here, but it
+// would mean the two platforms compile different call shapes for no reason.
+#define DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE 1
+
 // =============================================================================
 // Constant aliases
 // =============================================================================
@@ -70,6 +77,11 @@ constexpr int DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE = 0;
 constexpr int DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO = 0;
 constexpr int DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU = 0;
 constexpr int DOCA_GPUNETIO_VERBS_SYNC_SCOPE_THREAD = 0;
+// Inert like the rest: the CQ-poll acquire scope is an NVIDIA/Blackwell
+// concern (there it selects CCTL.IVALL vs NOP). Spelled here because
+// `kCqAcquireScope` names it and is compiled on both platforms.
+constexpr int DOCA_GPUNETIO_VERBS_SYNC_SCOPE_CTA = 0;
+constexpr int DOCA_GPUNETIO_VERBS_QP_SQ = 0;
 constexpr int DOCA_GPUNETIO_VERBS_EXEC_SCOPE_THREAD = 0;
 constexpr int DOCA_GPUNETIO_VERBS_SIGNAL_OP_ADD = 0;
 
@@ -86,7 +98,9 @@ constexpr uint8_t DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_FENCE =
 // Function shims — pure name-prefix forwarders
 // =============================================================================
 
-template <int MODE = 0>
+// QPT and ACQ mirror the NVIDIA qp_type / acquire-scope parameters and are
+// ignored here.
+template <int MODE = 0, int QPT = 0, int ACQ = 0>
 __device__ __forceinline__ uint64_t doca_gpu_dev_verbs_reserve_wq_slots(
     doca_gpu_dev_verbs_qp* qp,
     uint32_t numSlots) {
@@ -179,7 +193,8 @@ __device__ __forceinline__ void doca_gpu_dev_verbs_submit(
       qp, nextWqeIdx);
 }
 
-template <int MODE = 0, int HANDLER = 0>
+// ACQ mirrors the NVIDIA acquire-scope parameter and is ignored here.
+template <int MODE = 0, int HANDLER = 0, int ACQ = 0>
 __device__ __forceinline__ void doca_gpu_dev_verbs_wait(
     doca_gpu_dev_verbs_qp* qp,
     uint64_t ticket) {
@@ -223,7 +238,9 @@ doca_gpu_dev_verbs_qp_get_cq_sq(doca_gpu_dev_verbs_qp* qp) {
   return prims_amd_gda::prims_amd_gda_gpu_dev_verbs_qp_get_cq_sq(qp);
 }
 
-template <int MODE = 0>
+// QPT and ACQ mirror the NVIDIA qp_type / acquire-scope parameters and are
+// ignored here.
+template <int MODE = 0, int QPT = 0, int ACQ = 0>
 __device__ __forceinline__ int doca_gpu_dev_verbs_poll_one_cq_at(
     doca_gpu_dev_verbs_cq* cq,
     uint64_t consIndex) {

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cerrno>
+#include <cstdlib>
 #include <cstring>
 #include <optional>
 #include <stdexcept>
@@ -50,6 +51,7 @@ constexpr int kHopLimit = 255;
 // The device-visible companion QP is created by create_qp_group_hl() with
 // mainAttr and therefore uses config_.qpDepth.
 constexpr uint32_t kLoopbackCompanionQpDepth = 32;
+constexpr uint32_t kCollapsedCqProbeDepth = 32;
 } // namespace
 
 namespace {
@@ -153,6 +155,41 @@ uint8_t resolveMaxRdAtomic(const MultipeerIbgdaTransportConfig& config) {
         fmt::format("maxRdAtomic={} is not a power of two in [1, 128]", value));
   }
   return static_cast<uint8_t>(value);
+}
+
+std::optional<bool> resolveCollapsedCqMode(
+    const MultipeerIbgdaTransportConfig& config) {
+  // Standalone Link-EP does not initialize NCCL CVARs, but must still honor
+  // the environment kill switch before constructing this transport. Remove
+  // this direct read when Link-EP initializes CVARs before transport setup.
+  if (const char* mode = std::getenv("MCCL_IBGDA_COLLAPSED_CQ_MODE");
+      mode != nullptr) {
+    if (std::strcmp(mode, "on") == 0) {
+      return true;
+    }
+    if (std::strcmp(mode, "off") == 0) {
+      return false;
+    }
+    if (std::strcmp(mode, "auto") == 0) {
+      return config.enableCollapsedCq;
+    }
+    LOG_FIRST_N(WARNING, 1) << "Ignoring unknown MCCL_IBGDA_COLLAPSED_CQ_MODE='"
+                            << mode << "'; expected auto, on, or off";
+  }
+  if (MCCL_IBGDA_COLLAPSED_CQ_MODE ==
+      MCCL_IBGDA_COLLAPSED_CQ_MODE_DEFAULTCVARVALUE) {
+    return config.enableCollapsedCq;
+  }
+  using Mode = decltype(MCCL_IBGDA_COLLAPSED_CQ_MODE);
+  switch (MCCL_IBGDA_COLLAPSED_CQ_MODE) {
+    case Mode::on:
+      return true;
+    case Mode::off:
+      return false;
+    case Mode::auto_:
+      break;
+  }
+  return std::nullopt;
 }
 
 // Largest power of two <= limit, or 0 when limit is 0.
@@ -452,6 +489,90 @@ void checkDocaError(doca_error_t err, const char* msg) {
   }
 }
 
+#ifndef __HIP_PLATFORM_AMD__
+#ifndef PRIMS_IBGDA_DISABLE_COLLAPSED_CQ
+// Probe through the high-level QP path so the CQ uses GPU UMEM, like
+// production. CX8 rejects an otherwise equivalent collapsed CQ backed by
+// internal host UMEM.
+doca_error_t
+tryCreateProbeQp(doca_gpu* gpuDev, ::ibv_pd* ibvPd, bool collapsed) {
+  doca_gpu_verbs_qp_init_attr_hl attr{};
+  attr.gpu_dev = gpuDev;
+  attr.ibpd = ibvPd;
+  attr.sq_nwqe = kCollapsedCqProbeDepth;
+  attr.nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO;
+  attr.mreg_type = DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_DEFAULT;
+  attr.send_dbr_mode_ext = DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR;
+  attr.cq_collapsed = collapsed;
+
+  doca_gpu_verbs_qp_hl* qp = nullptr;
+  const doca_error_t createStatus = doca_gpu_verbs_create_qp_hl(&attr, &qp);
+  if (createStatus != DOCA_SUCCESS) {
+    return createStatus;
+  }
+  if (qp == nullptr) {
+    return DOCA_ERROR_BAD_STATE;
+  }
+  checkDocaError(
+      doca_gpu_verbs_destroy_qp_hl(qp),
+      "Failed to destroy collapsed-CQ capability-probe QP");
+  return DOCA_SUCCESS;
+}
+#endif
+
+bool resolveCollapsedCqForNic(
+    const MultipeerIbgdaTransportConfig& config,
+    doca_gpu* gpuDev,
+    ::ibv_pd* ibvPd,
+    const std::string& deviceName) {
+#ifdef PRIMS_IBGDA_DISABLE_COLLAPSED_CQ
+  static_cast<void>(gpuDev);
+  static_cast<void>(ibvPd);
+  if (config.enableCollapsedCq.value_or(false)) {
+    throw std::runtime_error(
+        fmt::format(
+            "NIC {} cannot use collapsed CQs because this build links a GPUNetIO "
+            "host library without collapsed-CQ creation support",
+            deviceName));
+  }
+  return false;
+#else
+  if (!collapsedCqNeedsCapabilityProbe(config)) {
+    return false;
+  }
+
+  const doca_error_t collapsedStatus = tryCreateProbeQp(gpuDev, ibvPd, true);
+  if (collapsedStatus == DOCA_SUCCESS) {
+    return true;
+  }
+  if (config.enableCollapsedCq.value_or(false)) {
+    throw std::runtime_error(
+        fmt::format(
+            "NIC {} rejected collapsed CQ creation: {}",
+            deviceName,
+            docaErrorToString(collapsedStatus)));
+  }
+
+  const doca_error_t ringStatus = tryCreateProbeQp(gpuDev, ibvPd, false);
+  if (ringStatus != DOCA_SUCCESS) {
+    throw std::runtime_error(
+        fmt::format(
+            "NIC {} rejected both collapsed and ring CQ capability probes: "
+            "collapsed={}, ring={}",
+            deviceName,
+            docaErrorToString(collapsedStatus),
+            docaErrorToString(ringStatus)));
+  }
+  LOG_FIRST_N(WARNING, 1)
+      << "MultipeerIbgdaTransport: NIC " << deviceName
+      << " rejected or could not create a collapsed CQ ("
+      << docaErrorToString(collapsedStatus)
+      << "); the ring-CQ control succeeded, so auto mode will use ring CQs";
+  return false;
+#endif
+}
+#endif
+
 } // namespace
 
 // Helper method implementations
@@ -488,6 +609,9 @@ void MultipeerIbgdaTransport::openIbDevice() {
   // all NICs — same fabric/HCA generation assumed), matching the prior inline
   // behavior.
   nicDoca_.resize(numNics_);
+#ifndef __HIP_PLATFORM_AMD__
+  bool allNicsAcceptCollapsedCq = true;
+#endif
   const doca_verbs_addr_type addrType =
       (nics_[0].linkLayer == ibverbx::IBV_LINK_LAYER_INFINIBAND)
       ? DOCA_VERBS_ADDR_TYPE_IB_NO_GRH
@@ -496,6 +620,12 @@ void MultipeerIbgdaTransport::openIbDevice() {
              : DOCA_VERBS_ADDR_TYPE_IPv6);
   for (int n = 0; n < numNics_; ++n) {
 #ifndef __HIP_PLATFORM_AMD__
+    allNicsAcceptCollapsedCq &= resolveCollapsedCqForNic(
+        config_,
+        docaGpu_,
+        reinterpret_cast<::ibv_pd*>(nics_[n].ibvPd),
+        nics_[n].deviceName);
+
     // Narrow the read/atomic depth to the most restrictive NIC before any QP
     // exists. At the default depth of 1 this returns immediately and issues no
     // capability query.
@@ -583,6 +713,15 @@ void MultipeerIbgdaTransport::openIbDevice() {
     err = doca_verbs_ah_attr_set_sl(nicDoca_[n].ahAttr, config_.serviceLevel);
     checkDocaError(err, "Failed to set service level");
   }
+#ifndef __HIP_PLATFORM_AMD__
+  collapsedCq_ =
+      collapsedCqActiveForTransport(config_, allNicsAcceptCollapsedCq);
+  LOG(INFO) << "MultipeerIbgdaTransport: collapsed_cq_mode="
+            << (config_.enableCollapsedCq.has_value()
+                    ? (*config_.enableCollapsedCq ? "on" : "off")
+                    : "auto")
+            << " active=" << collapsedCq_;
+#endif
 }
 
 void MultipeerIbgdaTransport::allocateResources() {
@@ -941,6 +1080,13 @@ void MultipeerIbgdaTransport::createPeerQps(int peerIndex) {
     mainAttr.sq_nwqe = config_.qpDepth;
     mainAttr.nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO;
     mainAttr.mreg_type = DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_DEFAULT;
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(PRIMS_IBGDA_DISABLE_COLLAPSED_CQ)
+    // Collapsed CQ: the NIC writes every CQE to slot 0 and the poller keys off
+    // the CQE's own wqe_counter instead of ring position, so one success can
+    // retire several completions at once. Applies to the device-visible main
+    // and companion QPs (create_qp_group_hl shares this attr).
+    mainAttr.cq_collapsed = collapsedCq_;
+#endif
 #ifndef __HIP_PLATFORM_AMD__
     mainAttr.send_dbr_mode_ext = nicDoca_[nic].useReliableDoorbell
         ? DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_HW
@@ -955,6 +1101,12 @@ void MultipeerIbgdaTransport::createPeerQps(int peerIndex) {
 #endif
 
     doca_gpu_verbs_qp_init_attr_hl loopbackAttr = mainAttr;
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(PRIMS_IBGDA_DISABLE_COLLAPSED_CQ)
+    // The standalone loopback QP is the responder peer of the device companion
+    // QP; it never posts device-side WQEs and its send CQ is never polled from
+    // the GPU. Leave it a ring CQ -- CQ format is local, not negotiated.
+    loopbackAttr.cq_collapsed = false;
+#endif
     loopbackAttr.sq_nwqe = kLoopbackCompanionQpDepth;
 #ifndef __HIP_PLATFORM_AMD__
     loopbackAttr.send_dbr_mode_ext =
@@ -1017,6 +1169,7 @@ P2pIbgdaTransportBuildParams MultipeerIbgdaTransport::buildPeerTransportParams(
   params.maxChannels = config_.max_num_channels;
   params.qpDirectionCount = config_.fixedChannelDirectionCount();
   params.qpsPerConnection = config_.qpsPerConnection;
+  params.collapsedCq = collapsedCq_;
   params.h_nicDeviceIbgdaResources.resize(numNics_);
   for (int n = 0; n < numNics_; ++n) {
     auto& nicSpec = params.h_nicDeviceIbgdaResources[n];
@@ -1120,6 +1273,7 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
     // MCCL_IBGDA_MAX_RD_ATOMIC) before any NIC or QP exists, so a bad value
     // fails immediately.
     maxRdAtomic_ = resolveMaxRdAtomic(config_);
+    config_.enableCollapsedCq = resolveCollapsedCqMode(config_);
 
     // Resolve CUDA driver function pointers (NVIDIA-only; AMD doesn't
     // use the CUDA driver API for GPU memory allocation).

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
@@ -215,6 +215,10 @@ class MultipeerIbgdaTransport
    */
   int getGidIndex() const;
 
+  bool collapsedCqActive() const {
+    return collapsedCq_;
+  }
+
  private:
   // Helper methods
   void initDocaGpu();
@@ -259,6 +263,10 @@ class MultipeerIbgdaTransport
   // taken in the ctor, then clamped to NIC capability in openIbDevice(). The
   // default of 1 reproduces the pre-existing wire behaviour exactly.
   uint8_t maxRdAtomic_{1};
+
+  // One local format for every device-visible main and companion CQ. Resolved
+  // before any QP is created; the host-only loopback CQs remain ordinary rings.
+  bool collapsedCq_{false};
 
   // numNics_ is inherited (protected) from MultiPeerIbTransport;
   // nicDoca_.size() == numNics_ after openIbDevice().

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cu
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cu
@@ -47,6 +47,8 @@ P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
         << "All peers must have the same qpsPerConnection";
     CHECK_EQ(params[i].qpDirectionCount, params[0].qpDirectionCount)
         << "All peers must have the same qpDirectionCount";
+    CHECK_EQ(params[i].collapsedCq, params[0].collapsedCq)
+        << "All local device transports must use the resolved CQ format";
     CHECK_EQ(
         static_cast<int>(params[i].h_nicDeviceIbgdaResources.size()), numNics)
         << "All peers must have the same numNics";
@@ -223,7 +225,8 @@ P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
         DeviceSpan<IbLocalChannel>(
             d_allLocalChannels + i * params[i].maxChannels,
             params[i].maxChannels),
-        params[i].channelLayout);
+        params[i].channelLayout,
+        params[i].collapsedCq);
   }
 
   // 4. Allocate and copy transport objects to GPU.
@@ -373,7 +376,8 @@ void writeDeviceTransportSlot(
       params.qpsPerConnection,
       params.qpDirectionCount,
       DeviceSpan<IbLocalChannel>(d_localChannels, params.maxChannels),
-      params.channelLayout);
+      params.channelLayout,
+      params.collapsedCq);
 
   err = cudaMemcpy(
       deviceArray + peerIndex,

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cuh
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cuh
@@ -74,6 +74,7 @@ struct P2pIbgdaTransportBuildParams {
   int qpsPerConnection{1};
   int qpDirectionCount{1};
   IbChannelLayout channelLayout{};
+  bool collapsedCq{false};
 };
 
 /**

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -707,9 +707,8 @@ class P2pIbgdaTransportDevice {
       const AbortDevice& abortDevice = AbortDevice()) {
     IbgdaLane lane =
         lane_from_ordinal(channelId, IbDirection::Send, ticket.completionId);
-    const int status = doca_gpu_dev_verbs_poll_one_cq_at<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
-        doca_gpu_dev_verbs_qp_get_cq_sq(lane.qp), ticket.value);
+    const int status =
+        poll_cq_once(doca_gpu_dev_verbs_qp_get_cq_sq(lane.qp), ticket.value);
     if (status == 0) {
       return true;
     }
@@ -1137,15 +1136,11 @@ class P2pIbgdaTransportDevice {
       // this once per QP lane.
       const AbortDevice& abortDevice = AbortDevice()) {
     if (!abortDevice.isEnabled()) {
-      doca_gpu_dev_verbs_wait<
-          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
-          DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp, ticket);
+      wait_cq(qp, ticket);
     } else {
       int status;
       do {
-        status = doca_gpu_dev_verbs_poll_one_cq_at<
-            DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
-            doca_gpu_dev_verbs_qp_get_cq_sq(qp), ticket);
+        status = poll_cq_once(doca_gpu_dev_verbs_qp_get_cq_sq(qp), ticket);
         if (status == EBUSY) {
           FT_ABORT_BREAK(
               abortDevice,
@@ -1529,9 +1524,82 @@ class P2pIbgdaTransportDevice {
   static constexpr auto kQpSharingMode =
       DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE;
 
+  // Scope of the acquire fence DOCA runs after observing a completion. On
+  // Blackwell the SYS form is `CCTL.IVALL`, a whole-L1 invalidate, worth ~1.6us
+  // per op; CTA is a NOP.
+  //
+  // CTA is correct here only because no path in this transport reads
+  // NIC-written data through L1 after a completion: we issue no RDMA READ,
+  // atomic results go to a discard sink, staging and SQ-ring reuse are writes,
+  // and wait_signal_impl() reads the signal via a system-scope atomic load that
+  // carries its own invalidate. Adding an RDMA READ, or any post-completion
+  // load of remotely-written memory that is not a system-scope atomic, means
+  // this must go back to SYS. Nothing enforces that; see
+  // third-party/nvidia-doca/patches/README.md.
+  //
+  // Scoped here rather than via a macro on purpose: the DOCA headers are shared
+  // with ncclx GIN, which does issue RDMA READ.
+  static constexpr auto kCqAcquireScope = DOCA_GPUNETIO_VERBS_SYNC_SCOPE_CTA;
+
+  // The DOCA calls that opt into `acquire_scope` go through the three wrappers
+  // below, because the parameter is not always there. The counter and
+  // cooperative-put paths still call DOCA directly and keep SYS.
+  //
+  // ncclx bundles its own copy of the DOCA device headers at the SAME include
+  // path this file uses (`device/doca_gpunetio_dev_verbs_*.cuh`; see
+  // ncclx/v2_3x/src/transport/net_ib/gdaki/doca-gpunetio/include, exported
+  // publicly with `header_namespace = ""`). In a target that links both prims
+  // and ncclx -- the torchcomms integration tests, for instance -- `-I` order
+  // decides which copy we compile against, and it is not necessarily ours.
+  // Passing the extra template argument unconditionally fails there with
+  // "no instance of function template ... matches the argument list".
+  //
+  // So feature-detect on the macro our vendored header defines. Where our copy
+  // wins we get the CTA scope; where ncclx's wins we make the stock call and
+  // keep the SYS-scope fence -- slower, never wrong. The fallback is the
+  // *strong* fence, so a shadowed build is correct by construction.
   __device__ __forceinline__ uint64_t
   reserve_wqes(doca_gpu_dev_verbs_qp* qp, uint32_t count) const {
+    // Same acquire scope as the completion path: the SQ-slot wait polls the
+    // same CQ, so without this it keeps the SYS-scope L1 invalidate once per
+    // posting operation. Only fires once the SQ has wrapped.
+#ifdef DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE
+    return doca_gpu_dev_verbs_reserve_wq_slots<
+        kQpSharingMode,
+        DOCA_GPUNETIO_VERBS_QP_SQ,
+        kCqAcquireScope>(qp, count);
+#else
     return doca_gpu_dev_verbs_reserve_wq_slots<kQpSharingMode>(qp, count);
+#endif
+  }
+
+  __device__ __forceinline__ int poll_cq_once(
+      doca_gpu_dev_verbs_cq* cq,
+      doca_gpu_dev_verbs_ticket_t ticket) const {
+#ifdef DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE
+    return doca_gpu_dev_verbs_poll_one_cq_at<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_QP_SQ,
+        kCqAcquireScope>(cq, ticket);
+#else
+    return doca_gpu_dev_verbs_poll_one_cq_at<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(cq, ticket);
+#endif
+  }
+
+  __device__ __forceinline__ void wait_cq(
+      doca_gpu_dev_verbs_qp* qp,
+      doca_gpu_dev_verbs_ticket_t ticket) const {
+#ifdef DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE
+    doca_gpu_dev_verbs_wait<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO,
+        kCqAcquireScope>(qp, ticket);
+#else
+    doca_gpu_dev_verbs_wait<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp, ticket);
+#endif
   }
 
   __device__ __forceinline__ void mark_wqes_ready_mode(

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -40,6 +40,88 @@ struct Memcpy;
 
 inline constexpr uint64_t kDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
 
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(PRIMS_IBGDA_DISABLE_COLLAPSED_CQ)
+// Buck targets that also link ncclx can see its older DOCA headers at this same
+// include path. Keep collapsed-CQ polling in Prims and depend only on the
+// common v2.30 CQ/CQE prefix instead of extending the vendored DOCA API.
+static_assert(offsetof(doca_gpu_dev_verbs_cq, cqe_daddr) == 0);
+static_assert(offsetof(doca_gpu_dev_verbs_cq, cqe_num) == 12);
+static_assert(offsetof(doca_gpu_dev_verbs_cq, cqe_ci) == 24);
+static_assert(sizeof(doca_gpunetio_ib_mlx5_cqe64) == 64);
+static_assert(offsetof(doca_gpunetio_ib_mlx5_cqe64, wqe_counter) == 60);
+static_assert(offsetof(doca_gpunetio_ib_mlx5_cqe64, op_own) == 63);
+
+template <
+    doca_gpu_dev_verbs_resource_sharing_mode SharingMode,
+    doca_gpu_dev_verbs_sync_scope AcquireScope>
+__device__ __forceinline__ int prims_ibgda_poll_collapsed_cq_once(
+    doca_gpu_dev_verbs_cq* cq,
+    uint64_t ticket) {
+  const uint64_t consumerIndex =
+      doca_gpu_dev_verbs_load_relaxed<SharingMode>(&cq->cqe_ci);
+  if (ticket < consumerIndex) {
+    return 0;
+  }
+
+  auto* cqe = reinterpret_cast<doca_gpunetio_ib_mlx5_cqe64*>(
+      __ldg(reinterpret_cast<uintptr_t*>(&cq->cqe_daddr)));
+  auto* cqeTail = reinterpret_cast<uint32_t*>(
+      reinterpret_cast<uint8_t*>(cqe) + sizeof(*cqe) - sizeof(uint32_t));
+  const uint32_t cqeChunk = doca_gpu_dev_verbs_bswap32(
+      doca_gpu_dev_verbs_load_relaxed_sys_global(cqeTail));
+  uint16_t wqeCounter = cqeChunk >> 16;
+  const uint8_t opcode =
+      (cqeChunk & 0xff) >> DOCA_GPUNETIO_VERBS_MLX5_CQE_OPCODE_SHIFT;
+
+#if DOCA_GPUNETIO_VERBS_ENABLE_DEBUG == 1
+  if (opcode == DOCA_GPUNETIO_IB_MLX5_CQE_REQ_ERR) {
+    doca_gpu_dev_verbs_cq_print_cqe_err(cqe);
+  }
+#endif
+  // An RC QP cannot recover after a request error. Check the sticky slot before
+  // the bounded ticket window so later SQ-reclamation waits also escape.
+  if (opcode == DOCA_GPUNETIO_IB_MLX5_CQE_REQ_ERR) {
+    return -EIO;
+  }
+
+  const uint32_t cqeCount = __ldg(&cq->cqe_num);
+  // Relaxed receive placement does not relax completion delivery order. The
+  // collapsed CQE therefore remains a completion frontier; see
+  // third-party/rdma-core/stablev57/providers/mlx5/man/mlx5dv_create_qp.3.md.
+  // Prims tickets name the completed WQE itself, so a counter one behind is
+  // still busy. Upstream v4's `- 2` is off by one for that convention.
+  if (ticket >= consumerIndex + cqeCount ||
+      opcode == DOCA_GPUNETIO_IB_MLX5_CQE_INVALID ||
+      static_cast<uint16_t>(
+          static_cast<uint16_t>(ticket) - wqeCounter - uint16_t{1}) <
+          cqeCount) {
+    return EBUSY;
+  }
+
+  ++wqeCounter;
+  const uint64_t newConsumerIndex = ((ticket & ~0xffffULL) | wqeCounter) +
+      ((static_cast<uint16_t>(ticket) > wqeCounter) ? 0x10000ULL : 0);
+  doca_gpu_dev_verbs_fence_acquire<AcquireScope>();
+  doca_gpu_dev_verbs_atomic_max<uint64_t, SharingMode>(
+      &cq->cqe_ci, newConsumerIndex);
+  return 0;
+}
+
+template <
+    doca_gpu_dev_verbs_resource_sharing_mode SharingMode,
+    doca_gpu_dev_verbs_sync_scope AcquireScope>
+__device__ __forceinline__ int prims_ibgda_wait_collapsed_cq(
+    doca_gpu_dev_verbs_cq* cq,
+    uint64_t ticket) {
+  int status;
+  do {
+    status = prims_ibgda_poll_collapsed_cq_once<SharingMode, AcquireScope>(
+        cq, ticket);
+  } while (status == EBUSY);
+  return status;
+}
+#endif
+
 // `PIPES_DEVICE_TRAP()` is defined in `comms/prims/core/DeviceMacros.cuh` and
 // is intentionally available across all `comms/prims` device headers.
 //
@@ -192,6 +274,7 @@ class P2pIbgdaTransportDevice {
    *                              slot-index counter API.
    * @param channelLayout         Optional pipelined send/recv channel layout.
    *                              When empty, send()/recv() are unavailable.
+   * @param collapsedCq           Whether device-visible QPs use collapsed CQs.
    */
   __host__ __device__ P2pIbgdaTransportDevice(
       DeviceSpan<NicDeviceIbgdaResources> nicDevices,
@@ -204,7 +287,8 @@ class P2pIbgdaTransportDevice {
       int qpsPerConnection = 1,
       int qpDirectionCount = kIbDirections,
       DeviceSpan<IbLocalChannel> localChannels = {},
-      IbChannelLayout channelLayout = {})
+      IbChannelLayout channelLayout = {},
+      bool collapsedCq = false)
       : nicDevices_(nicDevices),
         ownedRemoteSignalBuf_(ownedRemoteSignalBuf),
         ownedLocalSignalBuf_(ownedLocalSignalBuf),
@@ -215,7 +299,8 @@ class P2pIbgdaTransportDevice {
         qpsPerConnection_(qpsPerConnection),
         qpDirectionCount_(qpDirectionCount),
         localChannels_(localChannels),
-        channelLayout_(channelLayout) {}
+        channelLayout_(channelLayout),
+        collapsedCq_(collapsedCq) {}
 
   // IBGDA round-robins each send/recv chunk's RDMA_WRITE + DATA_READY atomic-FA
   // across per-lane single-writer DATA_READY slots (one per QP lane; see
@@ -1136,7 +1221,15 @@ class P2pIbgdaTransportDevice {
       // this once per QP lane.
       const AbortDevice& abortDevice = AbortDevice()) {
     if (!abortDevice.isEnabled()) {
-      wait_cq(qp, ticket);
+      const int status = wait_cq(qp, ticket);
+      if (status != 0) {
+        printf(
+            "P2pIbgdaTransportDevice: wait_local_on_qp completion failed "
+            "(ticket=%llu status=%d)\n",
+            static_cast<unsigned long long>(ticket),
+            status);
+        PIPES_DEVICE_TRAP();
+      }
     } else {
       int status;
       do {
@@ -1155,10 +1248,9 @@ class P2pIbgdaTransportDevice {
           //
           // No `!isEnabled()` trap arm here, unlike `is_local_completion_ready`
           // below: this whole branch is inside the `else` of `isEnabled()`, so
-          // the handle is enabled by construction. With FT off the function
-          // takes the blocking `doca_gpu_dev_verbs_wait` above and never
-          // inspects a status at all, so there is no disabled-path error to
-          // preserve.
+          // the handle is enabled by construction. The disabled collapsed-CQ
+          // path above traps on a returned CQ error; the stock ring wait has a
+          // void interface and retains its existing behavior.
           // Gated on the CAS result so the diagnostic is one-shot. An error CQE
           // is sticky and this function is re-entered by its caller's spin
           // loop, so printing first meant one printf plus one system-scope CAS
@@ -1439,8 +1531,9 @@ class P2pIbgdaTransportDevice {
     // Leader reserves WQE slots for all threads
     uint64_t base_wqe_idx = 0;
     if (group.is_leader()) {
-      base_wqe_idx = doca_gpu_dev_verbs_reserve_wq_slots<
-          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(qp, group.group_size);
+      base_wqe_idx =
+          reserve_wqes_mode<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+              qp, group.group_size);
     }
     base_wqe_idx = group.broadcast<uint64_t>(base_wqe_idx);
 
@@ -1496,7 +1589,6 @@ class P2pIbgdaTransportDevice {
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes) {
-    doca_gpu_dev_verbs_ticket_t ticket;
     doca_gpu_dev_verbs_addr localAddr = {
         .addr = reinterpret_cast<uint64_t>(localBuf.ptr),
         .key = localBuf.lkey_per_device[lane.nic_id].value};
@@ -1504,12 +1596,17 @@ class P2pIbgdaTransportDevice {
         .addr = reinterpret_cast<uint64_t>(remoteBuf.ptr),
         .key = remoteBuf.rkey_per_device[lane.nic_id].value};
 
+#ifdef __HIP_PLATFORM_AMD__
+    doca_gpu_dev_verbs_ticket_t ticket;
     doca_gpu_dev_verbs_put<
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
         DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO,
         DOCA_GPUNETIO_VERBS_EXEC_SCOPE_THREAD>(
         lane.qp, remoteAddr, localAddr, nbytes, &ticket);
     return ticket;
+#else
+    return put_single_local(lane.qp, remoteAddr, localAddr, nbytes);
+#endif
   }
 
   // --- WQ slot lifecycle ---
@@ -1558,24 +1655,17 @@ class P2pIbgdaTransportDevice {
   // wins we get the CTA scope; where ncclx's wins we make the stock call and
   // keep the SYS-scope fence -- slower, never wrong. The fallback is the
   // *strong* fence, so a shadowed build is correct by construction.
-  __device__ __forceinline__ uint64_t
-  reserve_wqes(doca_gpu_dev_verbs_qp* qp, uint32_t count) const {
-    // Same acquire scope as the completion path: the SQ-slot wait polls the
-    // same CQ, so without this it keeps the SYS-scope L1 invalidate once per
-    // posting operation. Only fires once the SQ has wrapped.
-#ifdef DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE
-    return doca_gpu_dev_verbs_reserve_wq_slots<
-        kQpSharingMode,
-        DOCA_GPUNETIO_VERBS_QP_SQ,
-        kCqAcquireScope>(qp, count);
-#else
-    return doca_gpu_dev_verbs_reserve_wq_slots<kQpSharingMode>(qp, count);
-#endif
-  }
 
   __device__ __forceinline__ int poll_cq_once(
       doca_gpu_dev_verbs_cq* cq,
       doca_gpu_dev_verbs_ticket_t ticket) const {
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(PRIMS_IBGDA_DISABLE_COLLAPSED_CQ)
+    if (collapsedCq_) {
+      return prims_ibgda_poll_collapsed_cq_once<
+          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+          kCqAcquireScope>(cq, ticket);
+    }
+#endif
 #ifdef DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE
     return doca_gpu_dev_verbs_poll_one_cq_at<
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
@@ -1587,9 +1677,16 @@ class P2pIbgdaTransportDevice {
 #endif
   }
 
-  __device__ __forceinline__ void wait_cq(
+  __device__ __forceinline__ int wait_cq(
       doca_gpu_dev_verbs_qp* qp,
       doca_gpu_dev_verbs_ticket_t ticket) const {
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(PRIMS_IBGDA_DISABLE_COLLAPSED_CQ)
+    if (collapsedCq_) {
+      return prims_ibgda_wait_collapsed_cq<
+          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+          kCqAcquireScope>(doca_gpu_dev_verbs_qp_get_cq_sq(qp), ticket);
+    }
+#endif
 #ifdef DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE
     doca_gpu_dev_verbs_wait<
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
@@ -1600,6 +1697,109 @@ class P2pIbgdaTransportDevice {
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
         DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp, ticket);
 #endif
+    return 0;
+  }
+
+  template <doca_gpu_dev_verbs_resource_sharing_mode SharingMode>
+  __device__ __forceinline__ uint64_t
+  reserve_wqes_mode(doca_gpu_dev_verbs_qp* qp, uint32_t count) const {
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(PRIMS_IBGDA_DISABLE_COLLAPSED_CQ)
+    if (collapsedCq_) {
+      // The stock availability check uses the ring-CQ poller. Reserve first,
+      // then perform the same last-slot capacity check with the collapsed
+      // frontier poller. This transport never calls
+      // doca_gpu_verbs_reset_tracking_and_memory(), so cqe_rsvd remains zero;
+      // collapsed CQs always place their single visible CQE in slot zero.
+      const uint64_t firstWqe =
+          doca_gpu_dev_verbs_reserve_wq_slots<SharingMode>(
+              qp,
+              count,
+              DOCA_GPUNETIO_VERBS_GPU_CODE_OPT_SKIP_AVAILABILITY_CHECK);
+      const uint64_t lastWqe = firstWqe + count - 1;
+      const uint16_t sqDepth = __ldg(&qp->sq_wqe_num);
+      if (lastWqe >= sqDepth) {
+        // A request error is terminal for this one-CQ-per-RC-QP design, and the
+        // poller leaves it sticky. Returning lets the caller reach its
+        // abort-aware completion drain; spinning here would hide the error
+        // forever, while trapping would defeat FT.
+        (void)prims_ibgda_wait_collapsed_cq<SharingMode, kCqAcquireScope>(
+            doca_gpu_dev_verbs_qp_get_cq_sq(qp), lastWqe - sqDepth);
+      }
+      return firstWqe;
+    }
+#endif
+#ifdef DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE
+    return doca_gpu_dev_verbs_reserve_wq_slots<
+        SharingMode,
+        DOCA_GPUNETIO_VERBS_QP_SQ,
+        kCqAcquireScope>(qp, count);
+#else
+    return doca_gpu_dev_verbs_reserve_wq_slots<SharingMode>(qp, count);
+#endif
+  }
+
+#ifndef __HIP_PLATFORM_AMD__
+  __device__ __forceinline__ uint64_t put_single_local(
+      doca_gpu_dev_verbs_qp* qp,
+      doca_gpu_dev_verbs_addr remoteAddr,
+      doca_gpu_dev_verbs_addr localAddr,
+      std::size_t nbytes) const {
+    uint32_t numChunks = doca_gpu_dev_verbs_div_ceil_aligned_pow2_32bits(
+        nbytes, DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE_SHIFT);
+    numChunks = numChunks > 1 ? numChunks : 1;
+    const uint64_t firstWqe =
+        reserve_wqes_mode<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+            qp, numChunks);
+    uint64_t lastWqe = firstWqe;
+    std::size_t remainingBytes = nbytes;
+
+#pragma unroll 1
+    for (uint64_t chunk = 0; chunk < numChunks; ++chunk) {
+      lastWqe = firstWqe + chunk;
+      const std::size_t chunkBytes =
+          remainingBytes > DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE
+          ? DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE
+          : remainingBytes;
+      auto* wqe = doca_gpu_dev_verbs_get_wqe_ptr(qp, lastWqe);
+      if (chunkBytes > 0) {
+        doca_gpu_dev_verbs_wqe_prepare_write(
+            qp,
+            wqe,
+            static_cast<uint16_t>(lastWqe),
+            DOCA_GPUNETIO_IB_MLX5_OPCODE_RDMA_WRITE,
+            DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+            0,
+            remoteAddr.addr + chunk * DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE,
+            remoteAddr.key,
+            localAddr.addr + chunk * DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE,
+            localAddr.key,
+            static_cast<uint32_t>(chunkBytes));
+      } else {
+        doca_gpu_dev_verbs_wqe_prepare_nop(
+            qp,
+            wqe,
+            static_cast<uint16_t>(lastWqe),
+            DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE);
+      }
+      remainingBytes -= chunkBytes;
+    }
+
+    doca_gpu_dev_verbs_mark_wqes_ready<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(qp, firstWqe, lastWqe);
+    doca_gpu_dev_verbs_submit<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_THREAD,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp, lastWqe + 1);
+    return lastWqe;
+  }
+#endif
+
+  __device__ __forceinline__ uint64_t
+  reserve_wqes(doca_gpu_dev_verbs_qp* qp, uint32_t count) const {
+    // Same acquire scope as the completion path: the SQ-slot wait polls the
+    // same CQ, so without this it keeps the SYS-scope L1 invalidate once per
+    // posting operation. Only fires once the SQ has wrapped.
+    return reserve_wqes_mode<kQpSharingMode>(qp, count);
   }
 
   __device__ __forceinline__ void mark_wqes_ready_mode(
@@ -1765,8 +1965,9 @@ class P2pIbgdaTransportDevice {
     uint64_t numChunks = doca_gpu_dev_verbs_div_ceil_aligned_pow2(
         nbytes, DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE_SHIFT);
     numChunks = numChunks > 1 ? numChunks : 1;
-    uint64_t baseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(qp, numChunks);
+    uint64_t baseWqeIdx =
+        reserve_wqes_mode<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+            qp, numChunks);
     uint64_t wqeIdx = baseWqeIdx;
     std::size_t remainingSize = nbytes;
 
@@ -1799,8 +2000,9 @@ class P2pIbgdaTransportDevice {
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
         qp, baseWqeIdx, lastPutWqeIdx);
 
-    uint64_t companionBaseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(companionQp, 2);
+    uint64_t companionBaseWqeIdx =
+        reserve_wqes_mode<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+            companionQp, 2);
     uint64_t companionWqeIdx = companionBaseWqeIdx;
     doca_gpu_dev_verbs_wqe* wqePtr =
         doca_gpu_dev_verbs_get_wqe_ptr(companionQp, companionWqeIdx);
@@ -1882,8 +2084,9 @@ class P2pIbgdaTransportDevice {
     uint64_t numChunks = doca_gpu_dev_verbs_div_ceil_aligned_pow2(
         nbytes, DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE_SHIFT);
     numChunks = numChunks > 1 ? numChunks : 1;
-    uint64_t baseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(qp, numChunks + 1);
+    uint64_t baseWqeIdx =
+        reserve_wqes_mode<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+            qp, numChunks + 1);
     uint64_t wqeIdx = baseWqeIdx;
     std::size_t remainingSize = nbytes;
 
@@ -1932,8 +2135,9 @@ class P2pIbgdaTransportDevice {
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
         qp, baseWqeIdx, signalWqeIdx);
 
-    uint64_t companionBaseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(companionQp, 2);
+    uint64_t companionBaseWqeIdx =
+        reserve_wqes_mode<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+            companionQp, 2);
     uint64_t companionWqeIdx = companionBaseWqeIdx;
     wqePtr = doca_gpu_dev_verbs_get_wqe_ptr(companionQp, companionWqeIdx);
     doca_gpu_dev_verbs_wqe_prepare_wait(
@@ -2012,8 +2216,9 @@ class P2pIbgdaTransportDevice {
         counterSinkAddr,
         counterVal);
 #else
-    uint64_t baseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(companionQp, 2);
+    uint64_t baseWqeIdx =
+        reserve_wqes_mode<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+            companionQp, 2);
     uint64_t wqeIdx = baseWqeIdx;
     doca_gpu_dev_verbs_wqe* wqePtr =
         doca_gpu_dev_verbs_get_wqe_ptr(companionQp, wqeIdx);
@@ -2959,6 +3164,7 @@ class P2pIbgdaTransportDevice {
   DeviceSpan<IbLocalChannel> localChannels_{};
 
   IbChannelLayout channelLayout_{};
+  bool collapsedCq_{false};
 };
 
 } // namespace comms::prims

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3460,6 +3460,19 @@ cvars:
      capability query and forces VALID_DBR. Host-only loopback QPs always use
      VALID_DBR. This policy is NVIDIA-only and ignored on AMD.
 
+ - name        : MCCL_IBGDA_COLLAPSED_CQ_MODE
+   type        : enum
+   default     : auto
+   choices     : auto, on, off
+   description : |-
+     Select the completion-queue format for the Prims IBGDA transport. auto
+     probes every selected NIC and uses collapsed CQs only when all of them
+     accept the firmware CREATE_CQ request; otherwise it falls back to ordinary
+     ring CQs. on requires every selected NIC to accept collapsed CQ creation
+     and fails transport initialization otherwise. off skips the probe and
+     forces ring CQs. Host-only loopback QPs always use ring CQs. This policy is
+     NVIDIA-only and ignored on AMD.
+
  - name        : MCCL_IBGDA_WARP_PROXY_ENABLE
    type        : bool
    default     : false

--- a/comms/utils/cvars/tests/CvarInitUT.cc
+++ b/comms/utils/cvars/tests/CvarInitUT.cc
@@ -52,6 +52,7 @@ class CvarInitTest : public ::testing::Test {
     unsetenv("NCCL_MIN_CTAS");
     unsetenv("MCCL_BOOTSTRAP_TCP_KEEPALIVE_ENABLED");
     unsetenv("MCCL_IBGDA_RELIABLE_DOORBELL_MODE");
+    unsetenv("MCCL_IBGDA_COLLAPSED_CQ_MODE");
     unsetenv("MCCL_IBGDA_QP_ORDERING_SEMANTIC");
   }
 };
@@ -83,6 +84,29 @@ TEST_F(CvarInitTest, McclIbgdaReliableDoorbellModeParsesAllModes) {
     setenv("MCCL_IBGDA_RELIABLE_DOORBELL_MODE", value, 1);
     ncclCvarInit();
     EXPECT_EQ(MCCL_IBGDA_RELIABLE_DOORBELL_MODE, expected);
+  }
+}
+
+TEST_F(CvarInitTest, McclIbgdaCollapsedCqModeDefaultsToAuto) {
+  MCCL_IBGDA_COLLAPSED_CQ_MODE = MCCL_IBGDA_COLLAPSED_CQ_MODE::off;
+  ncclCvarInit();
+  EXPECT_EQ(MCCL_IBGDA_COLLAPSED_CQ_MODE, MCCL_IBGDA_COLLAPSED_CQ_MODE::auto_);
+  EXPECT_EQ(static_cast<int>(MCCL_IBGDA_COLLAPSED_CQ_MODE_DEFAULTCVARVALUE), 0);
+}
+
+TEST_F(CvarInitTest, McclIbgdaCollapsedCqModeParsesAllModes) {
+  using Mode = decltype(MCCL_IBGDA_COLLAPSED_CQ_MODE);
+  const std::vector<std::pair<const char*, Mode>> modes{
+      {"auto", Mode::auto_},
+      {"on", Mode::on},
+      {"off", Mode::off},
+  };
+  for (const auto& [value, expected] : modes) {
+    MCCL_IBGDA_COLLAPSED_CQ_MODE =
+        expected == Mode::auto_ ? Mode::on : Mode::auto_;
+    setenv("MCCL_IBGDA_COLLAPSED_CQ_MODE", value, 1);
+    ncclCvarInit();
+    EXPECT_EQ(MCCL_IBGDA_COLLAPSED_CQ_MODE, expected);
   }
 }
 


### PR DESCRIPTION
Summary:

Use mlx5 collapsed completion queues for the device-visible Prims IBGDA main and companion QPs. The NIC overwrites CQ slot 0, and a Prims-local nonblocking poller advances the software completion frontier from the CQE WQE counter. One later CQE can therefore retire earlier WQE tickets, avoiding redundant CQ-memory polls in sequences such as `put+signal -> wait_local(WRITE) -> flush(ATOMIC)`.

The poller follows the upstream GPUNetIO v4 collapsed-CQ frontier algorithm, adapted to Prims' ticket convention: Prims tickets name the WQE, whereas upstream's consumer index names WQE+1. The reservation path uses the same collapsed-aware frontier rather than DOCA's ring-CQ availability poll. Large puts retain the stock multi-WQE chunking and completion behavior. This change does not suppress CQEs: every posted WQE remains signalled.

Add `MCCL_IBGDA_COLLAPSED_CQ_MODE=auto|on|off`. `auto` probes collapsed creation on every selected NIC and enables the format only when every NIC accepts it; `on` fails closed; `off` skips the probe and is the operational kill switch. If both the collapsed probe and its ring control fail, initialization fails loudly because the probe cannot distinguish unsupported collapse from a broken QP-creation environment. The mode is resolved inside `MultipeerIbgdaTransport`, so both Ctran and standalone Link-EP honor it. Link-EP does not initialize NCCL CVARs today, so the resolver reads the raw environment first, then an initialized non-default CVar, then the explicit transport config.

Host CQ creation and device polling are selected by the same resolved bit. Host-only loopback QPs remain ring CQs. `PRIMS_IBGDA_DISABLE_COLLAPSED_CQ` keeps the legacy ncclx v2.29 Make/Conda path on ring CQs: that path can compile Prims against the installed newer header while its hidden bundled GPUNetIO host implementation has no `cq_collapsed` field and hardcodes CQC `cc=0`. Stable v2.30 and OSS MCCL are not gated; their header and host implementation support collapsed CQ creation.

The automatic probe proves that collapsed creation succeeds, not that an arbitrarily mismatched linked implementation honored the format. Supported packages keep GPUNetIO headers and host objects from the same source revision; the known mixed v2.29 path is explicitly gated. A functional loopback probe can harden this further in a follow-up.

Add policy/CVar tests, fabricated-CQE tests for frontier/error/window/wrap semantics, format assertions, a forced ring/collapsed depth-32 real-NIC wrap test covering main and companion QPs, delayed bad-rkey error polling, and a microbenchmark for `put+signal -> wait_local(WRITE) -> flush(ATOMIC)`.

The existing ANS transport cases are detached from this test target because nvCOMP Dx currently rejects GB300-native code generation. The tests remain in their separately buildable target and can be reattached when `AnsCompress` supports sm_103a.

Reviewed By: Scusemua, saifhhasan

Differential Revision: D118687121
