### PR TITLE
ctran: force receiver-side flush when spray mode is in effect (#4026)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceDirect.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceDirect.cc
@@ -8,6 +8,7 @@
 #include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/algos/common/OccupancyUtils.h"
+#include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/commSpecs.h"
@@ -249,6 +250,12 @@ static commResult_t impl(
   static thread_local auto allReduceConfig =
       comm->ctran_->algo->getCollToVcConfig(CollType::ALLREDUCE);
 
+  // Set-once ambient IB config for this collective; all inter-node puts below
+  // (steps 2, 3, 7) observe it without per-call overrides. Note steps 3 and 7
+  // previously used the VC default; they now follow the collective override.
+  CtranIbActiveConfigRAII activeIbConfig(
+      comm->ctran_->mapper->ctranIbPtr(), allReduceConfig);
+
   while (totalStepCount) {
     size_t chunkCount = stepCount / nRanks;
     size_t chunk = chunkCount * typeSize;
@@ -295,8 +302,7 @@ static commResult_t impl(
               CtranMapperConfig{
                   .memHdl_ = recvHdl,
                   .remoteAccessKey_ = interNodeRemoteTmpAccessKey,
-                  .notify_ = true,
-                  .ibConfig_ = allReduceConfig},
+                  .notify_ = true},
               &req));
           interNodePutReq[n] = std::unique_ptr<CtranMapperRequest>(req);
         }

--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -24,6 +24,7 @@
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/algos/CtranAlgoConsts.h"
 #include "comms/ctran/algos/common/OccupancyUtils.h"
+#include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/CtranLogUtils.h"
@@ -324,8 +325,12 @@ inline void progressSendPostTrans(
   char* tmpSendBuf = reinterpret_cast<char*>(resource.tmpSendBuf) +
       tmpChunkId * algoCtx.chunkSize;
 
-  CtranIbConfig* allReduceConfig =
-      resource.ibConfig ? &*resource.ibConfig : nullptr;
+  // Set-once ambient IB config for the puts issued below. This progress
+  // function runs on the GPE thread after ctranAllReduceRing returns, so the
+  // guard lives here (the issuing scope), not at collective entry.
+  CtranIbActiveConfigRAII activeIbConfig(
+      resource.comm->ctran_->mapper->ctranIbPtr(),
+      resource.ibConfig ? &*resource.ibConfig : nullptr);
 
   CtranMapperRequest* req;
   FB_COMMCHECKTHROW_EX(
@@ -337,8 +342,7 @@ inline void progressSendPostTrans(
           CtranMapperConfig{
               .memHdl_ = resource.tmpSendBufHdl,
               .remoteAccessKey_ = args.rightRemKey,
-              .notify_ = true,
-              .ibConfig_ = allReduceConfig},
+              .notify_ = true},
           &req),
       resource.comm->logMetaData_);
   dataSResps.at(round).reset(req);
@@ -729,8 +733,12 @@ inline void progressRevSendPostTrans(
   char* tmpSendBufRev = reinterpret_cast<char*>(resource.tmpSendBufRev) +
       tmpChunkId * algoCtx.chunkSize;
 
-  CtranIbConfig* allReduceConfig =
-      resource.ibConfig ? &*resource.ibConfig : nullptr;
+  // Set-once ambient IB config for the puts issued below. This progress
+  // function runs on the GPE thread after ctranAllReduceRing returns, so the
+  // guard lives here (the issuing scope), not at collective entry.
+  CtranIbActiveConfigRAII activeIbConfig(
+      resource.comm->ctran_->mapper->ctranIbPtr(),
+      resource.ibConfig ? &*resource.ibConfig : nullptr);
 
   CtranMapperRequest* req;
   FB_COMMCHECKTHROW_EX(
@@ -742,8 +750,7 @@ inline void progressRevSendPostTrans(
           CtranMapperConfig{
               .memHdl_ = resource.tmpSendBufRevHdl,
               .remoteAccessKey_ = args.leftRemKeyRev,
-              .notify_ = true,
-              .ibConfig_ = allReduceConfig},
+              .notify_ = true},
           &req),
       resource.comm->logMetaData_);
   revDataSResps.at(round).reset(req);

--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -405,6 +405,13 @@ inline void progressRecvPostFlush(
   char* tmpRecvBuf = reinterpret_cast<char*>(resource.tmpRecvBuf) +
       tmpChunkId * algoCtx.chunkSize;
 
+  // Ambient config for the spray-forced flush check in iflush. This runs
+  // on the GPE thread after ctranAllReduceRing returns, so the guard lives
+  // here (the issuing scope), mirroring the send-side progress functions.
+  CtranIbActiveConfigRAII activeIbConfig(
+      resource.comm->ctran_->mapper->ctranIbPtr(),
+      resource.ibConfig ? &*resource.ibConfig : nullptr);
+
   CtranMapperRequest* req = nullptr;
   FB_COMMCHECKTHROW_EX(
       resource.comm->ctran_->mapper->iflush(
@@ -797,6 +804,13 @@ inline void progressRevRecvPostFlush(
   int tmpChunkId = getTmpChunkId(algoCtx, round);
   char* tmpRecvBufRev = reinterpret_cast<char*>(resource.tmpRecvBufRev) +
       tmpChunkId * algoCtx.chunkSize;
+
+  // Ambient config for the spray-forced flush check in iflush. This runs
+  // on the GPE thread after ctranAllReduceRing returns, so the guard lives
+  // here (the issuing scope), mirroring the send-side progress functions.
+  CtranIbActiveConfigRAII activeIbConfig(
+      resource.comm->ctran_->mapper->ctranIbPtr(),
+      resource.ibConfig ? &*resource.ibConfig : nullptr);
 
   CtranMapperRequest* req = nullptr;
   FB_COMMCHECKTHROW_EX(

--- a/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
@@ -7,6 +7,7 @@
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/algos/PersistentCleanup.h"
 #include "comms/ctran/algos/common/NvlUtils.h"
+#include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/regcache/IpcRegCache.h"
@@ -234,6 +235,11 @@ commResult_t ctranAllToAllPIbImpl(
       ? alltoallpIbConfig->qpScalingTh
       : NCCL_CTRAN_IB_QP_SCALING_THRESHOLD;
 
+  // Set-once ambient IB config for this collective; the data-phase puts below
+  // observe it without per-call overrides.
+  CtranIbActiveConfigRAII activeIbConfig(
+      comm->ctran_->mapper->ctranIbPtr(), alltoallpIbConfig);
+
   CTRAN_PROFILER_IF(
       profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
 
@@ -256,7 +262,6 @@ commResult_t ctranAllToAllPIbImpl(
             .memHdl_ = sendMemHdl,
             .remoteAccessKey_ = pArgs->remoteAccessKeys[peer],
             .notify_ = true /*notify*/,
-            .ibConfig_ = alltoallpIbConfig,
             .ibFastPath_ = enableFastPath},
         &ibPutReqs[idx++]));
     if (useProfiler) {

--- a/comms/ctran/algos/AllToAll/AllToAllvImpl.h
+++ b/comms/ctran/algos/AllToAll/AllToAllvImpl.h
@@ -7,6 +7,7 @@
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -210,6 +211,11 @@ commResult_t ctranAllToAllvIbImpl(
   static thread_local auto alltoallvIbConfig =
       comm->ctran_->algo->getCollToVcConfig(CollType::ALLTOALL);
 
+  // Set-once ambient IB config for this collective; the data-phase puts below
+  // observe it without per-call overrides.
+  CtranIbActiveConfigRAII activeIbConfig(
+      comm->ctran_->mapper->ctranIbPtr(), alltoallvIbConfig);
+
   // issue network puts:
   // - Sender puts data for peers, whenever received the remote recvbuff handle
   // - Exit until all peers' put have been issued (putPeers becomes empty)
@@ -252,7 +258,6 @@ commResult_t ctranAllToAllvIbImpl(
             .memHdl_ = sendMemHdl[peer],
             .remoteAccessKey_ = remoteAccessKeys[peer],
             .notify_ = true, /*notify*/
-            .ibConfig_ = alltoallvIbConfig,
             .ibFastPath_ = enableFastPath},
         &ibPutReqs[idx++]));
     if (useProfiler) {

--- a/comms/ctran/algos/SendRecv/SendRecvImpl.h
+++ b/comms/ctran/algos/SendRecv/SendRecvImpl.h
@@ -9,6 +9,7 @@
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/utils/CtranLogUtils.h"
@@ -242,6 +243,10 @@ inline commResult_t sendRecvImpl(
   static thread_local auto sendRecvConfig =
       comm->ctran_->algo->getCollToVcConfig(CollType::SENDRECV);
 
+  // Set-once ambient IB config for this group; the puts below observe it
+  // without per-call overrides.
+  CtranIbActiveConfigRAII activeIbConfig(mapper->ctranIbPtr(), sendRecvConfig);
+
   // As we recv control msgs, issue PUT operations
   bool isIssuedFirst = false;
   while (putReqs.size() < sendOpGroup.size() && !comm->testAbort()) {
@@ -281,8 +286,7 @@ inline commResult_t sendRecvImpl(
                 .memHdl_ = sendMemHdl[i],
                 .remoteAccessKey_ = remoteAccessKey[i],
                 .notify_ = true,
-                .kernElem_ = op->send.kElem,
-                .ibConfig_ = sendRecvConfig},
+                .kernElem_ = op->send.kElem},
             &req));
         putReqs[i] = std::unique_ptr<CtranMapperRequest>(req);
         timestamp->putIssued.push_back(

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -943,8 +943,20 @@ commResult_t CtranIb::iflush(
     CtranIbRequest* req) {
   FB_COMMCHECK(checkEpochLock(this));
 
-  if (enableLocalFlush_ && localRegHdl != nullptr) {
+  // Spray mode needs a receiver-side flush for data integrity even when
+  // NCCL_CTRAN_NET_FORCE_FLUSH=0 (see sprayFlushRequired). localVc may not
+  // exist when local flush was disabled at construction; create it lazily.
+  // A null registration still skips: with no IB registration there are no
+  // RDMA writes to order against, and LocalVirtualConn::iflush requires a
+  // valid registration.
+  if ((enableLocalFlush_ || sprayFlushRequired()) && localRegHdl != nullptr) {
     CTRAN_IB_PER_OBJ_LOCK_GUARD(localVcMutex, {
+      if (localVc == nullptr) {
+        localVc = std::make_unique<LocalVirtualConn>(devices, ncclLogData);
+      }
+      // Publish before posting so the progress loop routes this flush's
+      // CQE to localVc even after the collective's ambient config is gone.
+      localFlushUsed_.store(true, std::memory_order_release);
       auto& vc = localVc;
       return vc->iflush(dbuf, localRegHdl, req);
     });

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -263,7 +263,6 @@ class CtranIb {
       void* ibRegElem,
       CtranIbRemoteAccessKey remoteAccessKey,
       bool notify,
-      CtranIbConfig* config,
       CtranIbRequest* req,
       bool fast = false) {
     return iputImpl<PerfConfig>(
@@ -274,7 +273,6 @@ class CtranIb {
         ibRegElem,
         remoteAccessKey,
         notify,
-        config,
         req,
         fast);
   }
@@ -325,19 +323,10 @@ class CtranIb {
       int peerRank,
       void* ibRegElem,
       CtranIbRemoteAccessKey remoteAccessKey,
-      CtranIbConfig* config,
       CtranIbRequest* req,
       bool fast = false) {
     return igetImpl<PerfConfig>(
-        sbuf,
-        dbuf,
-        len,
-        peerRank,
-        ibRegElem,
-        remoteAccessKey,
-        config,
-        req,
-        fast);
+        sbuf, dbuf, len, peerRank, ibRegElem, remoteAccessKey, req, fast);
   }
 
   // Input arguments:
@@ -573,6 +562,7 @@ class CtranIb {
 
  private:
   friend class CtranIbRequest;
+  friend class CtranIbActiveConfigRAII;
   void init(
       CtranComm* comm,
       int rank,
@@ -849,6 +839,16 @@ class CtranIb {
     return commSuccess;
   }
 
+  // Ambient per-collective IB config override. Null clears back to VC
+  // defaults. See activeIbConfig_.
+  inline void setActiveIbConfig(const CtranIbConfig* config) {
+    activeIbConfig_ = config;
+  }
+
+  inline const CtranIbConfig* activeIbConfig() const {
+    return activeIbConfig_;
+  }
+
   template <typename PerfConfig = DefaultPerfCollConfig>
   inline commResult_t iputBatchImpl(
       const std::vector<PutIbMsg>& puts,
@@ -859,8 +859,11 @@ class CtranIb {
         vcState_.getVc<PerfConfig>(peerRank);
     FB_COMMCHECK(checkValidVc(vc, peerRank));
 
-    CTRAN_IB_PER_OBJ_LOCK_GUARD(
-        vc->mutex, { FB_COMMCHECK(vc->iputBatch<PerfConfig>(puts)); });
+    CTRAN_IB_PER_OBJ_LOCK_GUARD(vc->mutex, {
+      // Sole config source: the ambient per-collective config. There is
+      // no per-call override at this level; use setActiveIbConfig.
+      FB_COMMCHECK(vc->iputBatch<PerfConfig>(puts, activeIbConfig_));
+    });
 
     return commSuccess;
   }
@@ -874,7 +877,6 @@ class CtranIb {
       void* ibRegElem,
       CtranIbRemoteAccessKey remoteAccessKey,
       bool notify,
-      CtranIbConfig* config,
       CtranIbRequest* req,
       bool fast) {
     FB_COMMCHECK(checkEpochLock(this));
@@ -884,6 +886,8 @@ class CtranIb {
     FB_COMMCHECK(checkValidVc(vc, peerRank));
 
     CTRAN_IB_PER_OBJ_LOCK_GUARD(vc->mutex, {
+      // Sole config source: the ambient per-collective config. There is
+      // no per-call override at this level; use setActiveIbConfig.
       FB_COMMCHECK(vc->iput<PerfConfig>(
           sbuf,
           dbuf,
@@ -891,7 +895,7 @@ class CtranIb {
           ibRegElem,
           remoteAccessKey,
           notify,
-          config,
+          activeIbConfig_,
           req,
           fast));
     });
@@ -907,7 +911,6 @@ class CtranIb {
       int peerRank,
       void* ibRegElem,
       CtranIbRemoteAccessKey remoteAccessKey,
-      CtranIbConfig* config,
       CtranIbRequest* req,
       bool fast) {
     FB_COMMCHECK(checkEpochLock(this));
@@ -917,8 +920,17 @@ class CtranIb {
     FB_COMMCHECK(checkValidVc(vc, peerRank));
 
     CTRAN_IB_PER_OBJ_LOCK_GUARD(vc->mutex, {
+      // Sole config source: the ambient per-collective config. There is
+      // no per-call override at this level; use setActiveIbConfig.
       FB_COMMCHECK(vc->iget<PerfConfig>(
-          sbuf, dbuf, len, ibRegElem, remoteAccessKey, config, req, fast));
+          sbuf,
+          dbuf,
+          len,
+          ibRegElem,
+          remoteAccessKey,
+          activeIbConfig_,
+          req,
+          fast));
     });
 
     return commSuccess;
@@ -1125,6 +1137,13 @@ class CtranIb {
   std::string commDesc;
   CommLogData ncclLogData;
   bool enableLocalFlush_{true};
+  // Ambient per-collective IB config (override for puts/gets issued while
+  // set). Set once at collective scope entry via CtranIbActiveConfigRAII
+  // (EpochLock-style); read at op-issue time, when VC snapshots the resolved
+  // values into PutInfo/GetInfo. Null (default) means VC defaults govern.
+  // Contract: set only when no ops are outstanding (collective boundary),
+  // while holding the epoch lock like all other CtranIb critical-path state.
+  const CtranIbConfig* activeIbConfig_{nullptr};
   BootstrapMode bootstrapMode{BootstrapMode::kDefaultServer};
 
   std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory_;
@@ -1168,6 +1187,35 @@ class CtranIb {
   std::unordered_map<std::string, uint32_t> pgToTrafficClassMap_;
 
   std::shared_ptr<::comms::fault_tolerance::Abort> abortCtrl_{nullptr};
+};
+
+// EpochLock-style scope guard for the ambient per-collective IB config:
+// sets it on entry, restores the previous value on exit (null-safe).
+// Unlike epochLock(), nesting is allowed — save/restore keeps each scope's
+// config intact. Pair with collective scope: all puts/gets issued inside
+// observe `config` unless they carry an explicit per-op override.
+class CtranIbActiveConfigRAII {
+ public:
+  CtranIbActiveConfigRAII(CtranIb* ctranIb, const CtranIbConfig* config)
+      : ctranIb_(ctranIb) {
+    if (ctranIb_ != nullptr) {
+      prev_ = ctranIb_->activeIbConfig();
+      ctranIb_->setActiveIbConfig(config);
+    }
+  }
+
+  ~CtranIbActiveConfigRAII() {
+    if (ctranIb_ != nullptr) {
+      ctranIb_->setActiveIbConfig(prev_);
+    }
+  }
+
+  CtranIbActiveConfigRAII(const CtranIbActiveConfigRAII&) = delete;
+  CtranIbActiveConfigRAII& operator=(const CtranIbActiveConfigRAII&) = delete;
+
+ private:
+  CtranIb* ctranIb_{nullptr};
+  const CtranIbConfig* prev_{nullptr};
 };
 
 // Convenient RAII class to guard CtranIb epoch lock.

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -4,6 +4,7 @@
 #define CTRAN_IB_H_
 
 #include <folly/SocketAddress.h>
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
@@ -849,6 +850,19 @@ class CtranIb {
     return activeIbConfig_;
   }
 
+  // True when a receiver-side flush is required for spray-mode data
+  // integrity even if NCCL_CTRAN_NET_FORCE_FLUSH=0: spray delivers data
+  // with plain RDMA writes and a separate WRITE_IMM notify, so the data
+  // may not be GPU-visible when the notify arrives. Spray is in effect
+  // when the ambient per-collective override selects it, or when any
+  // established VC's default mode is spray (and no override says
+  // otherwise — over-flushing in that corner is safe, only a perf cost).
+  inline bool sprayFlushRequired() const {
+    return (activeIbConfig_ != nullptr &&
+            activeIbConfig_->vcMode == NCCL_CTRAN_IB_VC_MODE::spray) ||
+        vcState_.anyVcDefaultUsesSpray();
+  }
+
   template <typename PerfConfig = DefaultPerfCollConfig>
   inline commResult_t iputBatchImpl(
       const std::vector<PutIbMsg>& puts,
@@ -1078,11 +1092,15 @@ class CtranIb {
           continueWhileLoop = true;
         }
 
-        if (enableLocalFlush_) {
+        // Also route here when a spray-forced flush was ever issued: its CQE
+        // can be polled after the issuing collective's ambient config is
+        // gone. localFlushUsed_ is set before the WQE is posted.
+        if (enableLocalFlush_ ||
+            localFlushUsed_.load(std::memory_order_acquire)) {
           CTRAN_IB_PER_OBJ_LOCK_GUARD(localVcMutex, {
             auto& vc = localVc;
             // First check if it is a local flush CQE
-            if (wc.qp_num == vc->qpNum(device)) {
+            if (vc != nullptr && wc.qp_num == vc->qpNum(device)) {
               CQE_ERROR_CHECK(wc, rank, "localFlush");
               FB_COMMCHECK(vc->processCqe(wc.opcode, device));
               continue;
@@ -1144,6 +1162,12 @@ class CtranIb {
   // Contract: set only when no ops are outstanding (collective boundary),
   // while holding the epoch lock like all other CtranIb critical-path state.
   const CtranIbConfig* activeIbConfig_{nullptr};
+  // Sticky: a real local-flush WQE was issued at least once (via the
+  // spray-forced path below while enableLocalFlush_ is false). Keeps the
+  // progress loop routing local-flush CQEs to localVc after the issuing
+  // collective's ambient config is gone. Set (release) under localVcMutex
+  // before posting the WQE; read (acquire) in the CQE dispatch path.
+  std::atomic<bool> localFlushUsed_{false};
   BootstrapMode bootstrapMode{BootstrapMode::kDefaultServer};
 
   std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory_;

--- a/comms/ctran/backends/ib/CtranIbVc.h
+++ b/comms/ctran/backends/ib/CtranIbVc.h
@@ -434,7 +434,7 @@ class CtranIbVirtualConn {
   }
 
   // Getter function for vcMode_
-  inline enum NCCL_CTRAN_IB_VC_MODE getVcMode() {
+  inline enum NCCL_CTRAN_IB_VC_MODE getVcMode() const {
     return vcMode_;
   }
 

--- a/comms/ctran/backends/ib/CtranIbVc.h
+++ b/comms/ctran/backends/ib/CtranIbVc.h
@@ -174,7 +174,6 @@ struct PutIbMsg {
   void* ibRegElem;
   CtranIbRemoteAccessKey remoteAccessKey;
   bool notify;
-  CtranIbConfig* config;
   CtranIbRequest* req;
 };
 
@@ -308,7 +307,9 @@ class CtranIbVirtualConn {
   }
 
   // Implementation to put data from local sbuf to a dbuf in remote rank over
-  // the established IB connection.
+  // the established IB connection. The per-call config selects the QP
+  // settings for this op; CtranIb always passes its ambient per-collective
+  // config (set via setActiveIbConfig), null selects the VC defaults.
   template <typename PerfConfig = DefaultPerfCollConfig>
   inline commResult_t iput(
       const void* sbuf,
@@ -317,7 +318,7 @@ class CtranIbVirtualConn {
       void* ibRegElem,
       CtranIbRemoteAccessKey remoteAccessKey,
       bool notify,
-      CtranIbConfig* config,
+      const CtranIbConfig* config,
       CtranIbRequest* req,
       bool fast) {
     return iputImpl<PerfConfig>(
@@ -325,8 +326,10 @@ class CtranIbVirtualConn {
   }
 
   template <typename PerfConfig = DefaultPerfCollConfig>
-  inline commResult_t iputBatch(const std::vector<PutIbMsg>& msgs) {
-    return iputBatchImpl<PerfConfig>(msgs);
+  inline commResult_t iputBatch(
+      const std::vector<PutIbMsg>& msgs,
+      const CtranIbConfig* ambient = nullptr) {
+    return iputBatchImpl<PerfConfig>(msgs, ambient);
   }
 
   // Implementation to get data from a sbuf in remote rank to a local dbuf over
@@ -338,7 +341,7 @@ class CtranIbVirtualConn {
       std::size_t len,
       void* ibRegElem,
       CtranIbRemoteAccessKey remoteAccessKey,
-      CtranIbConfig* config,
+      const CtranIbConfig* config,
       CtranIbRequest* req,
       bool fast) {
     return igetImpl<PerfConfig>(
@@ -524,8 +527,8 @@ class CtranIbVirtualConn {
   template <typename OpPtr>
   inline uint64_t nextWqeSize(const OpPtr& op) {
     const uint64_t remData = op->len - op->offset;
-    const auto opQps = std::min(getOpQps(op->config), maxNumQps_);
-    return std::min(remData, maxWqeSizeFor(op->config, op->len, opQps));
+    const auto opQps = std::min(op->numQps, maxNumQps_);
+    return std::min(remData, maxWqeSizeFor(op->qpScalingTh, op->len, opQps));
   }
 
   // Returns the IB device that hosts the control QPs for this VC.
@@ -681,16 +684,19 @@ class CtranIbVirtualConn {
   // else an equal split (len / qps); clamped to [mtu_, maxMsgSize_]. The
   // single-WQE fast path passes qps=1 (no QP scaling, so the fallback is the
   // whole message).
+  inline uint64_t maxWqeSizeFor(size_t qpScalingTh, uint64_t len, int qps) {
+    const uint64_t raw = qpScalingTh > 0 ? qpScalingTh : len / std::max(qps, 1);
+    return std::min(maxMsgSize_, std::max(raw, mtu_));
+  }
+
   inline uint64_t
   maxWqeSizeFor(const CtranIbConfig* config, uint64_t len, int qps) {
-    const auto scalingTh = getOpScalingTh(config);
-    const uint64_t raw = scalingTh > 0 ? scalingTh : len / std::max(qps, 1);
-    return std::min(maxMsgSize_, std::max(raw, mtu_));
+    return maxWqeSizeFor(getOpScalingTh(config), len, qps);
   }
 
   template <typename PerfConfig = DefaultPerfCollConfig>
   inline bool
-  isFastPutValid(CtranIbConfig* config, size_t len, size_t numMessages) {
+  isFastPutValid(const CtranIbConfig* config, size_t len, size_t numMessages) {
     if (outstandingPuts_.size() > 0 || pendingPuts_.size() > 0) {
       CTRAN_LOG(
           INFO,
@@ -764,7 +770,9 @@ class CtranIbVirtualConn {
   }
 
   template <typename PerfConfig = DefaultPerfCollConfig>
-  inline commResult_t iputBatchImpl(const std::vector<PutIbMsg>& msgs) {
+  inline commResult_t iputBatchImpl(
+      const std::vector<PutIbMsg>& msgs,
+      const CtranIbConfig* ambient = nullptr) {
     std::vector<ibverbx::ibv_send_wr> sendBatchWrs(msgs.size());
     std::vector<ibverbx::ibv_sge> sendBatchSges(msgs.size());
 
@@ -775,7 +783,7 @@ class CtranIbVirtualConn {
     bool sendChained = true;
     // first check if all the messages can be sent over the fast path
     for (auto& put : msgs) {
-      if (!isFastPutValid<PerfConfig>(put.config, put.len, msgs.size())) {
+      if (!isFastPutValid<PerfConfig>(ambient, put.len, msgs.size())) {
         // Fallback to slow path and non batched writes
         sendChained = false;
         break;
@@ -797,7 +805,7 @@ class CtranIbVirtualConn {
                 put.ibRegElem,
                 put.remoteAccessKey,
                 put.notify,
-                put.config,
+                ambient,
                 put.req,
                 false));
       }
@@ -848,7 +856,7 @@ class CtranIbVirtualConn {
       void* ibRegElem,
       CtranIbRemoteAccessKey remoteAccessKey,
       bool notify,
-      CtranIbConfig* config,
+      const CtranIbConfig* config,
       CtranIbRequest* req,
       bool fast) {
     std::vector<uint32_t> lkeys;
@@ -895,7 +903,6 @@ class CtranIbVirtualConn {
           .ibRegElem = ibRegElem,
           .remoteAccessKey = remoteAccessKey,
           .notify = notify,
-          .config = config,
           .req = req};
       int device = getIbDevFromQpIdx(iputFastQpIdx_);
 
@@ -934,7 +941,9 @@ class CtranIbVirtualConn {
               std::move(rkeys),
               notify,
               req,
-              config,
+              getOpQps(config),
+              getOpMaxQpMsgs(config),
+              getOpScalingTh(config),
               getOpVcMode(config),
               putId));
       FB_COMMCHECK(tryToPostOp(
@@ -954,7 +963,7 @@ class CtranIbVirtualConn {
       std::size_t len,
       void* ibRegElem,
       CtranIbRemoteAccessKey remoteAccessKey,
-      CtranIbConfig* config,
+      const CtranIbConfig* config,
       CtranIbRequest* req,
       bool fast) {
     std::vector<uint32_t> lkeys;
@@ -1053,7 +1062,9 @@ class CtranIbVirtualConn {
               std::move(lkeys),
               std::move(rkeys),
               req,
-              config,
+              getOpQps(config),
+              getOpMaxQpMsgs(config),
+              getOpScalingTh(config),
               getOpVcMode(config),
               getId));
       FB_COMMCHECK(tryToPostOp(
@@ -1398,8 +1409,8 @@ class CtranIbVirtualConn {
     while (sent && (pendingOpQueue.size() > 0)) {
       sent = false;
       auto& op = pendingOpQueue.front();
-      auto qps = std::min(getOpQps(op->config), maxNumQps_);
-      auto maxmsgs = std::min(getOpMaxQpMsgs(op->config), maxQpMsgs_);
+      auto qps = std::min(op->numQps, maxNumQps_);
+      auto maxmsgs = std::min(op->qpMsgs, maxQpMsgs_);
       // Interleave this op's WQEs across NICs only when enabled, the VC spans
       // >1 NIC, and each WQE is large enough to be bandwidth-bound. Small WQEs
       // (<= qpInterleaveMinWqeSize_) are latency-bound; spreading them across
@@ -1444,7 +1455,7 @@ class CtranIbVirtualConn {
     uint64_t remData = put->len - put->offset;
     // Write WQEs of max size qpScalingTh_, else divide the message among QPs.
     uint64_t maxWqeSize = maxWqeSizeFor(
-        put->config, put->len, std::min(getOpQps(put->config), maxNumQps_));
+        put->qpScalingTh, put->len, std::min(put->numQps, maxNumQps_));
     auto toSend = std::min(remData, maxWqeSize);
     bool finalWriteOfPut = toSend == remData;
 
@@ -1525,7 +1536,7 @@ class CtranIbVirtualConn {
     uint64_t remData = get->len - get->offset;
     // Write WQEs of max size qpScalingTh_, else divide the message among QPs.
     uint64_t maxWqeSize = maxWqeSizeFor(
-        get->config, get->len, std::min(getOpQps(get->config), maxNumQps_));
+        get->qpScalingTh, get->len, std::min(get->numQps, maxNumQps_));
     auto toSend = std::min(remData, maxWqeSize);
     bool finalReadOfGet = toSend == remData;
 
@@ -1800,6 +1811,10 @@ class CtranIbVirtualConn {
     std::deque<std::unique_ptr<ControlPostedRecvWr>> enqueuedWrs_;
   } recvCtrl_;
 
+  // Per-call IB config values are snapshotted (not the pointer) at issue
+  // time: progress paths (tryToPostOp, queueWrite/ReadOnQp) drain an op over
+  // many polls, and must observe the config that was in effect when the op
+  // was issued even if the ambient per-collective config changes afterwards.
   struct PutInfo {
     PutInfo(
         const void* sbuf,
@@ -1809,7 +1824,9 @@ class CtranIbVirtualConn {
         std::vector<uint32_t> rkeys,
         bool notify,
         CtranIbRequest* req,
-        CtranIbConfig* config,
+        int numQps,
+        int qpMsgs,
+        size_t qpScalingTh,
         enum NCCL_CTRAN_IB_VC_MODE vcMode,
         const uint64_t putId)
         : sbuf(sbuf),
@@ -1819,7 +1836,9 @@ class CtranIbVirtualConn {
           rkeys(std::move(rkeys)),
           notify(notify),
           req(req),
-          config(config),
+          numQps(numQps),
+          qpMsgs(qpMsgs),
+          qpScalingTh(qpScalingTh),
           vcMode(vcMode),
           putId{putId} {}
     const void* sbuf;
@@ -1829,7 +1848,9 @@ class CtranIbVirtualConn {
     std::vector<uint32_t> rkeys;
     bool notify;
     CtranIbRequest* req;
-    CtranIbConfig* config;
+    int numQps;
+    int qpMsgs;
+    size_t qpScalingTh;
     enum NCCL_CTRAN_IB_VC_MODE vcMode;
 
     size_t offset{0};
@@ -1846,7 +1867,9 @@ class CtranIbVirtualConn {
         std::vector<uint32_t> lkeys,
         std::vector<uint32_t> rkeys,
         CtranIbRequest* req,
-        CtranIbConfig* config,
+        int numQps,
+        int qpMsgs,
+        size_t qpScalingTh,
         enum NCCL_CTRAN_IB_VC_MODE vcMode,
         const uint64_t getId)
         : sbuf(sbuf),
@@ -1855,7 +1878,9 @@ class CtranIbVirtualConn {
           lkeys(std::move(lkeys)),
           rkeys(std::move(rkeys)),
           req(req),
-          config(config),
+          numQps(numQps),
+          qpMsgs(qpMsgs),
+          qpScalingTh(qpScalingTh),
           vcMode(vcMode),
           getId{getId} {}
     const void* sbuf;
@@ -1864,7 +1889,9 @@ class CtranIbVirtualConn {
     std::vector<uint32_t> lkeys;
     std::vector<uint32_t> rkeys;
     CtranIbRequest* req;
-    CtranIbConfig* config;
+    int numQps;
+    int qpMsgs;
+    size_t qpScalingTh;
     enum NCCL_CTRAN_IB_VC_MODE vcMode;
 
     size_t offset{0};

--- a/comms/ctran/backends/ib/VcState.h
+++ b/comms/ctran/backends/ib/VcState.h
@@ -103,6 +103,24 @@ class VcState {
     connectedPeerMap_.at(peerRank) = true;
   }
 
+  // True if any established VC's default QP mode is spray. Used by the
+  // spray-forced flush path: spray data writes need a receiver-side flush
+  // for GPU visibility even when NCCL_CTRAN_NET_FORCE_FLUSH=0. VC defaults
+  // are fixed at construction (setDefaultQPConfig), so reading vcMode_
+  // under the maps lock without per-VC mutexes is safe.
+  inline bool anyVcDefaultUsesSpray() const {
+    auto locked = vcStateMaps_.rlock();
+    for (const auto& [peerRank, vcs] : locked->rankToVcs) {
+      (void)peerRank;
+      for (const auto& vc : vcs) {
+        if (vc != nullptr && vc->getVcMode() == NCCL_CTRAN_IB_VC_MODE::spray) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   // Whether connectedPeerMap_ has been sized (non-empty means nRanks is
   // known). Used by preConnect() to early-out when no comm is associated.
   inline bool hasConnectedPeerMap() const {

--- a/comms/ctran/backends/ib/benchmarks/CtranIbBench.cc
+++ b/comms/ctran/backends/ib/benchmarks/CtranIbBench.cc
@@ -229,6 +229,11 @@ benchmarkIput(benchmark::State& state, CtranIbConfig config, bool withNotify) {
   const size_t bufferSize = state.range(0);
   auto ctx = setupBenchmarkContext(bufferSize);
 
+  // The per-call config override is gone; the config is now ambient and is
+  // installed once for the scope that issues the puts, so each registered
+  // variant still measures its own config.
+  CtranIbActiveConfigRAII activeConfig(ctx.senderIb.get(), &config);
+
   // Benchmark the iput operation
   for (auto _ : state) {
     CtranIbRequest ibReq;
@@ -240,7 +245,6 @@ benchmarkIput(benchmark::State& state, CtranIbConfig config, bool withNotify) {
             ctx.senderRegHdl, /* ibRegElem */
             ctx.ibReceiveKey, /* remoteAccessKey */
             withNotify, /* notify */
-            &config, /* config */
             &ibReq, /* req */
             false /* fast */
             ) != commSuccess) {
@@ -272,7 +276,11 @@ benchmarkIget(benchmark::State& state, CtranIbConfig config, bool withNotify) {
   const size_t bufferSize = state.range(0);
   auto ctx = setupBenchmarkContext(bufferSize);
 
-  // Benchmark the iput operation
+  // See benchmarkIput: the config is ambient now, installed once for the
+  // scope that issues the gets.
+  CtranIbActiveConfigRAII activeConfig(ctx.receiverIb.get(), &config);
+
+  // Benchmark the iget operation
   for (auto _ : state) {
     CtranIbRequest ibReq;
     if (ctx.receiverIb->iget(
@@ -282,7 +290,6 @@ benchmarkIget(benchmark::State& state, CtranIbConfig config, bool withNotify) {
             kDummyRank, /* peerRank */
             ctx.receiverRegHdl, /* ibRegElem */
             ctx.ibSendKey, /* remoteAccessKey */
-            &config, /* config */
             &ibReq, /* req */
             false /* fast */
             ) != commSuccess) {
@@ -361,6 +368,10 @@ static void benchmarkMultiPut(benchmark::State& state, int numPuts) {
       .qpMsgs = 128,
   };
 
+  // See benchmarkIput: the config is ambient now, installed once for the
+  // scope that issues the puts.
+  CtranIbActiveConfigRAII activeConfig(ctx.senderIb.get(), &config);
+
   std::vector<double> sumDeltaUs(numPuts, 0.0);
 
   for (auto _ : state) {
@@ -381,7 +392,6 @@ static void benchmarkMultiPut(benchmark::State& state, int numPuts) {
               ctx.senderRegHdl,
               ctx.ibReceiveKey,
               true /* notify */,
-              &config,
               &putReq[i],
               false /* fast */) != commSuccess) {
         throw ctran::utils::Exception("iput failed", commSystemError);

--- a/comms/ctran/backends/ib/tests/CtranIbConnectionTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbConnectionTest.cc
@@ -119,7 +119,6 @@ class CtranIbConnectionTest : public ::testing::Test {
 
       // Perform RDMA put
       CtranIbRequest putRequest;
-      CtranIbConfig config;
 
       if (doTransfer) {
         commResult_t putResult = ctranIb->iput(
@@ -130,7 +129,6 @@ class CtranIbConnectionTest : public ::testing::Test {
             regElem, // local registration element
             remoteKey, // remote access key
             true, // notify
-            &config, // config
             &putRequest, // request
             false // fast
         );

--- a/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
@@ -193,7 +193,6 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
               key,
               notifyMode == NotifyMode::notifyAll ||
                   (i == numPuts - 1 && notifyMode == NotifyMode::notifyLast),
-              nullptr,
               localSignal || i == numPuts - 1 ? &putReq : nullptr,
               /* fast */ true));
         } else {
@@ -208,7 +207,6 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
               // receiver side progress
               notifyMode == NotifyMode::notifyAll ||
                   (i == numPuts - 1 && notifyMode == NotifyMode::notifyLast),
-              nullptr,
               localSignal || i == numPuts - 1 ? &putReq : nullptr));
         }
 
@@ -371,7 +369,6 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
             srcRank,
             handle,
             key,
-            nullptr,
             localSignal || i == numGets - 1 ? &getReq : nullptr));
 
         if (localSignal || i == numGets - 1) {
@@ -580,7 +577,6 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
             handle,
             key,
             false, // notify
-            nullptr,
             &fallbackPutReq));
       }
 
@@ -607,7 +603,6 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
             totalNotifications++;
           }
 
-          putMsg.config = nullptr;
           if (i == batchSize - 1) {
             requests.emplace_back(std::make_unique<CtranIbRequest>());
             putMsg.req = requests.back().get();
@@ -632,7 +627,6 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
               handle,
               key,
               true, // notify
-              nullptr,
               &putReq));
           totalNotifications++;
           COMMCHECK_TEST(waitIbReq(putReq, ctranIb));
@@ -649,7 +643,6 @@ class CtranIbTest : public ctran::CtranDistTestFixture {
               handle,
               key,
               true, // notify (required for fast put)
-              nullptr,
               &fastPutReq,
               true)); // fast
           totalNotifications++;
@@ -1702,7 +1695,6 @@ TEST_F(CtranIbTest, MultiPutTrafficProfiler) {
               handle,
               remoteKey,
               true,
-              nullptr,
               &putReqs[i]);
         }
       }
@@ -1765,15 +1757,7 @@ TEST_F(CtranIbTest, InvalidPeer) {
     CtranIbRemoteAccessKey key{};
     EXPECT_EQ(
         ctranIb->iput(
-            nullptr,
-            nullptr,
-            1024,
-            invalidPeer,
-            nullptr,
-            key,
-            true,
-            nullptr,
-            &req),
+            nullptr, nullptr, 1024, invalidPeer, nullptr, key, true, &req),
         commInternalError);
 
     EXPECT_EQ(ctranIb->notify(invalidPeer, &req), commInternalError);
@@ -1805,7 +1789,6 @@ TEST_F(CtranIbTest, NotReadyPeer) {
             nullptr,
             key,
             true,
-            nullptr,
             nullptr /*req*/),
         commInternalError);
 
@@ -1860,7 +1843,6 @@ TEST_F(CtranIbTest, InvalidMemoryWaitNotify) {
         handle,
         invalidKey, // Invalid rkey
         true, // notify
-        nullptr,
         &putReq);
     EXPECT_EQ(putResult, commSuccess);
 
@@ -2105,7 +2087,6 @@ TEST_F(CtranIbTest, pgTrafficClassConfig) {
             nullptr,
             key,
             true,
-            nullptr,
             nullptr /*req*/),
         commInternalError);
 
@@ -2162,7 +2143,6 @@ TEST_F(CtranIbTest, pgTrafficClassConfigWithoutComm) {
             nullptr,
             key,
             true,
-            nullptr,
             nullptr /*req*/),
         commInternalError);
 
@@ -2358,7 +2338,6 @@ TEST_P(CtranIbTestParam, InvalidIputFastNotify) {
         handle,
         key,
         /* notify */ true,
-        nullptr,
         &putReqFast,
         /* fast */ true);
     EXPECT_EQ(res, commSystemError);
@@ -2373,7 +2352,6 @@ TEST_P(CtranIbTestParam, InvalidIputFastNotify) {
           handle,
           key,
           /* notify */ true,
-          nullptr,
           (i == NCCL_CTRAN_IB_QP_MAX_MSGS - 1) ? &putReqFast : nullptr,
           /* fast */ true);
       EXPECT_EQ(res, commSuccess);
@@ -2388,7 +2366,6 @@ TEST_P(CtranIbTestParam, InvalidIputFastNotify) {
         handle,
         key,
         /* notify */ true,
-        nullptr,
         &putReqFast,
         /* fast */ true);
     EXPECT_EQ(res, commSystemError);
@@ -2405,7 +2382,6 @@ TEST_P(CtranIbTestParam, InvalidIputFastNotify) {
         handle,
         key,
         /* notify */ true,
-        nullptr,
         &putReq));
     // Failure case 3: issuing fast iput without waiting on regular put
     // completion
@@ -2417,7 +2393,6 @@ TEST_P(CtranIbTestParam, InvalidIputFastNotify) {
         handle,
         key,
         /* notify */ true,
-        nullptr,
         &putReqFast,
         /* fast */ true);
     EXPECT_EQ(res, commSystemError);
@@ -2434,7 +2409,6 @@ TEST_P(CtranIbTestParam, InvalidIputFastNotify) {
         handle,
         key,
         /* notify */ true,
-        nullptr,
         &putReqFast,
         /* fast */ true));
     COMMCHECK_TEST(waitIbReq(putReqFast, ctranIb));
@@ -2525,7 +2499,6 @@ TEST_P(CtranIbTestParam, GpuMemPutNoSignalMixedFastRegular) {
           handle,
           key,
           /* notify */ true,
-          /* config */ nullptr,
           /* req */ nullptr,
           /* fast */ true)); // NoSignal
     }
@@ -2539,7 +2512,6 @@ TEST_P(CtranIbTestParam, GpuMemPutNoSignalMixedFastRegular) {
           handle,
           key,
           /* notify */ (i == numPuts - 1) ? true : false, // NoNotify
-          nullptr,
           (i == numPuts - 1) ? &putReq : nullptr)); // NoSignal
     }
     COMMCHECK_TEST(waitIbReq(putReq, ctranIb));
@@ -2626,7 +2598,6 @@ TEST_P(CtranIbTestParam, GpuMemPutNotifyLastMixedFastRegular) {
           handle,
           key,
           /* notify */ false, // NoNotify
-          /* config */ nullptr,
           /* req */ nullptr, // NoSignal
           /* fast */ true));
     }
@@ -2640,7 +2611,6 @@ TEST_P(CtranIbTestParam, GpuMemPutNotifyLastMixedFastRegular) {
           handle,
           key,
           /* notify */ (i == numPuts - 1) ? true : false, // notifyLast
-          nullptr,
           (i == numPuts - 1) ? &putReq : nullptr)); // NoSignal
     }
     COMMCHECK_TEST(waitIbReq(putReq, ctranIb));

--- a/comms/ctran/backends/ib/tests/CtranIbDqplbRelayDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDqplbRelayDistUT.cc
@@ -250,7 +250,6 @@ class CtranIbDqplbRelayTest : public ctran::CtranDistTestFixture {
           handle,
           key,
           notifyAll || put == kPutOffsets.size() - 1,
-          nullptr,
           &putReqs[put]));
     }
 
@@ -286,7 +285,6 @@ class CtranIbDqplbRelayTest : public ctran::CtranDistTestFixture {
           handle,
           key,
           /*notify*/ true,
-          nullptr,
           &putReqs[put]));
     }
 

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -1882,7 +1882,6 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
           .ibRegElem = regElem->ibRegElem,
           .remoteAccessKey = remoteAccessKey.ibKey,
           .notify = put.config.notify_,
-          .config = put.config.ibConfig_,
           .req = put.req == nullptr ? nullptr : &(put.req->ibReq),
       };
       msgs.emplace_back(std::move(msg));
@@ -1917,7 +1916,6 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     const auto kernElem = config.kernElem_;
     const auto& remoteAccessKey = config.remoteAccessKey_;
     const auto& notify = config.notify_;
-    const auto& ibConfig = config.ibConfig_;
     if (remoteAccessKey.backend == CtranMapperBackend::IB ||
         // If kernElem is not provided, falls back to IB
         // NOTE: it requires a match with the receiver side waitNotify, where it
@@ -1960,7 +1958,6 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
             regElem->ibRegElem,
             remoteAccessKey.ibKey,
             notify,
-            ibConfig,
             ibReqPtr,
             config.ibFastPath_));
       } else {
@@ -2052,7 +2049,6 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperRequest* req) {
     const auto shdl = config.memHdl_;
     const auto& remoteAccessKey = config.remoteAccessKey_;
-    const auto& ibConfig = config.ibConfig_;
     if (remoteAccessKey.backend == CtranMapperBackend::IB) {
       if (req != nullptr) {
         if (this->ctranIb != nullptr) {
@@ -2090,7 +2086,6 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
             peerRank,
             regElem->ibRegElem,
             remoteAccessKey.ibKey,
-            ibConfig,
             ibReqPtr,
             config.ibFastPath_));
       } else {

--- a/comms/ctran/mapper/CtranMapperTypes.h
+++ b/comms/ctran/mapper/CtranMapperTypes.h
@@ -59,14 +59,12 @@ struct CtranMapperRemoteAccessKey {
 };
 
 struct KernelElem;
-struct CtranIbConfig;
 
 struct CtranMapperConfig {
   void* memHdl_{nullptr};
   CtranMapperRemoteAccessKey remoteAccessKey_{CtranMapperBackend::UNSET};
   bool notify_{false};
   KernelElem* kernElem_{nullptr};
-  CtranIbConfig* ibConfig_{nullptr};
   bool ibFastPath_{false};
 };
 

--- a/comms/ctran/mapper/tests/CtranDistMapperBackendUT.cc
+++ b/comms/ctran/mapper/tests/CtranDistMapperBackendUT.cc
@@ -74,7 +74,6 @@ class CtranDistMapperBackendTest : public ctran::CtranDistTestFixture {
       const std::vector<int>& ranks,
       std::vector<void*>& remoteBufs,
       std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-      CtranIbConfig* config,
       const bool lowlatency,
       const bool ibFastPath = false) {
     const auto myRank = comm_->statex_.get()->rank();
@@ -102,7 +101,6 @@ class CtranDistMapperBackendTest : public ctran::CtranDistTestFixture {
                   .remoteAccessKey_ = remoteAccessKeys[peer],
                   .notify_ = ibFastPath,
                   .kernElem_ = kElem,
-                  .ibConfig_ = config,
                   .ibFastPath_ = ibFastPath},
               static_cast<CtranMapperRequest*>(nullptr)),
           commSuccess);
@@ -121,7 +119,6 @@ class CtranDistMapperBackendTest : public ctran::CtranDistTestFixture {
                   .remoteAccessKey_ = remoteAccessKeys[peer],
                   .notify_ = ibFastPath,
                   .kernElem_ = kElem,
-                  .ibConfig_ = config,
                   .ibFastPath_ = ibFastPath},
               &req),
           commSuccess);
@@ -146,7 +143,6 @@ class CtranDistMapperBackendTest : public ctran::CtranDistTestFixture {
                     .remoteAccessKey_ = remoteAccessKeys[peer],
                     .notify_ = true,
                     .kernElem_ = kElem,
-                    .ibConfig_ = config,
                     .ibFastPath_ = ibFastPath},
                 &user_allocated_req),
             commSuccess);
@@ -162,7 +158,6 @@ class CtranDistMapperBackendTest : public ctran::CtranDistTestFixture {
                     .remoteAccessKey_ = remoteAccessKeys[peer],
                     .notify_ = true,
                     .kernElem_ = kElem,
-                    .ibConfig_ = config,
                     .ibFastPath_ = ibFastPath},
                 &user_allocated_req),
             commSuccess);
@@ -259,7 +254,7 @@ TEST_P(CtranDistMapperBackendPerfConfigTestParam, IntraNodeUseIb) {
     std::vector<CtranMapperNotify> notifies(ranks.size());
     ASSERT_EQ(mapper->initNotifyBatchIB(ranks, notifies), commSuccess);
     issuePutsAndWaitForCompletion(
-        buf, sendHdl, ranks, remoteBufs, remoteAccessKeys, nullptr, lowlatency);
+        buf, sendHdl, ranks, remoteBufs, remoteAccessKeys, lowlatency);
 
     ASSERT_EQ(
         mapper->iPutCount[CtranMapperBackend::IB], ranks.size() * putTimes);
@@ -322,7 +317,7 @@ TEST_P(CtranDistMapperBackendPerfConfigTestParam, IntraNodeUseNvl) {
     ASSERT_EQ(mapper->iPutCount[CtranMapperBackend::NVL], 0);
 
     issuePutsAndWaitForCompletion(
-        buf, sendHdl, ranks, remoteBufs, remoteAccessKeys, nullptr, perfconfig);
+        buf, sendHdl, ranks, remoteBufs, remoteAccessKeys, perfconfig);
   }
 
   ASSERT_EQ(mapper->iPutCount[CtranMapperBackend::IB], 0);
@@ -382,7 +377,7 @@ TEST_P(
     // issue puts to all ranks, they should use NVL for intra-node and IB for
     // inter-node
     issuePutsAndWaitForCompletion(
-        buf, sendHdl, ranks, remoteBufs, remoteAccessKeys, nullptr, lowlatency);
+        buf, sendHdl, ranks, remoteBufs, remoteAccessKeys, lowlatency);
   }
 
   ASSERT_EQ(
@@ -460,7 +455,6 @@ TEST_P(CtranDistMapperBackendPerfConfigTestParam, InteNodeUseIbFastPut) {
         ranks,
         remoteBufs,
         remoteAccessKeys,
-        nullptr,
         lowlatency,
         /*ibFastPath=*/true);
 

--- a/comms/torchcomms/transport/RdmaTransport.cpp
+++ b/comms/torchcomms/transport/RdmaTransport.cpp
@@ -351,7 +351,6 @@ folly::SemiFuture<commResult_t> RdmaTransport::write(
         localBuffer->localKey(),
         ibRemoteKey,
         notify,
-        nullptr,
         &work->ibReq,
         false);
     if (ibRes != commSuccess && ibRes != commInProgress) {
@@ -433,7 +432,6 @@ folly::SemiFuture<commResult_t> RdmaTransport::read(
       kDummyRank,
       localBuffer->localKey(),
       ibRemoteKey,
-      nullptr,
       &work->ibReq,
       false);
   if (ibRes != commSuccess && ibRes != commInProgress) {


### PR DESCRIPTION
Summary:

Spray delivers data with plain RDMA writes plus a separate WRITE_IMM
notify, so data may not be GPU-visible when the notify arrives. iflush
now issues a real flush when spray is in effect even if
NCCL_CTRAN_NET_FORCE_FLUSH=0: either the ambient per-collective override
selects spray, or any established VC's default mode is spray.

Also handled: lazily create localVc on first spray-forced flush (absent
when local flush was disabled at construction); route local-flush CQEs
via a sticky localFlushUsed_ flag so completions polled after the
collective's guard exits are not misrouted; set the ambient guard in the
ring GPE-thread recv-flush progress fns where iflush is issued.

Differential Revision: D118736655


