### PR TITLE
MCCL: enable bidirectional Ring by default (#4027)

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2067,14 +2067,15 @@ cvars:
 
  - name        : MCCL_ALLREDUCE_RING_BIDIRECTIONAL_ENABLE
    type        : bool
-   default     : false
+   default     : true
    description : |-
      Enable bidirectional Ring reduce-scatter and all-gather for non-LL
      collectives with more than two nodes on both staged-copy and registered
      zero-copy paths. Out-of-place ranks stage their input before running the
      same peer schedule. Fine-grained tracing is suppressed without changing
      that schedule. A divergent value across ranks fails communicator
-     initialization.
+     initialization. Enabled by default; set false to use the unidirectional
+     Ring path.
 
  - name        : NCCL_CTRAN_PIPES_TRACE_ENABLE
    type        : bool


### PR DESCRIPTION
Summary:

Set `MCCL_ALLREDUCE_RING_BIDIRECTIONAL_ENABLE` to true by default now that both staged-copy and registered zero-copy Ring paths support it. Keep the explicit false override for forcing the unidirectional Ring path.

Reviewed By: Scusemua

Differential Revision: D118814025


