### PR TITLE
Log cgroup limits and peaks

### DIFF
--- a/scripts/ci_log_resources_post.sh
+++ b/scripts/ci_log_resources_post.sh
@@ -3,4 +3,10 @@
 du -sh build/ncclx/obj build/ncclx/lib 2>/dev/null || true
 free -g || true
 df -h . || true
+echo "=== memory high-water mark ===" || true
+cat /sys/fs/cgroup/memory.peak 2>/dev/null \
+  || cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes 2>/dev/null || true
+echo "=== oom_kill counter ===" || true
+cat /sys/fs/cgroup/memory.events 2>/dev/null | grep -E "max|oom" \
+  || cat /sys/fs/cgroup/memory/memory.oom_control 2>/dev/null || true
 exit 0

--- a/scripts/ci_log_resources_pre.sh
+++ b/scripts/ci_log_resources_pre.sh
@@ -3,4 +3,12 @@
 free -g || true
 df -h . || true
 ulimit -a || true
+echo "=== cgroup placement ===" || true
+cat /proc/self/cgroup 2>/dev/null | head -5 || true
+echo "=== memory limit (v2 then v1) ===" || true
+cat /sys/fs/cgroup/memory.max 2>/dev/null \
+  || cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || true
+echo "=== mounts ===" || true
+df -h / /tmp /dev/shm . 2>/dev/null || true
+nproc || true
 exit 0


### PR DESCRIPTION
Summary:
- Wheel-build CI jobs die to memory pressure with no record of whether the build container hit its own limit or was killed from outside, so every OOM is a guessing game.
- The pre-build resource hook now logs the container's cgroup placement, its memory limit (cgroup v2 with v1 fallback), the visible mounts, and the CPU count; the post-build hook logs the lifetime memory high-water mark and the OOM-kill counter.
- The reading rule is peak vs limit: a peak near the limit proves the container OOM'd itself, a peak far below it points outside the container. Every probe fails open, so the instrumentation can never fail the build.

Differential Revision: D118821855


