### PR TITLE
MCCL: select bidirectional Ring by message size (#4029)

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2067,14 +2067,15 @@ cvars:
 
  - name        : MCCL_ALLREDUCE_RING_BIDIRECTIONAL_ENABLE
    type        : bool
-   default     : false
+   default     : true
    description : |-
      Enable bidirectional Ring reduce-scatter and all-gather for non-LL
      collectives with more than two nodes on both staged-copy and registered
      zero-copy paths. Out-of-place ranks stage their input before running the
      same peer schedule. Fine-grained tracing is suppressed without changing
      that schedule. A divergent value across ranks fails communicator
-     initialization.
+     initialization. Enabled by default; set false to use the unidirectional
+     Ring path.
 
  - name        : NCCL_CTRAN_PIPES_TRACE_ENABLE
    type        : bool

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2077,6 +2077,21 @@ cvars:
      initialization. Enabled by default; set false to use the unidirectional
      Ring path.
 
+ - name        : MCCL_ALLREDUCE_RING_BIDIR_MAX_BYTES
+   type        : uint64_t
+   default     : 0
+   description : |-
+     Total message bytes strictly below which MCCL fused Ring AllReduce uses
+     the bidirectional schedule when
+     MCCL_ALLREDUCE_RING_BIDIRECTIONAL_ENABLE is enabled. This threshold is
+     resolved for every collective call rather than communicator creation.
+     Set it identically on every rank; like the collective's count and
+     datatype, a divergent value can select incompatible peer schedules.
+
+       0  (default) apply no size gate; preserve the enabled setting at every
+          message size.
+      >0  use bidirectional strictly below this many total message bytes.
+
  - name        : NCCL_CTRAN_PIPES_TRACE_ENABLE
    type        : bool
    default     : false


### PR DESCRIPTION
Summary:

Add `MCCL_ALLREDUCE_RING_BIDIR_MAX_BYTES` as an unsigned, per-collective exclusive byte threshold layered onto the existing Ring bidirectional enable, node-count, and LL conditions. `0` applies no size gate and preserves current behavior; a positive value enables bidirectional Ring only below the threshold.

Read the threshold for every collective launch and select through the existing host-side kernel machinery, with no device-side branch. Log the resolved decision and threshold whenever the Ring launch summary changes.

Also fix a latent rank-uniformity bug by using communicator-wide `nNodes` instead of `ring.nNodes` in the predicate. `ring.nNodes` is unset on ranks that do not own an IB segment in uneven local-rank topologies; using it could select incompatible schedules across ranks now that bidirectional Ring is enabled by default. Count, datatype, and communicator `nNodes` are collective-uniform. As with the existing per-call LL and CTRAN Ring size gates, the threshold is a job-wide configuration value and must be identical on every rank; adding a per-launch agreement collective would defeat the latency optimization.

Add policy boundary/default tests and an IB-only integration test that sets the threshold after communicator construction, runs below/equal/above/below it on one communicator, validates correctness, and verifies the resolved launch decision flips `true/false/false/true`.

Differential Revision: D118821267


