### PR TITLE
Share non-quantized Direct IB range execution

### DIFF
--- a/comms/prims/collectives/DirectCollectiveUtils.cuh
+++ b/comms/prims/collectives/DirectCollectiveUtils.cuh
@@ -27,10 +27,11 @@ struct MemcpyAndSelfCopy {
   }
 };
 
-__device__ __forceinline__ std::size_t direct_pipeline_window(
-    const P2pNvlTransportDevice* peers,
-    int my_rank,
-    int num_ranks) {
+// PeerArray may be a dense transport pointer or a lightweight view that maps a
+// phase-local rank into a global unified transport table.
+template <typename PeerArray>
+__device__ __forceinline__ std::size_t
+direct_pipeline_window(const PeerArray& peers, int my_rank, int num_ranks) {
   std::size_t window = 0;
   for (int peer = 0; peer < num_ranks; ++peer) {
     if (peer == my_rank) {

--- a/comms/prims/collectives/DirectNvlSchedule.cuh
+++ b/comms/prims/collectives/DirectNvlSchedule.cuh
@@ -1,0 +1,125 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+#define PRIMS_DIRECT_NVL_SCHEDULE_HOST_DEVICE __host__ __device__
+#else
+#define PRIMS_DIRECT_NVL_SCHEDULE_HOST_DEVICE
+#endif
+
+namespace comms::prims {
+
+/** Communication direction for one Direct NVLink peer walk. */
+enum class DirectNvlPeerRole : std::uint8_t {
+  SEND,
+  RECEIVE,
+};
+
+/**
+ * Iterate over every non-self local peer.
+ *
+ * With rotation disabled, both roles retain the legacy ascending-rank order.
+ * With rotation enabled, send and receive walks are complementary for a given
+ * channel and step, spreading simultaneous channels over different peers.
+ * Callers own the rotation policy because its threshold is algorithm tuning,
+ * not a property of the transport. `local_size` must be greater than one;
+ * collective entry points handle the single-rank identity before constructing
+ * an iterator.
+ */
+class DirectNvlPeerIterator {
+ public:
+  PRIMS_DIRECT_NVL_SCHEDULE_HOST_DEVICE constexpr DirectNvlPeerIterator(
+      int local_rank,
+      int local_size,
+      std::uint32_t channel,
+      DirectNvlPeerRole role,
+      bool rotate_peers)
+      : local_rank_(local_rank),
+        peer_count_(local_size - 1),
+        peer_index_(0),
+        peer_step_(1) {
+    if (rotate_peers) {
+      const std::uint32_t peer_count = static_cast<std::uint32_t>(peer_count_);
+      const int channel_offset = static_cast<int>(
+          channel < peer_count ? channel : channel % peer_count);
+      if (role == DirectNvlPeerRole::SEND) {
+        peer_index_ = local_rank - 1 - channel_offset;
+        if (peer_index_ < 0) {
+          peer_index_ += peer_count_;
+        }
+        peer_step_ = -1;
+      } else {
+        peer_index_ = local_rank + channel_offset;
+        if (peer_index_ >= peer_count_) {
+          peer_index_ -= peer_count_;
+        }
+      }
+    }
+  }
+
+  PRIMS_DIRECT_NVL_SCHEDULE_HOST_DEVICE constexpr int next() {
+    // Iterate in the dense local_size-1 index space, then insert self again.
+    const int peer = peer_index_ + (peer_index_ >= local_rank_);
+    peer_index_ += peer_step_;
+    if (peer_index_ < 0) {
+      peer_index_ += peer_count_;
+    } else if (peer_index_ >= peer_count_) {
+      peer_index_ -= peer_count_;
+    }
+    return peer;
+  }
+
+ private:
+  int local_rank_;
+  int peer_count_;
+  int peer_index_;
+  int peer_step_;
+};
+
+/** Owner-major source chunks: all destination-domain chunks for one owner. */
+struct DirectNvlContiguousOwnerLayout {
+  PRIMS_DIRECT_NVL_SCHEDULE_HOST_DEVICE static constexpr std::size_t
+  source_chunk(
+      std::size_t destination_domain,
+      std::size_t local_owner,
+      std::size_t /* local_size */,
+      std::size_t num_destination_domains) {
+    return local_owner * num_destination_domains + destination_domain;
+  }
+
+  PRIMS_DIRECT_NVL_SCHEDULE_HOST_DEVICE static constexpr std::size_t
+  packed_chunk(std::size_t destination_domain) {
+    return destination_domain;
+  }
+};
+
+/**
+ * Node-major source chunks with owner-strided packing.
+ *
+ * A local owner `l` collects global chunks `(d * local_size + l)` for every
+ * destination domain `d`, and packs them as consecutive chunks `[d]` for the
+ * following inter-domain ReduceScatter phase.
+ */
+struct DirectNvlNodeMajorOwnerStridedLayout {
+  PRIMS_DIRECT_NVL_SCHEDULE_HOST_DEVICE static constexpr std::size_t
+  source_chunk(
+      std::size_t destination_domain,
+      std::size_t local_owner,
+      std::size_t local_size,
+      std::size_t /* num_destination_domains */) {
+    return destination_domain * local_size + local_owner;
+  }
+
+  PRIMS_DIRECT_NVL_SCHEDULE_HOST_DEVICE static constexpr std::size_t
+  packed_chunk(std::size_t destination_domain) {
+    return destination_domain;
+  }
+};
+
+} // namespace comms::prims
+
+#undef PRIMS_DIRECT_NVL_SCHEDULE_HOST_DEVICE

--- a/comms/prims/collectives/ReduceScatterDirectIb.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIb.cu
@@ -3,6 +3,7 @@
 #include <atomic>
 
 #include "comms/prims/collectives/ReduceScatterDirectIb.cuh"
+#include "comms/prims/collectives/ReduceScatterDirectIbCore.cuh"
 
 #include "comms/prims/core/Checks.h"
 #include "comms/prims/core/CopyOp.cuh"
@@ -91,9 +92,13 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
     }
 
     for (int step = 0; step < W - 1; ++step) {
-      const int peer_offset =
-          kStaggerChannels ? (step + channel) % (W - 1) : step;
-      const int peer = (my_rank + 1 + peer_offset) % W;
+      const int peer = direct_ib_reduce_scatter_peer_for_step(
+          my_rank,
+          W,
+          channel,
+          step,
+          DirectIbReduceScatterRole::RECEIVE,
+          kStaggerChannels);
       const char* local_input = !args.in_place && step == 0
           ? reinterpret_cast<const char*>(own_src)
           : output_bytes;
@@ -121,9 +126,13 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
     }
 
     for (int step = 0; step < W - 1; ++step) {
-      const int peer_offset =
-          kStaggerChannels ? (step + channel) % (W - 1) : step;
-      const int peer = (my_rank + W - 1 - peer_offset) % W;
+      const int peer = direct_ib_reduce_scatter_peer_for_step(
+          my_rank,
+          W,
+          channel,
+          step,
+          DirectIbReduceScatterRole::SEND,
+          kStaggerChannels);
       TiledBuffer<const T> send_tile(
           input_base + static_cast<std::size_t>(peer) * args.chunk_elements,
           args.chunk_elements,

--- a/comms/prims/collectives/ReduceScatterDirectIb.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIb.cu
@@ -4,6 +4,7 @@
 
 #include "comms/prims/collectives/ReduceScatterDirectIb.cuh"
 #include "comms/prims/collectives/ReduceScatterDirectIbCore.cuh"
+#include "comms/prims/collectives/ReduceScatterDirectIbExecution.cuh"
 
 #include "comms/prims/core/Checks.h"
 #include "comms/prims/core/CopyOp.cuh"
@@ -74,6 +75,35 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_kernel(
     return;
   }
   char* output_bytes = reinterpret_cast<char*>(output);
+
+  if constexpr (!kQuantized) {
+    direct_ib_reduce_scatter_role_range<
+        T,
+        DirectIbReceiveReduction<ReduceOp>,
+        kStaggerChannels>(
+        my_rank,
+        W,
+        DirectIbStridedInput<T>{
+            .data = input_base,
+            .chunkStrideBytes = args.chunk_elements * sizeof(T),
+        },
+        static_cast<std::size_t>(channel) * output_tile.tile_elements,
+        DirectIbOutput<T>{
+            .data = output,
+            .initialization = args.in_place
+                ? ReduceScatterOutputInitialization::ALREADY_INITIALIZED
+                : ReduceScatterOutputInitialization::COPY_OWN_INPUT,
+        },
+        output_tile.tile_size(channel),
+        DirectIbReceiveReduction<ReduceOp>{},
+        max_sig,
+        args.peers,
+        group,
+        is_recv ? DirectIbReduceScatterRole::RECEIVE
+                : DirectIbReduceScatterRole::SEND,
+        abortDevice);
+    return;
+  }
 
   if (is_recv) {
     const T* own_src = input_base +

--- a/comms/prims/collectives/ReduceScatterDirectIbCore.cuh
+++ b/comms/prims/collectives/ReduceScatterDirectIbCore.cuh
@@ -1,0 +1,55 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+#define PRIMS_DIRECT_IB_RS_HOST_DEVICE_INLINE \
+  __host__ __device__ __forceinline__
+#else
+#define PRIMS_DIRECT_IB_RS_HOST_DEVICE_INLINE inline
+#endif
+
+namespace comms::prims {
+
+/** Communication role assigned to a Direct IB ReduceScatter thread group. */
+enum class DirectIbReduceScatterRole : std::uint8_t {
+  RECEIVE,
+  SEND,
+};
+
+/**
+ * Return the peer for one step of the matched Direct IB ReduceScatter walk.
+ *
+ * A receiver visits peers in the positive direction while the matching sender
+ * visits them in the negative direction. Channel staggering rotates both walks
+ * by the same amount, preserving the one-to-one send/receive pairing while
+ * spreading channels across peers. The rank and step preconditions are
+ * `0 <= my_rank < num_ranks` and `0 <= step < num_ranks - 1`. For the
+ * single-rank identity, the function returns `my_rank` without performing
+ * modulo arithmetic.
+ */
+PRIMS_DIRECT_IB_RS_HOST_DEVICE_INLINE constexpr int
+direct_ib_reduce_scatter_peer_for_step(
+    int my_rank,
+    int num_ranks,
+    std::uint32_t channel,
+    int step,
+    DirectIbReduceScatterRole role,
+    bool stagger_channels = true) {
+  if (num_ranks <= 1) {
+    return my_rank;
+  }
+  const auto peer_count = static_cast<std::uint32_t>(num_ranks - 1);
+  const auto peer_offset = stagger_channels
+      ? (static_cast<std::uint32_t>(step) + channel) % peer_count
+      : static_cast<std::uint32_t>(step);
+  return role == DirectIbReduceScatterRole::RECEIVE
+      ? (my_rank + 1 + static_cast<int>(peer_offset)) % num_ranks
+      : (my_rank + num_ranks - 1 - static_cast<int>(peer_offset)) % num_ranks;
+}
+
+} // namespace comms::prims
+
+#undef PRIMS_DIRECT_IB_RS_HOST_DEVICE_INLINE

--- a/comms/prims/collectives/ReduceScatterDirectIbExecution.cuh
+++ b/comms/prims/collectives/ReduceScatterDirectIbExecution.cuh
@@ -1,0 +1,164 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+#include "comms/prims/collectives/ReduceScatterDirectIbCore.cuh"
+#include "comms/prims/collectives/ReduceScatterExecution.h"
+#include "comms/prims/core/AbortCheck.cuh"
+#include "comms/prims/core/CopyUtils.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+
+namespace comms::prims {
+
+template <typename T>
+struct DirectIbStridedInput {
+  const T* data{nullptr};
+  std::size_t chunkStrideBytes{0};
+
+  __host__ __device__ __forceinline__ const T* chunkData(int rank) const {
+    return reinterpret_cast<const T*>(
+        reinterpret_cast<const char*>(data) +
+        static_cast<std::size_t>(rank) * chunkStrideBytes);
+  }
+};
+
+template <typename T>
+struct DirectIbOutput {
+  T* data{nullptr};
+  ReduceScatterOutputInitialization initialization{
+      ReduceScatterOutputInitialization::COPY_OWN_INPUT};
+};
+
+template <typename ReduceOp>
+struct DirectIbReceiveReduction {
+  template <typename T>
+  __device__ __forceinline__ void seedSingleRank(
+      ThreadGroup& group,
+      T* output,
+      const T* ownSource,
+      std::size_t rangeBytes,
+      ReduceScatterOutputInitialization initialization) const {
+    if (initialization == ReduceScatterOutputInitialization::COPY_OWN_INPUT) {
+      memcpy_vectorized(
+          reinterpret_cast<char*>(output),
+          reinterpret_cast<const char*>(ownSource),
+          rangeBytes,
+          group);
+    }
+  }
+
+  template <typename Transport>
+  __device__ __forceinline__ void receive(
+      Transport& transport,
+      ThreadGroup& group,
+      char* output,
+      const char* ownSource,
+      std::size_t rangeBytes,
+      std::size_t signalingBytes,
+      const AbortDevice& abort,
+      ReduceScatterOutputInitialization initialization,
+      int step) const {
+    const char* localInput =
+        initialization == ReduceScatterOutputInitialization::COPY_OWN_INPUT &&
+            step == 0
+        ? ownSource
+        : output;
+    transport.template recv<ReduceOp>(
+        group, output, rangeBytes, signalingBytes, abort, localInput);
+  }
+};
+
+/**
+ * Execute one explicit range for an already assigned blocking Direct-IB role.
+ *
+ * The caller owns role assignment, group geometry, and any phase barriers. The
+ * input contains one logical chunk per IB rank and chunkStrideBytes may include
+ * padding. Preconditions: 0 <= ibRank < ibSize, range offset plus length fits
+ * in every logical input chunk without overflow, pointers have T alignment,
+ * and output is disjoint from the requested input ranges unless it is already
+ * initialized. peers is indexed in this phase-local IB rank space, returns a
+ * copyable transport, and is never accessed for ibRank itself. group identity
+ * and block identity are preserved when selecting and invoking peers.
+ */
+template <
+    typename T,
+    typename ReductionPolicy,
+    bool kStaggerChannels = true,
+    typename PeerAccessor>
+__device__ __forceinline__ void direct_ib_reduce_scatter_role_range(
+    int ibRank,
+    int ibSize,
+    DirectIbStridedInput<T> input,
+    std::size_t rangeOffsetElements,
+    DirectIbOutput<T> output,
+    std::size_t rangeElements,
+    const ReductionPolicy& reduction,
+    std::size_t signalingBytes,
+    const PeerAccessor& peers,
+    ThreadGroup& group,
+    DirectIbReduceScatterRole role,
+    const AbortDevice& abort) {
+  const std::size_t rangeBytes = rangeElements * sizeof(T);
+  if (rangeBytes == 0) {
+    return;
+  }
+
+  char* outputBytes = reinterpret_cast<char*>(output.data);
+  if (role == DirectIbReduceScatterRole::RECEIVE) {
+    const T* ownSource = input.chunkData(ibRank) + rangeOffsetElements;
+    if (ibSize <= 1) {
+      reduction.seedSingleRank(
+          group, output.data, ownSource, rangeBytes, output.initialization);
+      return;
+    }
+
+    const int channel = static_cast<int>(group.group_id);
+    for (int step = 0; step < ibSize - 1; ++step) {
+      const int peer = direct_ib_reduce_scatter_peer_for_step(
+          ibRank,
+          ibSize,
+          channel,
+          step,
+          DirectIbReduceScatterRole::RECEIVE,
+          kStaggerChannels);
+      auto transport = peers[peer];
+      reduction.receive(
+          transport,
+          group,
+          outputBytes,
+          reinterpret_cast<const char*>(ownSource),
+          rangeBytes,
+          signalingBytes,
+          abort,
+          output.initialization,
+          step);
+    }
+    return;
+  }
+
+  if (ibSize <= 1) {
+    return;
+  }
+  const int channel = static_cast<int>(group.group_id);
+  for (int step = 0; step < ibSize - 1; ++step) {
+    const int peer = direct_ib_reduce_scatter_peer_for_step(
+        ibRank,
+        ibSize,
+        channel,
+        step,
+        DirectIbReduceScatterRole::SEND,
+        kStaggerChannels);
+    const T* sendData = input.chunkData(peer) + rangeOffsetElements;
+    auto transport = peers[peer];
+    transport.send(
+        group,
+        reinterpret_cast<const char*>(sendData),
+        rangeBytes,
+        signalingBytes,
+        abort);
+  }
+}
+
+} // namespace comms::prims

--- a/comms/prims/collectives/ReduceScatterDirectIbV2.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIbV2.cu
@@ -2,6 +2,8 @@
 
 #include "comms/prims/collectives/ReduceScatterDirectIbV2.cuh"
 
+#include "comms/prims/collectives/ReduceScatterDirectIbCore.cuh"
+
 #include "comms/prims/core/Checks.h"
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/TiledBuffer.cuh"
@@ -277,7 +279,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
       if (group.is_leader()) {
         for (int i = 0; i < count; ++i) {
           const int step = base + i;
-          rpeer_of[i] = (my_rank + 1 + (step + channel) % (W - 1)) % W;
+          rpeer_of[i] = direct_ib_reduce_scatter_peer_for_step(
+              my_rank, W, channel, step, DirectIbReduceScatterRole::RECEIVE);
           for (int sl = 0; sl < kSlots; ++sl) {
             rviews[sl][i] = detail::RecvChunkAcquisition{};
           }
@@ -434,7 +437,8 @@ __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_ib_v2_kernel(
       bool posted[kMaxPeersInFlight];
       for (int i = 0; i < count; ++i) {
         const int step = base + i;
-        peer_of[i] = (my_rank + W - 1 - (step + channel) % (W - 1)) % W;
+        peer_of[i] = direct_ib_reduce_scatter_peer_for_step(
+            my_rank, W, channel, step, DirectIbReduceScatterRole::SEND);
         posted[i] = false;
         auto transport = args.peers[peer_of[i]];
         transport.init_registered_send_progress(

--- a/comms/prims/collectives/ReduceScatterExecution.h
+++ b/comms/prims/collectives/ReduceScatterExecution.h
@@ -1,0 +1,14 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+namespace comms::prims {
+
+enum class ReduceScatterOutputInitialization : std::uint8_t {
+  COPY_OWN_INPUT,
+  ALREADY_INITIALIZED,
+};
+
+} // namespace comms::prims

--- a/comms/prims/collectives/tests/DirectIbReduceScatterCoreTest.cpp
+++ b/comms/prims/collectives/tests/DirectIbReduceScatterCoreTest.cpp
@@ -1,0 +1,122 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "comms/prims/collectives/ReduceScatterDirectIbCore.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+int legacy_peer_for_step(
+    int rank,
+    int num_ranks,
+    std::uint32_t channel,
+    int step,
+    DirectIbReduceScatterRole role,
+    bool stagger_channels) {
+  const int peer_offset = stagger_channels
+      ? static_cast<int>(
+            (static_cast<std::uint32_t>(step) + channel) %
+            static_cast<std::uint32_t>(num_ranks - 1))
+      : step;
+  return role == DirectIbReduceScatterRole::RECEIVE
+      ? (rank + 1 + peer_offset) % num_ranks
+      : (rank + num_ranks - 1 - peer_offset) % num_ranks;
+}
+
+void expect_matched_peer_walk(int num_ranks, bool stagger_channels) {
+  const std::vector<std::uint32_t> channels{
+      0,
+      1,
+      static_cast<std::uint32_t>(num_ranks - 1),
+      static_cast<std::uint32_t>(num_ranks),
+      static_cast<std::uint32_t>(2 * num_ranks + 1),
+  };
+  for (const std::uint32_t channel : channels) {
+    for (int rank = 0; rank < num_ranks; ++rank) {
+      std::vector<bool> visited(num_ranks, false);
+      for (int step = 0; step < num_ranks - 1; ++step) {
+        const int peer = direct_ib_reduce_scatter_peer_for_step(
+            rank,
+            num_ranks,
+            channel,
+            step,
+            DirectIbReduceScatterRole::RECEIVE,
+            stagger_channels);
+        ASSERT_GE(peer, 0);
+        ASSERT_LT(peer, num_ranks);
+        EXPECT_NE(peer, rank);
+        EXPECT_FALSE(visited[peer]);
+        visited[peer] = true;
+
+        EXPECT_EQ(
+            direct_ib_reduce_scatter_peer_for_step(
+                peer,
+                num_ranks,
+                channel,
+                step,
+                DirectIbReduceScatterRole::SEND,
+                stagger_channels),
+            rank);
+      }
+
+      for (int peer = 0; peer < num_ranks; ++peer) {
+        EXPECT_EQ(visited[peer], peer != rank);
+      }
+    }
+  }
+}
+
+TEST(DirectIbReduceScatterCoreTest, PeerWalkMatchesLegacyOrdering) {
+  for (const int num_ranks : {2, 3, 4, 7, 8, 31, 32, 127, 128, 255, 256}) {
+    for (std::uint32_t channel = 0; channel < 256; ++channel) {
+      for (int rank = 0; rank < num_ranks; ++rank) {
+        for (int step = 0; step < num_ranks - 1; ++step) {
+          for (const auto role :
+               {DirectIbReduceScatterRole::RECEIVE,
+                DirectIbReduceScatterRole::SEND}) {
+            EXPECT_EQ(
+                direct_ib_reduce_scatter_peer_for_step(
+                    rank, num_ranks, channel, step, role, true),
+                legacy_peer_for_step(
+                    rank, num_ranks, channel, step, role, true));
+            EXPECT_EQ(
+                direct_ib_reduce_scatter_peer_for_step(
+                    rank, num_ranks, channel, step, role, false),
+                legacy_peer_for_step(
+                    rank, num_ranks, channel, step, role, false));
+          }
+        }
+      }
+    }
+  }
+}
+
+TEST(DirectIbReduceScatterCoreTest, StaggeredWalkIsMatchedPermutation) {
+  for (const int num_ranks : {2, 3, 4, 7, 8, 31, 32, 127, 128, 255, 256}) {
+    expect_matched_peer_walk(num_ranks, true);
+  }
+}
+
+TEST(DirectIbReduceScatterCoreTest, UnstaggeredWalkIsMatchedPermutation) {
+  for (const int num_ranks : {2, 3, 4, 7, 8, 31, 32, 127, 128, 255, 256}) {
+    expect_matched_peer_walk(num_ranks, false);
+  }
+}
+
+TEST(DirectIbReduceScatterCoreTest, SingleRankIdentityReturnsSelf) {
+  EXPECT_EQ(
+      direct_ib_reduce_scatter_peer_for_step(
+          0, 1, 0, 0, DirectIbReduceScatterRole::RECEIVE),
+      0);
+  EXPECT_EQ(
+      direct_ib_reduce_scatter_peer_for_step(
+          0, 1, 0, 0, DirectIbReduceScatterRole::SEND),
+      0);
+}
+
+} // namespace
+} // namespace comms::prims::test

--- a/comms/prims/collectives/tests/DirectIbReduceScatterExecutionTest.cc
+++ b/comms/prims/collectives/tests/DirectIbReduceScatterExecutionTest.cc
@@ -1,0 +1,172 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <vector>
+
+#include "comms/prims/collectives/ReduceScatterDirectIbExecution.cuh"
+#include "comms/prims/collectives/tests/DirectIbReduceScatterExecutionTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+namespace comms::prims::test {
+namespace {
+
+TEST(DirectIbReduceScatterExecutionTest, StridedInputMapsPhaseRanks) {
+  float values[16]{};
+  const DirectIbStridedInput<float> input{
+      .data = values,
+      .chunkStrideBytes = 5 * sizeof(float),
+  };
+  EXPECT_EQ(input.chunkData(0), values);
+  EXPECT_EQ(input.chunkData(1), values + 5);
+  EXPECT_EQ(input.chunkData(2), values + 10);
+}
+
+TEST(DirectIbReduceScatterExecutionTest, CopiesOffsetRangeFromPaddedChunk) {
+  constexpr std::size_t kChunkElements = 19;
+  constexpr std::size_t kStrideElements = 24;
+  constexpr std::size_t kOffsetElements = 3;
+  constexpr std::size_t kRangeElements = 13;
+  std::vector<float> input(kStrideElements, -1.0F);
+  for (std::size_t index = 0; index < kChunkElements; ++index) {
+    input[index] = static_cast<float>(index) + 0.25F;
+  }
+  std::vector<float> output(kRangeElements, -2.0F);
+  meta::comms::DeviceBuffer inputDevice(input.size() * sizeof(float));
+  meta::comms::DeviceBuffer outputDevice(output.size() * sizeof(float));
+  CUDACHECK_TEST(cudaMemcpy(
+      inputDevice.get(),
+      input.data(),
+      input.size() * sizeof(float),
+      cudaMemcpyHostToDevice));
+
+  launchDirectIbSingleRankRange(
+      static_cast<const float*>(inputDevice.get()),
+      kStrideElements,
+      static_cast<float*>(outputDevice.get()),
+      kOffsetElements,
+      kRangeElements,
+      /*outputAlreadyInitialized=*/false);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  CUDACHECK_TEST(cudaMemcpy(
+      output.data(),
+      outputDevice.get(),
+      output.size() * sizeof(float),
+      cudaMemcpyDeviceToHost));
+  for (std::size_t index = 0; index < kRangeElements; ++index) {
+    EXPECT_EQ(output[index], input[kOffsetElements + index]);
+  }
+}
+
+TEST(DirectIbReduceScatterExecutionTest, PreservesInitializedAndEmptyRanges) {
+  constexpr std::size_t kElements = 17;
+  const std::vector<float> input(kElements, 3.0F);
+  const std::vector<float> expected(kElements, 7.0F);
+  std::vector<float> output(kElements);
+  meta::comms::DeviceBuffer inputDevice(kElements * sizeof(float));
+  meta::comms::DeviceBuffer outputDevice(kElements * sizeof(float));
+  CUDACHECK_TEST(cudaMemcpy(
+      inputDevice.get(),
+      input.data(),
+      kElements * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemcpy(
+      outputDevice.get(),
+      expected.data(),
+      kElements * sizeof(float),
+      cudaMemcpyHostToDevice));
+
+  launchDirectIbSingleRankRange(
+      static_cast<const float*>(inputDevice.get()),
+      kElements,
+      static_cast<float*>(outputDevice.get()),
+      /*rangeOffsetElements=*/0,
+      kElements,
+      /*outputAlreadyInitialized=*/true);
+  launchDirectIbSingleRankRange(
+      /*input=*/nullptr,
+      /*strideElements=*/0,
+      /*output=*/nullptr,
+      /*rangeOffsetElements=*/0,
+      /*rangeElements=*/0,
+      /*outputAlreadyInitialized=*/false);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  CUDACHECK_TEST(cudaMemcpy(
+      output.data(),
+      outputDevice.get(),
+      output.size() * sizeof(float),
+      cudaMemcpyDeviceToHost));
+  EXPECT_EQ(output, expected);
+}
+
+TEST(DirectIbReduceScatterExecutionTest, ExecutesPeerWalksAndInitialization) {
+  constexpr std::size_t kStrideElements = 7;
+  constexpr std::size_t kOffsetElements = 2;
+  constexpr std::size_t kRanks = 4;
+  std::vector<float> input(kRanks * kStrideElements);
+  for (std::size_t index = 0; index < input.size(); ++index) {
+    input[index] = static_cast<float>(index) + 0.5F;
+  }
+
+  meta::comms::DeviceBuffer inputDevice(input.size() * sizeof(float));
+  meta::comms::DeviceBuffer outputDevice(
+      kDirectIbTraceChannels * 3 * sizeof(float));
+  meta::comms::DeviceBuffer traceDevice(3 * sizeof(DirectIbExecutionTrace));
+  CUDACHECK_TEST(cudaMemcpy(
+      inputDevice.get(),
+      input.data(),
+      input.size() * sizeof(float),
+      cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(
+      cudaMemset(traceDevice.get(), 0, 3 * sizeof(DirectIbExecutionTrace)));
+
+  launchDirectIbPeerWalkTrace(
+      static_cast<const float*>(inputDevice.get()),
+      static_cast<float*>(outputDevice.get()),
+      static_cast<DirectIbExecutionTrace*>(traceDevice.get()));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  DirectIbExecutionTrace traces[3]{};
+  CUDACHECK_TEST(cudaMemcpy(
+      traces, traceDevice.get(), sizeof(traces), cudaMemcpyDeviceToHost));
+  const int expectedRecvPeers[3][kDirectIbTraceChannels][kDirectIbTracePeers] =
+      {
+          {{2, 3, 0}, {2, 3, 0}},
+          {{2, 3, 0}, {3, 0, 2}},
+          {{2, 3, 0}, {3, 0, 2}},
+      };
+  const int expectedSendPeers[3][kDirectIbTraceChannels][kDirectIbTracePeers] =
+      {
+          {{0, 3, 2}, {0, 3, 2}},
+          {{0, 3, 2}, {3, 2, 0}},
+          {{0, 3, 2}, {3, 2, 0}},
+      };
+  for (int mode = 0; mode < 3; ++mode) {
+    for (int channel = 0; channel < kDirectIbTraceChannels; ++channel) {
+      EXPECT_EQ(traces[mode].recvCount[channel], kDirectIbTracePeers);
+      EXPECT_EQ(traces[mode].sendCount[channel], kDirectIbTracePeers);
+      for (int step = 0; step < kDirectIbTracePeers; ++step) {
+        EXPECT_EQ(
+            traces[mode].recvPeers[channel][step],
+            expectedRecvPeers[mode][channel][step]);
+        const int sendPeer = expectedSendPeers[mode][channel][step];
+        const std::size_t sendOffset =
+            static_cast<std::size_t>(sendPeer) * kStrideElements +
+            kOffsetElements;
+        EXPECT_EQ(traces[mode].sendPeers[channel][step], sendPeer);
+        EXPECT_EQ(
+            traces[mode].sendFirstValue[channel][step], input[sendOffset]);
+        EXPECT_EQ(
+            traces[mode].recvInputKind[channel][step],
+            mode < 2 && step == 0 ? kDirectIbTraceOwnInput
+                                  : kDirectIbTraceOutput);
+      }
+    }
+  }
+}
+
+} // namespace
+} // namespace comms::prims::test

--- a/comms/prims/collectives/tests/DirectIbReduceScatterExecutionTest.cu
+++ b/comms/prims/collectives/tests/DirectIbReduceScatterExecutionTest.cu
@@ -1,0 +1,232 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/collectives/tests/DirectIbReduceScatterExecutionTest.cuh"
+
+#include <cuda_runtime.h>
+
+#include "comms/prims/collectives/ReduceScatterDirectIbExecution.cuh"
+#include "comms/prims/core/CopyOp.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+constexpr int kBlockThreads = 128;
+using ReduceOp = TileReduceStaged<float, SumOp, 1024, kBlockThreads>;
+
+constexpr int kTraceIbRank = 1;
+constexpr int kTraceIbSize = 4;
+constexpr std::size_t kTraceStrideElements = 7;
+constexpr std::size_t kTraceOffsetElements = 2;
+constexpr std::size_t kTraceRangeElements = 3;
+
+struct UnusedTransport {
+  template <typename Op>
+  __device__ void recv(
+      ThreadGroup&,
+      char*,
+      std::size_t,
+      std::size_t,
+      const AbortDevice&,
+      const char*) {}
+
+  __device__ void send(
+      ThreadGroup&,
+      const char*,
+      std::size_t,
+      std::size_t,
+      const AbortDevice&) {}
+};
+
+__global__ void directIbSingleRankRangeKernel(
+    const float* input,
+    std::size_t strideElements,
+    float* output,
+    std::size_t rangeOffsetElements,
+    std::size_t rangeElements,
+    ReduceScatterOutputInitialization initialization) {
+  auto group = make_block_group();
+  direct_ib_reduce_scatter_role_range<
+      float,
+      DirectIbReceiveReduction<ReduceOp>>(
+      /*ibRank=*/0,
+      /*ibSize=*/1,
+      DirectIbStridedInput<float>{
+          .data = input,
+          .chunkStrideBytes = strideElements * sizeof(float),
+      },
+      rangeOffsetElements,
+      DirectIbOutput<float>{
+          .data = output,
+          .initialization = initialization,
+      },
+      rangeElements,
+      DirectIbReceiveReduction<ReduceOp>{},
+      /*signalingBytes=*/0,
+      /*peers=*/static_cast<const UnusedTransport*>(nullptr),
+      group,
+      DirectIbReduceScatterRole::RECEIVE,
+      AbortDevice{});
+}
+
+struct RecordingTransport {
+  int peer{0};
+  const char* ownSource{nullptr};
+  const char* output{nullptr};
+  DirectIbExecutionTrace* trace{nullptr};
+
+  template <typename Op>
+  __device__ void recv(
+      ThreadGroup& group,
+      char*,
+      std::size_t,
+      std::size_t,
+      const AbortDevice&,
+      const char* localInput) {
+    if (group.thread_id_in_group != 0) {
+      return;
+    }
+    const auto channel = static_cast<int>(group.group_id);
+    const int step = trace->recvCount[channel]++;
+    trace->recvPeers[channel][step] = peer;
+    trace->recvInputKind[channel][step] = localInput == ownSource
+        ? kDirectIbTraceOwnInput
+        : (localInput == output ? kDirectIbTraceOutput : 0);
+  }
+
+  __device__ void send(
+      ThreadGroup& group,
+      const char* data,
+      std::size_t,
+      std::size_t,
+      const AbortDevice&) {
+    if (group.thread_id_in_group != 0) {
+      return;
+    }
+    const auto channel = static_cast<int>(group.group_id);
+    const int step = trace->sendCount[channel]++;
+    trace->sendPeers[channel][step] = peer;
+    trace->sendFirstValue[channel][step] =
+        *reinterpret_cast<const float*>(data);
+  }
+};
+
+struct RecordingPeerAccessor {
+  const char* ownSource{nullptr};
+  const char* output{nullptr};
+  DirectIbExecutionTrace* trace{nullptr};
+
+  __device__ RecordingTransport operator[](int peer) const {
+    return RecordingTransport{
+        .peer = peer,
+        .ownSource = ownSource,
+        .output = output,
+        .trace = trace,
+    };
+  }
+};
+
+template <
+    bool kStaggerChannels,
+    ReduceScatterOutputInitialization kInitialization>
+__global__ void directIbPeerWalkTraceKernel(
+    const float* input,
+    float* output,
+    DirectIbExecutionTrace* trace) {
+  auto group = make_block_group();
+  const auto channel = static_cast<std::size_t>(group.group_id);
+  const float* ownSource =
+      input + kTraceIbRank * kTraceStrideElements + kTraceOffsetElements;
+  float* channelOutput = output + channel * kTraceRangeElements;
+  const RecordingPeerAccessor peers{
+      .ownSource = reinterpret_cast<const char*>(ownSource),
+      .output = reinterpret_cast<const char*>(channelOutput),
+      .trace = trace,
+  };
+
+  direct_ib_reduce_scatter_role_range<
+      float,
+      DirectIbReceiveReduction<ReduceOp>,
+      kStaggerChannels>(
+      kTraceIbRank,
+      kTraceIbSize,
+      DirectIbStridedInput<float>{
+          .data = input,
+          .chunkStrideBytes = kTraceStrideElements * sizeof(float),
+      },
+      kTraceOffsetElements,
+      DirectIbOutput<float>{
+          .data = channelOutput,
+          .initialization = kInitialization,
+      },
+      kTraceRangeElements,
+      DirectIbReceiveReduction<ReduceOp>{},
+      /*signalingBytes=*/17,
+      peers,
+      group,
+      DirectIbReduceScatterRole::RECEIVE,
+      AbortDevice{});
+  group.sync();
+  direct_ib_reduce_scatter_role_range<
+      float,
+      DirectIbReceiveReduction<ReduceOp>,
+      kStaggerChannels>(
+      kTraceIbRank,
+      kTraceIbSize,
+      DirectIbStridedInput<float>{
+          .data = input,
+          .chunkStrideBytes = kTraceStrideElements * sizeof(float),
+      },
+      kTraceOffsetElements,
+      DirectIbOutput<float>{
+          .data = channelOutput,
+          .initialization = kInitialization,
+      },
+      kTraceRangeElements,
+      DirectIbReceiveReduction<ReduceOp>{},
+      /*signalingBytes=*/17,
+      peers,
+      group,
+      DirectIbReduceScatterRole::SEND,
+      AbortDevice{});
+}
+
+} // namespace
+
+void launchDirectIbSingleRankRange(
+    const float* input,
+    std::size_t strideElements,
+    float* output,
+    std::size_t rangeOffsetElements,
+    std::size_t rangeElements,
+    bool outputAlreadyInitialized) {
+  directIbSingleRankRangeKernel<<<1, kBlockThreads>>>(
+      input,
+      strideElements,
+      output,
+      rangeOffsetElements,
+      rangeElements,
+      outputAlreadyInitialized
+          ? ReduceScatterOutputInitialization::ALREADY_INITIALIZED
+          : ReduceScatterOutputInitialization::COPY_OWN_INPUT);
+}
+
+void launchDirectIbPeerWalkTrace(
+    const float* input,
+    float* output,
+    DirectIbExecutionTrace* traces) {
+  directIbPeerWalkTraceKernel<
+      false,
+      ReduceScatterOutputInitialization::COPY_OWN_INPUT>
+      <<<kDirectIbTraceChannels, kBlockThreads>>>(input, output, traces);
+  directIbPeerWalkTraceKernel<
+      true,
+      ReduceScatterOutputInitialization::COPY_OWN_INPUT>
+      <<<kDirectIbTraceChannels, kBlockThreads>>>(input, output, traces + 1);
+  directIbPeerWalkTraceKernel<
+      true,
+      ReduceScatterOutputInitialization::ALREADY_INITIALIZED>
+      <<<kDirectIbTraceChannels, kBlockThreads>>>(input, output, traces + 2);
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/collectives/tests/DirectIbReduceScatterExecutionTest.cuh
+++ b/comms/prims/collectives/tests/DirectIbReduceScatterExecutionTest.cuh
@@ -1,0 +1,36 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+namespace comms::prims::test {
+
+inline constexpr int kDirectIbTraceChannels = 2;
+inline constexpr int kDirectIbTracePeers = 3;
+inline constexpr int kDirectIbTraceOwnInput = 1;
+inline constexpr int kDirectIbTraceOutput = 2;
+
+struct DirectIbExecutionTrace {
+  int recvCount[kDirectIbTraceChannels]{};
+  int sendCount[kDirectIbTraceChannels]{};
+  int recvPeers[kDirectIbTraceChannels][kDirectIbTracePeers]{};
+  int sendPeers[kDirectIbTraceChannels][kDirectIbTracePeers]{};
+  int recvInputKind[kDirectIbTraceChannels][kDirectIbTracePeers]{};
+  float sendFirstValue[kDirectIbTraceChannels][kDirectIbTracePeers]{};
+};
+
+void launchDirectIbSingleRankRange(
+    const float* input,
+    std::size_t strideElements,
+    float* output,
+    std::size_t rangeOffsetElements,
+    std::size_t rangeElements,
+    bool outputAlreadyInitialized);
+
+void launchDirectIbPeerWalkTrace(
+    const float* input,
+    float* output,
+    DirectIbExecutionTrace* traces);
+
+} // namespace comms::prims::test

--- a/comms/prims/collectives/tests/DirectNvlScheduleTest.cc
+++ b/comms/prims/collectives/tests/DirectNvlScheduleTest.cc
@@ -1,0 +1,238 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "comms/prims/collectives/DirectNvlSchedule.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+// Preserve coverage through the largest peer table of the extracted callers
+// without coupling this transport-neutral schedule test back to MCCL.
+constexpr int kMaxCallerLocalSize = 72;
+
+constexpr int expected_rotated_peer(
+    int local_rank,
+    int local_size,
+    std::uint32_t channel,
+    std::uint32_t step,
+    DirectNvlPeerRole role) {
+  const int offset = static_cast<int>(
+      (static_cast<std::uint64_t>(channel) + step) %
+      static_cast<std::uint32_t>(local_size - 1));
+  return role == DirectNvlPeerRole::SEND
+      ? (local_rank + local_size - 1 - offset) % local_size
+      : (local_rank + 1 + offset) % local_size;
+}
+
+TEST(DirectNvlScheduleTest, RotatedWalksPairAndCoverEveryPeer) {
+  for (int local_size = 2; local_size <= kMaxCallerLocalSize; ++local_size) {
+    for (std::uint32_t channel_index = 0;
+         channel_index < static_cast<std::uint32_t>(local_size);
+         ++channel_index) {
+      const std::uint32_t channel =
+          channel_index == static_cast<std::uint32_t>(local_size - 1)
+          ? std::numeric_limits<std::uint32_t>::max()
+          : channel_index;
+      for (int local_rank = 0; local_rank < local_size; ++local_rank) {
+        SCOPED_TRACE(
+            ::testing::Message() << "local_size=" << local_size << " channel="
+                                 << channel << " local_rank=" << local_rank);
+        DirectNvlPeerIterator sends(
+            local_rank,
+            local_size,
+            channel,
+            DirectNvlPeerRole::SEND,
+            /*rotate_peers=*/true);
+        DirectNvlPeerIterator receives(
+            local_rank,
+            local_size,
+            channel,
+            DirectNvlPeerRole::RECEIVE,
+            /*rotate_peers=*/true);
+        std::vector<int> sent(local_size);
+        std::vector<int> received(local_size);
+        for (int step = 0; step < 2 * (local_size - 1); ++step) {
+          const int send_peer = sends.next();
+          const int receive_peer = receives.next();
+          EXPECT_EQ(
+              send_peer,
+              expected_rotated_peer(
+                  local_rank,
+                  local_size,
+                  channel,
+                  step,
+                  DirectNvlPeerRole::SEND));
+          EXPECT_EQ(
+              receive_peer,
+              expected_rotated_peer(
+                  local_rank,
+                  local_size,
+                  channel,
+                  step,
+                  DirectNvlPeerRole::RECEIVE));
+          sent.at(send_peer)++;
+          received.at(receive_peer)++;
+
+          EXPECT_EQ(
+              expected_rotated_peer(
+                  send_peer,
+                  local_size,
+                  channel,
+                  step,
+                  DirectNvlPeerRole::RECEIVE),
+              local_rank);
+        }
+        for (int peer = 0; peer < local_size; ++peer) {
+          const int expected_count = peer == local_rank ? 0 : 2;
+          EXPECT_EQ(sent.at(peer), expected_count);
+          EXPECT_EQ(received.at(peer), expected_count);
+        }
+      }
+    }
+  }
+}
+
+TEST(DirectNvlScheduleTest, RankOrderWalkPreservesLegacyOrder) {
+  for (int local_size = 2; local_size <= kMaxCallerLocalSize; ++local_size) {
+    for (const std::uint32_t channel :
+         {0U,
+          static_cast<std::uint32_t>(local_size - 2),
+          std::numeric_limits<std::uint32_t>::max()}) {
+      for (int local_rank = 0; local_rank < local_size; ++local_rank) {
+        DirectNvlPeerIterator sends(
+            local_rank,
+            local_size,
+            channel,
+            DirectNvlPeerRole::SEND,
+            /*rotate_peers=*/false);
+        DirectNvlPeerIterator receives(
+            local_rank,
+            local_size,
+            channel,
+            DirectNvlPeerRole::RECEIVE,
+            /*rotate_peers=*/false);
+        for (int cycle = 0; cycle < 2; ++cycle) {
+          for (int peer = 0; peer < local_size; ++peer) {
+            if (peer == local_rank) {
+              continue;
+            }
+            EXPECT_EQ(sends.next(), peer);
+            EXPECT_EQ(receives.next(), peer);
+          }
+        }
+      }
+    }
+  }
+}
+
+TEST(DirectNvlScheduleTest, OwnerFilteringKeepsEdgesPaired) {
+  for (const int local_size : {2, 3, 4, 7, 8, 16, kMaxCallerLocalSize}) {
+    for (int owner_count = 1; owner_count <= local_size; ++owner_count) {
+      for (const bool rotate_peers : {false, true}) {
+        for (std::uint32_t channel = 0;
+             channel < static_cast<std::uint32_t>(local_size - 1);
+             ++channel) {
+          std::vector<std::vector<int>> sends(
+              local_size, std::vector<int>(local_size));
+          std::vector<std::vector<int>> receives(
+              local_size, std::vector<int>(local_size));
+          for (int local_rank = 0; local_rank < local_size; ++local_rank) {
+            DirectNvlPeerIterator send_peers(
+                local_rank,
+                local_size,
+                channel,
+                DirectNvlPeerRole::SEND,
+                rotate_peers);
+            DirectNvlPeerIterator receive_peers(
+                local_rank,
+                local_size,
+                channel,
+                DirectNvlPeerRole::RECEIVE,
+                rotate_peers);
+            const int owner_steps = rotate_peers
+                ? local_size - 1
+                : owner_count - static_cast<int>(local_rank < owner_count);
+            for (int step = 0; step < owner_steps; ++step) {
+              const int owner = send_peers.next();
+              if (owner < owner_count) {
+                sends.at(local_rank).at(owner)++;
+              }
+            }
+            if (local_rank < owner_count) {
+              for (int step = 0; step < local_size - 1; ++step) {
+                receives.at(receive_peers.next()).at(local_rank)++;
+              }
+            }
+          }
+          EXPECT_EQ(sends, receives)
+              << "local_size=" << local_size << " owner_count=" << owner_count
+              << " channel=" << channel << " rotate_peers=" << rotate_peers;
+        }
+      }
+    }
+  }
+}
+
+template <std::size_t kDomains, std::size_t kLocalSize>
+void expect_node_major_owner_packing() {
+  std::vector<bool> source_chunks(kDomains * kLocalSize);
+  for (std::size_t domain = 0; domain < kDomains; ++domain) {
+    for (std::size_t owner = 0; owner < kLocalSize; ++owner) {
+      const std::size_t source =
+          DirectNvlNodeMajorOwnerStridedLayout::source_chunk(
+              domain, owner, kLocalSize, kDomains);
+      EXPECT_EQ(source, domain * kLocalSize + owner);
+      ASSERT_LT(source, source_chunks.size());
+      EXPECT_FALSE(source_chunks.at(source));
+      source_chunks.at(source) = true;
+      EXPECT_EQ(
+          DirectNvlNodeMajorOwnerStridedLayout::packed_chunk(domain), domain);
+    }
+  }
+  for (const bool visited : source_chunks) {
+    EXPECT_TRUE(visited);
+  }
+}
+
+TEST(DirectNvlScheduleTest, NodeMajorTwoByFourPacksByDomain) {
+  expect_node_major_owner_packing<2, 4>();
+}
+
+TEST(DirectNvlScheduleTest, NodeMajorFourByTwoPacksByDomain) {
+  expect_node_major_owner_packing<4, 2>();
+}
+
+TEST(DirectNvlScheduleTest, ContiguousOwnerLayoutGroupsOwnerBatches) {
+  constexpr std::size_t kDomains = 4;
+  constexpr std::size_t kLocalSize = 2;
+  for (std::size_t owner = 0; owner < kLocalSize; ++owner) {
+    for (std::size_t domain = 0; domain < kDomains; ++domain) {
+      EXPECT_EQ(
+          DirectNvlContiguousOwnerLayout::source_chunk(
+              domain, owner, kLocalSize, kDomains),
+          owner * kDomains + domain);
+      EXPECT_EQ(DirectNvlContiguousOwnerLayout::packed_chunk(domain), domain);
+    }
+  }
+}
+
+TEST(DirectNvlScheduleTest, LayoutUsesSizeTForLargeChunkIndices) {
+  constexpr std::size_t kLocalSize = std::size_t{1} << 20;
+  constexpr std::size_t kDomain = (std::size_t{1} << 20) + 3;
+  constexpr std::size_t kOwner = kLocalSize - 1;
+  constexpr std::size_t kExpected = kDomain * kLocalSize + kOwner;
+  static_assert(kExpected > std::numeric_limits<std::uint32_t>::max());
+  EXPECT_EQ(
+      DirectNvlNodeMajorOwnerStridedLayout::source_chunk(
+          kDomain, kOwner, kLocalSize, kDomain + 1),
+      kExpected);
+}
+
+} // namespace
+} // namespace comms::prims::test


### PR DESCRIPTION
Summary:
Extract the blocking Direct IB V1 role-local peer walk into a force-inlined Prims helper with explicit rank geometry, strided input, range, output initialization, peer accessor, reduction policy, signaling, role, and abort state.

Migrate the existing standalone non-quantized kernel to the helper while preserving its launcher, thread-role geometry, peer ordering, in-place behavior, and launch configuration. Quantized V1 and V2 remain on their existing implementations.

Add focused GPU tests for strided and offset ranges, single-rank identity, empty and already-initialized output, and fake-transport multi-rank send/receive walks with staggered and unstaggered channels.

Differential Revision: D118710186


