### PR TITLE
MCCL: derive fused Ring channel budget at communicator init

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -72,9 +72,9 @@ struct ctranPrimsConfig {
 // Per-communicator override first, global CVAR second. Both the transport
 // (comm init) and the collective launch geometry (per call) must resolve these
 // the same way, so they share these helpers rather than reading the CVAR
-// directly. NOTE: mccl's own launch-geometry validation still reads
-// MCCL_MAX_NCHANNELS / MCCL_MAX_NBLOCKS globally; a communicator that overrides
-// these and also runs mccl collectives would be validated against the global.
+// directly. MCCL may provision the shared transport above a Ring-specific
+// launch bound; other MCCL algorithms retain their existing global-cvar
+// behavior.
 inline int64_t ctranPrimsResolvedMaxChannels(const ctranPrimsConfig& pc) {
   return pc.maxChannels > 0 ? pc.maxChannels
                             : static_cast<int64_t>(MCCL_MAX_NCHANNELS);

--- a/comms/utils/cvars/extractcvars.py
+++ b/comms/utils/cvars/extractcvars.py
@@ -653,6 +653,8 @@ def populateHFile(allcvars, outputFilename):
     file.write("\n")
     file.write("namespace ncclx {\n")
 
+    file.write("bool isCvarExplicitlySet(std::string_view name);\n\n")
+
     file.write(
         "constexpr std::array<std::string_view, <@numCvars>> cvarNames = {<@cvarNames>};\n"
     )

--- a/comms/utils/cvars/nccl_cvars.cc.in
+++ b/comms/utils/cvars/nccl_cvars.cc.in
@@ -33,6 +33,11 @@ static std::unordered_map<std::string, std::string>& nccl_config() {
   return config;
 };
 
+bool isCvarExplicitlySet(std::string_view name) {
+  const std::string key{name};
+  return getenv(key.c_str()) != nullptr || nccl_config().contains(key);
+}
+
 static void initEnvSet(std::unordered_set<std::string>& env);
 static void readCvarEnv();
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3452,7 +3452,14 @@ cvars:
      Maximum number of fixed prims IB channels per peer. Channels index
      staging, signal, and QP resources through ThreadGroup::group_id and do
      not necessarily map one-to-one to CUDA blocks; for example, ctree uses
-     two channels per block.
+     two channels per block. When MCCL fused Ring is selected and this cvar is
+     not explicitly configured, communicator initialization derives the Ring
+     budget from requested blocks * virtual stripes and caps it at the
+     transport limit of 64. Because the IB transport is shared by collectives,
+     transport provisioning is never reduced below this cvar's default even
+     when Ring's launch bound is smaller. An explicit value always wins. Ring
+     snapshots both counts so launch validation cannot desynchronize from the
+     provisioned transport.
 
  - name        : MCCL_IB_MODE
    type        : enum

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2067,14 +2067,15 @@ cvars:
 
  - name        : MCCL_ALLREDUCE_RING_BIDIRECTIONAL_ENABLE
    type        : bool
-   default     : false
+   default     : true
    description : |-
      Enable bidirectional Ring reduce-scatter and all-gather for non-LL
      collectives with more than two nodes on both staged-copy and registered
      zero-copy paths. Out-of-place ranks stage their input before running the
      same peer schedule. Fine-grained tracing is suppressed without changing
      that schedule. A divergent value across ranks fails communicator
-     initialization.
+     initialization. Enabled by default; set false to use the unidirectional
+     Ring path.
 
  - name        : NCCL_CTRAN_PIPES_TRACE_ENABLE
    type        : bool

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2077,6 +2077,21 @@ cvars:
      initialization. Enabled by default; set false to use the unidirectional
      Ring path.
 
+ - name        : MCCL_ALLREDUCE_RING_BIDIR_MAX_BYTES
+   type        : uint64_t
+   default     : 0
+   description : |-
+     Total message bytes strictly below which MCCL fused Ring AllReduce uses
+     the bidirectional schedule when
+     MCCL_ALLREDUCE_RING_BIDIRECTIONAL_ENABLE is enabled. This threshold is
+     resolved for every collective call rather than communicator creation.
+     Set it identically on every rank; like the collective's count and
+     datatype, a divergent value can select incompatible peer schedules.
+
+       0  (default) apply no size gate; preserve the enabled setting at every
+          message size.
+      >0  use bidirectional strictly below this many total message bytes.
+
  - name        : NCCL_CTRAN_PIPES_TRACE_ENABLE
    type        : bool
    default     : false

--- a/comms/utils/cvars/tests/CvarInitUT.cc
+++ b/comms/utils/cvars/tests/CvarInitUT.cc
@@ -53,12 +53,22 @@ class CvarInitTest : public ::testing::Test {
     unsetenv("MCCL_BOOTSTRAP_TCP_KEEPALIVE_ENABLED");
     unsetenv("MCCL_IBGDA_RELIABLE_DOORBELL_MODE");
     unsetenv("MCCL_IBGDA_QP_ORDERING_SEMANTIC");
+    unsetenv("MCCL_MAX_NCHANNELS");
   }
 };
 
 TEST_F(CvarInitTest, BasicInitialization) {
   // Test basic ncclCvarInit functionality
   EXPECT_NO_THROW(ncclCvarInit());
+}
+
+TEST_F(CvarInitTest, ReportsExplicitCvarEvenWhenValueEqualsDefault) {
+  ncclCvarInit();
+  EXPECT_FALSE(ncclx::isCvarExplicitlySet("__NCCL_UNIT_TEST_INT_CVAR__"));
+
+  setenv("__NCCL_UNIT_TEST_INT_CVAR__", "0", 1);
+  ncclCvarInit();
+  EXPECT_TRUE(ncclx::isCvarExplicitlySet("__NCCL_UNIT_TEST_INT_CVAR__"));
 }
 
 TEST_F(CvarInitTest, McclIbgdaReliableDoorbellModeDefaultsToAuto) {


### PR DESCRIPTION
Summary: When `MCCL_MAX_NCHANNELS` is unset for fused Ring, derive the exact Ring launch budget once at communicator initialization from requested blocks, stripes, and lanes, capped at 64. Preserve at least the legacy configured channel count when provisioning the shared Prims transport so other collectives are not under-provisioned. Rank-check the resolved value, provenance, validity, and source block cap; reject invalid or divergent geometry uniformly. Keep explicit settings unchanged, warn once when their budget clamps blocks, and report actual Ring staging footprint in the launch summary.

Differential Revision: D118840886


