### PR TITLE
Make trace handles cancellable (#4033)

### DIFF
--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -247,6 +247,11 @@ commResult_t CtranGpe::Impl::submit(
       colltraceCreatesRecord ? meta::comms::colltrace::getCollTraceHandle(
                                    comm, opGroup, kernelConfig, ifchecksum)
                              : nullptr;
+  // Every exit below this point -- early return, or goto fail -- must release
+  // the record it just took out, or the next collective inherits a stale
+  // pending trace.
+  meta::comms::colltrace::CollTraceEnqueueGuard colltraceEnqueueGuard{
+      colltraceHandle};
 
   // Arm the collective kernel to publish its own start/end timestamps into the
   // colltrace ring, replacing the host-launched timestamp kernels for the
@@ -542,6 +547,7 @@ commResult_t CtranGpe::Impl::submit(
   if (colltraceHandle != nullptr) {
     colltraceHandle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
   }
+  colltraceEnqueueGuard.disarm();
 
   CTRAN_LOG_SUBSYS(
       INFO,

--- a/comms/ctran/gpe/tests/CtranGpeUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeUT.cc
@@ -18,6 +18,10 @@
 #include "comms/ctran/gpe/tests/CtranGpeUTKernels.h"
 #include "comms/ctran/tests/CtranTestUtils.h"
 #include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/colltrace/CollTraceEvent.h"
+#include "comms/utils/colltrace/CollTraceHandle.h"
+#include "comms/utils/colltrace/tests/MockTypes.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 #if not defined(__HIP_PLATFORM_AMD__) and not defined(__HIP_PLATFORM_HCC__)
 #include <cupti.h> // @manual
 #include "comms/utils/test_utils/CudaGraphTestUtils.h"
@@ -2574,3 +2578,145 @@ TEST_F(CtranGpeTest, TerminateWaitsForGpeKernelSyncPoolDrain) {
   gpeThread.join();
 }
 #endif
+
+namespace {
+
+// Installs a MockCollTrace on the comm that hands out one real
+// CollTraceHandle, so the launch paths exercise the genuine cancellation
+// gate while the test can observe whether cancel() actually fired. Also turns
+// colltrace on for the probe's lifetime -- getCollTraceHandle short-circuits
+// to nullptr when NCCL_COLLTRACE is empty.
+class ScopedCollTraceProbe {
+ public:
+  explicit ScopedCollTraceProbe(CtranComm* comm) : comm_(comm) {
+    previousCvar_ = NCCL_COLLTRACE;
+    setenv("NCCL_COLLTRACE", "trace", 1);
+    NCCL_COLLTRACE = {"trace"};
+
+    gate_ = std::make_shared<meta::comms::colltrace::EagerCancellationGate>(
+        [this](meta::comms::colltrace::CollTraceEvent&) noexcept {
+          cancelCount_.fetch_add(1, std::memory_order_relaxed);
+          return folly::unit;
+        });
+    handle_ = std::make_shared<meta::comms::colltrace::CollTraceHandle>(
+        collTrace_.get(), &event_, gate_);
+
+    ON_CALL(*collTrace_, recordCollective(testing::_, testing::_))
+        .WillByDefault([this](auto, auto) {
+          recordCount_.fetch_add(1, std::memory_order_relaxed);
+          return meta::comms::CommsMaybe<
+              std::shared_ptr<meta::comms::colltrace::ICollTraceHandle>>(
+              handle_);
+        });
+    ON_CALL(*collTrace_, triggerEventState(testing::_, testing::_))
+        .WillByDefault(testing::Return(folly::unit));
+
+    comm_->colltraceNew_ = collTrace_;
+  }
+
+  ~ScopedCollTraceProbe() {
+    comm_->colltraceNew_ = nullptr;
+    unsetenv("NCCL_COLLTRACE");
+    NCCL_COLLTRACE = previousCvar_;
+  }
+
+  ScopedCollTraceProbe(const ScopedCollTraceProbe&) = delete;
+  ScopedCollTraceProbe& operator=(const ScopedCollTraceProbe&) = delete;
+  ScopedCollTraceProbe(ScopedCollTraceProbe&&) = delete;
+  ScopedCollTraceProbe& operator=(ScopedCollTraceProbe&&) = delete;
+
+  int cancelCount() const {
+    return cancelCount_.load(std::memory_order_relaxed);
+  }
+
+  int recordCount() const {
+    return recordCount_.load(std::memory_order_relaxed);
+  }
+
+ private:
+  CtranComm* comm_;
+  std::vector<std::string> previousCvar_;
+  std::shared_ptr<testing::NiceMock<meta::comms::colltrace::MockCollTrace>>
+      collTrace_{std::make_shared<
+          testing::NiceMock<meta::comms::colltrace::MockCollTrace>>()};
+  meta::comms::colltrace::CollTraceEvent event_{};
+  std::shared_ptr<meta::comms::colltrace::EagerCancellationGate> gate_;
+  std::shared_ptr<meta::comms::colltrace::CollTraceHandle> handle_;
+  std::atomic<int> cancelCount_{0};
+  std::atomic<int> recordCount_{0};
+};
+
+std::vector<std::unique_ptr<struct OpElem>> makeSendOpGroup(
+    CtranComm* comm,
+    uint64_t opCount) {
+  std::vector<std::unique_ptr<struct OpElem>> ops;
+  auto op =
+      std::make_unique<struct OpElem>(OpElem::opType::SEND, comm, opCount);
+  op->send.sendbuff = nullptr;
+  op->send.count = 0;
+  op->send.datatype = commInt8;
+  op->send.peerRank = 0;
+  ops.push_back(std::move(op));
+  return ops;
+}
+
+} // namespace
+
+// The enqueue contract requires a recorded handle to reach either
+// AfterEnqueueKernel or cancel(). A kernel launch that fails after
+// BeforeEnqueueKernel used to take neither path, stranding pendingEnqueueColl_
+// so the next collective reported an overlap and dropped the stale trace.
+// A null kernel forces the launch to fail, as in SubmitOpBadCudaKernel.
+TEST_F(CtranGpeTest, SubmitLaunchFailureCancelsCollTraceHandle) {
+  auto gpe = std::unique_ptr<CtranGpe>(new CtranGpe(cudaDev, dummyComm));
+  ScopedCollTraceProbe probe(dummyComm);
+
+  cudaStream_t stream = nullptr;
+  CUDACHECK_TEST(cudaStreamCreate(&stream));
+
+  // Empty op group: the kernel launch is the only fallible step, so no GPE
+  // command is left waiting on a flag the failed kernel never signals.
+  std::vector<std::unique_ptr<struct OpElem>> emptyOps;
+  auto kernelConfig =
+      KernelConfig(KernelConfig::KernelType::ALLGATHER, stream, "dummyAlgo", 0);
+  kernelConfig.args.devState_d = dummyDevState_d;
+
+  EXPECT_NE(
+      gpe->submit(std::move(emptyOps), nullptr, kernelConfig, nullptr),
+      commSuccess);
+
+  EXPECT_EQ(probe.recordCount(), 1) << "the launch path must record a handle";
+  EXPECT_EQ(probe.cancelCount(), 1)
+      << "a failed launch must release the colltrace record";
+
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+}
+
+// The mirror of the above: a submit that reaches AfterEnqueueKernel disarms
+// the guard, so the handle must not be cancelled.
+TEST_F(CtranGpeTest, SubmitSuccessDoesNotCancelCollTraceHandle) {
+  auto gpe = std::unique_ptr<CtranGpe>(new CtranGpe(cudaDev, dummyComm));
+  ScopedCollTraceProbe probe(dummyComm);
+
+  cudaStream_t stream = nullptr;
+  CUDACHECK_TEST(cudaStreamCreate(&stream));
+
+  constexpr uint64_t kOpCount = 101;
+  auto kernelConfig = KernelConfig(
+      KernelConfig::KernelType::SEND, stream, "dummyAlgo", kOpCount);
+  kernelConfig.args.devState_d = dummyDevState_d;
+
+  EXPECT_EQ(
+      gpe->submit(
+          makeSendOpGroup(dummyComm, kOpCount),
+          &CtranGpeTestAlgoFunc,
+          kernelConfig,
+          reinterpret_cast<void*>(CtranGpeTestKernel)),
+      commSuccess);
+
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+  EXPECT_EQ(probe.recordCount(), 1) << "the launch path must record a handle";
+  EXPECT_EQ(probe.cancelCount(), 0)
+      << "a completed enqueue must leave the colltrace record in place";
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+}

--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
@@ -75,11 +75,6 @@ void deregisterLifecycleFeed(ncclComm_t comm) {
       registry->end());
 }
 
-uint64_t getNextLifecycleFeedCommId() {
-  static std::atomic<uint64_t> nextCommId{1};
-  return nextCommId.fetch_add(1, std::memory_order_relaxed);
-}
-
 enum class KernelPlanType { none, single, multiple };
 
 template <typename T, T* T::* next>
@@ -401,7 +396,7 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
     plugins.push_back(
         std::make_unique<meta::comms::colltrace::LifecycleEventFeedPlugin>(
             meta::comms::colltrace::LifecycleEventFeedConfig{
-                .commId = getNextLifecycleFeedCommId(),
+                .commId = meta::comms::colltrace::getNextLifecycleFeedCommId(),
                 .loggerName = std::string{::ncclx::logging::kNcclxLoggerName},
             }));
   }

--- a/comms/ncclx/v2_30/src/enqueue.cc
+++ b/comms/ncclx/v2_30/src/enqueue.cc
@@ -1748,6 +1748,11 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
   // [META] Colltrace handle creation and in-kernel graph timestamp arming.
   auto colltraceHandle = ncclx::colltrace::prepareNcclKernelColltrace(
       plan, launchStream, comm->compCap);
+  // Every `goto do_return` below is a launch failure that never reaches
+  // AfterEnqueueKernel; the guard releases the record so the next collective
+  // does not inherit a stale pending trace.
+  meta::comms::colltrace::CollTraceEnqueueGuard colltraceEnqueueGuard{
+      colltraceHandle};
 
   int driverVersion;
   NCCLCHECKGOTO(ncclCudaDriverVersion(&driverVersion), ret, do_return);
@@ -1823,12 +1828,14 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
     colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::BeforeEnqueueKernel);
     CUCHECKGOTO(cuLaunchKernelEx(&launchConfig, fn, nullptr, extra), ret, do_return);
     colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::AfterEnqueueKernel);
+    colltraceEnqueueGuard.disarm();
   #endif
   } else {
     // Standard kernel launch
     colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::BeforeEnqueueKernel);
     CUCHECKGOTO(cuLaunchKernel(fn, grid.x, grid.y, grid.z, block.x, block.y, block.z, smem, launchStream, nullptr, extra), ret, do_return);
     colltraceHandle->trigger(meta::comms::colltrace::CollTraceHandleTriggerState::AfterEnqueueKernel);
+    colltraceEnqueueGuard.disarm();
   }
 
 do_return:

--- a/comms/utils/colltrace/CollMetadataImpl.h
+++ b/comms/utils/colltrace/CollMetadataImpl.h
@@ -87,8 +87,7 @@ class CollMetadataImpl : public ICollMetadata {
   folly::dynamic toDynamic() const noexcept override {
     folly::dynamic result = folly::dynamic::object();
 
-    result.update(
-        folly::DynamicConstructor<CommLogData>::construct(commMetadata_));
+    result.update(commLogDataToDynamic(commMetadata_));
     result.update(backendSpecificMetadata_.toDynamic());
     result.update(genericMetadata_.toDynamic());
     result["MetadataType"] = std::string(GenericMetadata::getMetadataType());
@@ -97,7 +96,7 @@ class CollMetadataImpl : public ICollMetadata {
   }
   void fromDynamic(const folly::dynamic& d) noexcept override {
     // Use the fromDynamic methods for the other components
-    commMetadata_ = folly::DynamicConverter<CommLogData>::convert(d);
+    commMetadata_ = commLogDataFromDynamic(d);
     backendSpecificMetadata_ = BackendSpecificMetadata::fromDynamic(d);
     genericMetadata_ = GenericMetadata::fromDynamic(d);
   }

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -123,6 +123,10 @@ CollTrace::CollTrace(
           folly::MPMCQueue<std::unique_ptr<CollTraceEvent>>{
               config_.maxPendingQueueSize}),
       plugins_(std::move(plugins)) {
+  eagerCancellationGate_ = std::make_shared<EagerCancellationGate>(
+      [this](CollTraceEvent& event) { return cancelEvent(event); });
+  graphCancellationGate_ = std::make_shared<GraphCancellationGate>(
+      [this](uint32_t collId) { return cancelGraphCollective(collId); });
   if (NCCL_COLLTRACE_TRACE_CUDA_GRAPH &&
       graphColltraceSupported(logPrefix_, config_.loggerName)) {
     // Eagerly initialize the globaltimer calibration singleton now (outside
@@ -178,6 +182,8 @@ CollTrace::CollTrace(
 }
 
 CollTrace::~CollTrace() {
+  eagerCancellationGate_->shutdown();
+  graphCancellationGate_->shutdown();
   // Set the cancellation flag under the flush mutex so waitFlush()
   // can't miss the state change between its predicate check and wait.
   {
@@ -193,17 +199,20 @@ CollTrace::~CollTrace() {
   for (auto& [_, handle] : eventToHandleMap_) {
     handle->invalidate();
   }
-  // Invalidate all graph handles.
-  for (auto& [_, state] : graphStateMap_) {
-    for (auto& [_, collEntry] : state->collectives) {
-      if (auto h = collEntry.handle.lock()) {
-        h->invalidate();
-      }
-    }
-  }
-  // Wait for the thread to finish
+  // Stop the only thread that removes graph state before walking that state.
   if (traceCollThread_.joinable()) {
     traceCollThread_.join();
+  }
+  // Invalidate all graph handles.
+  {
+    std::lock_guard<std::mutex> lock(graphStateMutex_);
+    for (auto& [_, state] : graphStateMap_) {
+      for (auto& [_, collEntry] : state->collectives) {
+        if (auto h = collEntry.handle.lock()) {
+          h->invalidate();
+        }
+      }
+    }
   }
 }
 
@@ -316,8 +325,8 @@ CommsMaybe<std::shared_ptr<ICollTraceHandle>> CollTrace::recordCollective(
       .collRecord = std::make_shared<CollRecord>(collId, std::move(metadata)),
       .waitEvent = std::move(waitEvent),
   });
-  auto handle =
-      std::make_shared<CollTraceHandle>(this, pendingEnqueueColl_.get());
+  auto handle = std::make_shared<CollTraceHandle>(
+      this, pendingEnqueueColl_.get(), eagerCancellationGate_);
   eventToHandleMap_.emplace(pendingEnqueueColl_.get(), handle);
   triggerPlugins<&ICollTracePlugin::afterCollRecorded>(
       *logger_, plugins_, *pendingEnqueueColl_);
@@ -326,6 +335,42 @@ CommsMaybe<std::shared_ptr<ICollTraceHandle>> CollTrace::recordCollective(
 
 ICollTracePlugin* CollTrace::getPluginByName(std::string name) noexcept {
   return folly::get_ptr(pluginByName_, name);
+}
+
+CommsMaybeVoid CollTrace::cancelEvent(CollTraceEvent& collEvent) noexcept {
+  if (&collEvent == pendingEnqueueColl_.get()) {
+    eventToHandleMap_.erase(&collEvent);
+    pendingEnqueueColl_.reset();
+    return folly::unit;
+  }
+
+  std::lock_guard<std::mutex> lock(graphStateMutex_);
+  for (auto& [_, state] : graphStateMap_) {
+    for (auto& collective : state->collectives) {
+      if (collective.second.event.get() == &collEvent) {
+        collective.second.cancelled = true;
+        hasCancelledGraphCollectives_.store(true, std::memory_order_release);
+        return folly::unit;
+      }
+    }
+  }
+  return folly::makeUnexpected(
+      CommsError("CollTrace event is no longer pending", commInvalidArgument));
+}
+
+CommsMaybeVoid CollTrace::cancelGraphCollective(uint32_t collId) noexcept {
+  std::lock_guard<std::mutex> lock(graphStateMutex_);
+  for (auto& [_, state] : graphStateMap_) {
+    auto collective = state->collectives.find(collId);
+    if (collective == state->collectives.end()) {
+      continue;
+    }
+    collective->second.cancelled = true;
+    hasCancelledGraphCollectives_.store(true, std::memory_order_release);
+    return folly::unit;
+  }
+  return folly::makeUnexpected(
+      CommsError("CollTrace event is no longer pending", commInvalidArgument));
 }
 
 CommsMaybeVoid CollTrace::triggerEventState(
@@ -352,7 +397,9 @@ CommsMaybeVoid CollTrace::triggerEventState(
       triggerPlugins<&ICollTracePlugin::afterCollKernelScheduled>(
           *logger_, plugins_, collEvent); // Trigger before calling waitEvent
       EXPECT_CHECK(collEvent.waitEvent->afterCollKernelScheduled());
-      collEvent.collRecord->getTimingInfo().setCollEnqueueTs(precisionNow());
+      auto enqueueTime = collEvent.waitEvent->getCollEnqueueTime();
+      collEvent.collRecord->getTimingInfo().setCollEnqueueTs(
+          enqueueTime.hasValue() ? enqueueTime.value() : precisionNow());
       if (pendingTraceColls_.write(std::move(pendingEnqueueColl_))) {
         return folly::unit;
         // If the write fails, pendingEnqueueColl_ will not be moved. Do a
@@ -433,10 +480,9 @@ CollTrace::recordGraphCollectiveImpl(
   });
   auto* registrationEvent = collEvent.get();
 
-  auto handle = std::make_shared<GraphCollTraceHandle>(
-      rawWaitEvent, std::move(recordPtr));
-
   uint32_t collId = rawWaitEvent->getCollId();
+  auto handle = std::make_shared<GraphCollTraceHandle>(
+      rawWaitEvent, std::move(recordPtr), graphCancellationGate_, collId);
 
   GraphCollectiveEntry collectiveEntry{
       .graphWaitEvent = rawWaitEvent,
@@ -517,6 +563,25 @@ void CollTrace::pollGraphEvents(
       return false;
     });
 
+    if (hasCancelledGraphCollectives_.exchange(
+            false, std::memory_order_acq_rel)) {
+      for (auto& [_, state] : graphStateMap_) {
+        std::erase_if(state->collectives, [this](const auto& entry) {
+          if (!entry.second.cancelled) {
+            return false;
+          }
+          if (auto handle = entry.second.handle.lock()) {
+            handle->invalidate();
+          }
+          const auto collId = entry.first;
+          collIdMap_.erase(collId);
+          progressingGraphCollectives_.erase(collId);
+          inFlightReplays_.erase(collId);
+          return true;
+        });
+      }
+    }
+
     // add new collectives that aren't in collIdMap_ yet.
     for (auto& [_, state] : graphStateMap_) {
       for (auto& [collId, collEntry] : state->collectives) {
@@ -525,6 +590,10 @@ void CollTrace::pollGraphEvents(
         }
       }
     }
+  }
+
+  if (config_.afterGraphSweepHook) {
+    config_.afterGraphSweepHook();
   }
 
   if (collIdMap_.empty()) {
@@ -544,6 +613,16 @@ void CollTrace::pollGraphEvents(
         }
 
         auto& collEntry = *(it->second);
+        // Cancellation can land after the sweep above exchanged the flag but
+        // before this entry is dispatched, so re-check under the mutex that
+        // publishes it. Without this, ring entries already queued for a
+        // cancelled collId still become plugin actions.
+        {
+          std::lock_guard<std::mutex> lock(graphStateMutex_);
+          if (collEntry.cancelled) {
+            return;
+          }
+        }
         auto timestamp = cal.toWallClock(entry.timestamp);
 
         if (isStartEvent) {
@@ -618,10 +697,18 @@ void CollTrace::pollGraphEvents(
   // than collIdMap_ (the templates) so that progressing fires against the
   // actual replay record with correct timing.
   auto now = precisionNow();
-  for (auto collId : progressingGraphCollectives_) {
-    auto it = inFlightReplays_.find(collId);
-    if (it != inFlightReplays_.end()) {
-      actions.insert({it->second.get(), PendingActionType::kProgressing, now});
+  {
+    std::lock_guard<std::mutex> lock(graphStateMutex_);
+    for (auto collId : progressingGraphCollectives_) {
+      auto entryIt = collIdMap_.find(collId);
+      if (entryIt != collIdMap_.end() && entryIt->second->cancelled) {
+        continue;
+      }
+      auto it = inFlightReplays_.find(collId);
+      if (it != inFlightReplays_.end()) {
+        actions.insert(
+            {it->second.get(), PendingActionType::kProgressing, now});
+      }
     }
   }
 }

--- a/comms/utils/colltrace/CollTrace.h
+++ b/comms/utils/colltrace/CollTrace.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <chrono>
+#include <functional>
 #include <latch>
 #include <mutex>
 #include <set>
@@ -35,6 +36,7 @@ namespace meta::comms::colltrace {
 
 struct GraphCollTraceState;
 struct GraphCollectiveEntry;
+class GraphCancellationGate;
 class GraphCudaWaitEvent;
 
 // Whether graph-captured collectives can be timed on the *current* device.
@@ -69,6 +71,11 @@ struct CollTraceConfig {
   // If we have too many pending events, we will start dropping events.
   // 1024 should be enough for most of the cases.
   ::size_t maxPendingQueueSize{kDefaultMaxPendingQueueSize};
+
+  // Test seam. Invoked on the poll thread after the cancelled-collective
+  // sweep and before any ring entry is dispatched, so a test can land a
+  // cancellation exactly in that window. Empty in production.
+  std::function<void()> afterGraphSweepHook;
 };
 
 // Action types for the unified polling pipeline.
@@ -132,6 +139,8 @@ class CollTrace : public ICollTrace {
       CollTraceEvent& collEvent,
       CollTraceHandleTriggerState state) noexcept override;
 
+  CommsMaybeVoid cancelEvent(CollTraceEvent& collEvent) noexcept override;
+
   uint64_t requestFlush() noexcept override;
   void waitFlush(uint64_t gen) noexcept override;
 
@@ -141,6 +150,7 @@ class CollTrace : public ICollTrace {
   CommsMaybe<std::shared_ptr<ICollTraceHandle>> recordGraphCollectiveImpl(
       std::unique_ptr<ICollMetadata> metadata,
       std::unique_ptr<ICollWaitEvent> waitEvent) noexcept;
+  CommsMaybeVoid cancelGraphCollective(uint32_t collId) noexcept;
 
   /****************************************************************************
    * Start of Private Methods for CollTrace thread. All of these methods should
@@ -196,6 +206,7 @@ class CollTrace : public ICollTrace {
   // Remove by: CollTrace Thread
   folly::ConcurrentHashMap<CollTraceEvent*, std::shared_ptr<CollTraceHandle>>
       eventToHandleMap_;
+  std::shared_ptr<EagerCancellationGate> eagerCancellationGate_;
 
   std::unordered_map<std::string, ICollTracePlugin&> pluginByName_;
   std::vector<std::unique_ptr<ICollTracePlugin>> plugins_;
@@ -213,6 +224,8 @@ class CollTrace : public ICollTrace {
   std::mutex graphStateMutex_;
   std::unordered_map<unsigned long long, std::shared_ptr<GraphCollTraceState>>
       graphStateMap_;
+  std::shared_ptr<GraphCancellationGate> graphCancellationGate_;
+  std::atomic<bool> hasCancelledGraphCollectives_{false};
 
   // Single shared ring buffer for ALL cuda graphs. RAII-managed via
   // HRDWRingBuffer (mapped pinned memory, GPU-writable, CPU-readable).

--- a/comms/utils/colltrace/CollTraceHandle.cc
+++ b/comms/utils/colltrace/CollTraceHandle.cc
@@ -25,8 +25,15 @@ std::string_view triggerStateToStr(CollTraceHandleTriggerState state) {
   }
 }
 
-CollTraceHandle::CollTraceHandle(ICollTrace* collTrace, CollTraceEvent* event)
-    : state_(CollTraceHandleState{.collTrace_ = collTrace, .event_ = event}) {}
+CollTraceHandle::CollTraceHandle(
+    ICollTrace* collTrace,
+    CollTraceEvent* event,
+    std::shared_ptr<EagerCancellationGate> cancellationGate)
+    : state_(
+          CollTraceHandleState{
+              .collTrace_ = collTrace,
+              .event_ = event,
+              .cancellationGate_ = std::move(cancellationGate)}) {}
 
 CommsMaybeVoid CollTraceHandle::checkTriggerStateValidity(
     CollTraceHandleTriggerState state) noexcept {
@@ -126,15 +133,50 @@ CollTraceHandle::getCollRecord() noexcept {
   return stateReadLocked->event_->collRecord;
 }
 
+CommsMaybeVoid CollTraceHandle::cancel() noexcept {
+  std::shared_ptr<EagerCancellationGate> cancellationGate;
+  CollTraceEvent* event;
+  {
+    auto stateWriteLocked = state_.wlock();
+    if (stateWriteLocked->referenceInvalidated_) {
+      return folly::unit;
+    }
+    if (stateWriteLocked->event_ == nullptr) {
+      return folly::makeUnexpected(CommsError(
+          "Cannot cancel a handle without an owning CollTrace event",
+          commInternalError));
+    }
+
+    cancellationGate = std::move(stateWriteLocked->cancellationGate_);
+    event = stateWriteLocked->event_;
+    stateWriteLocked->referenceInvalidated_ = true;
+    stateWriteLocked->collTrace_ = nullptr;
+    stateWriteLocked->event_ = nullptr;
+  }
+  if (cancellationGate == nullptr) {
+    return folly::makeUnexpected(CommsError(
+        "Cannot cancel a handle without an owning CollTrace",
+        commInternalError));
+  }
+  return cancellationGate->cancel(event);
+}
+
 CommsMaybeVoid CollTraceHandle::invalidate() noexcept {
-  // Set the invalidated flag
-  state_.wlock()->referenceInvalidated_ = true;
+  auto stateWriteLocked = state_.wlock();
+  stateWriteLocked->referenceInvalidated_ = true;
+  stateWriteLocked->collTrace_ = nullptr;
+  stateWriteLocked->event_ = nullptr;
+  stateWriteLocked->cancellationGate_ = nullptr;
 
   return folly::unit;
 }
 
 void CollTraceHandle::invalidateUnsafe() noexcept {
-  state_.unsafeGetUnlocked().referenceInvalidated_ = true;
+  auto& state = state_.unsafeGetUnlocked();
+  state.referenceInvalidated_ = true;
+  state.collTrace_ = nullptr;
+  state.event_ = nullptr;
+  state.cancellationGate_ = nullptr;
 }
 
 } // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/CollTraceHandle.h
+++ b/comms/utils/colltrace/CollTraceHandle.h
@@ -3,7 +3,11 @@
 #pragma once
 
 #include <atomic>
+#include <functional>
+#include <memory>
+#include <mutex>
 #include <string_view>
+#include <utility>
 
 #include <folly/Synchronized.h>
 #include <folly/dynamic.h>
@@ -26,6 +30,34 @@ std::string_view triggerStateToStr(CollTraceHandleTriggerState state);
 
 class ICollTrace; // Declear CollTrace to avoid circular dependency
 
+class EagerCancellationGate {
+ public:
+  using Cancel = std::function<CommsMaybeVoid(CollTraceEvent&)>;
+
+  explicit EagerCancellationGate(Cancel cancel) : cancel_(std::move(cancel)) {}
+
+  // Takes the event by pointer, not by reference: the caller cannot safely
+  // form the reference before entering the gate, because teardown can destroy
+  // the owner's event storage first. The pointer is dereferenced only under
+  // mutex_, after the callback has been confirmed live.
+  CommsMaybeVoid cancel(CollTraceEvent* event) noexcept {
+    std::lock_guard lock(mutex_);
+    if (!cancel_ || event == nullptr) {
+      return folly::unit;
+    }
+    return cancel_(*event);
+  }
+
+  void shutdown() noexcept {
+    std::lock_guard lock(mutex_);
+    cancel_ = nullptr;
+  }
+
+ private:
+  std::mutex mutex_;
+  Cancel cancel_;
+};
+
 // Define the interface so that we can use it to handle legacy colltrace
 class ICollTraceHandle {
  public:
@@ -36,6 +68,9 @@ class ICollTraceHandle {
       std::string pluginName,
       folly::dynamic params) noexcept = 0;
   virtual CommsMaybe<std::shared_ptr<ICollRecord>> getCollRecord() noexcept = 0;
+  // Cancel is part of the enqueue state machine and must be called by the
+  // thread that records and triggers this handle, before AfterEnqueueKernel.
+  virtual CommsMaybeVoid cancel() noexcept = 0;
   virtual CommsMaybeVoid invalidate() noexcept = 0;
 
   // In-kernel colltrace: expose the graph ring device handle + collId so the
@@ -48,10 +83,58 @@ class ICollTraceHandle {
   }
 };
 
+// Cancels the handle on scope exit unless disarmed. A launch path that records
+// a handle and then returns early -- driver lookup failure, kernel launch
+// failure -- would otherwise strand the pending record, and the next
+// collective would report an overlap and drop the stranded trace. Arm this at
+// the record site and disarm it once AfterEnqueueKernel has succeeded.
+class CollTraceEnqueueGuard {
+ public:
+  CollTraceEnqueueGuard() noexcept = default;
+  explicit CollTraceEnqueueGuard(
+      std::shared_ptr<ICollTraceHandle> handle) noexcept
+      : handle_(std::move(handle)) {}
+
+  CollTraceEnqueueGuard(CollTraceEnqueueGuard&& other) noexcept
+      : handle_(std::exchange(other.handle_, nullptr)) {}
+
+  CollTraceEnqueueGuard& operator=(CollTraceEnqueueGuard&& other) noexcept {
+    if (this != &other) {
+      cancelNow();
+      handle_ = std::exchange(other.handle_, nullptr);
+    }
+    return *this;
+  }
+
+  CollTraceEnqueueGuard(const CollTraceEnqueueGuard&) = delete;
+  CollTraceEnqueueGuard& operator=(const CollTraceEnqueueGuard&) = delete;
+
+  ~CollTraceEnqueueGuard() {
+    cancelNow();
+  }
+
+  void disarm() noexcept {
+    handle_ = nullptr;
+  }
+
+ private:
+  void cancelNow() noexcept {
+    if (handle_ != nullptr) {
+      handle_->cancel();
+      handle_ = nullptr;
+    }
+  }
+
+  std::shared_ptr<ICollTraceHandle> handle_;
+};
+
 // Handle to be returned to the user for triggering stages for the collective.
 class CollTraceHandle : public ICollTraceHandle {
  public:
-  CollTraceHandle(ICollTrace* collTrace, CollTraceEvent* event);
+  CollTraceHandle(
+      ICollTrace* collTrace,
+      CollTraceEvent* event,
+      std::shared_ptr<EagerCancellationGate> cancellationGate = nullptr);
 
   CommsMaybeVoid trigger(CollTraceHandleTriggerState state) noexcept override;
 
@@ -60,6 +143,8 @@ class CollTraceHandle : public ICollTraceHandle {
       folly::dynamic params) noexcept override;
 
   CommsMaybe<std::shared_ptr<ICollRecord>> getCollRecord() noexcept override;
+
+  CommsMaybeVoid cancel() noexcept override;
 
   CommsMaybeVoid invalidate() noexcept override;
 
@@ -99,6 +184,7 @@ class CollTraceHandle : public ICollTraceHandle {
     // trigger the right event. It should not be used to access the event
     // object directly.
     CollTraceEvent* event_;
+    std::shared_ptr<EagerCancellationGate> cancellationGate_;
 
     // This is used to ensure that the handle is not used after the collective
     // or colltrace is destroyed. CollTrace will be responsible for signaling

--- a/comms/utils/colltrace/CollTraceInterface.h
+++ b/comms/utils/colltrace/CollTraceInterface.h
@@ -29,6 +29,8 @@ class ICollTrace {
       CollTraceEvent& collEvent,
       CollTraceHandleTriggerState state) noexcept = 0;
 
+  virtual CommsMaybeVoid cancelEvent(CollTraceEvent& collEvent) noexcept = 0;
+
   // Request the poll thread to drain all pending events and return a
   // generation token. gen=0 is reserved as the no-op default; real
   // implementations start at 1 (via fetch_add(1)+1).

--- a/comms/utils/colltrace/CommLogDataSerialize.cc
+++ b/comms/utils/colltrace/CommLogDataSerialize.cc
@@ -2,11 +2,9 @@
 
 #include "comms/utils/colltrace/CommLogDataSerialize.h"
 
-// We need to define in folly namespace, so intentionally not using namespace
-// here.
+namespace meta::comms::colltrace {
 
-folly::dynamic folly::DynamicConstructor<CommLogData>::construct(
-    const CommLogData& m) {
+folly::dynamic commLogDataToDynamic(const CommLogData& m) {
   folly::dynamic result = folly::dynamic::object();
 
   result["commId"] = m.commId;
@@ -18,8 +16,7 @@ folly::dynamic folly::DynamicConstructor<CommLogData>::construct(
   return result;
 }
 
-CommLogData folly::DynamicConverter<CommLogData>::convert(
-    const folly::dynamic& d) {
+CommLogData commLogDataFromDynamic(const folly::dynamic& d) {
   CommLogData result;
 
   result.commId = d["commId"].asInt();
@@ -29,4 +26,16 @@ CommLogData folly::DynamicConverter<CommLogData>::convert(
   result.nRanks = d["nRanks"].asInt();
 
   return result;
+}
+
+} // namespace meta::comms::colltrace
+
+folly::dynamic folly::DynamicConstructor<CommLogData>::construct(
+    const CommLogData& m) {
+  return meta::comms::colltrace::commLogDataToDynamic(m);
+}
+
+CommLogData folly::DynamicConverter<CommLogData>::convert(
+    const folly::dynamic& d) {
+  return meta::comms::colltrace::commLogDataFromDynamic(d);
 }

--- a/comms/utils/colltrace/CommLogDataSerialize.h
+++ b/comms/utils/colltrace/CommLogDataSerialize.h
@@ -7,6 +7,13 @@
 
 #include "comms/utils/commSpecs.h"
 
+namespace meta::comms::colltrace {
+
+folly::dynamic commLogDataToDynamic(const CommLogData& metadata);
+CommLogData commLogDataFromDynamic(const folly::dynamic& dynamic);
+
+} // namespace meta::comms::colltrace
+
 namespace folly {
 
 // Defines dynamic constructor for ICollMetadata so we can use it during

--- a/comms/utils/colltrace/CudaWaitEvent.cc
+++ b/comms/utils/colltrace/CudaWaitEvent.cc
@@ -240,6 +240,8 @@ CudaWaitEvent::CudaWaitEvent(cudaStream_t stream)
       startWaitPoint_(stream, CudaWaitPoint::WaitPointType::start),
       endWaitPoint_(stream, CudaWaitPoint::WaitPointType::end) {}
 
+CudaWaitEvent::~CudaWaitEvent() = default;
+
 CommsMaybeVoid CudaWaitEvent::beforeCollKernelScheduled() noexcept {
   return startWaitPoint_.recordEvent();
 }

--- a/comms/utils/colltrace/CudaWaitEvent.h
+++ b/comms/utils/colltrace/CudaWaitEvent.h
@@ -122,7 +122,7 @@ class CudaWaitEvent : public ICollWaitEvent {
  public:
   CudaWaitEvent(cudaStream_t stream);
 
-  ~CudaWaitEvent() = default;
+  ~CudaWaitEvent() override;
 
   CommsMaybeVoid beforeCollKernelScheduled() noexcept override;
 

--- a/comms/utils/colltrace/DummyCollTraceHandle.h
+++ b/comms/utils/colltrace/DummyCollTraceHandle.h
@@ -28,6 +28,10 @@ class DummyCollTraceHandle : public ICollTraceHandle {
     return std::shared_ptr<ICollRecord>{nullptr};
   }
 
+  CommsMaybeVoid cancel() noexcept override {
+    return folly::Unit{};
+  }
+
   CommsMaybeVoid invalidate() noexcept override {
     return folly::Unit{};
   }

--- a/comms/utils/colltrace/GraphCollTraceHandle.h
+++ b/comms/utils/colltrace/GraphCollTraceHandle.h
@@ -3,6 +3,11 @@
 #pragma once
 
 #include <cassert>
+#include <functional>
+#include <memory>
+#include <mutex>
+
+#include <folly/Synchronized.h>
 
 #include "comms/utils/colltrace/CollRecord.h"
 #include "comms/utils/colltrace/CollTraceHandle.h"
@@ -12,6 +17,30 @@
 
 namespace meta::comms::colltrace {
 
+class GraphCancellationGate {
+ public:
+  using Cancel = std::function<CommsMaybeVoid(uint32_t)>;
+
+  explicit GraphCancellationGate(Cancel cancel) : cancel_(std::move(cancel)) {}
+
+  CommsMaybeVoid cancel(uint32_t collId) noexcept {
+    std::lock_guard lock(mutex_);
+    if (!cancel_) {
+      return folly::unit;
+    }
+    return cancel_(collId);
+  }
+
+  void shutdown() noexcept {
+    std::lock_guard lock(mutex_);
+    cancel_ = nullptr;
+  }
+
+ private:
+  std::mutex mutex_;
+  Cancel cancel_;
+};
+
 // Handle for graph-captured collectives. Unlike CollTraceHandle, this does
 // not interact with the serial queue. It delegates before/after kernel
 // scheduling to the underlying ICollWaitEvent and is otherwise a no-op.
@@ -19,24 +48,33 @@ class GraphCollTraceHandle : public ICollTraceHandle {
  public:
   explicit GraphCollTraceHandle(
       ICollWaitEvent* waitEvent,
-      std::shared_ptr<ICollRecord> record)
-      : waitEvent_(waitEvent), record_(std::move(record)) {}
+      std::shared_ptr<ICollRecord> record,
+      std::shared_ptr<GraphCancellationGate> cancellationGate,
+      uint32_t collId)
+      : state_(
+            State{
+                .waitEvent = waitEvent,
+                .record = std::move(record),
+                .cancellationGate = std::move(cancellationGate),
+                .collId = collId,
+            }) {}
 
   ~GraphCollTraceHandle() override = default;
 
   CommsMaybeVoid trigger(CollTraceHandleTriggerState state) noexcept override {
-    if (waitEvent_ == nullptr) {
+    auto handleState = state_.rlock();
+    if (handleState->waitEvent == nullptr) {
       return folly::Unit{};
     }
     switch (state) {
       case CollTraceHandleTriggerState::BeforeEnqueueKernel:
-        return waitEvent_->beforeCollKernelScheduled();
+        return handleState->waitEvent->beforeCollKernelScheduled();
       case CollTraceHandleTriggerState::AfterEnqueueKernel:
-        return waitEvent_->afterCollKernelScheduled();
+        return handleState->waitEvent->afterCollKernelScheduled();
       case CollTraceHandleTriggerState::KernelStarted:
-        return waitEvent_->signalCollStart();
+        return handleState->waitEvent->signalCollStart();
       case CollTraceHandleTriggerState::KernelFinished:
-        return waitEvent_->signalCollEnd();
+        return handleState->waitEvent->signalCollEnd();
       case CollTraceHandleTriggerState::NumTriggerStates:
         return folly::Unit{};
     }
@@ -50,17 +88,36 @@ class GraphCollTraceHandle : public ICollTraceHandle {
   }
 
   CommsMaybe<std::shared_ptr<ICollRecord>> getCollRecord() noexcept override {
-    return record_;
+    return state_.rlock()->record;
+  }
+
+  CommsMaybeVoid cancel() noexcept override {
+    std::shared_ptr<GraphCancellationGate> cancellationGate;
+    uint32_t collId;
+    {
+      auto handleState = state_.wlock();
+      cancellationGate = std::move(handleState->cancellationGate);
+      collId = handleState->collId;
+      handleState->waitEvent = nullptr;
+      handleState->record = nullptr;
+    }
+    if (cancellationGate == nullptr) {
+      return folly::unit;
+    }
+    return cancellationGate->cancel(collId);
   }
 
   CommsMaybeVoid invalidate() noexcept override {
-    waitEvent_ = nullptr;
-    record_ = nullptr;
+    auto handleState = state_.wlock();
+    handleState->waitEvent = nullptr;
+    handleState->record = nullptr;
+    handleState->cancellationGate = nullptr;
     return folly::Unit{};
   }
 
   ColltraceDeviceHandle getColltraceDeviceHandle() noexcept override {
-    auto* graphWaitEvent = graphWaitEvent_();
+    auto handleState = state_.rlock();
+    auto* graphWaitEvent = graphWaitEvent_(handleState->waitEvent);
     if (graphWaitEvent == nullptr || !graphWaitEvent->hasRingBuffer()) {
       return {};
     }
@@ -76,19 +133,25 @@ class GraphCollTraceHandle : public ICollTraceHandle {
   }
 
  private:
+  struct State {
+    ICollWaitEvent* waitEvent;
+    std::shared_ptr<ICollRecord> record;
+    std::shared_ptr<GraphCancellationGate> cancellationGate;
+    uint32_t collId;
+  };
+
   // waitEvent_ is always a GraphCudaWaitEvent for this handle (constructed by
   // CollTrace::recordGraphCollectiveImpl), or null after invalidate(). This is
   // on the submit hot path, so static_cast avoids RTTI; the debug-only assert
   // catches any future violation of that invariant.
-  GraphCudaWaitEvent* graphWaitEvent_() const {
+  static GraphCudaWaitEvent* graphWaitEvent_(ICollWaitEvent* waitEvent) {
     assert(
-        waitEvent_ == nullptr ||
-        dynamic_cast<GraphCudaWaitEvent*>(waitEvent_) != nullptr);
-    return static_cast<GraphCudaWaitEvent*>(waitEvent_);
+        waitEvent == nullptr ||
+        dynamic_cast<GraphCudaWaitEvent*>(waitEvent) != nullptr);
+    return static_cast<GraphCudaWaitEvent*>(waitEvent);
   }
 
-  ICollWaitEvent* waitEvent_;
-  std::shared_ptr<ICollRecord> record_;
+  folly::Synchronized<State> state_;
 };
 
 } // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/GraphCollTraceState.h
+++ b/comms/utils/colltrace/GraphCollTraceState.h
@@ -26,6 +26,7 @@ struct GraphCollectiveEntry {
   // the handle when the CUDA graph is destroyed, preventing use-after-free
   // of the raw GraphCudaWaitEvent pointer held by the handle.
   std::weak_ptr<ICollTraceHandle> handle;
+  bool cancelled{false};
 };
 
 // Per-graph coordinator for all graph-captured collectives. Manages CUDA

--- a/comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.cc
+++ b/comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.cc
@@ -20,6 +20,11 @@ constexpr uint32_t kBacklogCheckPeriod = 256;
 
 } // namespace
 
+uint64_t getNextLifecycleFeedCommId() noexcept {
+  static std::atomic<uint64_t> nextCommId{1};
+  return nextCommId.fetch_add(1, std::memory_order_relaxed);
+}
+
 LifecycleEventFeedPlugin::LifecycleEventFeedPlugin(
     const LifecycleEventFeedConfig& config)
     : commId_(config.commId),

--- a/comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.h
+++ b/comms/utils/colltrace/plugins/LifecycleEventFeedPlugin.h
@@ -41,6 +41,8 @@ struct LifecycleEventFeedConfig {
   std::string loggerName{"comms"};
 };
 
+uint64_t getNextLifecycleFeedCommId() noexcept;
+
 class LifecycleEventFeedPlugin : public ICollTracePlugin {
  public:
   explicit LifecycleEventFeedPlugin(

--- a/comms/utils/colltrace/plugins/tests/LifecycleEventFeedPluginUT.cc
+++ b/comms/utils/colltrace/plugins/tests/LifecycleEventFeedPluginUT.cc
@@ -29,6 +29,13 @@ CollTraceEvent makeEvent(
   };
 }
 
+TEST(LifecycleEventFeedPluginTest, SharedCommunicatorIdsAreUnique) {
+  const auto first = getNextLifecycleFeedCommId();
+  const auto second = getNextLifecycleFeedCommId();
+
+  EXPECT_EQ(second, first + 1);
+}
+
 TEST(LifecycleEventFeedPluginTest, DrainsUnreadLifecycleEvents) {
   constexpr uint64_t kCommId = 17;
   constexpr uint64_t kCollId = 23;

--- a/comms/utils/colltrace/tests/CollTraceHandleUT.cc
+++ b/comms/utils/colltrace/tests/CollTraceHandleUT.cc
@@ -1,10 +1,15 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <atomic>
+#include <barrier>
+#include <thread>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "comms/utils/colltrace/CollTraceEvent.h"
 #include "comms/utils/colltrace/CollTraceHandle.h"
+#include "comms/utils/colltrace/GraphCollTraceHandle.h"
 #include "comms/utils/colltrace/tests/MockTypes.h"
 
 using namespace meta::comms;
@@ -18,12 +23,17 @@ class CollTraceHandleTest : public ::testing::Test {
   void SetUp() override {
     mockCollTrace = std::make_unique<MockCollTrace>();
     emptyEvent = std::make_unique<CollTraceEvent>(nullptr, nullptr);
+    cancellationGate =
+        std::make_shared<EagerCancellationGate>([this](CollTraceEvent& event) {
+          return mockCollTrace->cancelEvent(event);
+        });
     handle = std::make_unique<CollTraceHandle>(
-        mockCollTrace.get(), emptyEvent.get());
+        mockCollTrace.get(), emptyEvent.get(), cancellationGate);
   }
 
   std::unique_ptr<MockCollTrace> mockCollTrace;
   std::unique_ptr<CollTraceEvent> emptyEvent;
+  std::shared_ptr<EagerCancellationGate> cancellationGate;
   std::unique_ptr<CollTraceHandle> handle;
 };
 
@@ -140,6 +150,168 @@ TEST_F(CollTraceHandleTest, Invalidate) {
       handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
   EXPECT_FALSE(triggerResult.hasValue());
   EXPECT_EQ(triggerResult.error().errorCode, commInvalidArgument);
+}
+
+TEST_F(CollTraceHandleTest, CancelRemovesOwnedEventAndInvalidatesHandle) {
+  EXPECT_CALL(*mockCollTrace, cancelEvent(testing::Ref(*emptyEvent)))
+      .WillOnce(Return(folly::unit));
+
+  const auto cancelResult = handle->cancel();
+  ASSERT_TRUE(cancelResult.hasValue()) << cancelResult.error().message;
+
+  auto triggerResult =
+      handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+  EXPECT_FALSE(triggerResult.hasValue());
+  EXPECT_EQ(triggerResult.error().errorCode, commInvalidArgument);
+}
+
+TEST(GraphCancellationGateTest, ShutdownDrainsInFlightCancellation) {
+  std::barrier callbackEntered{2};
+  std::barrier releaseCallback{2};
+  std::barrier shutdownStarted{2};
+  std::atomic<int> callbackCount{0};
+  std::atomic_bool shutdownFinished{false};
+  auto gate = std::make_shared<GraphCancellationGate>([&](uint32_t collId) {
+    EXPECT_EQ(collId, 17);
+    callbackEntered.arrive_and_wait();
+    releaseCallback.arrive_and_wait();
+    callbackCount.fetch_add(1, std::memory_order_relaxed);
+    return folly::unit;
+  });
+
+  std::thread cancelThread([&] { EXPECT_TRUE(gate->cancel(17).hasValue()); });
+  callbackEntered.arrive_and_wait();
+
+  std::thread shutdownThread([&] {
+    shutdownStarted.arrive_and_wait();
+    gate->shutdown();
+    shutdownFinished.store(true, std::memory_order_release);
+  });
+  shutdownStarted.arrive_and_wait();
+  EXPECT_FALSE(shutdownFinished.load(std::memory_order_acquire));
+
+  releaseCallback.arrive_and_wait();
+  cancelThread.join();
+  shutdownThread.join();
+
+  EXPECT_TRUE(shutdownFinished.load(std::memory_order_acquire));
+  EXPECT_EQ(callbackCount.load(std::memory_order_relaxed), 1);
+  EXPECT_TRUE(gate->cancel(17).hasValue());
+  EXPECT_EQ(callbackCount.load(std::memory_order_relaxed), 1);
+}
+
+TEST(EagerCancellationGateTest, ShutdownDrainsInFlightCancellation) {
+  CollTraceEvent event{
+      .collRecord = nullptr,
+      .waitEvent = nullptr,
+      .replayId = std::nullopt,
+      .capturedCollId = std::nullopt};
+  std::barrier callbackEntered{2};
+  std::barrier releaseCallback{2};
+  std::atomic_bool shutdownFinished{false};
+  auto gate = std::make_shared<EagerCancellationGate>(
+      [&](CollTraceEvent& cancelledEvent) {
+        EXPECT_EQ(&cancelledEvent, &event);
+        callbackEntered.arrive_and_wait();
+        releaseCallback.arrive_and_wait();
+        return folly::unit;
+      });
+
+  std::thread cancelThread(
+      [&] { EXPECT_TRUE(gate->cancel(&event).hasValue()); });
+  callbackEntered.arrive_and_wait();
+
+  std::thread shutdownThread([&] {
+    gate->shutdown();
+    shutdownFinished.store(true, std::memory_order_release);
+  });
+  EXPECT_FALSE(shutdownFinished.load(std::memory_order_acquire));
+
+  releaseCallback.arrive_and_wait();
+  cancelThread.join();
+  shutdownThread.join();
+
+  EXPECT_TRUE(shutdownFinished.load(std::memory_order_acquire));
+  EXPECT_TRUE(gate->cancel(&event).hasValue());
+}
+
+// Teardown that completes before cancellation even reaches the gate must not
+// leave the caller holding a reference to the destroyed event: the gate is
+// entered with a pointer and never dereferences it once shutdown() has run.
+TEST(EagerCancellationGateTest, TeardownBeforeCancelLeavesGateInert) {
+  auto ownedEvent = std::make_unique<CollTraceEvent>(nullptr, nullptr);
+  std::atomic<int> callbackCount{0};
+  auto gate = std::make_shared<EagerCancellationGate>(
+      [&](CollTraceEvent& /* cancelledEvent */) {
+        callbackCount.fetch_add(1, std::memory_order_relaxed);
+        return folly::unit;
+      });
+
+  auto* rawEvent = ownedEvent.get();
+  gate->shutdown();
+  ownedEvent.reset();
+
+  EXPECT_TRUE(gate->cancel(rawEvent).hasValue());
+  EXPECT_EQ(callbackCount.load(std::memory_order_relaxed), 0);
+}
+
+// Cancellation that is already parked on the gate mutex when teardown starts
+// must still run to completion against a live event, and shutdown() must wait
+// for it rather than freeing the event underneath it.
+TEST(EagerCancellationGateTest, TeardownDuringCancelWaitsForCallback) {
+  auto ownedEvent = std::make_unique<CollTraceEvent>(nullptr, nullptr);
+  std::barrier callbackEntered{2};
+  std::barrier releaseCallback{2};
+  std::atomic_bool shutdownFinished{false};
+  std::atomic<int> callbackCount{0};
+  auto gate = std::make_shared<EagerCancellationGate>(
+      [&](CollTraceEvent& cancelledEvent) {
+        EXPECT_EQ(&cancelledEvent, ownedEvent.get());
+        callbackEntered.arrive_and_wait();
+        releaseCallback.arrive_and_wait();
+        callbackCount.fetch_add(1, std::memory_order_relaxed);
+        return folly::unit;
+      });
+
+  auto* rawEvent = ownedEvent.get();
+  std::thread cancelThread(
+      [&] { EXPECT_TRUE(gate->cancel(rawEvent).hasValue()); });
+  callbackEntered.arrive_and_wait();
+
+  std::thread teardownThread([&] {
+    gate->shutdown();
+    shutdownFinished.store(true, std::memory_order_release);
+    ownedEvent.reset();
+  });
+  EXPECT_FALSE(shutdownFinished.load(std::memory_order_acquire));
+
+  releaseCallback.arrive_and_wait();
+  cancelThread.join();
+  teardownThread.join();
+
+  EXPECT_TRUE(shutdownFinished.load(std::memory_order_acquire));
+  EXPECT_EQ(callbackCount.load(std::memory_order_relaxed), 1);
+  EXPECT_EQ(ownedEvent, nullptr);
+}
+
+TEST_F(CollTraceHandleTest, EnqueueGuardCancelsUnlessDisarmed) {
+  EXPECT_CALL(*mockCollTrace, cancelEvent(testing::Ref(*emptyEvent)))
+      .WillOnce(Return(folly::unit));
+
+  {
+    CollTraceEnqueueGuard guard(
+        std::shared_ptr<ICollTraceHandle>(std::move(handle)));
+  }
+}
+
+TEST_F(CollTraceHandleTest, EnqueueGuardDisarmSuppressesCancel) {
+  EXPECT_CALL(*mockCollTrace, cancelEvent(_)).Times(0);
+
+  {
+    CollTraceEnqueueGuard guard(
+        std::shared_ptr<ICollTraceHandle>(std::move(handle)));
+    guard.disarm();
+  }
 }
 
 // Test with null CollTrace

--- a/comms/utils/colltrace/tests/CollTraceUT.cc
+++ b/comms/utils/colltrace/tests/CollTraceUT.cc
@@ -184,6 +184,19 @@ TEST_F(CollTraceTest, TriggerEventState) {
       handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel));
 }
 
+TEST_F(CollTraceTest, CancelPendingCollectiveAllowsNextRecord) {
+  auto firstHandle = collTrace->recordCollective(
+      std::make_unique<StrictMock<MockCollMetadata>>(),
+      std::make_unique<NiceMock<MockCollWaitEvent>>());
+  ASSERT_TRUE(firstHandle.hasValue());
+  EXPECT_VALUE(firstHandle.value()->cancel());
+
+  auto secondHandle = collTrace->recordCollective(
+      std::make_unique<StrictMock<MockCollMetadata>>(),
+      std::make_unique<NiceMock<MockCollWaitEvent>>());
+  EXPECT_VALUE(secondHandle);
+}
+
 // Test complete workflow with multiple collectives
 TEST_F(CollTraceTest, CompleteWorkflow) {
   // Create first collective

--- a/comms/utils/colltrace/tests/GraphCollTraceUT.cc
+++ b/comms/utils/colltrace/tests/GraphCollTraceUT.cc
@@ -10,7 +10,9 @@
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
 
 #include <atomic>
+#include <barrier>
 #include <chrono>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <set>
@@ -210,6 +212,13 @@ class GraphColltraceProgressingTest : public ::testing::Test {
 
     hrdw_ring_buffer::GlobaltimerCalibration::get();
 
+    createCollTrace(nullptr);
+  }
+
+  // Replaces colltrace_ (and progressPlugin_) with a fresh instance. The hook
+  // lets a test stop the poll thread between its cancellation sweep and its
+  // ring dispatch.
+  void createCollTrace(std::function<void()> afterGraphSweepHook) {
     auto progressPlugin = std::make_unique<ProgressTrackingPlugin>();
     progressPlugin_ = progressPlugin.get();
 
@@ -217,7 +226,9 @@ class GraphColltraceProgressingTest : public ::testing::Test {
     plugins.push_back(std::move(progressPlugin));
     CommLogData logData{};
     colltrace_ = std::make_shared<CollTrace>(
-        CollTraceConfig{.maxCheckCancelInterval = std::chrono::milliseconds{1}},
+        CollTraceConfig{
+            .maxCheckCancelInterval = std::chrono::milliseconds{1},
+            .afterGraphSweepHook = std::move(afterGraphSweepHook)},
         logData,
         [this]() -> meta::comms::CommsMaybeVoid {
           // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
@@ -365,6 +376,101 @@ TEST_F(GraphColltraceProgressingTest, DetectsInFlightCollective) {
   auto completedIds = progressPlugin_->getCompletedCollIds();
   EXPECT_EQ(completedIds.size(), kNumColls)
       << "All collectives should be marked completed after stream sync";
+}
+
+TEST_F(GraphColltraceProgressingTest, CancelledCaptureIgnoresReplayEvents) {
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  ASSERT_EQ(
+      cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  auto handle = colltrace_
+                    ->recordCollective(
+                        std::make_unique<SimpleMetadata>(),
+                        std::make_unique<GraphCudaWaitEvent>(stream_))
+                    .value();
+  const auto deviceHandle = handle->getColltraceDeviceHandle();
+  ASSERT_TRUE(handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel)
+                  .hasValue());
+  writeColltraceRing(deviceHandle, GraphCollTracePhase::kStart);
+  writeColltraceRing(deviceHandle, GraphCollTracePhase::kEnd);
+  ASSERT_TRUE(handle->cancel().hasValue());
+
+  CapturedGraph graph;
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  ASSERT_EQ(cudaStreamEndCapture(stream_, &graph.graph), cudaSuccess);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  ASSERT_EQ(
+      cudaGraphInstantiate(&graph.instance, graph.graph, nullptr, nullptr, 0),
+      cudaSuccess);
+  ASSERT_EQ(cudaGraphLaunch(graph.instance, stream_), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+  colltrace_->waitFlush(colltrace_->requestFlush());
+
+  EXPECT_TRUE(progressPlugin_->getStartedCollIds().empty());
+  EXPECT_TRUE(progressPlugin_->getCompletedCollIds().empty());
+  const auto cancelledRecord = handle->getCollRecord();
+  ASSERT_TRUE(cancelledRecord.hasValue());
+  EXPECT_EQ(cancelledRecord.value(), nullptr);
+}
+
+// The sweep that erases cancelled collectives runs once per poll pass, before
+// the ring is drained. A cancellation that lands in between must still be
+// honoured, or entries already queued for the cancelled collId become plugin
+// actions. The hook parks the poll thread in exactly that window.
+TEST_F(GraphColltraceProgressingTest, CancelAfterSweepSuppressesQueuedEntries) {
+  std::barrier sweepReached{2};
+  std::barrier cancelRecorded{2};
+  std::atomic_bool parkNextSweep{false};
+  createCollTrace([&] {
+    if (!parkNextSweep.exchange(false, std::memory_order_acq_rel)) {
+      return;
+    }
+    sweepReached.arrive_and_wait();
+    cancelRecorded.arrive_and_wait();
+  });
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  ASSERT_EQ(
+      cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  auto handle = colltrace_
+                    ->recordCollective(
+                        std::make_unique<SimpleMetadata>(),
+                        std::make_unique<GraphCudaWaitEvent>(stream_))
+                    .value();
+  const auto deviceHandle = handle->getColltraceDeviceHandle();
+  ASSERT_TRUE(handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel)
+                  .hasValue());
+  writeColltraceRing(deviceHandle, GraphCollTracePhase::kStart);
+  writeColltraceRing(deviceHandle, GraphCollTracePhase::kEnd);
+  ASSERT_TRUE(handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel)
+                  .hasValue());
+
+  CapturedGraph graph;
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  ASSERT_EQ(cudaStreamEndCapture(stream_, &graph.graph), cudaSuccess);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  ASSERT_EQ(
+      cudaGraphInstantiate(&graph.instance, graph.graph, nullptr, nullptr, 0),
+      cudaSuccess);
+
+  // Park the poll thread just past its sweep, then produce the ring entries
+  // and cancel while it is held there.
+  parkNextSweep.store(true, std::memory_order_release);
+  sweepReached.arrive_and_wait();
+  ASSERT_EQ(cudaGraphLaunch(graph.instance, stream_), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+  ASSERT_TRUE(handle->cancel().hasValue());
+  cancelRecorded.arrive_and_wait();
+
+  colltrace_->waitFlush(colltrace_->requestFlush());
+
+  EXPECT_TRUE(progressPlugin_->getStartedCollIds().empty());
+  EXPECT_TRUE(progressPlugin_->getCompletedCollIds().empty());
+
+  // The hook closes over locals of this test body, so the poll thread must be
+  // joined before they go out of scope.
+  colltrace_.reset();
 }
 
 TEST_F(GraphColltraceProgressingTest, PreservesIdentityAcrossReplays) {

--- a/comms/utils/colltrace/tests/MockTypes.h
+++ b/comms/utils/colltrace/tests/MockTypes.h
@@ -24,6 +24,12 @@ class MockCollTrace : public ICollTrace {
       (noexcept, override));
 
   MOCK_METHOD(
+      CommsMaybeVoid,
+      cancelEvent,
+      (CollTraceEvent & collEvent),
+      (noexcept, override));
+
+  MOCK_METHOD(
       CommsMaybe<std::shared_ptr<ICollTraceHandle>>,
       recordCollective,
       (std::unique_ptr<ICollMetadata> metadata,


### PR DESCRIPTION
Summary:

- CollTrace handles could remain registered when a collective was abandoned before enqueue completed, leaving partial eager or graph records behind.
- Add explicit cancellation for eager and graph-backed handles, with graph-state cleanup that remains safe while progress runs concurrently.
- Move serialization and CUDA wait-event definitions out of headers so shared-library consumers link one implementation.

Differential Revision: D118542606


