### PR TITLE
Fail window registration loudly when NCCLX returns success with a null window (#4036)

### DIFF
--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
@@ -126,15 +126,34 @@ void TorchCommWindowNCCLX<Backend>::tensor_register(
         "[TorchCommWindowNCCLX][register]: contiguous tensor required.");
   }
 
-  buf_dtype_ = tensor.scalar_type();
-  win_size_ = tensor.numel() * tensor.element_size();
+  // Member state is published only once a window handle exists, so a failed
+  // registration leaves the window exactly as it was.
+  const size_t win_size = tensor.numel() * tensor.element_size();
 
-  auto buf_shape = tensor.sizes();
-  buf_shape_.clear();
-  buf_shape_.reserve(buf_shape.size());
-  for (size_t i = 0; i < buf_shape.size(); ++i) {
-    buf_shape_.push_back(buf_shape[i]);
-  }
+  // ncclCommWindowRegister can return ncclSuccess without producing a window:
+  // its CTRAN fast path always yields a handle, but once CTRAN is bypassed it
+  // falls through to the upstream symmetric path, which returns success with
+  // *win left null when comm->symmetricSupport is false (ncclx v2_30
+  // dev_runtime.cc). v2_31 drops the CTRAN path entirely, so revisit the advice
+  // below when the ncclx stable tag moves past 2.30.
+  //
+  // This must run before register_extra_window(), which CHECK_EQ-aborts on
+  // failure and would replace this message with a generic one.
+  const auto throwIfWindowMissing = [this]() {
+    if (win_ == nullptr) {
+      throw std::runtime_error(
+          "[TorchCommWindowNCCLX][register]: ncclCommWindowRegister returned "
+          "success but produced no window: CTRAN registration was bypassed and "
+          "the communicator also lacks symmetric-memory support. Set "
+          "NCCL_CTRAN_ENABLE=1 and leave NCCL_RMA_ALGO=ctran (a per-comm "
+          "useCtran hint overrides the env var) — on ncclx stable the whole "
+          "window API is CTRAN-backed, so map_remote_tensor/put/signal need it "
+          "even where symmetric support is available. To see which "
+          "symmetric-support prerequisite failed, rerun with NCCL_DEBUG=INFO "
+          "NCCL_DEBUG_SUBSYS=INIT and read the \"Symmetric memory is not "
+          "supported\" line.");
+    }
+  };
 
   if (torch_comm_->getGraphCaptureMode()) {
     {
@@ -142,10 +161,11 @@ void TorchCommWindowNCCLX<Backend>::tensor_register(
           torch_comm_->getCudaApi(), cudaStreamCaptureModeRelaxed};
       CHECK_EQ(
           nccl_api_->commWindowRegister(
-              tensor.data_ptr(), win_size_, nccl_comm_, &win_),
+              tensor.data_ptr(), win_size, nccl_comm_, &win_),
           ncclSuccess)
           << "[TorchCommWindowNCCLX]: NCCLX window registration failed "
           << "(graph capture).";
+      throwIfWindowMissing();
 
 #ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
       // Register the extra device-API window (sets nccl_orig_win_) so that
@@ -166,7 +186,7 @@ void TorchCommWindowNCCLX<Backend>::tensor_register(
               nccl_comm_,
               &nccl_orig_win_,
               tensor.data_ptr(),
-              win_size_);
+              win_size);
         }
       }
 #endif
@@ -174,16 +194,27 @@ void TorchCommWindowNCCLX<Backend>::tensor_register(
   } else {
     CHECK_EQ(
         nccl_api_->commWindowRegister(
-            tensor.data_ptr(), win_size_, nccl_comm_, &win_),
+            tensor.data_ptr(), win_size, nccl_comm_, &win_),
         ncclSuccess)
         << "[TorchCommWindowNCCLX]: NCCLX window registration failed.";
+    throwIfWindowMissing();
 
 #ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
     // GIN: register a second window with NCCL_WIN_DEVICE_API flag.
     // Pipes: no-op (device window creation deferred to get_device_window).
     Backend::register_extra_window(
-        nccl_api_, nccl_comm_, &nccl_orig_win_, tensor.data_ptr(), win_size_);
+        nccl_api_, nccl_comm_, &nccl_orig_win_, tensor.data_ptr(), win_size);
 #endif
+  }
+
+  buf_dtype_ = tensor.scalar_type();
+  win_size_ = win_size;
+
+  auto buf_shape = tensor.sizes();
+  buf_shape_.clear();
+  buf_shape_.reserve(buf_shape.size());
+  for (size_t i = 0; i < buf_shape.size(); ++i) {
+    buf_shape_.push_back(buf_shape[i]);
   }
 
   // Store raw data pointer for get_device_window() fallback when

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommWindowNCCLXTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommWindowNCCLXTest.cpp
@@ -86,6 +86,62 @@ TEST_F(TorchCommWindowNCCLXTest, windowRegisterWithInvalidTensor) {
   EXPECT_NO_THROW(comm->finalize());
 }
 
+TEST_F(TorchCommWindowNCCLXTest, windowRegisterThrowsOnSuccessWithNullWindow) {
+  // Verifies: tensor_register() throws at registration time when
+  // commWindowRegister returns ncclSuccess but leaves the window handle null
+  // (NCCLX takes the upstream symmetric path once CTRAN is bypassed, and that
+  // path returns success without a window when the comm lacks symmetric
+  // support). Without this check the null only surfaced on first use as an
+  // opaque "NCCLX window is null" error far from the cause.
+  setupRankAndSize(0, 2);
+  auto comm = createMockedTorchComm();
+
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+  // Only the first registration yields a null window: later calls fall back to
+  // a valid handle so the device-API window registration (a second call on
+  // builds with NCCL_GIN_ENABLE) and the retry below are both unconstrained.
+  EXPECT_CALL(*nccl_mock_, commWindowRegister(_, _, _, _, _))
+      .WillOnce(DoAll(
+          SetArgPointee<3>(static_cast<NcclxWindow>(nullptr)),
+          Return(ncclSuccess)))
+      .WillRepeatedly(DoAll(
+          SetArgPointee<3>(reinterpret_cast<NcclxWindow>(0x5000)),
+          Return(ncclSuccess)));
+
+  EXPECT_NO_THROW(comm->init(*device_, "test_name", default_options_));
+
+  auto tensor = createTestTensor({10, 10});
+  auto win = comm->new_window();
+  EXPECT_THROW(
+      {
+        try {
+          win->tensor_register(tensor);
+        } catch (const std::runtime_error& e) {
+          EXPECT_TRUE(
+              std::string(e.what()).find("produced no window") !=
+              std::string::npos)
+              << "unexpected error: " << e.what();
+          throw;
+        }
+      },
+      std::runtime_error);
+
+  // The failed attempt must not publish any window state, so that a retry
+  // starts from scratch instead of inheriting the failed buffer.
+  EXPECT_EQ(win->get_size(), 0u);
+  EXPECT_FALSE(win->get_tensor().has_value());
+  EXPECT_TRUE(win->getShape().empty());
+
+  EXPECT_NO_THROW(win->tensor_register(tensor));
+  EXPECT_EQ(
+      win->get_size(),
+      static_cast<size_t>(tensor.numel()) * tensor.element_size());
+  EXPECT_TRUE(win->get_tensor().has_value());
+
+  EXPECT_NO_THROW(comm->finalize());
+}
+
 TEST_F(
     TorchCommNCCLXTest,
     WindowOperationsWithoutInitializationThrowException) {


### PR DESCRIPTION
Summary:

`TorchCommWindowNCCLX::tensor_register` only checks the return code of
`commWindowRegister`. On ncclx stable (v2_30), `ncclCommWindowRegister`
(`dev_runtime.cc`) first tries a CTRAN fast path that always yields a handle;
once CTRAN is bypassed it falls through to the upstream symmetric path, which
returns `ncclSuccess` with `*win = nullptr` at the `!comm->symmetricSupport`
early-out. So a job running with `NCCL_CTRAN_ENABLE=0` against a comm that also
lacks symmetric support gets success with no window. The null then surfaces only
on first use — `map_remote_tensor` / `put` / `signal` throw an opaque
"[TorchCommWindowNCCLX]: NCCLX window is null" far from the cause, typically
mid-training inside a collective.

Observed in practice on MAST job
[farm-jongsoo_sdc_rail_v4_v17_tpp_535_MAST_TES-jongsoo-78df805a](https://msl-runs.internalmeta.com/mast/farm-jongsoo_sdc_rail_v4_v17_tpp_535_MAST_TES-jongsoo-78df805a/summary):
a GB300 job using the a2a_hier FSDP reduce-scatter (which registers its
scratch buffer as a ctwin window via `nccl_utils.ctwin_tensor_register`)
crashed at step 1 in `map_remote_tensor` with the null-window error, because
the tier NCCL env profile ships `NCCL_CTRAN_ENABLE=0`. Nothing in the error
pointed at CTRAN; diagnosing it required tracing the register path through
torchcomms into ncclx.

With this change the failure happens at `tensor_register` time with a message
naming both conditions and the one knob that fixes it, plus the
`NCCL_DEBUG=INFO NCCL_DEBUG_SUBSYS=INIT` line that reports which
symmetric-support prerequisite actually failed.

Per review feedback:

- Buffer metadata (`buf_dtype_`, `win_size_`, `buf_shape_`) is published only
  after the null check passes, so a failed registration leaves the window
  exactly as it was.
- The null check runs immediately after `commWindowRegister`, before
  `Backend::register_extra_window`. That call `CHECK_EQ`s its result, so a comm
  that also fails device-API registration would otherwise abort with a generic
  "Extra window registration failed" before this message could be thrown. This
  also removes the need to unwind a device-API window on the failure path.
- The message names CTRAN because it is the actionable knob: on ncclx stable
  the whole window API is CTRAN-backed (`ncclWinSharedQuery`, which backs
  `map_remote_tensor`, only finds handles inserted by the CTRAN branch at
  `dev_runtime.cc:1512`), whereas the `symmetricSupport` inputs are mostly
  topology or already-default (`NCCL_WIN_ENABLE` is 1, cuMem autodetects). A
  code comment flags that v2_31 drops the CTRAN path, so this advice must be
  revisited when the `stable` tag moves past 2.30.

Reviewed By: minsii

Differential Revision: D118754656


