### PR TITLE
Track local-flush completions per NIC device (#4038)

### DIFF
--- a/comms/ctran/backends/ib/BootstrapInternal.cc
+++ b/comms/ctran/backends/ib/BootstrapInternal.cc
@@ -27,18 +27,10 @@
 #include "comms/ctran/utils/Debug.h"
 #include "comms/ctran/utils/Exception.h"
 #include "comms/ctran/utils/ExtUtils.h"
+#include "comms/utils/StrUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/ScubaLogger.h"
-
-// strerrorname_np() is a glibc >= 2.32 GNU extension. Guard its use so builds
-// against older glibc (e.g. the OSS almalinux toolchain) still compile; the
-// error name simply falls back to "UNKNOWN" there.
-#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
-#if __GLIBC_PREREQ(2, 32)
-#define IBVERBX_HAS_STRERRORNAME_NP 1
-#endif
-#endif
 
 namespace {
 const std::string kCtranIbLogEventName{"CtranIb-QpExchange"};
@@ -48,18 +40,14 @@ const uint64_t kBootstrapMagic = 0xfaceb00cdeadbeef;
 std::string socketErrorContext(int error) {
   const bool hasValidMagnitude = error != std::numeric_limits<int>::min();
   const int errnoValue = hasValidMagnitude && error < 0 ? -error : error;
-  const char* errorName = nullptr;
-#ifdef IBVERBX_HAS_STRERRORNAME_NP
-  if (hasValidMagnitude) {
-    errorName = ::strerrorname_np(errnoValue);
-  }
-#endif
+  const std::string errorName =
+      hasValidMagnitude ? errnoToNameStr(errnoValue) : "UNKNOWN";
   const std::string description =
       hasValidMagnitude ? folly::errnoStr(errnoValue) : "invalid errno value";
   return fmt::format(
       "origin=socket_error subsystem=ctran_ib error_code={} error_name={} error_description=\"{}\"",
       error,
-      errorName != nullptr ? errorName : "UNKNOWN",
+      errorName,
       folly::cEscape<std::string>(description));
 }
 } // namespace

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -943,13 +943,22 @@ commResult_t CtranIb::iflush(
     CtranIbRequest* req) {
   FB_COMMCHECK(checkEpochLock(this));
 
-  if (enableLocalFlush_) {
+  if (enableLocalFlush_ && localRegHdl != nullptr) {
     CTRAN_IB_PER_OBJ_LOCK_GUARD(localVcMutex, {
       auto& vc = localVc;
       return vc->iflush(dbuf, localRegHdl, req);
     });
   } else {
-    req->complete();
+    // A buffer with no IB registration never received IB RDMA writes, so there
+    // is nothing to order against and skipping is correct. Local flush being
+    // disabled altogether is the expected steady state, not an anomaly, so it
+    // stays silent.
+    if (enableLocalFlush_) {
+      CTRAN_LOG(WARN, "CTRAN-IB: No IB registration for flush, skip");
+    }
+    if (req != nullptr) {
+      FB_COMMCHECK(req->complete());
+    }
     return commSuccess;
   }
 }

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -1072,7 +1072,7 @@ class CtranIb {
             // First check if it is a local flush CQE
             if (wc.qp_num == vc->qpNum(device)) {
               CQE_ERROR_CHECK(wc, rank, "localFlush");
-              FB_COMMCHECK(vc->processCqe(wc.opcode));
+              FB_COMMCHECK(vc->processCqe(wc.opcode, device));
               continue;
             }
           });

--- a/comms/ctran/backends/ib/CtranIbLocalVc.cc
+++ b/comms/ctran/backends/ib/CtranIbLocalVc.cc
@@ -17,7 +17,9 @@ namespace ctran::ib {
 LocalVirtualConn::LocalVirtualConn(
     std::vector<CtranIbDevice>& devices,
     CommLogData commLogData)
-    : devices_(devices), commLogData_(std::move(commLogData)) {
+    : devices_(devices),
+      commLogData_(std::move(commLogData)),
+      tracker_(devices_.size()) {
   FB_CHECKABORT(
       devices_.size() <= NCCL_CTRAN_IB_DEVICES_PER_RANK,
       "Invalid number of devices {} received in flush virtual connection compared to NCCL_CTRAN_IB_DEVICES_PER_RANK {}",
@@ -109,6 +111,27 @@ commResult_t LocalVirtualConn::iflush(
     const void* ibRegElem,
     CtranIbRequest* req) {
   auto mrs = reinterpret_cast<const std::vector<ibverbx::IbvMr>*>(ibRegElem);
+  FB_CHECKABORT(
+      mrs->size() >= devices_.size(),
+      "Flush requires one memory region per device, but got {} regions for {} devices",
+      mrs->size(),
+      devices_.size());
+
+  // Each flush burns one send-queue slot per device and nothing upstream bounds
+  // the number of flushes in flight, so the queue depth has to be enforced here
+  // while the failure is still recoverable.
+  for (int device = 0; device < devices_.size(); device++) {
+    if (tracker_.outstanding(device) >= static_cast<size_t>(MAX_SEND_WR)) {
+      CTRAN_ERR(
+          commInternalError,
+          "CTRAN-IB: flush send queue is full on device {} ({} outstanding, max {})",
+          device,
+          tracker_.outstanding(device),
+          MAX_SEND_WR);
+      return commInternalError;
+    }
+  }
+
   for (int device = 0; device < devices_.size(); device++) {
     ibverbx::ibv_send_wr wr;
     memset(&wr, 0, sizeof(wr));
@@ -122,7 +145,21 @@ commResult_t LocalVirtualConn::iflush(
 
     ibverbx::ibv_send_wr* bad_wr{nullptr};
     auto maybeSend = ibvQps_[device].postSend(&wr, &bad_wr);
-    FOLLY_EXPECTED_CHECK(maybeSend);
+    if (maybeSend.hasError()) {
+      // Devices before this one already posted. Their CQEs will arrive with
+      // nothing tracked, so there is no recoverable exit.
+      FB_CHECKABORT(
+          device == 0,
+          "Failed to post flush RDMA READ on device {} after a partial post: {}",
+          device,
+          maybeSend.error().errStr);
+      CTRAN_ERR(
+          commSystemError,
+          "CTRAN-IB: failed to post flush RDMA READ on device {}: {}",
+          device,
+          maybeSend.error().errStr);
+      return commSystemError;
+    }
     CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-IB: posted flush on qpn {}, req {}",
@@ -130,32 +167,23 @@ commResult_t LocalVirtualConn::iflush(
         (void*)req);
   }
 
-  // Push one entry per device CQE. Only the last carries the actual req;
-  // earlier entries are nullptr so processCqe drains them without completing.
-  for (int device = 0; device < devices_.size(); device++) {
-    outstandingReqs_.push_back(device == devices_.size() - 1 ? req : nullptr);
-  }
+  // Tracking after the post loop keeps the failure path free of cleanup. The
+  // caller serializes iflush against CQE processing, so a completion can
+  // arrive in between but never be observed.
+  tracker_.track(req);
 
   return commSuccess;
 }
 
 commResult_t LocalVirtualConn::processCqe(
-    const enum ibverbx::ibv_wc_opcode opcode) {
+    const enum ibverbx::ibv_wc_opcode opcode,
+    const int device) {
   FB_CHECKABORT(
       opcode == ibverbx::IBV_WC_RDMA_READ,
       "Invalid opcode {} received in flush virtual connection",
       opcode);
 
-  // Since each flush is executed by network one by one, we complete each flush
-  // as simple FIFO. With multi-NIC, each iflush posts one RDMA READ per
-  // device; only the last entry carries the request to complete.
-  auto req = outstandingReqs_.front();
-  outstandingReqs_.pop_front();
-  if (req) {
-    FB_COMMCHECK(req->complete());
-  }
-
-  return commSuccess;
+  return tracker_.complete(device);
 }
 
 uint32_t LocalVirtualConn::qpNum(int device) const {

--- a/comms/ctran/backends/ib/CtranIbLocalVc.h
+++ b/comms/ctran/backends/ib/CtranIbLocalVc.h
@@ -2,10 +2,10 @@
 
 #pragma once
 
-#include <deque>
 #include <string>
 
 #include "comms/ctran/backends/ib/CtranIbBase.h"
+#include "comms/ctran/backends/ib/FlushCompletionTracker.h"
 #include "comms/ctran/ibverbx/Ibverbx.h"
 
 #include "comms/utils/commSpecs.h"
@@ -21,7 +21,9 @@ class LocalVirtualConn {
   commResult_t
   iflush(const void* dbuf, const void* ibRegElem, CtranIbRequest* req);
 
-  commResult_t processCqe(const enum ibverbx::ibv_wc_opcode opcode);
+  commResult_t processCqe(
+      const enum ibverbx::ibv_wc_opcode opcode,
+      const int device);
 
   uint32_t qpNum(int device = 0) const;
 
@@ -38,6 +40,6 @@ class LocalVirtualConn {
   CommLogData commLogData_;
 
   // Track completion of outstanding flushes
-  std::deque<CtranIbRequest*> outstandingReqs_;
+  FlushCompletionTracker tracker_;
 };
 } // namespace ctran::ib

--- a/comms/ctran/backends/ib/FlushCompletionTracker.h
+++ b/comms/ctran/backends/ib/FlushCompletionTracker.h
@@ -1,0 +1,75 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <vector>
+
+#include "comms/ctran/backends/ib/CtranIbBase.h"
+#include "comms/ctran/utils/Checks.h"
+
+namespace ctran::ib {
+
+/**
+ * Tracks completion of flushes that fan out one loopback RDMA READ per IB
+ * device.
+ *
+ * Every device owns its own CQ and its own loopback RC QP, so completion order
+ * is guaranteed only within a device, never across devices. A single shared
+ * FIFO would therefore allow a later flush's completion on one device to retire
+ * an earlier flush's slot, reporting that earlier flush as done while its READ
+ * on another device is still in flight. One FIFO per device plus a per-flush
+ * reference count makes a flush complete only once every device has reported.
+ *
+ * This puts a requirement on progress: a flush stays incomplete until every
+ * device's CQ has been polled, so a progress loop restricted to a subset of the
+ * devices can never retire a flush.
+ */
+class FlushCompletionTracker {
+ public:
+  explicit FlushCompletionTracker(const size_t numDevices)
+      : perDevice_(numDevices) {
+    // Without a per-device FIFO there is no completion to decrement the
+    // reference count that track() arms, so the flush would never retire.
+    FB_CHECKABORT(
+        numDevices > 0,
+        "Flush completion tracking requires at least one device, got {}",
+        numDevices);
+  }
+
+  // Register a flush that has one RDMA READ posted per device. A null request
+  // is tracked as a placeholder that drains without completing anything.
+  void track(CtranIbRequest* req) {
+    if (req != nullptr) {
+      req->setRefCount(static_cast<int>(perDevice_.size()));
+    }
+    for (auto& reqs : perDevice_) {
+      reqs.push_back(req);
+    }
+  }
+
+  // Retire the oldest flush slot of the given device. An out-of-range device
+  // escapes as std::out_of_range rather than as a commResult_t, since it can
+  // only mean the caller mismatched the CQ it polled with this tracker.
+  commResult_t complete(const int device) {
+    auto& reqs = perDevice_.at(device);
+    FB_CHECKABORT(
+        !reqs.empty(), "No outstanding flush tracked for device {}", device);
+    CtranIbRequest* const req = reqs.front();
+    reqs.pop_front();
+    if (req != nullptr) {
+      FB_COMMCHECK(req->complete());
+    }
+    return commSuccess;
+  }
+
+  size_t outstanding(const int device) const {
+    return perDevice_.at(device).size();
+  }
+
+ private:
+  std::vector<std::deque<CtranIbRequest*>> perDevice_;
+};
+
+} // namespace ctran::ib

--- a/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
@@ -371,6 +371,31 @@ TEST_F(CtranIbBootstrapCommonTest, EmptySocketIfnameFailsNoInterfaces) {
   }
 }
 
+// CtranMapper only allocates a request when the caller wants to track the
+// flush, so both skip paths of iflush have to tolerate a null request.
+TEST_F(CtranIbBootstrapCommonTest, IflushSkipPathsAcceptNullRequest) {
+  auto abortCtrl = comms::fault_tolerance::createAbort(/*enabled=*/true);
+  auto ctranIb = createCtranIb(
+      /*rank=*/0, CtranIb::BootstrapMode::kDefaultServer, abortCtrl);
+
+  CtranIbEpochRAII epochRAII(ctranIb.get());
+
+  // createCtranIb disables local flush, so the registration handle is never
+  // dereferenced and a non-null placeholder selects the disabled-flush path.
+  int placeholderRegHdl = 0;
+  EXPECT_EQ(
+      ctranIb->iflush(
+          /*dbuf=*/nullptr,
+          /*localRegHdl=*/&placeholderRegHdl,
+          /*req=*/nullptr),
+      commSuccess);
+
+  EXPECT_EQ(
+      ctranIb->iflush(
+          /*dbuf=*/nullptr, /*localRegHdl=*/nullptr, /*req=*/nullptr),
+      commSuccess);
+}
+
 // Test bootstrapStart with specified server address
 TEST_P(CtranIbBootstrapParameterizedTest, BootstrapStartSpecifiedServer) {
   SocketServerAddr serverAddr = getSocketServerAddress();

--- a/comms/ctran/backends/ib/tests/FlushCompletionTrackerUT.cc
+++ b/comms/ctran/backends/ib/tests/FlushCompletionTrackerUT.cc
@@ -1,0 +1,101 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/backends/ib/CtranIbBase.h"
+#include "comms/ctran/backends/ib/FlushCompletionTracker.h"
+
+using ctran::ib::FlushCompletionTracker;
+
+TEST(FlushCompletionTrackerDeathTest, ZeroDevicesAborts) {
+  EXPECT_DEATH(
+      FlushCompletionTracker(/*numDevices=*/0),
+      "Flush completion tracking requires at least one device");
+}
+
+TEST(FlushCompletionTrackerDeathTest, CompleteOnEmptyDeviceAborts) {
+  FlushCompletionTracker tracker(/*numDevices=*/2);
+
+  EXPECT_DEATH(
+      tracker.complete(0), "No outstanding flush tracked for device 0");
+}
+
+TEST(FlushCompletionTrackerTest, SingleDeviceIsFifo) {
+  FlushCompletionTracker tracker(/*numDevices=*/1);
+  CtranIbRequest firstFlush;
+  CtranIbRequest secondFlush;
+
+  tracker.track(&firstFlush);
+  tracker.track(&secondFlush);
+  EXPECT_EQ(tracker.outstanding(0), 2);
+
+  EXPECT_EQ(tracker.complete(0), commSuccess);
+  EXPECT_TRUE(firstFlush.isComplete());
+  EXPECT_FALSE(secondFlush.isComplete());
+
+  EXPECT_EQ(tracker.complete(0), commSuccess);
+  EXPECT_TRUE(secondFlush.isComplete());
+  EXPECT_EQ(tracker.outstanding(0), 0);
+}
+
+// Encodes the defect this class exists to prevent: with a single shared FIFO,
+// draining two completions from device 0 would positionally retire the first
+// flush even though its read on device 1 is still in flight.
+TEST(FlushCompletionTrackerTest, SkewedCrossDeviceCompletion) {
+  FlushCompletionTracker tracker(/*numDevices=*/2);
+  CtranIbRequest firstFlush;
+  CtranIbRequest secondFlush;
+
+  tracker.track(&firstFlush);
+  tracker.track(&secondFlush);
+
+  EXPECT_EQ(tracker.complete(0), commSuccess);
+  // Retiring a device-0 slot must leave device 1 untouched, otherwise the
+  // deques are not independent and cross-device skew is unrepresentable.
+  EXPECT_EQ(tracker.outstanding(0), 1);
+  EXPECT_EQ(tracker.outstanding(1), 2);
+
+  EXPECT_EQ(tracker.complete(0), commSuccess);
+  EXPECT_FALSE(firstFlush.isComplete());
+  EXPECT_FALSE(secondFlush.isComplete());
+
+  EXPECT_EQ(tracker.complete(1), commSuccess);
+  EXPECT_TRUE(firstFlush.isComplete());
+  EXPECT_FALSE(secondFlush.isComplete());
+
+  EXPECT_EQ(tracker.complete(1), commSuccess);
+  EXPECT_TRUE(secondFlush.isComplete());
+}
+
+TEST(FlushCompletionTrackerTest, AllDevicesRequiredForSingleFlush) {
+  constexpr int kNumDevices = 4;
+  FlushCompletionTracker tracker(kNumDevices);
+  CtranIbRequest flush;
+
+  tracker.track(&flush);
+  for (int device = 0; device < kNumDevices - 1; device++) {
+    EXPECT_EQ(tracker.complete(device), commSuccess);
+    EXPECT_FALSE(flush.isComplete());
+  }
+
+  EXPECT_EQ(tracker.complete(kNumDevices - 1), commSuccess);
+  EXPECT_TRUE(flush.isComplete());
+}
+
+TEST(FlushCompletionTrackerTest, NullSlotsDrainWithoutCompleting) {
+  FlushCompletionTracker tracker(/*numDevices=*/2);
+  CtranIbRequest flush;
+
+  tracker.track(nullptr);
+  tracker.track(&flush);
+
+  EXPECT_EQ(tracker.complete(0), commSuccess);
+  EXPECT_EQ(tracker.complete(1), commSuccess);
+  EXPECT_FALSE(flush.isComplete());
+
+  EXPECT_EQ(tracker.complete(0), commSuccess);
+  EXPECT_FALSE(flush.isComplete());
+
+  EXPECT_EQ(tracker.complete(1), commSuccess);
+  EXPECT_TRUE(flush.isComplete());
+}

--- a/comms/utils/StrUtils.h
+++ b/comms/utils/StrUtils.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <chrono>
+#include <cstring>
 #include <fstream>
 #include <iomanip>
 #include <iterator>
@@ -20,6 +21,25 @@ inline std::string hashToHexStr(const uint64_t hash) {
   std::stringstream ss;
   ss << std::hex << hash;
   return ss.str();
+}
+
+/**
+ * Return the symbolic name of an errno value, e.g. "EINVAL".
+ * strerrorname_np was added in glibc 2.32 and is declared only under
+ * _GNU_SOURCE, so it is unavailable on some OSS toolchains. Returns "UNKNOWN"
+ * there and for unrecognized errno values.
+ */
+inline std::string errnoToNameStr([[maybe_unused]] const int errnoValue) {
+#if defined(__GLIBC__) && defined(__GLIBC_PREREQ) && defined(_GNU_SOURCE)
+#if __GLIBC_PREREQ(2, 32)
+  const char* name = ::strerrorname_np(errnoValue);
+  return name != nullptr ? name : "UNKNOWN";
+#else
+  return "UNKNOWN";
+#endif
+#else
+  return "UNKNOWN";
+#endif
 }
 
 template <typename T>


### PR DESCRIPTION
Summary:

## Bug

`LocalVirtualConn::iflush` posts one loopback RDMA READ per IB device. Completions went into a single shared FIFO and were retired by position. IB orders completions within a device, never across devices, so position is the wrong key.

Config that puts two flushes in flight at once:

```
ctsrdpipeline, nNodes = 4     ->  nSteps = log2(4) = 2      steps 0, 1
step 1 carries 2^1 = 2 chunks
those chunks arrive in 2 batches  ->  progressRecvFwd posts 2 iflush
NCCL_CTRAN_IB_DEVICES_PER_RANK = 2  ->  each iflush posts 2 READs
```

Shared FIFO once both are posted. One slot per device per flush, only the last slot of each flush carries the request:

```
front ->  [ null ][  F1  ][ null ][  F2  ]  <- back
            d0      d1      d0      d1
```

`progressInternal` polls one CQE per device per pass and skips a device whose CQ is empty. So device 1 can lag:

| pass | dev0 CQ  | dev1 CQ  | pops | result |
|------|----------|----------|------|--------|
| k    | F1.dev0  | empty    | null | -      |
| k+1  | F2.dev0  | empty    | F1   | **F1 reported COMPLETE, F1.dev1 still in flight** |
| k+2  | empty    | F1.dev1  | null | -      |
| k+3  | empty    | F2.dev1  | F2   | F2 completes, by coincidence |

At k+1 the consumer is released early. `progressPuts` sees `testRequest(F1)` true and issues the forwarded `iput`, which reads a recvbuff chunk the NIC has not finished writing. Wrong bytes behind a valid notify. No hang, no error.

`AllGather/StreamedRd` and `AllReduceRing` both gate on individual flush requests and leave several flushes outstanding, so both are exposed.

## Fix

Retire by device, not by position. One FIFO per device, plus a per-flush refcount of `numDevices`. A CQE from device `d` pops device `d`'s own queue and decrements that request. The flush retires when the refcount reaches zero, so only after every device has reported.

```
device 0 ->  [ F1 ][ F2 ]        F1.refcount = 2
device 1 ->  [ F1 ][ F2 ]        F2.refcount = 2
```

Same CQE order as above:

| pass | CQE     | pops from | result |
|------|---------|-----------|--------|
| k    | F1.dev0 | dev0      | F1 refcount 2 -> 1 |
| k+1  | F2.dev0 | dev0      | F2 refcount 2 -> 1 |
| k+2  | F1.dev1 | dev1      | F1 refcount 1 -> 0, **COMPLETE** |
| k+3  | F2.dev1 | dev1      | F2 refcount 1 -> 0, COMPLETE |

Both halves carry weight. Per-device queues give correct attribution; the refcount is what withholds completion until the slow device reports.

Also fixed, same file:

- Skip the flush when the buffer carries no IB registration, rather than dereferencing a null handle. Such a buffer never received IB writes, so there is nothing to order.
- Tolerate a null request in the flush-disabled path.
- Require one memory region per device. A short vector yields a bogus rkey and a flush that orders nothing.
- Bound in-flight flushes by the QP send-queue depth, while exhaustion is still a recoverable error.
- Treat a post failure on the first device as recoverable, since nothing is posted yet. A partial post is fatal: the per-device queues are then permanently out of step.

Reviewed By: harishkc77

Differential Revision: D118906933
