### PR TITLE
Always set the flush request on CtranMapper::iflush skip paths (#4039)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -401,7 +401,7 @@ inline void progressRecvPostFlush(
   char* tmpRecvBuf = reinterpret_cast<char*>(resource.tmpRecvBuf) +
       tmpChunkId * algoCtx.chunkSize;
 
-  CtranMapperRequest* req;
+  CtranMapperRequest* req = nullptr;
   FB_COMMCHECKTHROW_EX(
       resource.comm->ctran_->mapper->iflush(
           tmpRecvBuf, resource.tmpRecvBufHdl, &req),

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -943,13 +943,22 @@ commResult_t CtranIb::iflush(
     CtranIbRequest* req) {
   FB_COMMCHECK(checkEpochLock(this));
 
-  if (enableLocalFlush_) {
+  if (enableLocalFlush_ && localRegHdl != nullptr) {
     CTRAN_IB_PER_OBJ_LOCK_GUARD(localVcMutex, {
       auto& vc = localVc;
       return vc->iflush(dbuf, localRegHdl, req);
     });
   } else {
-    req->complete();
+    // A buffer with no IB registration never received IB RDMA writes, so there
+    // is nothing to order against and skipping is correct. Local flush being
+    // disabled altogether is the expected steady state, not an anomaly, so it
+    // stays silent.
+    if (enableLocalFlush_) {
+      CTRAN_LOG(WARN, "CTRAN-IB: No IB registration for flush, skip");
+    }
+    if (req != nullptr) {
+      FB_COMMCHECK(req->complete());
+    }
     return commSuccess;
   }
 }

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -1072,7 +1072,7 @@ class CtranIb {
             // First check if it is a local flush CQE
             if (wc.qp_num == vc->qpNum(device)) {
               CQE_ERROR_CHECK(wc, rank, "localFlush");
-              FB_COMMCHECK(vc->processCqe(wc.opcode));
+              FB_COMMCHECK(vc->processCqe(wc.opcode, device));
               continue;
             }
           });

--- a/comms/ctran/backends/ib/CtranIbLocalVc.cc
+++ b/comms/ctran/backends/ib/CtranIbLocalVc.cc
@@ -17,7 +17,9 @@ namespace ctran::ib {
 LocalVirtualConn::LocalVirtualConn(
     std::vector<CtranIbDevice>& devices,
     CommLogData commLogData)
-    : devices_(devices), commLogData_(std::move(commLogData)) {
+    : devices_(devices),
+      commLogData_(std::move(commLogData)),
+      tracker_(devices_.size()) {
   FB_CHECKABORT(
       devices_.size() <= NCCL_CTRAN_IB_DEVICES_PER_RANK,
       "Invalid number of devices {} received in flush virtual connection compared to NCCL_CTRAN_IB_DEVICES_PER_RANK {}",
@@ -109,6 +111,27 @@ commResult_t LocalVirtualConn::iflush(
     const void* ibRegElem,
     CtranIbRequest* req) {
   auto mrs = reinterpret_cast<const std::vector<ibverbx::IbvMr>*>(ibRegElem);
+  FB_CHECKABORT(
+      mrs->size() >= devices_.size(),
+      "Flush requires one memory region per device, but got {} regions for {} devices",
+      mrs->size(),
+      devices_.size());
+
+  // Each flush burns one send-queue slot per device and nothing upstream bounds
+  // the number of flushes in flight, so the queue depth has to be enforced here
+  // while the failure is still recoverable.
+  for (int device = 0; device < devices_.size(); device++) {
+    if (tracker_.outstanding(device) >= static_cast<size_t>(MAX_SEND_WR)) {
+      CTRAN_ERR(
+          commInternalError,
+          "CTRAN-IB: flush send queue is full on device {} ({} outstanding, max {})",
+          device,
+          tracker_.outstanding(device),
+          MAX_SEND_WR);
+      return commInternalError;
+    }
+  }
+
   for (int device = 0; device < devices_.size(); device++) {
     ibverbx::ibv_send_wr wr;
     memset(&wr, 0, sizeof(wr));
@@ -122,7 +145,21 @@ commResult_t LocalVirtualConn::iflush(
 
     ibverbx::ibv_send_wr* bad_wr{nullptr};
     auto maybeSend = ibvQps_[device].postSend(&wr, &bad_wr);
-    FOLLY_EXPECTED_CHECK(maybeSend);
+    if (maybeSend.hasError()) {
+      // Devices before this one already posted. Their CQEs will arrive with
+      // nothing tracked, so there is no recoverable exit.
+      FB_CHECKABORT(
+          device == 0,
+          "Failed to post flush RDMA READ on device {} after a partial post: {}",
+          device,
+          maybeSend.error().errStr);
+      CTRAN_ERR(
+          commSystemError,
+          "CTRAN-IB: failed to post flush RDMA READ on device {}: {}",
+          device,
+          maybeSend.error().errStr);
+      return commSystemError;
+    }
     CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-IB: posted flush on qpn {}, req {}",
@@ -130,32 +167,23 @@ commResult_t LocalVirtualConn::iflush(
         (void*)req);
   }
 
-  // Push one entry per device CQE. Only the last carries the actual req;
-  // earlier entries are nullptr so processCqe drains them without completing.
-  for (int device = 0; device < devices_.size(); device++) {
-    outstandingReqs_.push_back(device == devices_.size() - 1 ? req : nullptr);
-  }
+  // Tracking after the post loop keeps the failure path free of cleanup. The
+  // caller serializes iflush against CQE processing, so a completion can
+  // arrive in between but never be observed.
+  tracker_.track(req);
 
   return commSuccess;
 }
 
 commResult_t LocalVirtualConn::processCqe(
-    const enum ibverbx::ibv_wc_opcode opcode) {
+    const enum ibverbx::ibv_wc_opcode opcode,
+    const int device) {
   FB_CHECKABORT(
       opcode == ibverbx::IBV_WC_RDMA_READ,
       "Invalid opcode {} received in flush virtual connection",
       opcode);
 
-  // Since each flush is executed by network one by one, we complete each flush
-  // as simple FIFO. With multi-NIC, each iflush posts one RDMA READ per
-  // device; only the last entry carries the request to complete.
-  auto req = outstandingReqs_.front();
-  outstandingReqs_.pop_front();
-  if (req) {
-    FB_COMMCHECK(req->complete());
-  }
-
-  return commSuccess;
+  return tracker_.complete(device);
 }
 
 uint32_t LocalVirtualConn::qpNum(int device) const {

--- a/comms/ctran/backends/ib/CtranIbLocalVc.h
+++ b/comms/ctran/backends/ib/CtranIbLocalVc.h
@@ -2,10 +2,10 @@
 
 #pragma once
 
-#include <deque>
 #include <string>
 
 #include "comms/ctran/backends/ib/CtranIbBase.h"
+#include "comms/ctran/backends/ib/FlushCompletionTracker.h"
 #include "comms/ctran/ibverbx/Ibverbx.h"
 
 #include "comms/utils/commSpecs.h"
@@ -21,7 +21,9 @@ class LocalVirtualConn {
   commResult_t
   iflush(const void* dbuf, const void* ibRegElem, CtranIbRequest* req);
 
-  commResult_t processCqe(const enum ibverbx::ibv_wc_opcode opcode);
+  commResult_t processCqe(
+      const enum ibverbx::ibv_wc_opcode opcode,
+      const int device);
 
   uint32_t qpNum(int device = 0) const;
 
@@ -38,6 +40,6 @@ class LocalVirtualConn {
   CommLogData commLogData_;
 
   // Track completion of outstanding flushes
-  std::deque<CtranIbRequest*> outstandingReqs_;
+  FlushCompletionTracker tracker_;
 };
 } // namespace ctran::ib

--- a/comms/ctran/backends/ib/FlushCompletionTracker.h
+++ b/comms/ctran/backends/ib/FlushCompletionTracker.h
@@ -1,0 +1,75 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <vector>
+
+#include "comms/ctran/backends/ib/CtranIbBase.h"
+#include "comms/ctran/utils/Checks.h"
+
+namespace ctran::ib {
+
+/**
+ * Tracks completion of flushes that fan out one loopback RDMA READ per IB
+ * device.
+ *
+ * Every device owns its own CQ and its own loopback RC QP, so completion order
+ * is guaranteed only within a device, never across devices. A single shared
+ * FIFO would therefore allow a later flush's completion on one device to retire
+ * an earlier flush's slot, reporting that earlier flush as done while its READ
+ * on another device is still in flight. One FIFO per device plus a per-flush
+ * reference count makes a flush complete only once every device has reported.
+ *
+ * This puts a requirement on progress: a flush stays incomplete until every
+ * device's CQ has been polled, so a progress loop restricted to a subset of the
+ * devices can never retire a flush.
+ */
+class FlushCompletionTracker {
+ public:
+  explicit FlushCompletionTracker(const size_t numDevices)
+      : perDevice_(numDevices) {
+    // Without a per-device FIFO there is no completion to decrement the
+    // reference count that track() arms, so the flush would never retire.
+    FB_CHECKABORT(
+        numDevices > 0,
+        "Flush completion tracking requires at least one device, got {}",
+        numDevices);
+  }
+
+  // Register a flush that has one RDMA READ posted per device. A null request
+  // is tracked as a placeholder that drains without completing anything.
+  void track(CtranIbRequest* req) {
+    if (req != nullptr) {
+      req->setRefCount(static_cast<int>(perDevice_.size()));
+    }
+    for (auto& reqs : perDevice_) {
+      reqs.push_back(req);
+    }
+  }
+
+  // Retire the oldest flush slot of the given device. An out-of-range device
+  // escapes as std::out_of_range rather than as a commResult_t, since it can
+  // only mean the caller mismatched the CQ it polled with this tracker.
+  commResult_t complete(const int device) {
+    auto& reqs = perDevice_.at(device);
+    FB_CHECKABORT(
+        !reqs.empty(), "No outstanding flush tracked for device {}", device);
+    CtranIbRequest* const req = reqs.front();
+    reqs.pop_front();
+    if (req != nullptr) {
+      FB_COMMCHECK(req->complete());
+    }
+    return commSuccess;
+  }
+
+  size_t outstanding(const int device) const {
+    return perDevice_.at(device).size();
+  }
+
+ private:
+  std::vector<std::deque<CtranIbRequest*>> perDevice_;
+};
+
+} // namespace ctran::ib

--- a/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
@@ -371,6 +371,31 @@ TEST_F(CtranIbBootstrapCommonTest, EmptySocketIfnameFailsNoInterfaces) {
   }
 }
 
+// CtranMapper only allocates a request when the caller wants to track the
+// flush, so both skip paths of iflush have to tolerate a null request.
+TEST_F(CtranIbBootstrapCommonTest, IflushSkipPathsAcceptNullRequest) {
+  auto abortCtrl = comms::fault_tolerance::createAbort(/*enabled=*/true);
+  auto ctranIb = createCtranIb(
+      /*rank=*/0, CtranIb::BootstrapMode::kDefaultServer, abortCtrl);
+
+  CtranIbEpochRAII epochRAII(ctranIb.get());
+
+  // createCtranIb disables local flush, so the registration handle is never
+  // dereferenced and a non-null placeholder selects the disabled-flush path.
+  int placeholderRegHdl = 0;
+  EXPECT_EQ(
+      ctranIb->iflush(
+          /*dbuf=*/nullptr,
+          /*localRegHdl=*/&placeholderRegHdl,
+          /*req=*/nullptr),
+      commSuccess);
+
+  EXPECT_EQ(
+      ctranIb->iflush(
+          /*dbuf=*/nullptr, /*localRegHdl=*/nullptr, /*req=*/nullptr),
+      commSuccess);
+}
+
 // Test bootstrapStart with specified server address
 TEST_P(CtranIbBootstrapParameterizedTest, BootstrapStartSpecifiedServer) {
   SocketServerAddr serverAddr = getSocketServerAddress();

--- a/comms/ctran/backends/ib/tests/FlushCompletionTrackerUT.cc
+++ b/comms/ctran/backends/ib/tests/FlushCompletionTrackerUT.cc
@@ -1,0 +1,101 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/backends/ib/CtranIbBase.h"
+#include "comms/ctran/backends/ib/FlushCompletionTracker.h"
+
+using ctran::ib::FlushCompletionTracker;
+
+TEST(FlushCompletionTrackerDeathTest, ZeroDevicesAborts) {
+  EXPECT_DEATH(
+      FlushCompletionTracker(/*numDevices=*/0),
+      "Flush completion tracking requires at least one device");
+}
+
+TEST(FlushCompletionTrackerDeathTest, CompleteOnEmptyDeviceAborts) {
+  FlushCompletionTracker tracker(/*numDevices=*/2);
+
+  EXPECT_DEATH(
+      tracker.complete(0), "No outstanding flush tracked for device 0");
+}
+
+TEST(FlushCompletionTrackerTest, SingleDeviceIsFifo) {
+  FlushCompletionTracker tracker(/*numDevices=*/1);
+  CtranIbRequest firstFlush;
+  CtranIbRequest secondFlush;
+
+  tracker.track(&firstFlush);
+  tracker.track(&secondFlush);
+  EXPECT_EQ(tracker.outstanding(0), 2);
+
+  EXPECT_EQ(tracker.complete(0), commSuccess);
+  EXPECT_TRUE(firstFlush.isComplete());
+  EXPECT_FALSE(secondFlush.isComplete());
+
+  EXPECT_EQ(tracker.complete(0), commSuccess);
+  EXPECT_TRUE(secondFlush.isComplete());
+  EXPECT_EQ(tracker.outstanding(0), 0);
+}
+
+// Encodes the defect this class exists to prevent: with a single shared FIFO,
+// draining two completions from device 0 would positionally retire the first
+// flush even though its read on device 1 is still in flight.
+TEST(FlushCompletionTrackerTest, SkewedCrossDeviceCompletion) {
+  FlushCompletionTracker tracker(/*numDevices=*/2);
+  CtranIbRequest firstFlush;
+  CtranIbRequest secondFlush;
+
+  tracker.track(&firstFlush);
+  tracker.track(&secondFlush);
+
+  EXPECT_EQ(tracker.complete(0), commSuccess);
+  // Retiring a device-0 slot must leave device 1 untouched, otherwise the
+  // deques are not independent and cross-device skew is unrepresentable.
+  EXPECT_EQ(tracker.outstanding(0), 1);
+  EXPECT_EQ(tracker.outstanding(1), 2);
+
+  EXPECT_EQ(tracker.complete(0), commSuccess);
+  EXPECT_FALSE(firstFlush.isComplete());
+  EXPECT_FALSE(secondFlush.isComplete());
+
+  EXPECT_EQ(tracker.complete(1), commSuccess);
+  EXPECT_TRUE(firstFlush.isComplete());
+  EXPECT_FALSE(secondFlush.isComplete());
+
+  EXPECT_EQ(tracker.complete(1), commSuccess);
+  EXPECT_TRUE(secondFlush.isComplete());
+}
+
+TEST(FlushCompletionTrackerTest, AllDevicesRequiredForSingleFlush) {
+  constexpr int kNumDevices = 4;
+  FlushCompletionTracker tracker(kNumDevices);
+  CtranIbRequest flush;
+
+  tracker.track(&flush);
+  for (int device = 0; device < kNumDevices - 1; device++) {
+    EXPECT_EQ(tracker.complete(device), commSuccess);
+    EXPECT_FALSE(flush.isComplete());
+  }
+
+  EXPECT_EQ(tracker.complete(kNumDevices - 1), commSuccess);
+  EXPECT_TRUE(flush.isComplete());
+}
+
+TEST(FlushCompletionTrackerTest, NullSlotsDrainWithoutCompleting) {
+  FlushCompletionTracker tracker(/*numDevices=*/2);
+  CtranIbRequest flush;
+
+  tracker.track(nullptr);
+  tracker.track(&flush);
+
+  EXPECT_EQ(tracker.complete(0), commSuccess);
+  EXPECT_EQ(tracker.complete(1), commSuccess);
+  EXPECT_FALSE(flush.isComplete());
+
+  EXPECT_EQ(tracker.complete(0), commSuccess);
+  EXPECT_FALSE(flush.isComplete());
+
+  EXPECT_EQ(tracker.complete(1), commSuccess);
+  EXPECT_TRUE(flush.isComplete());
+}

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -741,32 +741,35 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    *   - buf: the local buffer to flush
    *   - regHdl: the local registration handle of the local buffer
    * Output arguments:
-   *   - req: the request object to track the progress of the flush.
+   *   - req: the request object to track the progress of the flush. Must not
+   * be null. Owned by the caller and always set on success; when no flush is
+   * posted (no IB backend or no IB registration) the request comes back
+   * already complete.
    */
   inline commResult_t
   iflush(const void* buf, const void* regHdl, CtranMapperRequest** req) {
+    FB_COMMCHECK(this->checkValidReq(req, __func__));
+
     if (this->ctranIb) {
       auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(
           const_cast<void*>(regHdl));
-      if (!regElem) {
-        CTRAN_LOG(WARN, "CTRAN-MAPPER: No IB registration for flush, skip");
+      if (regElem) {
+        auto regLk = regElem->stateMnger.rlock();
+        // Ownership transfers to the caller only once the flush is posted; on
+        // an error path the caller's pointer is left untouched.
+        auto reqOwner = std::make_unique<CtranMapperRequest>();
+        FB_COMMCHECK(
+            this->ctranIb->iflush(buf, regElem->ibRegElem, &(reqOwner->ibReq)));
+        *req = reqOwner.release();
         return commSuccess;
       }
-      auto regLk = regElem->stateMnger.rlock();
-      CtranIbRequest* ibReq = nullptr;
-      if (req) {
-        *req = new CtranMapperRequest();
-        ibReq = &((*req)->ibReq);
-      }
-      FB_COMMCHECK(this->ctranIb->iflush(buf, regElem->ibRegElem, ibReq));
-    } else if (this->ctranTcpDm) {
-      // TCPDM: flush is unnecessary — data arrives via kernel unpack.
-      // Return a pre-completed request so callers can poll normally.
-      if (req) {
-        *req = new CtranMapperRequest();
-        (*req)->setComplete();
-      }
+      CTRAN_LOG(WARN, "CTRAN-MAPPER: No IB registration for flush, skip");
     }
+    // No flush was posted: either no IB backend (TCPDM needs none, data
+    // arrives via kernel unpack) or no IB registration for the buffer.
+    // Return a pre-completed request so callers can poll normally.
+    *req = new CtranMapperRequest();
+    (*req)->setComplete();
     return commSuccess;
   }
 

--- a/comms/ctran/mapper/tests/CtranMapperUT.cc
+++ b/comms/ctran/mapper/tests/CtranMapperUT.cc
@@ -955,6 +955,91 @@ TEST_F(CtranMapperTest, icopyNoReq) {
   CUDACHECK_TEST(cudaFree(srcBuf));
 }
 
+TEST_F(CtranMapperTest, iflushRejectsNullReq) {
+  mapper = std::make_unique<CtranMapper>(dummyComm_);
+
+  EXPECT_EQ(mapper->iflush(buf, hdl, nullptr), commInternalError);
+}
+
+TEST_F(CtranMapperTest, iflushUnregisteredBufReturnsCompletedReq) {
+  mapper = std::make_unique<CtranMapper>(dummyComm_);
+  const auto rank = dummyComm_->statex_->rank();
+  ASSERT_TRUE(mapper->hasBackend(rank, CtranMapperBackend::IB));
+
+  // No IB registration for the buffer, so no flush is posted.
+  CtranMapperRequest* rawReq = nullptr;
+  ASSERT_EQ(mapper->iflush(buf, nullptr, &rawReq), commSuccess);
+  const std::unique_ptr<CtranMapperRequest> req(rawReq);
+  ASSERT_THAT(req, testing::NotNull());
+
+  bool isComplete = false;
+  EXPECT_EQ(mapper->testRequest(req.get(), &isComplete), commSuccess);
+  EXPECT_TRUE(isComplete);
+}
+
+TEST_F(CtranMapperTest, iflushWithoutIbBackendReturnsCompletedReq) {
+  SysEnvRAII backendsEnv("NCCL_CTRAN_BACKENDS", "nvl, socket");
+  ncclCvarInit();
+
+  mapper = std::make_unique<CtranMapper>(dummyComm_);
+  const auto rank = dummyComm_->statex_->rank();
+  ASSERT_FALSE(mapper->hasBackend(rank, CtranMapperBackend::IB));
+  ASSERT_FALSE(mapper->hasBackend(rank, CtranMapperBackend::TCPDM));
+
+  // The buffer is registered, so only the missing IB backend can skip the
+  // flush.
+  void* regHdl = nullptr;
+  bool dynamicRegist = false;
+  ASSERT_EQ(
+      mapper->searchRegHandle(buf, bufSize, &regHdl, &dynamicRegist),
+      commSuccess);
+  ASSERT_THAT(regHdl, testing::NotNull());
+
+  CtranMapperRequest* rawReq = nullptr;
+  ASSERT_EQ(mapper->iflush(buf, regHdl, &rawReq), commSuccess);
+  const std::unique_ptr<CtranMapperRequest> req(rawReq);
+  ASSERT_THAT(req, testing::NotNull());
+
+  bool isComplete = false;
+  EXPECT_EQ(mapper->testRequest(req.get(), &isComplete), commSuccess);
+  EXPECT_TRUE(isComplete);
+
+  if (dynamicRegist) {
+    EXPECT_EQ(mapper->deregDynamic(regHdl), commSuccess);
+  }
+}
+
+TEST_F(CtranMapperTest, iflushBackendErrorLeavesReqUntouched) {
+  mapper = std::make_unique<CtranMapper>(dummyComm_);
+  const auto rank = dummyComm_->statex_->rank();
+  ASSERT_TRUE(mapper->hasBackend(rank, CtranMapperBackend::IB));
+
+  void* regHdl = nullptr;
+  bool dynamicRegist = false;
+  ASSERT_EQ(
+      mapper->searchRegHandle(buf, bufSize, &regHdl, &dynamicRegist),
+      commSuccess);
+  ASSERT_THAT(regHdl, testing::NotNull());
+
+  {
+    // Calling into the IB backend without holding the epoch lock is the only
+    // error CtranIb::iflush can report without a fake device.
+    EnvRAII epochLockEnv(NCCL_CTRAN_IB_EPOCH_LOCK_ENABLE, true);
+    EnvRAII epochCheckEnv(NCCL_CTRAN_IB_EPOCH_LOCK_ENFORCE_CHECK, true);
+
+    // A sentinel proves the error path never writes to the caller's pointer,
+    // rather than merely leaving it null.
+    auto* const sentinel = reinterpret_cast<CtranMapperRequest*>(0xdeadbeef);
+    CtranMapperRequest* req = sentinel;
+    EXPECT_EQ(mapper->iflush(buf, regHdl, &req), commInternalError);
+    EXPECT_EQ(req, sentinel);
+  }
+
+  if (dynamicRegist) {
+    EXPECT_EQ(mapper->deregDynamic(regHdl), commSuccess);
+  }
+}
+
 TEST_F(CtranMapperTest, ReqInit) {
   mapper = std::make_unique<CtranMapper>(dummyComm_);
   const auto rank = this->dummyComm_->statex_->rank();


### PR DESCRIPTION
Summary:

`CtranMapper::iflush` returned `commSuccess` on two paths without writing its `req` output: a buffer with no IB registration, and neither backend configured. Callers were told the call succeeded, then read an output that was never set. `AllReduceRing::progressRecvPostFlush` made that reachable. It declared `CtranMapperRequest* req;` uninitialized and passed the result to `unique_ptr::reset`, which frees a garbage address. Its reverse twin already initialized the pointer.

The request is also allocated before the backend call, so an error return abandoned it. The caller got an error and a live request nobody owned.

- Return a pre-completed request on every success path, matching the TCPDM branch. Callers poll the same way whether or not a flush was posted.
- Fold the TCPDM arm into the shared tail. Gating on `ctranTcpDm` is what left the no-backend case unhandled.
- Own the request with `unique_ptr`, release it into the out-param after the backend call succeeds.
- Initialize the request pointer in `progressRecvPostFlush`.
- State the ownership rule in the `iflush` doc comment.

Reviewed By: harishkc77

Differential Revision: D118915336


