### PR TITLE
Wait for AGP puts to drain before releasing the stream (#4040)

### DIFF
--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -150,6 +150,11 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   for (auto& putReq : putReqs) {
     FB_COMMCHECK(mapper->waitRequest(&putReq));
   }
+  // Steps >= 1 put from recvbuff. Release the end kernel now that they drained.
+  // Do not move into a scope guard. It fires after waitPipeEnd and deadlocks.
+  if (nLocalRanks > 1 && resource->pipeSync != nullptr) {
+    resource->pipeSync->post(nNodes - 1);
+  }
   waitPipeEnd(*resource, comm);
   CTRAN_PROFILER_IF(
       profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
@@ -377,6 +382,9 @@ commResult_t AlgoImpl::execPipeline(
     PipeEndKernArgs kernArgs = {
         // Pass pipeSync to reset the flag before starting the next pipeline
         .pipeSync = resource_.pipeSync,
+        // The GPE worker posts steps 0..nNodes-2, so nNodes-1 is one past the
+        // last and cannot be satisfied by an ordinary step post.
+        .endSyncStep = nNodes > 1 ? nNodes - 1 : -1,
     };
     config.algoArgs = reinterpret_cast<void*>(&kernArgs);
     if (colltraceGroupOpen) {

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cu
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cu
@@ -93,6 +93,14 @@ __global__ void ncclKernelAllGatherPPipeEnd(
     CtranAlgoDeviceState* devState,
     PipeEndKernArgs args) {
   ctran::device::ColltraceEventScope colltraceScope(f);
+  int* const flag = f ? const_cast<int*>(f->flag_) : nullptr;
+  // waitPost reads device globals that only this sets.
+  ctran::device::devLoadAbortFlags(flag, devState);
+
+  // Must run before reset. Reset clears postFlag, so the value would be lost.
+  if (args.endSyncStep >= 0) {
+    GpeKernelSyncDev::waitPost(args.pipeSync, 0, args.endSyncStep);
+  }
 
   // Reset sync flag for next GPE->kernel pipeline sync to use
   GpeKernelSyncDev::reset(args.pipeSync, 0);
@@ -142,6 +150,15 @@ __global__ void ncclKernelAllGatherPSrdPipeEnd(
     CtranAlgoDeviceState* devState,
     PipeEndKernArgs args) {
   ctran::device::ColltraceEventScope colltraceScope(flag);
+  int* const abortFlag = flag ? const_cast<int*>(flag->flag_) : nullptr;
+  // waitPost reads device globals that only this sets.
+  ctran::device::devLoadAbortFlags(abortFlag, devState);
+
+  // Must run before reset. Reset clears postFlag, so the value would be lost.
+  if (args.endSyncStep >= 0) {
+    GpeKernelSyncDev::waitPost(args.pipeSync, 0, args.endSyncStep);
+  }
+
   // Reset sync flag for next GPE->kernel pipeline sync to use
   GpeKernelSyncDev::reset(args.pipeSync, 0);
 

--- a/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
@@ -172,6 +172,11 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   CTRAN_PROFILER_IF(
       profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
   FB_COMMCHECK(progressSteps(ctx, nodeId));
+  // Puts read recvbuff. Release the end kernel now that they have drained.
+  // Do not move into a scope guard. It fires after waitPipeEnd and deadlocks.
+  if (nLocalRanks > 1 && resource->pipeSync != nullptr) {
+    resource->pipeSync->post(recvPlan.nSteps());
+  }
   waitPipeEnd(*resource, comm);
   CTRAN_PROFILER_IF(
       profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
@@ -375,6 +380,7 @@ commResult_t AlgoImpl::execStreamedRecursiveDoubling(
 
     PipeEndKernArgs endArgs = {
         .pipeSync = resource_.pipeSync,
+        .endSyncStep = nNodes > 1 ? recvPlan.nSteps() : -1,
     };
     config.algoArgs = reinterpret_cast<void*>(&endArgs);
     if (colltraceGroupOpen) {

--- a/comms/ctran/algos/AllGatherP/Types.h
+++ b/comms/ctran/algos/AllGatherP/Types.h
@@ -79,6 +79,9 @@ constexpr int kPipeEndDone = 0;
 
 struct PipeEndKernArgs {
   GpeKernelSync* pipeSync;
+  // Step the GPE worker posts once its puts drain. One past the last real step.
+  // Negative means no GPE worker runs, so nobody posts. Do not wait then.
+  int endSyncStep;
 };
 
 struct PipeSyncKernArgs {

--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -401,7 +401,7 @@ inline void progressRecvPostFlush(
   char* tmpRecvBuf = reinterpret_cast<char*>(resource.tmpRecvBuf) +
       tmpChunkId * algoCtx.chunkSize;
 
-  CtranMapperRequest* req;
+  CtranMapperRequest* req = nullptr;
   FB_COMMCHECKTHROW_EX(
       resource.comm->ctran_->mapper->iflush(
           tmpRecvBuf, resource.tmpRecvBufHdl, &req),

--- a/comms/ctran/backends/ib/BootstrapInternal.cc
+++ b/comms/ctran/backends/ib/BootstrapInternal.cc
@@ -27,18 +27,10 @@
 #include "comms/ctran/utils/Debug.h"
 #include "comms/ctran/utils/Exception.h"
 #include "comms/ctran/utils/ExtUtils.h"
+#include "comms/utils/StrUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/ScubaLogger.h"
-
-// strerrorname_np() is a glibc >= 2.32 GNU extension. Guard its use so builds
-// against older glibc (e.g. the OSS almalinux toolchain) still compile; the
-// error name simply falls back to "UNKNOWN" there.
-#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
-#if __GLIBC_PREREQ(2, 32)
-#define IBVERBX_HAS_STRERRORNAME_NP 1
-#endif
-#endif
 
 namespace {
 const std::string kCtranIbLogEventName{"CtranIb-QpExchange"};
@@ -48,18 +40,14 @@ const uint64_t kBootstrapMagic = 0xfaceb00cdeadbeef;
 std::string socketErrorContext(int error) {
   const bool hasValidMagnitude = error != std::numeric_limits<int>::min();
   const int errnoValue = hasValidMagnitude && error < 0 ? -error : error;
-  const char* errorName = nullptr;
-#ifdef IBVERBX_HAS_STRERRORNAME_NP
-  if (hasValidMagnitude) {
-    errorName = ::strerrorname_np(errnoValue);
-  }
-#endif
+  const std::string errorName =
+      hasValidMagnitude ? errnoToNameStr(errnoValue) : "UNKNOWN";
   const std::string description =
       hasValidMagnitude ? folly::errnoStr(errnoValue) : "invalid errno value";
   return fmt::format(
       "origin=socket_error subsystem=ctran_ib error_code={} error_name={} error_description=\"{}\"",
       error,
-      errorName != nullptr ? errorName : "UNKNOWN",
+      errorName,
       folly::cEscape<std::string>(description));
 }
 } // namespace

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -943,13 +943,22 @@ commResult_t CtranIb::iflush(
     CtranIbRequest* req) {
   FB_COMMCHECK(checkEpochLock(this));
 
-  if (enableLocalFlush_) {
+  if (enableLocalFlush_ && localRegHdl != nullptr) {
     CTRAN_IB_PER_OBJ_LOCK_GUARD(localVcMutex, {
       auto& vc = localVc;
       return vc->iflush(dbuf, localRegHdl, req);
     });
   } else {
-    req->complete();
+    // A buffer with no IB registration never received IB RDMA writes, so there
+    // is nothing to order against and skipping is correct. Local flush being
+    // disabled altogether is the expected steady state, not an anomaly, so it
+    // stays silent.
+    if (enableLocalFlush_) {
+      CTRAN_LOG(WARN, "CTRAN-IB: No IB registration for flush, skip");
+    }
+    if (req != nullptr) {
+      FB_COMMCHECK(req->complete());
+    }
     return commSuccess;
   }
 }

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -1072,7 +1072,7 @@ class CtranIb {
             // First check if it is a local flush CQE
             if (wc.qp_num == vc->qpNum(device)) {
               CQE_ERROR_CHECK(wc, rank, "localFlush");
-              FB_COMMCHECK(vc->processCqe(wc.opcode));
+              FB_COMMCHECK(vc->processCqe(wc.opcode, device));
               continue;
             }
           });

--- a/comms/ctran/backends/ib/CtranIbLocalVc.cc
+++ b/comms/ctran/backends/ib/CtranIbLocalVc.cc
@@ -17,7 +17,9 @@ namespace ctran::ib {
 LocalVirtualConn::LocalVirtualConn(
     std::vector<CtranIbDevice>& devices,
     CommLogData commLogData)
-    : devices_(devices), commLogData_(std::move(commLogData)) {
+    : devices_(devices),
+      commLogData_(std::move(commLogData)),
+      tracker_(devices_.size()) {
   FB_CHECKABORT(
       devices_.size() <= NCCL_CTRAN_IB_DEVICES_PER_RANK,
       "Invalid number of devices {} received in flush virtual connection compared to NCCL_CTRAN_IB_DEVICES_PER_RANK {}",
@@ -109,6 +111,27 @@ commResult_t LocalVirtualConn::iflush(
     const void* ibRegElem,
     CtranIbRequest* req) {
   auto mrs = reinterpret_cast<const std::vector<ibverbx::IbvMr>*>(ibRegElem);
+  FB_CHECKABORT(
+      mrs->size() >= devices_.size(),
+      "Flush requires one memory region per device, but got {} regions for {} devices",
+      mrs->size(),
+      devices_.size());
+
+  // Each flush burns one send-queue slot per device and nothing upstream bounds
+  // the number of flushes in flight, so the queue depth has to be enforced here
+  // while the failure is still recoverable.
+  for (int device = 0; device < devices_.size(); device++) {
+    if (tracker_.outstanding(device) >= static_cast<size_t>(MAX_SEND_WR)) {
+      CTRAN_ERR(
+          commInternalError,
+          "CTRAN-IB: flush send queue is full on device {} ({} outstanding, max {})",
+          device,
+          tracker_.outstanding(device),
+          MAX_SEND_WR);
+      return commInternalError;
+    }
+  }
+
   for (int device = 0; device < devices_.size(); device++) {
     ibverbx::ibv_send_wr wr;
     memset(&wr, 0, sizeof(wr));
@@ -122,7 +145,21 @@ commResult_t LocalVirtualConn::iflush(
 
     ibverbx::ibv_send_wr* bad_wr{nullptr};
     auto maybeSend = ibvQps_[device].postSend(&wr, &bad_wr);
-    FOLLY_EXPECTED_CHECK(maybeSend);
+    if (maybeSend.hasError()) {
+      // Devices before this one already posted. Their CQEs will arrive with
+      // nothing tracked, so there is no recoverable exit.
+      FB_CHECKABORT(
+          device == 0,
+          "Failed to post flush RDMA READ on device {} after a partial post: {}",
+          device,
+          maybeSend.error().errStr);
+      CTRAN_ERR(
+          commSystemError,
+          "CTRAN-IB: failed to post flush RDMA READ on device {}: {}",
+          device,
+          maybeSend.error().errStr);
+      return commSystemError;
+    }
     CTRAN_LOG_TRACE(
         COLL,
         "CTRAN-IB: posted flush on qpn {}, req {}",
@@ -130,32 +167,23 @@ commResult_t LocalVirtualConn::iflush(
         (void*)req);
   }
 
-  // Push one entry per device CQE. Only the last carries the actual req;
-  // earlier entries are nullptr so processCqe drains them without completing.
-  for (int device = 0; device < devices_.size(); device++) {
-    outstandingReqs_.push_back(device == devices_.size() - 1 ? req : nullptr);
-  }
+  // Tracking after the post loop keeps the failure path free of cleanup. The
+  // caller serializes iflush against CQE processing, so a completion can
+  // arrive in between but never be observed.
+  tracker_.track(req);
 
   return commSuccess;
 }
 
 commResult_t LocalVirtualConn::processCqe(
-    const enum ibverbx::ibv_wc_opcode opcode) {
+    const enum ibverbx::ibv_wc_opcode opcode,
+    const int device) {
   FB_CHECKABORT(
       opcode == ibverbx::IBV_WC_RDMA_READ,
       "Invalid opcode {} received in flush virtual connection",
       opcode);
 
-  // Since each flush is executed by network one by one, we complete each flush
-  // as simple FIFO. With multi-NIC, each iflush posts one RDMA READ per
-  // device; only the last entry carries the request to complete.
-  auto req = outstandingReqs_.front();
-  outstandingReqs_.pop_front();
-  if (req) {
-    FB_COMMCHECK(req->complete());
-  }
-
-  return commSuccess;
+  return tracker_.complete(device);
 }
 
 uint32_t LocalVirtualConn::qpNum(int device) const {

--- a/comms/ctran/backends/ib/CtranIbLocalVc.h
+++ b/comms/ctran/backends/ib/CtranIbLocalVc.h
@@ -2,10 +2,10 @@
 
 #pragma once
 
-#include <deque>
 #include <string>
 
 #include "comms/ctran/backends/ib/CtranIbBase.h"
+#include "comms/ctran/backends/ib/FlushCompletionTracker.h"
 #include "comms/ctran/ibverbx/Ibverbx.h"
 
 #include "comms/utils/commSpecs.h"
@@ -21,7 +21,9 @@ class LocalVirtualConn {
   commResult_t
   iflush(const void* dbuf, const void* ibRegElem, CtranIbRequest* req);
 
-  commResult_t processCqe(const enum ibverbx::ibv_wc_opcode opcode);
+  commResult_t processCqe(
+      const enum ibverbx::ibv_wc_opcode opcode,
+      const int device);
 
   uint32_t qpNum(int device = 0) const;
 
@@ -38,6 +40,6 @@ class LocalVirtualConn {
   CommLogData commLogData_;
 
   // Track completion of outstanding flushes
-  std::deque<CtranIbRequest*> outstandingReqs_;
+  FlushCompletionTracker tracker_;
 };
 } // namespace ctran::ib

--- a/comms/ctran/backends/ib/FlushCompletionTracker.h
+++ b/comms/ctran/backends/ib/FlushCompletionTracker.h
@@ -1,0 +1,75 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <vector>
+
+#include "comms/ctran/backends/ib/CtranIbBase.h"
+#include "comms/ctran/utils/Checks.h"
+
+namespace ctran::ib {
+
+/**
+ * Tracks completion of flushes that fan out one loopback RDMA READ per IB
+ * device.
+ *
+ * Every device owns its own CQ and its own loopback RC QP, so completion order
+ * is guaranteed only within a device, never across devices. A single shared
+ * FIFO would therefore allow a later flush's completion on one device to retire
+ * an earlier flush's slot, reporting that earlier flush as done while its READ
+ * on another device is still in flight. One FIFO per device plus a per-flush
+ * reference count makes a flush complete only once every device has reported.
+ *
+ * This puts a requirement on progress: a flush stays incomplete until every
+ * device's CQ has been polled, so a progress loop restricted to a subset of the
+ * devices can never retire a flush.
+ */
+class FlushCompletionTracker {
+ public:
+  explicit FlushCompletionTracker(const size_t numDevices)
+      : perDevice_(numDevices) {
+    // Without a per-device FIFO there is no completion to decrement the
+    // reference count that track() arms, so the flush would never retire.
+    FB_CHECKABORT(
+        numDevices > 0,
+        "Flush completion tracking requires at least one device, got {}",
+        numDevices);
+  }
+
+  // Register a flush that has one RDMA READ posted per device. A null request
+  // is tracked as a placeholder that drains without completing anything.
+  void track(CtranIbRequest* req) {
+    if (req != nullptr) {
+      req->setRefCount(static_cast<int>(perDevice_.size()));
+    }
+    for (auto& reqs : perDevice_) {
+      reqs.push_back(req);
+    }
+  }
+
+  // Retire the oldest flush slot of the given device. An out-of-range device
+  // escapes as std::out_of_range rather than as a commResult_t, since it can
+  // only mean the caller mismatched the CQ it polled with this tracker.
+  commResult_t complete(const int device) {
+    auto& reqs = perDevice_.at(device);
+    FB_CHECKABORT(
+        !reqs.empty(), "No outstanding flush tracked for device {}", device);
+    CtranIbRequest* const req = reqs.front();
+    reqs.pop_front();
+    if (req != nullptr) {
+      FB_COMMCHECK(req->complete());
+    }
+    return commSuccess;
+  }
+
+  size_t outstanding(const int device) const {
+    return perDevice_.at(device).size();
+  }
+
+ private:
+  std::vector<std::deque<CtranIbRequest*>> perDevice_;
+};
+
+} // namespace ctran::ib

--- a/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
@@ -371,6 +371,31 @@ TEST_F(CtranIbBootstrapCommonTest, EmptySocketIfnameFailsNoInterfaces) {
   }
 }
 
+// CtranMapper only allocates a request when the caller wants to track the
+// flush, so both skip paths of iflush have to tolerate a null request.
+TEST_F(CtranIbBootstrapCommonTest, IflushSkipPathsAcceptNullRequest) {
+  auto abortCtrl = comms::fault_tolerance::createAbort(/*enabled=*/true);
+  auto ctranIb = createCtranIb(
+      /*rank=*/0, CtranIb::BootstrapMode::kDefaultServer, abortCtrl);
+
+  CtranIbEpochRAII epochRAII(ctranIb.get());
+
+  // createCtranIb disables local flush, so the registration handle is never
+  // dereferenced and a non-null placeholder selects the disabled-flush path.
+  int placeholderRegHdl = 0;
+  EXPECT_EQ(
+      ctranIb->iflush(
+          /*dbuf=*/nullptr,
+          /*localRegHdl=*/&placeholderRegHdl,
+          /*req=*/nullptr),
+      commSuccess);
+
+  EXPECT_EQ(
+      ctranIb->iflush(
+          /*dbuf=*/nullptr, /*localRegHdl=*/nullptr, /*req=*/nullptr),
+      commSuccess);
+}
+
 // Test bootstrapStart with specified server address
 TEST_P(CtranIbBootstrapParameterizedTest, BootstrapStartSpecifiedServer) {
   SocketServerAddr serverAddr = getSocketServerAddress();

--- a/comms/ctran/backends/ib/tests/FlushCompletionTrackerUT.cc
+++ b/comms/ctran/backends/ib/tests/FlushCompletionTrackerUT.cc
@@ -1,0 +1,101 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/backends/ib/CtranIbBase.h"
+#include "comms/ctran/backends/ib/FlushCompletionTracker.h"
+
+using ctran::ib::FlushCompletionTracker;
+
+TEST(FlushCompletionTrackerDeathTest, ZeroDevicesAborts) {
+  EXPECT_DEATH(
+      FlushCompletionTracker(/*numDevices=*/0),
+      "Flush completion tracking requires at least one device");
+}
+
+TEST(FlushCompletionTrackerDeathTest, CompleteOnEmptyDeviceAborts) {
+  FlushCompletionTracker tracker(/*numDevices=*/2);
+
+  EXPECT_DEATH(
+      tracker.complete(0), "No outstanding flush tracked for device 0");
+}
+
+TEST(FlushCompletionTrackerTest, SingleDeviceIsFifo) {
+  FlushCompletionTracker tracker(/*numDevices=*/1);
+  CtranIbRequest firstFlush;
+  CtranIbRequest secondFlush;
+
+  tracker.track(&firstFlush);
+  tracker.track(&secondFlush);
+  EXPECT_EQ(tracker.outstanding(0), 2);
+
+  EXPECT_EQ(tracker.complete(0), commSuccess);
+  EXPECT_TRUE(firstFlush.isComplete());
+  EXPECT_FALSE(secondFlush.isComplete());
+
+  EXPECT_EQ(tracker.complete(0), commSuccess);
+  EXPECT_TRUE(secondFlush.isComplete());
+  EXPECT_EQ(tracker.outstanding(0), 0);
+}
+
+// Encodes the defect this class exists to prevent: with a single shared FIFO,
+// draining two completions from device 0 would positionally retire the first
+// flush even though its read on device 1 is still in flight.
+TEST(FlushCompletionTrackerTest, SkewedCrossDeviceCompletion) {
+  FlushCompletionTracker tracker(/*numDevices=*/2);
+  CtranIbRequest firstFlush;
+  CtranIbRequest secondFlush;
+
+  tracker.track(&firstFlush);
+  tracker.track(&secondFlush);
+
+  EXPECT_EQ(tracker.complete(0), commSuccess);
+  // Retiring a device-0 slot must leave device 1 untouched, otherwise the
+  // deques are not independent and cross-device skew is unrepresentable.
+  EXPECT_EQ(tracker.outstanding(0), 1);
+  EXPECT_EQ(tracker.outstanding(1), 2);
+
+  EXPECT_EQ(tracker.complete(0), commSuccess);
+  EXPECT_FALSE(firstFlush.isComplete());
+  EXPECT_FALSE(secondFlush.isComplete());
+
+  EXPECT_EQ(tracker.complete(1), commSuccess);
+  EXPECT_TRUE(firstFlush.isComplete());
+  EXPECT_FALSE(secondFlush.isComplete());
+
+  EXPECT_EQ(tracker.complete(1), commSuccess);
+  EXPECT_TRUE(secondFlush.isComplete());
+}
+
+TEST(FlushCompletionTrackerTest, AllDevicesRequiredForSingleFlush) {
+  constexpr int kNumDevices = 4;
+  FlushCompletionTracker tracker(kNumDevices);
+  CtranIbRequest flush;
+
+  tracker.track(&flush);
+  for (int device = 0; device < kNumDevices - 1; device++) {
+    EXPECT_EQ(tracker.complete(device), commSuccess);
+    EXPECT_FALSE(flush.isComplete());
+  }
+
+  EXPECT_EQ(tracker.complete(kNumDevices - 1), commSuccess);
+  EXPECT_TRUE(flush.isComplete());
+}
+
+TEST(FlushCompletionTrackerTest, NullSlotsDrainWithoutCompleting) {
+  FlushCompletionTracker tracker(/*numDevices=*/2);
+  CtranIbRequest flush;
+
+  tracker.track(nullptr);
+  tracker.track(&flush);
+
+  EXPECT_EQ(tracker.complete(0), commSuccess);
+  EXPECT_EQ(tracker.complete(1), commSuccess);
+  EXPECT_FALSE(flush.isComplete());
+
+  EXPECT_EQ(tracker.complete(0), commSuccess);
+  EXPECT_FALSE(flush.isComplete());
+
+  EXPECT_EQ(tracker.complete(1), commSuccess);
+  EXPECT_TRUE(flush.isComplete());
+}

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -741,32 +741,35 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    *   - buf: the local buffer to flush
    *   - regHdl: the local registration handle of the local buffer
    * Output arguments:
-   *   - req: the request object to track the progress of the flush.
+   *   - req: the request object to track the progress of the flush. Must not
+   * be null. Owned by the caller and always set on success; when no flush is
+   * posted (no IB backend or no IB registration) the request comes back
+   * already complete.
    */
   inline commResult_t
   iflush(const void* buf, const void* regHdl, CtranMapperRequest** req) {
+    FB_COMMCHECK(this->checkValidReq(req, __func__));
+
     if (this->ctranIb) {
       auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(
           const_cast<void*>(regHdl));
-      if (!regElem) {
-        CTRAN_LOG(WARN, "CTRAN-MAPPER: No IB registration for flush, skip");
+      if (regElem) {
+        auto regLk = regElem->stateMnger.rlock();
+        // Ownership transfers to the caller only once the flush is posted; on
+        // an error path the caller's pointer is left untouched.
+        auto reqOwner = std::make_unique<CtranMapperRequest>();
+        FB_COMMCHECK(
+            this->ctranIb->iflush(buf, regElem->ibRegElem, &(reqOwner->ibReq)));
+        *req = reqOwner.release();
         return commSuccess;
       }
-      auto regLk = regElem->stateMnger.rlock();
-      CtranIbRequest* ibReq = nullptr;
-      if (req) {
-        *req = new CtranMapperRequest();
-        ibReq = &((*req)->ibReq);
-      }
-      FB_COMMCHECK(this->ctranIb->iflush(buf, regElem->ibRegElem, ibReq));
-    } else if (this->ctranTcpDm) {
-      // TCPDM: flush is unnecessary — data arrives via kernel unpack.
-      // Return a pre-completed request so callers can poll normally.
-      if (req) {
-        *req = new CtranMapperRequest();
-        (*req)->setComplete();
-      }
+      CTRAN_LOG(WARN, "CTRAN-MAPPER: No IB registration for flush, skip");
     }
+    // No flush was posted: either no IB backend (TCPDM needs none, data
+    // arrives via kernel unpack) or no IB registration for the buffer.
+    // Return a pre-completed request so callers can poll normally.
+    *req = new CtranMapperRequest();
+    (*req)->setComplete();
     return commSuccess;
   }
 

--- a/comms/ctran/mapper/tests/CtranMapperUT.cc
+++ b/comms/ctran/mapper/tests/CtranMapperUT.cc
@@ -955,6 +955,91 @@ TEST_F(CtranMapperTest, icopyNoReq) {
   CUDACHECK_TEST(cudaFree(srcBuf));
 }
 
+TEST_F(CtranMapperTest, iflushRejectsNullReq) {
+  mapper = std::make_unique<CtranMapper>(dummyComm_);
+
+  EXPECT_EQ(mapper->iflush(buf, hdl, nullptr), commInternalError);
+}
+
+TEST_F(CtranMapperTest, iflushUnregisteredBufReturnsCompletedReq) {
+  mapper = std::make_unique<CtranMapper>(dummyComm_);
+  const auto rank = dummyComm_->statex_->rank();
+  ASSERT_TRUE(mapper->hasBackend(rank, CtranMapperBackend::IB));
+
+  // No IB registration for the buffer, so no flush is posted.
+  CtranMapperRequest* rawReq = nullptr;
+  ASSERT_EQ(mapper->iflush(buf, nullptr, &rawReq), commSuccess);
+  const std::unique_ptr<CtranMapperRequest> req(rawReq);
+  ASSERT_THAT(req, testing::NotNull());
+
+  bool isComplete = false;
+  EXPECT_EQ(mapper->testRequest(req.get(), &isComplete), commSuccess);
+  EXPECT_TRUE(isComplete);
+}
+
+TEST_F(CtranMapperTest, iflushWithoutIbBackendReturnsCompletedReq) {
+  SysEnvRAII backendsEnv("NCCL_CTRAN_BACKENDS", "nvl, socket");
+  ncclCvarInit();
+
+  mapper = std::make_unique<CtranMapper>(dummyComm_);
+  const auto rank = dummyComm_->statex_->rank();
+  ASSERT_FALSE(mapper->hasBackend(rank, CtranMapperBackend::IB));
+  ASSERT_FALSE(mapper->hasBackend(rank, CtranMapperBackend::TCPDM));
+
+  // The buffer is registered, so only the missing IB backend can skip the
+  // flush.
+  void* regHdl = nullptr;
+  bool dynamicRegist = false;
+  ASSERT_EQ(
+      mapper->searchRegHandle(buf, bufSize, &regHdl, &dynamicRegist),
+      commSuccess);
+  ASSERT_THAT(regHdl, testing::NotNull());
+
+  CtranMapperRequest* rawReq = nullptr;
+  ASSERT_EQ(mapper->iflush(buf, regHdl, &rawReq), commSuccess);
+  const std::unique_ptr<CtranMapperRequest> req(rawReq);
+  ASSERT_THAT(req, testing::NotNull());
+
+  bool isComplete = false;
+  EXPECT_EQ(mapper->testRequest(req.get(), &isComplete), commSuccess);
+  EXPECT_TRUE(isComplete);
+
+  if (dynamicRegist) {
+    EXPECT_EQ(mapper->deregDynamic(regHdl), commSuccess);
+  }
+}
+
+TEST_F(CtranMapperTest, iflushBackendErrorLeavesReqUntouched) {
+  mapper = std::make_unique<CtranMapper>(dummyComm_);
+  const auto rank = dummyComm_->statex_->rank();
+  ASSERT_TRUE(mapper->hasBackend(rank, CtranMapperBackend::IB));
+
+  void* regHdl = nullptr;
+  bool dynamicRegist = false;
+  ASSERT_EQ(
+      mapper->searchRegHandle(buf, bufSize, &regHdl, &dynamicRegist),
+      commSuccess);
+  ASSERT_THAT(regHdl, testing::NotNull());
+
+  {
+    // Calling into the IB backend without holding the epoch lock is the only
+    // error CtranIb::iflush can report without a fake device.
+    EnvRAII epochLockEnv(NCCL_CTRAN_IB_EPOCH_LOCK_ENABLE, true);
+    EnvRAII epochCheckEnv(NCCL_CTRAN_IB_EPOCH_LOCK_ENFORCE_CHECK, true);
+
+    // A sentinel proves the error path never writes to the caller's pointer,
+    // rather than merely leaving it null.
+    auto* const sentinel = reinterpret_cast<CtranMapperRequest*>(0xdeadbeef);
+    CtranMapperRequest* req = sentinel;
+    EXPECT_EQ(mapper->iflush(buf, regHdl, &req), commInternalError);
+    EXPECT_EQ(req, sentinel);
+  }
+
+  if (dynamicRegist) {
+    EXPECT_EQ(mapper->deregDynamic(regHdl), commSuccess);
+  }
+}
+
 TEST_F(CtranMapperTest, ReqInit) {
   mapper = std::make_unique<CtranMapper>(dummyComm_);
   const auto rank = this->dummyComm_->statex_->rank();

--- a/comms/ctran/tests/CtranDistAllgatherCtwinTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherCtwinTests.cc
@@ -5,6 +5,9 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
 #include <unordered_map>
 #include <vector>
 
@@ -20,6 +23,43 @@
 #include "comms/testinfra/TestsCuUtils.h"
 
 using namespace ctran;
+
+namespace {
+
+// Defaults for the back-to-back reuse case. kDefaultB2bIters is the burst
+// length: collectives enqueued with no host sync in between. Each needs its own
+// device snapshot slot. Rounds repeat the burst without growing that memory.
+constexpr int kDefaultB2bIters = 32;
+constexpr int kDefaultB2bRounds = 4;
+constexpr size_t kDefaultB2bSendCount = 64 * 1024;
+
+constexpr const char* kB2bItersEnv = "CTRAN_CTWIN_B2B_ITERS";
+constexpr const char* kB2bRoundsEnv = "CTRAN_CTWIN_B2B_ROUNDS";
+constexpr const char* kB2bSendCountEnv = "CTRAN_CTWIN_B2B_SEND_COUNT";
+
+// Reads a positive integer override; falls back when unset, empty, or not a
+// positive integer.
+long long envPositiveOr(const char* name, long long fallback) {
+  const char* const raw = std::getenv(name);
+  if (raw == nullptr || raw[0] == '\0') {
+    return fallback;
+  }
+  const long long parsed = std::atoll(raw);
+  return parsed > 0 ? parsed : fallback;
+}
+
+// Value peer `peer` contributes at element `index` on iteration `iter`. Every
+// element is distinct across peers, iterations and offsets. A partially written
+// chunk then differs from the reference at every offset in the stale region. A
+// constant per-chunk fill, as the functional cases use, would hide it.
+int stressPattern(int peer, int iter, size_t index) {
+  const uint32_t mixed = 0x9E3779B9u * static_cast<uint32_t>(peer + 1) +
+      0x85EBCA6Bu * static_cast<uint32_t>(iter + 1) +
+      static_cast<uint32_t>(index);
+  return static_cast<int>(mixed);
+}
+
+} // namespace
 
 // Window-based persistent allgather (ctwin). Registers a symmetric ipc_only
 // window over a cumem recvbuf, runs allgather with algo=ctwin (in-place, so the
@@ -640,6 +680,197 @@ TEST_F(CtranAllgatherCtwinTest, ForceVariants) {
   oobBarrier();
   freeSymmetricWindow(win, winBase, windowBytes);
 }
+
+// Back-to-back reuse of recvbuff across collectives. Both AGP pipeline variants
+// put from recvbuff. The drain that proves the NIC finished reading runs after
+// the stream was already released. The next collective can then overwrite a
+// buffer a put is still reading. The end kernel's wait on endSyncStep is the
+// fence.
+//
+// Three things are needed to see it. Every iteration sends different values. A
+// constant fill writes the same bytes and hides the overwrite. The collectives
+// run back-to-back on one stream. A per-iteration sync drains the puts and
+// hides it too. Every element is checked. The corruption is a partial region
+// inside one chunk.
+class CtranAllgatherCtwinBackToBackTest
+    : public CtranAllgatherCtwinTest,
+      public ::testing::WithParamInterface<enum NCCL_ALLGATHER_ALGO> {};
+
+TEST_P(CtranAllgatherCtwinBackToBackTest, SourceBufferReuse) {
+  const enum NCCL_ALLGATHER_ALGO algo = GetParam();
+  const char* const algoName = algo == NCCL_ALLGATHER_ALGO::ctwin_rdpipeline
+      ? "ctwin_rdpipeline"
+      : "ctwin_pipeline";
+
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skipping ctwin test";
+  }
+  if (ctranComm->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found, skip test";
+  }
+  const int nNodes = ctranComm->statex_->nNodes();
+  const int nLocalRanks = ctranComm->statex_->nLocalRanks();
+  // The reader is a GPE put, which needs nNodes > 1. The fence is the end
+  // kernel, which is only submitted at nLocalRanks > 1.
+  if (nNodes < 2 || nLocalRanks < 2) {
+    GTEST_SKIP() << "the put/recvbuff WAR needs nNodes>1 and nLocalRanks>1 to "
+                 << "be reached; got nNodes=" << nNodes
+                 << " nLocalRanks=" << nLocalRanks;
+  }
+  if (algo == NCCL_ALLGATHER_ALGO::ctwin_rdpipeline &&
+      (nNodes & (nNodes - 1)) != 0) {
+    GTEST_SKIP() << "ctwin_rdpipeline requires power-of-2 nNodes, got "
+                 << nNodes;
+  }
+
+  const int itersPerRound =
+      static_cast<int>(envPositiveOr(kB2bItersEnv, kDefaultB2bIters));
+  const int numRounds =
+      static_cast<int>(envPositiveOr(kB2bRoundsEnv, kDefaultB2bRounds));
+  const size_t sendCount = static_cast<size_t>(
+      envPositiveOr(kB2bSendCountEnv, kDefaultB2bSendCount));
+
+  const size_t typeSize = commTypeSize(dt);
+  const size_t chunkBytes = sendCount * typeSize;
+  const size_t windowElems = sendCount * numRanks;
+  const size_t windowBytes = windowElems * typeSize;
+
+  if (globalRank == 0) {
+    LOG(WARNING) << "ctwin back-to-back reuse: algo=" << algoName
+                 << " itersPerRound=" << itersPerRound
+                 << " rounds=" << numRounds << " sendCount=" << sendCount
+                 << " nRanks=" << numRanks << " nNodes=" << nNodes
+                 << " nLocalRanks=" << nLocalRanks;
+  }
+
+  CtranWin* win = nullptr;
+  void* winBase = createSymmetricWindow(windowBytes, &win);
+  ASSERT_NE(win, nullptr);
+  void* const recvbuf = winBase;
+
+  // A distinct sendbuf per iteration, all staged before the burst. During the
+  // burst the only writer to recvbuf is the collective itself.
+  void* sendPool = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&sendPool, chunkBytes * itersPerRound));
+  // Snapshots stay on the device during the burst. A D2H copy here would be as
+  // long as the race window and would hide it. One D2H after the burst.
+  void* snapPool = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&snapPool, windowBytes * itersPerRound));
+
+  std::vector<int> observed(windowElems * itersPerRound);
+  std::vector<int> stage(sendCount * itersPerRound);
+  std::vector<int> expected(windowElems);
+
+  // Every rank runs every round even after a mismatch. Returning early would
+  // desync the per-round barrier.
+  int corruptedIters = 0;
+  int firstBadIter = -1;
+  int firstBadPeer = -1;
+  size_t firstBadElement = 0;
+  int firstBadObserved = 0;
+  int firstBadExpected = 0;
+
+  for (int round = 0; round < numRounds; round++) {
+    for (int k = 0; k < itersPerRound; k++) {
+      const int globalIter = round * itersPerRound + k;
+      for (size_t i = 0; i < sendCount; i++) {
+        stage[k * sendCount + i] = stressPattern(globalRank, globalIter, i);
+      }
+    }
+    CUDACHECK_TEST(cudaMemcpy(
+        sendPool, stage.data(), chunkBytes * itersPerRound, cudaMemcpyDefault));
+    // Poisoned once per round. Poisoning inside the burst would need a
+    // barrier, and no barrier may run there.
+    CUDACHECK_TEST(cudaMemset(recvbuf, 0xEE, windowBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    oobBarrier();
+
+    // The burst. No sync and no barrier until every collective is enqueued.
+    // Iteration k+1 writes recvbuf while iteration k's puts may still read it.
+    for (int k = 0; k < itersPerRound; k++) {
+      ASSERT_EQ(
+          ctranAllGather(
+              static_cast<char*>(sendPool) + k * chunkBytes,
+              recvbuf,
+              sendCount,
+              dt,
+              ctranComm.get(),
+              stream,
+              algo),
+          commSuccess);
+      CUDACHECK_TEST(cudaMemcpyAsync(
+          static_cast<char*>(snapPool) + k * windowBytes,
+          recvbuf,
+          windowBytes,
+          cudaMemcpyDeviceToDevice,
+          stream));
+    }
+    CUDACHECK_TEST(cudaStreamSynchronize(stream));
+    CUDACHECK_TEST(cudaMemcpy(
+        observed.data(),
+        snapPool,
+        windowBytes * itersPerRound,
+        cudaMemcpyDefault));
+
+    for (int k = 0; k < itersPerRound; k++) {
+      const int globalIter = round * itersPerRound + k;
+      for (int peer = 0; peer < numRanks; peer++) {
+        const size_t base = static_cast<size_t>(peer) * sendCount;
+        for (size_t i = 0; i < sendCount; i++) {
+          expected[base + i] = stressPattern(peer, globalIter, i);
+        }
+      }
+      const int* const got = observed.data() + k * windowElems;
+      const auto diff = std::mismatch(expected.begin(), expected.end(), got);
+      if (diff.first != expected.end()) {
+        corruptedIters++;
+        if (firstBadIter < 0) {
+          const size_t index =
+              static_cast<size_t>(std::distance(expected.begin(), diff.first));
+          firstBadIter = globalIter;
+          firstBadPeer = static_cast<int>(index / sendCount);
+          firstBadElement = index % sendCount;
+          firstBadObserved = *diff.second;
+          firstBadExpected = *diff.first;
+        }
+      }
+    }
+    oobBarrier();
+  }
+
+  // Report the rate even on success. A zero only means something next to the
+  // rate the same config gives without the fence.
+  std::cout << "ctwin back-to-back reuse result: algo=" << algoName
+            << " rank=" << globalRank << " corruptedIters=" << corruptedIters
+            << " of " << (numRounds * itersPerRound)
+            << " sendCount=" << sendCount << std::endl;
+
+  EXPECT_EQ(corruptedIters, 0)
+      << algoName << " returned wrong data on " << corruptedIters << " of "
+      << (numRounds * itersPerRound) << " back-to-back iterations at rank "
+      << globalRank << " (nNodes=" << nNodes << " nLocalRanks=" << nLocalRanks
+      << "); first mismatch at iteration " << firstBadIter
+      << ", chunk from peer " << firstBadPeer << ", element " << firstBadElement
+      << " (byte offset " << firstBadElement * typeSize
+      << " within that chunk): observed " << firstBadObserved << ", expected "
+      << firstBadExpected;
+
+  CUDACHECK_TEST(cudaFree(snapPool));
+  CUDACHECK_TEST(cudaFree(sendPool));
+  oobBarrier();
+  freeSymmetricWindow(win, winBase, windowBytes);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CtranTest,
+    CtranAllgatherCtwinBackToBackTest,
+    ::testing::Values(
+        NCCL_ALLGATHER_ALGO::ctwin_rdpipeline,
+        NCCL_ALLGATHER_ALGO::ctwin_pipeline),
+    [](const ::testing::TestParamInfo<enum NCCL_ALLGATHER_ALGO>& info) {
+      return info.param == NCCL_ALLGATHER_ALGO::ctwin_rdpipeline ? "SrdPipeline"
+                                                                 : "Pipeline";
+    });
 
 // A/B for NCCL_CTRAN_AGP_SKIP_MC_INTRA_BARRIER, both settings in one job so a
 // single launch covers the knob on and off.

--- a/comms/utils/StrUtils.h
+++ b/comms/utils/StrUtils.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <chrono>
+#include <cstring>
 #include <fstream>
 #include <iomanip>
 #include <iterator>
@@ -20,6 +21,25 @@ inline std::string hashToHexStr(const uint64_t hash) {
   std::stringstream ss;
   ss << std::hex << hash;
   return ss.str();
+}
+
+/**
+ * Return the symbolic name of an errno value, e.g. "EINVAL".
+ * strerrorname_np was added in glibc 2.32 and is declared only under
+ * _GNU_SOURCE, so it is unavailable on some OSS toolchains. Returns "UNKNOWN"
+ * there and for unrecognized errno values.
+ */
+inline std::string errnoToNameStr([[maybe_unused]] const int errnoValue) {
+#if defined(__GLIBC__) && defined(__GLIBC_PREREQ) && defined(_GNU_SOURCE)
+#if __GLIBC_PREREQ(2, 32)
+  const char* name = ::strerrorname_np(errnoValue);
+  return name != nullptr ? name : "UNKNOWN";
+#else
+  return "UNKNOWN";
+#endif
+#else
+  return "UNKNOWN";
+#endif
 }
 
 template <typename T>


### PR DESCRIPTION
Summary:

## Bug

AGP releases the stream before it waits for its outgoing puts to drain. Those puts source from recvbuff, so the next collective can overwrite a buffer a put is still reading.

Where the source comes from:

```
ctsrdpipeline  own chunk at recvbuff + rank*sendSize, put on every step
               (copyToSelf wrote that chunk moments earlier)
ctpipeline     forwarded chunks at recvbuff + offset, steps >= 1
               steps run 0..nNodes-2, so step 1 exists only at nNodes >= 3
```

Order of events on one rank, collective N followed by N+1:

```
GPE worker                             stream
----------                             ------
iput   <- NIC starts reading
          recvbuff[rank]
post(step)  ------------------------>  released
                                       NVL bcast, PipeEnd     (collective N ends)
                                       copyToSelf             (collective N+1)
                                         writes recvbuff[rank]   <-- overwrites a
                                                                     source still
waitAllPuts                                                          being read
  (drain proves the NIC
   finished, but only here)
```

The drain is the only thing that proves the local NIC finished reading the source, and it runs after the release rather than before it. Zoomer measures about 60us between PipeEnd and the next collective's copy-to-self, so the put has roughly that long to still be in flight. The peer then receives a mix of old and new bytes behind a valid notify. No hang, no error.

## Fix

Hold the end kernel until the worker confirms the puts drained. The worker posts a step value only after the drain, and the end kernel waits for that value before it releases.

```
GPE worker                             stream
----------                             ------
iput
post(step)  ------------------------>  released for the NVL bcast
waitAllPuts
post(endSyncStep)  ----------------->  PipeEnd wakes
                                       PipeEnd
                                       copyToSelf             (now safe)
```

The value is one past the last real step, so no ordinary step post can satisfy the wait:

| variant | steps the worker posts | endSyncStep |
|---------|------------------------|-------------|
| ctsrdpipeline | 0 .. nSteps-1 | nSteps |
| ctpipeline | 0 .. nNodes-2 | nNodes-1 |
| no GPE worker (nNodes == 1) | none | -1, and the kernel does not wait |

The last row matters: the end kernel is submitted whenever nLocalRanks > 1, but the worker only runs when nNodes > 1. Without the negative case the kernel would wait for a value nobody posts.

Also in this diff:

- Both end kernels load the abort-flag globals before waiting, since the wait reads them.
- New test `CtranAllgatherCtwinBackToBackTest.SourceBufferReuse`, run over both variants.

Reviewed By: harishkc77

Differential Revision: D118961602
