### PR TITLE
Share one errno-name helper between ctran and mccl

### DIFF
--- a/comms/ctran/backends/ib/BootstrapInternal.cc
+++ b/comms/ctran/backends/ib/BootstrapInternal.cc
@@ -27,18 +27,10 @@
 #include "comms/ctran/utils/Debug.h"
 #include "comms/ctran/utils/Exception.h"
 #include "comms/ctran/utils/ExtUtils.h"
+#include "comms/utils/StrUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/ScubaLogger.h"
-
-// strerrorname_np() is a glibc >= 2.32 GNU extension. Guard its use so builds
-// against older glibc (e.g. the OSS almalinux toolchain) still compile; the
-// error name simply falls back to "UNKNOWN" there.
-#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
-#if __GLIBC_PREREQ(2, 32)
-#define IBVERBX_HAS_STRERRORNAME_NP 1
-#endif
-#endif
 
 namespace {
 const std::string kCtranIbLogEventName{"CtranIb-QpExchange"};
@@ -48,18 +40,14 @@ const uint64_t kBootstrapMagic = 0xfaceb00cdeadbeef;
 std::string socketErrorContext(int error) {
   const bool hasValidMagnitude = error != std::numeric_limits<int>::min();
   const int errnoValue = hasValidMagnitude && error < 0 ? -error : error;
-  const char* errorName = nullptr;
-#ifdef IBVERBX_HAS_STRERRORNAME_NP
-  if (hasValidMagnitude) {
-    errorName = ::strerrorname_np(errnoValue);
-  }
-#endif
+  const std::string errorName =
+      hasValidMagnitude ? errnoToNameStr(errnoValue) : "UNKNOWN";
   const std::string description =
       hasValidMagnitude ? folly::errnoStr(errnoValue) : "invalid errno value";
   return fmt::format(
       "origin=socket_error subsystem=ctran_ib error_code={} error_name={} error_description=\"{}\"",
       error,
-      errorName != nullptr ? errorName : "UNKNOWN",
+      errorName,
       folly::cEscape<std::string>(description));
 }
 } // namespace

--- a/comms/utils/StrUtils.h
+++ b/comms/utils/StrUtils.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <chrono>
+#include <cstring>
 #include <fstream>
 #include <iomanip>
 #include <iterator>
@@ -20,6 +21,25 @@ inline std::string hashToHexStr(const uint64_t hash) {
   std::stringstream ss;
   ss << std::hex << hash;
   return ss.str();
+}
+
+/**
+ * Return the symbolic name of an errno value, e.g. "EINVAL".
+ * strerrorname_np was added in glibc 2.32 and is declared only under
+ * _GNU_SOURCE, so it is unavailable on some OSS toolchains. Returns "UNKNOWN"
+ * there and for unrecognized errno values.
+ */
+inline std::string errnoToNameStr([[maybe_unused]] const int errnoValue) {
+#if defined(__GLIBC__) && defined(__GLIBC_PREREQ) && defined(_GNU_SOURCE)
+#if __GLIBC_PREREQ(2, 32)
+  const char* name = ::strerrorname_np(errnoValue);
+  return name != nullptr ? name : "UNKNOWN";
+#else
+  return "UNKNOWN";
+#endif
+#else
+  return "UNKNOWN";
+#endif
 }
 
 template <typename T>


### PR DESCRIPTION
Summary:
`strerrorname_np` needs a glibc >= 2.32 guard or OSS builds fail to compile. Two places in comms call it, and until now each carried its own guard: `mccl/bootstrap/Bootstrap.cpp` had one, and `ctran/backends/ib/BootstrapInternal.cc` got one in D118649440. Keeping two copies of the same version check invites drift.

Move it to `comms/utils/StrUtils.h` and have both call it.

- Add `errnoToNameStr` to `comms/utils/StrUtils.h`. Returns the symbolic name, or "UNKNOWN" when the function is unavailable or the errno is unrecognized.
- Use it from `ctran/backends/ib/BootstrapInternal.cc` and drop the `IBVERBX_HAS_STRERRORNAME_NP` macro D118649440 added, which no longer has a caller.
- Delete mccl's local `errnoName` and migrate `mccl/bootstrap/Bootstrap.cpp` to the shared one.

This started as a fix for the same OSS break that D118649440 fixed, landing while this was in review. The build fix is no longer needed; what remains is one implementation instead of two.

The shared version also tests `_GNU_SOURCE`, which the other two did not. That turns out to be belt-and-braces rather than load-bearing: g++ defines `_GNU_SOURCE` automatically for C++ on Linux, so the glibc version was always the real constraint.

```
$ echo | g++ -dM -E -x c++ - | grep -c _GNU_SOURCE   # 1
$ echo | g++ -dM -E -x c   - | grep -c _GNU_SOURCE   # 0
```

The `#if` has to nest. `__GLIBC_PREREQ(2, 32)` cannot share an `#if` with `defined(__GLIBC_PREREQ)`: the preprocessor expands before it evaluates and does not short-circuit, so on a non-glibc toolchain the undefined identifier becomes `0(2, 32)` and fails to parse.

Reviewed By: rmahidhar

Differential Revision: D118968804


