### PR TITLE
Add opt-in direct-linked RDMA provider

### DIFF
--- a/comms/ctran/CMakeLists.txt
+++ b/comms/ctran/CMakeLists.txt
@@ -70,3 +70,14 @@ target_include_directories(ctran PRIVATE
 if(MCCL_ENABLE_PRIMS)
     target_compile_definitions(ctran PRIVATE ENABLE_PRIMS=1)
 endif()
+
+if(TARGET mccl_rdma_core)
+    # This directory's ctran target is the sole CMake owner of this source.
+    # Keep this source-local define and the provider link together if that
+    # ownership changes; other ibverbx translation units use wrapper types.
+    set_property(SOURCE
+        "${CMAKE_CURRENT_SOURCE_DIR}/ibverbx/IbverbxSymbols.cc"
+        APPEND PROPERTY COMPILE_DEFINITIONS IBVERBX_BUILD_RDMA_CORE=1
+    )
+    target_link_libraries(ctran PRIVATE mccl_rdma_core)
+endif()

--- a/comms/ctran/ibverbx/Ibverbx.cc
+++ b/comms/ctran/ibverbx/Ibverbx.cc
@@ -3,11 +3,6 @@
 #include "comms/ctran/ibverbx/Ibverbx.h"
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
 
-#ifdef IBVERBX_BUILD_RDMA_CORE
-#include <infiniband/mlx5dv.h>
-#include <infiniband/verbs.h>
-#endif
-
 #include <dlfcn.h>
 #include <folly/ScopeGuard.h>
 #include <folly/Singleton.h>

--- a/comms/ctran/ibverbx/IbverbxSymbols.cc
+++ b/comms/ctran/ibverbx/IbverbxSymbols.cc
@@ -2,6 +2,11 @@
 
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
 
+#ifdef IBVERBX_BUILD_RDMA_CORE
+#include <infiniband/mlx5dv.h>
+#include <infiniband/verbs.h>
+#endif
+
 #include <dlfcn.h>
 #include <folly/ScopeGuard.h>
 #include <folly/synchronization/CallOnce.h>
@@ -11,6 +16,15 @@
 namespace ibverbx {
 
 IbvSymbols ibvSymbols;
+
+// Wheel validation reads this after debug symbols have been stripped.
+#ifdef IBVERBX_BUILD_RDMA_CORE
+[[gnu::used, gnu::retain]] static constexpr char kIbverbxLinkMode[] =
+    "ibverbx-link-mode:direct-rdma-core";
+#else
+[[gnu::used, gnu::retain]] static constexpr char kIbverbxLinkMode[] =
+    "ibverbx-link-mode:dynamic";
+#endif
 
 #define IBVERBS_VERSION "IBVERBS_1.1"
 

--- a/comms/ctran/ibverbx/IbverbxSymbols.h
+++ b/comms/ctran/ibverbx/IbverbxSymbols.h
@@ -4,11 +4,6 @@
 
 #include "comms/ctran/ibverbx/Ibvcore.h"
 
-#ifdef IBVERBX_BUILD_RDMA_CORE
-#include <infiniband/mlx5dv.h>
-#include <infiniband/verbs.h>
-#endif
-
 namespace ibverbx {
 
 struct IbvSymbols {

--- a/comms/ctran/ibverbx/README.md
+++ b/comms/ctran/ibverbx/README.md
@@ -26,16 +26,20 @@ This builds the library with the `-DIBVERBX_BUILD_RDMA_CORE` compiler flag, whic
 
 When the `-DIBVERBX_BUILD_RDMA_CORE` flag is set:
 
-1. **Header files** (`Ibverbx.h` and `Ibvcore.h`):
-   - Include `<infiniband/verbs.h>` directly
-
-2. **Implementation** (`Ibverbx.cc`):
+1. **Implementation and symbol initialization** (`IbverbxSymbols.cc`):
+   - Includes `<infiniband/verbs.h>` and `<infiniband/mlx5dv.h>` directly
    - The `buildIbvSymbols()` function assigns function pointers directly to the real InfiniBand functions
    - Skips the dynamic loading code path entirely
 
-3. **Build configuration** (`BUCK`):
+2. **Build configuration** (`BUCK` or CMake):
    - Links against the `rdma-core` external dependency
    - Adds the compiler flag to enable conditional compilation
+
+For CMake builds, enable direct linking by setting
+`CTRAN_IBVERBX_RDMA_CORE_ROOT` to a prefix containing `include/infiniband` and
+the provider libraries under `lib` or `lib64`. Leaving it empty preserves the
+default dynamic-loading mode. CMake exposes the selected headers and libraries
+through the shared `mccl_rdma_core` interface target.
 
 ## Usage
 
@@ -49,7 +53,7 @@ Both build variants provide the same API and can be used interchangeably. Choose
 The library always uses `ibverbx::` struct definitions that are identical to the real InfiniBand types, regardless of build configuration. All types are defined in the `ibverbx` namespace (e.g., `ibverbx::ibv_device`, `ibverbx::ibv_context`, `ibverbx::ibv_qp`, etc.) to avoid namespace conflicts with system InfiniBand headers.
 
 The conditional compilation (`#ifdef IBVERBX_BUILD_RDMA_CORE`) only affects:
-- Whether to include `<infiniband/verbs.h>` directly or use dynamic loading
+- Whether `IbverbxSymbols.cc` includes the RDMA headers directly
 - Function pointer assignment in `buildIbvSymbols()` (direct assignment vs dlsym)
 - Build dependencies and linking against rdma-core libraries
 

--- a/comms/ctran/ibverbx/tests/IbverbxDcMultiRankTest.cc
+++ b/comms/ctran/ibverbx/tests/IbverbxDcMultiRankTest.cc
@@ -112,7 +112,7 @@ class DcMultiRankTestFixture : public meta::comms::MpiBaseTestFixture {
   std::optional<ibverbx::IbvQp> dci_;
   std::optional<ibverbx::IbvQp> dct_;
   ibverbx::ibv_qp_ex* exQp_{nullptr};
-  struct mlx5dv_qp_ex* dvQp_{nullptr};
+  ibverbx::mlx5dv_qp_ex* dvQp_{nullptr};
   ibverbx::ibv_gid gid_{};
 };
 

--- a/comms/prims/CMakeLists.txt
+++ b/comms/prims/CMakeLists.txt
@@ -79,10 +79,11 @@ target_compile_definitions(prims PRIVATE
 
 # Third-party link deps every consumer of the prims transports needs, declared
 # here so they propagate automatically to any target that links the `prims`
-# OBJECT library (PUBLIC = usage requirement). Resolved from CONDA_LIB (and
-# THIRD_PARTY_LIB when set). doca_gpunetio: IBGDA; ibverbs/mlx5: IB verbs;
-# dl: NVML dlopen. The CUDA driver (libcuda) is deliberately NOT linked: prims
-# (platform/CudaDriverLazy.cc) and ctran (CudaWrap.cc) resolve driver entry
+# OBJECT library (PUBLIC = usage requirement). Direct-link builds use the
+# coherent ibverbs/mlx5 contract from `mccl_rdma_core`; other builds retain the
+# existing linker-name lookup. doca_gpunetio provides IBGDA; dl supports NVML
+# dlopen. The CUDA driver is deliberately NOT linked:
+# prims (platform/CudaDriverLazy.cc) and ctran (CudaWrap.cc) resolve driver entry
 # points lazily via cudaGetDriverEntryPoint, so only CUDA::cudart is a link-time
 # dep. Hard-linking cuda_driver would add a libcuda.so.1 NEEDED that breaks
 # import on driverless build/verify hosts.
@@ -92,10 +93,13 @@ if(DEFINED THIRD_PARTY_LIB)
 endif()
 target_link_libraries(prims PUBLIC
     "-ldoca_gpunetio"
-    "-libverbs"
-    "-lmlx5"
     "-ldl"
 )
+if(TARGET mccl_rdma_core)
+    target_link_libraries(prims PUBLIC mccl_rdma_core)
+else()
+    target_link_libraries(prims PUBLIC "-libverbs" "-lmlx5")
+endif()
 
 # Install prims' public headers (ctran's installed headers #include
 # "comms/prims/..." under ENABLE_PRIMS, so these must ship for the exported


### PR DESCRIPTION
Summary: PAFT UV exposed a split where DOCA and CTRAN loaded different libibverbs/libmlx5 provider families. Add an opt-in MCCL CMake provider target and compile only IbverbxSymbols.cc in the existing direct-rdma-core mode, so CTRAN, PRIMS, and DOCA share one linker-selected provider pair. Public ibverbx headers and builds that leave the provider root empty retain the existing wrapper types and dynamic-loading behavior. This diff contains only the core CTRAN/MCCL capability; UV wheel producer wiring and final artifact validation are separate child diffs. It also qualifies the DC multi-rank fixture type after the public headers stop exposing system mlx5 types.

Reviewed By: eastzone

Differential Revision: D118649440


