### PR TITLE
Cap extension build parallelism

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,8 @@ class build_ext(build_ext_orig):
             f"-DUSE_TRANSPORT_CCA_HOOK={flag_str(USE_TRANSPORT_CCA_HOOK)}",
             f"-DUSE_TRITON={flag_str(USE_TRITON)}",
         ]
-        build_args = ["--", "-j"]
+        build_jobs = os.environ.get("NCCL_BUILD_JOBS")
+        build_args = ["--", "-j", build_jobs] if build_jobs else ["--", "-j"]
 
         os.chdir(str(build_temp))
         self.spawn(["cmake", str(cwd)] + cmake_args)


### PR DESCRIPTION
Summary:
- The wheel's extension (ninja) build phase runs uncapped while the NCCLX make phase already honors a job cap, so device-heavy translation units can exhaust builder memory and die mid-build instead of surviving to packaging. The root cause is that setup.py always forwards a bare -j, which overrides any ambient parallelism cap.
- Honor the existing NCCL_BUILD_JOBS knob when set and keep the bare -j fallback when unset, so local builds are unchanged; the wheel build script already exports the knob, so CI picks up the cap with no workflow changes.

Differential Revision: D118978591


