### PR TITLE
Pre-build NCCLX before cmake

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -84,6 +84,9 @@ jobs:
 
         export DISABLED_TESTS="${{ vars.DISABLED_TESTS }}"
 
+        # NCCLX is ON by default and cmake configure no longer builds it.
+        bash build_ncclx.sh
+
         # Build and run C++ tests
         cmake -B build_tests -G Ninja -DBUILD_TESTS=ON
         cmake --build build_tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,8 @@ lintrunner --take CLANGFORMAT
 
 Enabled via `-DBUILD_TESTS=ON` cmake flag. Tests are in `comms/torchcomms/tests/unit/cpp/`.
 
+Direct `cmake` configure no longer builds NCCLX. With NCCLX enabled (the default), run `./build_ncclx.sh` first (or pass `-DUSE_NCCLX=OFF`).
+
 ```bash
 # Full build-and-test from repo root
 ctest --build-and-test ./ ./build --build-generator "Ninja" \

--- a/comms/torchcomms/cmake/third_party/build_ncclx.cmake
+++ b/comms/torchcomms/cmake/third_party/build_ncclx.cmake
@@ -2,25 +2,20 @@
 
 include_guard(GLOBAL)
 
-# When USE_NCCLX is enabled and we're not using system libs, run build_ncclx.sh
-# to build gflags/glog/fmt/folly/NCCLX into CONDA_PREFIX. This must
-# happen before the other third-party includes so find_package() can discover
-# the libraries that build_ncclx.sh installs.
+# When USE_NCCLX is enabled and we're not using system libs, the NCCLX build
+# dir must already exist: build it ahead of time with ./build_ncclx.sh from
+# the repo root (python setup.py does this automatically when needed).
+# Configure fails fast here so a missing build breaks in seconds with the
+# recovery command instead of deep inside find_package().
 if(USE_NCCLX AND NOT USE_SYSTEM_LIBS)
     set(NCCLX_BUILD_DIR $ENV{BUILDDIR})
     if(NOT NCCLX_BUILD_DIR)
         set(NCCLX_BUILD_DIR "${ROOT}/build/ncclx")
     endif()
     if(NOT EXISTS "${NCCLX_BUILD_DIR}")
-        message(STATUS "NCCLX build dir not found at ${NCCLX_BUILD_DIR}, running build_ncclx.sh...")
-        execute_process(
-            COMMAND ${ROOT}/build_ncclx.sh
-            WORKING_DIRECTORY ${ROOT}
-            RESULT_VARIABLE _ncclx_result
-            ERROR_VARIABLE _ncclx_error
-        )
-        if(_ncclx_result)
-            message(FATAL_ERROR "NCCLX build failed: ${_ncclx_result}\n${_ncclx_error}")
-        endif()
+        message(FATAL_ERROR
+            "NCCLX build dir not found at ${NCCLX_BUILD_DIR}. "
+            "Build it first from the repo root with ./build_ncclx.sh "
+            "(or point BUILDDIR at an existing build dir).")
     endif()
 endif()

--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,8 @@ class build_ext(build_ext_orig):
             f"-DUSE_TRANSPORT_CCA_HOOK={flag_str(USE_TRANSPORT_CCA_HOOK)}",
             f"-DUSE_TRITON={flag_str(USE_TRITON)}",
         ]
-        build_args = ["--", "-j"]
+        build_jobs = os.environ.get("NCCL_BUILD_JOBS")
+        build_args = ["--", "-j", build_jobs] if build_jobs else ["--", "-j"]
 
         os.chdir(str(build_temp))
         self.spawn(["cmake", str(cwd)] + cmake_args)

--- a/setup.py
+++ b/setup.py
@@ -168,6 +168,24 @@ class build_ext(build_ext_orig):
     def build_cmake(self, ext):
         cwd = pathlib.Path().absolute()
 
+        # Build NCCLX third-party deps + lib before CMake configure, mirroring
+        # the old configure-time hook's guard for this path (NCCLX on, build
+        # dir absent; setup.py never opts into USE_SYSTEM_LIBS itself).
+        # build_ncclx.sh derives NCCL_HOME/BASE_DIR from PWD, so it must run
+        # with cwd=ROOT; self.spawn takes no cwd, hence chdir + restore.
+        # Failures raise as today with the script's own diagnostics.
+        if USE_NCCLX:
+            ncclx_build_dir = os.environ.get("BUILDDIR") or os.path.join(
+                ROOT, "build", "ncclx"
+            )
+            if not os.path.exists(ncclx_build_dir):
+                prev_cwd = pathlib.Path().absolute()
+                os.chdir(ROOT)
+                try:
+                    self.spawn([os.path.join(ROOT, "build_ncclx.sh")])
+                finally:
+                    os.chdir(str(prev_cwd))
+
         # these dirs will be created in build_py, so if you don't have
         # any python sources to bundle, the dirs will be missing
         build_temp = pathlib.Path(self.build_temp).absolute()


### PR DESCRIPTION
Summary:
- `cmake` configure shells out to `build_ncclx.sh` whenever the NCCLX build dir is absent, so a fresh configure either hangs for the hour-long third-party + NCCLX build or fails deep in dependency discovery with the blame pointing at the wrong team
- Move the build to an explicit pre-step: `setup.py` builds NCCLX before configuring when NCCLX is on and the build dir is absent, and bare `cmake` configure now fails within seconds naming the missing dir and the recovery command
- No change to what gets built (sources, flags, architectures, install layout); the direct-`cmake` CI job keeps working via an explicit script step

Differential Revision: D118979560


