### PR TITLE
Flush received RDMA data before it is consumed, across algos (#4047)

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherBrucksFF.cc
+++ b/comms/ctran/algos/AllGather/AllGatherBrucksFF.cc
@@ -217,9 +217,14 @@ static commResult_t impl(
     // Wait for first step notification from srcPeer, at which point we have
     // first half of all blocks for next step
     FB_COMMCHECK(comm->ctran_->mapper->waitNotify(notifyVec[i].get()));
-
+    // Flush the received blocks before forwarding them as next-step sends;
+    // the notify CQE does not order the NIC's payload writes into HBM. On the
+    // final step, the second-half flush below orders both halves.
     // Post first half of messages for next step, if there is a next step
     if (i < (nSteps - 1)) {
+      if (notifyVec[i]->backend == CtranMapperBackend::IB) {
+        FB_COMMCHECK(comm->ctran_->mapper->flush(recvbuff, memHdl));
+      }
       dstPeer = dstAtStep(nRanks, rank, i + 1);
       sends = sendsAtStep(nRanks, rank, i + 1);
 
@@ -265,6 +270,11 @@ static commResult_t impl(
 
     // Wait for second step notification from srcPeer
     FB_COMMCHECK(comm->ctran_->mapper->waitNotify(notifyVec.at(i).get()));
+    // Same flush as above: these blocks are forwarded at step i+1 (or read by
+    // the user after the last step).
+    if (notifyVec[i]->backend == CtranMapperBackend::IB) {
+      FB_COMMCHECK(comm->ctran_->mapper->flush(recvbuff, memHdl));
+    }
   }
 
   // // Wait for signal from all receives

--- a/comms/ctran/algos/AllGather/AllGatherDirect.cc
+++ b/comms/ctran/algos/AllGather/AllGatherDirect.cc
@@ -169,6 +169,7 @@ static commResult_t impl(
       profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
 
   // Wait for all PUTs to complete
+  bool hasIbRecv = false;
   for (int p = 1; p < nRanks; p++) {
     int peer = (rank + p) % nRanks;
 
@@ -184,6 +185,15 @@ static commResult_t impl(
       timestamp->putComplete.push_back(CtranMapperTimestampPoint(peer));
     }
     FB_COMMCHECK(comm->ctran_->mapper->waitNotify(notifyVec[peer].get()));
+    hasIbRecv |= notifyVec[peer]->backend == CtranMapperBackend::IB;
+  }
+
+  // Flush inter-node RDMA writes into recvbuff before the stream is released;
+  // the notify CQE does not order payload writes into HBM. No-op unless local
+  // flush is enabled (e.g. GB300, pre-H100 arch, or
+  // NCCL_CTRAN_NET_FORCE_FLUSH).
+  if (hasIbRecv) {
+    FB_COMMCHECK(comm->ctran_->mapper->flush(op->allgather.recvbuff, memHdl));
   }
 
   // Wait for intranode bcast to complete

--- a/comms/ctran/algos/AllGather/AllGatherRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherRing.cc
@@ -122,6 +122,14 @@ static commResult_t impl(
       if (!notifyRcvd) {
         break;
       }
+      // Flush the just-received chunk before it is forwarded (or read by the
+      // user after the final step); the notify CQE does not order the NIC's
+      // payload writes, and the forwarding NIC may otherwise read stale HBM.
+      // No-op unless local flush is enabled. TODO(perf): switch to an
+      // iflush-gated forward (StreamedRd pattern) to keep the ring pipelined.
+      if (notifyLeft->backend == CtranMapperBackend::IB) {
+        FB_COMMCHECK(mapper->flush(op->allgather.recvbuff, memHdl));
+      }
       // Don't queue send for final step
       if (blockNum < nRanks - 2) {
         int blockId = (rank - blockNum - 1 + nRanks) % nRanks;

--- a/comms/ctran/algos/AllGatherP/DirectImpl.cc
+++ b/comms/ctran/algos/AllGatherP/DirectImpl.cc
@@ -142,6 +142,12 @@ commResult_t gpnFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   for (auto& notify : notifyVec) {
     FB_COMMCHECK(mapper->waitNotify(notify.get()));
   }
+  // Flush received RDMA writes into recvbuff before the stream is released,
+  // matching the other AllGatherP variants; the notify CQE does not order
+  // payload writes into HBM.
+  if (!notifyVec.empty()) {
+    FB_COMMCHECK(mapper->flush(pArgs->recvbuff, pArgs->recvHdl));
+  }
   // Wait for all local PUTs to complete
   for (auto& req : pReqs) {
     FB_COMMCHECK(mapper->waitRequest(req.get()));

--- a/comms/ctran/algos/Broadcast/BroadcastBinomialTree.cc
+++ b/comms/ctran/algos/Broadcast/BroadcastBinomialTree.cc
@@ -287,6 +287,12 @@ static commResult_t impl(
     FB_COMMCHECK(mapper->waitRequest(sendReq));
     // Wait for the put from the sender to complete
     FB_COMMCHECK(mapper->waitNotify(notifyParent.get()));
+    // Flush the received data before it is forwarded to children (or read by
+    // the user on a leaf); the notify CQE does not order the NIC's payload
+    // writes into HBM.
+    if (notifyParent->backend == CtranMapperBackend::IB) {
+      FB_COMMCHECK(mapper->flush(op->broadcast.recvbuff, recvHdl));
+    }
   }
 
   // 4. Send data to all children in order

--- a/comms/ctran/algos/RMA/Get.cc
+++ b/comms/ctran/algos/RMA/Get.cc
@@ -72,6 +72,11 @@ static commResult_t getImpl(
   auto getReq = std::unique_ptr<CtranMapperRequest>(req);
   FB_COMMCHECK(comm->ctran_->mapper->waitRequest(getReq.get()));
 
+  // Flush the RDMA READ payload into recvbuff before returning; the
+  // requester-side CQE does not order the NIC's writes into HBM. Must run
+  // before the handle is deregistered below.
+  FB_COMMCHECK(comm->ctran_->mapper->flush(op->get.recvbuff, localMemHdl));
+
   // Deregister the sendbuffer if it is automatically registered by the
   // mapper->searchRegHandle()
   if (localReg) {

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterRHD.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterRHD.cc
@@ -149,6 +149,11 @@ static commResult_t impl(
 
     // make sure send from peer is completed
     FB_COMMCHECK(comm->ctran_->mapper->waitNotify(notifyVec[i].get()));
+    // Drain the peer's RDMA WRITE into tmpRecvBuf before the reduce kernel
+    // reads it; the notify CQE does not order payload writes into HBM.
+    if (notifyVec[i]->backend == CtranMapperBackend::IB) {
+      FB_COMMCHECK(comm->ctran_->mapper->flush(tmpRecvBuf, tmpHdl));
+    }
 
     // Local reduce
     for (size_t j = 0; j < (nRanks >> (i + 1)); j++) {

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterRing.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterRing.cc
@@ -185,7 +185,7 @@ static commResult_t impl(
       const void* putSrc = (i == 0) ? sendBuf + putPos * recvSize : redBuf;
       void* putHdl = (i == 0) ? sendHdl : tmpRegHdl;
 
-      CtranMapperRequest* iputReq = nullptr;
+      CtranMapperRequest* iputReqPtr = nullptr;
       FB_COMMCHECK(mapper->iput(
           putSrc,
           remoteTmpBuf, // use first half of tmpbuf to receive data
@@ -195,14 +195,21 @@ static commResult_t impl(
               .memHdl_ = putHdl,
               .remoteAccessKey_ = remoteTmpAccessKey,
               .notify_ = true},
-          &iputReq));
+          &iputReqPtr));
+      auto iputReq = std::unique_ptr<CtranMapperRequest>(iputReqPtr);
 
       FB_COMMCHECK(mapper->waitNotify(notifyLeft.get()));
+      // Drain the peer's RDMA WRITE into tmpBuf before the reduce kernel
+      // reads it. The notify CQE does not order the NIC's payload writes
+      // into HBM. No-op unless local flush is enabled (e.g. GB300,
+      // pre-H100 arch, or NCCL_CTRAN_NET_FORCE_FLUSH).
+      if (notifyLeft->backend == CtranMapperBackend::IB) {
+        FB_COMMCHECK(mapper->flush(recvBuf, tmpRegHdl));
+      }
 
       // Local reduce will update redBuf, let's ensure the previous put has
       // finished so redBuf can be updated
-      FB_COMMCHECK(mapper->waitRequest(iputReq));
-      delete iputReq;
+      FB_COMMCHECK(mapper->waitRequest(iputReq.get()));
 
       kElem->reduce.ndsts = 1;
       kElem->reduce.nsrcs = 2; // Always reduce from 2 srcs (tmpBuf, srcbuf)

--- a/comms/ctran/algos/SendRecv/SendRecvImpl.h
+++ b/comms/ctran/algos/SendRecv/SendRecvImpl.h
@@ -320,6 +320,37 @@ inline commResult_t sendRecvImpl(
     FB_COMMCHECK(mapper->waitNotify(notifyVec[i].get()));
   }
 
+  // Flush received RDMA writes into each recvbuff before the stream is
+  // released; the notify CQE does not order payload writes into HBM. Keep all
+  // requests alive and wait for the complete batch before using the buffers or
+  // deregistering the handles below.
+  constexpr size_t kMaxFlushBatchSize =
+      MAX_SEND_WR / CTRAN_MAX_IB_DEVICES_PER_RANK;
+  static_assert(kMaxFlushBatchSize > 0);
+  std::vector<std::unique_ptr<CtranMapperRequest>> flushReqs;
+  flushReqs.reserve(kMaxFlushBatchSize);
+  auto waitFlushes = [&]() -> commResult_t {
+    for (const auto& req : flushReqs) {
+      FB_COMMCHECK(mapper->waitRequest(req.get()));
+    }
+    flushReqs.clear();
+    return commSuccess;
+  };
+  for (auto i = 0; i < recvOpGroup.size(); i++) {
+    auto op = recvOpGroup[i];
+    if (notifyVec[i]->backend == CtranMapperBackend::IB) {
+      CtranMapperRequest* req = nullptr;
+      FB_COMMCHECK(mapper->iflush(op->recv.recvbuff, recvMemHdl[i], &req));
+      if (req != nullptr) {
+        flushReqs.emplace_back(req);
+        if (flushReqs.size() == kMaxFlushBatchSize) {
+          FB_COMMCHECK(waitFlushes());
+        }
+      }
+    }
+  }
+  FB_COMMCHECK(waitFlushes());
+
   // Deregister temporary registrations
   for (auto hdl : tmpRegHdls) {
     FB_COMMCHECK(mapper->deregDynamic(hdl));


### PR DESCRIPTION
Summary:

Several ctran algorithms consume NIC-written data gated only on the host-side
notify CQE, with no `mapper->flush`. The notify CQE proves the CQE was
delivered, not that the NIC's payload writes reached HBM; on split PCIe
paths the two are not ordered (see the comment on `CtranMapper::flush`). The
consumer — a reduce kernel, a forwarding `iput`, or the user's next kernel
after the stream is released — can then read stale bytes behind a valid
notify. Silent corruption, no hang, no error.

`AllReduceDirect` (`waitNotify -> flush -> post`), `AllReduceRing` (dedicated
`kRecvFlush` stage), and `AllToAllv`/`AllToAllP` (flush after
`waitAllNotifies`, e01bb8a3af37) already implement the receive-boundary
flush; this diff brings the remaining consumers in line:

- `ReduceScatterRing`/`ReduceScatterRHD`: flush the tmp recv buffer between
  `waitNotify` and the reduce-kernel post. A reduction folds stale bytes
  into a numerically plausible partial sum that propagates ring/tree-wide.
- `AllGatherDirect` (forced default for `nLocalRanks > 1`): flush recvbuff
  after the inter-node notify loop, before the stream is released.
- `AllGatherRing` / `AllGatherBrucksFF`: flush the just-received chunk
  before forwarding it — the outbound NIC's DMA read is not ordered against
  another inbound NIC's writes — and thereby also before the final user
  read. Blocking flush per step for now; an iflush-gated forward
  (StreamedRd pattern) is the follow-up to restore pipelining.
- `AllGatherP` ctdirect: the one AGP variant D107941271 ("Restore CTRAN
  flush") missed; Pipeline/RD/SRD got the identical flush there.
- `SendRecv`: flush each IB recvbuff after the notify loop, before the
  temporary deregistrations; the kernel-side notify elem is revoked for IB
  peers, so nothing else gates the release.
- `CompressedAllToAllv` (both impls): the flush the uncompressed clone has;
  the decompress kernel reads the compressed recv staging buffer.
- `BroadcastBinomialTree`: flush after the parent notify on non-root ranks,
  before forwarding to children (and before the leaf user read).
- `RMA Get`: flush recvbuff after the requester-side CQE, before the handle
  is deregistered.

All flushes are no-ops unless local flush is enabled: GB300 (arch 1030),
pre-H100 arch, ROCm, or `NCCL_CTRAN_NET_FORCE_FLUSH=1`. Default H100/H200
behavior is unchanged.

Found by an audit seeded from D118961602 and D118906933 (the same
receive-boundary-ordering bug class). Related coverage gap, not addressed
here: no CI lane runs any collective with local flush enabled, so this
entire family is invisible to H100 CI.

Differential Revision: D118965974
