### PR TITLE
Guard getRemoteKeysImpl against a null IB registration handle (#4048)

### DIFF
--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -144,10 +144,14 @@ class CtranIb {
   // Input arguments:
   //   - ibRegElem: the ibRegElem of the local buffer that stores the
   //                registration handle.
+  // Throws ctran::utils::Exception if the registration metadata is invalid.
   static CtranIbRemoteAccessKey getRemoteAccessKey(void* ibRegElem) {
     CtranIbRemoteAccessKey key;
-    key.nKeys = NCCL_CTRAN_IB_DEVICES_PER_RANK;
-    ctran::ib::getRemoteKeysImpl(ibRegElem, key.rkeys);
+    const int configuredDeviceCount = NCCL_CTRAN_IB_DEVICES_PER_RANK;
+    FB_COMMCHECKTHROW_EX_NOCOMM(
+        ctran::ib::getRemoteKeysImpl(
+            ibRegElem, configuredDeviceCount, key.rkeys));
+    key.nKeys = configuredDeviceCount;
     return key;
   }
 
@@ -742,10 +746,15 @@ class CtranIb {
 
   static inline commResult_t
   exportMemImpl(const void* buf, void* ibRegElem, ControlMsg& msg) {
+    const int configuredDeviceCount = NCCL_CTRAN_IB_DEVICES_PER_RANK;
+    std::array<uint32_t, CTRAN_MAX_IB_DEVICES_PER_RANK> rkeys{};
+    FB_COMMCHECK(
+        ctran::ib::getRemoteKeysImpl(ibRegElem, configuredDeviceCount, rkeys));
+
     msg.setType(ControlMsgType::IB_EXPORT_MEM);
     msg.ibDesc.remoteAddr = reinterpret_cast<uint64_t>(buf);
-    msg.ibDesc.nKeys = NCCL_CTRAN_IB_DEVICES_PER_RANK;
-    ctran::ib::getRemoteKeysImpl(ibRegElem, msg.ibDesc.rkeys);
+    msg.ibDesc.nKeys = configuredDeviceCount;
+    msg.ibDesc.rkeys = rkeys;
 
     return commSuccess;
   }
@@ -754,8 +763,31 @@ class CtranIb {
       void** buf,
       CtranIbRemoteAccessKey* key,
       const ControlMsg& msg) {
+    if (buf == nullptr || key == nullptr) {
+      CTRAN_ERR(
+          commInvalidArgument,
+          "CTRAN-IB: importMem called with a null output pointer");
+      return commInvalidArgument;
+    }
+
+    const int configuredDeviceCount = NCCL_CTRAN_IB_DEVICES_PER_RANK;
+    FB_COMMCHECK(
+        ctran::ib::validateConfiguredDeviceCount(
+            configuredDeviceCount, key->rkeys.size()));
+    // IB device indices are rank-symmetric, so every peer must export the same
+    // number of keys configured locally.
+    if (msg.ibDesc.nKeys != configuredDeviceCount) {
+      CTRAN_ERR(
+          commInvalidArgument,
+          "CTRAN-IB: received {} rkeys but {} devices are configured; "
+          "NCCL_CTRAN_IB_DEVICES_PER_RANK must match across ranks",
+          msg.ibDesc.nKeys,
+          configuredDeviceCount);
+      return commInvalidArgument;
+    }
+
     (*buf) = reinterpret_cast<void*>(msg.ibDesc.remoteAddr);
-    for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
+    for (int device = 0; device < configuredDeviceCount; device++) {
       key->rkeys[device] = msg.ibDesc.rkeys[device];
     }
     key->nKeys = msg.ibDesc.nKeys;

--- a/comms/ctran/backends/ib/CtranIbImpl.h
+++ b/comms/ctran/backends/ib/CtranIbImpl.h
@@ -7,6 +7,7 @@
 #include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/ibverbx/Ibvcore.h"
 #include "comms/ctran/ibverbx/Ibverbx.h"
+#include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/CtranLogUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -38,13 +39,67 @@
   } while (0)
 
 namespace ctran::ib {
-inline void getRemoteKeysImpl(
-    void* ibRegElem,
-    std::array<uint32_t, CTRAN_MAX_IB_DEVICES_PER_RANK>& rkeys) {
-  auto mrs = reinterpret_cast<std::vector<ibverbx::IbvMr>*>(ibRegElem);
-  for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
-    rkeys.at(device) = (*mrs)[device].mr()->rkey;
+inline commResult_t validateConfiguredDeviceCount(
+    const int configuredDeviceCount,
+    const size_t rkeyCapacity) {
+  if (configuredDeviceCount <= 0) {
+    CTRAN_ERR(
+        commInvalidArgument,
+        "CTRAN-IB: invalid configured IB device count {}",
+        configuredDeviceCount);
+    return commInvalidArgument;
   }
+  if (static_cast<size_t>(configuredDeviceCount) > rkeyCapacity) {
+    CTRAN_ERR(
+        commInvalidArgument,
+        "CTRAN-IB: configured IB device count {} exceeds rkey capacity {}",
+        configuredDeviceCount,
+        rkeyCapacity);
+    return commInvalidArgument;
+  }
+  return commSuccess;
+}
+
+inline commResult_t getRemoteKeysImpl(
+    void* ibRegElem,
+    const int configuredDeviceCount,
+    std::array<uint32_t, CTRAN_MAX_IB_DEVICES_PER_RANK>& rkeys) {
+  if (ibRegElem == nullptr) {
+    CTRAN_ERR(
+        commInvalidArgument,
+        "CTRAN-IB: getRemoteKeys called with a null IB registration handle");
+    return commInvalidArgument;
+  }
+
+  FB_COMMCHECK(
+      validateConfiguredDeviceCount(configuredDeviceCount, rkeys.size()));
+  const auto deviceCount = static_cast<size_t>(configuredDeviceCount);
+
+  const auto* mrs =
+      reinterpret_cast<const std::vector<ibverbx::IbvMr>*>(ibRegElem);
+  if (mrs->size() < deviceCount) {
+    CTRAN_ERR(
+        commInvalidArgument,
+        "CTRAN-IB: registration carries {} memory regions but {} devices are "
+        "configured",
+        mrs->size(),
+        deviceCount);
+    return commInvalidArgument;
+  }
+  // Validate every MR before mutating the output.
+  for (size_t device = 0; device < deviceCount; device++) {
+    if ((*mrs)[device].mr() == nullptr) {
+      CTRAN_ERR(
+          commInvalidArgument,
+          "CTRAN-IB: registration memory region {} is null",
+          device);
+      return commInvalidArgument;
+    }
+  }
+  for (size_t device = 0; device < deviceCount; device++) {
+    rkeys[device] = (*mrs)[device].mr()->rkey;
+  }
+  return commSuccess;
 }
 } // namespace ctran::ib
 #endif

--- a/comms/ctran/backends/ib/tests/CtranIbRegMemUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbRegMemUT.cc
@@ -2,6 +2,9 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+#include <utility>
+
 #include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/tests/CtranTestUtils.h"
 #include "comms/ctran/utils/LogInit.h"
@@ -17,7 +20,117 @@ class CtranIbRegMemTest : public ::testing::Test {
     ncclCvarInit();
     ctran::logging::initCtranLogging(true /*alwaysInit*/);
   }
+
+  void expectImportMemFailureDoesNotModifyOutputs(
+      const int configuredDeviceCount,
+      const int receivedKeyCount) {
+    EnvRAII devicesPerRank(
+        NCCL_CTRAN_IB_DEVICES_PER_RANK, configuredDeviceCount);
+    ControlMsg msg(ControlMsgType::IB_EXPORT_MEM);
+    msg.ibDesc.nKeys = receivedKeyCount;
+
+    int originalBuf{};
+    void* buf = &originalBuf;
+    CtranIbRemoteAccessKey key{};
+    key.nKeys = 7;
+    key.rkeys.fill(11);
+    const auto originalKey = key;
+
+    EXPECT_EQ(CtranIb::importMem(&buf, &key, msg), commInvalidArgument);
+    EXPECT_EQ(buf, &originalBuf);
+    EXPECT_EQ(key.nKeys, originalKey.nKeys);
+    EXPECT_EQ(key.rkeys, originalKey.rkeys);
+  }
 };
+
+TEST_F(CtranIbRegMemTest, ExportMemRejectsNullRegistrationHandle) {
+  EnvRAII devicesPerRank(NCCL_CTRAN_IB_DEVICES_PER_RANK, 1);
+  ControlMsg msg;
+  EXPECT_EQ(CtranIb::exportMem(nullptr, nullptr, msg), commInvalidArgument);
+  EXPECT_EQ(msg.type, ControlMsgType::UNSPECIFIED);
+}
+
+TEST_F(CtranIbRegMemTest, ExportMemRejectsShortRegistration) {
+  EnvRAII devicesPerRank(NCCL_CTRAN_IB_DEVICES_PER_RANK, 1);
+  std::vector<ibverbx::IbvMr> mrs;
+  ControlMsg msg;
+  EXPECT_EQ(CtranIb::exportMem(nullptr, &mrs, msg), commInvalidArgument);
+  EXPECT_EQ(msg.type, ControlMsgType::UNSPECIFIED);
+}
+
+TEST_F(CtranIbRegMemTest, ExportMemRejectsNullMemoryRegion) {
+  EnvRAII devicesPerRank(NCCL_CTRAN_IB_DEVICES_PER_RANK, 1);
+  constexpr size_t bufSize = 8192;
+  auto hostMem = std::make_unique<char[]>(bufSize);
+  void* ibRegElem = nullptr;
+  try {
+    ASSERT_EQ(
+        CtranIb::regMem(hostMem.get(), bufSize, 0, &ibRegElem), commSuccess);
+  } catch (const std::bad_alloc&) {
+    GTEST_SKIP() << "IB backend not enabled. Skip test";
+  }
+
+  auto* mrs = reinterpret_cast<std::vector<ibverbx::IbvMr>*>(ibRegElem);
+  ASSERT_EQ(mrs->size(), 1);
+  auto movedMr = std::move(mrs->front());
+  EXPECT_NE(movedMr.mr(), nullptr);
+  EXPECT_EQ(mrs->front().mr(), nullptr);
+  ControlMsg msg;
+  EXPECT_EQ(CtranIb::exportMem(nullptr, ibRegElem, msg), commInvalidArgument);
+  EXPECT_EQ(msg.type, ControlMsgType::UNSPECIFIED);
+
+  mrs->front() = std::move(movedMr);
+  EXPECT_EQ(CtranIb::deregMem(ibRegElem), commSuccess);
+}
+
+TEST_F(CtranIbRegMemTest, ExportMemRejectsNonpositiveDeviceCount) {
+  EnvRAII devicesPerRank(NCCL_CTRAN_IB_DEVICES_PER_RANK, 0);
+  std::vector<ibverbx::IbvMr> mrs;
+  ControlMsg msg;
+  EXPECT_EQ(CtranIb::exportMem(nullptr, &mrs, msg), commInvalidArgument);
+  EXPECT_EQ(msg.type, ControlMsgType::UNSPECIFIED);
+}
+
+TEST_F(CtranIbRegMemTest, ExportMemRejectsTooManyDevices) {
+  EnvRAII devicesPerRank(
+      NCCL_CTRAN_IB_DEVICES_PER_RANK, CTRAN_MAX_IB_DEVICES_PER_RANK + 1);
+  std::vector<ibverbx::IbvMr> mrs;
+  ControlMsg msg;
+  EXPECT_EQ(CtranIb::exportMem(nullptr, &mrs, msg), commInvalidArgument);
+  EXPECT_EQ(msg.type, ControlMsgType::UNSPECIFIED);
+}
+
+TEST_F(CtranIbRegMemTest, GetRemoteAccessKeyRejectsNullRegistrationHandle) {
+  EnvRAII devicesPerRank(NCCL_CTRAN_IB_DEVICES_PER_RANK, 1);
+  EXPECT_THROW(CtranIb::getRemoteAccessKey(nullptr), ctran::utils::Exception);
+}
+
+TEST_F(CtranIbRegMemTest, ImportMemRejectsTooManyDevices) {
+  expectImportMemFailureDoesNotModifyOutputs(
+      CTRAN_MAX_IB_DEVICES_PER_RANK + 1, CTRAN_MAX_IB_DEVICES_PER_RANK);
+}
+
+TEST_F(CtranIbRegMemTest, ImportMemRejectsMismatchedKeyCount) {
+  expectImportMemFailureDoesNotModifyOutputs(1, 2);
+}
+
+TEST_F(CtranIbRegMemTest, ImportMemRejectsNullOutputs) {
+  EnvRAII devicesPerRank(NCCL_CTRAN_IB_DEVICES_PER_RANK, 1);
+  ControlMsg msg(ControlMsgType::IB_EXPORT_MEM);
+  msg.ibDesc.nKeys = 1;
+
+  int originalBuf{};
+  void* buf = &originalBuf;
+  CtranIbRemoteAccessKey key{};
+  key.nKeys = 7;
+  const auto originalKey = key;
+
+  EXPECT_EQ(CtranIb::importMem(nullptr, &key, msg), commInvalidArgument);
+  EXPECT_EQ(key.nKeys, originalKey.nKeys);
+  EXPECT_EQ(key.rkeys, originalKey.rkeys);
+  EXPECT_EQ(CtranIb::importMem(&buf, nullptr, msg), commInvalidArgument);
+  EXPECT_EQ(buf, &originalBuf);
+}
 
 class CtranIbCpuRegMemTestParam
     : public CtranIbRegMemTest,


### PR DESCRIPTION
Summary:

getRemoteKeysImpl dereferences one IB memory region per configured device. A null registration handle or invalid region metadata previously caused a GPE-thread SEGV or invalid rkey access with little attribution.

Validate null handles, configured device-count bounds, registration vector size, and each memory region before copying keys. Reuse the same validated count for exported metadata and the throwing getRemoteAccessKey wrapper.

Import now validates output pointers and the configured count before mutation. It also requires the peer key count to match the local count, as required by CTRAN IB rank-symmetric NCCL_CTRAN_IB_DEVICES_PER_RANK configuration and downstream device-indexed key lookup.

Add regression coverage for invalid export metadata, import count mismatches, null outputs, exception propagation, and unchanged outputs on failure.

Found by an audit seeded from D118961602 and D118906933.

Differential Revision: D118965975
