### PR TITLE
Do not throw from memCacheAllocator's destructor

### DIFF
--- a/comms/ctran/memory/memCacheAllocator.cc
+++ b/comms/ctran/memory/memCacheAllocator.cc
@@ -110,7 +110,10 @@ commResult_t memCacheAllocator::reset() {
 
 memCacheAllocator::~memCacheAllocator() {
   CTRAN_LOG_SUBSYS(INFO, INIT, "Shutting down NCCLX memory cache allocator");
-  FB_COMMCHECKTHROW_EX_NOCOMM(reset());
+  // Destructors are implicitly noexcept, so a throw here calls terminate.
+  // reset() returns commInvalidUsage when regions are still outstanding, which
+  // is worth a log but must not take the process down.
+  FB_COMMCHECKIGNORE(reset());
 }
 
 std::shared_ptr<memRegion> memCacheAllocator::getFreeMemReg(


### PR DESCRIPTION
Summary:
`~memCacheAllocator` calls `FB_COMMCHECKTHROW_EX_NOCOMM(reset())`. Destructors are implicitly `noexcept`, so a throw there calls `std::terminate` and kills the process. `reset()` returns `commInvalidUsage` when regions are still outstanding, which is a real possibility at shutdown.

Switch to `FB_COMMCHECKIGNORE`, which already exists for this and logs at WARN instead of throwing. Same pattern is used elsewhere in ctran, for example the dereg guard in `AllGatherP/PipelineImpl.cc`.

The throwing call came in with D90199464 in January, which introduced `FB_COMMCHECKTHROW_EX_NOCOMM` and applied it here. The destructor itself is older.

Differential Revision: D118984601


