### PR TITLE
comms/uniflow: name the recv phase counter for what it measures, and read it atomically

### DIFF
--- a/comms/uniflow/controller/Controller.h
+++ b/comms/uniflow/controller/Controller.h
@@ -56,19 +56,39 @@ class Conn {
   /// the only place the two can be told apart -- above this layer a recv() is
   /// one opaque wait.
   ///
-  /// headerWaitNs is a first-byte latency: for a get it covers the network
-  /// round trip plus everything the peer did before it started replying, so it
-  /// separates "the remote is slow" from "our drain is slow". Relaxed atomics,
-  /// written only by the reader thread; a torn read across a reset costs a
-  /// misattributed sample, never correctness.
+  /// interFrameStallNs is the reader's residual stall between frames -- time
+  /// blocked on a length prefix with nothing arriving. It equals a first-byte
+  /// latency only for the first frame after idle.
+  ///
+  /// It is NOT the round trip plus the peer's work, and must not be read that
+  /// way: a get responder stages asynchronously (it posts the copy, returns to
+  /// its socket, and queues the reply when the copy signals), so the
+  /// responder's staging and the round trip are overlapped with our own drain
+  /// and cannot appear in our block on the prefix. The arithmetic says the same
+  /// thing -- 3.1us measured here against 92.9us for a same-sized local device
+  /// copy; the responder's copy cannot be 30x cheaper than ours.
+  ///
+  /// Idle time inside the measurement bracket also lands here, so its share of
+  /// the total is only meaningful across back-to-back traffic.
+  ///
+  /// Relaxed atomics. Accumulated by the reader thread and read-and-cleared by
+  /// whichever thread brackets a measurement, so two threads do touch them;
+  /// relaxed is still sound because nothing orders against them and nothing
+  /// branches on them. Do not restate the old "a torn read across a reset"
+  /// rationale: an atomic load does not tear, and the read path exchanges
+  /// rather than load-then-stores, so there is no window for a sample to fall
+  /// into.
   struct RecvPhaseStats {
-    std::atomic<uint64_t> headerWaitNs{0};
+    std::atomic<uint64_t> interFrameStallNs{0};
     std::atomic<uint64_t> payloadDrainNs{0};
     std::atomic<uint64_t> frames{0};
     std::atomic<uint64_t> payloadBytes{0};
 
+    /// Tests only. The transport's reporting path reads and clears with
+    /// exchange() rather than calling this; it is kept so a test can scope one
+    /// measurement without standing up a transport.
     void reset() {
-      headerWaitNs.store(0, std::memory_order_relaxed);
+      interFrameStallNs.store(0, std::memory_order_relaxed);
       payloadDrainNs.store(0, std::memory_order_relaxed);
       frames.store(0, std::memory_order_relaxed);
       payloadBytes.store(0, std::memory_order_relaxed);

--- a/comms/uniflow/controller/TcpController.cpp
+++ b/comms/uniflow/controller/TcpController.cpp
@@ -651,7 +651,7 @@ Result<size_t> TcpConn<IOPolicy>::syncRecv(std::vector<uint8_t>& data) {
     return Err(ErrCode::NotConnected, "Socket is not connected");
   }
 
-  // Split the wait: blocking on the length prefix is first-byte latency,
+  // Split the wait: blocking on the next length prefix is inter-frame stall,
   // blocking on the payload is drain time. Two clock reads per frame (~20ns
   // each) against a frame that takes hundreds of microseconds.
   auto& stats = recvPhaseStats();
@@ -683,7 +683,7 @@ Result<size_t> TcpConn<IOPolicy>::syncRecv(std::vector<uint8_t>& data) {
 
   const auto tDone = std::chrono::steady_clock::now();
   using ns = std::chrono::nanoseconds;
-  stats.headerWaitNs.fetch_add(
+  stats.interFrameStallNs.fetch_add(
       std::chrono::duration_cast<ns>(tFirstByte - tStart).count(),
       std::memory_order_relaxed);
   stats.payloadDrainNs.fetch_add(
@@ -737,7 +737,7 @@ Result<size_t> TcpConn<IOPolicy>::syncRecv(std::span<uint8_t> buf) {
 
   const auto tDone = std::chrono::steady_clock::now();
   using ns = std::chrono::nanoseconds;
-  stats.headerWaitNs.fetch_add(
+  stats.interFrameStallNs.fetch_add(
       std::chrono::duration_cast<ns>(tFirstByte - tStart).count(),
       std::memory_order_relaxed);
   stats.payloadDrainNs.fetch_add(

--- a/comms/uniflow/controller/tests/TcpConnTest.cpp
+++ b/comms/uniflow/controller/tests/TcpConnTest.cpp
@@ -139,7 +139,7 @@ TEST_P(TcpConnTest, SpanRecvRecordsPhaseStats) {
   EXPECT_EQ(stats.payloadBytes.load(std::memory_order_relaxed), sent.size());
 
   stats.reset();
-  EXPECT_EQ(stats.headerWaitNs.load(std::memory_order_relaxed), 0);
+  EXPECT_EQ(stats.interFrameStallNs.load(std::memory_order_relaxed), 0);
   EXPECT_EQ(stats.payloadDrainNs.load(std::memory_order_relaxed), 0);
   EXPECT_EQ(stats.frames.load(std::memory_order_relaxed), 0);
   EXPECT_EQ(stats.payloadBytes.load(std::memory_order_relaxed), 0);

--- a/comms/uniflow/drivers/cuda/CudaApi.cpp
+++ b/comms/uniflow/drivers/cuda/CudaApi.cpp
@@ -171,6 +171,18 @@ Status CudaApi::memcpyPeerAsync(
 
 // --- Stream ---
 
+Status CudaApi::streamCreateNonBlocking(cudaStream_t* stream) {
+  CUDA_CHECK(
+      cudaStreamCreateWithFlags(stream, cudaStreamNonBlocking),
+      ErrCode::DriverError);
+  return Ok();
+}
+
+Status CudaApi::streamDestroy(cudaStream_t stream) {
+  CUDA_CHECK(cudaStreamDestroy(stream), ErrCode::DriverError);
+  return Ok();
+}
+
 Status CudaApi::streamSynchronize(cudaStream_t stream) {
   CUDA_CHECK(cudaStreamSynchronize(stream), ErrCode::DriverError);
   return Ok();

--- a/comms/uniflow/drivers/cuda/CudaApi.h
+++ b/comms/uniflow/drivers/cuda/CudaApi.h
@@ -76,6 +76,16 @@ class CudaApi {
 
   // --- Stream ---
 
+  /// Creates a stream that does NOT implicitly synchronize with the null
+  /// stream (`cudaStreamNonBlocking`). A copy issued on the null stream
+  /// serialises against every blocking stream on the device, so a thread that
+  /// synchronizes it ends up waiting for unrelated application GPU work. Where
+  /// that thread also holds a resource someone else waits on, that is a
+  /// deadlock rather than a delay.
+  virtual Status streamCreateNonBlocking(cudaStream_t* stream);
+
+  virtual Status streamDestroy(cudaStream_t stream);
+
   virtual Status streamSynchronize(cudaStream_t stream);
 
   // --- Event ---

--- a/comms/uniflow/drivers/cuda/mock/MockCudaApi.h
+++ b/comms/uniflow/drivers/cuda/mock/MockCudaApi.h
@@ -68,6 +68,14 @@ class MockCudaApi : public CudaApi {
        cudaStream_t stream),
       (override));
 
+  MOCK_METHOD(
+      Status,
+      streamCreateNonBlocking,
+      (cudaStream_t * stream),
+      (override));
+
+  MOCK_METHOD(Status, streamDestroy, (cudaStream_t stream), (override));
+
   MOCK_METHOD(Status, streamSynchronize, (cudaStream_t stream), (override));
 
   MOCK_METHOD(Status, eventCreate, (cudaEvent_t * event), (override));

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -344,6 +344,10 @@ TcpTransport::TcpTransport(
   h2dState_ = std::make_shared<H2dPollState>();
   h2dState_->evb = evb_;
   h2dState_->cudaApi = cudaApi_;
+  reply_->evb = evb_;
+  reply_->cudaApi = cudaApi_;
+  reply_->lanes = laneSet_;
+  reply_->registry = registry_;
 }
 
 Status TcpTransport::hostFromDevice(
@@ -782,17 +786,25 @@ Status TcpTransport::establishLanes(
   return Ok();
 }
 
-size_t TcpTransport::laneCapBytes() const {
-  const size_t lanes = lanes_.empty() ? 1 : lanes_.size();
-  return kMaxOutQueueBytes / lanes;
+size_t TcpTransport::laneCapBytesOn(const TcpLaneSet& lanes) {
+  const size_t count = lanes.v.empty() ? 1 : lanes.v.size();
+  return kMaxOutQueueBytes / count;
 }
 
-size_t TcpTransport::pickLane() {
-  if (lanes_.size() <= 1) {
+size_t TcpTransport::laneCapBytes() const {
+  return laneCapBytesOn(*laneSet_);
+}
+
+size_t TcpTransport::pickLaneOn(TcpLaneSet& lanes) {
+  if (lanes.v.size() <= 1) {
     return 0;
   }
   return static_cast<size_t>(
-      nextLane_.fetch_add(1, std::memory_order_relaxed) % lanes_.size());
+      lanes.nextLane.fetch_add(1, std::memory_order_relaxed) % lanes.v.size());
+}
+
+size_t TcpTransport::pickLane() {
+  return pickLaneOn(*laneSet_);
 }
 
 controller::Conn* TcpTransport::primaryConn() const {
@@ -1028,7 +1040,7 @@ Result<PendingPutWave> TcpTransport::launchPutWave(
     std::span<const PlannedPutFrame> wave,
     void* stream,
     size_t startIdx) {
-  auto pool = stagingPool();
+  auto pool = stagingPool(reply_);
   if (!pool) {
     return std::move(pool).error();
   }
@@ -1316,26 +1328,48 @@ std::shared_ptr<TcpPinnedSlabPool> TcpTransport::receivePoolIfCreated() {
       &receiveSlabPool_, std::memory_order_acquire);
 }
 
-Result<std::shared_ptr<TcpPinnedSlabPool>> TcpTransport::stagingPool() {
-  std::lock_guard<std::mutex> lk(poolMu_);
-  if (slabPool_ != nullptr) {
-    return slabPool_;
+Result<std::shared_ptr<TcpPinnedSlabPool>> TcpTransport::stagingPool(
+    const std::shared_ptr<TcpReplyState>& state) {
+  std::lock_guard<std::mutex> lk(state->poolMu);
+  if (state->pool != nullptr) {
+    return state->pool;
   }
-  if (cudaApi_ == nullptr) {
+  // Refuse to CREATE one once teardown has begun. shutdown() sets `stopping`,
+  // then snapshots and closes the pool under poolMu, and only then joins the
+  // readers -- so a reader reaching here in that last window would allocate a
+  // fresh kStagingSlabCount of pinned slabs that shutdown() has already walked
+  // past. Nothing would ever close it: the memory would live until the last
+  // TcpReplyState reference drops, and a thread blocking in acquire() on it
+  // would have no `closed_` escape. Checking here rather than at each call site
+  // covers every caller, including respondToVramRead() on the reader thread.
+  //
+  // Lock order is poolMu -> mu, established here and nowhere reversed: no code
+  // takes poolMu while holding mu. Holding mu only for the flag read keeps it
+  // off the cudaHostAlloc below, which is ~124 MiB of page-locked memory and
+  // would otherwise stall every admission point for its duration.
+  {
+    std::lock_guard<std::mutex> stateLk(state->mu);
+    if (state->stopping) {
+      return Err(
+          ErrCode::NotConnected,
+          "tcp read: reply path stopped before the staging pool existed");
+    }
+  }
+  if (state->cudaApi == nullptr) {
     return Err(ErrCode::InvalidArgument, "tcp read: no CUDA API for VRAM");
   }
   // Header and payload contiguous in one slab, so a staged frame is still a
   // single buffer and the send path needs no scatter-gather.
   auto pool = TcpPinnedSlabPool::create(
-      cudaApi_,
+      state->cudaApi,
       sizeof(TcpMsgHeader) + kMaxChunkSize,
       kStagingSlabCount,
       kStagingSlabsReservedForReader);
   if (!pool) {
     return std::move(pool).error();
   }
-  slabPool_ = pool.value();
-  return slabPool_;
+  state->pool = pool.value();
+  return state->pool;
 }
 
 Status TcpTransport::respondToVramRead(
@@ -1352,7 +1386,7 @@ Status TcpTransport::respondToVramRead(
             " bytes exceeds the staging slab payload (" +
             std::to_string(kMaxChunkSize) + ")");
   }
-  auto pool = stagingPool();
+  auto pool = stagingPool(reply_);
   if (!pool) {
     return std::move(pool).error();
   }
@@ -1362,10 +1396,11 @@ Status TcpTransport::respondToVramRead(
   if (!slab) {
     return deferReadReply(replyHeader, std::move(lease));
   }
-  return startReadReply(replyHeader, std::move(lease), std::move(slab));
+  return startReadReply(reply_, replyHeader, std::move(lease), std::move(slab));
 }
 
 Status TcpTransport::startReadReply(
+    const std::shared_ptr<TcpReplyState>& state,
     const TcpMsgHeader& replyHeader,
     TcpSegmentRegistry::Lease lease,
     TcpPinnedSlab slab) {
@@ -1381,14 +1416,33 @@ Status TcpTransport::startReadReply(
   // taken back, and reading from a segment a waiting erase() is now free to
   // deregister. drainPendingReadReplies() waits for exactly this reason; the
   // error paths here need the same barrier.
+  // Best-effort refusal BEFORE any device work. The post-copy check below is
+  // the authoritative one -- it holds `mu` and closes the race -- but reaching
+  // only that one means every ReadRequest the reader picks up between
+  // shutdown() setting `stopping` and the reader join issues a D2H copy plus an
+  // event that are guaranteed to be discarded, and then pays a full
+  // cudaStreamSynchronize on the reader thread to wait the copy out. That
+  // synchronize delays the lane->reader.join() shutdown() is already blocked
+  // on, and on the startDeferredReadReplies() path it blocks the event loop
+  // instead. Checking here skips both. A stale read is harmless: it can only
+  // mean doing the work we would have done anyway, and the post-copy check
+  // still catches it.
+  {
+    std::lock_guard<std::mutex> lk(state->mu);
+    if (state->stopping) {
+      return Err(
+          ErrCode::NotConnected,
+          "tcp read: transport stopped before staging a VRAM read");
+    }
+  }
   bool copyIssued = false;
   try {
-    CudaDeviceGuard guard(*cudaApi_, deviceId);
+    CudaDeviceGuard guard(*state->cudaApi, deviceId);
     // Into pinned memory, so this returns once the copy is enqueued. The same
     // call into a pageable destination -- a plain vector -- is specified to
     // complete synchronously, which parks whichever thread issued it for the
     // length of the transfer. On this path that thread is the reader.
-    if (auto st = cudaApi_->memcpyAsync(
+    if (auto st = state->cudaApi->memcpyAsync(
             frame.mutableData() + sizeof(TcpMsgHeader),
             src,
             replyHeader.len,
@@ -1402,35 +1456,51 @@ Status TcpTransport::startReadReply(
     copyIssued = true;
     // The guard already has deviceId current, so these wait on the right device
     // without nesting another guard.
-    if (auto st = cudaApi_->eventCreate(&event); !st) {
-      (void)cudaApi_->streamSynchronize(/*stream=*/nullptr);
+    if (auto st = state->cudaApi->eventCreate(&event); !st) {
+      (void)state->cudaApi->streamSynchronize(/*stream=*/nullptr);
       return st;
     }
-    if (auto st = cudaApi_->eventRecord(event, /*stream=*/nullptr); !st) {
-      (void)cudaApi_->eventDestroy(event);
-      (void)cudaApi_->streamSynchronize(/*stream=*/nullptr);
+    if (auto st = state->cudaApi->eventRecord(event, /*stream=*/nullptr); !st) {
+      (void)state->cudaApi->eventDestroy(event);
+      (void)state->cudaApi->streamSynchronize(/*stream=*/nullptr);
       return st;
     }
   } catch (const std::exception& e) {
     if (copyIssued) {
-      waitForStagedCopy(deviceId);
+      waitForStagedCopy(state, deviceId);
     }
     return Err(
         ErrCode::InvalidArgument,
         "tcp read: VRAM staging needs a selectable deviceId, got " +
             std::to_string(deviceId) + ": " + e.what());
   }
+  bool stopping = false;
   {
-    std::lock_guard<std::mutex> lk(stagingMu_);
-    pendingReplies_.push_back(
-        PendingReadReply{
-            std::move(frame),
-            std::move(lease),
-            event,
-            replyHeader.reqId,
-            deviceId});
+    std::lock_guard<std::mutex> lk(state->mu);
+    if (state->stopping) {
+      stopping = true;
+    } else {
+      state->pending.push_back(
+          PendingReadReply{
+              std::move(frame),
+              std::move(lease),
+              event,
+              replyHeader.reqId,
+              deviceId});
+    }
   }
-  schedulePendingReplyPoll();
+  if (stopping) {
+    // drainPendingReadReplies() has already swept the queue, so pushing here
+    // would leave a lease in a queue nothing drains again -- the same shape as
+    // the deferReadReply() refusal below. The copy is waited out first because
+    // it is still running into `frame`, which unwinds as this returns.
+    waitForStagedCopy(state, deviceId);
+    (void)state->cudaApi->eventDestroy(event);
+    return Err(
+        ErrCode::NotConnected,
+        "tcp read: transport stopped while staging a VRAM read");
+  }
+  schedulePendingReplyPoll(state);
   return Ok();
 }
 
@@ -1465,6 +1535,21 @@ Status TcpTransport::deferReadReply(
   // admitInflightBulk() take their mutex first for the same reason.
   {
     std::lock_guard<std::mutex> lk(stagingMu_);
+    // `stopping` as well as connBroken_, in the same critical section as the
+    // push. shutdown() sets stopping before the reader join, while connBroken_
+    // is only set later by failAllPending(), so between those two points this
+    // was the one admission point that would still grow a queue -- the entry
+    // then never starts (scheduleDeferredReadReplies() returns early on
+    // stopping) and is discarded by drainPendingReadReplies(). Harmless today
+    // because that drain runs after the joins, but the asymmetry with the other
+    // four admission points reads as a guarantee that no queue grows once
+    // stopping is set, and that guarantee is what a future caller would rely
+    // on.
+    if (reply_->stopping) {
+      return Err(
+          ErrCode::NotConnected,
+          "tcp read: reply path stopped while deferring a VRAM read");
+    }
     if (connBroken_.load(std::memory_order_acquire)) {
       return Err(
           ErrCode::NotConnected,
@@ -1495,22 +1580,38 @@ Status TcpTransport::deferReadReply(
   // there is no next release: the read never starts and its lease keeps erase()
   // blocked. Redundant kicks are harmless -- startDeferredReadReplies()
   // re-tests both the pool and the queue under the lock.
-  scheduleDeferredReadReplies();
+  scheduleDeferredReadReplies(reply_);
   return Ok();
 }
 
-void TcpTransport::scheduleDeferredReadReplies() {
+void TcpTransport::scheduleDeferredReadReplies(
+    const std::shared_ptr<TcpReplyState>& state) {
   {
-    std::lock_guard<std::mutex> lk(stagingMu_);
-    if (deferredReplies_.empty()) {
+    std::lock_guard<std::mutex> lk(state->mu);
+    if (state->stopping || state->deferred.empty()) {
       return;
     }
   }
-  evb_->dispatch([this]() noexcept { startDeferredReadReplies(); });
+  // `state` rather than `this`: the callback may not run until after the
+  // transport is gone, and by then the senders are joined, so anything it
+  // queues simply sits in a queue that dies with the lane set.
+  state->evb->dispatch([state]() noexcept { startDeferredReadReplies(state); });
 }
 
-void TcpTransport::startDeferredReadReplies() {
-  auto pool = stagingPool();
+void TcpTransport::startDeferredReadReplies(
+    const std::shared_ptr<TcpReplyState>& state) {
+  // Cheap early refusal: this runs from an evb_->dispatch() that may have been
+  // queued just before shutdown() set `stopping`, so there is no point taking a
+  // slab and popping an entry for work that will be refused. stagingPool()
+  // makes the same test authoritatively for every caller, so this is an
+  // optimisation rather than the guarantee -- see the lock-order note there.
+  {
+    std::lock_guard<std::mutex> lk(state->mu);
+    if (state->stopping) {
+      return;
+    }
+  }
+  auto pool = stagingPool(state);
   if (!pool) {
     return;
   }
@@ -1524,8 +1625,8 @@ void TcpTransport::startDeferredReadReplies() {
     }
     DeferredReadReply deferred;
     {
-      std::lock_guard<std::mutex> lk(stagingMu_);
-      if (deferredReplies_.empty()) {
+      std::lock_guard<std::mutex> lk(state->mu);
+      if (state->stopping || state->deferred.empty()) {
         // Returning here releases the slab without using it, and deliberately
         // does not reschedule. An entry queued between this test and that
         // release is still covered, because deferReadReply() is the only
@@ -1535,8 +1636,8 @@ void TcpTransport::startDeferredReadReplies() {
         // that does not kick would reopen the window.
         return;
       }
-      deferred = std::move(deferredReplies_.front());
-      deferredReplies_.pop_front();
+      deferred = std::move(state->deferred.front());
+      state->deferred.pop_front();
     }
     TcpMsgHeader replyHeader{};
     replyHeader.op = static_cast<uint8_t>(TcpOp::ReadReply);
@@ -1545,12 +1646,28 @@ void TcpTransport::startDeferredReadReplies() {
     replyHeader.offset = deferred.offset;
     replyHeader.len = deferred.len;
     if (auto st = startReadReply(
-            replyHeader, std::move(deferred.lease), std::move(slab));
+            state, replyHeader, std::move(deferred.lease), std::move(slab));
         !st) {
+      // A `stopping` refusal is an ordinary part of teardown, not a failure:
+      // startReadReply() returns NotConnected once shutdown() has swept the
+      // queues. Logging it at ERROR made every clean shutdown look like a
+      // staging fault, and the Error frame it enqueued goes onto lanes that are
+      // already closed, so nothing observes it either. Genuine staging failures
+      // still get both.
+      bool stopping = false;
+      {
+        std::lock_guard<std::mutex> lk(state->mu);
+        stopping = state->stopping;
+      }
+      if (stopping) {
+        return;
+      }
       UNIFLOW_LOG_ERROR(
           "tcp read: deferred VRAM staging failed: {}", st.error().message());
-      (void)enqueueFrame(
-          makeHeaderFrame(TcpOp::Error, deferred.reqId), /*mayBlock=*/false);
+      (void)enqueueOn(
+          state,
+          makeHeaderFrame(TcpOp::Error, deferred.reqId),
+          /*mayBlock=*/false);
     }
   }
 }
@@ -1832,18 +1949,20 @@ void TcpTransport::drainPendingH2d() {
   }
 }
 
-void TcpTransport::schedulePendingReplyPoll() {
+void TcpTransport::schedulePendingReplyPoll(
+    const std::shared_ptr<TcpReplyState>& state) {
   {
-    std::lock_guard<std::mutex> lk(stagingMu_);
-    if (replyPollScheduled_ || pendingReplies_.empty()) {
+    std::lock_guard<std::mutex> lk(state->mu);
+    if (state->stopping || state->pollScheduled || state->pending.empty()) {
       return;
     }
-    replyPollScheduled_ = true;
+    state->pollScheduled = true;
   }
-  evb_->dispatch([this]() noexcept { pollPendingReadReplies(); });
+  state->evb->dispatch([state]() noexcept { pollPendingReadReplies(state); });
 }
 
-void TcpTransport::pollPendingReadReplies() {
+void TcpTransport::pollPendingReadReplies(
+    const std::shared_ptr<TcpReplyState>& state) {
   while (true) {
     TcpFrame ready;
     PendingReadReply failed;
@@ -1853,17 +1972,21 @@ void TcpTransport::pollPendingReadReplies() {
     bool haveFailure = false;
     bool stillRunning = false;
     {
-      std::lock_guard<std::mutex> lk(stagingMu_);
-      if (pendingReplies_.empty()) {
-        replyPollScheduled_ = false;
+      std::lock_guard<std::mutex> lk(state->mu);
+      // Teardown has drained the queue and is not waiting on this callback to
+      // leave, so there is nothing left to retire and nothing to reschedule.
+      if (state->stopping || state->pending.empty()) {
+        state->pollScheduled = false;
         return;
       }
-      auto& front = pendingReplies_.front();
-      auto done = cudaApi_->eventQuery(static_cast<cudaEvent_t>(front.event));
+      auto& front = state->pending.front();
+      auto done =
+          state->cudaApi->eventQuery(static_cast<cudaEvent_t>(front.event));
       if (done.hasValue() && !done.value()) {
         stillRunning = true;
       } else {
-        (void)cudaApi_->eventDestroy(static_cast<cudaEvent_t>(front.event));
+        (void)state->cudaApi->eventDestroy(
+            static_cast<cudaEvent_t>(front.event));
         if (done.hasError()) {
           failedReqId = front.reqId;
           failedDeviceId = front.deviceId;
@@ -1880,7 +2003,7 @@ void TcpTransport::pollPendingReadReplies() {
           haveReady = true;
         }
         // Releases the lease, which is what lets a waiting erase() proceed.
-        pendingReplies_.pop_front();
+        state->pending.pop_front();
       }
     }
     if (stillRunning) {
@@ -1893,39 +2016,44 @@ void TcpTransport::pollPendingReadReplies() {
       // takes stagingMu_ to enqueue, and it should never wait on the
       // EventBase's queue to do it.
       std::this_thread::yield();
-      evb_->dispatch([this]() noexcept { pollPendingReadReplies(); });
+      state->evb->dispatch(
+          [state]() noexcept { pollPendingReadReplies(state); });
       return;
     }
     // Queued outside the lock: enqueueFrame takes a lane mutex, and holding two
     // of the transport's mutexes at once is how lock cycles start.
     if (haveReady) {
-      (void)enqueueFrame(std::move(ready), /*mayBlock=*/false);
+      (void)enqueueOn(state, std::move(ready), /*mayBlock=*/false);
     } else if (haveFailure) {
       // Wait before `failed` goes out of scope, for the same reason
       // drainPendingReadReplies() waits: a copy that may still be running would
       // otherwise be left writing into a slab the pool is about to hand to the
       // next staging copy.
-      waitForStagedCopy(failedDeviceId);
+      waitForStagedCopy(state, failedDeviceId);
       // Dropping it here releases the slab, so a deferred read may now be
       // startable -- which is why this happens before the scheduling call
       // below.
       failed = PendingReadReply{};
-      (void)enqueueFrame(
-          makeHeaderFrame(TcpOp::Error, failedReqId), /*mayBlock=*/false);
-      scheduleDeferredReadReplies();
+      (void)enqueueOn(
+          state,
+          makeHeaderFrame(TcpOp::Error, failedReqId),
+          /*mayBlock=*/false);
+      scheduleDeferredReadReplies(state);
     }
   }
 }
 
-void TcpTransport::waitForStagedCopy(int deviceId) noexcept {
-  if (cudaApi_ == nullptr) {
+void TcpTransport::waitForStagedCopy(
+    const std::shared_ptr<TcpReplyState>& state,
+    int deviceId) noexcept {
+  if (state->cudaApi == nullptr) {
     return;
   }
   try {
     // Per-device: a bare streamSynchronize would only cover whichever device
     // happened to be current, leaving a copy on any other device still running.
-    CudaDeviceGuard guard(*cudaApi_, deviceId);
-    (void)cudaApi_->streamSynchronize(/*stream=*/nullptr);
+    CudaDeviceGuard guard(*state->cudaApi, deviceId);
+    (void)state->cudaApi->streamSynchronize(/*stream=*/nullptr);
   } catch (const std::exception&) {
     // The device is already unusable, so there is nothing left to wait for.
   }
@@ -1949,7 +2077,7 @@ void TcpTransport::drainPendingReadReplies() {
   // first even though the replies themselves are being abandoned.
   if (cudaApi_ != nullptr) {
     for (auto& reply : pending) {
-      waitForStagedCopy(reply.deviceId);
+      waitForStagedCopy(reply_, reply.deviceId);
       (void)cudaApi_->eventDestroy(static_cast<cudaEvent_t>(reply.event));
     }
   }
@@ -2018,10 +2146,20 @@ Status TcpTransport::admitInflight(uint64_t reqId, TcpInflight entry) {
 }
 
 bool TcpTransport::enqueueFrame(TcpFrame frame, bool mayBlock) {
+  return enqueueOn(reply_, std::move(frame), mayBlock);
+}
+
+bool TcpTransport::enqueueOn(
+    const std::shared_ptr<TcpReplyState>& state,
+    TcpFrame frame,
+    bool mayBlock) {
+  // Copied out so the lane set stays alive for this call even if the transport
+  // is torn down concurrently.
+  const std::shared_ptr<TcpLaneSet> lanes = state->lanes;
   // No lanes means connect() never ran (or teardown already cleared them).
   // Indexing here would be undefined; refusing matches the documented contract
   // that a frame may simply not be queued.
-  if (lanes_.empty()) {
+  if (lanes == nullptr || lanes->v.empty()) {
     return false;
   }
   const size_t bytes = frame.size();
@@ -2029,8 +2167,8 @@ bool TcpTransport::enqueueFrame(TcpFrame frame, bool mayBlock) {
   // carries its own reqId/segId/offset, so the peer places it without needing
   // arrival order and any lane is equivalent. Only Send is order-sensitive, and
   // it does not come through here (see enqueueSendFrame).
-  auto& lane = *lanes_[pickLane()];
-  const size_t cap = laneCapBytes();
+  auto& lane = *lanes->v[pickLaneOn(*lanes)];
+  const size_t cap = laneCapBytesOn(*lanes);
   {
     std::unique_lock<std::mutex> lk(lane.mu);
     if (mayBlock) {
@@ -2039,8 +2177,9 @@ bool TcpTransport::enqueueFrame(TcpFrame frame, bool mayBlock) {
       // drains slows down instead of growing the queue. An empty queue always
       // admits, however large the frame, or a payload bigger than the cap could
       // never drain and would wedge here forever.
-      lane.cv.wait(lk, [this, &lane, bytes, cap]() {
-        return lane.outClosed || connBroken_.load(std::memory_order_acquire) ||
+      lane.cv.wait(lk, [&lanes, &lane, bytes, cap]() {
+        return lane.outClosed ||
+            lanes->broken.load(std::memory_order_acquire) ||
             lane.queue.empty() || lane.bytes + bytes <= cap;
       });
     }
@@ -2060,7 +2199,7 @@ bool TcpTransport::enqueueFrame(TcpFrame frame, bool mayBlock) {
     // outClosed alone therefore lets a frame admitted before the sweep land in
     // the cleared queue and go out on the wire for an op whose caller has
     // already been told it failed.
-    if (lane.outClosed || connBroken_.load(std::memory_order_acquire)) {
+    if (lane.outClosed || lanes->broken.load(std::memory_order_acquire)) {
       return false;
     }
     lane.queue.push_back(TcpOutItem{std::move(frame), nullptr});
@@ -2317,7 +2456,7 @@ void TcpTransport::senderLoop(size_t laneIdx) noexcept {
     // slab; dispatching the restart rather than running it here keeps device
     // work off the thread whose only job is to keep the socket draining.
     item = TcpOutItem{};
-    scheduleDeferredReadReplies();
+    scheduleDeferredReadReplies(reply_);
   }
 }
 
@@ -3097,6 +3236,16 @@ void TcpTransport::shutdown() {
   // in-progress send on the sender thread. A no-op for a lane a reader already
   // refused, in which case it is on its way out anyway.
   closeLanesOnce();
+
+  // Before the pool close and the drains below, not after: a reply callback
+  // admitted after drainPendingReadReplies() has swept would push a lease back
+  // into a queue nothing drains again. Every reply-path entry point re-tests
+  // this under the same mutex, so setting it here is what makes the sweep
+  // final.
+  {
+    std::lock_guard<std::mutex> lk(reply_->mu);
+    reply_->stopping = true;
+  }
 
   // Closed before the joins: this is the one pool with a *blocking* acquire,
   // and the thread parked in it is not one we own. acquire() waits on `freed_`

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -369,6 +369,42 @@ Status TcpTransport::hostFromDevice(
   return cudaApi_->streamSynchronize(s);
 }
 
+Result<void*> TcpTransport::writeStreamFor(int deviceId) {
+  std::lock_guard<std::mutex> lk(writeStreamMu_);
+  auto it = writeStreams_.find(deviceId);
+  if (it != writeStreams_.end()) {
+    return it->second;
+  }
+  if (cudaApi_ == nullptr) {
+    return Err(
+        ErrCode::InvalidArgument, "tcp write: no CUDA API for a VRAM segment");
+  }
+  cudaStream_t stream{};
+  // CudaDeviceGuard throws when setDevice fails, and it is deliberately NOT
+  // caught here. Before this stream existed the first guard on this path was
+  // the one inside deviceFromHost, and its throw is what handleFrame's catch
+  // turns into a failed connection -- see
+  // VramStagingThrowDoesNotAbortTheReader. Swallowing it here would silently
+  // narrow that behaviour, which is a separate decision from removing the null
+  // stream (see C-049).
+  CudaDeviceGuard guard(*cudaApi_, deviceId);
+  if (auto st = cudaApi_->streamCreateNonBlocking(&stream); !st) {
+    return std::move(st).error();
+  }
+  // Destroyed here if publishing it throws. shutdown() only destroys streams it
+  // finds in writeStreams_, so a stream created but never inserted is
+  // unreachable: handleFrame() catches the exception and keeps the process
+  // alive, and the stream then leaks for the transport's lifetime. The
+  // CudaDeviceGuard above is still in scope, so this runs on the right device.
+  try {
+    writeStreams_.emplace(deviceId, static_cast<void*>(stream));
+  } catch (...) {
+    (void)cudaApi_->streamDestroy(stream);
+    throw;
+  }
+  return static_cast<void*>(stream);
+}
+
 Status TcpTransport::deviceFromHost(
     void* devDst,
     const void* hostSrc,
@@ -2775,8 +2811,23 @@ void TcpTransport::handleFrameImpl(
         if (header.len > 0) {
           void* dst = static_cast<uint8_t*>(entry->ptr) + header.offset;
           if (entry->memType == MemoryType::VRAM) {
-            st = deviceFromHost(
-                dst, payload.data(), header.len, entry->deviceId);
+            // On a dedicated non-blocking stream, never the null stream. The
+            // lease above is held across this copy and erase() waits on it, so
+            // a null-stream copy -- which serialises against every blocking
+            // stream on the device -- would park the reader on unrelated
+            // application GPU work that only the reader could unblock. Bounded
+            // here by this copy alone.
+            auto stream = writeStreamFor(entry->deviceId);
+            if (stream.hasError()) {
+              st = std::move(stream).error();
+            } else {
+              st = deviceFromHost(
+                  dst,
+                  payload.data(),
+                  header.len,
+                  entry->deviceId,
+                  stream.value());
+            }
           } else {
             std::memcpy(dst, payload.data(), header.len);
           }
@@ -3386,6 +3437,25 @@ void TcpTransport::shutdown() {
   // transport goes away: a staged reply's frame is memory the device may still
   // be writing into.
   drainPendingReadReplies();
+
+  // After the reader is joined, so no Write copy can still be using one. Every
+  // such copy was synchronized before its handler returned, so none has pending
+  // work at this point.
+  {
+    std::lock_guard<std::mutex> lk(writeStreamMu_);
+    for (auto& [deviceId, stream] : writeStreams_) {
+      if (stream == nullptr || cudaApi_ == nullptr) {
+        continue;
+      }
+      try {
+        CudaDeviceGuard guard(*cudaApi_, deviceId);
+        (void)cudaApi_->streamDestroy(static_cast<cudaStream_t>(stream));
+      } catch (const std::exception&) {
+        // The device is already unusable; the stream goes with it.
+      }
+    }
+    writeStreams_.clear();
+  }
 
   // Compare-exchange, not load-then-store: a concurrent bind() failure setting
   // Error in the gap between a load and a store would be clobbered back to

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -2588,49 +2588,93 @@ void TcpTransport::senderLoop(size_t laneIdx) noexcept {
 }
 
 // Logs the get-path phase split and zeroes it, so a caller can bracket one
-// measurement. Reports the reader's own view: time blocked waiting for a frame
-// to start (first-byte latency -- network plus whatever the peer did before
-// replying), time draining a frame once started, and time in the copy to the
-// caller's destination. Anything unaccounted for is reader-thread work between
-// those points.
+// measurement. Reports the reader's own view: the inter-frame stall (blocked on
+// a length prefix with nothing arriving), time draining a frame once started,
+// and time in the copy to the caller's destination. Anything unaccounted for is
+// reader-thread work between those points.
+//
+// The stall is NOT the round trip plus the peer's work. A get responder stages
+// asynchronously, so its staging and the round trip overlap our own drain and
+// cannot show up in our block on the prefix -- see RecvPhaseStats for the
+// measurement that settles it.
 void TcpTransport::logAndResetPhaseStats(std::string_view label) {
+  // lanes_ is read without a lock, so this may only be called between a
+  // completed connect() and shutdown(). establishLanes() fills it during
+  // connect(), and the reader and sender threads read it unlocked only because
+  // they are created after that, which supplies the happens-before. This is a
+  // public method reachable from any thread and the emptiness check below
+  // supplies no such ordering, so the contract is the caller's to keep. Stated
+  // rather than locked because no caller needs the lock: the only callers
+  // bracket a measurement from the thread that ran connect().
   if (lanes_.empty()) {
+    // Nothing to report, but the transport-level counters are cleared anyway.
+    // They are not lane-scoped, so anything already accounted here would
+    // otherwise carry into the next measurement window. Clearing
+    // unconditionally makes the bracketing a property of this function rather
+    // than of the connect()/shutdown() contract holding -- one less thing that
+    // has to be true for a measurement to mean what it says.
+    (void)dstCopyNs_.exchange(0, std::memory_order_relaxed);
+    (void)dstCopyCount_.exchange(0, std::memory_order_relaxed);
+    (void)receiveSlabAttempts_.exchange(0, std::memory_order_relaxed);
+    (void)receiveSlabMisses_.exchange(0, std::memory_order_relaxed);
+    (void)vectorReceiveCount_.exchange(0, std::memory_order_relaxed);
+    (void)stagingNs_.exchange(0, std::memory_order_relaxed);
+    (void)stagingBytes_.exchange(0, std::memory_order_relaxed);
+    (void)stagingWaves_.exchange(0, std::memory_order_relaxed);
+    (void)stagingChunks_.exchange(0, std::memory_order_relaxed);
+    // Unconditional, like the reporting path below: h2dState_ is assigned once
+    // in the constructor and never reset, so it is non-null for the whole
+    // lifetime a caller can reach this from. Guarding it here while the
+    // reporting path dereferences it freely would imply an invariant that does
+    // not exist, and send the next reader looking for the null case that makes
+    // the other path a crash.
+    (void)h2dState_->copyNs.exchange(0, std::memory_order_relaxed);
+    (void)h2dState_->copyCount.exchange(0, std::memory_order_relaxed);
     return;
   }
   // Summed over every lane: each lane has its own reader and its own stats, so
   // reading lane 0 alone would report 1/N of the traffic and hide any imbalance
   // between lanes. Per-lane frame counts are logged too, since an uneven split
   // is itself a finding.
-  uint64_t frames = 0, hdrNs = 0, drainNs = 0, bytes = 0;
+  //
+  // exchange, not load-then-reset: each counter is read and cleared in one
+  // step, so a sample the reader records mid-sweep is carried into the next
+  // window rather than dropped. That is the whole guarantee, and it is worth
+  // not overstating -- the 4N lane counters and the transport counters are
+  // still exchanged at distinct instants, so a frame whose stall was already
+  // taken but whose count lands just after still straddles two windows.
+  // Load-then-clear would be strictly worse: 4N loads then 4N stores, with
+  // every sample recorded in between lost outright rather than deferred.
+  uint64_t frames = 0, stallNs = 0, drainNs = 0, bytes = 0;
   std::string perLaneFrames;
   for (size_t i = 0; i < lanes_.size(); ++i) {
     if (lanes_[i] == nullptr || lanes_[i]->conn == nullptr) {
       continue;
     }
     auto& lrs = lanes_[i]->conn->recvPhaseStats();
-    const uint64_t lf = lrs.frames.load(std::memory_order_relaxed);
+    const uint64_t lf = lrs.frames.exchange(0, std::memory_order_relaxed);
     frames += lf;
-    hdrNs += lrs.headerWaitNs.load(std::memory_order_relaxed);
-    drainNs += lrs.payloadDrainNs.load(std::memory_order_relaxed);
-    bytes += lrs.payloadBytes.load(std::memory_order_relaxed);
+    stallNs += lrs.interFrameStallNs.exchange(0, std::memory_order_relaxed);
+    drainNs += lrs.payloadDrainNs.exchange(0, std::memory_order_relaxed);
+    bytes += lrs.payloadBytes.exchange(0, std::memory_order_relaxed);
     perLaneFrames += (i == 0 ? "" : ",") + std::to_string(lf);
   }
-  const uint64_t copyNs = dstCopyNs_.load(std::memory_order_relaxed) +
-      h2dState_->copyNs.load(std::memory_order_relaxed);
-  const uint64_t copies = dstCopyCount_.load(std::memory_order_relaxed) +
-      h2dState_->copyCount.load(std::memory_order_relaxed);
+  const uint64_t copyNs = dstCopyNs_.exchange(0, std::memory_order_relaxed) +
+      h2dState_->copyNs.exchange(0, std::memory_order_relaxed);
+  const uint64_t copies = dstCopyCount_.exchange(0, std::memory_order_relaxed) +
+      h2dState_->copyCount.exchange(0, std::memory_order_relaxed);
   const uint64_t slabAttempts =
-      receiveSlabAttempts_.load(std::memory_order_relaxed);
+      receiveSlabAttempts_.exchange(0, std::memory_order_relaxed);
   const uint64_t slabMisses =
-      receiveSlabMisses_.load(std::memory_order_relaxed);
+      receiveSlabMisses_.exchange(0, std::memory_order_relaxed);
   const uint64_t vectorReceives =
-      vectorReceiveCount_.load(std::memory_order_relaxed);
+      vectorReceiveCount_.exchange(0, std::memory_order_relaxed);
 
   if (frames == 0) {
     UNIFLOW_LOG_INFO("tcp phases [{}]: no frames", label);
   } else {
     const double totalNs =
-        static_cast<double>(hdrNs) + static_cast<double>(drainNs);
+        static_cast<double>(stallNs) + static_cast<double>(drainNs);
     const auto pct = [totalNs](uint64_t v) {
       return totalNs > 0.0 ? 100.0 * static_cast<double>(v) / totalNs : 0.0;
     };
@@ -2642,15 +2686,16 @@ void TcpTransport::logAndResetPhaseStats(std::string_view label) {
         ? static_cast<double>(bytes) / static_cast<double>(drainNs)
         : 0.0;
     UNIFLOW_LOG_INFO(
-        "tcp phases [{}]: frames={} bytes={} | first-byte {:.1f}us/frame "
+        "tcp phases [{}]: frames={} bytes={} | interframe_stall "
+        "{:.1f}us/frame "
         "({:.1f}%) | drain {:.1f}us/frame ({:.1f}%, {:.2f} GB/s) | dstcopy "
         "{:.1f}us x{} ({:.1f}% of wire) | receive_slabs attempts={} misses={} "
         "vector_recvs={} | lanes={} frames_per_lane=[{}]",
         label,
         frames,
         bytes,
-        static_cast<double>(hdrNs) / frames / 1000.0,
-        pct(hdrNs),
+        static_cast<double>(stallNs) / frames / 1000.0,
+        pct(stallNs),
         static_cast<double>(drainNs) / frames / 1000.0,
         pct(drainNs),
         drainGBps,
@@ -2663,18 +2708,16 @@ void TcpTransport::logAndResetPhaseStats(std::string_view label) {
         lanes_.size(),
         perLaneFrames);
   }
-  for (auto& lane : lanes_) {
-    if (lane != nullptr && lane->conn != nullptr) {
-      lane->conn->recvPhaseStats().reset();
-    }
-  }
   // Reported separately from the frame block above: on a put run this side
   // receives only Acks, so gating the staging numbers on receive frames would
   // hide them exactly where they matter.
-  const uint64_t stgNs = stagingNs_.load(std::memory_order_relaxed);
-  const uint64_t stgBytes = stagingBytes_.load(std::memory_order_relaxed);
-  const uint64_t stgWaves = stagingWaves_.load(std::memory_order_relaxed);
-  const uint64_t stgChunks = stagingChunks_.load(std::memory_order_relaxed);
+  const uint64_t stgNs = stagingNs_.exchange(0, std::memory_order_relaxed);
+  const uint64_t stgBytes =
+      stagingBytes_.exchange(0, std::memory_order_relaxed);
+  const uint64_t stgWaves =
+      stagingWaves_.exchange(0, std::memory_order_relaxed);
+  const uint64_t stgChunks =
+      stagingChunks_.exchange(0, std::memory_order_relaxed);
   if (stgWaves > 0) {
     UNIFLOW_LOG_INFO(
         "tcp put wave residency [{}]: waves={} chunks={} bytes={} | "
@@ -2688,17 +2731,6 @@ void TcpTransport::logAndResetPhaseStats(std::string_view label) {
                 static_cast<double>(stgChunks) / 1000.0
                       : 0.0);
   }
-  stagingNs_.store(0, std::memory_order_relaxed);
-  stagingBytes_.store(0, std::memory_order_relaxed);
-  stagingWaves_.store(0, std::memory_order_relaxed);
-  stagingChunks_.store(0, std::memory_order_relaxed);
-  dstCopyNs_.store(0, std::memory_order_relaxed);
-  dstCopyCount_.store(0, std::memory_order_relaxed);
-  h2dState_->copyNs.store(0, std::memory_order_relaxed);
-  h2dState_->copyCount.store(0, std::memory_order_relaxed);
-  receiveSlabAttempts_.store(0, std::memory_order_relaxed);
-  receiveSlabMisses_.store(0, std::memory_order_relaxed);
-  vectorReceiveCount_.store(0, std::memory_order_relaxed);
 }
 
 void TcpTransport::readerLoop(size_t laneIdx) noexcept {

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -1409,13 +1409,10 @@ Status TcpTransport::startReadReply(
       static_cast<const uint8_t*>(lease->ptr) + replyHeader.offset;
   TcpFrame frame(std::move(slab), sizeof(TcpMsgHeader) + replyHeader.len);
   std::memcpy(frame.mutableData(), &replyHeader, sizeof(replyHeader));
+  // Stays a local until eventRecord() succeeds: the two failure paths below own
+  // the handle they created, and publishing it to `pending` earlier would let
+  // the barrier destroy it a second time.
   cudaEvent_t event{};
-  // Once the copy is enqueued, every way out of this function has to wait for
-  // it. Returning an error unwinds `frame` and `lease`, and the copy is
-  // asynchronous: the GPU would be left writing into a buffer the allocator has
-  // taken back, and reading from a segment a waiting erase() is now free to
-  // deregister. drainPendingReadReplies() waits for exactly this reason; the
-  // error paths here need the same barrier.
   // Best-effort refusal BEFORE any device work. The post-copy check below is
   // the authoritative one -- it holds `mu` and closes the race -- but reaching
   // only that one means every ReadRequest the reader picks up between
@@ -1435,7 +1432,69 @@ Status TcpTransport::startReadReply(
           "tcp read: transport stopped before staging a VRAM read");
     }
   }
+
+  // The entry owns the slab, the lease and the event from HERE, not from the
+  // push. Built early because push_back materialises its argument before it
+  // allocates: with a temporary there, deque growth that throws destroys that
+  // temporary at the end of the full-expression -- returning the slab to the
+  // pool while the D2H is still writing into it -- and does so INSIDE the
+  // locked scope, whereas the barrier below only runs at function exit. The
+  // wait would then come after the slab was already reusable, which is the one
+  // ordering this whole mechanism exists to prevent.
+  PendingReadReply pending{
+      std::move(frame),
+      std::move(lease),
+      /*event=*/nullptr,
+      replyHeader.reqId,
+      deviceId};
+
   bool copyIssued = false;
+  bool handedOff = false;
+  // Waits out an issued copy on every exit that is not a hand-off, and destroys
+  // the event it would otherwise leak. Declared after `pending` so it destructs
+  // FIRST -- the wait has to happen while the slab and the lease are still
+  // alive. Covers the paths that do not return: the push and the dispatch below
+  // are outside the try and both can throw (deque growth, the EventBase queue).
+  //
+  // Copy and move are deleted because a second barrier would wait and destroy
+  // the same event twice; that makes this a non-aggregate, hence the ctor.
+  class CopyBarrier {
+   public:
+    CopyBarrier(
+        const std::shared_ptr<TcpReplyState>& state,
+        const bool& issued,
+        const bool& handedOff,
+        void*& event,
+        int deviceId)
+        : state_(state),
+          issued_(issued),
+          handedOff_(handedOff),
+          event_(event),
+          deviceId_(deviceId) {}
+    CopyBarrier(const CopyBarrier&) = delete;
+    CopyBarrier& operator=(const CopyBarrier&) = delete;
+    CopyBarrier(CopyBarrier&&) = delete;
+    CopyBarrier& operator=(CopyBarrier&&) = delete;
+    ~CopyBarrier() {
+      if (handedOff_ || !issued_) {
+        return;
+      }
+      waitForStagedCopy(state_, deviceId_);
+      // An entry that was never pushed is one drainPendingReadReplies() will
+      // never see, so nothing else would ever destroy this.
+      if (event_ != nullptr) {
+        (void)state_->cudaApi->eventDestroy(static_cast<cudaEvent_t>(event_));
+        event_ = nullptr;
+      }
+    }
+
+   private:
+    const std::shared_ptr<TcpReplyState>& state_;
+    const bool& issued_;
+    const bool& handedOff_;
+    void*& event_;
+    int deviceId_;
+  } copyBarrier{state, copyIssued, handedOff, pending.event, deviceId};
   try {
     CudaDeviceGuard guard(*state->cudaApi, deviceId);
     // Into pinned memory, so this returns once the copy is enqueued. The same
@@ -1443,7 +1502,7 @@ Status TcpTransport::startReadReply(
     // complete synchronously, which parks whichever thread issued it for the
     // length of the transfer. On this path that thread is the reader.
     if (auto st = state->cudaApi->memcpyAsync(
-            frame.mutableData() + sizeof(TcpMsgHeader),
+            pending.frame.mutableData() + sizeof(TcpMsgHeader),
             src,
             replyHeader.len,
             cudaMemcpyDeviceToHost,
@@ -1465,6 +1524,9 @@ Status TcpTransport::startReadReply(
       (void)state->cudaApi->streamSynchronize(/*stream=*/nullptr);
       return st;
     }
+    // Only now, so the two failure paths above stay solely responsible for the
+    // handle they created and the barrier cannot double-destroy it.
+    pending.event = event;
   } catch (const std::exception& e) {
     if (copyIssued) {
       waitForStagedCopy(state, deviceId);
@@ -1480,26 +1542,36 @@ Status TcpTransport::startReadReply(
     if (state->stopping) {
       stopping = true;
     } else {
-      state->pending.push_back(
-          PendingReadReply{
-              std::move(frame),
-              std::move(lease),
-              event,
-              replyHeader.reqId,
-              deviceId});
+      state->pending.push_back(std::move(pending));
     }
   }
   if (stopping) {
     // drainPendingReadReplies() has already swept the queue, so pushing here
     // would leave a lease in a queue nothing drains again -- the same shape as
-    // the deferReadReply() refusal below. The copy is waited out first because
-    // it is still running into `frame`, which unwinds as this returns.
-    waitForStagedCopy(state, deviceId);
-    (void)state->cudaApi->eventDestroy(event);
+    // the deferReadReply() refusal below. The wait and the eventDestroy are the
+    // barrier's, since `pending` still owns both.
     return Err(
         ErrCode::NotConnected,
         "tcp read: transport stopped while staging a VRAM read");
   }
+  // Past the stopping refusal means the push happened, so the deque entry owns
+  // the slab, the lease and the event, and the drain is the barrier from here.
+  // Set after that branch rather than beside the push so a throw from the push
+  // itself is still covered.
+  handedOff = true;
+  // A throw out of the dispatch below therefore does NOT wait or destroy -- the
+  // entry owns both and doing either would race the drain. The entry is then on
+  // `pending`, and drainPendingReadReplies() at teardown waits for the copy,
+  // destroys the event and releases the lease, so nothing leaks. Accepted
+  // rather than popped back off: unwinding a push to re-take a lock we just
+  // released would add a failure mode worse than the delay.
+  //
+  // That cost is bounded ONLY because schedulePendingReplyPoll() clears
+  // pollScheduled on the throwing path. If it did not, this would not be one
+  // delayed lease: the flag gates every later call, so the poll loop would be
+  // dead for the connection's life, nothing would retire a staged reply again,
+  // and an exhausted pool would push every VRAM read down deferReadReply() with
+  // nothing to drain it.
   schedulePendingReplyPoll(state);
   return Ok();
 }
@@ -1958,7 +2030,22 @@ void TcpTransport::schedulePendingReplyPoll(
     }
     state->pollScheduled = true;
   }
-  state->evb->dispatch([state]() noexcept { pollPendingReadReplies(state); });
+  // pollScheduled is cleared again if the dispatch throws. dispatch() is a
+  // queue push that allocates, so it can; and the flag is the gate every later
+  // call checks first, so leaving it set would not delay one poll -- it would
+  // kill the poll loop for the life of the connection. Nothing would retire a
+  // staged reply again, each would keep its lease and its pinned slab, and once
+  // the pool is exhausted every VRAM read would degrade into deferReadReply()
+  // with nothing left to drain it.
+  try {
+    state->evb->dispatch([state]() noexcept { pollPendingReadReplies(state); });
+  } catch (...) {
+    {
+      std::lock_guard<std::mutex> lk(state->mu);
+      state->pollScheduled = false;
+    }
+    throw;
+  }
 }
 
 void TcpTransport::pollPendingReadReplies(
@@ -2050,8 +2137,12 @@ void TcpTransport::waitForStagedCopy(
     return;
   }
   try {
-    // Per-device: a bare streamSynchronize would only cover whichever device
-    // happened to be current, leaving a copy on any other device still running.
+    // The device has to be made current first because this waits on the *null*
+    // stream, and the null stream is per-device: a bare streamSynchronize would
+    // cover whichever device happened to be current and leave this copy
+    // running. That reasoning is specific to the null stream. A
+    // caller-supplied stream is one stream regardless of which device is
+    // current, so selecting a device per copy would buy nothing there.
     CudaDeviceGuard guard(*state->cudaApi, deviceId);
     (void)state->cudaApi->streamSynchronize(/*stream=*/nullptr);
   } catch (const std::exception&) {

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -864,6 +864,13 @@ class TcpTransport : public Transport {
 
   void shutdown() override;
 
+  /// Logs the get-path phase split (inter-frame stall / drain / destination
+  /// copy) and clears it, so a caller can bracket one measurement. Reads lanes_
+  /// without a lock: callable only between a completed connect() and
+  /// shutdown(). See the definition for why that is a contract rather than a
+  /// mutex.
+  void logAndResetPhaseStats(std::string_view label);
+
  private:
   // Needs handleFrame() plus the outbound queue to drive peer-supplied frames
   // directly and assert the bounds checks reject them. Those checks are the
@@ -879,12 +886,6 @@ class TcpTransport : public Transport {
   // member, because each reader owns exactly one socket.
   void readerLoop(size_t laneIdx) noexcept;
 
- public:
-  /// Logs the get-path phase split (first-byte / drain / destination copy) and
-  /// zeroes it so callers can bracket a single measurement.
-  void logAndResetPhaseStats(std::string_view label);
-
- private:
   // Sender thread, one per lane: drains that lane's queue and performs its
   // socket sends. One writer per socket, which is what keeps TcpConn's
   // single-writer requirement satisfied.

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -890,11 +890,25 @@ class TcpTransport : public Transport {
   void handleFrameImpl(
       std::span<const uint8_t> frame,
       TcpPinnedSlab receiveSlab);
+  // Both defined below, after TcpLane. Declared up here so the static
+  // reply-path helpers can take them by shared_ptr.
+  struct TcpLaneSet;
+  struct TcpReplyState;
+
   // Queues one fire-and-forget framed message for the sender thread.
   // `mayBlock` must be true only for caller threads. Returns false if the frame
   // was not queued (transport closing, or the reader hit the cap and refused
   // the connection).
   [[nodiscard]] bool enqueueFrame(TcpFrame frame, bool mayBlock);
+  // enqueueFrame without a `this`. The reply callbacks queue through this, so
+  // none of them needs the transport to still exist. enqueueFrame() delegates
+  // here, so there is one implementation of the admission rules.
+  [[nodiscard]] static bool enqueueOn(
+      const std::shared_ptr<TcpReplyState>& state,
+      TcpFrame frame,
+      bool mayBlock);
+  static size_t pickLaneOn(TcpLaneSet& lanes);
+  static size_t laneCapBytesOn(const TcpLaneSet& lanes);
   // Queues a run of frames. A group small enough not to be worth parallelising
   // goes on ONE lane as an indivisible step, either every frame queued or none:
   // enqueuing one at a time would let a sender start transmitting a partially
@@ -962,9 +976,15 @@ class TcpTransport : public Transport {
       TcpSegmentRegistry::Lease lease);
   // Builds the reply in `slab` and starts its D2H copy, handing the frame to
   // the staging queue so the reader can go back to draining the socket instead
-  // of waiting on the device. Consumes the lease and the slab. Returns an error
-  // only if the copy could not be started, in which case nothing was queued.
-  Status startReadReply(
+  // of waiting on the device. Consumes the lease and the slab.
+  //
+  // An error does NOT imply that no device work happened. Two shapes:
+  // the copy could not be started, in which case nothing was queued; or the
+  // reply path was already stopping, in which case the copy WAS issued and then
+  // waited out before this returned NotConnected. Callers must therefore not
+  // read an error as "the device is untouched" -- only as "nothing was queued".
+  static Status startReadReply(
+      const std::shared_ptr<TcpReplyState>& state,
       const TcpMsgHeader& replyHeader,
       TcpSegmentRegistry::Lease lease,
       TcpPinnedSlab slab);
@@ -1011,11 +1031,13 @@ class TcpTransport : public Transport {
   // on the EventBase, never inline at the point a slab is released: that point
   // is the sender thread, and launching copies there would block the drain that
   // frees the next slab.
-  void startDeferredReadReplies();
+  static void startDeferredReadReplies(
+      const std::shared_ptr<TcpReplyState>& state);
   // Kicks startDeferredReadReplies() on the EventBase. Called wherever a
   // staging slab goes back to the pool. Cheap and safe when nothing is
   // deferred.
-  void scheduleDeferredReadReplies();
+  static void scheduleDeferredReadReplies(
+      const std::shared_ptr<TcpReplyState>& state);
   // The staging pool, created on first use. Building it in the constructor
   // would charge every peer kStagingSlabCount slabs of pinned host memory --
   // ~124 MiB, and there is one transport per peer -- including the DRAM-only
@@ -1023,7 +1045,8 @@ class TcpTransport : public Transport {
   //
   // Named as the constant, not restated as a number: the previous wording
   // hardcoded a figure and went stale when kStagingSlabCount was re-derived.
-  Result<std::shared_ptr<TcpPinnedSlabPool>> stagingPool();
+  static Result<std::shared_ptr<TcpPinnedSlabPool>> stagingPool(
+      const std::shared_ptr<TcpReplyState>& state);
   // The independent inbound pool. It is created only for async-enabled,
   // non-zero VRAM get(), and is sized to the wire cap because recv(span)
   // consumes the length prefix before it can reject an undersized buffer.
@@ -1054,13 +1077,17 @@ class TcpTransport : public Transport {
   // Retires staged replies whose copy has finished, oldest first. Runs on the
   // EventBase, never on the reader thread: polling from the reader would put
   // the head-of-line block straight back.
-  void pollPendingReadReplies();
+  static void pollPendingReadReplies(
+      const std::shared_ptr<TcpReplyState>& state);
   // Kicks the poll loop if it is not already running. Safe from any thread.
-  void schedulePendingReplyPoll();
+  static void schedulePendingReplyPoll(
+      const std::shared_ptr<TcpReplyState>& state);
   /// Waits for a staged D2H copy on `deviceId` whose completion is otherwise
   /// unknown, so the frame it targets can be released. Used on the paths where
   /// a copy was issued but the event never became a usable completion signal.
-  void waitForStagedCopy(int deviceId) noexcept;
+  static void waitForStagedCopy(
+      const std::shared_ptr<TcpReplyState>& state,
+      int deviceId) noexcept;
 
   /// Waits for outstanding staging copies and drops the frames, then discards
   /// whatever was still deferred. Called during teardown, because the GPU may
@@ -1168,12 +1195,88 @@ class TcpTransport : public Transport {
     size_t bytes{0};
     bool outClosed{false};
   };
-  // Indirected because TcpLane holds an atomic and a thread, so it is neither
-  // copyable nor movable and the vector must never have to relocate it. Written
-  // only by connect() under lifecycleMu_, and read by the reader threads, the
-  // sender thread and shutdown() -- all of which run only after connect() has
-  // installed every lane.
-  std::vector<std::unique_ptr<TcpLane>> lanes_;
+  /// The lane set, owned separately from the transport.
+  ///
+  /// Held by shared_ptr so an EventBase callback that outlives the transport
+  /// can still enqueue into it harmlessly: by then the senders are joined, so
+  /// the frame simply sits in a queue that dies with this object. That is what
+  /// lets the reply callbacks below drop their `this` capture entirely.
+  struct TcpLaneSet {
+    // Indirected because TcpLane holds an atomic and a thread, so it is neither
+    // copyable nor movable and the vector must never have to relocate it.
+    // Written only by connect() under lifecycleMu_, and read by the reader
+    // threads, the sender thread and shutdown() -- all of which run only after
+    // connect() has installed every lane.
+    std::vector<std::unique_ptr<TcpLane>> v;
+    std::atomic<bool> broken{false};
+    // Round-robin cursor. Relaxed: an occasional duplicate or skipped index
+    // only perturbs balance, and nothing reads it for correctness.
+    std::atomic<uint64_t> nextLane{0};
+  };
+
+  /// Everything the EventBase-dispatched reply callbacks touch, owned
+  /// separately from the transport for the same reason.
+  ///
+  /// This is the H2dPollState pattern already used on the H2D path
+  /// (pollPendingH2d is static and takes its state), applied to the reply path.
+  /// The callbacks are static and take this state, so none of them can hold a
+  /// `this` that the destructor has already freed -- the bug is impossible
+  /// rather than guarded, and teardown never has to block waiting for a
+  /// callback to leave a critical section.
+  struct TcpReplyState {
+    // MEMBER ORDER IS LOAD-BEARING. Members are destroyed in reverse
+    // declaration order, so this reads bottom-up as the destruction sequence:
+    //
+    //   1. `pending` / `deferred` go first, releasing the Leases and slabs they
+    //      hold WHILE the objects those releases reach into are still alive.
+    //   2. then `registry` / `cudaApi` / `pool` / `lanes`, which those releases
+    //      needed.
+    //   3. the mutexes last, so nothing is destroyed while notionally guarded.
+    //
+    // Getting this backwards is not theoretical: `registry` used to be declared
+    // last, which destroyed it FIRST, so a Lease still sitting in `pending`
+    // would have called releaseLease() through a raw pointer to a destroyed
+    // registry -- defeating the entire reason the member exists.
+    std::mutex mu;
+    /// Its own mutex rather than `mu`: acquiring a slab can wait (put(), from a
+    /// caller thread), and the staging queue must stay available to the reader
+    /// while it does.
+    std::mutex poolMu;
+    /// Set by shutdown() under `mu`. A callback that wakes after teardown sees
+    /// it and returns without touching anything.
+    bool stopping{false};
+    bool pollScheduled{false};
+    /// Keeps the registry alive for as long as any lease might outlive the
+    /// transport. TcpSegmentRegistry::Lease holds a RAW registry pointer and
+    /// dereferences it in ~Lease to release, while leases travel this path --
+    /// startReadReply's parameter, `pending`, `deferred`. The transport is
+    /// normally the registry's only owner, so a callback still in flight when
+    /// ~TcpTransport() finishes -- say one that popped a deferred entry, then
+    /// saw `stopping` and is waiting out its copy -- would release into freed
+    /// memory. Held here for the same reason as cudaApi and lanes: a callback
+    /// must not reach through a transport that may already be gone.
+    ///
+    /// Declared BEFORE the queues below so it outlives the leases they hold.
+    std::shared_ptr<TcpSegmentRegistry> registry;
+    /// Copies, so a callback never reaches through the transport for them.
+    std::shared_ptr<CudaApi> cudaApi;
+    std::shared_ptr<TcpPinnedSlabPool> pool;
+    std::shared_ptr<TcpLaneSet> lanes;
+    EventBase* evb{nullptr};
+    /// Declared LAST so these are destroyed FIRST: emptying them releases
+    /// leases into the still-live registry above, and slabs into the still-live
+    /// pool.
+    std::deque<PendingReadReply> pending;
+    std::deque<DeferredReadReply> deferred;
+  };
+
+  std::shared_ptr<TcpLaneSet> laneSet_{std::make_shared<TcpLaneSet>()};
+  std::shared_ptr<TcpReplyState> reply_{std::make_shared<TcpReplyState>()};
+
+  // Aliases onto the two objects above, so the rest of this class keeps naming
+  // these the way it always has. Declared after them: reference members are
+  // bound in declaration order.
+  std::vector<std::unique_ptr<TcpLane>>& lanes_{laneSet_->v};
 
   // get-path copy accounting, paired with Conn::RecvPhaseStats. Reader thread
   // only; relaxed because a torn read across a reset misattributes a sample and
@@ -1341,34 +1444,31 @@ class TcpTransport : public Transport {
   // first to finish rather than returning while teardown is still running.
   std::atomic<bool> shutdown_{false};
 
-  // Round-robin cursor for lane selection. Relaxed: an occasional duplicate or
-  // skipped index only perturbs balance, and nothing reads it for correctness.
-  std::atomic<uint64_t> nextLane_{0};
   std::atomic<bool> running_{false};
-  std::atomic<bool> connBroken_{false};
+  std::atomic<bool>& connBroken_{laneSet_->broken};
 
   // Guards the staging queue, which the reader thread appends to and the
   // EventBase drains.
-  std::mutex stagingMu_;
-  std::deque<PendingReadReply> pendingReplies_;
+  std::mutex& stagingMu_{reply_->mu};
+  std::deque<PendingReadReply>& pendingReplies_{reply_->pending};
   // Retired strictly front-first. Copies for one device go on that device's
   // stream and so signal in issue order; across devices they are independent,
   // so a reply that is ready can wait behind an older one still running.
   // Ordered retirement is still correct -- offsets make out-of-order replies
   // safe on the wire, this only costs latency -- and a transport serves one
   // peer, which in practice means one device.
-  bool replyPollScheduled_{false};
+  bool& replyPollScheduled_{reply_->pollScheduled};
   // VRAM reads that arrived with the pool exhausted, oldest first. Bounded by
   // kMaxInflightRequests for the same reason inflight_ is: it grows on
   // peer-supplied frames, and the reader will not stop reading them.
-  std::deque<DeferredReadReply> deferredReplies_;
+  std::deque<DeferredReadReply>& deferredReplies_{reply_->deferred};
 
   // Created on first VRAM staging need, then never replaced. Its own mutex
   // rather than stagingMu_: acquiring a slab can wait (put(), from a caller
   // thread), and the staging queue must stay available to the reader while it
   // does.
-  std::mutex poolMu_;
-  std::shared_ptr<TcpPinnedSlabPool> slabPool_;
+  std::mutex& poolMu_{reply_->poolMu};
+  std::shared_ptr<TcpPinnedSlabPool>& slabPool_{reply_->pool};
 
   // Separate from the outbound/responder staging pool: receive slabs must hold
   // any legal wire frame, not just one kMaxChunkSize payload.

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -483,12 +483,23 @@ class TcpSegmentRegistry {
   /// for longer still: its copy has not been issued yet and starts only once a
   /// slab frees up.
   ///
-  /// What this can no longer do is deadlock. The reader thread does not wait
-  /// for any of it -- staging is asynchronous and exhaustion defers rather than
-  /// blocks -- so it keeps delivering inbound frames, including whatever the
-  /// application's GPU work is itself waiting on. Giving the staging copies a
-  /// dedicated non-blocking stream would remove the remaining wait on unrelated
-  /// device work.
+  /// **On the read-reply path** this can no longer deadlock. The reader thread
+  /// does not wait for any of that staging -- the copy is asynchronous and
+  /// exhaustion defers rather than blocks -- so it keeps delivering inbound
+  /// frames, including whatever the application's GPU work is itself waiting
+  /// on. Giving the staging copies a dedicated non-blocking stream would remove
+  /// the remaining wait on unrelated device work.
+  ///
+  /// The claim is scoped deliberately: it is about the read-reply path, not
+  /// about erase() in general. An inbound `TcpOp::Write` into a VRAM segment
+  /// also holds a lease across its H2D copy, and that copy the reader *does*
+  /// wait for. It runs on a dedicated non-blocking stream, so the wait is
+  /// bounded by that one copy and not by unrelated application GPU work --
+  /// which is what keeps it a delay rather than a deadlock. On the null stream
+  /// it was the latter: the reader would wait on every blocking stream on the
+  /// device, including work that could only be unblocked by a frame the parked
+  /// reader was itself supposed to deliver. A DRAM-only deployment never had
+  /// that exposure, because there the copy under lease is a plain memcpy.
   void erase(uint64_t segId) {
     std::unique_lock<std::mutex> lk(mu_);
     auto it = segs_.find(segId);
@@ -1469,6 +1480,25 @@ class TcpTransport : public Transport {
   // does.
   std::mutex& poolMu_{reply_->poolMu};
   std::shared_ptr<TcpPinnedSlabPool>& slabPool_{reply_->pool};
+
+  /// Non-blocking streams for inbound `TcpOp::Write` H2D copies, one per
+  /// device, created on first use for that device. Per-device because a stream
+  /// belongs to the device it was created on and registered segments may sit on
+  /// different devices -- one transport-wide stream would be used with the
+  /// wrong device current.
+  ///
+  /// The point of them is the lease. The Write handler holds a registry lease
+  /// across its copy, and erase() waits on that lease; on the null stream the
+  /// copy also waits on every blocking stream on the device, so the reader
+  /// could be parked on application GPU work that only the reader could
+  /// unblock. A non-blocking stream bounds the wait by the copy itself.
+  std::mutex writeStreamMu_;
+  std::unordered_map<int, void*> writeStreams_;
+
+  /// The non-blocking stream for `deviceId`, creating it on first use. Returns
+  /// an error rather than falling back to the null stream: the fallback is the
+  /// deadlock this exists to remove, so a Write is failed loudly instead.
+  Result<void*> writeStreamFor(int deviceId);
 
   // Separate from the outbound/responder staging pool: receive slabs must hold
   // any legal wire frame, not just one kMaxChunkSize payload.

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
@@ -955,6 +955,58 @@ TEST_F(TcpTransportFrameTest, InBoundsWriteIsApplied) {
   EXPECT_FALSE(queuedErrorFrame());
 }
 
+// The reader holds a registry lease across an inbound Write's H2D copy, and
+// erase() waits on that lease. On the null stream the copy also waits on every
+// blocking stream on the device, so the reader could be parked on application
+// GPU work that only the reader itself could unblock -- a deadlock, not a
+// delay. The copy therefore has to go on a stream of the transport's own.
+TEST_F(TcpTransportFrameTest, AVramWriteCopyDoesNotUseTheNullStream) {
+  constexpr uint64_t kVramSegId = kSegId + 220;
+  constexpr size_t kLen = 8;
+  std::vector<std::byte> vram(kLen, std::byte{0});
+  registry_->add(
+      kVramSegId, vram.data(), kLen, MemoryType::VRAM, /*deviceId=*/0);
+
+  MockStream created{};
+  EXPECT_CALL(*cudaApi_, streamCreateNonBlocking(::testing::_))
+      .WillOnce([&](MockStream* out) -> Status {
+        // MockStream, not cudaStream_t: this TU is not hipified, so under ROCm
+        // the cuda name does not exist here while the alias -- declared in the
+        // hipified MockCudaApi.h -- resolves in both builds. Same reason the
+        // event stubs above spell their parameter `auto`.
+        //
+        // A distinct non-null handle, so the assertion below cannot pass by
+        // accident on a null stream.
+        created = reinterpret_cast<MockStream>(0xB0B0);
+        *out = created;
+        return Ok();
+      });
+
+  MockStream copyStream = reinterpret_cast<MockStream>(0);
+  bool copied = false;
+  EXPECT_CALL(
+      *cudaApi_,
+      memcpyAsync(
+          ::testing::_, ::testing::_, kLen, kMockMemcpyH2D, ::testing::_))
+      .WillOnce(
+          [&](void* d, const void* src, size_t n, auto, auto stream) -> Status {
+            copyStream = static_cast<MockStream>(stream);
+            std::memcpy(d, src, n);
+            copied = true;
+            return Ok();
+          });
+
+  feed(makeFrame(TcpOp::Write, kVramSegId, /*offset=*/0, /*len=*/kLen, kLen));
+
+  ASSERT_TRUE(copied) << "the VRAM write should have issued an H2D copy";
+  EXPECT_NE(copyStream, reinterpret_cast<MockStream>(0))
+      << "an inbound VRAM write must not copy on the null stream: the reader "
+         "waits for this copy while holding a lease erase() waits on";
+  EXPECT_EQ(copyStream, created)
+      << "it must be the transport's own non-blocking stream";
+  EXPECT_FALSE(queuedErrorFrame());
+}
+
 TEST(TcpOpStateTest, FailureWaitsForReservedWriteToRetire) {
   TcpOpState state;
   state.remaining = 1;

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
@@ -563,7 +563,7 @@ class TcpTransportFrameTest : public ::testing::Test {
   /// The transport's own staging pool, created on the first call exactly as a
   /// VRAM read would create it.
   std::shared_ptr<TcpPinnedSlabPool> transportStagingPool() {
-    auto pool = transport_->stagingPool();
+    auto pool = TcpTransport::stagingPool(transport_->reply_);
     EXPECT_TRUE(pool.hasValue());
     return pool.hasValue() ? pool.value() : nullptr;
   }


### PR DESCRIPTION
Summary:
Addresses three review comments on D117132683 (`Controller.h:59`, `TcpTransport.cpp:1194`, and the ai-reviewer note on `TcpTransport.h:532-538`).

**1. The counter is renamed for what it measures.** `headerWaitNs` was documented as "a first-byte latency: for a get it covers the network round trip plus everything the peer did before it started replying". It does not. D117053165 made the get responder stage asynchronously -- it posts the `memcpyAsync`, returns to its socket, and queues the reply when the copy signals -- so the responder's staging and the round trip are overlapped with our own drain and cannot appear in our block on the length prefix. The diff's own numbers say the same thing: 3.1us measured here against 92.9us for a same-sized local device copy; the responder's D2H cannot be 30x cheaper than ours.

What the counter actually aggregates is the residual inter-frame stall, which equals a first-byte latency only for the first frame after idle. It is now `interFrameStallNs`, and the doc says both that and the fact that idle time inside the bracket lands here, so its share of the total is only meaningful across back-to-back traffic.

This matters beyond naming: the conclusion "responder-side optimization cannot help get" was drawn from this counter meaning something it does not.

**2. Every counter is read and cleared in one step.** `logAndResetPhaseStats` read each counter and cleared it later, so a sample the reader recorded in between was dropped rather than carried forward, and the counters cleared at different instants -- letting one window pair a copy count with frames from an earlier one. With N lanes that was 4N loads in one loop followed by 4N stores in another, plus 11 transport-level stores. All 15 are now `exchange(0)`, and both reset paths are gone.

**3. `lanes_` is read without a lock, and that is now stated.** `logAndResetPhaseStats` is public and reachable from any thread; the emptiness check supplies no ordering. `establishLanes()` fills `lanes_` during `connect()`, and the reader and sender threads read it unlocked only because they are created after that, which supplies the happens-before. No current caller needs a lock -- the only callers bracket a measurement from the thread that ran `connect()` -- so this is documented as a contract on both the declaration and the definition rather than taking `lifecycleMu_`.

Also moves the declaration into the public section. It had been a five-line `public:` island in the middle of the private block; `TcpTransport` now has exactly one `public:`/`private:` pair.

**Why this is at the top of the stack rather than amended into D117132683.** `logAndResetPhaseStats` is rewritten four times above that diff -- D117155852 adds the `h2dState_` counters, D117632428 adds three `receiveSlab*` counters, D117545615 replaces `dataConn_` with `primaryConn()`, and the lane work replaces that with per-lane iteration. Amending D117132683 required resolving the same function four times, two of those resolutions semantic. Applied here it lands once against the final shape. The cost is that the counter carries its misleading name and doc through the diffs in between.

Reviewed By: yexiangd

Differential Revision: D118526443


