### PR TITLE
comms/uniflow/tcp: cap the endpoints a peer can advertise

### DIFF
--- a/comms/uniflow/benchmarks/Rendezvous.cpp
+++ b/comms/uniflow/benchmarks/Rendezvous.cpp
@@ -3,7 +3,6 @@
 #include "comms/uniflow/benchmarks/Rendezvous.h"
 
 #include <algorithm>
-#include <cerrno>
 #include <cstring>
 
 #include "comms/uniflow/controller/TcpController.h"
@@ -119,7 +118,7 @@ Result<std::vector<PeerConnection>> Rendezvous::establish(
   return peers;
 }
 
-/// Retry recv on EAGAIN — the peer may be slow to reach the barrier during
+/// Retry recv on a timeout — the peer may be slow to reach the barrier during
 /// long benchmark runs, causing SO_RCVTIMEO to fire.
 ///
 /// The bound is 300 retries x the connection's SO_RCVTIMEO. The rendezvous is
@@ -138,19 +137,31 @@ static Result<size_t> recvRetryEagain(
     if (result) {
       return result;
     }
-    if ((errno == EAGAIN || errno == EWOULDBLOCK) && retries < kMaxRetries) {
+    // Tested on the error code, not the global errno. errno is unreliable by
+    // the time it is readable here: recv() returns through a promise/future,
+    // and the failure path builds its message with
+    // std::system_category().message() and a concatenation first -- four
+    // allocation sites between the syscall and this line, any of which may set
+    // errno. syncRecv now reports a timeout as ErrCode::Timeout, which survives
+    // the round trip intact.
+    const bool timedOut = result.error().code() == ErrCode::Timeout;
+    if (timedOut && retries < kMaxRetries) {
       ++retries;
       UNIFLOW_LOG_INFO(
-          "barrier: recv got EAGAIN, retrying ({}/{})...",
-          retries,
-          kMaxRetries);
+          "barrier: recv timed out, retrying ({}/{})...", retries, kMaxRetries);
       continue;
     }
-    if (retries >= kMaxRetries) {
+    if (timedOut) {
+      // Only a genuine timeout is reported as one. The previous form keyed this
+      // branch on the retry count alone, so a connection error arriving after
+      // the retries happened to be exhausted was reported as an EAGAIN timeout
+      // -- the wrong cause, in the message an operator reads while diagnosing a
+      // stall.
       return Err(
-          ErrCode::ConnectionFailed,
+          ErrCode::Timeout,
           "barrier: recv timed out after " + std::to_string(kMaxRetries) +
-              " EAGAIN retries (~5 minutes)");
+              " retries of the connection's SO_RCVTIMEO (~2.5 hours at the "
+              "default 30s)");
     }
     return result;
   }

--- a/comms/uniflow/controller/Controller.h
+++ b/comms/uniflow/controller/Controller.h
@@ -56,19 +56,39 @@ class Conn {
   /// the only place the two can be told apart -- above this layer a recv() is
   /// one opaque wait.
   ///
-  /// headerWaitNs is a first-byte latency: for a get it covers the network
-  /// round trip plus everything the peer did before it started replying, so it
-  /// separates "the remote is slow" from "our drain is slow". Relaxed atomics,
-  /// written only by the reader thread; a torn read across a reset costs a
-  /// misattributed sample, never correctness.
+  /// interFrameStallNs is the reader's residual stall between frames -- time
+  /// blocked on a length prefix with nothing arriving. It equals a first-byte
+  /// latency only for the first frame after idle.
+  ///
+  /// It is NOT the round trip plus the peer's work, and must not be read that
+  /// way: a get responder stages asynchronously (it posts the copy, returns to
+  /// its socket, and queues the reply when the copy signals), so the
+  /// responder's staging and the round trip are overlapped with our own drain
+  /// and cannot appear in our block on the prefix. The arithmetic says the same
+  /// thing -- 3.1us measured here against 92.9us for a same-sized local device
+  /// copy; the responder's copy cannot be 30x cheaper than ours.
+  ///
+  /// Idle time inside the measurement bracket also lands here, so its share of
+  /// the total is only meaningful across back-to-back traffic.
+  ///
+  /// Relaxed atomics. Accumulated by the reader thread and read-and-cleared by
+  /// whichever thread brackets a measurement, so two threads do touch them;
+  /// relaxed is still sound because nothing orders against them and nothing
+  /// branches on them. Do not restate the old "a torn read across a reset"
+  /// rationale: an atomic load does not tear, and the read path exchanges
+  /// rather than load-then-stores, so there is no window for a sample to fall
+  /// into.
   struct RecvPhaseStats {
-    std::atomic<uint64_t> headerWaitNs{0};
+    std::atomic<uint64_t> interFrameStallNs{0};
     std::atomic<uint64_t> payloadDrainNs{0};
     std::atomic<uint64_t> frames{0};
     std::atomic<uint64_t> payloadBytes{0};
 
+    /// Tests only. The transport's reporting path reads and clears with
+    /// exchange() rather than calling this; it is kept so a test can scope one
+    /// measurement without standing up a transport.
     void reset() {
-      headerWaitNs.store(0, std::memory_order_relaxed);
+      interFrameStallNs.store(0, std::memory_order_relaxed);
       payloadDrainNs.store(0, std::memory_order_relaxed);
       frames.store(0, std::memory_order_relaxed);
       payloadBytes.store(0, std::memory_order_relaxed);

--- a/comms/uniflow/controller/TcpController.cpp
+++ b/comms/uniflow/controller/TcpController.cpp
@@ -651,7 +651,7 @@ Result<size_t> TcpConn<IOPolicy>::syncRecv(std::vector<uint8_t>& data) {
     return Err(ErrCode::NotConnected, "Socket is not connected");
   }
 
-  // Split the wait: blocking on the length prefix is first-byte latency,
+  // Split the wait: blocking on the next length prefix is inter-frame stall,
   // blocking on the payload is drain time. Two clock reads per frame (~20ns
   // each) against a frame that takes hundreds of microseconds.
   auto& stats = recvPhaseStats();
@@ -683,7 +683,7 @@ Result<size_t> TcpConn<IOPolicy>::syncRecv(std::vector<uint8_t>& data) {
 
   const auto tDone = std::chrono::steady_clock::now();
   using ns = std::chrono::nanoseconds;
-  stats.headerWaitNs.fetch_add(
+  stats.interFrameStallNs.fetch_add(
       std::chrono::duration_cast<ns>(tFirstByte - tStart).count(),
       std::memory_order_relaxed);
   stats.payloadDrainNs.fetch_add(
@@ -737,7 +737,7 @@ Result<size_t> TcpConn<IOPolicy>::syncRecv(std::span<uint8_t> buf) {
 
   const auto tDone = std::chrono::steady_clock::now();
   using ns = std::chrono::nanoseconds;
-  stats.headerWaitNs.fetch_add(
+  stats.interFrameStallNs.fetch_add(
       std::chrono::duration_cast<ns>(tFirstByte - tStart).count(),
       std::memory_order_relaxed);
   stats.payloadDrainNs.fetch_add(

--- a/comms/uniflow/controller/TcpController.cpp
+++ b/comms/uniflow/controller/TcpController.cpp
@@ -508,6 +508,29 @@ bool TcpConn<IOPolicy>::sendAllVec(std::span<iovec> iov) {
   return true;
 }
 
+// Classifies a failed recvAll() while errno is still the one recvAll saw.
+//
+// recvAll restores errno before returning false precisely so a caller can read
+// it, but only until the next call that can overwrite it -- and formatting the
+// message allocates. So this captures first and formats second. Callers must
+// not read the global errno after the Result has travelled anywhere; that was
+// the defect this replaces, where a retry loop tested errno after a
+// promise/future round trip and several string constructions.
+//
+// A timeout is reported as ErrCode::Timeout rather than ConnectionFailed
+// because the two mean different things on a connected socket. SO_RCVTIMEO is
+// set on every connected socket to bound the handshake against a peer that
+// accepts and then stops responding; on a socket that is merely idle between
+// transfers the same timeout fires with EAGAIN, and a caller that cannot tell
+// those apart has to treat normal idleness as a dead peer.
+Err classifyRecvFailure(const char* what) {
+  const int savedErrno = errno;
+  const bool timedOut = savedErrno == EAGAIN || savedErrno == EWOULDBLOCK;
+  return Err(
+      timedOut ? ErrCode::Timeout : ErrCode::ConnectionFailed,
+      std::string(what) + ": " + std::system_category().message(savedErrno));
+}
+
 template <typename IOPolicy>
 bool TcpConn<IOPolicy>::recvAll(void* buf, size_t len) {
   auto* ptr = static_cast<uint8_t*>(buf);
@@ -519,6 +542,28 @@ bool TcpConn<IOPolicy>::recvAll(void* buf, size_t len) {
         continue;
       }
       int savedErrno = errno;
+      // A timeout that lands MID-FRAME is not idleness, and must not be
+      // reported as one. recvAll holds no cross-call reassembly state, so the
+      // bytes already taken off the socket cannot be resumed: a caller that
+      // treats ErrCode::Timeout as an idle gap and retries would read the
+      // remainder of this frame as a fresh length prefix, desynchronising the
+      // stream and most likely producing a garbage length. `remaining != len`
+      // catches progress made WITHIN this call only -- it cannot see that a
+      // previous recvAll already took the header off the socket, which is why
+      // syncRecv treats any failure of its payload read as fatal too. Reported
+      // as EPROTO so
+      // classifyRecvFailure() maps it to ConnectionFailed and the connection is
+      // torn down, which is what happened before timeouts became retryable.
+      if ((savedErrno == EAGAIN || savedErrno == EWOULDBLOCK) &&
+          remaining != len) {
+        UNIFLOW_LOG_ERROR(
+            "recvAll timed out mid-frame, tearing down: fd={} received={} "
+            "expected={}",
+            sock_,
+            len - remaining,
+            len);
+        savedErrno = EPROTO;
+      }
       UNIFLOW_LOG_ERROR(
           "recvAll failed: fd={} errno={} ({})",
           sock_,
@@ -659,9 +704,7 @@ Result<size_t> TcpConn<IOPolicy>::syncRecv(std::vector<uint8_t>& data) {
 
   uint32_t rawLen = 0;
   if (!recvAll(&rawLen, sizeof(rawLen))) {
-    return Err(
-        ErrCode::ConnectionFailed,
-        "recv header failed: " + std::system_category().message(errno));
+    return classifyRecvFailure("recv header failed");
   }
   const auto tFirstByte = std::chrono::steady_clock::now();
 
@@ -676,9 +719,25 @@ Result<size_t> TcpConn<IOPolicy>::syncRecv(std::vector<uint8_t>& data) {
 
   data.resize(len);
   if (len != 0 && !recvAll(data.data(), len)) {
-    return Err(
-        ErrCode::ConnectionFailed,
-        "recv payload failed: " + std::system_category().message(errno));
+    // Never reported as a retryable Timeout, whatever errno says. The header is
+    // already off the socket, so this frame is half-consumed and recvAll
+    // exposes no offset to resume from -- a caller that treated this as an idle
+    // gap and retried would read the payload as the next length prefix and
+    // desynchronise the stream. recvAll's own mid-frame guard cannot catch this
+    // case: the payload read starts with remaining == len, so a timeout that
+    // fires before the first payload byte arrives looks like zero progress to
+    // it, even though progress was made by the PREVIOUS recvAll call for the
+    // header.
+    auto failure = classifyRecvFailure("recv payload failed");
+    if (failure.code() == ErrCode::Timeout) {
+      return Err(
+          ErrCode::ConnectionFailed,
+          std::string(
+              "recv payload failed mid-frame after the header was "
+              "consumed: ") +
+              failure.message());
+    }
+    return failure;
   }
 
   const auto tDone = std::chrono::steady_clock::now();
@@ -707,9 +766,7 @@ Result<size_t> TcpConn<IOPolicy>::syncRecv(std::span<uint8_t> buf) {
 
   uint32_t rawLen = 0;
   if (!recvAll(&rawLen, sizeof(rawLen))) {
-    return Err(
-        ErrCode::ConnectionFailed,
-        "recv header failed: " + std::system_category().message(errno));
+    return classifyRecvFailure("recv header failed");
   }
   const auto tFirstByte = std::chrono::steady_clock::now();
 
@@ -730,9 +787,7 @@ Result<size_t> TcpConn<IOPolicy>::syncRecv(std::span<uint8_t> buf) {
   }
 
   if (len != 0 && !recvAll(buf.data(), len)) {
-    return Err(
-        ErrCode::ConnectionFailed,
-        "recv payload failed: " + std::system_category().message(errno));
+    return classifyRecvFailure("recv payload failed");
   }
 
   const auto tDone = std::chrono::steady_clock::now();

--- a/comms/uniflow/controller/tests/TcpConnTest.cpp
+++ b/comms/uniflow/controller/tests/TcpConnTest.cpp
@@ -139,7 +139,7 @@ TEST_P(TcpConnTest, SpanRecvRecordsPhaseStats) {
   EXPECT_EQ(stats.payloadBytes.load(std::memory_order_relaxed), sent.size());
 
   stats.reset();
-  EXPECT_EQ(stats.headerWaitNs.load(std::memory_order_relaxed), 0);
+  EXPECT_EQ(stats.interFrameStallNs.load(std::memory_order_relaxed), 0);
   EXPECT_EQ(stats.payloadDrainNs.load(std::memory_order_relaxed), 0);
   EXPECT_EQ(stats.frames.load(std::memory_order_relaxed), 0);
   EXPECT_EQ(stats.payloadBytes.load(std::memory_order_relaxed), 0);

--- a/comms/uniflow/controller/tests/TcpConnTest.cpp
+++ b/comms/uniflow/controller/tests/TcpConnTest.cpp
@@ -138,6 +138,29 @@ TEST_P(TcpConnTest, SpanRecvRecordsPhaseStats) {
   EXPECT_EQ(stats.frames.load(std::memory_order_relaxed), 1);
   EXPECT_EQ(stats.payloadBytes.load(std::memory_order_relaxed), sent.size());
 
+  // Asserted before the reset, which is the whole point of the split this test
+  // is named for. Checking them only afterwards -- as this test used to --
+  // makes both assertions 0 == 0 whatever the instrumentation did, so the phase
+  // timings could stop being recorded entirely and nothing here would notice.
+  //
+  // Only a lower bound is asserted, and the lower bound is not a guess.
+  // libstdc++'s steady_clock reads CLOCK_MONOTONIC, which reports 1ns
+  // resolution on this platform; 500k back-to-back read pairs with no work
+  // between them produced no zero deltas at all (smallest observed 80ns). The
+  // reads here are far apart than that: each brackets a blocking recv()
+  // syscall, which costs microseconds. So
+  // "> 0" is not a race against clock granularity.
+  //
+  // An upper bound WOULD be a timing assumption, which is what makes tests
+  // flaky under load, so none is asserted. A fake/injected clock was considered
+  // and rejected: it would assert that the code does arithmetic on numbers a
+  // test supplied, losing the only thing these assertions establish -- that the
+  // instrumentation records real elapsed time at all.
+  EXPECT_GT(stats.interFrameStallNs.load(std::memory_order_relaxed), 0u)
+      << "the wait for the length prefix was never recorded";
+  EXPECT_GT(stats.payloadDrainNs.load(std::memory_order_relaxed), 0u)
+      << "the payload drain was never recorded";
+
   stats.reset();
   EXPECT_EQ(stats.interFrameStallNs.load(std::memory_order_relaxed), 0);
   EXPECT_EQ(stats.payloadDrainNs.load(std::memory_order_relaxed), 0);

--- a/comms/uniflow/drivers/cuda/CudaApi.cpp
+++ b/comms/uniflow/drivers/cuda/CudaApi.cpp
@@ -171,6 +171,18 @@ Status CudaApi::memcpyPeerAsync(
 
 // --- Stream ---
 
+Status CudaApi::streamCreateNonBlocking(cudaStream_t* stream) {
+  CUDA_CHECK(
+      cudaStreamCreateWithFlags(stream, cudaStreamNonBlocking),
+      ErrCode::DriverError);
+  return Ok();
+}
+
+Status CudaApi::streamDestroy(cudaStream_t stream) {
+  CUDA_CHECK(cudaStreamDestroy(stream), ErrCode::DriverError);
+  return Ok();
+}
+
 Status CudaApi::streamSynchronize(cudaStream_t stream) {
   CUDA_CHECK(cudaStreamSynchronize(stream), ErrCode::DriverError);
   return Ok();

--- a/comms/uniflow/drivers/cuda/CudaApi.h
+++ b/comms/uniflow/drivers/cuda/CudaApi.h
@@ -76,6 +76,16 @@ class CudaApi {
 
   // --- Stream ---
 
+  /// Creates a stream that does NOT implicitly synchronize with the null
+  /// stream (`cudaStreamNonBlocking`). A copy issued on the null stream
+  /// serialises against every blocking stream on the device, so a thread that
+  /// synchronizes it ends up waiting for unrelated application GPU work. Where
+  /// that thread also holds a resource someone else waits on, that is a
+  /// deadlock rather than a delay.
+  virtual Status streamCreateNonBlocking(cudaStream_t* stream);
+
+  virtual Status streamDestroy(cudaStream_t stream);
+
   virtual Status streamSynchronize(cudaStream_t stream);
 
   // --- Event ---

--- a/comms/uniflow/drivers/cuda/mock/MockCudaApi.h
+++ b/comms/uniflow/drivers/cuda/mock/MockCudaApi.h
@@ -68,6 +68,14 @@ class MockCudaApi : public CudaApi {
        cudaStream_t stream),
       (override));
 
+  MOCK_METHOD(
+      Status,
+      streamCreateNonBlocking,
+      (cudaStream_t * stream),
+      (override));
+
+  MOCK_METHOD(Status, streamDestroy, (cudaStream_t stream), (override));
+
   MOCK_METHOD(Status, streamSynchronize, (cudaStream_t stream), (override));
 
   MOCK_METHOD(Status, eventCreate, (cudaEvent_t * event), (override));

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -2914,6 +2914,27 @@ void TcpTransport::handleFrameImpl(
     TcpPinnedSlab receiveSlab) {
   auto headerResult = deserializeTcpHeader(frame);
   if (!headerResult) {
+    // A lane hello arriving as a data frame is not a malformed peer, it is a
+    // lane-count mismatch. This side has one lane, so establishLanes() skipped
+    // the hello exchange -- that skip exists so the wire stays byte-identical
+    // for a peer built before lanes existed -- and a peer configured for more
+    // than one lane sent a hello anyway. It is shorter than a TcpMsgHeader, so
+    // without this it is dropped as malformed while the peer goes on to stripe
+    // onto sockets nobody ever accepted: a silent stall, not the clean
+    // handshake error the design intends.
+    //
+    // Both sides normally come from one configuration, so this cannot happen in
+    // practice -- which is exactly why it must not be silent if it does. Thrown
+    // rather than logged and dropped: handleFrame is noexcept and fails the
+    // connection, and a connection whose peer is striping onto sockets this
+    // side never accepted cannot carry traffic.
+    if (auto hello = TcpLaneHello::deserialize(frame); hello) {
+      throw std::runtime_error(
+          "tcp: peer sent a lane hello for " +
+          std::to_string(hello.value().laneCount) +
+          " lanes, but this side established 1 and skipped the hello "
+          "exchange; the lane counts must match");
+    }
     UNIFLOW_LOG_ERROR(
         "tcp: dropping malformed frame: {}", headerResult.error().message());
     return;

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -344,6 +344,10 @@ TcpTransport::TcpTransport(
   h2dState_ = std::make_shared<H2dPollState>();
   h2dState_->evb = evb_;
   h2dState_->cudaApi = cudaApi_;
+  reply_->evb = evb_;
+  reply_->cudaApi = cudaApi_;
+  reply_->lanes = laneSet_;
+  reply_->registry = registry_;
 }
 
 Status TcpTransport::hostFromDevice(
@@ -782,17 +786,25 @@ Status TcpTransport::establishLanes(
   return Ok();
 }
 
-size_t TcpTransport::laneCapBytes() const {
-  const size_t lanes = lanes_.empty() ? 1 : lanes_.size();
-  return kMaxOutQueueBytes / lanes;
+size_t TcpTransport::laneCapBytesOn(const TcpLaneSet& lanes) {
+  const size_t count = lanes.v.empty() ? 1 : lanes.v.size();
+  return kMaxOutQueueBytes / count;
 }
 
-size_t TcpTransport::pickLane() {
-  if (lanes_.size() <= 1) {
+size_t TcpTransport::laneCapBytes() const {
+  return laneCapBytesOn(*laneSet_);
+}
+
+size_t TcpTransport::pickLaneOn(TcpLaneSet& lanes) {
+  if (lanes.v.size() <= 1) {
     return 0;
   }
   return static_cast<size_t>(
-      nextLane_.fetch_add(1, std::memory_order_relaxed) % lanes_.size());
+      lanes.nextLane.fetch_add(1, std::memory_order_relaxed) % lanes.v.size());
+}
+
+size_t TcpTransport::pickLane() {
+  return pickLaneOn(*laneSet_);
 }
 
 controller::Conn* TcpTransport::primaryConn() const {
@@ -1028,7 +1040,7 @@ Result<PendingPutWave> TcpTransport::launchPutWave(
     std::span<const PlannedPutFrame> wave,
     void* stream,
     size_t startIdx) {
-  auto pool = stagingPool();
+  auto pool = stagingPool(reply_);
   if (!pool) {
     return std::move(pool).error();
   }
@@ -1316,26 +1328,48 @@ std::shared_ptr<TcpPinnedSlabPool> TcpTransport::receivePoolIfCreated() {
       &receiveSlabPool_, std::memory_order_acquire);
 }
 
-Result<std::shared_ptr<TcpPinnedSlabPool>> TcpTransport::stagingPool() {
-  std::lock_guard<std::mutex> lk(poolMu_);
-  if (slabPool_ != nullptr) {
-    return slabPool_;
+Result<std::shared_ptr<TcpPinnedSlabPool>> TcpTransport::stagingPool(
+    const std::shared_ptr<TcpReplyState>& state) {
+  std::lock_guard<std::mutex> lk(state->poolMu);
+  if (state->pool != nullptr) {
+    return state->pool;
   }
-  if (cudaApi_ == nullptr) {
+  // Refuse to CREATE one once teardown has begun. shutdown() sets `stopping`,
+  // then snapshots and closes the pool under poolMu, and only then joins the
+  // readers -- so a reader reaching here in that last window would allocate a
+  // fresh kStagingSlabCount of pinned slabs that shutdown() has already walked
+  // past. Nothing would ever close it: the memory would live until the last
+  // TcpReplyState reference drops, and a thread blocking in acquire() on it
+  // would have no `closed_` escape. Checking here rather than at each call site
+  // covers every caller, including respondToVramRead() on the reader thread.
+  //
+  // Lock order is poolMu -> mu, established here and nowhere reversed: no code
+  // takes poolMu while holding mu. Holding mu only for the flag read keeps it
+  // off the cudaHostAlloc below, which is ~124 MiB of page-locked memory and
+  // would otherwise stall every admission point for its duration.
+  {
+    std::lock_guard<std::mutex> stateLk(state->mu);
+    if (state->stopping) {
+      return Err(
+          ErrCode::NotConnected,
+          "tcp read: reply path stopped before the staging pool existed");
+    }
+  }
+  if (state->cudaApi == nullptr) {
     return Err(ErrCode::InvalidArgument, "tcp read: no CUDA API for VRAM");
   }
   // Header and payload contiguous in one slab, so a staged frame is still a
   // single buffer and the send path needs no scatter-gather.
   auto pool = TcpPinnedSlabPool::create(
-      cudaApi_,
+      state->cudaApi,
       sizeof(TcpMsgHeader) + kMaxChunkSize,
       kStagingSlabCount,
       kStagingSlabsReservedForReader);
   if (!pool) {
     return std::move(pool).error();
   }
-  slabPool_ = pool.value();
-  return slabPool_;
+  state->pool = pool.value();
+  return state->pool;
 }
 
 Status TcpTransport::respondToVramRead(
@@ -1352,7 +1386,7 @@ Status TcpTransport::respondToVramRead(
             " bytes exceeds the staging slab payload (" +
             std::to_string(kMaxChunkSize) + ")");
   }
-  auto pool = stagingPool();
+  auto pool = stagingPool(reply_);
   if (!pool) {
     return std::move(pool).error();
   }
@@ -1362,10 +1396,11 @@ Status TcpTransport::respondToVramRead(
   if (!slab) {
     return deferReadReply(replyHeader, std::move(lease));
   }
-  return startReadReply(replyHeader, std::move(lease), std::move(slab));
+  return startReadReply(reply_, replyHeader, std::move(lease), std::move(slab));
 }
 
 Status TcpTransport::startReadReply(
+    const std::shared_ptr<TcpReplyState>& state,
     const TcpMsgHeader& replyHeader,
     TcpSegmentRegistry::Lease lease,
     TcpPinnedSlab slab) {
@@ -1381,14 +1416,33 @@ Status TcpTransport::startReadReply(
   // taken back, and reading from a segment a waiting erase() is now free to
   // deregister. drainPendingReadReplies() waits for exactly this reason; the
   // error paths here need the same barrier.
+  // Best-effort refusal BEFORE any device work. The post-copy check below is
+  // the authoritative one -- it holds `mu` and closes the race -- but reaching
+  // only that one means every ReadRequest the reader picks up between
+  // shutdown() setting `stopping` and the reader join issues a D2H copy plus an
+  // event that are guaranteed to be discarded, and then pays a full
+  // cudaStreamSynchronize on the reader thread to wait the copy out. That
+  // synchronize delays the lane->reader.join() shutdown() is already blocked
+  // on, and on the startDeferredReadReplies() path it blocks the event loop
+  // instead. Checking here skips both. A stale read is harmless: it can only
+  // mean doing the work we would have done anyway, and the post-copy check
+  // still catches it.
+  {
+    std::lock_guard<std::mutex> lk(state->mu);
+    if (state->stopping) {
+      return Err(
+          ErrCode::NotConnected,
+          "tcp read: transport stopped before staging a VRAM read");
+    }
+  }
   bool copyIssued = false;
   try {
-    CudaDeviceGuard guard(*cudaApi_, deviceId);
+    CudaDeviceGuard guard(*state->cudaApi, deviceId);
     // Into pinned memory, so this returns once the copy is enqueued. The same
     // call into a pageable destination -- a plain vector -- is specified to
     // complete synchronously, which parks whichever thread issued it for the
     // length of the transfer. On this path that thread is the reader.
-    if (auto st = cudaApi_->memcpyAsync(
+    if (auto st = state->cudaApi->memcpyAsync(
             frame.mutableData() + sizeof(TcpMsgHeader),
             src,
             replyHeader.len,
@@ -1402,35 +1456,51 @@ Status TcpTransport::startReadReply(
     copyIssued = true;
     // The guard already has deviceId current, so these wait on the right device
     // without nesting another guard.
-    if (auto st = cudaApi_->eventCreate(&event); !st) {
-      (void)cudaApi_->streamSynchronize(/*stream=*/nullptr);
+    if (auto st = state->cudaApi->eventCreate(&event); !st) {
+      (void)state->cudaApi->streamSynchronize(/*stream=*/nullptr);
       return st;
     }
-    if (auto st = cudaApi_->eventRecord(event, /*stream=*/nullptr); !st) {
-      (void)cudaApi_->eventDestroy(event);
-      (void)cudaApi_->streamSynchronize(/*stream=*/nullptr);
+    if (auto st = state->cudaApi->eventRecord(event, /*stream=*/nullptr); !st) {
+      (void)state->cudaApi->eventDestroy(event);
+      (void)state->cudaApi->streamSynchronize(/*stream=*/nullptr);
       return st;
     }
   } catch (const std::exception& e) {
     if (copyIssued) {
-      waitForStagedCopy(deviceId);
+      waitForStagedCopy(state, deviceId);
     }
     return Err(
         ErrCode::InvalidArgument,
         "tcp read: VRAM staging needs a selectable deviceId, got " +
             std::to_string(deviceId) + ": " + e.what());
   }
+  bool stopping = false;
   {
-    std::lock_guard<std::mutex> lk(stagingMu_);
-    pendingReplies_.push_back(
-        PendingReadReply{
-            std::move(frame),
-            std::move(lease),
-            event,
-            replyHeader.reqId,
-            deviceId});
+    std::lock_guard<std::mutex> lk(state->mu);
+    if (state->stopping) {
+      stopping = true;
+    } else {
+      state->pending.push_back(
+          PendingReadReply{
+              std::move(frame),
+              std::move(lease),
+              event,
+              replyHeader.reqId,
+              deviceId});
+    }
   }
-  schedulePendingReplyPoll();
+  if (stopping) {
+    // drainPendingReadReplies() has already swept the queue, so pushing here
+    // would leave a lease in a queue nothing drains again -- the same shape as
+    // the deferReadReply() refusal below. The copy is waited out first because
+    // it is still running into `frame`, which unwinds as this returns.
+    waitForStagedCopy(state, deviceId);
+    (void)state->cudaApi->eventDestroy(event);
+    return Err(
+        ErrCode::NotConnected,
+        "tcp read: transport stopped while staging a VRAM read");
+  }
+  schedulePendingReplyPoll(state);
   return Ok();
 }
 
@@ -1465,6 +1535,21 @@ Status TcpTransport::deferReadReply(
   // admitInflightBulk() take their mutex first for the same reason.
   {
     std::lock_guard<std::mutex> lk(stagingMu_);
+    // `stopping` as well as connBroken_, in the same critical section as the
+    // push. shutdown() sets stopping before the reader join, while connBroken_
+    // is only set later by failAllPending(), so between those two points this
+    // was the one admission point that would still grow a queue -- the entry
+    // then never starts (scheduleDeferredReadReplies() returns early on
+    // stopping) and is discarded by drainPendingReadReplies(). Harmless today
+    // because that drain runs after the joins, but the asymmetry with the other
+    // four admission points reads as a guarantee that no queue grows once
+    // stopping is set, and that guarantee is what a future caller would rely
+    // on.
+    if (reply_->stopping) {
+      return Err(
+          ErrCode::NotConnected,
+          "tcp read: reply path stopped while deferring a VRAM read");
+    }
     if (connBroken_.load(std::memory_order_acquire)) {
       return Err(
           ErrCode::NotConnected,
@@ -1495,22 +1580,38 @@ Status TcpTransport::deferReadReply(
   // there is no next release: the read never starts and its lease keeps erase()
   // blocked. Redundant kicks are harmless -- startDeferredReadReplies()
   // re-tests both the pool and the queue under the lock.
-  scheduleDeferredReadReplies();
+  scheduleDeferredReadReplies(reply_);
   return Ok();
 }
 
-void TcpTransport::scheduleDeferredReadReplies() {
+void TcpTransport::scheduleDeferredReadReplies(
+    const std::shared_ptr<TcpReplyState>& state) {
   {
-    std::lock_guard<std::mutex> lk(stagingMu_);
-    if (deferredReplies_.empty()) {
+    std::lock_guard<std::mutex> lk(state->mu);
+    if (state->stopping || state->deferred.empty()) {
       return;
     }
   }
-  evb_->dispatch([this]() noexcept { startDeferredReadReplies(); });
+  // `state` rather than `this`: the callback may not run until after the
+  // transport is gone, and by then the senders are joined, so anything it
+  // queues simply sits in a queue that dies with the lane set.
+  state->evb->dispatch([state]() noexcept { startDeferredReadReplies(state); });
 }
 
-void TcpTransport::startDeferredReadReplies() {
-  auto pool = stagingPool();
+void TcpTransport::startDeferredReadReplies(
+    const std::shared_ptr<TcpReplyState>& state) {
+  // Cheap early refusal: this runs from an evb_->dispatch() that may have been
+  // queued just before shutdown() set `stopping`, so there is no point taking a
+  // slab and popping an entry for work that will be refused. stagingPool()
+  // makes the same test authoritatively for every caller, so this is an
+  // optimisation rather than the guarantee -- see the lock-order note there.
+  {
+    std::lock_guard<std::mutex> lk(state->mu);
+    if (state->stopping) {
+      return;
+    }
+  }
+  auto pool = stagingPool(state);
   if (!pool) {
     return;
   }
@@ -1524,8 +1625,8 @@ void TcpTransport::startDeferredReadReplies() {
     }
     DeferredReadReply deferred;
     {
-      std::lock_guard<std::mutex> lk(stagingMu_);
-      if (deferredReplies_.empty()) {
+      std::lock_guard<std::mutex> lk(state->mu);
+      if (state->stopping || state->deferred.empty()) {
         // Returning here releases the slab without using it, and deliberately
         // does not reschedule. An entry queued between this test and that
         // release is still covered, because deferReadReply() is the only
@@ -1535,8 +1636,8 @@ void TcpTransport::startDeferredReadReplies() {
         // that does not kick would reopen the window.
         return;
       }
-      deferred = std::move(deferredReplies_.front());
-      deferredReplies_.pop_front();
+      deferred = std::move(state->deferred.front());
+      state->deferred.pop_front();
     }
     TcpMsgHeader replyHeader{};
     replyHeader.op = static_cast<uint8_t>(TcpOp::ReadReply);
@@ -1545,12 +1646,28 @@ void TcpTransport::startDeferredReadReplies() {
     replyHeader.offset = deferred.offset;
     replyHeader.len = deferred.len;
     if (auto st = startReadReply(
-            replyHeader, std::move(deferred.lease), std::move(slab));
+            state, replyHeader, std::move(deferred.lease), std::move(slab));
         !st) {
+      // A `stopping` refusal is an ordinary part of teardown, not a failure:
+      // startReadReply() returns NotConnected once shutdown() has swept the
+      // queues. Logging it at ERROR made every clean shutdown look like a
+      // staging fault, and the Error frame it enqueued goes onto lanes that are
+      // already closed, so nothing observes it either. Genuine staging failures
+      // still get both.
+      bool stopping = false;
+      {
+        std::lock_guard<std::mutex> lk(state->mu);
+        stopping = state->stopping;
+      }
+      if (stopping) {
+        return;
+      }
       UNIFLOW_LOG_ERROR(
           "tcp read: deferred VRAM staging failed: {}", st.error().message());
-      (void)enqueueFrame(
-          makeHeaderFrame(TcpOp::Error, deferred.reqId), /*mayBlock=*/false);
+      (void)enqueueOn(
+          state,
+          makeHeaderFrame(TcpOp::Error, deferred.reqId),
+          /*mayBlock=*/false);
     }
   }
 }
@@ -1832,18 +1949,20 @@ void TcpTransport::drainPendingH2d() {
   }
 }
 
-void TcpTransport::schedulePendingReplyPoll() {
+void TcpTransport::schedulePendingReplyPoll(
+    const std::shared_ptr<TcpReplyState>& state) {
   {
-    std::lock_guard<std::mutex> lk(stagingMu_);
-    if (replyPollScheduled_ || pendingReplies_.empty()) {
+    std::lock_guard<std::mutex> lk(state->mu);
+    if (state->stopping || state->pollScheduled || state->pending.empty()) {
       return;
     }
-    replyPollScheduled_ = true;
+    state->pollScheduled = true;
   }
-  evb_->dispatch([this]() noexcept { pollPendingReadReplies(); });
+  state->evb->dispatch([state]() noexcept { pollPendingReadReplies(state); });
 }
 
-void TcpTransport::pollPendingReadReplies() {
+void TcpTransport::pollPendingReadReplies(
+    const std::shared_ptr<TcpReplyState>& state) {
   while (true) {
     TcpFrame ready;
     PendingReadReply failed;
@@ -1853,17 +1972,21 @@ void TcpTransport::pollPendingReadReplies() {
     bool haveFailure = false;
     bool stillRunning = false;
     {
-      std::lock_guard<std::mutex> lk(stagingMu_);
-      if (pendingReplies_.empty()) {
-        replyPollScheduled_ = false;
+      std::lock_guard<std::mutex> lk(state->mu);
+      // Teardown has drained the queue and is not waiting on this callback to
+      // leave, so there is nothing left to retire and nothing to reschedule.
+      if (state->stopping || state->pending.empty()) {
+        state->pollScheduled = false;
         return;
       }
-      auto& front = pendingReplies_.front();
-      auto done = cudaApi_->eventQuery(static_cast<cudaEvent_t>(front.event));
+      auto& front = state->pending.front();
+      auto done =
+          state->cudaApi->eventQuery(static_cast<cudaEvent_t>(front.event));
       if (done.hasValue() && !done.value()) {
         stillRunning = true;
       } else {
-        (void)cudaApi_->eventDestroy(static_cast<cudaEvent_t>(front.event));
+        (void)state->cudaApi->eventDestroy(
+            static_cast<cudaEvent_t>(front.event));
         if (done.hasError()) {
           failedReqId = front.reqId;
           failedDeviceId = front.deviceId;
@@ -1880,7 +2003,7 @@ void TcpTransport::pollPendingReadReplies() {
           haveReady = true;
         }
         // Releases the lease, which is what lets a waiting erase() proceed.
-        pendingReplies_.pop_front();
+        state->pending.pop_front();
       }
     }
     if (stillRunning) {
@@ -1893,39 +2016,44 @@ void TcpTransport::pollPendingReadReplies() {
       // takes stagingMu_ to enqueue, and it should never wait on the
       // EventBase's queue to do it.
       std::this_thread::yield();
-      evb_->dispatch([this]() noexcept { pollPendingReadReplies(); });
+      state->evb->dispatch(
+          [state]() noexcept { pollPendingReadReplies(state); });
       return;
     }
     // Queued outside the lock: enqueueFrame takes a lane mutex, and holding two
     // of the transport's mutexes at once is how lock cycles start.
     if (haveReady) {
-      (void)enqueueFrame(std::move(ready), /*mayBlock=*/false);
+      (void)enqueueOn(state, std::move(ready), /*mayBlock=*/false);
     } else if (haveFailure) {
       // Wait before `failed` goes out of scope, for the same reason
       // drainPendingReadReplies() waits: a copy that may still be running would
       // otherwise be left writing into a slab the pool is about to hand to the
       // next staging copy.
-      waitForStagedCopy(failedDeviceId);
+      waitForStagedCopy(state, failedDeviceId);
       // Dropping it here releases the slab, so a deferred read may now be
       // startable -- which is why this happens before the scheduling call
       // below.
       failed = PendingReadReply{};
-      (void)enqueueFrame(
-          makeHeaderFrame(TcpOp::Error, failedReqId), /*mayBlock=*/false);
-      scheduleDeferredReadReplies();
+      (void)enqueueOn(
+          state,
+          makeHeaderFrame(TcpOp::Error, failedReqId),
+          /*mayBlock=*/false);
+      scheduleDeferredReadReplies(state);
     }
   }
 }
 
-void TcpTransport::waitForStagedCopy(int deviceId) noexcept {
-  if (cudaApi_ == nullptr) {
+void TcpTransport::waitForStagedCopy(
+    const std::shared_ptr<TcpReplyState>& state,
+    int deviceId) noexcept {
+  if (state->cudaApi == nullptr) {
     return;
   }
   try {
     // Per-device: a bare streamSynchronize would only cover whichever device
     // happened to be current, leaving a copy on any other device still running.
-    CudaDeviceGuard guard(*cudaApi_, deviceId);
-    (void)cudaApi_->streamSynchronize(/*stream=*/nullptr);
+    CudaDeviceGuard guard(*state->cudaApi, deviceId);
+    (void)state->cudaApi->streamSynchronize(/*stream=*/nullptr);
   } catch (const std::exception&) {
     // The device is already unusable, so there is nothing left to wait for.
   }
@@ -1949,7 +2077,7 @@ void TcpTransport::drainPendingReadReplies() {
   // first even though the replies themselves are being abandoned.
   if (cudaApi_ != nullptr) {
     for (auto& reply : pending) {
-      waitForStagedCopy(reply.deviceId);
+      waitForStagedCopy(reply_, reply.deviceId);
       (void)cudaApi_->eventDestroy(static_cast<cudaEvent_t>(reply.event));
     }
   }
@@ -2018,10 +2146,20 @@ Status TcpTransport::admitInflight(uint64_t reqId, TcpInflight entry) {
 }
 
 bool TcpTransport::enqueueFrame(TcpFrame frame, bool mayBlock) {
+  return enqueueOn(reply_, std::move(frame), mayBlock);
+}
+
+bool TcpTransport::enqueueOn(
+    const std::shared_ptr<TcpReplyState>& state,
+    TcpFrame frame,
+    bool mayBlock) {
+  // Copied out so the lane set stays alive for this call even if the transport
+  // is torn down concurrently.
+  const std::shared_ptr<TcpLaneSet> lanes = state->lanes;
   // No lanes means connect() never ran (or teardown already cleared them).
   // Indexing here would be undefined; refusing matches the documented contract
   // that a frame may simply not be queued.
-  if (lanes_.empty()) {
+  if (lanes == nullptr || lanes->v.empty()) {
     return false;
   }
   const size_t bytes = frame.size();
@@ -2029,8 +2167,8 @@ bool TcpTransport::enqueueFrame(TcpFrame frame, bool mayBlock) {
   // carries its own reqId/segId/offset, so the peer places it without needing
   // arrival order and any lane is equivalent. Only Send is order-sensitive, and
   // it does not come through here (see enqueueSendFrame).
-  auto& lane = *lanes_[pickLane()];
-  const size_t cap = laneCapBytes();
+  auto& lane = *lanes->v[pickLaneOn(*lanes)];
+  const size_t cap = laneCapBytesOn(*lanes);
   {
     std::unique_lock<std::mutex> lk(lane.mu);
     if (mayBlock) {
@@ -2039,8 +2177,9 @@ bool TcpTransport::enqueueFrame(TcpFrame frame, bool mayBlock) {
       // drains slows down instead of growing the queue. An empty queue always
       // admits, however large the frame, or a payload bigger than the cap could
       // never drain and would wedge here forever.
-      lane.cv.wait(lk, [this, &lane, bytes, cap]() {
-        return lane.outClosed || connBroken_.load(std::memory_order_acquire) ||
+      lane.cv.wait(lk, [&lanes, &lane, bytes, cap]() {
+        return lane.outClosed ||
+            lanes->broken.load(std::memory_order_acquire) ||
             lane.queue.empty() || lane.bytes + bytes <= cap;
       });
     }
@@ -2060,7 +2199,7 @@ bool TcpTransport::enqueueFrame(TcpFrame frame, bool mayBlock) {
     // outClosed alone therefore lets a frame admitted before the sweep land in
     // the cleared queue and go out on the wire for an op whose caller has
     // already been told it failed.
-    if (lane.outClosed || connBroken_.load(std::memory_order_acquire)) {
+    if (lane.outClosed || lanes->broken.load(std::memory_order_acquire)) {
       return false;
     }
     lane.queue.push_back(TcpOutItem{std::move(frame), nullptr});
@@ -2317,7 +2456,7 @@ void TcpTransport::senderLoop(size_t laneIdx) noexcept {
     // slab; dispatching the restart rather than running it here keeps device
     // work off the thread whose only job is to keep the socket draining.
     item = TcpOutItem{};
-    scheduleDeferredReadReplies();
+    scheduleDeferredReadReplies(reply_);
   }
 }
 
@@ -3097,6 +3236,16 @@ void TcpTransport::shutdown() {
   // in-progress send on the sender thread. A no-op for a lane a reader already
   // refused, in which case it is on its way out anyway.
   closeLanesOnce();
+
+  // Before the pool close and the drains below, not after: a reply callback
+  // admitted after drainPendingReadReplies() has swept would push a lease back
+  // into a queue nothing drains again. Every reply-path entry point re-tests
+  // this under the same mutex, so setting it here is what makes the sweep
+  // final.
+  {
+    std::lock_guard<std::mutex> lk(reply_->mu);
+    reply_->stopping = true;
+  }
 
   // Closed before the joins: this is the one pool with a *blocking* acquire,
   // and the thread parked in it is not one we own. acquire() waits on `freed_`

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -369,6 +369,42 @@ Status TcpTransport::hostFromDevice(
   return cudaApi_->streamSynchronize(s);
 }
 
+Result<void*> TcpTransport::writeStreamFor(int deviceId) {
+  std::lock_guard<std::mutex> lk(writeStreamMu_);
+  auto it = writeStreams_.find(deviceId);
+  if (it != writeStreams_.end()) {
+    return it->second;
+  }
+  if (cudaApi_ == nullptr) {
+    return Err(
+        ErrCode::InvalidArgument, "tcp write: no CUDA API for a VRAM segment");
+  }
+  cudaStream_t stream{};
+  // CudaDeviceGuard throws when setDevice fails, and it is deliberately NOT
+  // caught here. Before this stream existed the first guard on this path was
+  // the one inside deviceFromHost, and its throw is what handleFrame's catch
+  // turns into a failed connection -- see
+  // VramStagingThrowDoesNotAbortTheReader. Swallowing it here would silently
+  // narrow that behaviour, which is a separate decision from removing the null
+  // stream (see C-049).
+  CudaDeviceGuard guard(*cudaApi_, deviceId);
+  if (auto st = cudaApi_->streamCreateNonBlocking(&stream); !st) {
+    return std::move(st).error();
+  }
+  // Destroyed here if publishing it throws. shutdown() only destroys streams it
+  // finds in writeStreams_, so a stream created but never inserted is
+  // unreachable: handleFrame() catches the exception and keeps the process
+  // alive, and the stream then leaks for the transport's lifetime. The
+  // CudaDeviceGuard above is still in scope, so this runs on the right device.
+  try {
+    writeStreams_.emplace(deviceId, static_cast<void*>(stream));
+  } catch (...) {
+    (void)cudaApi_->streamDestroy(stream);
+    throw;
+  }
+  return static_cast<void*>(stream);
+}
+
 Status TcpTransport::deviceFromHost(
     void* devDst,
     const void* hostSrc,
@@ -2775,8 +2811,23 @@ void TcpTransport::handleFrameImpl(
         if (header.len > 0) {
           void* dst = static_cast<uint8_t*>(entry->ptr) + header.offset;
           if (entry->memType == MemoryType::VRAM) {
-            st = deviceFromHost(
-                dst, payload.data(), header.len, entry->deviceId);
+            // On a dedicated non-blocking stream, never the null stream. The
+            // lease above is held across this copy and erase() waits on it, so
+            // a null-stream copy -- which serialises against every blocking
+            // stream on the device -- would park the reader on unrelated
+            // application GPU work that only the reader could unblock. Bounded
+            // here by this copy alone.
+            auto stream = writeStreamFor(entry->deviceId);
+            if (stream.hasError()) {
+              st = std::move(stream).error();
+            } else {
+              st = deviceFromHost(
+                  dst,
+                  payload.data(),
+                  header.len,
+                  entry->deviceId,
+                  stream.value());
+            }
           } else {
             std::memcpy(dst, payload.data(), header.len);
           }
@@ -3386,6 +3437,25 @@ void TcpTransport::shutdown() {
   // transport goes away: a staged reply's frame is memory the device may still
   // be writing into.
   drainPendingReadReplies();
+
+  // After the reader is joined, so no Write copy can still be using one. Every
+  // such copy was synchronized before its handler returned, so none has pending
+  // work at this point.
+  {
+    std::lock_guard<std::mutex> lk(writeStreamMu_);
+    for (auto& [deviceId, stream] : writeStreams_) {
+      if (stream == nullptr || cudaApi_ == nullptr) {
+        continue;
+      }
+      try {
+        CudaDeviceGuard guard(*cudaApi_, deviceId);
+        (void)cudaApi_->streamDestroy(static_cast<cudaStream_t>(stream));
+      } catch (const std::exception&) {
+        // The device is already unusable; the stream goes with it.
+      }
+    }
+    writeStreams_.clear();
+  }
 
   // Compare-exchange, not load-then-store: a concurrent bind() failure setting
   // Error in the gap between a load and a store would be clobbered back to

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -519,6 +519,19 @@ Status TcpTransport::connect(std::span<const uint8_t> remoteInfo) {
     return Err(
         ErrCode::InvalidArgument, "tcp connect: transport must be bound first");
   }
+  if (!hasPeerLivenessDetection()) {
+    // Said once per connect rather than left to be rediscovered. With neither
+    // keepalive nor TCP_USER_TIMEOUT, the read timeout is the only thing that
+    // can notice a dead peer -- so the reader must keep treating an idle
+    // timeout as fatal, and an idle gap longer than it will close a healthy
+    // connection. That is the pre-existing behaviour, not a new one, but it is
+    // a choice this config is making silently.
+    UNIFLOW_LOG_WARN(
+        "tcp connect: socket config sets neither keepalive nor "
+        "TCP_USER_TIMEOUT, so an idle gap longer than the recv timeout will "
+        "close the connection; set enableKeepalive or userTimeout to tolerate "
+        "idle peers");
+  }
 
   auto peerResult = TcpTransportInfo::deserialize(remoteInfo);
   if (!peerResult) {
@@ -2803,6 +2816,24 @@ void TcpTransport::readerLoop(size_t laneIdx) noexcept {
                                 receiveSlab.data(), receiveSlab.capacity()})
                         .get();
       if (!result) {
+        if (result.error().code() == ErrCode::Timeout &&
+            hasPeerLivenessDetection()) {
+          // Idle, not dead. SO_RCVTIMEO is set on every connected socket to
+          // bound the *handshake* against a peer that accepts and then stops
+          // responding; it is not a steady-state read deadline. An idle gap
+          // between transfers -- the normal state of a prefill/decode
+          // connection between bursts -- fires the same timeout, and breaking
+          // here tore the connection down and failed every in-flight op for it.
+          //
+          // Dead peers are detected by SO_KEEPALIVE and TCP_USER_TIMEOUT, which
+          // this transport's own socket config already plumbs, and which is the
+          // mechanism actually designed for it. Guarded on that being true: a
+          // config with neither -- osDefaults() sets every field nullopt, and
+          // Linux defaults keepalive off -- has no other liveness signal, so
+          // tolerating the timeout there would trade a wrongly-closed
+          // connection for one that never notices a dead peer at all.
+          continue;
+        }
         break;
       }
       const auto* receiveData = receiveSlab.data();
@@ -2816,7 +2847,12 @@ void TcpTransport::readerLoop(size_t laneIdx) noexcept {
     vectorReceiveCount_.fetch_add(1, std::memory_order_relaxed);
     auto result = conn->recv(msg).get();
     if (!result) {
-      // Connection closed, errored, or idle-timed-out; stop reading.
+      if (result.error().code() == ErrCode::Timeout &&
+          hasPeerLivenessDetection()) {
+        // Idle rather than closed or errored -- see the slab path above.
+        continue;
+      }
+      // Connection closed or errored; stop reading.
       break;
     }
     handleFrame(msg);

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -293,6 +293,19 @@ Result<TcpTransportInfo> TcpTransportInfo::deserialize(
   // keeps the old exact-size guarantee: trailing junk is still rejected.
   size_t offset = sizeof(header) + header.hostLen;
   while (offset < data.size()) {
+    // Bounded before an Endpoint is built, not after. connect() does compare
+    // the count against the local device count, but only once the whole vector
+    // exists, and a record whose host is empty is a bare 4-byte Header -- so an
+    // uncapped parse turns peer-supplied bytes into ~16.7M Endpoint objects at
+    // the control channel's 64 MiB limit, and more on the paths that reach
+    // connect() without passing through the controller.
+    if (info.endpointCount() >= kMaxLanes) {
+      return Err(
+          ErrCode::InvalidArgument,
+          "tcp transport info advertises more than " +
+              std::to_string(kMaxLanes) +
+              " endpoints, which is above the lane cap");
+    }
     if (data.size() - offset < sizeof(Header)) {
       return Err(
           ErrCode::InvalidArgument,
@@ -589,8 +602,9 @@ Status TcpTransport::connect(std::span<const uint8_t> remoteInfo) {
 
   // Lanes are configured per device, so every device gets a full complement and
   // no device can end up without a lane. It is the product that has to fit the
-  // uint16_t the hello addresses lanes with.
-  constexpr size_t kMaxLanes = 1024;
+  // uint16_t the hello addresses lanes with. kMaxLanes lives in the header
+  // because deserialize() bounds the peer's endpoint count against the same
+  // number.
   const size_t lanesPerDevice =
       std::max<size_t>(config_.numSocketsPerDevice, 1);
   const size_t laneCount = lanesPerDevice * localDevices;

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -2588,49 +2588,93 @@ void TcpTransport::senderLoop(size_t laneIdx) noexcept {
 }
 
 // Logs the get-path phase split and zeroes it, so a caller can bracket one
-// measurement. Reports the reader's own view: time blocked waiting for a frame
-// to start (first-byte latency -- network plus whatever the peer did before
-// replying), time draining a frame once started, and time in the copy to the
-// caller's destination. Anything unaccounted for is reader-thread work between
-// those points.
+// measurement. Reports the reader's own view: the inter-frame stall (blocked on
+// a length prefix with nothing arriving), time draining a frame once started,
+// and time in the copy to the caller's destination. Anything unaccounted for is
+// reader-thread work between those points.
+//
+// The stall is NOT the round trip plus the peer's work. A get responder stages
+// asynchronously, so its staging and the round trip overlap our own drain and
+// cannot show up in our block on the prefix -- see RecvPhaseStats for the
+// measurement that settles it.
 void TcpTransport::logAndResetPhaseStats(std::string_view label) {
+  // lanes_ is read without a lock, so this may only be called between a
+  // completed connect() and shutdown(). establishLanes() fills it during
+  // connect(), and the reader and sender threads read it unlocked only because
+  // they are created after that, which supplies the happens-before. This is a
+  // public method reachable from any thread and the emptiness check below
+  // supplies no such ordering, so the contract is the caller's to keep. Stated
+  // rather than locked because no caller needs the lock: the only callers
+  // bracket a measurement from the thread that ran connect().
   if (lanes_.empty()) {
+    // Nothing to report, but the transport-level counters are cleared anyway.
+    // They are not lane-scoped, so anything already accounted here would
+    // otherwise carry into the next measurement window. Clearing
+    // unconditionally makes the bracketing a property of this function rather
+    // than of the connect()/shutdown() contract holding -- one less thing that
+    // has to be true for a measurement to mean what it says.
+    (void)dstCopyNs_.exchange(0, std::memory_order_relaxed);
+    (void)dstCopyCount_.exchange(0, std::memory_order_relaxed);
+    (void)receiveSlabAttempts_.exchange(0, std::memory_order_relaxed);
+    (void)receiveSlabMisses_.exchange(0, std::memory_order_relaxed);
+    (void)vectorReceiveCount_.exchange(0, std::memory_order_relaxed);
+    (void)stagingNs_.exchange(0, std::memory_order_relaxed);
+    (void)stagingBytes_.exchange(0, std::memory_order_relaxed);
+    (void)stagingWaves_.exchange(0, std::memory_order_relaxed);
+    (void)stagingChunks_.exchange(0, std::memory_order_relaxed);
+    // Unconditional, like the reporting path below: h2dState_ is assigned once
+    // in the constructor and never reset, so it is non-null for the whole
+    // lifetime a caller can reach this from. Guarding it here while the
+    // reporting path dereferences it freely would imply an invariant that does
+    // not exist, and send the next reader looking for the null case that makes
+    // the other path a crash.
+    (void)h2dState_->copyNs.exchange(0, std::memory_order_relaxed);
+    (void)h2dState_->copyCount.exchange(0, std::memory_order_relaxed);
     return;
   }
   // Summed over every lane: each lane has its own reader and its own stats, so
   // reading lane 0 alone would report 1/N of the traffic and hide any imbalance
   // between lanes. Per-lane frame counts are logged too, since an uneven split
   // is itself a finding.
-  uint64_t frames = 0, hdrNs = 0, drainNs = 0, bytes = 0;
+  //
+  // exchange, not load-then-reset: each counter is read and cleared in one
+  // step, so a sample the reader records mid-sweep is carried into the next
+  // window rather than dropped. That is the whole guarantee, and it is worth
+  // not overstating -- the 4N lane counters and the transport counters are
+  // still exchanged at distinct instants, so a frame whose stall was already
+  // taken but whose count lands just after still straddles two windows.
+  // Load-then-clear would be strictly worse: 4N loads then 4N stores, with
+  // every sample recorded in between lost outright rather than deferred.
+  uint64_t frames = 0, stallNs = 0, drainNs = 0, bytes = 0;
   std::string perLaneFrames;
   for (size_t i = 0; i < lanes_.size(); ++i) {
     if (lanes_[i] == nullptr || lanes_[i]->conn == nullptr) {
       continue;
     }
     auto& lrs = lanes_[i]->conn->recvPhaseStats();
-    const uint64_t lf = lrs.frames.load(std::memory_order_relaxed);
+    const uint64_t lf = lrs.frames.exchange(0, std::memory_order_relaxed);
     frames += lf;
-    hdrNs += lrs.headerWaitNs.load(std::memory_order_relaxed);
-    drainNs += lrs.payloadDrainNs.load(std::memory_order_relaxed);
-    bytes += lrs.payloadBytes.load(std::memory_order_relaxed);
+    stallNs += lrs.interFrameStallNs.exchange(0, std::memory_order_relaxed);
+    drainNs += lrs.payloadDrainNs.exchange(0, std::memory_order_relaxed);
+    bytes += lrs.payloadBytes.exchange(0, std::memory_order_relaxed);
     perLaneFrames += (i == 0 ? "" : ",") + std::to_string(lf);
   }
-  const uint64_t copyNs = dstCopyNs_.load(std::memory_order_relaxed) +
-      h2dState_->copyNs.load(std::memory_order_relaxed);
-  const uint64_t copies = dstCopyCount_.load(std::memory_order_relaxed) +
-      h2dState_->copyCount.load(std::memory_order_relaxed);
+  const uint64_t copyNs = dstCopyNs_.exchange(0, std::memory_order_relaxed) +
+      h2dState_->copyNs.exchange(0, std::memory_order_relaxed);
+  const uint64_t copies = dstCopyCount_.exchange(0, std::memory_order_relaxed) +
+      h2dState_->copyCount.exchange(0, std::memory_order_relaxed);
   const uint64_t slabAttempts =
-      receiveSlabAttempts_.load(std::memory_order_relaxed);
+      receiveSlabAttempts_.exchange(0, std::memory_order_relaxed);
   const uint64_t slabMisses =
-      receiveSlabMisses_.load(std::memory_order_relaxed);
+      receiveSlabMisses_.exchange(0, std::memory_order_relaxed);
   const uint64_t vectorReceives =
-      vectorReceiveCount_.load(std::memory_order_relaxed);
+      vectorReceiveCount_.exchange(0, std::memory_order_relaxed);
 
   if (frames == 0) {
     UNIFLOW_LOG_INFO("tcp phases [{}]: no frames", label);
   } else {
     const double totalNs =
-        static_cast<double>(hdrNs) + static_cast<double>(drainNs);
+        static_cast<double>(stallNs) + static_cast<double>(drainNs);
     const auto pct = [totalNs](uint64_t v) {
       return totalNs > 0.0 ? 100.0 * static_cast<double>(v) / totalNs : 0.0;
     };
@@ -2642,15 +2686,16 @@ void TcpTransport::logAndResetPhaseStats(std::string_view label) {
         ? static_cast<double>(bytes) / static_cast<double>(drainNs)
         : 0.0;
     UNIFLOW_LOG_INFO(
-        "tcp phases [{}]: frames={} bytes={} | first-byte {:.1f}us/frame "
+        "tcp phases [{}]: frames={} bytes={} | interframe_stall "
+        "{:.1f}us/frame "
         "({:.1f}%) | drain {:.1f}us/frame ({:.1f}%, {:.2f} GB/s) | dstcopy "
         "{:.1f}us x{} ({:.1f}% of wire) | receive_slabs attempts={} misses={} "
         "vector_recvs={} | lanes={} frames_per_lane=[{}]",
         label,
         frames,
         bytes,
-        static_cast<double>(hdrNs) / frames / 1000.0,
-        pct(hdrNs),
+        static_cast<double>(stallNs) / frames / 1000.0,
+        pct(stallNs),
         static_cast<double>(drainNs) / frames / 1000.0,
         pct(drainNs),
         drainGBps,
@@ -2663,18 +2708,16 @@ void TcpTransport::logAndResetPhaseStats(std::string_view label) {
         lanes_.size(),
         perLaneFrames);
   }
-  for (auto& lane : lanes_) {
-    if (lane != nullptr && lane->conn != nullptr) {
-      lane->conn->recvPhaseStats().reset();
-    }
-  }
   // Reported separately from the frame block above: on a put run this side
   // receives only Acks, so gating the staging numbers on receive frames would
   // hide them exactly where they matter.
-  const uint64_t stgNs = stagingNs_.load(std::memory_order_relaxed);
-  const uint64_t stgBytes = stagingBytes_.load(std::memory_order_relaxed);
-  const uint64_t stgWaves = stagingWaves_.load(std::memory_order_relaxed);
-  const uint64_t stgChunks = stagingChunks_.load(std::memory_order_relaxed);
+  const uint64_t stgNs = stagingNs_.exchange(0, std::memory_order_relaxed);
+  const uint64_t stgBytes =
+      stagingBytes_.exchange(0, std::memory_order_relaxed);
+  const uint64_t stgWaves =
+      stagingWaves_.exchange(0, std::memory_order_relaxed);
+  const uint64_t stgChunks =
+      stagingChunks_.exchange(0, std::memory_order_relaxed);
   if (stgWaves > 0) {
     UNIFLOW_LOG_INFO(
         "tcp put wave residency [{}]: waves={} chunks={} bytes={} | "
@@ -2688,17 +2731,6 @@ void TcpTransport::logAndResetPhaseStats(std::string_view label) {
                 static_cast<double>(stgChunks) / 1000.0
                       : 0.0);
   }
-  stagingNs_.store(0, std::memory_order_relaxed);
-  stagingBytes_.store(0, std::memory_order_relaxed);
-  stagingWaves_.store(0, std::memory_order_relaxed);
-  stagingChunks_.store(0, std::memory_order_relaxed);
-  dstCopyNs_.store(0, std::memory_order_relaxed);
-  dstCopyCount_.store(0, std::memory_order_relaxed);
-  h2dState_->copyNs.store(0, std::memory_order_relaxed);
-  h2dState_->copyCount.store(0, std::memory_order_relaxed);
-  receiveSlabAttempts_.store(0, std::memory_order_relaxed);
-  receiveSlabMisses_.store(0, std::memory_order_relaxed);
-  vectorReceiveCount_.store(0, std::memory_order_relaxed);
 }
 
 void TcpTransport::readerLoop(size_t laneIdx) noexcept {

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -1825,7 +1825,7 @@ Status TcpTransport::startAsyncH2d(
       const auto syncStatus =
           waitForH2dCopy(h2dState_, uncertain.deviceId, uncertain.stream);
       if (syncStatus.hasError()) {
-        quarantineH2d(h2dState_, std::move(uncertain));
+        abortOnUnquiescedH2d(std::move(uncertain));
         return syncStatus;
       }
       destroyH2dEvent(h2dState_, uncertain.deviceId, uncertain.event);
@@ -1835,8 +1835,7 @@ Status TcpTransport::startAsyncH2d(
   } catch (const std::exception& e) {
     if (copyIssued &&
         waitForH2dCopy(h2dState_, entry.deviceId, entry.stream).hasError()) {
-      quarantineH2d(
-          h2dState_,
+      abortOnUnquiescedH2d(
           PendingH2d{
               entry.state,
               std::move(slab),
@@ -1892,7 +1891,7 @@ Status TcpTransport::startAsyncH2d(
 
   if (auto syncStatus = waitForH2dCopy(h2dState_, entry.deviceId, entry.stream);
       syncStatus.hasError()) {
-    quarantineH2d(h2dState_, std::move(pending));
+    abortOnUnquiescedH2d(std::move(pending));
     return syncStatus;
   }
   destroyH2dEvent(h2dState_, entry.deviceId, event);
@@ -1970,7 +1969,7 @@ void TcpTransport::pollPendingH2d(
 
     if (queryFailed) {
       if (waitForH2dCopy(state, retired.deviceId, retired.stream).hasError()) {
-        quarantineH2d(state, std::move(retired));
+        abortOnUnquiescedH2d(std::move(retired));
         std::lock_guard<std::mutex> lk(state->mu);
         state->retiringState.reset();
         --state->activeRetirements;
@@ -2023,23 +2022,50 @@ void TcpTransport::destroyH2dEvent(
   }
 }
 
-void TcpTransport::quarantineH2d(
-    const std::shared_ptr<H2dPollState>& state,
-    PendingH2d copy) noexcept {
-  // Neither the event nor stream established quiescence. Deliberately retain
-  // the write reservation and slab: resolving or recycling either could let
-  // the caller or pool free memory still touched by DMA.
-  copy.state->fail(
-      Err(ErrCode::DriverError,
-          "tcp get: destination copy could not be safely quiesced"));
-  std::lock_guard<std::mutex> lk(state->mu);
-  for (auto& slot : state->quarantined) {
-    if (!slot.has_value()) {
-      slot.emplace(std::move(copy));
-      state->quarantineKeepalive = state;
-      return;
-    }
-  }
+// Does not return. Code after a call to this is unreachable; the name says so
+// because the call sites' trailing cleanup is left in place rather than
+// deleted, so it stays correct if this is ever downgraded to something
+// recoverable.
+[[noreturn]] void TcpTransport::abortOnUnquiescedH2d(PendingH2d copy) noexcept {
+  // Neither the event nor a stream synchronize could establish that the device
+  // had finished writing into the caller's destination. Nothing here is
+  // recoverable, and the two obvious options are both wrong:
+  //
+  //  - resolving the op releases the caller to free memory the DMA may still be
+  //    writing;
+  //  - retaining it quietly -- what this did before -- leaves the caller's
+  //    future permanently unresolved. tryBeginWrite() already counted the write
+  //    and only endWrite() retires it, so fail() latches without settling the
+  //    promise. Worse, a retained copy keeps its receive slab: after two such
+  //    events both slabs are gone, `receiveSlab` is always null, and the async
+  //    path silently stops being taken at all. The old std::terminate() below
+  //    the slot loop was therefore unreachable -- a third copy needs a third
+  //    slab, and there are only two.
+  //
+  // So this dies instead, loudly and at the point of detection. What gets us
+  // here is a sticky CUDA error -- illegal address, launch failure, device lost
+  // -- after which every later call on this device fails too. A transport
+  // factory owns exactly one deviceId and one CudaApi and hands both to every
+  // transport it creates, so no other transport in this process has a working
+  // device left to protect. Consumers run one GPU per process under a
+  // supervisor, so this is a restart rather than an outage.
+  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - copy.launchedAt);
+  UNIFLOW_LOG_ERROR(
+      "tcp get: destination copy could not be quiesced; aborting. device={} "
+      "stream={} reqId={} launched {}ms ago. The device is no longer usable, so "
+      "the caller's destination cannot be released safely and no later copy on "
+      "this device would succeed.",
+      copy.deviceId,
+      reinterpret_cast<uintptr_t>(copy.stream),
+      copy.reqId,
+      elapsed.count());
+  // Flushed explicitly, because the whole point of this path is to die loudly.
+  // The logger is spdlog's async non-blocking one (create_async_nb with
+  // overrun_oldest, drained by a background thread), so without this the
+  // message is still in the ring buffer when std::terminate() runs and the
+  // process dies silently -- the one outcome this function exists to prevent.
+  ::uniflow::logging::getLogger()->flush();
   std::terminate();
 }
 
@@ -2052,8 +2078,17 @@ void TcpTransport::drainPendingH2d() {
     state->drained.wait(lk, [&]() { return state->activeRetirements == 0; });
   }
   for (auto& copy : pending) {
+    // Aborting here, on the shutdown path, is deliberate. shutdown() is a
+    // public method and not the same thing as process exit -- a caller may shut
+    // one transport down and carry on -- so an unquiesceable copy means the
+    // same thing it means anywhere else: the device may still be writing into
+    // the caller's destination, and endWrite() below would release them to free
+    // it. Completing shutdown "successfully" would also leave a process holding
+    // a device that no later copy can use, since what gets us here is a sticky
+    // CUDA error. The `continue` is unreachable; it documents that the loop
+    // does not fall through to the endWrite() below.
     if (waitForH2dCopy(state, copy.deviceId, copy.stream).hasError()) {
-      quarantineH2d(state, std::move(copy));
+      abortOnUnquiescedH2d(std::move(copy));
       continue;
     }
     destroyH2dEvent(state, copy.deviceId, copy.event);

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -2623,6 +2623,22 @@ void TcpTransport::senderLoop(size_t laneIdx) noexcept {
       // down, so leaving the other lanes admitting work would queue frames for
       // a connection that is already gone.
       closeAllLaneQueues();
+      // The sockets too, not just the queues. Closing a queue stops new work
+      // being admitted; it does not wake a reader already parked in a blocking
+      // recv on a lane whose own socket is still healthy. With one socket the
+      // failing lane's reader errored out on its next recv, so this was
+      // invisible. With N lanes the other N-1 readers stay parked on sockets
+      // that are fine, on a transport that is already failed.
+      //
+      // A recv timeout no longer bounds that wait: readerLoop treats
+      // ErrCode::Timeout as idleness and continues, because an idle gap between
+      // transfers is not a dead peer. That is right for the get path, and it is
+      // what makes closing the sockets here necessary rather than merely
+      // tidier -- without it those readers wait for shutdown().
+      //
+      // closeLanesOnce() is idempotent per lane, so overlapping with a reader
+      // that refused its own connection, or with shutdown(), is safe.
+      closeLanesOnce();
       if (item.onSent) {
         item.onSent->fail(Err(ErrCode::ConnectionFailed, "tcp: send failed"));
       }

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -1409,13 +1409,10 @@ Status TcpTransport::startReadReply(
       static_cast<const uint8_t*>(lease->ptr) + replyHeader.offset;
   TcpFrame frame(std::move(slab), sizeof(TcpMsgHeader) + replyHeader.len);
   std::memcpy(frame.mutableData(), &replyHeader, sizeof(replyHeader));
+  // Stays a local until eventRecord() succeeds: the two failure paths below own
+  // the handle they created, and publishing it to `pending` earlier would let
+  // the barrier destroy it a second time.
   cudaEvent_t event{};
-  // Once the copy is enqueued, every way out of this function has to wait for
-  // it. Returning an error unwinds `frame` and `lease`, and the copy is
-  // asynchronous: the GPU would be left writing into a buffer the allocator has
-  // taken back, and reading from a segment a waiting erase() is now free to
-  // deregister. drainPendingReadReplies() waits for exactly this reason; the
-  // error paths here need the same barrier.
   // Best-effort refusal BEFORE any device work. The post-copy check below is
   // the authoritative one -- it holds `mu` and closes the race -- but reaching
   // only that one means every ReadRequest the reader picks up between
@@ -1435,7 +1432,69 @@ Status TcpTransport::startReadReply(
           "tcp read: transport stopped before staging a VRAM read");
     }
   }
+
+  // The entry owns the slab, the lease and the event from HERE, not from the
+  // push. Built early because push_back materialises its argument before it
+  // allocates: with a temporary there, deque growth that throws destroys that
+  // temporary at the end of the full-expression -- returning the slab to the
+  // pool while the D2H is still writing into it -- and does so INSIDE the
+  // locked scope, whereas the barrier below only runs at function exit. The
+  // wait would then come after the slab was already reusable, which is the one
+  // ordering this whole mechanism exists to prevent.
+  PendingReadReply pending{
+      std::move(frame),
+      std::move(lease),
+      /*event=*/nullptr,
+      replyHeader.reqId,
+      deviceId};
+
   bool copyIssued = false;
+  bool handedOff = false;
+  // Waits out an issued copy on every exit that is not a hand-off, and destroys
+  // the event it would otherwise leak. Declared after `pending` so it destructs
+  // FIRST -- the wait has to happen while the slab and the lease are still
+  // alive. Covers the paths that do not return: the push and the dispatch below
+  // are outside the try and both can throw (deque growth, the EventBase queue).
+  //
+  // Copy and move are deleted because a second barrier would wait and destroy
+  // the same event twice; that makes this a non-aggregate, hence the ctor.
+  class CopyBarrier {
+   public:
+    CopyBarrier(
+        const std::shared_ptr<TcpReplyState>& state,
+        const bool& issued,
+        const bool& handedOff,
+        void*& event,
+        int deviceId)
+        : state_(state),
+          issued_(issued),
+          handedOff_(handedOff),
+          event_(event),
+          deviceId_(deviceId) {}
+    CopyBarrier(const CopyBarrier&) = delete;
+    CopyBarrier& operator=(const CopyBarrier&) = delete;
+    CopyBarrier(CopyBarrier&&) = delete;
+    CopyBarrier& operator=(CopyBarrier&&) = delete;
+    ~CopyBarrier() {
+      if (handedOff_ || !issued_) {
+        return;
+      }
+      waitForStagedCopy(state_, deviceId_);
+      // An entry that was never pushed is one drainPendingReadReplies() will
+      // never see, so nothing else would ever destroy this.
+      if (event_ != nullptr) {
+        (void)state_->cudaApi->eventDestroy(static_cast<cudaEvent_t>(event_));
+        event_ = nullptr;
+      }
+    }
+
+   private:
+    const std::shared_ptr<TcpReplyState>& state_;
+    const bool& issued_;
+    const bool& handedOff_;
+    void*& event_;
+    int deviceId_;
+  } copyBarrier{state, copyIssued, handedOff, pending.event, deviceId};
   try {
     CudaDeviceGuard guard(*state->cudaApi, deviceId);
     // Into pinned memory, so this returns once the copy is enqueued. The same
@@ -1443,7 +1502,7 @@ Status TcpTransport::startReadReply(
     // complete synchronously, which parks whichever thread issued it for the
     // length of the transfer. On this path that thread is the reader.
     if (auto st = state->cudaApi->memcpyAsync(
-            frame.mutableData() + sizeof(TcpMsgHeader),
+            pending.frame.mutableData() + sizeof(TcpMsgHeader),
             src,
             replyHeader.len,
             cudaMemcpyDeviceToHost,
@@ -1465,6 +1524,9 @@ Status TcpTransport::startReadReply(
       (void)state->cudaApi->streamSynchronize(/*stream=*/nullptr);
       return st;
     }
+    // Only now, so the two failure paths above stay solely responsible for the
+    // handle they created and the barrier cannot double-destroy it.
+    pending.event = event;
   } catch (const std::exception& e) {
     if (copyIssued) {
       waitForStagedCopy(state, deviceId);
@@ -1480,26 +1542,36 @@ Status TcpTransport::startReadReply(
     if (state->stopping) {
       stopping = true;
     } else {
-      state->pending.push_back(
-          PendingReadReply{
-              std::move(frame),
-              std::move(lease),
-              event,
-              replyHeader.reqId,
-              deviceId});
+      state->pending.push_back(std::move(pending));
     }
   }
   if (stopping) {
     // drainPendingReadReplies() has already swept the queue, so pushing here
     // would leave a lease in a queue nothing drains again -- the same shape as
-    // the deferReadReply() refusal below. The copy is waited out first because
-    // it is still running into `frame`, which unwinds as this returns.
-    waitForStagedCopy(state, deviceId);
-    (void)state->cudaApi->eventDestroy(event);
+    // the deferReadReply() refusal below. The wait and the eventDestroy are the
+    // barrier's, since `pending` still owns both.
     return Err(
         ErrCode::NotConnected,
         "tcp read: transport stopped while staging a VRAM read");
   }
+  // Past the stopping refusal means the push happened, so the deque entry owns
+  // the slab, the lease and the event, and the drain is the barrier from here.
+  // Set after that branch rather than beside the push so a throw from the push
+  // itself is still covered.
+  handedOff = true;
+  // A throw out of the dispatch below therefore does NOT wait or destroy -- the
+  // entry owns both and doing either would race the drain. The entry is then on
+  // `pending`, and drainPendingReadReplies() at teardown waits for the copy,
+  // destroys the event and releases the lease, so nothing leaks. Accepted
+  // rather than popped back off: unwinding a push to re-take a lock we just
+  // released would add a failure mode worse than the delay.
+  //
+  // That cost is bounded ONLY because schedulePendingReplyPoll() clears
+  // pollScheduled on the throwing path. If it did not, this would not be one
+  // delayed lease: the flag gates every later call, so the poll loop would be
+  // dead for the connection's life, nothing would retire a staged reply again,
+  // and an exhausted pool would push every VRAM read down deferReadReply() with
+  // nothing to drain it.
   schedulePendingReplyPoll(state);
   return Ok();
 }
@@ -1958,7 +2030,22 @@ void TcpTransport::schedulePendingReplyPoll(
     }
     state->pollScheduled = true;
   }
-  state->evb->dispatch([state]() noexcept { pollPendingReadReplies(state); });
+  // pollScheduled is cleared again if the dispatch throws. dispatch() is a
+  // queue push that allocates, so it can; and the flag is the gate every later
+  // call checks first, so leaving it set would not delay one poll -- it would
+  // kill the poll loop for the life of the connection. Nothing would retire a
+  // staged reply again, each would keep its lease and its pinned slab, and once
+  // the pool is exhausted every VRAM read would degrade into deferReadReply()
+  // with nothing left to drain it.
+  try {
+    state->evb->dispatch([state]() noexcept { pollPendingReadReplies(state); });
+  } catch (...) {
+    {
+      std::lock_guard<std::mutex> lk(state->mu);
+      state->pollScheduled = false;
+    }
+    throw;
+  }
 }
 
 void TcpTransport::pollPendingReadReplies(
@@ -2050,8 +2137,12 @@ void TcpTransport::waitForStagedCopy(
     return;
   }
   try {
-    // Per-device: a bare streamSynchronize would only cover whichever device
-    // happened to be current, leaving a copy on any other device still running.
+    // The device has to be made current first because this waits on the *null*
+    // stream, and the null stream is per-device: a bare streamSynchronize would
+    // cover whichever device happened to be current and leave this copy
+    // running. That reasoning is specific to the null stream. A
+    // caller-supplied stream is one stream regardless of which device is
+    // current, so selecting a device per copy would buy nothing there.
     CudaDeviceGuard guard(*state->cudaApi, deviceId);
     (void)state->cudaApi->streamSynchronize(/*stream=*/nullptr);
   } catch (const std::exception&) {

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -1852,9 +1852,15 @@ Status TcpTransport::startAsyncH2d(
     if (event != nullptr) {
       destroyH2dEvent(h2dState_, entry.deviceId, event);
     }
+    // Deliberately broad, so the message reports what happened rather than
+    // diagnosing why. Today the only throw source is CudaDeviceGuard's
+    // setDevice, but the guarded region also runs the copy, so naming
+    // device selection as the cause would mislabel anything else that threw --
+    // a bad_alloc while building this very string, for instance. e.what()
+    // carries the real cause.
     status =
         Err(ErrCode::InvalidArgument,
-            "tcp get: VRAM destination needs a selectable deviceId, got " +
+            "tcp get: VRAM destination copy threw for deviceId " +
                 std::to_string(entry.deviceId) + ": " + e.what());
     entry.state->endWrite(status);
     return status;
@@ -3075,12 +3081,35 @@ void TcpTransport::handleFrameImpl(
           const auto tCopyStart = std::chrono::steady_clock::now();
           Status st = Ok();
           if (entry.memType == MemoryType::VRAM) {
-            st = deviceFromHost(
-                entry.dst,
-                payload.data(),
-                header.len,
-                entry.deviceId,
-                entry.stream);
+            // Returned as a Status rather than allowed to throw. This lambda
+            // runs under writeAndComplete, which rethrows after recording the
+            // failure, and its caller is handleFrameImpl -- so an escaping
+            // exception reaches handleFrame's noexcept boundary, which stops
+            // the reader and fails every other inflight op on the connection.
+            //
+            // That escalation is right where protocol state is in doubt, which
+            // is what the inbound-staging path does. It is wrong here: this
+            // op's admission was already erased above, endWrite records its
+            // failure, and the only thing left half-written is this caller's
+            // own destination, which a failed op already leaves undefined. The
+            // throw comes from CudaDeviceGuard on a locally-registered
+            // deviceId, so a caller's own misconfiguration would otherwise take
+            // down transfers belonging to everyone else on the connection.
+            try {
+              st = deviceFromHost(
+                  entry.dst,
+                  payload.data(),
+                  header.len,
+                  entry.deviceId,
+                  entry.stream);
+            } catch (const std::exception& e) {
+              // Broad on purpose; see the retirement path's note. The message
+              // says the copy threw, not what it presumes threw it.
+              st =
+                  Err(ErrCode::InvalidArgument,
+                      "tcp get: VRAM destination copy threw for deviceId " +
+                          std::to_string(entry.deviceId) + ": " + e.what());
+            }
           } else {
             std::memcpy(entry.dst, payload.data(), header.len);
           }

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -879,6 +879,22 @@ class TcpTransport : public Transport {
   // Reader thread, one per lane: blocking recv + demultiplex on that lane's
   // socket until it closes. Takes the lane index rather than reading a single
   // member, because each reader owns exactly one socket.
+  /// True when something other than the read timeout can notice a dead peer.
+  ///
+  /// Tolerating an idle SO_RCVTIMEO is only safe if death is detected some
+  /// other way. Keepalive and TCP_USER_TIMEOUT are those ways, and the default
+  /// config sets both. TcpSocketConfig::osDefaults() sets neither -- every
+  /// field is nullopt -- and Linux's own keepalive default is off, so on that
+  /// config the read timeout is the only liveness signal there is, and the
+  /// reader has to keep treating it as one.
+  ///
+  /// enableKeepalive is read with value_or(false), not has_value(): nullopt
+  /// means "leave it to the OS", and the OS answer is off.
+  bool hasPeerLivenessDetection() const {
+    return config_.socketConfig.enableKeepalive.value_or(false) ||
+        config_.socketConfig.userTimeout.has_value();
+  }
+
   void readerLoop(size_t laneIdx) noexcept;
 
   // Sender thread, one per lane: drains that lane's queue and performs its

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -864,6 +864,13 @@ class TcpTransport : public Transport {
 
   void shutdown() override;
 
+  /// Logs the get-path phase split (inter-frame stall / drain / destination
+  /// copy) and clears it, so a caller can bracket one measurement. Reads lanes_
+  /// without a lock: callable only between a completed connect() and
+  /// shutdown(). See the definition for why that is a contract rather than a
+  /// mutex.
+  void logAndResetPhaseStats(std::string_view label);
+
  private:
   // Needs handleFrame() plus the outbound queue to drive peer-supplied frames
   // directly and assert the bounds checks reject them. Those checks are the
@@ -879,12 +886,6 @@ class TcpTransport : public Transport {
   // member, because each reader owns exactly one socket.
   void readerLoop(size_t laneIdx) noexcept;
 
- public:
-  /// Logs the get-path phase split (first-byte / drain / destination copy) and
-  /// zeroes it so callers can bracket a single measurement.
-  void logAndResetPhaseStats(std::string_view label);
-
- private:
   // Sender thread, one per lane: drains that lane's queue and performs its
   // socket sends. One writer per socket, which is what keeps TcpConn's
   // single-writer requirement satisfied.

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -62,6 +62,21 @@ inline constexpr std::string_view kDefaultFrontendDevicePrefix = "eth";
 /// TcpTransportConfig::maxFrontendDevices.
 inline constexpr size_t kDefaultMaxFrontendDevices = 2;
 
+/// Ceiling on lanes per connection, and so on the endpoints a peer may
+/// advertise. The lane hello addresses lanes with a uint16_t, and lanes are
+/// configured per device as numSocketsPerDevice * devices, so this bounds the
+/// product.
+///
+/// It bounds the wire parser for the same reason: endpoints are one per device,
+/// connect() requires a peer's endpoint count to equal the local device count,
+/// and numSocketsPerDevice is at least 1 -- so a peer advertising more
+/// endpoints than this could never connect, and refusing them while parsing
+/// rejects nothing that would otherwise have worked. Shared rather than
+/// restated at both sites: two independent copies of this number could drift
+/// apart while each looked right on its own, which is the mistake
+/// maxFrontendDevices already records.
+inline constexpr size_t kMaxLanes = 1024;
+
 /// How many frontend NICs this host actually has -- the hardware ceiling, not a
 /// policy. Enumerates on first call and caches, so it is 0 only when the host
 /// has no usable frontend port at all (none up, or none with a live global

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include <algorithm>
-#include <array>
 #include <atomic>
 #include <cassert>
 #include <chrono>
@@ -711,10 +710,6 @@ struct H2dPollState {
   std::condition_variable drained;
   std::deque<PendingH2d> pending;
   std::shared_ptr<TcpOpState> retiringState;
-  // There are exactly two receive slabs, so at most two copies can become
-  // unquiesceable. Fixed slots avoid allocating on this driver-failure path.
-  std::array<std::optional<PendingH2d>, 2> quarantined;
-  std::shared_ptr<H2dPollState> quarantineKeepalive;
   bool pollScheduled{false};
   bool stopping{false};
   size_t activeRetirements{0};
@@ -1082,9 +1077,10 @@ class TcpTransport : public Transport {
       const std::shared_ptr<H2dPollState>& state,
       int deviceId,
       void* event) noexcept;
-  static void quarantineH2d(
-      const std::shared_ptr<H2dPollState>& state,
-      PendingH2d copy) noexcept;
+  // Terminal: never returns. Everything it reports comes from `copy`, so it
+  // deliberately takes no H2dPollState -- the decision to die does not depend
+  // on poll state.
+  [[noreturn]] static void abortOnUnquiescedH2d(PendingH2d copy) noexcept;
   void drainPendingH2d();
   // Retires staged replies whose copy has finished, oldest first. Runs on the
   // EventBase, never on the reader thread: polling from the reader would put

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -890,11 +890,25 @@ class TcpTransport : public Transport {
   void handleFrameImpl(
       std::span<const uint8_t> frame,
       TcpPinnedSlab receiveSlab);
+  // Both defined below, after TcpLane. Declared up here so the static
+  // reply-path helpers can take them by shared_ptr.
+  struct TcpLaneSet;
+  struct TcpReplyState;
+
   // Queues one fire-and-forget framed message for the sender thread.
   // `mayBlock` must be true only for caller threads. Returns false if the frame
   // was not queued (transport closing, or the reader hit the cap and refused
   // the connection).
   [[nodiscard]] bool enqueueFrame(TcpFrame frame, bool mayBlock);
+  // enqueueFrame without a `this`. The reply callbacks queue through this, so
+  // none of them needs the transport to still exist. enqueueFrame() delegates
+  // here, so there is one implementation of the admission rules.
+  [[nodiscard]] static bool enqueueOn(
+      const std::shared_ptr<TcpReplyState>& state,
+      TcpFrame frame,
+      bool mayBlock);
+  static size_t pickLaneOn(TcpLaneSet& lanes);
+  static size_t laneCapBytesOn(const TcpLaneSet& lanes);
   // Queues a run of frames. A group small enough not to be worth parallelising
   // goes on ONE lane as an indivisible step, either every frame queued or none:
   // enqueuing one at a time would let a sender start transmitting a partially
@@ -962,9 +976,15 @@ class TcpTransport : public Transport {
       TcpSegmentRegistry::Lease lease);
   // Builds the reply in `slab` and starts its D2H copy, handing the frame to
   // the staging queue so the reader can go back to draining the socket instead
-  // of waiting on the device. Consumes the lease and the slab. Returns an error
-  // only if the copy could not be started, in which case nothing was queued.
-  Status startReadReply(
+  // of waiting on the device. Consumes the lease and the slab.
+  //
+  // An error does NOT imply that no device work happened. Two shapes:
+  // the copy could not be started, in which case nothing was queued; or the
+  // reply path was already stopping, in which case the copy WAS issued and then
+  // waited out before this returned NotConnected. Callers must therefore not
+  // read an error as "the device is untouched" -- only as "nothing was queued".
+  static Status startReadReply(
+      const std::shared_ptr<TcpReplyState>& state,
       const TcpMsgHeader& replyHeader,
       TcpSegmentRegistry::Lease lease,
       TcpPinnedSlab slab);
@@ -1011,11 +1031,13 @@ class TcpTransport : public Transport {
   // on the EventBase, never inline at the point a slab is released: that point
   // is the sender thread, and launching copies there would block the drain that
   // frees the next slab.
-  void startDeferredReadReplies();
+  static void startDeferredReadReplies(
+      const std::shared_ptr<TcpReplyState>& state);
   // Kicks startDeferredReadReplies() on the EventBase. Called wherever a
   // staging slab goes back to the pool. Cheap and safe when nothing is
   // deferred.
-  void scheduleDeferredReadReplies();
+  static void scheduleDeferredReadReplies(
+      const std::shared_ptr<TcpReplyState>& state);
   // The staging pool, created on first use. Building it in the constructor
   // would charge every peer kStagingSlabCount slabs of pinned host memory --
   // ~124 MiB, and there is one transport per peer -- including the DRAM-only
@@ -1023,7 +1045,8 @@ class TcpTransport : public Transport {
   //
   // Named as the constant, not restated as a number: the previous wording
   // hardcoded a figure and went stale when kStagingSlabCount was re-derived.
-  Result<std::shared_ptr<TcpPinnedSlabPool>> stagingPool();
+  static Result<std::shared_ptr<TcpPinnedSlabPool>> stagingPool(
+      const std::shared_ptr<TcpReplyState>& state);
   // The independent inbound pool. It is created only for async-enabled,
   // non-zero VRAM get(), and is sized to the wire cap because recv(span)
   // consumes the length prefix before it can reject an undersized buffer.
@@ -1054,13 +1077,17 @@ class TcpTransport : public Transport {
   // Retires staged replies whose copy has finished, oldest first. Runs on the
   // EventBase, never on the reader thread: polling from the reader would put
   // the head-of-line block straight back.
-  void pollPendingReadReplies();
+  static void pollPendingReadReplies(
+      const std::shared_ptr<TcpReplyState>& state);
   // Kicks the poll loop if it is not already running. Safe from any thread.
-  void schedulePendingReplyPoll();
+  static void schedulePendingReplyPoll(
+      const std::shared_ptr<TcpReplyState>& state);
   /// Waits for a staged D2H copy on `deviceId` whose completion is otherwise
   /// unknown, so the frame it targets can be released. Used on the paths where
   /// a copy was issued but the event never became a usable completion signal.
-  void waitForStagedCopy(int deviceId) noexcept;
+  static void waitForStagedCopy(
+      const std::shared_ptr<TcpReplyState>& state,
+      int deviceId) noexcept;
 
   /// Waits for outstanding staging copies and drops the frames, then discards
   /// whatever was still deferred. Called during teardown, because the GPU may
@@ -1168,12 +1195,88 @@ class TcpTransport : public Transport {
     size_t bytes{0};
     bool outClosed{false};
   };
-  // Indirected because TcpLane holds an atomic and a thread, so it is neither
-  // copyable nor movable and the vector must never have to relocate it. Written
-  // only by connect() under lifecycleMu_, and read by the reader threads, the
-  // sender thread and shutdown() -- all of which run only after connect() has
-  // installed every lane.
-  std::vector<std::unique_ptr<TcpLane>> lanes_;
+  /// The lane set, owned separately from the transport.
+  ///
+  /// Held by shared_ptr so an EventBase callback that outlives the transport
+  /// can still enqueue into it harmlessly: by then the senders are joined, so
+  /// the frame simply sits in a queue that dies with this object. That is what
+  /// lets the reply callbacks below drop their `this` capture entirely.
+  struct TcpLaneSet {
+    // Indirected because TcpLane holds an atomic and a thread, so it is neither
+    // copyable nor movable and the vector must never have to relocate it.
+    // Written only by connect() under lifecycleMu_, and read by the reader
+    // threads, the sender thread and shutdown() -- all of which run only after
+    // connect() has installed every lane.
+    std::vector<std::unique_ptr<TcpLane>> v;
+    std::atomic<bool> broken{false};
+    // Round-robin cursor. Relaxed: an occasional duplicate or skipped index
+    // only perturbs balance, and nothing reads it for correctness.
+    std::atomic<uint64_t> nextLane{0};
+  };
+
+  /// Everything the EventBase-dispatched reply callbacks touch, owned
+  /// separately from the transport for the same reason.
+  ///
+  /// This is the H2dPollState pattern already used on the H2D path
+  /// (pollPendingH2d is static and takes its state), applied to the reply path.
+  /// The callbacks are static and take this state, so none of them can hold a
+  /// `this` that the destructor has already freed -- the bug is impossible
+  /// rather than guarded, and teardown never has to block waiting for a
+  /// callback to leave a critical section.
+  struct TcpReplyState {
+    // MEMBER ORDER IS LOAD-BEARING. Members are destroyed in reverse
+    // declaration order, so this reads bottom-up as the destruction sequence:
+    //
+    //   1. `pending` / `deferred` go first, releasing the Leases and slabs they
+    //      hold WHILE the objects those releases reach into are still alive.
+    //   2. then `registry` / `cudaApi` / `pool` / `lanes`, which those releases
+    //      needed.
+    //   3. the mutexes last, so nothing is destroyed while notionally guarded.
+    //
+    // Getting this backwards is not theoretical: `registry` used to be declared
+    // last, which destroyed it FIRST, so a Lease still sitting in `pending`
+    // would have called releaseLease() through a raw pointer to a destroyed
+    // registry -- defeating the entire reason the member exists.
+    std::mutex mu;
+    /// Its own mutex rather than `mu`: acquiring a slab can wait (put(), from a
+    /// caller thread), and the staging queue must stay available to the reader
+    /// while it does.
+    std::mutex poolMu;
+    /// Set by shutdown() under `mu`. A callback that wakes after teardown sees
+    /// it and returns without touching anything.
+    bool stopping{false};
+    bool pollScheduled{false};
+    /// Keeps the registry alive for as long as any lease might outlive the
+    /// transport. TcpSegmentRegistry::Lease holds a RAW registry pointer and
+    /// dereferences it in ~Lease to release, while leases travel this path --
+    /// startReadReply's parameter, `pending`, `deferred`. The transport is
+    /// normally the registry's only owner, so a callback still in flight when
+    /// ~TcpTransport() finishes -- say one that popped a deferred entry, then
+    /// saw `stopping` and is waiting out its copy -- would release into freed
+    /// memory. Held here for the same reason as cudaApi and lanes: a callback
+    /// must not reach through a transport that may already be gone.
+    ///
+    /// Declared BEFORE the queues below so it outlives the leases they hold.
+    std::shared_ptr<TcpSegmentRegistry> registry;
+    /// Copies, so a callback never reaches through the transport for them.
+    std::shared_ptr<CudaApi> cudaApi;
+    std::shared_ptr<TcpPinnedSlabPool> pool;
+    std::shared_ptr<TcpLaneSet> lanes;
+    EventBase* evb{nullptr};
+    /// Declared LAST so these are destroyed FIRST: emptying them releases
+    /// leases into the still-live registry above, and slabs into the still-live
+    /// pool.
+    std::deque<PendingReadReply> pending;
+    std::deque<DeferredReadReply> deferred;
+  };
+
+  std::shared_ptr<TcpLaneSet> laneSet_{std::make_shared<TcpLaneSet>()};
+  std::shared_ptr<TcpReplyState> reply_{std::make_shared<TcpReplyState>()};
+
+  // Aliases onto the two objects above, so the rest of this class keeps naming
+  // these the way it always has. Declared after them: reference members are
+  // bound in declaration order.
+  std::vector<std::unique_ptr<TcpLane>>& lanes_{laneSet_->v};
 
   // get-path copy accounting, paired with Conn::RecvPhaseStats. Reader thread
   // only; relaxed because a torn read across a reset misattributes a sample and
@@ -1341,34 +1444,31 @@ class TcpTransport : public Transport {
   // first to finish rather than returning while teardown is still running.
   std::atomic<bool> shutdown_{false};
 
-  // Round-robin cursor for lane selection. Relaxed: an occasional duplicate or
-  // skipped index only perturbs balance, and nothing reads it for correctness.
-  std::atomic<uint64_t> nextLane_{0};
   std::atomic<bool> running_{false};
-  std::atomic<bool> connBroken_{false};
+  std::atomic<bool>& connBroken_{laneSet_->broken};
 
   // Guards the staging queue, which the reader thread appends to and the
   // EventBase drains.
-  std::mutex stagingMu_;
-  std::deque<PendingReadReply> pendingReplies_;
+  std::mutex& stagingMu_{reply_->mu};
+  std::deque<PendingReadReply>& pendingReplies_{reply_->pending};
   // Retired strictly front-first. Copies for one device go on that device's
   // stream and so signal in issue order; across devices they are independent,
   // so a reply that is ready can wait behind an older one still running.
   // Ordered retirement is still correct -- offsets make out-of-order replies
   // safe on the wire, this only costs latency -- and a transport serves one
   // peer, which in practice means one device.
-  bool replyPollScheduled_{false};
+  bool& replyPollScheduled_{reply_->pollScheduled};
   // VRAM reads that arrived with the pool exhausted, oldest first. Bounded by
   // kMaxInflightRequests for the same reason inflight_ is: it grows on
   // peer-supplied frames, and the reader will not stop reading them.
-  std::deque<DeferredReadReply> deferredReplies_;
+  std::deque<DeferredReadReply>& deferredReplies_{reply_->deferred};
 
   // Created on first VRAM staging need, then never replaced. Its own mutex
   // rather than stagingMu_: acquiring a slab can wait (put(), from a caller
   // thread), and the staging queue must stay available to the reader while it
   // does.
-  std::mutex poolMu_;
-  std::shared_ptr<TcpPinnedSlabPool> slabPool_;
+  std::mutex& poolMu_{reply_->poolMu};
+  std::shared_ptr<TcpPinnedSlabPool>& slabPool_{reply_->pool};
 
   // Separate from the outbound/responder staging pool: receive slabs must hold
   // any legal wire frame, not just one kMaxChunkSize payload.

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -483,12 +483,23 @@ class TcpSegmentRegistry {
   /// for longer still: its copy has not been issued yet and starts only once a
   /// slab frees up.
   ///
-  /// What this can no longer do is deadlock. The reader thread does not wait
-  /// for any of it -- staging is asynchronous and exhaustion defers rather than
-  /// blocks -- so it keeps delivering inbound frames, including whatever the
-  /// application's GPU work is itself waiting on. Giving the staging copies a
-  /// dedicated non-blocking stream would remove the remaining wait on unrelated
-  /// device work.
+  /// **On the read-reply path** this can no longer deadlock. The reader thread
+  /// does not wait for any of that staging -- the copy is asynchronous and
+  /// exhaustion defers rather than blocks -- so it keeps delivering inbound
+  /// frames, including whatever the application's GPU work is itself waiting
+  /// on. Giving the staging copies a dedicated non-blocking stream would remove
+  /// the remaining wait on unrelated device work.
+  ///
+  /// The claim is scoped deliberately: it is about the read-reply path, not
+  /// about erase() in general. An inbound `TcpOp::Write` into a VRAM segment
+  /// also holds a lease across its H2D copy, and that copy the reader *does*
+  /// wait for. It runs on a dedicated non-blocking stream, so the wait is
+  /// bounded by that one copy and not by unrelated application GPU work --
+  /// which is what keeps it a delay rather than a deadlock. On the null stream
+  /// it was the latter: the reader would wait on every blocking stream on the
+  /// device, including work that could only be unblocked by a frame the parked
+  /// reader was itself supposed to deliver. A DRAM-only deployment never had
+  /// that exposure, because there the copy under lease is a plain memcpy.
   void erase(uint64_t segId) {
     std::unique_lock<std::mutex> lk(mu_);
     auto it = segs_.find(segId);
@@ -1469,6 +1480,25 @@ class TcpTransport : public Transport {
   // does.
   std::mutex& poolMu_{reply_->poolMu};
   std::shared_ptr<TcpPinnedSlabPool>& slabPool_{reply_->pool};
+
+  /// Non-blocking streams for inbound `TcpOp::Write` H2D copies, one per
+  /// device, created on first use for that device. Per-device because a stream
+  /// belongs to the device it was created on and registered segments may sit on
+  /// different devices -- one transport-wide stream would be used with the
+  /// wrong device current.
+  ///
+  /// The point of them is the lease. The Write handler holds a registry lease
+  /// across its copy, and erase() waits on that lease; on the null stream the
+  /// copy also waits on every blocking stream on the device, so the reader
+  /// could be parked on application GPU work that only the reader could
+  /// unblock. A non-blocking stream bounds the wait by the copy itself.
+  std::mutex writeStreamMu_;
+  std::unordered_map<int, void*> writeStreams_;
+
+  /// The non-blocking stream for `deviceId`, creating it on first use. Returns
+  /// an error rather than falling back to the null stream: the fallback is the
+  /// deadlock this exists to remove, so a Write is failed loudly instead.
+  Result<void*> writeStreamFor(int deviceId);
 
   // Separate from the outbound/responder staging pool: receive slabs must hold
   // any legal wire frame, not just one kMaxChunkSize payload.

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportConnectTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportConnectTest.cpp
@@ -620,6 +620,43 @@ TEST(TcpTransportInfoTest, RejectsTrailingGarbage) {
   EXPECT_EQ(parsed.error().code(), ErrCode::InvalidArgument);
 }
 
+// The record count is peer-supplied, and connect() only compares it against the
+// local device count once the whole vector exists. An endpoint whose host is
+// empty is a bare 4-byte Header, so without a cap the 64 MiB the control
+// channel admits parses into ~16.7M Endpoint objects before being rejected --
+// and the callers that reach connect() without going through the controller are
+// bounded only by the uint32_t child length, which is far larger.
+TEST(TcpTransportInfoTest, RejectsMoreEndpointsThanLanesCanAddress) {
+  TcpTransportInfo info;
+  info.host = "2401:db00::1";
+  info.port = 100;
+  // One past the cap, since the primary endpoint counts toward it.
+  info.extraEndpoints.resize(kMaxLanes);
+
+  auto parsed = TcpTransportInfo::deserialize(info.serialize());
+
+  ASSERT_TRUE(parsed.hasError())
+      << "an endpoint count above the lane cap has to be refused while parsing,"
+         " not after the vector has been built";
+  EXPECT_EQ(parsed.error().code(), ErrCode::InvalidArgument);
+}
+
+// The complement, and the one that matters more: the cap must not refuse a
+// count connect() would have accepted. kMaxLanes endpoints is reachable with
+// numSocketsPerDevice == 1, so this is a legal configuration and not a boundary
+// curiosity.
+TEST(TcpTransportInfoTest, AcceptsTheLargestAddressableEndpointCount) {
+  TcpTransportInfo info;
+  info.host = "2401:db00::1";
+  info.port = 100;
+  info.extraEndpoints.resize(kMaxLanes - 1);
+
+  auto parsed = TcpTransportInfo::deserialize(info.serialize());
+
+  ASSERT_TRUE(parsed.hasValue()) << parsed.error().message();
+  EXPECT_EQ(parsed.value().endpointCount(), kMaxLanes);
+}
+
 // Placement is derived from the lane index on both sides rather than
 // negotiated, so a device-count mismatch has to be caught up front. Left
 // undetected it would put lanes on the wrong NIC, which is the exact class of

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
@@ -955,6 +955,58 @@ TEST_F(TcpTransportFrameTest, InBoundsWriteIsApplied) {
   EXPECT_FALSE(queuedErrorFrame());
 }
 
+// The reader holds a registry lease across an inbound Write's H2D copy, and
+// erase() waits on that lease. On the null stream the copy also waits on every
+// blocking stream on the device, so the reader could be parked on application
+// GPU work that only the reader itself could unblock -- a deadlock, not a
+// delay. The copy therefore has to go on a stream of the transport's own.
+TEST_F(TcpTransportFrameTest, AVramWriteCopyDoesNotUseTheNullStream) {
+  constexpr uint64_t kVramSegId = kSegId + 220;
+  constexpr size_t kLen = 8;
+  std::vector<std::byte> vram(kLen, std::byte{0});
+  registry_->add(
+      kVramSegId, vram.data(), kLen, MemoryType::VRAM, /*deviceId=*/0);
+
+  MockStream created{};
+  EXPECT_CALL(*cudaApi_, streamCreateNonBlocking(::testing::_))
+      .WillOnce([&](MockStream* out) -> Status {
+        // MockStream, not cudaStream_t: this TU is not hipified, so under ROCm
+        // the cuda name does not exist here while the alias -- declared in the
+        // hipified MockCudaApi.h -- resolves in both builds. Same reason the
+        // event stubs above spell their parameter `auto`.
+        //
+        // A distinct non-null handle, so the assertion below cannot pass by
+        // accident on a null stream.
+        created = reinterpret_cast<MockStream>(0xB0B0);
+        *out = created;
+        return Ok();
+      });
+
+  MockStream copyStream = reinterpret_cast<MockStream>(0);
+  bool copied = false;
+  EXPECT_CALL(
+      *cudaApi_,
+      memcpyAsync(
+          ::testing::_, ::testing::_, kLen, kMockMemcpyH2D, ::testing::_))
+      .WillOnce(
+          [&](void* d, const void* src, size_t n, auto, auto stream) -> Status {
+            copyStream = static_cast<MockStream>(stream);
+            std::memcpy(d, src, n);
+            copied = true;
+            return Ok();
+          });
+
+  feed(makeFrame(TcpOp::Write, kVramSegId, /*offset=*/0, /*len=*/kLen, kLen));
+
+  ASSERT_TRUE(copied) << "the VRAM write should have issued an H2D copy";
+  EXPECT_NE(copyStream, reinterpret_cast<MockStream>(0))
+      << "an inbound VRAM write must not copy on the null stream: the reader "
+         "waits for this copy while holding a lease erase() waits on";
+  EXPECT_EQ(copyStream, created)
+      << "it must be the transport's own non-blocking stream";
+  EXPECT_FALSE(queuedErrorFrame());
+}
+
 TEST(TcpOpStateTest, FailureWaitsForReservedWriteToRetire) {
   TcpOpState state;
   state.remaining = 1;

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
@@ -563,7 +563,7 @@ class TcpTransportFrameTest : public ::testing::Test {
   /// The transport's own staging pool, created on the first call exactly as a
   /// VRAM read would create it.
   std::shared_ptr<TcpPinnedSlabPool> transportStagingPool() {
-    auto pool = transport_->stagingPool();
+    auto pool = TcpTransport::stagingPool(transport_->reply_);
     EXPECT_TRUE(pool.hasValue());
     return pool.hasValue() ? pool.value() : nullptr;
   }

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
@@ -80,6 +80,42 @@ class FailingConn : public controller::Conn {
   int closeCount{0};
 };
 
+/// A connection whose recv() reports ErrCode::Timeout a fixed number of times
+/// and then fails for real. Models an idle data socket: SO_RCVTIMEO fires while
+/// the peer is simply between transfers, and only afterwards does the
+/// connection actually break.
+class IdleThenFailConn : public controller::Conn {
+ public:
+  explicit IdleThenFailConn(int timeouts) : remaining_(timeouts) {}
+
+  std::future<Result<size_t>> send(std::span<const uint8_t> data) override {
+    return make_ready_future<Result<size_t>>(Result<size_t>(data.size()));
+  }
+  std::future<Result<size_t>> recv(std::vector<uint8_t>&) override {
+    return make_ready_future<Result<size_t>>(next());
+  }
+  std::future<Result<size_t>> recv(std::span<uint8_t>) override {
+    return make_ready_future<Result<size_t>>(next());
+  }
+  void close() override {}
+
+  int timeoutsDelivered() const {
+    return delivered_.load(std::memory_order_acquire);
+  }
+
+ private:
+  Result<size_t> next() {
+    if (remaining_.fetch_sub(1, std::memory_order_acq_rel) > 0) {
+      delivered_.fetch_add(1, std::memory_order_release);
+      return Err(ErrCode::Timeout, "test: recv timed out while idle");
+    }
+    return Err(ErrCode::ConnectionFailed, "test: connection really failed");
+  }
+
+  std::atomic<int> remaining_;
+  std::atomic<int> delivered_{0};
+};
+
 /// A connection that accepts every send and counts them, for the tests that
 /// need the sender to actually drain the queue.
 class CountingConn : public controller::Conn {
@@ -508,6 +544,26 @@ class TcpTransportFrameTest : public ::testing::Test {
 
   void runSenderLoop() {
     transport_->senderLoop(0);
+  }
+
+  /// Runs lane 0's reader loop on the calling thread. It returns when the loop
+  /// exits, so a test can assert on *whether* it exited rather than polling.
+  void runReaderLoop() {
+    transport_->readerLoop(0);
+  }
+
+  /// Drops both liveness mechanisms, the way TcpSocketConfig::osDefaults()
+  /// does.
+  void clearPeerLivenessConfig() {
+    transport_->config_.socketConfig.enableKeepalive = std::nullopt;
+    transport_->config_.socketConfig.userTimeout = std::nullopt;
+  }
+
+  IdleThenFailConn& installIdleThenFailConn(int timeouts) {
+    auto conn = std::make_unique<IdleThenFailConn>(timeouts);
+    auto& ref = *conn;
+    installLaneConn(std::move(conn));
+    return ref;
   }
 
   /// Installs a connection whose send() parks until released, so the sender
@@ -1214,6 +1270,58 @@ TEST_F(
       std::string::npos)
       << "the failure must be attributed to this op's own copy, not to a "
          "connection error";
+}
+
+// SO_RCVTIMEO is set on every connected socket to bound the *handshake* against
+// a peer that accepts and then stops responding. It is not a read deadline, but
+// it applies for the connection's whole life, so an idle gap between transfers
+// -- the normal state of a prefill/decode connection between bursts -- fires
+// exactly the same EAGAIN. Treating that as a dead peer tore the connection
+// down every 30s of quiet and failed every in-flight op with it.
+//
+// The reader must consume timeouts and keep serving, and still exit on a real
+// failure. Dead peers are detected by SO_KEEPALIVE / TCP_USER_TIMEOUT, which
+// the socket config already plumbs.
+TEST_F(TcpTransportFrameTest, AnIdleRecvTimeoutDoesNotEndTheReader) {
+  setConnected();
+  setReaderRunning();
+  // Three idle timeouts, then the connection genuinely breaks. Without the fix
+  // the loop exits on the first one and only one is ever delivered.
+  auto& conn = installIdleThenFailConn(/*timeouts=*/3);
+
+  // Returns when the loop exits, which the real failure guarantees it will.
+  runReaderLoop();
+
+  // That runReaderLoop() returned at all is the proof it still exits on a real
+  // failure -- a reader that treated every error as idleness would spin here
+  // and the test would time out rather than fail. running_ is deliberately not
+  // asserted: readerLoop does not clear it on the way out, shutdown() does, so
+  // EXPECT_FALSE(readerRunning()) would be asserting something this code never
+  // promised.
+  EXPECT_EQ(conn.timeoutsDelivered(), 3)
+      << "the reader stopped on an idle timeout instead of continuing; a "
+         "prefill/decode connection would be torn down between bursts";
+}
+
+// The other half of the contract. Tolerating an idle timeout is only safe when
+// something else can notice a dead peer; osDefaults() sets neither keepalive
+// nor TCP_USER_TIMEOUT, and Linux defaults keepalive off, so there the read
+// timeout is the only liveness signal there is. Continuing on it would trade a
+// wrongly-closed connection for one that never notices the peer is gone.
+TEST_F(
+    TcpTransportFrameTest,
+    AnIdleTimeoutStillEndsTheReaderWithNoLivenessConfig) {
+  setConnected();
+  setReaderRunning();
+  clearPeerLivenessConfig();
+  // Offers three timeouts; only the first should ever be taken.
+  auto& conn = installIdleThenFailConn(/*timeouts=*/3);
+
+  runReaderLoop();
+
+  EXPECT_EQ(conn.timeoutsDelivered(), 1)
+      << "with no keepalive and no TCP_USER_TIMEOUT the read timeout is the only "
+         "way a dead peer is ever noticed, so the reader must still stop on it";
 }
 
 // A vector-backed READ_REPLY still copies synchronously. Resolving the op's

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
@@ -365,6 +365,13 @@ class TcpTransportFrameTest : public ::testing::Test {
     return transport_->running_.load(std::memory_order_acquire);
   }
 
+  /// Arms the reader flag. The fixture never starts a reader loop, so running_
+  /// is false by default -- a test asserting the reader SURVIVES something has
+  /// to set it first, or the assertion passes for the wrong reason.
+  void setReaderRunning() {
+    transport_->running_.store(true, std::memory_order_release);
+  }
+
   /// Registers `chunks` in-flight READ chunks sharing one op state, the way a
   /// multi-chunk get() does. Chunk reqId 1 targets `dst`; the rest stand in for
   /// siblings whose replies have not arrived yet. VRAM so the copy runs through
@@ -1154,6 +1161,59 @@ TEST_F(TcpTransportFrameTest, AsyncReadReplyFailureWaitsForEventRetirement) {
       future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
   EXPECT_TRUE(future.get().hasError());
   EXPECT_EQ(dst, std::vector<uint8_t>(kLen, uint8_t{0xCD}));
+}
+
+// The sibling test below asserts that a throw during *inbound staging* fails
+// the connection, and that is right: protocol state is in doubt there. This is
+// the other direction -- the get destination copy -- where it is not, and one
+// op's local misconfiguration must not take the connection with it.
+//
+// The throw comes from CudaDeviceGuard on a deviceId the *caller* registered,
+// so without this the caller's own mistake fails every unrelated transfer on
+// the connection and stops the reader. Its admission is already erased and its
+// future already failed, and the only half-written buffer is the caller's own
+// destination, which a failed op leaves undefined anyway.
+TEST_F(
+    TcpTransportFrameTest,
+    AThrowingGetDestinationCopyKeepsTheConnectionAndReaderAlive) {
+  constexpr size_t kLen = 64;
+  std::vector<uint8_t> dst(kLen, 0);
+  // Two chunks so that a connection failure would be distinguishable: it would
+  // resolve this op with a connection error instead of the copy's own. Note
+  // postReadChunks returns ONE future for the whole op, so there is no separate
+  // sibling operation here whose survival could be asserted -- what is checked
+  // below is that the connection and reader stay live and that the failure
+  // keeps its own cause.
+  auto future = postReadChunks(dst.data(), kLen, /*chunks=*/2);
+  setReaderRunning();
+
+  // postReadChunks registers deviceId 0, so this is the guard the copy builds.
+  EXPECT_CALL(*cudaApi_, setDevice(0))
+      .WillRepeatedly(
+          ::testing::Return(
+              Err(ErrCode::InvalidArgument, "test: no such device")));
+
+  feed(makeFrame(TcpOp::ReadReply, kSegId, /*offset=*/0, kLen, kLen));
+
+  EXPECT_FALSE(connBroken())
+      << "one op's destination-copy throw must not fail the connection: its "
+         "admission is already erased and nothing transport-internal is left "
+         "inconsistent";
+  EXPECT_TRUE(readerRunning())
+      << "the reader must keep serving the other transfers on this connection";
+
+  // The op itself is still failed, and with the reason rather than a generic
+  // one.
+  ASSERT_EQ(future.wait_for(std::chrono::seconds(1)), std::future_status::ready)
+      << "the op whose copy threw must be resolved, not left hanging";
+  const Status status = future.get();
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::InvalidArgument);
+  EXPECT_NE(
+      status.error().message().find("destination copy threw"),
+      std::string::npos)
+      << "the failure must be attributed to this op's own copy, not to a "
+         "connection error";
 }
 
 // A vector-backed READ_REPLY still copies synchronously. Resolving the op's

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
@@ -1324,6 +1324,33 @@ TEST_F(
          "way a dead peer is ever noticed, so the reader must still stop on it";
 }
 
+// establishLanes() skips the hello exchange when this side has one lane, so the
+// wire stays byte-identical for a peer built before lanes existed. The cost is
+// that a peer configured for more lanes sends a hello this side never reads: it
+// is shorter than a TcpMsgHeader, so it used to be dropped as malformed while
+// the peer went on striping onto sockets nobody accepted -- a silent stall, and
+// the opposite of the clean handshake error the design promises.
+//
+// One configuration normally drives both sides, so this cannot happen in
+// practice. That is the reason it must be loud if it does.
+TEST_F(
+    TcpTransportFrameTest,
+    ALaneHelloOnASingleLaneTransportFailsTheConnection) {
+  setConnected();
+  setReaderRunning();
+
+  TcpLaneHello hello{};
+  hello.laneIndex = 0;
+  hello.laneCount = 4;
+  hello.sessionId = 0xABCDEF;
+  feed(hello.serialize());
+
+  EXPECT_TRUE(connBroken())
+      << "a lane hello arriving as a data frame means the peer is striping onto "
+         "sockets this side never accepted; dropping it strands the peer "
+         "silently";
+}
+
 // A vector-backed READ_REPLY still copies synchronously. Resolving the op's
 // future is what releases the caller to free its destination, so that fallback
 // copy and completion remain one atomic lifetime reservation.


### PR DESCRIPTION
Summary:
`TcpTransportInfo::deserialize` consumes extra-endpoint records until the buffer
is exhausted, with no bound on how many it will build. Raised by mahi on
D117632611; filed as C-086 in the audit register.

Every individual read is already bounds-checked, so this is not a memory-safety
defect -- it is amplification. A record whose host is empty is a bare 4-byte
packed `Header`, and `connect()` does not compare the peer's endpoint count
against the local device count until the whole vector exists. So the 64 MiB the
control channel admits (`kMaxMessageSize`, `TcpController.cpp:88`) parses into
~16.7M `Endpoint` objects -- a `uint16_t` plus a `std::string` each -- before
being rejected for a count mismatch.

The 64 MiB ceiling is not universal, which is the part that decides this is
worth a bound rather than a comment. It holds where the bytes are carried by
`controller::TcpConn`: the `UniflowAgent` handshake, the vLLM connector, and the
benchmark rendezvous. It does not hold for `MultiTransport::connect()` as
exposed to Python (`UniflowPy.cpp:480-498`), for the TorchStore/TorchComms
handshake, or for the MPI integration tests. On those the only structural bound
is the `uint32_t` child length, so the record ceiling is ~1.07G, and a
`bad_alloc` escapes a `Result`-returning contract while the allocation pressure
lands on unrelated work in the process.

**The cap is `kMaxLanes`, and it rejects nothing that could ever connect.**
Endpoints are one per device; `connect()` requires `peer.endpointCount() ==
localDevices`; and `laneCount = numSocketsPerDevice * localDevices` is already
capped at `kMaxLanes` with `numSocketsPerDevice` at least 1. So a peer
advertising more endpoints than the lane cap could never have completed a
handshake, and refusing it while parsing only moves the rejection earlier.

`kMaxLanes` moves from a function-local `constexpr` in `connect()` to the header
so both sites read one number. That is the point rather than tidying: this file
already carries the record of two copies of `maxFrontendDevices` that "could
drift apart while each looked right on its own", asserted since by
`FrontendDeviceCapDefaultsToTwo`. Two independent 1024s here would repeat it.

mahi suggested 255, "to mirror the lane addressing". That mirrored an earlier
cap; at tip the lane cap is 1024 over a `uint16_t` hello. 255 would also be
safe, but it would be a number with no referent in the code.

Not a data-path change. `deserialize` runs once per `connect()`, off the reader
and sender threads, and is not reached by `put()`, `get()`, `send`/`recv` or the
frame wire format, so no two-host benchmark applies and none is claimed.

Differential Revision: D118599423
