### PR TITLE
Add intent-oriented logging macro names

### DIFF
--- a/comms/ctran/utils/CtranLogUtils.h
+++ b/comms/ctran/utils/CtranLogUtils.h
@@ -45,9 +45,14 @@
     }                                                                    \
   } while (false)
 
+#define CTRAN_TRACE(subsys, format, ...) \
+  CTRAN_LOG_TRACE(subsys, format, ##__VA_ARGS__)
+
 #define CTRAN_ERR(code, ...)                                                  \
   do {                                                                        \
     const auto _ctran_error_message = fmt::format(__VA_ARGS__);               \
     CTRAN_LOG(ERR, "{}", _ctran_error_message);                               \
     ::meta::comms::logger::logCommErrorToScuba((code), _ctran_error_message); \
   } while (false)
+
+#define CTRAN_REPORT_ERROR(code, ...) CTRAN_ERR(code, __VA_ARGS__)

--- a/comms/ctran/utils/tests/LogUT.cc
+++ b/comms/ctran/utils/tests/LogUT.cc
@@ -80,13 +80,13 @@ TEST_F(CtranUtilsLogTest, TestCtranLoggerPreservesLastError) {
       testing::HasSubstr("Spdlog CTRAN error 42"));
 }
 
-TEST_F(CtranUtilsLogTest, TestCtranErrEvaluatesArgumentsOnce) {
+TEST_F(CtranUtilsLogTest, TestCtranReportErrorEvaluatesArgumentsOnce) {
   auto& logger =
       meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName);
   logger.set_level(spdlog::level::err);
 
   int evaluated = 0;
-  CTRAN_ERR(commInternalError, "CTRAN error {}", ++evaluated);
+  CTRAN_REPORT_ERROR(commInternalError, "CTRAN error {}", ++evaluated);
 
   EXPECT_EQ(evaluated, 1);
   EXPECT_THAT(
@@ -243,7 +243,7 @@ TEST_F(CtranUtilsLogTest, TestCtranTraceFormat) {
   meta::comms::logger::setSubSystemMask(meta::comms::logger::SubSystem::COLL);
 
   testing::internal::CaptureStdout();
-  CTRAN_LOG_TRACE(COLL, "trace value {}", 42);
+  CTRAN_TRACE(COLL, "trace value {}", 42);
   logger.flush();
   const auto output = testing::internal::GetCapturedStdout();
 

--- a/comms/ncclx/meta/NcclxChecks.h
+++ b/comms/ncclx/meta/NcclxChecks.h
@@ -33,22 +33,23 @@ inline ::meta::comms::CommsError getCommsErrorFromCudaError(
 
 } // namespace ncclx::logging::detail
 
-#define NCCLX_CUDA_CHECK_EXPECTED(command)                               \
-  do {                                                                   \
-    const auto _ncclx_cuda_error = (command);                            \
-    if (_ncclx_cuda_error != cudaSuccess) {                              \
-      NCCLX_ERR(commUnhandledCudaError, "Call for {} failed", #command); \
-      return folly::makeUnexpected(                                      \
-          ::ncclx::logging::detail::getCommsErrorFromCudaError(          \
-              _ncclx_cuda_error, __FILE__, __LINE__, #command));         \
-    }                                                                    \
+#define NCCLX_CUDA_CHECK_EXPECTED(command)                         \
+  do {                                                             \
+    const auto _ncclx_cuda_error = (command);                      \
+    if (_ncclx_cuda_error != cudaSuccess) {                        \
+      NCCLX_REPORT_ERROR(                                          \
+          commUnhandledCudaError, "Call for {} failed", #command); \
+      return folly::makeUnexpected(                                \
+          ::ncclx::logging::detail::getCommsErrorFromCudaError(    \
+              _ncclx_cuda_error, __FILE__, __LINE__, #command));   \
+    }                                                              \
   } while (false)
 
 #define NCCLX_CUDACHECKTHROW(command)             \
   do {                                            \
     const auto _ncclx_cuda_error = (command);     \
     if (_ncclx_cuda_error != cudaSuccess) {       \
-      NCCLX_ERR(                                  \
+      NCCLX_REPORT_ERROR(                         \
           commUnhandledCudaError,                 \
           "{}:{} Cuda failure {}",                \
           __FILE__,                               \

--- a/comms/ncclx/meta/NcclxLogUtils.h
+++ b/comms/ncclx/meta/NcclxLogUtils.h
@@ -27,3 +27,5 @@
     NCCLX_LOG(ERR, "{}", _ncclx_error_message);                               \
     ::meta::comms::logger::logCommErrorToScuba((code), _ncclx_error_message); \
   } while (false)
+
+#define NCCLX_REPORT_ERROR(code, ...) NCCLX_ERR(code, __VA_ARGS__)


### PR DESCRIPTION
Summary: Expose intent-oriented aliases for named MCCL logging, CTRAN tracing, and CTRAN/NCCLX error reporting while retaining the established macro spellings for source compatibility. Existing macro expansions remain unchanged; only the two NCCLX CUDA-check call sites and focused tests adopt the clearer names.

Differential Revision: D118990909


