### PR TITLE
comms/uniflow/tcp: bound the staging-pool acquire so an exhausted pool fails instead of hanging

### DIFF
--- a/comms/uniflow/transport/tcp/TcpPinnedSlabPool.cpp
+++ b/comms/uniflow/transport/tcp/TcpPinnedSlabPool.cpp
@@ -152,7 +152,9 @@ TcpPinnedSlab TcpPinnedSlabPool::tryAcquire(bool allowReserved) {
       slabSize_};
 }
 
-Result<std::vector<TcpPinnedSlab>> TcpPinnedSlabPool::acquire(size_t count) {
+Result<std::vector<TcpPinnedSlab>> TcpPinnedSlabPool::acquire(
+    size_t count,
+    std::chrono::milliseconds timeout) {
   if (count == 0) {
     return std::vector<TcpPinnedSlab>{};
   }
@@ -166,11 +168,41 @@ Result<std::vector<TcpPinnedSlab>> TcpPinnedSlabPool::acquire(size_t count) {
   std::vector<size_t> indices;
   {
     std::unique_lock<std::mutex> lk(mu_);
-    freed_.wait(lk, [this, count]() {
+    // wait_for returns the predicate's value, so `satisfied` is false only if
+    // the deadline expired with the pool still short. closed_ is checked first
+    // because a shutdown is the more specific answer: close() makes the
+    // predicate true, so a pool closed while waiting reports closure rather
+    // than a coincidental expiry.
+    const bool satisfied = freed_.wait_for(lk, timeout, [this, count]() {
       return closed_ || free_.size() >= count + reservedForReader_;
     });
     if (closed_) {
       return Err(ErrCode::NotConnected, "TcpPinnedSlabPool: pool is closed");
+    }
+    if (!satisfied) {
+      // Says what was wanted, what was there, and what it means, because the
+      // whole point of the deadline is that this is diagnosable where a hang
+      // was not. A caller seeing this has either lost its peer or is running
+      // more concurrent transfers than the pool was sized for.
+      // NOT the benign, retryable Timeout that readerLoop and the benchmark
+      // rendezvous continue on: that one means "an idle socket had nothing
+      // yet", whereas this means "the pool stayed exhausted for the whole
+      // deadline", which a retry would only repeat. ResourceExhausted is
+      // already taken here for a request that could NEVER be satisfied (count
+      // above unreserved capacity); collapsing the two would lose that
+      // distinction. A caller must not apply the idle-socket retry convention
+      // to this code.
+      return Err(
+          ErrCode::Timeout,
+          "TcpPinnedSlabPool: waited " + std::to_string(timeout.count()) +
+              "ms for " + std::to_string(count) + " slabs, only " +
+              std::to_string(
+                  free_.size() > reservedForReader_
+                      ? free_.size() - reservedForReader_
+                      : 0) +
+              " of " + std::to_string(slabCount_ - reservedForReader_) +
+              " unreserved slabs are free; the peer has stopped draining or "
+              "more transfers are in flight than the pool is sized for");
     }
     indices.assign(free_.end() - static_cast<ptrdiff_t>(count), free_.end());
     free_.resize(free_.size() - count);

--- a/comms/uniflow/transport/tcp/TcpPinnedSlabPool.h
+++ b/comms/uniflow/transport/tcp/TcpPinnedSlabPool.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
@@ -108,8 +109,37 @@ class TcpPinnedSlabPool
   /// waiter here holds nothing.
   ///
   /// Fails if `count` exceeds the unreserved capacity (it could never be
-  /// satisfied) or if the pool has been closed.
-  Result<std::vector<TcpPinnedSlab>> acquire(size_t count);
+  /// satisfied), if the pool has been closed, or if `timeout` elapses first.
+  ///
+  /// The deadline is what keeps an exhausted pool from turning a caller into a
+  /// permanent hang. This is the only blocking entry point on the pool, put()
+  /// calls it on the application's own thread, and shutdown() never joins that
+  /// thread -- so before the deadline existed, `closed_` was the sole escape
+  /// and close() runs only from shutdown(). Concurrent puts reach that state
+  /// without anything going wrong on the wire: the pool is sized for one put()
+  /// in flight, so several of them each hold a wave and none can release
+  /// without returning from the acquire it is parked in. A timeout converts
+  /// that from a wedged application thread into a failed transfer the caller
+  /// can see.
+  ///
+  /// The default is deliberately far above any legitimate wait. One wave is at
+  /// most `kMaxPutWaveChunks * kMaxChunkSize`, which drains in milliseconds on
+  /// a healthy link, so a wait measured in tens of seconds already means the
+  /// sender has stopped making progress rather than fallen behind. It happens
+  /// to equal the DEFAULT connected-socket read timeout, and for the same
+  /// reason -- both answer "the peer has stopped" -- but they are two
+  /// independent numbers, not one: TcpSocketConfig::connTimeout is
+  /// configurable, so a caller that changes it makes them diverge. Do not read
+  /// this as a derived value.
+  ///
+  /// It is a defaulted parameter, but no production path passes anything else
+  /// -- launchPutWave() takes the default and nothing threads a value in from a
+  /// transport config. Treat 30s as fixed in deployment; the parameter exists
+  /// for tests, which do pass their own.
+  static constexpr std::chrono::seconds kDefaultAcquireTimeout{30};
+  Result<std::vector<TcpPinnedSlab>> acquire(
+      size_t count,
+      std::chrono::milliseconds timeout = kDefaultAcquireTimeout);
 
   /// Wakes every waiter and refuses further acquisition. Outstanding leases
   /// stay valid; this only stops new ones, so a shutdown does not pull memory

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -1112,6 +1112,11 @@ Result<PendingPutWave> TcpTransport::launchPutWave(
   // doing the same. This acquire is also the backpressure that bounds how many
   // waves can be in flight -- the pool is sized so it does not block a healthy
   // sender, so when it does block the sender has genuinely fallen behind.
+  //
+  // The wait is BOUNDED, and exceeding the bound fails this transfer rather
+  // than parking the caller's thread until teardown. This uses the default
+  // deadline: nothing threads a value in from a transport config, so in
+  // practice it is fixed at kDefaultAcquireTimeout for every deployment.
   auto leases = pool.value()->acquire(wave.size());
   if (!leases) {
     return std::move(leases).error();
@@ -3573,11 +3578,14 @@ void TcpTransport::shutdown() {
   }
 
   // Closed before the joins: this is the one pool with a *blocking* acquire,
-  // and the thread parked in it is not one we own. acquire() waits on `freed_`
-  // with no deadline and `closed_` as its only escape, and the put path calls
-  // it on the application's own thread, which shutdown() never joins. Without
-  // this a put() in flight across shutdown() parks forever, because the senders
-  // that would have freed a staging slab are about to be joined away.
+  // and the thread parked in it is not one we own. acquire() now has a
+  // deadline, so a caller can no longer be stranded indefinitely, but closing
+  // here is still what makes a shutdown prompt rather than something a put()
+  // discovers 30 seconds later -- and it reports the accurate reason, since a
+  // pool closed while a caller waits answers "closed" rather than "timed out".
+  // The put path calls acquire() on the application's own thread, which
+  // shutdown() never joins, and the senders that would have freed a staging
+  // slab are about to be joined away.
   //
   // close() only sets the flag and notifies, so outstanding leases stay valid
   // and doing this early costs nothing. The receive pool needs no equivalent --

--- a/comms/uniflow/transport/tcp/tests/unit/TcpPinnedSlabPoolTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpPinnedSlabPoolTest.cpp
@@ -159,6 +159,94 @@ TEST_F(TcpPinnedSlabPoolTest, CloseWakesWaitersAndRefusesNewLeases) {
   EXPECT_FALSE(static_cast<bool>(pool->tryAcquire(/*allowReserved=*/true)));
 }
 
+// The wait is bounded. Without a deadline this call parks until close(), and
+// close() runs only from shutdown() -- so an exhausted pool turns an
+// application thread in put() into a permanent hang rather than a failed
+// operation. That is reachable with concurrent puts: the pool is sized for one
+// put() in flight, so four of them each hold a wave and none can release
+// without returning from the acquire it is parked in.
+//
+// This test has a real negative control, which most of this fix class does not:
+// with the deadline removed the call never returns and the test times out
+// rather than passing. Elapsed time is asserted so a deadline that is silently
+// ignored
+// -- wait_for with a predicate already true, say -- cannot pass either.
+TEST_F(TcpPinnedSlabPoolTest, ABulkAcquireGivesUpRatherThanParkingForever) {
+  auto pool = makePool();
+  const size_t bulkCount = kSlabCount - kReserved;
+  auto held = pool->acquire(bulkCount);
+  ASSERT_TRUE(held.hasValue());
+
+  const auto t0 = std::chrono::steady_clock::now();
+  auto blocked = pool->acquire(bulkCount, std::chrono::milliseconds(150));
+  const auto elapsed = std::chrono::steady_clock::now() - t0;
+
+  ASSERT_TRUE(blocked.hasError())
+      << "an exhausted pool must refuse rather than park";
+  EXPECT_EQ(blocked.error().code(), ErrCode::Timeout);
+  EXPECT_LT(elapsed, std::chrono::seconds(10))
+      << "the deadline must actually bound the wait";
+  EXPECT_GE(elapsed, std::chrono::milliseconds(100))
+      << "it must wait for the deadline rather than failing immediately, or a "
+         "briefly-busy pool would fail a healthy put()";
+
+  // The lease is still good and the pool still works: a timeout is a refusal,
+  // not a teardown.
+  held.value().clear();
+  EXPECT_TRUE(
+      pool->acquire(bulkCount, std::chrono::milliseconds(150)).hasValue());
+}
+
+// close() must still win over the deadline: a shutdown should be reported as a
+// shutdown, not as a timeout that happens to coincide with one.
+TEST_F(TcpPinnedSlabPoolTest, CloseBeatsTheDeadline) {
+  auto pool = makePool();
+  auto held = pool->acquire(kSlabCount - kReserved);
+  ASSERT_TRUE(held.hasValue());
+
+  const auto start = std::chrono::steady_clock::now();
+  ErrCode observed{ErrCode::Timeout};
+  // Signalled immediately before the blocking call, so close() cannot run while
+  // the waiter has not even reached acquire(). Without it the main thread does
+  // nothing between spawn and close, so close() almost always wins, acquire()
+  // sees closed_ on its first predicate evaluation and returns without ever
+  // waiting -- the test then passes while never exercising the "close beats a
+  // pending deadline" interleaving it is named for.
+  //
+  // This narrows the window rather than closing it: being parked inside
+  // condition_variable::wait_for is not observable from outside. The elapsed
+  // check after the join is what makes the coverage real -- a deadline expiry
+  // would take 30s, so a prompt NotConnected can only mean close() ended it.
+  std::promise<void> atAcquire;
+  auto atAcquireFuture = atAcquire.get_future();
+  std::thread waiter([&]() {
+    atAcquire.set_value();
+    auto blocked =
+        pool->acquire(kSlabCount - kReserved, std::chrono::seconds(30));
+    EXPECT_TRUE(blocked.hasError());
+    if (blocked.hasError()) {
+      observed = blocked.error().code();
+    }
+  });
+
+  ASSERT_EQ(
+      atAcquireFuture.wait_for(std::chrono::seconds{5}),
+      std::future_status::ready)
+      << "the waiter thread never reached acquire()";
+
+  pool->close();
+  // No flag asserted after the join: join() already guarantees the lambda ran,
+  // so such an assertion could only fail if the threading guarantees themselves
+  // were broken. `observed` is the whole point of the test.
+  waiter.join();
+  EXPECT_LT(std::chrono::steady_clock::now() - start, std::chrono::seconds{25})
+      << "acquire() returned only after its 30s deadline, so the deadline ended "
+         "the wait rather than close() -- the test would then prove nothing "
+         "about close() winning";
+  EXPECT_EQ(observed, ErrCode::NotConnected)
+      << "a closed pool reports closure, not a deadline expiry";
+}
+
 TEST_F(TcpPinnedSlabPoolTest, CreateRejectsAnUnusableConfiguration) {
   EXPECT_TRUE(
       TcpPinnedSlabPool::create(cudaApi_, 0, kSlabCount, kReserved).hasError());


### PR DESCRIPTION
Summary:
`TcpPinnedSlabPool::acquire()` waited on `freed_` with no deadline and `closed_` as
its only escape, and `close()` runs only from `shutdown()`. It is the pool's one
blocking entry point, it has exactly one caller -- `launchPutWave` -- and that
caller runs on the application's own thread, which `shutdown()` never joins. So an
exhausted pool did not degrade a transfer, it wedged the caller's thread until
teardown.

That state is reachable without anything going wrong on the wire, which is what
makes this worth fixing rather than documenting. The pool is sized for **one**
`put()` in flight: `kStagingSlabCount` is `(kMaxPutWavesInFlight - 1) *
kMaxPutWaveChunks + kMaxOutQueueBytes / kMaxChunkSize + kMaxPutWaveChunks +
kStagingSlabsReservedForReader` = `(2-1)*7 + 16 + 7 + 1` = 31, and `acquire(7)`
needs `7 + 1` = 8 free. `put()` takes no transport-wide lock, so N callers can be
inside it at once, each holding one wave of 7 at the moment it acquires because
`drainWaves(1)` runs immediately before `launchPutWave`. Four concurrent VRAM puts
hold 28, leave 3, and all block -- permanently, because those 28 slabs sit in four
`inFlight` deques as launched-but-unqueued frames, so the sender has nothing to
drain and each caller could only release by returning from the acquire it is parked
in.

Raised by mahi on D118010137, and independently flagged by his reviewer-agent as
its one blocking item. Filed as C-103. This also discharges **C-064**, which asked
for exactly this deadline and had been deferred to a diff that was never created.

# Why a deadline rather than more slabs or a narrower contract

A concurrency factor on the `(kMaxPutWavesInFlight - 1) * kMaxPutWaveChunks` term
would cost pinned memory linearly in an assumed concurrency: at N=4 the term goes
7 -> 28 and the pool 31 -> 52 slabs, roughly 124 MiB -> 208 MiB per staging peer,
against a footprint C-062 already flags. And it would not remove the failure --
any N can be exceeded, so a deadlock at 4 becomes a deadlock at N+1. Sizing from a
number nobody has measured buys a moved cliff.

Documenting single-caller-per-transport belongs on `put()` regardless, but a
contract with no enforcement is the weakest form: nothing detects a violation, so a
violating caller still hangs silently.

The deadline changes the *class* of failure -- silent unbounded hang into a loud
bounded error -- which is correct whatever the concurrency turns out to be, needs no
measurement, and composes with either of the others if they are added later.

# The cost, stated rather than buried

A sender that legitimately falls behind for longer than the deadline now gets an
error where it previously waited and eventually succeeded. **A slow-but-working
transfer can now fail.** The default is what makes that acceptable rather than
reckless: one wave is at most `kMaxPutWaveChunks * kMaxChunkSize` = 28 MiB, which
drains in milliseconds on a healthy link, so a 30-second wait already means the peer
has stopped rather than slowed. It matches the connected-socket read timeout because
both answer "the peer has stopped", and one number for that is easier to reason
about than two that can drift. It is a parameter, so a caller that knows better can
say so.

`close()` still wins over the deadline: it makes the predicate true, so a pool closed
while a caller waits reports closure rather than a coincidental expiry.

Also corrects `shutdown()`'s comment, which asserted "no deadline and `closed_` as
its only escape" -- true when written, false as of this change. Three separate items
filed in this audit today were stale comments of exactly that kind.

Differential Revision: D118755410


