### PR TITLE
NCCLX: fix ncclparam link missing LDFLAGS

### DIFF
--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -394,7 +394,7 @@ $(BINDIR)/$(BINNAME): $(BINOBJ)
 $(BINDIR)/$(PARAMBIN): $(PARAMBINOBJ) $(LIBDIR)/$(LIBTARGET)
 	@printf "Linking    %-35s > %s\n" $(PARAMBIN) $@
 	mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) $< -o $@ -L$(LIBDIR) -L${CONDA_LIB_DIR} -lnccl -L${CUDA_LIB} -l$(CUDARTLIB) -lpthread -lrt -ldl -latomic
+	$(CXX) $(CXXFLAGS) $< -o $@ -L$(LIBDIR) -L${CONDA_LIB_DIR} -lnccl -L${CUDA_LIB} -l$(CUDARTLIB) -lpthread -lrt -ldl -latomic $(LDFLAGS)
 
 $(PKGDIR)/nccl.pc : nccl.pc.in
 	mkdir -p $(PKGDIR)


### PR DESCRIPTION
### Problem

The ncclparam binary links against libnccl.so but its link rule in comms/ncclx/v2_30/src/Makefile does not pass $(LDFLAGS), which contains THIRD_PARTY_LDFLAGS (glog, gflags, abseil, libevent, etc.). This causes undefined reference errors at link time when building with USE_SYSTEM_LIBS=1.

```
/usr/bin/ld: libnccl.so: undefined reference to `google::base::CheckOpMessageBuilder::NewString[abi:cxx11]()'
/usr/bin/ld: libnccl.so: undefined reference to `google::LogMessage::~LogMessage()'
/usr/bin/ld: libnccl.so: undefined reference to `google::LogMessage::stream()'
/usr/bin/ld: libnccl.so: undefined reference to `google::LogMessageFatal::LogMessageFatal(char const*, int)'
/usr/bin/ld: libnccl.so: undefined reference to `google::ErrnoLogMessage::ErrnoLogMessage(char const*, int, int, int, void (google::LogMessage::*)())'
/usr/bin/ld: libnccl.so: undefined reference to `google::FlagRegisterer::FlagRegisterer<int>(char const*, char const*, char const*, int*, int*)'
/usr/bin/ld: libnccl.so: undefined reference to `absl::lts_20240722::log_internal::LogMessage::OstreamView::stream()'
/usr/bin/ld: libnccl.so: undefined reference to `absl::lts_20240722::log_internal::LogMessage::~LogMessage()'
/usr/bin/ld: libnccl.so: undefined reference to `absl::lts_20240722::log_internal::LogEveryNSecState::ShouldLog(double)'
/usr/bin/ld: libnccl.so: undefined reference to `event_set'
/usr/bin/ld: libnccl.so: undefined reference to `event_base_get_method'
/usr/bin/ld: libnccl.so: undefined reference to `event_base_free'
/usr/bin/ld: libnccl.so: undefined reference to `double_conversion::DoubleToStringConverter::ToFixed(double, int, double_conversion::StringBuilder*) const'
collect2: error: ld returned 1 exit status
```
