### PR TITLE
comms/uniflow/tcp: pick frontend NICs by GPU NUMA locality, not by spreading

### DIFF
--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -333,8 +333,12 @@ MultiTransportFactory::MultiTransportFactory(
     // would otherwise bind a lane to a NIC that cannot serve it. Rejecting
     // rather than substituting is deliberate -- quietly swapping in a different
     // NIC would hide that the requested one went away.
+    // NUMA-ordered so this rank binds the ports its GPU is attached to. The
+    // membership check below is unaffected: unbounded returns every usable
+    // port whatever the order.
+    const int numaNode = gpuNumaNode(deviceId_);
     const auto usable = enumerateFrontendDevices(
-        options_.tcpDevicePrefix, std::numeric_limits<size_t>::max());
+        options_.tcpDevicePrefix, std::numeric_limits<size_t>::max(), numaNode);
     if (tcpConfig.bindToDevices.empty()) {
       tcpConfig.bindToDevices = usable;
       // The cap comes off the transport config, which is the single place it is

--- a/comms/uniflow/benchmarks/BenchmarkRunner.h
+++ b/comms/uniflow/benchmarks/BenchmarkRunner.h
@@ -49,6 +49,14 @@ struct BenchmarkConfig {
    * reports excellent throughput.
    */
   bool verify{true};
+  /*
+   * Cross-rank measurement barrier. A multi-GPU run launches N independent
+   * rank-pairs; nothing lines their timed loops up, so summing their
+   * bandwidths sums windows that do not coincide. When barrierDir is set all N
+   * rendezvous after warmup, immediately before the clock starts.
+   */
+  std::string barrierDir;
+  int barrierRanks{0};
 };
 
 class Benchmark {

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
@@ -11,10 +11,13 @@
 #include <cstdlib>
 #include <cstring>
 #include <deque>
+#include <filesystem>
+#include <fstream>
 #include <future>
 #include <iostream>
 #include <random>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -127,13 +130,126 @@ struct TransferResult {
 
 // Warmup then a pipelined timed loop keeping up to txDepth put/get calls in
 // flight over the single TCP connection.
+
+/*
+ * Filesystem barrier across the N rank-pairs of an aggregate run, keyed by
+ * (direction, size) so every size re-synchronises. Fails closed: a barrier
+ * that timed out silently would restore the defect it exists to remove.
+ */
+constexpr std::string_view kMarkerPrefix = "inst";
+
+bool measurementBarrier(
+    const BenchmarkConfig& config,
+    const std::string& tag,
+    int rank) {
+  const bool hasBarrierDir = !config.barrierDir.empty();
+  const bool hasBarrierRanks = config.barrierRanks > 0;
+  if (hasBarrierDir != hasBarrierRanks) {
+    UNIFLOW_LOG_ERROR(
+        "measurement barrier: --measurement-barrier-dir and "
+        "--measurement-barrier-ranks must be specified together");
+    return false;
+  }
+  if (config.barrierRanks <= 1) {
+    return true;
+  }
+  // The marker name is the only thing distinguishing instances. cudaDevice
+  // defaults to -1, so an aggregate run that forgot --cuda-device would have
+  // every instance write inst-1 and then wait out the full timeout.
+  if (rank < 0) {
+    UNIFLOW_LOG_ERROR(
+        "measurement barrier needs a unique per-instance key; got {}. Pass "
+        "--cuda-device (one per instance) when --measurement-barrier-ranks > 1",
+        rank);
+    return false;
+  }
+  namespace fs = std::filesystem;
+  std::error_code ec;
+  fs::path dir = fs::path(config.barrierDir) / tag;
+  fs::create_directories(dir, ec);
+  if (ec) {
+    UNIFLOW_LOG_ERROR(
+        "measurement barrier: cannot create {}: {}",
+        dir.string(),
+        ec.message());
+    return false;
+  }
+  // Keyed by GPU index, not bootstrap.rank: every initiator is rank 0 of its
+  // own pair, so ranks are not unique across instances.
+  // Nothing else writes this instance's marker, so finding it already there
+  // means the directory is being reused after an earlier run. Counting it
+  // would pre-satisfy the barrier and release early -- the same silent
+  // overstatement this change exists to remove -- so refuse instead.
+  const auto marker = dir / fmt::format("{}{}", kMarkerPrefix, rank);
+  const bool markerExists = fs::exists(marker, ec);
+  if (ec) {
+    UNIFLOW_LOG_ERROR(
+        "measurement barrier: cannot stat {}: {}",
+        marker.string(),
+        ec.message());
+    return false;
+  }
+  if (markerExists) {
+    UNIFLOW_LOG_ERROR(
+        "measurement barrier: {} already exists; pass a fresh "
+        "--measurement-barrier-dir per run",
+        marker.string());
+    return false;
+  }
+  {
+    std::ofstream f(marker);
+    if (!f) {
+      UNIFLOW_LOG_ERROR(
+          "measurement barrier: cannot write marker in {}", dir.string());
+      return false;
+    }
+  }
+
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(120);
+  while (std::chrono::steady_clock::now() < deadline) {
+    size_t n = 0;
+    fs::directory_iterator it(dir, ec);
+    if (ec) {
+      // A filesystem error is not "peers have not arrived yet"; spinning to
+      // the timeout would report it as one.
+      UNIFLOW_LOG_ERROR(
+          "measurement barrier: cannot read {}: {}",
+          dir.string(),
+          ec.message());
+      return false;
+    }
+    for (; it != fs::directory_iterator(); ++it) {
+      // Only this run's markers count. Anything else in the directory -- a
+      // foreign file, an editor temp, an NFS .nfs* silly-rename left behind by
+      // an unlinked marker -- would otherwise inflate the count and release
+      // the barrier before every rank arrived, which is the same silent
+      // under-synchronisation this change exists to remove.
+      if (it->path().filename().string().rfind(kMarkerPrefix, 0) == 0) {
+        ++n;
+      }
+    }
+    if (n >= static_cast<size_t>(config.barrierRanks)) {
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  UNIFLOW_LOG_ERROR(
+      "measurement barrier timed out at {} (rank {}, need {})",
+      tag,
+      rank,
+      config.barrierRanks);
+  return false;
+}
+
 TransferResult runTransfer(
     Transport& transport,
     RegisteredSegment& localReg,
     RemoteRegisteredSegment& remoteReg,
     size_t size,
     const std::string& dir,
-    const BenchmarkConfig& config) {
+    const BenchmarkConfig& config,
+    int rank) {
   using Clock = std::chrono::steady_clock;
   const int batchSize = std::max(1, config.batchSize);
   const int txDepth = std::max(1, config.txDepth);
@@ -191,6 +307,13 @@ TransferResult runTransfer(
     inflight.pop_front();
     return true;
   };
+
+  // All N ranks line up here, after their own warmup, so that every rank's
+  // timed window covers the same wall-clock interval and the per-rank
+  // bandwidths are summable. Barrier cost is outside the clock below.
+  if (!measurementBarrier(config, fmt::format("{}_{}", dir, size), rank)) {
+    return out;
+  }
 
   auto start = Clock::now();
   for (int b = 0; b < numBatches; ++b) {
@@ -654,7 +777,14 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
       if (tcpTransport != nullptr) {
         tcpTransport->logAndResetPhaseStats("reset");
       }
-      auto r = runTransfer(*transport, localReg, remoteReg, size, dir, config);
+      auto r = runTransfer(
+          *transport,
+          localReg,
+          remoteReg,
+          size,
+          dir,
+          config,
+          config.cudaDevice);
       if (!r.ok) {
         // Latched rather than returned: every remaining size has a barrier the
         // peer is going to execute.

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
@@ -581,8 +581,12 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
   const size_t maxDevices = discoveryConfig.resolveMaxFrontendDevices(
       std::string(::uniflow::kDefaultFrontendDevicePrefix));
   if (bindDevs_.empty()) {
+    // Per-GPU NUMA locality: instances on one host then stay off each other's
+    // uplinks, so a multi-instance number is not measuring self-contention.
     bindDevs_ = enumerateFrontendDevices(
-        std::string(::uniflow::kDefaultFrontendDevicePrefix), maxDevices);
+        std::string(::uniflow::kDefaultFrontendDevicePrefix),
+        maxDevices,
+        gpuNumaNode(config.cudaDevice));
     if (bindDevs_.empty()) {
       UNIFLOW_LOG_WARN(
           "TcpBandwidthBenchmark: no usable '{}' device found; leaving egress "

--- a/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/TcpBandwidthBenchmark.cpp
@@ -13,6 +13,7 @@
 #include <deque>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <future>
 #include <iostream>
 #include <random>
@@ -249,7 +250,8 @@ TransferResult runTransfer(
     size_t size,
     const std::string& dir,
     const BenchmarkConfig& config,
-    int rank) {
+    int rank,
+    const std::function<bool()>& peerAck) {
   using Clock = std::chrono::steady_clock;
   const int batchSize = std::max(1, config.batchSize);
   const int txDepth = std::max(1, config.txDepth);
@@ -336,6 +338,15 @@ TransferResult runTransfer(
     if (!completeOne()) {
       return out;
     }
+  }
+  /*
+   * Stop the clock only after the peer confirms. A resolved local future means
+   * this side handed the transfer off, not that the peer has it.
+   */
+  if (peerAck && !peerAck()) {
+    UNIFLOW_LOG_ERROR(
+        "TcpBandwidthBenchmark: peer ack failed at {} size {}", dir, size);
+    return out;
   }
   auto end = Clock::now();
 
@@ -753,7 +764,7 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
     }
   }
 
-  auto runDirection = [&](const std::string& dir) {
+  auto runDirection = [&](const std::string& dir) -> bool {
     // Seeded from the verify result: a failed correctness sweep still walks the
     // whole size sweep, meeting every barrier and reporting nothing.
     //
@@ -764,9 +775,15 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
     for (auto size : sizes) {
       if (!barrier(peers, bootstrap)) {
         UNIFLOW_LOG_ERROR("TcpBandwidthBenchmark: barrier failed");
-        return;
+        return false;
       }
       if (aborted || !isActiveRank) {
+        // Match the active rank's peer-ack barrier, or the two sides drift
+        // by one barrier per size and the final size hangs.
+        if (!barrier(peers, bootstrap)) {
+          UNIFLOW_LOG_ERROR("TcpBandwidthBenchmark: peer-ack barrier failed");
+          return false;
+        }
         continue;
       }
       // Bracket the timed loop so the phase split covers the same frames the
@@ -777,6 +794,7 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
       if (tcpTransport != nullptr) {
         tcpTransport->logAndResetPhaseStats("reset");
       }
+      bool peerAckFailed = false;
       auto r = runTransfer(
           *transport,
           localReg,
@@ -784,7 +802,15 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
           size,
           dir,
           config,
-          config.cudaDevice);
+          config.cudaDevice,
+          [&]() {
+            const bool ok = static_cast<bool>(barrier(peers, bootstrap));
+            peerAckFailed = !ok;
+            return ok;
+          });
+      if (peerAckFailed) {
+        return false;
+      }
       if (!r.ok) {
         // Latched rather than returned: every remaining size has a barrier the
         // peer is going to execute.
@@ -824,13 +850,20 @@ std::vector<BenchmarkResult> TcpBandwidthBenchmark::run(
           stats.avg,
           config.bidirectional ? "(bidirectional)" : "(unidirectional)");
     }
+    return true;
   };
 
   if (config.direction == "put" || config.direction == "both") {
-    runDirection("put");
+    if (!runDirection("put")) {
+      transport->shutdown();
+      return results;
+    }
   }
   if (config.direction == "get" || config.direction == "both") {
-    runDirection("get");
+    if (!runDirection("get")) {
+      transport->shutdown();
+      return results;
+    }
   }
 
   if (!barrier(peers, bootstrap)) {

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -78,6 +78,8 @@ struct CliOptions {
   // --tcp-bind-dev. Names are per-host, so the two hosts may need different
   // lists for the same pair of physical ports.
   std::string tcpBindDevs;
+  std::string barrierDir;
+  int barrierRanks{0};
 };
 
 std::vector<int> parseIntList(const std::string& s) {
@@ -213,6 +215,11 @@ void printUsage(const char* prog) {
       << "  --cuda-devices <list>  Comma-separated GPU indices for single-process multi-GPU (overrides --cuda-device)\n"
       << "  --gpu-nics <groups>    Per-GPU NIC map for multi-GPU: ';'-separated groups of comma-separated NICs, one per --cuda-devices entry\n"
       << "  --data-direct          Register GPU memory over the mlx5 Data Direct path (default: off)\n"
+      << "  --measurement-barrier-dir <path>  Shared dir used to line up the timed\n"
+      << "                         loops of N independent aggregate instances. Without\n"
+      << "                         it their windows stagger and summed bandwidth is\n"
+      << "                         overstated (measured overlap 1.0-2.1 of 8)\n"
+      << "  --measurement-barrier-ranks <n>   Number of instances to wait for\n"
       << "  --list                 List available benchmarks\n"
       << "  --help                 Show this help message\n"
       << "\n"
@@ -259,6 +266,8 @@ CliOptions parseArgs(int argc, char** argv) {
       {"tcp-sockets-per-nic", required_argument, nullptr, 270},
       {"tcp-bind-dev", no_argument, nullptr, 271},
       {"tcp-bind-devs", required_argument, nullptr, 272},
+      {"measurement-barrier-dir", required_argument, nullptr, 280},
+      {"measurement-barrier-ranks", required_argument, nullptr, 281},
       {"no-verify", no_argument, nullptr, 267},
       {"list", no_argument, nullptr, 'l'},
       {"help", no_argument, nullptr, 'h'},
@@ -358,6 +367,24 @@ CliOptions parseArgs(int argc, char** argv) {
         break;
       case 272:
         opts.tcpBindDevs = optarg;
+        break;
+      case 280:
+        opts.barrierDir = optarg;
+        break;
+      case 281:
+        try {
+          int parsed = std::stoi(optarg);
+          if (parsed < 1) {
+            std::cerr
+                << "Invalid value for --measurement-barrier-ranks: must be >= 1\n";
+            std::exit(1);
+          }
+          opts.barrierRanks = parsed;
+        } catch (const std::exception&) {
+          std::cerr << "Invalid value for --measurement-barrier-ranks: '"
+                    << optarg << "'\n";
+          std::exit(1);
+        }
         break;
       case 'd':
         opts.direction = optarg;
@@ -490,6 +517,13 @@ CliOptions parseArgs(int argc, char** argv) {
     opts.benchmark = "__list__";
   }
 
+  if (opts.barrierDir.empty() != (opts.barrierRanks == 0)) {
+    std::cerr
+        << "--measurement-barrier-dir and --measurement-barrier-ranks must "
+           "be specified together\n";
+    std::exit(1);
+  }
+
   return opts;
 }
 
@@ -554,6 +588,8 @@ int main(int argc, char** argv) {
   config.bidirectional = opts.bidirectional;
   config.dataDirect = opts.dataDirect;
   config.verify = !opts.noVerify;
+  config.barrierDir = opts.barrierDir;
+  config.barrierRanks = opts.barrierRanks;
   config.direction = opts.direction;
   config.batchSize = opts.batchSize;
   config.txDepth = opts.txDepth;

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -6,6 +6,8 @@
 #include <netinet/in.h>
 
 #include <algorithm>
+#include <array>
+#include <cctype>
 #include <cstdint>
 #include <cstring>
 #include <deque>
@@ -68,10 +70,51 @@ size_t TcpTransport::adaptiveGetChunk(size_t len, size_t laneCount) {
   return std::max(perLane, kMinAdaptiveChunkSize);
 }
 
+namespace {
+
+/// NUMA node behind a sysfs device dir, or kAnyNumaNode if unreadable -- an
+/// unknown topology must not silently exclude a port.
+int readNumaNodeFile(const std::filesystem::path& deviceDir) {
+  std::ifstream in(deviceDir / "numa_node");
+  int node = kAnyNumaNode;
+  if (!in.is_open() || !(in >> node)) {
+    return kAnyNumaNode;
+  }
+  return node < 0 ? kAnyNumaNode : node;
+}
+
+} // namespace
+
+int gpuNumaNode(int deviceId) {
+  // The benchmark's "host memory, no GPU" case: no locality to follow.
+  if (deviceId < 0) {
+    return kAnyNumaNode;
+  }
+  std::array<char, 64> busId{};
+  CudaApi cudaApi;
+  if (!cudaApi.getDevicePCIBusId(busId.data(), busId.size() - 1, deviceId)
+           .hasValue()) {
+    return kAnyNumaNode;
+  }
+  // The runtime spells the BDF uppercase; sysfs directories are lowercase.
+  std::string addr(busId.data());
+  std::transform(addr.begin(), addr.end(), addr.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  if (addr.empty()) {
+    return kAnyNumaNode;
+  }
+  return readNumaNodeFile(std::filesystem::path("/sys/bus/pci/devices") / addr);
+}
+
 std::vector<std::string> enumerateFrontendDevices(
     const std::string& prefix,
-    size_t maxDevices) {
+    size_t maxDevices,
+    int preferredNumaNode) {
   std::map<std::string, std::set<std::string>> byCard;
+  // Per card, not per port: ports of one card share its uplink, so they share
+  // its locality. First port seen decides.
+  std::map<std::string, int> cardNuma;
   std::error_code ec;
   std::filesystem::directory_iterator it("/sys/class/net", ec);
   if (ec) {
@@ -107,26 +150,55 @@ std::vector<std::string> enumerateFrontendDevices(
       // stacks, which is the safer guess.
       card = dev;
     }
+    if (byCard[card].empty()) {
+      // Through the PCI symlink, so this is the node the GPU side reads too.
+      cardNuma[card] = readNumaNodeFile(
+          std::filesystem::path("/sys/class/net") / dev / "device");
+    }
     byCard[card].insert(dev);
   }
 
-  std::vector<std::string> devices;
-  for (size_t round = 0; devices.size() < maxDevices; ++round) {
-    bool tookAny = false;
+  // Groups, not a sort: local must be drained to exhaustion before remote is
+  // touched, or the round-robin below would spread again. kAnyNumaNode gives
+  // one group of every card, reproducing the old order.
+  std::vector<std::vector<const std::string*>> groups;
+  if (preferredNumaNode == kAnyNumaNode) {
+    auto& all = groups.emplace_back();
     for (const auto& [card, ports] : byCard) {
-      if (ports.size() <= round) {
-        continue;
+      all.push_back(&card);
+    }
+  } else {
+    std::vector<const std::string*> local;
+    std::vector<const std::string*> remote;
+    for (const auto& [card, ports] : byCard) {
+      // Unreadable goes to remote: never stack onto a card we cannot show is
+      // this GPU's.
+      (cardNuma[card] == preferredNumaNode ? local : remote).push_back(&card);
+    }
+    groups.push_back(std::move(local));
+    groups.push_back(std::move(remote));
+  }
+
+  std::vector<std::string> devices;
+  for (const auto& group : groups) {
+    for (size_t round = 0; devices.size() < maxDevices; ++round) {
+      bool tookAny = false;
+      for (const auto* card : group) {
+        const auto& ports = byCard[*card];
+        if (ports.size() <= round) {
+          continue;
+        }
+        auto port = ports.begin();
+        std::advance(port, round);
+        devices.push_back(*port);
+        tookAny = true;
+        if (devices.size() == maxDevices) {
+          break;
+        }
       }
-      auto port = ports.begin();
-      std::advance(port, round);
-      devices.push_back(*port);
-      tookAny = true;
-      if (devices.size() == maxDevices) {
+      if (!tookAny) {
         break;
       }
-    }
-    if (!tookAny) {
-      break;
     }
   }
   return devices;

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -88,9 +88,29 @@ inline constexpr size_t kMaxLanes = 1024;
 /// told, instead of quietly receiving fewer than it asked for.
 size_t frontendDeviceCapacity(const std::string& prefix);
 
-/// Frontend data NICs to stripe lanes across, lowest name first and one port
-/// per PCI card before taking a second port from any card. Only devices that
-/// are up and carry a usable global address are returned.
+/// No NUMA preference: keep the old spread-first order. Also what an unknown
+/// node resolves to.
+inline constexpr int kAnyNumaNode = -1;
+
+/// NUMA node of a GPU, or kAnyNumaNode if undeterminable. Read through the
+/// device's PCI address, the same sysfs path the NICs are read from, so both
+/// sides of the affinity check come from one source. Shared rather than
+/// re-derived per caller so the two cannot disagree.
+int gpuNumaNode(int deviceId);
+
+/// Frontend data NICs to stripe lanes across. Only devices that are up and
+/// carry a usable global address are returned.
+///
+/// NUMA-affine when preferredNumaNode names a node: local cards are drained
+/// first -- one port per card before any card gives up a second -- and only
+/// then does it reach across. At the default cap of two that is both ports of
+/// the local card, stacking on purpose: spreading a job over every card beats
+/// stacking for that job alone, but two such jobs then congest each other. A
+/// job that wants every card raises the cap. Measured cost is on bindToDevices.
+///
+/// kAnyNumaNode keeps the old spread-first order exactly. In both modes a
+/// smaller cap yields a prefix of a larger one, so lane i is the same port
+/// whatever the cap.
 ///
 /// Leaving TcpTransportConfig::bindToDevices empty means no binding at all, so
 /// egress falls to the routing table and lands on one NIC. MultiTransport calls
@@ -98,7 +118,8 @@ size_t frontendDeviceCapacity(const std::string& prefix);
 /// MultiTransport shares the selection instead of re-deriving and drifting.
 std::vector<std::string> enumerateFrontendDevices(
     const std::string& prefix,
-    size_t maxDevices);
+    size_t maxDevices,
+    int preferredNumaNode = kAnyNumaNode);
 
 struct TcpTransportConfig {
   /// Socket options for this transport's *data* connections, which is all the
@@ -156,11 +177,12 @@ struct TcpTransportConfig {
   /// rather than bandwidth-bound, where striping is neutral to slightly
   /// negative; the gain grows with transfer size.
   ///
-  /// Pairing two ports on one PCI card measured no worse than two ports on
-  /// separate cards, even though raw iperf3 on this hardware shows a clear card
-  /// limit: this path does not yet reach what a single card sustains, so the
-  /// card is not the binding constraint. The receive-side H2D copy is, and card
-  /// affinity starts to matter once that is fixed.
+  /// Two ports on one card used to measure no worse than two on separate
+  /// cards, while the receive-side H2D copy -- not the card -- was binding.
+  /// Fixing that flipped it, as the old note here predicted: MI350X 2026-09-01,
+  /// 1 GPU put, tx-depth 8, n=3, separate cards peak 42.91 GB/s against 28.72.
+  /// So NUMA-affine selection trades ~1.5x of a solo job's bandwidth for
+  /// isolation between concurrent jobs; it is a choice, not a free win.
   ///
   /// Device names are per-host and need not match between peers: the same
   /// physical port is eth3 on one MI350 host and eth0 on the next.

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportConnectTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportConnectTest.cpp
@@ -12,7 +12,14 @@
 #include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <map>
 #include <memory>
+#include <optional>
+#include <set>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -697,5 +704,119 @@ TEST_F(TcpTransportConnectTest, RejectsPeerWithDifferentDeviceCount) {
 // There is no longer a guard for "fewer lanes than devices": lanes are counted
 // per device, so the product is always at least the device count and that state
 // is unreachable by construction.
+
+// --- NUMA-affine frontend selection ---------------------------------------
+//
+// Derived from the host's own topology, not hardcoded port names: the property
+// is "chosen by locality", which must hold on any machine.
+
+namespace {
+
+int numaOf(const std::string& dev) {
+  std::ifstream in("/sys/class/net/" + dev + "/device/numa_node");
+  int node = -1;
+  if (!in.is_open() || !(in >> node)) {
+    return -1;
+  }
+  return node;
+}
+
+// Ports grouped by NUMA node, counting only what discovery would accept.
+std::map<int, std::set<std::string>> usablePortsByNuma(
+    const std::string& prefix) {
+  std::map<int, std::set<std::string>> byNuma;
+  for (const auto& dev :
+       enumerateFrontendDevices(prefix, std::numeric_limits<size_t>::max())) {
+    byNuma[numaOf(dev)].insert(dev);
+  }
+  return byNuma;
+}
+
+// A node with >= 2 usable ports: the default cap, and where stacking and
+// spreading differ.
+std::optional<int> nodeWithTwoPorts(const std::string& prefix) {
+  for (const auto& [node, ports] : usablePortsByNuma(prefix)) {
+    if (node >= 0 && ports.size() >= 2) {
+      return node;
+    }
+  }
+  return std::nullopt;
+}
+
+} // namespace
+
+// The point of the change: two NICs with a preference must both be local.
+TEST(TcpTransportConfigTest, NumaAffineSelectionStaysOnTheLocalNode) {
+  const std::string prefix{kDefaultFrontendDevicePrefix};
+  const auto node = nodeWithTwoPorts(prefix);
+  if (!node.has_value()) {
+    GTEST_SKIP() << "no NUMA node with two usable '" << prefix << "' ports";
+  }
+  const auto devices = enumerateFrontendDevices(prefix, 2, *node);
+  ASSERT_EQ(devices.size(), 2UL);
+  for (const auto& dev : devices) {
+    EXPECT_EQ(numaOf(dev), *node) << dev << " is off-node; selection spread";
+  }
+}
+
+// A preference, not a filter: a cap above the local supply is still filled, or
+// an affine caller would get fewer lanes than a non-affine one -- and peers
+// derive lane count from this list.
+TEST(TcpTransportConfigTest, NumaAffineSelectionFillsTheCapAcrossNodes) {
+  const std::string prefix{kDefaultFrontendDevicePrefix};
+  const auto node = nodeWithTwoPorts(prefix);
+  if (!node.has_value()) {
+    GTEST_SKIP() << "no NUMA node with two usable '" << prefix << "' ports";
+  }
+  const size_t capacity = frontendDeviceCapacity(prefix);
+  const size_t localPorts = usablePortsByNuma(prefix)[*node].size();
+  if (capacity <= localPorts) {
+    GTEST_SKIP() << "host has no port outside the local node to fall back to";
+  }
+  const auto devices = enumerateFrontendDevices(prefix, capacity, *node);
+  EXPECT_EQ(devices.size(), capacity)
+      << "a NUMA preference must not shrink the returned count";
+  EXPECT_EQ(
+      std::set<std::string>(devices.begin(), devices.end()).size(),
+      devices.size())
+      << "a port must not be returned twice when falling back";
+  for (size_t i = 0; i < localPorts; ++i) {
+    EXPECT_EQ(numaOf(devices[i]), *node) << "locals must be drained first";
+  }
+}
+
+// The compatibility path: anything not passing a node keeps the old order.
+TEST(TcpTransportConfigTest, AnyNumaNodeReproducesTheOldOrder) {
+  const std::string prefix{kDefaultFrontendDevicePrefix};
+  const size_t capacity = frontendDeviceCapacity(prefix);
+  if (capacity == 0) {
+    GTEST_SKIP() << "no usable '" << prefix << "' device on this host";
+  }
+  EXPECT_EQ(
+      enumerateFrontendDevices(prefix, capacity),
+      enumerateFrontendDevices(prefix, capacity, kAnyNumaNode))
+      << "the default argument must be the no-preference path";
+}
+
+// Re-check under a preference: lane i is the same port whatever the cap.
+TEST(TcpTransportConfigTest, NumaAffineSelectionKeepsTheCapPrefixInvariant) {
+  const std::string prefix{kDefaultFrontendDevicePrefix};
+  const auto node = nodeWithTwoPorts(prefix);
+  if (!node.has_value()) {
+    GTEST_SKIP() << "no NUMA node with two usable '" << prefix << "' ports";
+  }
+  const size_t capacity = frontendDeviceCapacity(prefix);
+  const auto atTwo = enumerateFrontendDevices(prefix, 2, *node);
+  const auto atCapacity = enumerateFrontendDevices(prefix, capacity, *node);
+  ASSERT_LE(atTwo.size(), atCapacity.size());
+  EXPECT_TRUE(std::equal(atTwo.begin(), atTwo.end(), atCapacity.begin()))
+      << "device order must not depend on the cap";
+}
+
+// An absent GPU must not read as node 0: that would stack onto the first card.
+TEST(TcpTransportConfigTest, GpuNumaNodeIsUnknownForANonDevice) {
+  EXPECT_EQ(gpuNumaNode(-1), kAnyNumaNode)
+      << "the host-memory case has no GPU locality to follow";
+}
 
 } // namespace uniflow


### PR DESCRIPTION
Summary:
Discovery took one port per PCI card before any card gave up a second, so every
job spread across every card. That is the wrong default once a host runs more
than one job: two 4-GPU jobs on an 8-GPU MI350X both land on both cards and
congest each other.

enumerateFrontendDevices() now drains the cards local to the caller's NUMA node
before reaching across, so the default cap of two returns both ports of the
local card. MultiTransport and the benchmark pass their GPU's node, resolved in
gpuNumaNode(). kAnyNumaNode, including the default argument, keeps the old
order.

  before   gpu 0 -> eth0,eth2   gpu 4 -> eth0,eth2   (both jobs, both cards)
  after    gpu 0 -> eth0,eth1   gpu 4 -> eth2,eth3   (one card each)

This costs solo bandwidth and that is the trade, not an oversight: 1 GPU put,
tx-depth 8, n=3, separate cards peak 42.91 GB/s against 28.72 on one card. The
header note claiming a same-card pair measured no worse is updated -- it held
while the H2D copy was binding and predicted its own expiry. A job that wants
every card raises maxFrontendDevices.

Fallback is a preference, not a filter: a cap above the local supply is still
filled, since peers derive their lane count from this list. An unreadable NUMA
node sorts to remote rather than local.

Differential Revision: D118391115


