### PR TITLE
Match NCCL Ring BF16 AVG pre-multiply semantics

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -1485,12 +1485,15 @@ commResult_t ctranAllReduceRing(
             func, numThreads, config.launchSharedMemBytes())
       : 0;
   config.args.devState_d = comm->ctran_->algo->getDevState();
+  const float avgPreMul =
+      redOp == commAvg ? static_cast<float>(1.0 / nRanks) : 1.0f;
   ctran::allreduce::ring::KernArgs kernArgs{
       .sendbuff = sendbuff,
       .recvbuff = recvbuff,
       .datatype = datatype,
       .redOp = redOp,
       .count = count,
+      .avgPreMul = avgPreMul,
       .chunkSize = hostResource.chunkSize,
       .numChunks = hostResource.numChunks,
       .minShardSize = hostArgs.minShardSize,

--- a/comms/ctran/algos/AllReduce/AllReduceRing.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cuh
@@ -1,6 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #pragma once
+#include <type_traits>
+
 #include "comms/ctran/algos/AllReduce/AllReduceRingCommon.cuh"
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/ctran/algos/DevAlgoImpl.cuh"
@@ -46,6 +48,82 @@ __device__ __forceinline__ const T* getBufAtByteOffset(
     size_t offset) {
   return reinterpret_cast<const T*>(
       reinterpret_cast<const char*>(buf) + offset);
+}
+
+template <typename T, commRedOp_t RedOp>
+inline constexpr bool kUseBfloat16AvgPreMul =
+#if defined(__CUDA_BF16_TYPES_EXIST__)
+    std::is_same_v<T, __nv_bfloat16> && RedOp == commAvg;
+#else
+    false;
+#endif
+
+#if defined(__CUDA_BF16_TYPES_EXIST__)
+__device__ __forceinline__ __nv_bfloat16
+getBfloat16AvgPreMul(const KernArgs& args) {
+  if (args.avgPreMul == 0.0f) {
+    trap();
+  }
+  return __float2bfloat16(args.avgPreMul);
+}
+#endif
+
+template <typename T, commRedOp_t RedOp, bool FinalizeAvg>
+__device__ __forceinline__ void reduceRing(
+    const KernArgs& args,
+    const AlgoContext& algoCtx,
+    size_t nsrcs,
+    const T** srcs,
+    size_t ndsts,
+    T** dsts,
+    size_t count) {
+#if defined(__CUDA_BF16_TYPES_EXIST__)
+  if constexpr (kUseBfloat16AvgPreMul<T, RedOp>) {
+    localReducePreMulSumSrc0<T>(
+        nsrcs,
+        srcs,
+        ndsts,
+        dsts,
+        count,
+        blockIdx.x,
+        gridDim.x,
+        getBfloat16AvgPreMul(args));
+    return;
+  }
+#endif
+  if constexpr (RedOp == commAvg && !FinalizeAvg) {
+    localReduce<T, commSum>(
+        nsrcs, srcs, ndsts, dsts, count, blockIdx.x, gridDim.x, algoCtx.nRanks);
+  } else {
+    localReduce<T, RedOp>(
+        nsrcs, srcs, ndsts, dsts, count, blockIdx.x, gridDim.x, algoCtx.nRanks);
+  }
+}
+
+template <typename T, commRedOp_t RedOp>
+__device__ __forceinline__ void copyRing(
+    const KernArgs& args,
+    const AlgoContext& algoCtx,
+    const T* src,
+    T* dst,
+    size_t count) {
+#if defined(__CUDA_BF16_TYPES_EXIST__)
+  if constexpr (kUseBfloat16AvgPreMul<T, RedOp>) {
+    const T* srcs[1] = {src};
+    T* dsts[1] = {dst};
+    localReducePreMulSumSrc0<T>(
+        1,
+        srcs,
+        1,
+        dsts,
+        count,
+        blockIdx.x,
+        gridDim.x,
+        getBfloat16AvgPreMul(args));
+    return;
+  }
+#endif
+  ctranKernCopyRaw<T>(src, dst, count, blockIdx.x, gridDim.x);
 }
 
 template <typename T, commRedOp_t RedOp, bool Unpack>
@@ -139,17 +217,14 @@ __device__ __forceinline__ void _progressRecv(
     const T* srcs[2] = {send_data, tmpRecvBuf};
     if (isRecvFwd_ && !updateData) { // steps [0, n-1)
       // update only next step's sendBuf
-      if constexpr (RedOp == commAvg) {
-        localReduce<T, commSum>(
-            2, srcs, tmpSendBuf, roundArgs.numel, algoCtx.nRanks);
-      } else {
-        localReduce<T, RedOp>(
-            2, srcs, tmpSendBuf, roundArgs.numel, algoCtx.nRanks);
-      }
+      T* dsts[1] = {tmpSendBuf};
+      reduceRing<T, RedOp, /*FinalizeAvg=*/false>(
+          args, algoCtx, 2, srcs, 1, dsts, roundArgs.numel);
     } else if (isRecvFwd_ && updateData) { // step n-1
       // update both next step's sendBuf and data
       T* dsts[2] = {recv_data, tmpSendBuf};
-      localReduce<T, RedOp>(2, srcs, 2, dsts, roundArgs.numel, algoCtx.nRanks);
+      reduceRing<T, RedOp, /*FinalizeAvg=*/true>(
+          args, algoCtx, 2, srcs, 2, dsts, roundArgs.numel);
     }
   } else {
     if (isRecvFwd_ && updateData) { // steps [n, 2n-2)
@@ -218,8 +293,7 @@ __device__ __forceinline__ void _progressSend(
       tmpSendBuf,
       roundArgs.numel);
 
-  ctranKernCopyRaw<T>(
-      send_data, tmpSendBuf, roundArgs.numel, blockIdx.x, gridDim.x);
+  copyRing<T, RedOp>(args, algoCtx, send_data, tmpSendBuf, roundArgs.numel);
 
   // Notify host side its completion
   complete(args.sendCopySync, blockIdx.x, round);

--- a/comms/ctran/algos/AllReduce/AllReduceRingCommon.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceRingCommon.cuh
@@ -25,6 +25,7 @@ struct KernArgs {
   commDataType_t datatype;
   commRedOp_t redOp;
   size_t count;
+  float avgPreMul;
 
   size_t chunkSize;
   size_t numChunks;

--- a/comms/ctran/algos/localReduce.cuh
+++ b/comms/ctran/algos/localReduce.cuh
@@ -172,14 +172,20 @@ struct __align__(16) T_NBytes {
 };
 
 // Specialization for a fixed nvector count
-template <typename T, commRedOp_t RedOp, int NSrcs, int NDsts>
+template <
+    typename T,
+    commRedOp_t RedOp,
+    int NSrcs,
+    int NDsts,
+    bool PreMulSrc0 = false>
 __device__ __forceinline__ void localReduceVectorized(
     const T** srcs,
     T** dsts,
     size_t count,
     int workerId,
     int numWorkers,
-    size_t nRanks = 1) {
+    size_t nRanks = 1,
+    T preMul = T{}) {
   using TVec = T_NBytes<T, 16>;
   constexpr uint32_t kWordsPerVectorLoad = TVec::kWords;
   constexpr uint32_t kUnroll = 4;
@@ -225,6 +231,17 @@ __device__ __forceinline__ void localReduceVectorized(
       }
     }
 
+    if constexpr (PreMulSrc0) {
+#pragma unroll
+      for (int unrollIdx = 0; unrollIdx < kUnroll; ++unrollIdx) {
+#pragma unroll
+        for (int wordIdx = 0; wordIdx < kWordsPerVectorLoad; ++wordIdx) {
+          s[unrollIdx][0].v[wordIdx] =
+              reduceNcclOp1<T, commProd>(s[unrollIdx][0].v[wordIdx], preMul);
+        }
+      }
+    }
+
     // Reduce vertically along the vectors
     // However, here, the original kUnroll then NVectors loop order is faster
 #pragma unroll
@@ -255,6 +272,9 @@ __device__ __forceinline__ void localReduceVectorized(
   if (p.ownsTail) {
     for (uint32_t i = limitCount + threadIdx.x; i < count; i += blockDim.x) {
       T s = srcs[0][i];
+      if constexpr (PreMulSrc0) {
+        s = reduceNcclOp1<T, commProd>(s, preMul);
+      }
 #pragma unroll
       for (int j = 1; j < NSrcs; ++j) {
         s = reduceNcclOp1<T, RedOp>(s, srcs[j][i]);
@@ -285,7 +305,7 @@ __device__ __forceinline__ void localReduceVectorized(
 }
 
 // Specialization for a fixed nvector count
-template <typename T, commRedOp_t RedOp>
+template <typename T, commRedOp_t RedOp, bool PreMulSrc0 = false>
 __device__ __forceinline__ void localReduceFallback(
     uint32_t nsrcs,
     const T** srcs,
@@ -294,7 +314,8 @@ __device__ __forceinline__ void localReduceFallback(
     size_t count,
     int workerId,
     int numWorkers,
-    size_t nRanks = 1) {
+    size_t nRanks = 1,
+    T preMul = T{}) {
   constexpr int kVectors = CTRAN_MAX_NVL_PEERS;
   assert(nsrcs <= kVectors);
 
@@ -353,6 +374,9 @@ __device__ __forceinline__ void localReduceFallback(
       // reduce vertically along the vectors
 #pragma unroll
       for (int j = 0; j < kUnroll; ++j) {
+        if constexpr (PreMulSrc0) {
+          s[j][0] = reduceNcclOp1<T, commProd>(s[j][0], preMul);
+        }
         for (uint32_t k = 1; k < nsrcs; ++k) {
           s[j][0] = reduceNcclOp1<T, RedOp>(s[j][0], s[j][k]);
         }
@@ -372,6 +396,9 @@ __device__ __forceinline__ void localReduceFallback(
   if (p.ownsTail) {
     for (size_t i = p.limitUnroll + threadIdx.x; i < count; i += blockDim.x) {
       T s = srcs[0][i];
+      if constexpr (PreMulSrc0) {
+        s = reduceNcclOp1<T, commProd>(s, preMul);
+      }
 #pragma unroll
       for (int j = 1; j < nsrcs; ++j) {
         s = reduceNcclOp1<T, RedOp>(s, srcs[j][i]);
@@ -398,8 +425,8 @@ constexpr uint32_t kMax_uint32_t = std::numeric_limits<uint32_t>::max();
 // If commAvg is passed, it will apply element-wise average with nRanks
 // following the same partition as the reduce computation. It avoids expensive
 // cross-thread-block sync.
-template <typename T, commRedOp_t RedOp>
-__device__ __forceinline__ void localReduce(
+template <typename T, commRedOp_t RedOp, bool PreMulSrc0>
+__device__ __forceinline__ void localReduceImpl(
     size_t nsrcs,
     const T** srcs,
     size_t ndsts,
@@ -407,7 +434,8 @@ __device__ __forceinline__ void localReduce(
     size_t count,
     int workerId,
     int numWorkers,
-    size_t nRanks = 1) {
+    size_t nRanks,
+    T preMul) {
   // In order to use the optimized implementation:
   // -the src and dst pointers must be aligned to 16 bytes
   // -count must be sufficiently large, but under max uint32_t
@@ -424,43 +452,113 @@ __device__ __forceinline__ void localReduce(
 
   if (isAligned && isCountInBounds) {
     if (nsrcs == 8 && ndsts == 1) {
-      localReduceVectorized<T, RedOp, /*NSrcs=*/8, /*NDsts=*/1>(
-          srcs, dsts, count, workerId, numWorkers, nRanks);
+      localReduceVectorized<
+          T,
+          RedOp,
+          /*NSrcs=*/8,
+          /*NDsts=*/1,
+          PreMulSrc0>(srcs, dsts, count, workerId, numWorkers, nRanks, preMul);
       return;
     } else if (nsrcs == 4 && ndsts == 1) {
-      localReduceVectorized<T, RedOp, /*NSrcs=*/4, /*NDsts=*/1>(
-          srcs, dsts, count, workerId, numWorkers, nRanks);
+      localReduceVectorized<
+          T,
+          RedOp,
+          /*NSrcs=*/4,
+          /*NDsts=*/1,
+          PreMulSrc0>(srcs, dsts, count, workerId, numWorkers, nRanks, preMul);
       return;
     } else if (nsrcs == 2 && ndsts == 1) {
-      localReduceVectorized<T, RedOp, /*NSrcs=*/2, /*NDsts=*/1>(
-          srcs, dsts, count, workerId, numWorkers, nRanks);
+      localReduceVectorized<
+          T,
+          RedOp,
+          /*NSrcs=*/2,
+          /*NDsts=*/1,
+          PreMulSrc0>(srcs, dsts, count, workerId, numWorkers, nRanks, preMul);
       return;
     } else if (nsrcs == 8 && ndsts == 2) {
-      localReduceVectorized<T, RedOp, /*NSrcs=*/8, /*NDsts=*/2>(
-          srcs, dsts, count, workerId, numWorkers, nRanks);
+      localReduceVectorized<
+          T,
+          RedOp,
+          /*NSrcs=*/8,
+          /*NDsts=*/2,
+          PreMulSrc0>(srcs, dsts, count, workerId, numWorkers, nRanks, preMul);
       return;
     } else if (nsrcs == 2 && ndsts == 2) {
-      localReduceVectorized<T, RedOp, /*NSrcs=*/2, /*NDsts=*/2>(
-          srcs, dsts, count, workerId, numWorkers, nRanks);
+      localReduceVectorized<
+          T,
+          RedOp,
+          /*NSrcs=*/2,
+          /*NDsts=*/2,
+          PreMulSrc0>(srcs, dsts, count, workerId, numWorkers, nRanks, preMul);
       return;
     } else if (nsrcs == 1 && ndsts == 8) {
-      localReduceVectorized<T, RedOp, /*NSrcs=*/1, /*NDsts=*/8>(
-          srcs, dsts, count, workerId, numWorkers, nRanks);
+      localReduceVectorized<
+          T,
+          RedOp,
+          /*NSrcs=*/1,
+          /*NDsts=*/8,
+          PreMulSrc0>(srcs, dsts, count, workerId, numWorkers, nRanks, preMul);
       return;
     } else if (nsrcs == 8 && ndsts == 8) {
-      localReduceVectorized<T, RedOp, /*NSrcs=*/8, /*NDsts=*/8>(
-          srcs, dsts, count, workerId, numWorkers, nRanks);
+      localReduceVectorized<
+          T,
+          RedOp,
+          /*NSrcs=*/8,
+          /*NDsts=*/8,
+          PreMulSrc0>(srcs, dsts, count, workerId, numWorkers, nRanks, preMul);
       return;
     } else if (nsrcs == 1 && ndsts == 1) {
-      localReduceVectorized<T, RedOp, /*NSrcs=*/1, /*NDsts=*/1>(
-          srcs, dsts, count, workerId, numWorkers, nRanks);
+      localReduceVectorized<
+          T,
+          RedOp,
+          /*NSrcs=*/1,
+          /*NDsts=*/1,
+          PreMulSrc0>(srcs, dsts, count, workerId, numWorkers, nRanks, preMul);
       return;
     }
   }
 
   // Fallback slow implementation
-  localReduceFallback<T, RedOp>(
-      nsrcs, srcs, ndsts, dsts, count, workerId, numWorkers, nRanks);
+  localReduceFallback<T, RedOp, PreMulSrc0>(
+      nsrcs, srcs, ndsts, dsts, count, workerId, numWorkers, nRanks, preMul);
+}
+
+template <typename T, commRedOp_t RedOp>
+__device__ __forceinline__ void localReduce(
+    size_t nsrcs,
+    const T** srcs,
+    size_t ndsts,
+    T** dsts,
+    size_t count,
+    int workerId,
+    int numWorkers,
+    size_t nRanks = 1) {
+  localReduceImpl<T, RedOp, /*PreMulSrc0=*/false>(
+      nsrcs, srcs, ndsts, dsts, count, workerId, numWorkers, nRanks, T{});
+}
+
+// Callers must ensure every original contribution reaches source 0 exactly
+// once before using this reduction variant.
+template <typename T>
+__device__ __forceinline__ void localReducePreMulSumSrc0(
+    size_t nsrcs,
+    const T** srcs,
+    size_t ndsts,
+    T** dsts,
+    size_t count,
+    int workerId,
+    int numWorkers,
+    T preMul) {
+  localReduceImpl<T, commSum, /*PreMulSrc0=*/true>(
+      nsrcs,
+      srcs,
+      ndsts,
+      dsts,
+      count,
+      workerId,
+      numWorkers,
+      /*nRanks=*/1,
+      preMul);
 }
 
 template <typename T, commRedOp_t RedOp>

--- a/comms/ctran/tests/CtranDistAllReduceTest.cc
+++ b/comms/ctran/tests/CtranDistAllReduceTest.cc
@@ -6,7 +6,10 @@
 #include <gtest/gtest.h>
 #include <mpi.h>
 #include <stdlib.h>
+#include <algorithm>
+#include <cmath>
 #include <thread>
+#include <type_traits>
 #include "comms/ctran/utils/CtranLogger.h"
 
 #include "CtranUtUtils.h"
@@ -23,10 +26,54 @@ constexpr size_t VAL_RANGE = 1024;
 // numerical difference between CPU and GPU for floating points
 constexpr size_t VAL_RANGE_PROD = 8;
 
+#if defined(__CUDA_BF16_TYPES_EXIST__)
+namespace {
+
+float roundToBfloat16(float value) {
+  return static_cast<float>(static_cast<__nv_bfloat16>(value));
+}
+
+std::vector<float> bfloat16PreMulSumCyclicResults(
+    const std::vector<float>& inputs) {
+  const float preMul = roundToBfloat16(static_cast<float>(1.0 / inputs.size()));
+  std::vector<float> results;
+  results.reserve(2 * inputs.size());
+  const auto addResult = [&](float result) {
+    if (std::find(results.begin(), results.end(), result) == results.end()) {
+      results.push_back(result);
+    }
+  };
+  for (size_t start = 0; start < inputs.size(); ++start) {
+    // Native and widened BF16 paths round at different boundaries.
+    float roundedProductSum = 0.0f;
+    float fusedProductSum = 0.0f;
+    for (size_t offset = 0; offset < inputs.size(); ++offset) {
+      const float input =
+          roundToBfloat16(inputs[(start + offset) % inputs.size()]);
+      const float scaled = roundToBfloat16(input * preMul);
+      roundedProductSum = roundToBfloat16(roundedProductSum + scaled);
+      fusedProductSum = roundToBfloat16(fusedProductSum + input * preMul);
+    }
+    addResult(roundedProductSum);
+    addResult(fusedProductSum);
+  }
+  return results;
+}
+
+} // namespace
+#endif
+
 template <typename TYPE>
 class CtranAllReduceTest : public ctran::CtranDistTestFixture,
                            public CtranBaseTest {
  public:
+  struct AllReduceTestOptions {
+    std::vector<CtranMapperBackend> excludedBackends{CtranMapperBackend::NVL};
+    std::optional<float> constantInput;
+    std::vector<float> expectedConstantResults;
+    double constantResultTolerance{0.05};
+  };
+
   CtranAllReduceTest() = default;
   commDataType_t dt = ctran::getCommDataType<TYPE>();
   size_t bytes;
@@ -52,7 +99,8 @@ class CtranAllReduceTest : public ctran::CtranDistTestFixture,
       size_t count,
       TestInPlaceType inplace,
       commRedOp_t op,
-      MemAllocType memType) {
+      MemAllocType memType,
+      std::optional<float> constantInput = std::nullopt) {
     sendbuf = recvbuf = nullptr;
     bytes = count * commTypeSize(dt);
     if (bytes < CTRAN_MIN_REGISTRATION_SIZE) {
@@ -63,7 +111,9 @@ class CtranAllReduceTest : public ctran::CtranDistTestFixture,
     CUDACHECK_TEST(cudaHostAlloc(&hostbuf, bytes, 0));
     for (size_t i = 0; i < count; i++) {
       auto val = i % VAL_RANGE + globalRank;
-      if (op == commProd) {
+      if (constantInput.has_value()) {
+        hostbuf[i] = static_cast<TYPE>(*constantInput);
+      } else if (op == commProd) {
         // use smaller value range to avoid overflow or accumulated precision
         // loss for floating points
         hostbuf[i] = (TYPE)(val % VAL_RANGE_PROD);
@@ -121,25 +171,98 @@ class CtranAllReduceTest : public ctran::CtranDistTestFixture,
             static_cast<float>(baseVal) +
             static_cast<float>(this->numRanks - 1) / 2.0f);
       }
+      bool matches = observedVals[i] == exp;
+      float expectedForLog = static_cast<float>(exp);
+#if defined(__CUDA_BF16_TYPES_EXIST__)
+      if constexpr (std::is_same_v<TYPE, __nv_bfloat16>) {
+        if (op == commAvg) {
+          std::vector<float> inputs(this->numRanks);
+          for (int rank = 0; rank < this->numRanks; ++rank) {
+            inputs[rank] = static_cast<float>(baseVal + rank);
+          }
+          const auto expectedValues = bfloat16PreMulSumCyclicResults(inputs);
+          expectedForLog = expectedValues.front();
+          matches =
+              std::find(
+                  expectedValues.begin(),
+                  expectedValues.end(),
+                  static_cast<float>(observedVals[i])) != expectedValues.end();
+        }
+      }
+#endif
       // log the first 3 errors
       if (error_count < 3) {
-        EXPECT_EQ(observedVals[i], exp) << "  i=" << i << std::endl
-                                        << "  count=" << count << " on rank "
-                                        << this->globalRank << std::endl;
+        EXPECT_TRUE(matches)
+            << "  i=" << i << std::endl
+            << "  observed=" << static_cast<float>(observedVals[i])
+            << " expected=" << expectedForLog << std::endl
+            << "  count=" << count << " on rank " << this->globalRank
+            << std::endl;
       }
       // count errors
-      if (observedVals[i] != exp) {
+      if (!matches) {
         if (error_count < 20) {
           CTRAN_LOG_STREAM(WARN)
               << "error[" << error_count << "]: " << " data[" << i << "] "
               << static_cast<float>(observedVals[i]) << " vs exp "
-              << static_cast<float>(exp);
+              << expectedForLog;
         }
         error_count++;
       }
     }
     ASSERT_EQ(error_count, 0) << "  error count=" << count << " on rank "
                               << this->globalRank << std::endl;
+  }
+
+  void verifyConstantResult(
+      size_t count,
+      const std::vector<float>& expectedValues,
+      double relativeTolerance = 0.05) {
+    ASSERT_FALSE(expectedValues.empty());
+    std::vector<TYPE> observedVals(count, 117);
+    FB_CUDACHECKIGNORE(cudaMemcpy(
+        observedVals.data(),
+        recvbuf,
+        count * commTypeSize(dt),
+        cudaMemcpyDefault));
+
+    std::vector<double> roundedExpectedValues;
+    roundedExpectedValues.reserve(expectedValues.size());
+    for (const float expectedValue : expectedValues) {
+      roundedExpectedValues.push_back(
+          static_cast<float>(static_cast<TYPE>(expectedValue)));
+    }
+    int errorCount = 0;
+    for (size_t i = 0; i < count; i++) {
+      const double observed = static_cast<float>(observedVals[i]);
+      const bool matches = std::isfinite(observed) &&
+          std::any_of(roundedExpectedValues.begin(),
+                      roundedExpectedValues.end(),
+                      [&](double expected) {
+                        const double tolerance =
+                            std::max(std::abs(expected), 1.0) *
+                            relativeTolerance;
+                        return relativeTolerance == 0.0
+                            ? observed == expected
+                            : std::abs(observed - expected) <= tolerance;
+                      });
+      if (!matches) {
+        if (errorCount < 3) {
+          EXPECT_TRUE(std::isfinite(observed)) << "  i=" << i;
+          EXPECT_TRUE(matches)
+              << "  i=" << i << " observed=" << observed
+              << " first expected=" << roundedExpectedValues.front();
+        }
+        if (errorCount < 20) {
+          CTRAN_LOG_STREAM(WARN)
+              << "error[" << errorCount << "]: " << " data[" << i << "] "
+              << observed << " vs first exp " << roundedExpectedValues.front();
+        }
+        errorCount++;
+      }
+    }
+    ASSERT_EQ(errorCount, 0) << "  error count=" << errorCount << " on rank "
+                             << this->globalRank << std::endl;
   }
 
   /* test given Allreduce function */
@@ -158,13 +281,12 @@ class CtranAllReduceTest : public ctran::CtranDistTestFixture,
       TestInPlaceType inplace,
       commRedOp_t op,
       MemAllocType memType,
-      std::vector<CtranMapperBackend> excludedBackends = {
-          CtranMapperBackend::NVL}) {
+      const AllReduceTestOptions& options = {}) {
     if (memType == kCuMemAllocDisjoint && !NCCL_CTRAN_IB_DMABUF_ENABLE) {
       GTEST_SKIP() << "dmabuf is not supported, skip disjoint test";
     }
 
-    memorySetUp(count, inplace, op, memType);
+    memorySetUp(count, inplace, op, memType, options.constantInput);
 
     if (!ctranAllReduceSupport(ctranComm.get(), algo)) {
       GTEST_SKIP() << "ctranAllReduceSupport returns fails, skip test";
@@ -203,7 +325,15 @@ class CtranAllReduceTest : public ctran::CtranDistTestFixture,
 
     FB_CUDACHECKIGNORE(cudaStreamSynchronize(testStream));
 
-    verifyResult(count, op);
+    if (options.constantInput.has_value()) {
+      const auto expectedValues = options.expectedConstantResults.empty()
+          ? std::vector<float>{*options.constantInput}
+          : options.expectedConstantResults;
+      verifyConstantResult(
+          count, expectedValues, options.constantResultTolerance);
+    } else {
+      verifyResult(count, op);
+    }
 
     CUDACHECK_TEST(cudaDeviceSynchronize());
     // Sleep for a while to make sure all the colls are finished
@@ -231,7 +361,7 @@ class CtranAllReduceTest : public ctran::CtranDistTestFixture,
         ctranComm->ctran_.get(),
         ctranComm->statex_.get(),
         kMemNcclMemAlloc,
-        excludedBackends);
+        options.excludedBackends);
     verifyGpeLeak(ctranComm->ctran_.get());
 
     for (auto& segment : segments) {
@@ -418,6 +548,92 @@ TEST_P(CtranAllReduceRingTestParamBfloat16, AllReduceRingBfloat16) {
       op,
       memType);
 }
+
+class CtranAllReduceRingBfloat16AvgOverflowTest
+    : public CtranAllReduceTest<__nv_bfloat16>,
+      public ::testing::WithParamInterface<TestInPlaceType> {
+ public:
+  void SetUp() override {
+    if (!ctran::isNolocalTopo()) {
+      GTEST_SKIP() << "Ring AllReduce tests require nolocal topology; skip.";
+    }
+    CtranAllReduceTest::SetUp();
+  }
+};
+
+TEST_P(CtranAllReduceRingBfloat16AvgOverflowTest, PreMultiplyStaysFinite) {
+  ASSERT_GT(this->numRanks, 1);
+  constexpr float kBfloat16Max = 3.38953139e38f;
+  std::vector<float> inputs(this->numRanks);
+  for (int rank = 0; rank < this->numRanks; ++rank) {
+    const float fraction = 0.5f +
+        0.25f * static_cast<float>(rank) /
+            static_cast<float>(this->numRanks - 1);
+    inputs[rank] = fraction * kBfloat16Max;
+  }
+  const auto expectedValues = bfloat16PreMulSumCyclicResults(inputs);
+  ASSERT_TRUE(
+      std::all_of(
+          expectedValues.begin(), expectedValues.end(), [](float value) {
+            return std::isfinite(value);
+          }));
+  beginTest(
+      ctranAllReduceRing,
+      NCCL_ALLREDUCE_ALGO::ctring,
+      1024 * 1024 + 17,
+      GetParam(),
+      commAvg,
+      kMemNcclMemAlloc,
+      {
+          .constantInput = inputs.at(this->globalRank),
+          .expectedConstantResults = expectedValues,
+          .constantResultTolerance = 0.0,
+      });
+}
+
+TEST(CtranAllReduceRingBfloat16NcclReferenceTest, TenRankMaximumCanOverflow) {
+  constexpr float kBfloat16Max = 3.38953139e38f;
+  const auto expectedValues =
+      bfloat16PreMulSumCyclicResults(std::vector<float>(10, kBfloat16Max));
+  ASSERT_EQ(expectedValues.size(), 1);
+  EXPECT_TRUE(std::isinf(expectedValues.front()));
+  EXPECT_GT(expectedValues.front(), 0.0f);
+}
+
+class CtranAllReduceRingBfloat16NcclSemanticsTest
+    : public CtranAllReduceTest<__nv_bfloat16> {
+ public:
+  void SetUp() override {
+    if (!ctran::isNolocalTopo()) {
+      GTEST_SKIP() << "Ring AllReduce tests require nolocal topology; skip.";
+    }
+    CtranAllReduceTest::SetUp();
+  }
+};
+
+TEST_F(
+    CtranAllReduceRingBfloat16NcclSemanticsTest,
+    UsesBfloat16RoundedReciprocal) {
+  if (this->numRanks != 3) {
+    GTEST_SKIP() << "This test requires exactly three ranks";
+  }
+  constexpr float kInput = 0.4375f;
+  const std::vector<float> inputs(this->numRanks, kInput);
+  const auto expectedValues = bfloat16PreMulSumCyclicResults(inputs);
+  ASSERT_EQ(expectedValues.size(), 1);
+  beginTest(
+      ctranAllReduceRing,
+      NCCL_ALLREDUCE_ALGO::ctring,
+      16,
+      kTestOutOfPlace,
+      commAvg,
+      kMemNcclMemAlloc,
+      {
+          .constantInput = kInput,
+          .expectedConstantResults = expectedValues,
+          .constantResultTolerance = 0.0,
+      });
+}
 #endif
 
 auto testingValuesRing = ::testing::Values(
@@ -479,6 +695,14 @@ INSTANTIATE_TEST_SUITE_P(
 
 #if defined(__CUDA_BF16_TYPES_EXIST__)
 auto testingValuesRingBfloat16 = ::testing::Values(
+    std::make_tuple(16, kTestOutOfPlace, commSum, kMemNcclMemAlloc),
+    std::make_tuple(16, kTestInPlace, commSum, kMemNcclMemAlloc),
+    std::make_tuple(16, kTestOutOfPlace, commProd, kMemNcclMemAlloc),
+    std::make_tuple(16, kTestInPlace, commProd, kMemNcclMemAlloc),
+    std::make_tuple(16, kTestOutOfPlace, commMax, kMemNcclMemAlloc),
+    std::make_tuple(16, kTestInPlace, commMax, kMemNcclMemAlloc),
+    std::make_tuple(16, kTestOutOfPlace, commMin, kMemNcclMemAlloc),
+    std::make_tuple(16, kTestInPlace, commMin, kMemNcclMemAlloc),
     std::make_tuple(16, kTestOutOfPlace, commAvg, kMemNcclMemAlloc),
     std::make_tuple(16, kTestInPlace, commAvg, kMemNcclMemAlloc));
 
@@ -487,6 +711,11 @@ INSTANTIATE_TEST_SUITE_P(
     CtranAllReduceRingTestParamBfloat16,
     testingValuesRingBfloat16,
     getTestName);
+
+INSTANTIATE_TEST_SUITE_P(
+    CtranTest,
+    CtranAllReduceRingBfloat16AvgOverflowTest,
+    ::testing::Values(kTestOutOfPlace, kTestInPlace));
 #endif
 
 // =============================================================================
@@ -655,7 +884,7 @@ TEST_P(CtranAllReduceRingTcpDmTestFp32, AllReduceRingTcpDmFp32) {
       inplace,
       op,
       memType,
-      {CtranMapperBackend::NVL, CtranMapperBackend::IB});
+      {.excludedBackends = {CtranMapperBackend::NVL, CtranMapperBackend::IB}});
 }
 // Only add one test case as the current TCPDM backend does not support
 // consecutive ctrantcpdm create and destroy in the single process.


### PR DESCRIPTION
Summary:
Make legacy CTRAN Ring BF16 AVG follow NCCL-compatible pre-multiply semantics by scaling each original contribution with the BF16-rounded reciprocal before accumulation. The host computes the reciprocal from the current communicator rank count once per launch; the kernel narrows it to BF16 and rejects a missing zero scalar. Compile-time dispatch confines the behavior change to BF16 `AVG`, preserving BF16 `SUM`, `PROD`, `MAX`, and `MIN` plus every FP32 path.

The local reduction entry point is sum-only and requires explicit CTA worker coordinates and a multiplier, preventing argument misbinding and accidental double division. Exact test oracles now cover non-power-of-two rank counts, rank-dependent high-magnitude inputs, in-place and out-of-place BF16 AVG, small non-AVG regressions, tail ownership, and the ten-rank `BF16_MAX` boundary. Pre-multiplication avoids overflow from an unscaled intermediate sum but, like NCCL, does not guarantee finite results for every extreme BF16 input. The MCCL AllReduce documentation now records that boundary and distinguishes legacy Ring BF16 AVG from the other CTRAN AVG paths.

Reviewed By: rmahidhar

Differential Revision: D119110307


