### PR TITLE
Stop CTRAN kernels reserving ~36.8KB of ncclShmem (#4070)

### DIFF
--- a/comms/ctran/algos/DevCommon.cuh
+++ b/comms/ctran/algos/DevCommon.cuh
@@ -158,7 +158,9 @@ __device__ __forceinline__ void elemsFreeListByGroup(
 __device__ __forceinline__ void
 copy(uint4* dst, const uint4* src, size_t count);
 
-static inline __device__ void devStateLoadToShm(
+// __forceinline__: writes the per-TU static __shared__ statex/kernelFlag/
+// kernelDoAbort. See DevShmState.cuh.
+static __forceinline__ __device__ void devStateLoadToShm(
     int* flag,
     CtranAlgoDeviceState* devState) {
   const uint4* devStatePtr = reinterpret_cast<const uint4*>(devState);
@@ -183,7 +185,7 @@ static inline __device__ void devStateLoadToShm(
 #endif
 }
 
-static inline __device__ void devStateLoadToShm(
+static __forceinline__ __device__ void devStateLoadToShm(
     CtranAlgoDeviceState* devState) {
   devStateLoadToShm(&placeHolderKernelFlag, devState);
 }

--- a/comms/ctran/algos/DevShmState.cu
+++ b/comms/ctran/algos/DevShmState.cu
@@ -5,11 +5,8 @@
 
 #if defined(__HIP_PLATFORM_AMD__)
 #else
-// For CUDA, define the shared memory variables that are declared as extern in
-// DevCommon.cuh
-__shared__ ctran::CommStateXDev* statex;
-__shared__ int* kernelFlag;
-__shared__ bool kernelDoAbort;
+// statex/kernelFlag/kernelDoAbort are static __shared__ in DevShmState.cuh, so
+// they need no definition here.
 // TODO: remove once all kernels migrated to populate kernelFlag
 __constant__ int placeHolderKernelFlag = KERNEL_STARTED;
 #endif

--- a/comms/ctran/algos/DevShmState.cuh
+++ b/comms/ctran/algos/DevShmState.cuh
@@ -31,10 +31,23 @@ __device__ __forceinline__ CtranAlgoDeviceState& getShmDevState() {
 // Use dynamic shared memory because on GB200 shemDevState may exceeed the
 // static shared memory limit 48KB - declare as char array and cast to struct
 extern __shared__ char dynamicSharedMem[];
-// statex needs to be extern and will be defined in DevCommon.cu
-extern __shared__ ctran::CommStateXDev* statex;
-extern __shared__ int* kernelFlag;
-extern __shared__ bool kernelDoAbort;
+/* statex/kernelFlag/kernelDoAbort must keep internal linkage.
+ *
+ * nvlink gives every externally-linked __shared__ variable in a device-link
+ * unit one address in a single flat module-wide block. CTRAN is device-linked
+ * together with ncclx's src/device objects, whose common.cu defines
+ * __shared__ ncclShmemData ncclShmem (~36.8KB). As extern, these three land
+ * above ncclShmem in that block, so every kernel touching one of them reserves
+ * ~36.8KB of static shared memory it never reads - enough to keep a CTRAN
+ * kernel from being co-resident with a large GEMM.
+ *
+ * Consequence: every function that reads or writes them must be inlined into
+ * the kernel. A non-inlined __device__ function in another TU would silently
+ * bind to a different copy.
+ */
+static __shared__ ctran::CommStateXDev* statex;
+static __shared__ int* kernelFlag;
+static __shared__ bool kernelDoAbort;
 // TODO: remove once all kernels migrated to populate kernelFlag
 extern __constant__ int placeHolderKernelFlag;
 

--- a/comms/ctran/algos/common/GpeKernelDev.cuh
+++ b/comms/ctran/algos/common/GpeKernelDev.cuh
@@ -20,7 +20,9 @@ namespace ctran::device {
 
 // TODO(T243528798): remove this preload of devstate by splitting h2d/d2h
 // channels.
-static inline __device__ void devLoadAbortFlags(
+// __forceinline__: touches the static __shared__
+// statex/kernelFlag/kernelDoAbort, which are per-TU. See DevShmState.cuh.
+static __forceinline__ __device__ void devLoadAbortFlags(
     int* flag,
     CtranAlgoDeviceState* devState) {
   shmDevState.enableCancellableWaits = devState->enableCancellableWaits;
@@ -63,7 +65,8 @@ static inline __device__ void KernelStartGpeAndExit(
   comms::device::st_volatile_global(&f->flag_[bId], KERNEL_STARTED_AND_EXIT);
 }
 
-static inline __device__ bool KernelTestHostAbort(volatile int* flag) {
+// __forceinline__: reads the per-TU static __shared__ kernelDoAbort.
+static __forceinline__ __device__ bool KernelTestHostAbort(volatile int* flag) {
   // enableCancellableWaits is the feature guard. See comment on the struct
   // field.
   //
@@ -76,7 +79,10 @@ static inline __device__ bool KernelTestHostAbort(volatile int* flag) {
        (flag && comms::device::ld_volatile_global(flag) == KERNEL_HOST_ABORT));
 }
 
-static inline __device__ bool KernelTestHostAbortBlock(volatile int* flag) {
+// __forceinline__: reads/writes the per-TU static __shared__ kernelFlag and
+// kernelDoAbort.
+static __forceinline__ __device__ bool KernelTestHostAbortBlock(
+    volatile int* flag) {
   if (threadIdx.x == 0 && ctran::device::KernelTestHostAbort(kernelFlag)) {
     kernelDoAbort = true;
   }


### PR DESCRIPTION
Summary:

409 of ~470 CTRAN device kernels reserve **36,896 B** of static shared memory
each, even one-thread stream-holder kernels that move no data.
`ncclKernelAllGatherCtranStreamedRd` is 20 lines, declares no `__shared__`,
launches `grid=1, block=1` at `REG:36` -- and reserves 37,920 B in the ELF
(36,896 static + the 1,024 B driver reservation).

None of it is CTRAN's. `statex` / `kernelFlag` / `kernelDoAbort` are 32 bytes;
the other **36,864 B is ncclx's `__shared__ ncclShmemData ncclShmem`**
(`comms/ncclx/v2_30/src/device/common.cu:15`), which no CTRAN source
references.

nvlink assigns every externally-linked `__shared__` variable in a device-link
unit one address in a single flat module-wide block, and each kernel reserves
the prefix up to the highest-addressed symbol it touches. `src/device/Makefile`
compiles the CTRAN sources (plus `genctran.py`'s ~400 instantiations) into
ncclx's device build and `-dlink`s them with `common.cu.o`, so the three CTRAN
statics land *above* `ncclShmem` and drag the whole prefix in. Reconstructed
from SASS:

```
kernelFlag    @ 0x0000            <- ncclDevKernel_* pay 64 B for this one
ncclShmem     @ 0x0040 .. 0x9000  (36,800 B)
statex        @ 0x9008
kernelDoAbort @ 0x9012
dyn base      @ 0x9020 = 36,896
```

Giving the three internal linkage -- what the HIP path already does, with the
comment "this is fine since `__shared__` variables are per-kernel-block
anyway" -- removes them from that block. Each TU gets its own 32 bytes and no
prefix.

That makes the "every accessor must be inlined" requirement load-bearing (a
non-inlined `__device__` function in another TU would silently bind to a
different copy), so the five functions that touch these variables move from
`static inline __device__` to `static __forceinline__ __device__`.

Effect on the 409 kernels: static shared **36,896 -> 32**, ELF `.nv.shared`
**37,920 -> 1,056**, runtime **39,856 -> 2,992**. `ncclDevKernel_*` also shed
the 64 B they pay for `kernelFlag`.

Reviewed By: ngimel

Differential Revision: D118762634


