### PR TITLE
Preserve diagnostics across fatal shutdown (#4072)

### DIFF
--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -34,7 +34,6 @@
 #include "comms/utils/StrUtils.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/LogUtils.h"
 #include "folly/synchronization/CallOnce.h"
 
 using namespace ctran::ib;

--- a/comms/utils/logger/SpdlogLogger.cc
+++ b/comms/utils/logger/SpdlogLogger.cc
@@ -36,6 +36,34 @@ void reportCommsLoggingFailureToStderr(const char* level) noexcept {
   std::fflush(stderr);
 }
 
+class CommsDistSink final : public spdlog::sinks::dist_sink_mt {
+ public:
+  using spdlog::sinks::dist_sink_mt::dist_sink_mt;
+
+  void tryFlush() noexcept {
+    /*
+     * Production child sinks are terminal and do not re-enter comms logging.
+     * This is required before try-locking the non-recursive outer mutex.
+     */
+    std::unique_lock lock{mutex_, std::try_to_lock};
+    if (!lock) {
+      return;
+    }
+    /*
+     * This avoids waiting behind another operation through this distribution
+     * sink. Child-sink flushes can still block on their own mutexes or I/O,
+     * just as synchronous delivery of the fatal record can.
+     */
+    for (const auto& sink : sinks_) {
+      try {
+        sink->flush();
+      } catch (...) {
+        reportCommsLoggingFailureToStderr("ERROR");
+      }
+    }
+  }
+};
+
 [[noreturn]] void abortAfterCommsLoggingFailure() noexcept {
   reportCommsLoggingFailureToStderr("FATAL");
   std::abort();
@@ -177,14 +205,11 @@ class PeriodicSinkFlusher final {
 
   // Joins the flush thread so it cannot touch sinks or stdio during exit. The
   // flusher itself survives, so registerSink() from a running thread stays
-  // safe.
+  // safe. Keep workerMutex_ held through the join so concurrent shutdown
+  // callers cannot observe a stopped worker until it has actually stopped.
   void stopFlushing() noexcept {
-    std::unique_ptr<spdlog::details::periodic_worker> worker;
-    {
-      std::lock_guard lock{workerMutex_};
-      worker = std::move(worker_);
-    }
-    worker.reset();
+    std::lock_guard lock{workerMutex_};
+    worker_.reset();
   }
 
   void registerSink(const std::shared_ptr<spdlog::sinks::sink>& sink) {
@@ -200,6 +225,11 @@ class PeriodicSinkFlusher final {
       }
     }
     sinks_.push_back(sink);
+  }
+
+  bool runningForTesting() {
+    std::lock_guard lock{workerMutex_};
+    return worker_ != nullptr;
   }
 
  private:
@@ -241,6 +271,12 @@ PeriodicSinkFlusher& getPeriodicSinkFlusher() {
     return initialized;
   }();
   return *flusher;
+}
+
+void stopPeriodicSinkFlusher() noexcept {
+  if (auto* flusher = periodicSinkFlusher.load(std::memory_order_acquire)) {
+    flusher->stopFlushing();
+  }
 }
 
 class ErrorCallbackGuard {
@@ -357,6 +393,39 @@ NamedLoggerRegistry& getNamedLoggerRegistry() {
 
 std::atomic<CommsSpdlogLogger*> defaultLogger{nullptr};
 
+template <typename Callback>
+void forEachInitializedLoggerNoexcept(Callback&& callback) noexcept {
+  const auto invokeNoexcept = [&](CommsSpdlogLogger& logger) noexcept {
+    try {
+      callback(logger);
+    } catch (...) {
+      reportCommsLoggingFailureToStderr("ERROR");
+    }
+  };
+
+  if (auto* logger = defaultLogger.load(std::memory_order_acquire)) {
+    invokeNoexcept(*logger);
+  }
+  if (auto* registry = namedLoggerRegistry.load(std::memory_order_acquire)) {
+    std::vector<CommsSpdlogLogger*> loggers;
+    try {
+      {
+        std::shared_lock lock{registry->mutex};
+        loggers.reserve(registry->loggers.size());
+        for (const auto& [name, logger] : registry->loggers) {
+          (void)name;
+          loggers.push_back(logger.get());
+        }
+      }
+    } catch (...) {
+      reportCommsLoggingFailureToStderr("ERROR");
+    }
+    for (auto* logger : loggers) {
+      invokeNoexcept(*logger);
+    }
+  }
+}
+
 std::mutex& getCommsLoggingShutdownMutex() {
   /*
    * Concurrent callers must not return while another caller is still joining
@@ -367,8 +436,7 @@ std::mutex& getCommsLoggingShutdownMutex() {
   return *mutex;
 }
 
-std::shared_ptr<spdlog::sinks::dist_sink_mt> createOutputSink(
-    std::string_view logFilePath) {
+std::shared_ptr<CommsDistSink> createOutputSink(std::string_view logFilePath) {
   std::vector<std::shared_ptr<spdlog::sinks::sink>> sinks;
   if (logFilePath.empty()) {
     sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
@@ -388,13 +456,13 @@ std::shared_ptr<spdlog::sinks::dist_sink_mt> createOutputSink(
   for (auto& sink : sinks) {
     sink->set_formatter(makeFormatter());
   }
-  return std::make_shared<spdlog::sinks::dist_sink_mt>(std::move(sinks));
+  return std::make_shared<CommsDistSink>(std::move(sinks));
 }
 
-std::shared_ptr<spdlog::sinks::dist_sink_mt> createInitialOutputSink() {
+std::shared_ptr<CommsDistSink> createInitialOutputSink() {
   auto sink = std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
   sink->set_formatter(makeFormatter());
-  return std::make_shared<spdlog::sinks::dist_sink_mt>(
+  return std::make_shared<CommsDistSink>(
       std::vector<std::shared_ptr<spdlog::sinks::sink>>{std::move(sink)});
 }
 
@@ -402,6 +470,26 @@ std::shared_ptr<spdlog::sinks::dist_sink_mt> createInitialOutputSink() {
 
 void shutdownSpdlogForFatal() {
   getCommsThreadPoolState().stop();
+  if (auto* logger = defaultLogger.load(std::memory_order_acquire)) {
+    logger->tryFlushForFatal();
+  }
+  if (auto* registry = namedLoggerRegistry.load(std::memory_order_acquire)) {
+    std::shared_lock lock{registry->mutex, std::try_to_lock};
+    if (lock) {
+      /*
+       * Fatal shutdown must not wait to acquire the named-logger registry. It
+       * instead traverses under the try-locked registry: entries are never
+       * erased, and production child sinks do not re-enter named-logger
+       * lookup. This also avoids allocating a pointer snapshot before the
+       * fatal record. Holding the lock can delay concurrent logger creation
+       * while a child sink flushes, which is acceptable during termination.
+       */
+      for (const auto& [name, logger] : registry->loggers) {
+        (void)name;
+        logger->tryFlushForFatal();
+      }
+    }
+  }
 }
 
 void shutdownCommsLogging() noexcept {
@@ -412,40 +500,19 @@ void shutdownCommsLogging() noexcept {
     reportCommsLoggingFailureToStderr("ERROR");
   }
 
-  const auto flushLoggerNoexcept = [](CommsSpdlogLogger& logger) noexcept {
-    try {
-      logger.flush();
-    } catch (...) {
-      reportCommsLoggingFailureToStderr("ERROR");
-    }
-  };
-  if (auto* logger = defaultLogger.load(std::memory_order_acquire)) {
-    flushLoggerNoexcept(*logger);
-  }
-  if (auto* registry = namedLoggerRegistry.load(std::memory_order_acquire)) {
-    std::vector<CommsSpdlogLogger*> loggers;
-    try {
-      {
-        std::shared_lock lock{registry->mutex};
-        loggers.reserve(registry->loggers.size());
-        for (const auto& [name, logger] : registry->loggers) {
-          (void)name;
-          loggers.push_back(logger.get());
-        }
-      }
-    } catch (...) {
-      reportCommsLoggingFailureToStderr("ERROR");
-    }
-    for (auto* logger : loggers) {
-      flushLoggerNoexcept(*logger);
-    }
-  }
-  if (auto* flusher = periodicSinkFlusher.load(std::memory_order_acquire)) {
-    flusher->stopFlushing();
-  }
+  forEachInitializedLoggerNoexcept(
+      [](CommsSpdlogLogger& logger) { logger.flush(); });
+  stopPeriodicSinkFlusher();
 }
 
 namespace testing {
+
+void holdNamedLoggerRegistryLockForTesting(
+    const std::function<void()>& callback) {
+  auto& registry = getNamedLoggerRegistry();
+  std::unique_lock lock{registry.mutex};
+  callback();
+}
 
 void addSinkForTesting(
     CommsSpdlogLogger& logger,
@@ -470,6 +537,17 @@ bool globalThreadPoolAliveForTesting() {
 
 void shutdownAsyncThreadPoolForTesting() {
   getCommsThreadPoolState().stop();
+}
+
+void stopPeriodicSinkFlusherForTesting() {
+  stopPeriodicSinkFlusher();
+}
+
+bool periodicSinkFlusherRunningForTesting() {
+  if (auto* flusher = periodicSinkFlusher.load(std::memory_order_acquire)) {
+    return flusher->runningForTesting();
+  }
+  return false;
 }
 
 bool holdAsyncThreadPoolLeaseForTesting(const std::function<void()>& callback) {
@@ -532,7 +610,6 @@ void CommsLogStreamBase::log() {
 
 [[noreturn]] void CommsLogStreamBase::logFatalAndAbort() noexcept {
   try {
-    logger_.flush();
     shutdownSpdlogForFatal();
     logger_.logFatal(location_, stream_.str());
   } catch (...) {
@@ -606,6 +683,15 @@ void CommsSpdlogLogger::flush() {
   }
 }
 
+void CommsSpdlogLogger::tryFlushForFatal() noexcept {
+  try {
+    const auto state = loadState();
+    state->backend->outputSink->tryFlush();
+  } catch (...) {
+    reportCommsLoggingFailureToStderr("ERROR");
+  }
+}
+
 void CommsSpdlogLogger::log(
     spdlog::source_loc location,
     spdlog::level::level_enum level,
@@ -674,7 +760,7 @@ void CommsSpdlogLogger::storeState(std::shared_ptr<const State> state) {
 }
 
 std::shared_ptr<CommsSpdlogLogger::Backend> CommsSpdlogLogger::createBackend(
-    std::shared_ptr<spdlog::sinks::dist_sink_mt> outputSink,
+    std::shared_ptr<CommsDistSink> outputSink,
     std::string outputPath,
     bool asyncLogging) const {
   auto threadPoolLease = getCommsThreadPoolState().acquire();

--- a/comms/utils/logger/SpdlogLogger.h
+++ b/comms/utils/logger/SpdlogLogger.h
@@ -33,6 +33,8 @@ namespace meta::comms::logger {
 
 inline constexpr std::string_view kCommsLoggerName{"comms"};
 
+class CommsDistSink;
+
 class CommsSpdlogLogger {
  public:
   CommsSpdlogLogger();
@@ -124,12 +126,15 @@ class CommsSpdlogLogger {
       bool asyncLogging,
       spdlog::level::level_enum logLevel);
 
-  // Test-only: appends to the dist sink so a test can observe delivery from
-  // inside the sink call, which is the only point where the lease scoping in
-  // logFormatted() is visible.
+  /*
+   * Test-only: appends to the dist sink so a test can observe delivery from
+   * inside the sink call. Test sinks must not re-enter comms fatal logging.
+   */
   void addSinkForTesting(std::shared_ptr<spdlog::sinks::sink> sink);
 
  private:
+  friend void shutdownSpdlogForFatal();
+
   struct Configuration {
     std::string prefix{"COMMS"};
     std::function<int(void)> threadContextFn{[]() { return 0; }};
@@ -140,7 +145,7 @@ class CommsSpdlogLogger {
   struct Backend {
     std::string outputPath;
     std::shared_ptr<spdlog::logger> logger;
-    std::shared_ptr<spdlog::sinks::dist_sink_mt> outputSink;
+    std::shared_ptr<CommsDistSink> outputSink;
     std::shared_ptr<spdlog::logger> synchronousLogger;
   };
 
@@ -162,7 +167,7 @@ class CommsSpdlogLogger {
   std::shared_ptr<const State> loadState() const;
   void storeState(std::shared_ptr<const State> state);
   std::shared_ptr<Backend> createBackend(
-      std::shared_ptr<spdlog::sinks::dist_sink_mt> outputSink,
+      std::shared_ptr<CommsDistSink> outputSink,
       std::string outputPath,
       bool asyncLogging) const;
   void reconfigureImpl(
@@ -179,6 +184,7 @@ class CommsSpdlogLogger {
       std::string_view levelName,
       std::string_view message,
       bool bypassLevelGate);
+  void tryFlushForFatal() noexcept;
 
   std::string name_;
   std::atomic<spdlog::level::level_enum> logLevel_{spdlog::level::info};
@@ -302,18 +308,19 @@ bool shouldWriteCommsLogToStderr(std::string_view formattedMessage);
   SPDLOG_LOGGER_CALL(logger, ::spdlog::level::trace, __VA_ARGS__)
 
 /*
- * shutdownSpdlogForFatal() stops the library-owned async pool and nothing
- * else. That pool drains once every in-flight async post releases its lease;
- * synchronous delivery holds no lease. spdlog's global registry pool is left
- * running on purpose: draining it means registry::instance(), which may
- * already be gone when a FATAL fires during static destruction. The synchronous
- * logger and its output sinks remain valid throughout.
+ * shutdownSpdlogForFatal() drains the library-owned async pool before
+ * best-effort flushing initialized logger sinks. It does not join the periodic
+ * sink worker because that worker may already be waiting behind an unrelated
+ * blocked sink. It skips the named registry or a distribution sink when its
+ * outer lock is busy. Child-sink mutexes, I/O, and the final synchronous FATAL
+ * delivery may still block. spdlog's global registry pool is left running:
+ * registry::instance() may already be gone when a FATAL fires during static
+ * destruction.
  */
 #define COMMS_LOG_FATAL_IMPL(logger_expression, ...)                 \
   do {                                                               \
     try {                                                            \
       auto& _comms_logger = (logger_expression);                     \
-      _comms_logger.flush();                                         \
       ::meta::comms::logger::shutdownSpdlogForFatal();               \
       _comms_logger.logFatal(                                        \
           ::spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, \

--- a/comms/utils/logger/tests/SpdlogLoggerUT.cc
+++ b/comms/utils/logger/tests/SpdlogLoggerUT.cc
@@ -33,6 +33,8 @@ using meta::comms::logger::getSpdlogLogger;
 
 namespace meta::comms::logger::testing {
 bool holdAsyncThreadPoolLeaseForTesting(const std::function<void()>& callback);
+void holdNamedLoggerRegistryLockForTesting(
+    const std::function<void()>& callback);
 void waitForAsyncThreadPoolShutdownForTesting();
 bool asyncThreadPoolLeaseAvailableForTesting();
 void addSinkForTesting(
@@ -41,6 +43,8 @@ void addSinkForTesting(
 void initGlobalThreadPoolForTesting();
 bool globalThreadPoolAliveForTesting();
 void shutdownAsyncThreadPoolForTesting();
+void stopPeriodicSinkFlusherForTesting();
+bool periodicSinkFlusherRunningForTesting();
 } // namespace meta::comms::logger::testing
 
 // Runs a callback from inside sink delivery, which is the only point at which
@@ -60,6 +64,48 @@ class CallbackSink final : public spdlog::sinks::sink {
 
  private:
   std::function<void()> onLog_;
+};
+
+class ThrowingFlushSink final : public spdlog::sinks::sink {
+ public:
+  void log(const spdlog::details::log_msg& /* message */) override {}
+  [[noreturn]] void flush() override {
+    throw std::runtime_error{"test flush failure"};
+  }
+  void set_pattern(const std::string& /* pattern */) override {}
+  void set_formatter(
+      std::unique_ptr<spdlog::formatter> /* formatter */) override {}
+};
+
+class FlushReportingSink final : public spdlog::sinks::sink {
+ public:
+  FlushReportingSink(
+      std::thread::id producerThread,
+      std::string expectedMessage)
+      : producerThread_{producerThread},
+        expectedMessage_{std::move(expectedMessage)} {}
+
+  void log(const spdlog::details::log_msg& message) override {
+    const std::string_view payload{
+        message.payload.data(), message.payload.size()};
+    if (std::this_thread::get_id() != producerThread_ &&
+        payload.find(expectedMessage_) != std::string_view::npos) {
+      receivedAsynchronously_.store(true, std::memory_order_release);
+    }
+  }
+  void flush() override {
+    if (receivedAsynchronously_.load(std::memory_order_acquire)) {
+      std::fputs("queued async record flushed\n", stderr);
+    }
+  }
+  void set_pattern(const std::string& /* pattern */) override {}
+  void set_formatter(
+      std::unique_ptr<spdlog::formatter> /* formatter */) override {}
+
+ private:
+  const std::thread::id producerThread_;
+  const std::string expectedMessage_;
+  std::atomic<bool> receivedAsynchronously_{false};
 };
 
 /*
@@ -924,7 +970,7 @@ TEST(SpdlogLoggerTest, AsyncPoolShutdownIsNotBlockedBySynchronousDelivery) {
       "synchronous delivery must not block shutdown");
 }
 
-TEST(SpdlogLoggerTest, FatalDoesNotWaitForUnrelatedSynchronousDelivery) {
+TEST(SpdlogLoggerTest, FatalSkipsLoggerWithBusyDistributionSink) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_EXIT(
       {
@@ -933,11 +979,11 @@ TEST(SpdlogLoggerTest, FatalDoesNotWaitForUnrelatedSynchronousDelivery) {
         constexpr std::string_view kFatalContext{"comms.z_fatal_test"};
         auto& blockedLogger = getSpdlogLogger(kBlockedContext);
         blockedLogger.configure(
-            "BLOCKED", []() { return 0; }, {}, /*asyncLogging=*/false);
+            "BLOCKED", []() { return 0; }, {}, /*asyncLogging=*/true);
         blockedLogger.set_level(spdlog::level::info);
         auto& fatalLogger = getSpdlogLogger(kFatalContext);
         fatalLogger.configure(
-            "FATAL", []() { return 0; }, {}, /*asyncLogging=*/false);
+            "FATAL", []() { return 0; }, {}, /*asyncLogging=*/true);
         fatalLogger.set_level(spdlog::level::info);
 
         std::atomic<bool> deliveryStarted{false};
@@ -949,6 +995,8 @@ TEST(SpdlogLoggerTest, FatalDoesNotWaitForUnrelatedSynchronousDelivery) {
                 std::this_thread::sleep_for(std::chrono::milliseconds{1});
               }
             }));
+
+        meta::comms::logger::testing::shutdownAsyncThreadPoolForTesting();
 
         std::thread blockedDelivery{[&]() {
           COMMS_LOG_NAMED(
@@ -977,6 +1025,124 @@ TEST(SpdlogLoggerTest, FatalDoesNotWaitForUnrelatedSynchronousDelivery) {
       },
       ::testing::KilledBySignal(SIGABRT),
       "fatal must not wait for unrelated sink");
+}
+
+TEST(SpdlogLoggerTest, FatalShutdownTraversalSkipsBusyNamedLoggerRegistry) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_EXIT(
+      {
+        constexpr std::string_view kFatalContext{
+            "comms.fatal_busy_registry_test"};
+        auto& fatalLogger = getSpdlogLogger(kFatalContext);
+        fatalLogger.configure(
+            "FATAL", []() { return 0; }, {}, /*asyncLogging=*/true);
+        fatalLogger.set_level(spdlog::level::info);
+
+        std::atomic<bool> registryLockHeld{false};
+        std::thread blockedRegistry{[&]() {
+          meta::comms::logger::testing::holdNamedLoggerRegistryLockForTesting(
+              [&]() {
+                registryLockHeld.store(true, std::memory_order_release);
+                for (;;) {
+                  /* sleep override */
+                  std::this_thread::sleep_for(std::chrono::milliseconds{1});
+                }
+              });
+        }};
+        blockedRegistry.detach();
+        const auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::seconds{10};
+        while (!registryLockHeld.load(std::memory_order_acquire) &&
+               std::chrono::steady_clock::now() < deadline) {
+          /* sleep override */
+          std::this_thread::sleep_for(std::chrono::milliseconds{1});
+        }
+        if (!registryLockHeld.load(std::memory_order_acquire)) {
+          std::_Exit(2);
+        }
+
+        std::thread watchdog{[]() {
+          /* sleep override */
+          std::this_thread::sleep_for(std::chrono::seconds{10});
+          std::_Exit(3);
+        }};
+        watchdog.detach();
+        COMMS_LOG_FATAL_IMPL(fatalLogger, "fatal skips busy registry");
+      },
+      ::testing::KilledBySignal(SIGABRT),
+      "fatal skips busy registry");
+}
+
+TEST(SpdlogLoggerTest, FatalShutdownDoesNotDestroyPeriodicSinkFlusherWorker) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_EXIT(
+      {
+        auto& logger =
+            getSpdlogLogger("comms.fatal_keeps_periodic_flusher_worker");
+        logger.configure(
+            "FATAL", []() { return 0; }, {}, /*asyncLogging=*/true);
+        logger.set_level(spdlog::level::info);
+
+        if (!meta::comms::logger::testing::
+                periodicSinkFlusherRunningForTesting()) {
+          std::_Exit(2);
+        }
+
+        meta::comms::logger::shutdownSpdlogForFatal();
+        std::_Exit(
+            meta::comms::logger::testing::periodicSinkFlusherRunningForTesting()
+                ? 0
+                : 3);
+      },
+      ::testing::ExitedWithCode(0),
+      "");
+}
+
+TEST(SpdlogLoggerTest, FatalReportsSinkFlushFailure) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_DEATH(
+      {
+        auto& logger = getSpdlogLogger();
+        logger.configure(
+            "FATAL", []() { return 0; }, {}, /*asyncLogging=*/false);
+        logger.set_level(spdlog::level::info);
+        meta::comms::logger::testing::addSinkForTesting(
+            logger, std::make_shared<ThrowingFlushSink>());
+
+        COMMS_LOG(FATAL, "fatal after sink flush failure");
+      },
+      "ERROR: communications logging failed(.|\\n)*"
+      "FATAL fatal after sink flush failure");
+}
+
+TEST(SpdlogLoggerTest, FatalFlushesEveryAsyncLoggerSink) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_DEATH(
+      {
+        constexpr std::string_view kQueuedContext{"comms.a_queued_fatal_test"};
+        constexpr std::string_view kFatalContext{"comms.z_fatal_flush_test"};
+        auto& queuedLogger = getSpdlogLogger(kQueuedContext);
+        queuedLogger.configure(
+            "QUEUED", []() { return 0; }, {}, /*asyncLogging=*/true);
+        queuedLogger.set_level(spdlog::level::info);
+        auto& fatalLogger = getSpdlogLogger(kFatalContext);
+        fatalLogger.configure(
+            "FATAL", []() { return 0; }, {}, /*asyncLogging=*/true);
+        fatalLogger.set_level(spdlog::level::info);
+
+        meta::comms::logger::testing::stopPeriodicSinkFlusherForTesting();
+        if (!meta::comms::logger::testing::
+                asyncThreadPoolLeaseAvailableForTesting()) {
+          std::_Exit(2);
+        }
+        meta::comms::logger::testing::addSinkForTesting(
+            queuedLogger,
+            std::make_shared<FlushReportingSink>(
+                std::this_thread::get_id(), "queued before fatal"));
+        COMMS_LOG_NAMED(kQueuedContext, INFO, "queued before fatal");
+        COMMS_LOG_NAMED(kFatalContext, FATAL, "fatal flush trigger");
+      },
+      "queued async record flushed(.|\\n)*FATAL fatal flush trigger");
 }
 
 TEST(SpdlogLoggerTest, ShutdownWaitsForActiveSynchronousDelivery) {


### PR DESCRIPTION
Summary:

Folly flushed every registered handler before abort, but the migrated FATAL path only flushed the originating spdlog logger. Records drained from another component could remain in its buffered sink and disappear when abort skipped normal teardown.

Drain the private async pool, then best-effort flush every initialized comms distribution sink before emitting and explicitly flushing the synchronous FATAL record. Fatal shutdown deliberately does not stop or join the periodic sink worker: that worker may already be blocked behind an unrelated busy distribution sink, and joining it would prevent the fatal record from being emitted. A concurrent periodic flush can instead make the try-locked traversal skip that sink, preserving the intended best-effort behavior without adding an unbounded wait.

The fatal shutdown traversal skips a busy named-logger registry or distribution sink instead of waiting on its outer lock; child-sink mutexes or I/O may still block, as can named-logger resolution before the traversal, the final synchronous fatal record, and the legacy flush path. Normal shutdown retains its legacy order of flushing logger sinks before stopping and joining the periodic worker. After acquiring the registry shared lock, fatal shutdown intentionally holds it across the allocation-free traversal: registry entries are process-lifetime objects that are never erased, and production child sinks do not re-enter named-logger lookup. This can delay concurrent logger creation while a child sink flushes, but the process is already terminating. Concrete sink typing makes this fatal-flush contract compile-time checked. A child-sink flush failure emits a direct stderr breadcrumb and does not prevent attempts to flush the remaining sinks. This is deliberately not presented as a fully nonblocking abort guarantee. Ordinary logging retains its existing locking and hot-path behavior.

Normal shutdown and the test hook share the same private periodic-flusher stop operation, keeping their lifecycle behavior identical.

Also remove the unused legacy LogUtils include and dependency from CTRAN IB so the migrated-source contract remains enforceable on current master.

Reviewed By: shr

Differential Revision: D119207403


