### PR TITLE
Destroy the IBGDA transport's verbs objects on a background thread

### DIFF
--- a/comms/prims/tests/BoundedCleanupExecutorTest.cpp
+++ b/comms/prims/tests/BoundedCleanupExecutorTest.cpp
@@ -1,0 +1,81 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/transport/BoundedCleanupExecutor.h"
+
+#include <atomic>
+#include <functional>
+#include <future>
+
+#include <gtest/gtest.h>
+
+namespace comms::prims::detail {
+namespace {
+
+struct TestCleanup {
+  std::function<void()> fn;
+
+  void operator()() noexcept {
+    fn();
+  }
+};
+
+TEST(BoundedCleanupExecutorTest, RunsTaskAndDrains) {
+  // drain() must not return until the accepted cleanup has completed.
+  std::atomic<int> calls{0};
+  BoundedCleanupExecutor<TestCleanup> executor;
+  TestCleanup task{[&calls] { ++calls; }};
+
+  ASSERT_TRUE(executor.tryEnqueue(task));
+  executor.drain();
+
+  EXPECT_EQ(calls.load(), 1);
+}
+
+TEST(BoundedCleanupExecutorTest, RejectsWhileWorkerIsOccupied) {
+  // A blocked cleanup consumes the sole asynchronous slot; its successor stays
+  // caller-owned so the caller can reclaim it synchronously.
+  std::promise<void> started;
+  auto startedFuture = started.get_future();
+  std::promise<void> release;
+  auto releaseFuture = release.get_future().share();
+  std::atomic<int> calls{0};
+  BoundedCleanupExecutor<TestCleanup> executor;
+  TestCleanup blockingTask{[&] {
+    started.set_value();
+    releaseFuture.wait();
+    ++calls;
+  }};
+
+  ASSERT_TRUE(executor.tryEnqueue(blockingTask));
+  startedFuture.wait();
+
+  TestCleanup fallbackTask{[&calls] { ++calls; }};
+  ASSERT_FALSE(executor.tryEnqueue(fallbackTask));
+  fallbackTask();
+
+  release.set_value();
+  executor.drain();
+  EXPECT_EQ(calls.load(), 2);
+}
+
+TEST(BoundedCleanupExecutorTest, ShutdownDrainsAndRejectsNewTasks) {
+  // Shutdown drains accepted cleanup, is idempotent, and permanently closes
+  // admission so late owners can fall back synchronously.
+  std::atomic<int> calls{0};
+  BoundedCleanupExecutor<TestCleanup> executor;
+  TestCleanup queuedTask{[&calls] { ++calls; }};
+
+  ASSERT_TRUE(executor.tryEnqueue(queuedTask));
+  executor.shutdown();
+  EXPECT_EQ(calls.load(), 1);
+
+  TestCleanup rejectedTask{[&calls] { ++calls; }};
+  EXPECT_FALSE(executor.tryEnqueue(rejectedTask));
+  rejectedTask();
+  EXPECT_EQ(calls.load(), 2);
+
+  executor.shutdown();
+}
+
+} // namespace
+} // namespace comms::prims::detail

--- a/comms/prims/transport/BoundedCleanupExecutor.h
+++ b/comms/prims/transport/BoundedCleanupExecutor.h
@@ -1,0 +1,96 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <type_traits>
+#include <utility>
+
+namespace comms::prims::detail {
+
+/*
+ * Executes at most one cleanup task asynchronously. While that task is queued
+ * or running, callers retain ownership of subsequent tasks and can reclaim
+ * their resources synchronously instead of growing an unbounded backlog.
+ */
+template <typename Task>
+class BoundedCleanupExecutor final {
+  static_assert(std::is_nothrow_move_constructible_v<Task>);
+  static_assert(std::is_nothrow_invocable_v<Task&>);
+
+ public:
+  BoundedCleanupExecutor() : worker_([this] { run(); }) {}
+
+  ~BoundedCleanupExecutor() {
+    shutdown();
+  }
+
+  BoundedCleanupExecutor(const BoundedCleanupExecutor&) = delete;
+  BoundedCleanupExecutor& operator=(const BoundedCleanupExecutor&) = delete;
+  BoundedCleanupExecutor(BoundedCleanupExecutor&&) = delete;
+  BoundedCleanupExecutor& operator=(BoundedCleanupExecutor&&) = delete;
+
+  bool tryEnqueue(Task& task) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (stopping_ || occupied_) {
+      return false;
+    }
+    task_.emplace(std::move(task));
+    occupied_ = true;
+    cv_.notify_one();
+    return true;
+  }
+
+  void drain() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    cv_.wait(lock, [this] { return !occupied_; });
+  }
+
+  void shutdown() noexcept {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      stopping_ = true;
+    }
+    cv_.notify_all();
+    if (worker_.joinable()) {
+      worker_.join();
+    }
+  }
+
+ private:
+  void run() noexcept {
+    while (true) {
+      std::optional<Task> task;
+      {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait(lock, [this] { return stopping_ || task_.has_value(); });
+        if (!task_.has_value()) {
+          return;
+        }
+        task.emplace(std::move(*task_));
+        task_.reset();
+      }
+
+      (*task)();
+      task.reset();
+
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        occupied_ = false;
+      }
+      cv_.notify_all();
+    }
+  }
+
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  std::optional<Task> task_;
+  bool stopping_{false};
+  bool occupied_{false};
+  std::thread worker_;
+};
+
+} // namespace comms::prims::detail

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -211,6 +211,7 @@ void MultiPeerTransport::initFromTopology(
 
 MultiPeerTransport::~MultiPeerTransport() {
   free_device_handle();
+  (void)MultipeerIbgdaTransport::tryDeferCleanup(ibgdaTransport_);
 }
 
 std::optional<int> MultiPeerTransport::ibgda_max_groups() const {

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -18,6 +18,8 @@
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
+#include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -34,9 +36,10 @@
 #ifndef __HIP_PLATFORM_AMD__
 #include "comms/prims/platform/CudaDriverLazy.h"
 #include "comms/prims/platform/DocaHostUtils.h"
-// MCCL_IBGDA_MAX_RD_ATOMIC / MCCL_IBGDA_QP_ORDERING_SEMANTIC. Generated header.
+// MCCL_IBGDA_* runtime controls. Generated header.
 #include "comms/utils/cvars/nccl_cvars.h" // @manual
 #endif
+#include "comms/prims/transport/BoundedCleanupExecutor.h"
 #include "comms/prims/transport/ibgda/MultipeerIbgdaDeviceTransport.cuh"
 #include "comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cuh"
 #include "comms/prims/transport/rdma/NicDiscovery.h"
@@ -1325,13 +1328,45 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
           << " initialized on GPU " << gpuPciBusId_;
 }
 
+#ifndef __HIP_PLATFORM_AMD__
+namespace {
+
+struct VerbsTeardownTask {
+  VerbsTeardownTask(
+      int device,
+      std::unique_ptr<MultipeerIbgdaTransport> oldTransport) noexcept
+      : cudaDevice(device), transport(std::move(oldTransport)) {}
+
+  void operator()() noexcept {
+    cudaError_t err = cudaSetDevice(cudaDevice);
+    if (err == cudaSuccess) {
+      err = cudaFree(nullptr);
+    }
+    if (err != cudaSuccess) {
+      LOG(WARNING) << "MultipeerIbgdaTransport: deferred teardown could not "
+                      "bind CUDA device "
+                   << cudaDevice << ": " << cudaGetErrorString(err);
+    }
+    transport.reset();
+  }
+
+  int cudaDevice;
+  std::unique_ptr<MultipeerIbgdaTransport> transport;
+};
+
+detail::BoundedCleanupExecutor<VerbsTeardownTask>& verbsTeardownReaper() {
+  static detail::BoundedCleanupExecutor<VerbsTeardownTask> reaper;
+  return reaper;
+}
+
+} // namespace
+#endif
+
 MultipeerIbgdaTransport::~MultipeerIbgdaTransport() {
   cleanup();
 }
 
-void MultipeerIbgdaTransport::cleanup() {
-  auto& symbols = ibverbx::ibvSymbols;
-
+void MultipeerIbgdaTransport::cleanupGpuAllocationsAndStaging() noexcept {
   // Free all GPU memory (transport objects + QP pointer arrays)
   for (auto* ptr : gpuAllocations_) {
     if (ptr != nullptr) {
@@ -1348,6 +1383,75 @@ void MultipeerIbgdaTransport::cleanup() {
   // Free send/recv staging buffers (eager bulks + any lazy per-peer
   // allocations) via the shared base cleanup.
   cleanupSendRecvBuffers();
+}
+
+void MultipeerIbgdaTransport::cleanupRegisteredBuffers() noexcept {
+  auto registrations = registrationState_.wlock();
+  auto& symbols = ibverbx::ibvSymbols;
+  for (auto& [_, cached] : registrations->registeredBuffers) {
+    for (int n = 0; n < numNics_; ++n) {
+      if (cached.mrs[n] != nullptr &&
+          symbols.ibv_internal_dereg_mr != nullptr) {
+        symbols.ibv_internal_dereg_mr(cached.mrs[n]);
+      }
+    }
+  }
+  registrations->registeredBuffers.clear();
+}
+
+void MultipeerIbgdaTransport::prepareForDeferredCleanup() noexcept {
+  if (deferredCleanupPrepared_) {
+    return;
+  }
+  cleanupGpuAllocationsAndStaging();
+
+  // These registrations can refer to caller-owned allocations, which may be
+  // released as soon as the enclosing transport destructor returns.
+  cleanupSignalCounterResources();
+  cleanupRegisteredBuffers();
+  deferredCleanupPrepared_ = true;
+}
+
+bool MultipeerIbgdaTransport::tryDeferCleanup(
+    std::unique_ptr<MultipeerIbgdaTransport>& transport) noexcept {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  return false;
+#else
+  if (!transport || !MCCL_IBGDA_ASYNC_TEARDOWN) {
+    return false;
+  }
+
+  transport->prepareForDeferredCleanup();
+  const int cudaDevice = transport->config_.cudaDevice;
+  try {
+    auto& reaper = verbsTeardownReaper();
+    VerbsTeardownTask task(cudaDevice, std::move(transport));
+    if (reaper.tryEnqueue(task)) {
+      return true;
+    }
+    LOG(WARNING) << "MultipeerIbgdaTransport: teardown reaper is busy; "
+                    "destroying synchronously to bound retained resources";
+    task();
+    return true;
+  } catch (const std::exception& ex) {
+    LOG(WARNING) << "MultipeerIbgdaTransport: could not enqueue deferred "
+                    "teardown; destroying synchronously: "
+                 << ex.what();
+  } catch (...) {
+    LOG(WARNING) << "MultipeerIbgdaTransport: could not enqueue deferred "
+                    "teardown; destroying synchronously";
+  }
+  return !transport;
+#endif
+}
+
+void MultipeerIbgdaTransport::cleanup() noexcept {
+  if (!deferredCleanupPrepared_) {
+    cleanupGpuAllocationsAndStaging();
+  }
+
+  auto& symbols = ibverbx::ibvSymbols;
 
   // Destroy per-NIC QPs and loopback responders.
   for (auto& nic : nicDoca_) {
@@ -1371,22 +1475,11 @@ void MultipeerIbgdaTransport::cleanup() {
     nic.loopbackCompanionQps.clear();
   }
 
-  cleanupSignalCounterResources();
+  if (!deferredCleanupPrepared_) {
+    cleanupSignalCounterResources();
 
-  // Destroy user buffer MRs
-  {
-    auto registrations = registrationState_.wlock();
-    for (auto& [_, cached] : registrations->registeredBuffers) {
-      // numNics_=1 today; loop is the multi-NIC-ready shape (P2.x fills the
-      // rest of mrs[]).
-      for (int n = 0; n < numNics_; ++n) {
-        if (cached.mrs[n] != nullptr &&
-            symbols.ibv_internal_dereg_mr != nullptr) {
-          symbols.ibv_internal_dereg_mr(cached.mrs[n]);
-        }
-      }
-    }
-    registrations->registeredBuffers.clear();
+    // Destroy user buffer MRs
+    cleanupRegisteredBuffers();
   }
 
   // Destroy per-NIC sink MRs. Iterate over actual nicDoca_ entries
@@ -1402,7 +1495,7 @@ void MultipeerIbgdaTransport::cleanup() {
   }
 
   // Free sink buffer. NVIDIA: cuMem-allocated with gpuDirectRDMACapable.
-  // AMD: hipHostMalloc'd. Shared across NICs — only one allocation,
+  // AMD: hipHostMalloc'd. Shared across NICs -- only one allocation,
   // freed after all per-NIC MRs.
   if (sinkBuffer_ != nullptr) {
 #ifdef __HIP_PLATFORM_AMD__

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
@@ -226,7 +226,12 @@ class MultipeerIbgdaTransport
   void allocateResources();
   void registerMemory();
   void createQpGroups();
-  void cleanup();
+  void cleanup() noexcept;
+  void cleanupGpuAllocationsAndStaging() noexcept;
+  void cleanupRegisteredBuffers() noexcept;
+  void prepareForDeferredCleanup() noexcept;
+  static bool tryDeferCleanup(
+      std::unique_ptr<MultipeerIbgdaTransport>& transport) noexcept;
   // Connect a QP to a peer (or self for loopback). The nic argument selects
   // which local NIC's AH attrs / port to use; the peerInfo carries the
   // remote-side GID / LID / qpn. At numNics_=1 nic is always 0.
@@ -252,6 +257,7 @@ class MultipeerIbgdaTransport
   // lazy materialization, bootstrap exchangeWithPeer) and calls back into this
   // backend's doMaterializePeer()/cleanupPeerOnFailure() hooks.
   friend class MultiPeerIbTransport<MultipeerIbgdaTransport>;
+  friend class MultiPeerTransport;
 
   // myRank_/nRanks_/bootstrap_/config_/registrationState_/nics_/lazy-state are
   // inherited (protected) from MultiPeerIbTransport.
@@ -327,6 +333,7 @@ class MultipeerIbgdaTransport
 
   // All GPU allocations from buildDeviceTransportsOnGpu (freed in cleanup)
   std::vector<void*> gpuAllocations_;
+  bool deferredCleanupPrepared_{false};
 
   // Exchange info received from peers
   std::vector<IbgdaTransportExchInfo> peerExchInfo_;

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3447,6 +3447,19 @@ cvars:
      ibgda - use GPU-posted IBGDA.
      ibrc - use CPU-posted IBRC.
 
+ - name        : MCCL_IBGDA_ASYNC_TEARDOWN
+   type        : bool
+   default     : true
+   description : |-
+     Destroy the Prims IBGDA transport's QPs, internal sink MR, PDs, and device
+     contexts on a background thread instead of inline in the destructor.
+     Caller-visible GPU allocations and cached buffer registrations are still
+     released synchronously. A materialized transport holds peers x channels x
+     NICs QPs, and destroying them one uverbs ioctl at a time costs seconds per
+     MCCL reconfigure. At most one old transport generation is reclaimed
+     asynchronously per process; additional teardowns fall back to synchronous
+     reclamation.
+
  - name        : MCCL_IBGDA_RELIABLE_DOORBELL_MODE
    type        : enum
    default     : auto


### PR DESCRIPTION
Summary: Perf fix for MCCL reconfigure: once a Prims IBGDA transport has been used, its destructor tears down `peers x channels x NICs` QPs/MRs one uverbs `ioctl` at a time, inline on the caller (1.1 s at 4-GPU replicas, 2.3 s in the 64-GPU PAFT nightly). Move that teardown to a background reaper; kill switch `MCCL_IBGDA_ASYNC_TEARDOWN`.

Differential Revision: D119181770


