### PR TITLE
Internalize specialized logger macros

### DIFF
--- a/comms/ctran/utils/Checks.h
+++ b/comms/ctran/utils/Checks.h
@@ -501,13 +501,13 @@
     }                                                  \
   } while (0)
 
-#define FB_CHECKABORT(statement, ...)                     \
-  do {                                                    \
-    if (!(statement)) {                                   \
-      CTRAN_LOG_SYNC_ERR("Check failed: {}", #statement); \
-      CTRAN_LOG_SYNC_ERR(__VA_ARGS__);                    \
-      abort();                                            \
-    }                                                     \
+#define FB_CHECKABORT(statement, ...)                          \
+  do {                                                         \
+    if (!(statement)) {                                        \
+      CTRAN_LOG_SYNC_ERR_IMPL("Check failed: {}", #statement); \
+      CTRAN_LOG_SYNC_ERR_IMPL(__VA_ARGS__);                    \
+      abort();                                                 \
+    }                                                          \
   } while (0);
 
 #define FB_CHECKTHROW_EX_DIRECT(statement, rank, commHash, commDesc, msg)     \

--- a/comms/ctran/utils/CtranLogger.h
+++ b/comms/ctran/utils/CtranLogger.h
@@ -63,7 +63,7 @@ inline void configureStandaloneCtranLogging(
 #define CTRAN_LOG_STREAM(level) \
   COMMS_LOGGER_STREAM(::ctran::logging::getCtranLogger(), level)
 
-#define CTRAN_LOG_SYNC_ERR(...)                                          \
+#define CTRAN_LOG_SYNC_ERR_IMPL(...)                                     \
   do {                                                                   \
     static auto& _ctran_logger = ::meta::comms::logger::getSpdlogLogger( \
         ::ctran::logging::kCtranLoggerName);                             \
@@ -74,6 +74,9 @@ inline void configureStandaloneCtranLogging(
           __VA_ARGS__);                                                  \
     }                                                                    \
   } while (false)
+
+// Compatibility alias; new code should express the owning operation instead.
+#define CTRAN_LOG_SYNC_ERR(...) CTRAN_LOG_SYNC_ERR_IMPL(__VA_ARGS__)
 
 #define CTRAN_LOG_IF_IMPL(level, spdlog_level, condition, ...)           \
   do {                                                                   \

--- a/comms/ctran/utils/tests/ChecksUT.cc
+++ b/comms/ctran/utils/tests/ChecksUT.cc
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <csignal>
+#include <cstdlib>
 #include <string>
 
 #include <cuda_runtime.h>
@@ -61,6 +63,62 @@ class CtranUtilsCheckTest : public ::testing::Test {
  private:
   bool capturingStdout_{false};
 };
+
+TEST_F(CtranUtilsCheckTest, CheckAbortPreservesTwoSynchronousDiagnostics) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  EXPECT_DEATH(
+      {
+        meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName)
+            .configureOutput("/dev/null");
+        FB_CHECKABORT(false, "abort detail {}", 42);
+      },
+      "Check failed: false(.|\\n)*abort detail 42");
+}
+
+TEST_F(CtranUtilsCheckTest, CheckAbortPreservesArgumentEvaluationGates) {
+  int statementEvaluations = 0;
+  int messageEvaluations = 0;
+  FB_CHECKABORT(
+      ++statementEvaluations == 1,
+      "unused abort detail {}",
+      ++messageEvaluations);
+
+  EXPECT_EQ(statementEvaluations, 1);
+  EXPECT_EQ(messageEvaluations, 0);
+
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_EXIT(
+      {
+        meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName)
+            .set_level(spdlog::level::off);
+        FB_CHECKABORT(false, "disabled abort detail {}", []() -> int {
+          std::_Exit(42);
+        }());
+      },
+      ::testing::KilledBySignal(SIGABRT),
+      "");
+}
+
+TEST_F(CtranUtilsCheckTest, SyncErrCompatibilityAliasPreservesLevelGate) {
+  auto& logger =
+      meta::comms::logger::getSpdlogLogger(ctran::logging::kCtranLoggerName);
+  const std::string ctranSyncLogger{"caller argument"};
+  int messageEvaluations = 0;
+
+  logger.set_level(spdlog::level::off);
+  CTRAN_LOG_SYNC_ERR("disabled compatibility log {}", ++messageEvaluations);
+  logger.set_level(spdlog::level::err);
+  CTRAN_LOG_SYNC_ERR("enabled compatibility log {}", ++messageEvaluations);
+  CTRAN_LOG_SYNC_ERR("compatibility log preserves {}", ctranSyncLogger);
+
+  EXPECT_EQ(messageEvaluations, 1);
+  const auto output = getOutput();
+  EXPECT_THAT(output, testing::HasSubstr("enabled compatibility log 1"));
+  EXPECT_THAT(
+      output,
+      testing::HasSubstr("compatibility log preserves caller argument"));
+}
 
 TEST_F(CtranUtilsCheckTest, CudaCheck) {
   auto dummyFn = []() {

--- a/comms/utils/logger/tests/LegacyLoggingContractTest.bxl
+++ b/comms/utils/logger/tests/LegacyLoggingContractTest.bxl
@@ -106,11 +106,81 @@ _LEGACY_IDENTIFIER = regex(
         "|".join(_LEGACY_IDENTIFIERS),
     ),
 )
+_MCCL_ADAPTER_CONTEXT_SOURCE_PATHS = (
+    "fbcode//comms/mccl/adapter/bootstrap/Socket.cpp",
+    "fbcode//comms/mccl/adapter/mccl_adapter/Comm.cpp",
+    "fbcode//comms/mccl/adapter/mccl_adapter/Impl.cpp",
+)
+_INTERNAL_LOGGING_IDENTIFIERS = (
+    (
+        "MCCL_ACTIVE_LOGGER_CONTEXT_IMPL",
+        regex(
+            ".*(^|[^A-Za-z0-9_])MCCL_ACTIVE_LOGGER_CONTEXT_IMPL([^A-Za-z0-9_]|$).*",
+        ),
+        _MCCL_ADAPTER_CONTEXT_SOURCE_PATHS
+        + (
+            "fbcode//comms/mccl/utils/McclLogger.h",
+            "fbcode//comms/mccl/utils/tests/McclAdapterLoggerTest.cpp",
+        ),
+    ),
+    (
+        "MCCL_ACTIVE_LOGGER_IMPL",
+        regex(
+            ".*(^|[^A-Za-z0-9_])MCCL_ACTIVE_LOGGER_IMPL([^A-Za-z0-9_]|$).*",
+        ),
+        ("fbcode//comms/mccl/utils/McclLogger.h",),
+    ),
+    (
+        "MCCL_ACTIVE_LOGGER_NAME_IMPL",
+        regex(
+            ".*(^|[^A-Za-z0-9_])MCCL_ACTIVE_LOGGER_NAME_IMPL([^A-Za-z0-9_]|$).*",
+        ),
+        ("fbcode//comms/mccl/utils/McclLogger.h",),
+    ),
+    (
+        "CTRAN_LOG_SYNC_ERR",
+        regex(".*(^|[^A-Za-z0-9_])CTRAN_LOG_SYNC_ERR([^A-Za-z0-9_]|$).*"),
+        (
+            "fbcode//comms/ctran/utils/CtranLogger.h",
+            "fbcode//comms/ctran/utils/tests/ChecksUT.cc",
+        ),
+    ),
+    (
+        "CTRAN_LOG_SYNC_ERR_IMPL",
+        regex(".*(^|[^A-Za-z0-9_])CTRAN_LOG_SYNC_ERR_IMPL([^A-Za-z0-9_]|$).*"),
+        (
+            "fbcode//comms/ctran/utils/Checks.h",
+            "fbcode//comms/ctran/utils/CtranLogger.h",
+        ),
+    ),
+    (
+        "MCCL_LOG_WITH_NAME",
+        regex(".*(^|[^A-Za-z0-9_])MCCL_LOG_WITH_NAME([^A-Za-z0-9_]|$).*"),
+        (
+            "fbcode//comms/mccl/utils/McclLogger.h",
+            "fbcode//comms/mccl/utils/tests/McclLoggerTest.cpp",
+        ),
+    ),
+    (
+        "MCCL_LOG_WITH_LOGGER",
+        regex(".*(^|[^A-Za-z0-9_])MCCL_LOG_WITH_LOGGER([^A-Za-z0-9_]|$).*"),
+        ("fbcode//comms/mccl/utils/McclLogger.h",),
+    ),
+)
 _FOLLY_LOGGING_SYMBOL = regex(
     ".*(^|[^A-Za-z0-9_])folly::(Log[A-Za-z0-9_]*|logging)([^A-Za-z0-9_]|$).*",
 )
 _FOLLY_LOGGING_INCLUDE = regex(
     '^[ \\t]*#[ \\t]*include[ \\t]*[<"]folly/logging/.*',
+)
+_CPP_INCLUDE = regex("^[ \\t]*#[ \\t]*include([^A-Za-z0-9_]|$).*")
+_MCCL_CONTEXT_PUSH = '#pragmapush_macro("MCCL_ACTIVE_LOGGER_CONTEXT_IMPL")'
+_MCCL_CONTEXT_UNDEF = "#undefMCCL_ACTIVE_LOGGER_CONTEXT_IMPL"
+_MCCL_CONTEXT_DEFINE = "#defineMCCL_ACTIVE_LOGGER_CONTEXT_IMPL"
+_MCCL_CONTEXT_VALUE = "::mccl::logging::detail::AdapterLoggerContext"
+_MCCL_CONTEXT_POP = '#pragmapop_macro("MCCL_ACTIVE_LOGGER_CONTEXT_IMPL")'
+MCCL_CONTEXTUAL_LOGGING_MACRO = regex(
+    ".*(^|[^A-Za-z0-9_])(MCCL_LOG[A-Za-z0-9_]*|MCCL_ABORT)([^A-Za-z0-9_]|$).*",
 )
 _LEGACY_COMPATIBILITY_TARGETS = (
     "fbcode//comms/utils/logger:log_utils",
@@ -227,6 +297,124 @@ def _is_legacy_logging_dependency(label: str) -> bool:
 def _contains_folly_logging_include(line: str, starts_in_literal: bool) -> bool:
     return not starts_in_literal and _FOLLY_LOGGING_INCLUDE.match(line)
 
+def _check_mccl_adapter_context_structure(path: str, source_lines):
+    if path not in _MCCL_ADAPTER_CONTEXT_SOURCE_PATHS:
+        return []
+
+    violations = []
+    state = "before_push"
+    in_block_comment = False
+    raw_terminator = ""
+    literal_delimiter = ""
+    escaped = False
+    for line_number, line in enumerate(source_lines, 1):
+        line_starts_in_literal = bool(raw_terminator or literal_delimiter)
+        (
+            line_without_comments,
+            source_line,
+            in_block_comment,
+            raw_terminator,
+            literal_delimiter,
+            escaped,
+        ) = _strip_non_code_line(
+            line,
+            in_block_comment,
+            raw_terminator,
+            literal_delimiter,
+            escaped,
+        )
+        compact_directive = line_without_comments.replace(" ", "").replace("\t", "")
+        if state == "invalid":
+            continue
+        if not line_starts_in_literal and compact_directive == _MCCL_CONTEXT_PUSH:
+            if state != "before_push":
+                violations.append(
+                    "{}:{}: unexpected MCCL adapter logger context push".format(
+                        path,
+                        line_number,
+                    ),
+                )
+            else:
+                state = "after_push"
+        elif not line_starts_in_literal and compact_directive == _MCCL_CONTEXT_UNDEF:
+            if state != "after_push":
+                violations.append(
+                    "{}:{}: MCCL adapter logger context undef must follow its push".format(
+                        path,
+                        line_number,
+                    ),
+                )
+            else:
+                state = "after_undef"
+        elif not line_starts_in_literal and compact_directive == _MCCL_CONTEXT_DEFINE + "\\":
+            if state != "after_undef":
+                violations.append(
+                    "{}:{}: MCCL adapter logger context define must follow its undef".format(
+                        path,
+                        line_number,
+                    ),
+                )
+            else:
+                state = "after_define"
+        elif state == "after_define":
+            if line_starts_in_literal or compact_directive != _MCCL_CONTEXT_VALUE:
+                violations.append(
+                    "{}:{}: MCCL adapter logger context has an unexpected value".format(
+                        path,
+                        line_number,
+                    ),
+                )
+                state = "invalid"
+            else:
+                state = "active"
+        elif not line_starts_in_literal and compact_directive == _MCCL_CONTEXT_POP:
+            if state != "active":
+                violations.append(
+                    "{}:{}: MCCL adapter logger context pop must follow its define".format(
+                        path,
+                        line_number,
+                    ),
+                )
+            else:
+                state = "popped"
+        elif state in ("after_push", "after_undef") and source_line.strip():
+            violations.append(
+                "{}:{}: code appears inside MCCL adapter logger context setup".format(
+                    path,
+                    line_number,
+                ),
+            )
+            state = "invalid"
+        elif state == "active" and _CPP_INCLUDE.match(source_line):
+            violations.append(
+                "{}:{}: include appears inside MCCL adapter logger context override".format(
+                    path,
+                    line_number,
+                ),
+            )
+        elif state == "before_push" and MCCL_CONTEXTUAL_LOGGING_MACRO.match(source_line):
+            violations.append(
+                "{}:{}: MCCL logging appears before its adapter logger context".format(
+                    path,
+                    line_number,
+                ),
+            )
+        elif state == "popped" and source_line.strip():
+            violations.append(
+                "{}:{}: code appears after MCCL adapter logger context pop".format(
+                    path,
+                    line_number,
+                ),
+            )
+
+    if state not in ("popped", "invalid"):
+        violations.append(
+            "{}: MCCL adapter logger context must have one balanced push, define, and EOF pop".format(
+                path,
+            ),
+        )
+    return violations
+
 def _is_scoped_source(path: str) -> bool:
     has_source_extension = False
     for extension in _SOURCE_EXTENSIONS:
@@ -290,14 +478,15 @@ def _check_source_content(ctx: bxl.Context, migrated_targets) -> None:
         violations = []
         for path in sorted(source_by_path.keys()):
             source = source_by_path[path]
+            source_lines = artifacts[source].read_string().splitlines()
+            violations.extend(
+                _check_mccl_adapter_context_structure(path, source_lines),
+            )
             in_block_comment = False
             raw_terminator = ""
             literal_delimiter = ""
             escaped = False
-            for line_number, line in enumerate(
-                artifacts[source].read_string().splitlines(),
-                1,
-            ):
+            for line_number, line in enumerate(source_lines, 1):
                 line_starts_in_literal = bool(raw_terminator or literal_delimiter)
                 (
                     line_without_comments,
@@ -320,6 +509,15 @@ def _check_source_content(ctx: bxl.Context, migrated_targets) -> None:
                             line_number,
                         ),
                     )
+                for identifier, identifier_regex, allowed_paths in _INTERNAL_LOGGING_IDENTIFIERS:
+                    if path not in allowed_paths and identifier_regex.match(source_line):
+                        violations.append(
+                            "{}:{}: internal logging identifier {}".format(
+                                path,
+                                line_number,
+                                identifier,
+                            ),
+                        )
                 if _FOLLY_LOGGING_SYMBOL.match(source_line):
                     violations.append(
                         "{}:{}: direct Folly logging symbol".format(
@@ -431,6 +629,57 @@ def _validate_detector() -> None:
         _, source_code, _, _, _, _ = _strip_non_code_line(source)
         if _LEGACY_IDENTIFIER.match(source_code) or _FOLLY_LOGGING_SYMBOL.match(source_code):
             fail("Legacy logging detector rejected valid source: {}".format(source))
+
+    for identifier, identifier_regex, _ in _INTERNAL_LOGGING_IDENTIFIERS:
+        if not identifier_regex.match("{}(ERR, message)".format(identifier)):
+            fail("Internal logging detector missed: {}".format(identifier))
+        if identifier_regex.match("{}_IMPL(ERR, message)".format(identifier)):
+            fail("Internal logging detector matched a distinct identifier: {}".format(identifier))
+
+    adapter_source = _MCCL_ADAPTER_CONTEXT_SOURCE_PATHS[0]
+    valid_adapter_context = (
+        '#include "header.h"',
+        '#pragma push_macro("MCCL_ACTIVE_LOGGER_CONTEXT_IMPL")',
+        "#undef MCCL_ACTIVE_LOGGER_CONTEXT_IMPL",
+        "#define MCCL_ACTIVE_LOGGER_CONTEXT_IMPL \\",
+        "  ::mccl::logging::detail::AdapterLoggerContext",
+        "void adapterCall() {}",
+        'const char* text = R"tag(',
+        '#include "not-a-header.h"',
+        ')tag";',
+        '#pragma pop_macro("MCCL_ACTIVE_LOGGER_CONTEXT_IMPL")',
+        "// comments may follow the EOF pop",
+    )
+    if _check_mccl_adapter_context_structure(adapter_source, valid_adapter_context):
+        fail("MCCL adapter context detector rejected valid source")
+    valid_adapter_context_with_log_text = (
+        valid_adapter_context[:1]
+        + (
+            'const char* text = R"tag(',
+            'MCCL_LOG(ERR, "not code")',
+            ')tag";',
+        )
+        + valid_adapter_context[1:]
+    )
+    if _check_mccl_adapter_context_structure(
+        adapter_source,
+        valid_adapter_context_with_log_text,
+    ):
+        fail("MCCL adapter context detector rejected log text")
+    for invalid_adapter_context in (
+        valid_adapter_context[:1] + ('MCCL_LOG(ERR, "misrouted")',) + valid_adapter_context[1:],
+        valid_adapter_context[:1] + ('MCCL_ABORT("misrouted")',) + valid_adapter_context[1:],
+        valid_adapter_context[:2] + ("void codeBetweenPushAndUndef() {}",) + valid_adapter_context[2:],
+        valid_adapter_context[:3] + ("void codeBetweenUndefAndDefine() {}",) + valid_adapter_context[3:],
+        valid_adapter_context[:4] + ('#include "late.h"',) + valid_adapter_context[4:],
+        valid_adapter_context[:2] + valid_adapter_context[3:],
+        valid_adapter_context[:4] + ("  ::mccl::logging::detail::CoreLoggerContext",) + valid_adapter_context[5:],
+        valid_adapter_context[:-2],
+        valid_adapter_context + ("void lateCall() {}",),
+        valid_adapter_context + valid_adapter_context[1:-1],
+    ):
+        if not _check_mccl_adapter_context_structure(adapter_source, invalid_adapter_context):
+            fail("MCCL adapter context detector missed invalid source")
 
     _, block_comment, in_block_comment, raw_terminator, literal_delimiter, escaped = _strip_non_code_line(
         "/* XLOG(ERR)",


### PR DESCRIPTION
Summary:
Keep the developer-facing logging vocabulary focused on operation intent without breaking installed-header source compatibility.

Route FB_CHECKABORT through the implementation-only CTRAN_LOG_SYNC_ERR_IMPL path while preserving its two independently level-gated ERR records, record order, synchronous delivery, source location, lazy formatting-argument evaluation, and unconditional abort(). Retain CTRAN_LOG_SYNC_ERR only as a compatibility alias.

Remove all owned use of the undocumented arbitrary-name MCCL_LOG_WITH_NAME helper and exercise the supported MCCL_LOG path in the standalone fatal test. Retain MCCL_LOG_WITH_NAME as a compatibility alias because McclLogger.h is installed for external source consumers. Extend the migration drift test to reject new owned uses of these compatibility and internal routing macros outside their definition and implementation files.

Protect the adapter logger selection structure in the three adapter implementation sources. The drift test requires one push, undef, exact AdapterLoggerContext definition, and EOF pop sequence; rejects includes inside the override, contextual MCCL logging before the override, and code inserted between setup directives; and validates both positive literal controls and negative malformed structures. This prevents a future include move or early log from silently routing adapter diagnostics to the core MCCL logger.

This changes no production callsite behavior, logger state, sink, queue, lock, allocation, or hot-path branch.

Reviewed By: shr

Differential Revision: D119232293


