### PR TITLE
Bound send-before-receive payloads

### DIFF
--- a/comms/prims/collectives/DirectCollectiveUtils.cuh
+++ b/comms/prims/collectives/DirectCollectiveUtils.cuh
@@ -43,6 +43,38 @@ direct_pipeline_window(const PeerArray& peers, int my_rank, int num_ranks) {
   return window;
 }
 
+// Largest payload every non-self peer can reserve before receives advance the
+// channels. Use this for collective phases that issue all sends before any
+// matching receive, with at most one outstanding send per peer in each window.
+// Returns zero when there is no non-self peer, ranks are invalid, or any peer
+// reports no capacity.
+// `peers` must be indexable through `[0, num_ranks)`.
+template <typename PeerArray>
+__host__ __device__ __forceinline__ std::size_t
+direct_nvl_send_before_recv_payload_bytes(
+    const PeerArray& peers,
+    int my_rank,
+    int num_ranks,
+    std::size_t max_signal_bytes) {
+  if (num_ranks <= 1 || my_rank < 0 || my_rank >= num_ranks) {
+    return 0;
+  }
+
+  std::size_t payload_bytes = ~std::size_t{0};
+  for (int peer = 0; peer < num_ranks; ++peer) {
+    if (peer == my_rank) {
+      continue;
+    }
+    const std::size_t peer_bytes =
+        peers[peer].max_payload_without_peer_progress(max_signal_bytes);
+    if (peer_bytes == 0) {
+      return 0;
+    }
+    payload_bytes = peer_bytes < payload_bytes ? peer_bytes : payload_bytes;
+  }
+  return payload_bytes;
+}
+
 template <typename Group>
 __device__ __forceinline__ void
 hierarchical_allgather_nvl_broadcast_from_recvbuf(

--- a/comms/prims/collectives/tests/DirectNvlSendBeforeRecvTest.cc
+++ b/comms/prims/collectives/tests/DirectNvlSendBeforeRecvTest.cc
@@ -1,0 +1,82 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstddef>
+
+#include "comms/prims/collectives/DirectCollectiveUtils.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+P2pNvlTransportDevice makePeer(std::size_t windowBytes, std::size_t slotBytes) {
+  return P2pNvlTransportDevice(
+      /*myRank=*/0,
+      /*peerRank=*/1,
+      P2pNvlTransportOptions{
+          .pipelineDepth = slotBytes == 0 ? 0 : windowBytes / slotBytes,
+          .per_channel_buffer = windowBytes,
+          .per_channel_slot = slotBytes,
+          .max_num_channels = 1,
+      },
+      LocalState{},
+      RemoteState{});
+}
+
+TEST(DirectNvlSendBeforeRecvTest, ReservesWorstCaseSignalTail) {
+  constexpr std::size_t kWindowBytes = 256;
+  constexpr std::size_t kSlotBytes = 128;
+  const auto peer = makePeer(kWindowBytes, kSlotBytes);
+
+  // Zero, sub-protocol, and at-least-slot signal sizes use slot granularity.
+  EXPECT_EQ(peer.max_payload_without_peer_progress(0), 144);
+  EXPECT_EQ(peer.max_payload_without_peer_progress(15), 144);
+  EXPECT_EQ(peer.max_payload_without_peer_progress(128), 144);
+  EXPECT_EQ(peer.max_payload_without_peer_progress(129), 144);
+
+  // Partial-slot signal sizes are rounded down to the protocol alignment.
+  EXPECT_EQ(peer.max_payload_without_peer_progress(16), kWindowBytes);
+  EXPECT_EQ(peer.max_payload_without_peer_progress(17), kWindowBytes);
+  EXPECT_EQ(peer.max_payload_without_peer_progress(95), 192);
+  EXPECT_EQ(peer.max_payload_without_peer_progress(96), 176);
+}
+
+TEST(DirectNvlSendBeforeRecvTest, RejectsInvalidChannelGeometry) {
+  EXPECT_EQ(makePeer(0, 0).max_payload_without_peer_progress(0), 0);
+  EXPECT_EQ(makePeer(255, 128).max_payload_without_peer_progress(0), 0);
+  EXPECT_EQ(makePeer(256, 96).max_payload_without_peer_progress(0), 0);
+  EXPECT_EQ(makePeer(128, 256).max_payload_without_peer_progress(0), 0);
+}
+
+TEST(DirectNvlSendBeforeRecvTest, SelectsMinimumAcrossNonSelfPeers) {
+  const std::array peers = {
+      makePeer(/*windowBytes=*/0, /*slotBytes=*/0),
+      makePeer(/*windowBytes=*/512, /*slotBytes=*/128),
+      makePeer(/*windowBytes=*/256, /*slotBytes=*/128),
+  };
+
+  EXPECT_EQ(
+      direct_nvl_send_before_recv_payload_bytes(
+          peers,
+          /*my_rank=*/0,
+          /*num_ranks=*/3,
+          /*max_signal_bytes=*/96),
+      176);
+  EXPECT_EQ(direct_nvl_send_before_recv_payload_bytes(peers, 0, 1, 96), 0);
+  EXPECT_EQ(direct_nvl_send_before_recv_payload_bytes(peers, -1, 3, 96), 0);
+  EXPECT_EQ(direct_nvl_send_before_recv_payload_bytes(peers, 3, 3, 96), 0);
+}
+
+TEST(DirectNvlSendBeforeRecvTest, RejectsAnyInvalidPeer) {
+  const std::array peers = {
+      makePeer(/*windowBytes=*/256, /*slotBytes=*/128),
+      makePeer(/*windowBytes=*/255, /*slotBytes=*/128),
+      makePeer(/*windowBytes=*/512, /*slotBytes=*/128),
+  };
+
+  EXPECT_EQ(direct_nvl_send_before_recv_payload_bytes(peers, 0, 3, 96), 0);
+}
+
+} // namespace
+} // namespace comms::prims::test

--- a/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
@@ -223,6 +223,36 @@ class P2pNvlTransportDevice {
     return options_.per_channel_slot;
   }
 
+  /**
+   * Largest payload a drained channel can reserve without waiting for peer
+   * progress.
+   *
+   * A send channel is drained when SLOT_FREE has credited every reservation
+   * before its current send cursor. This is a static geometry bound; it does
+   * not inspect live cursor or credit state.
+   *
+   * send()/recv() align payloads to 16 bytes and may pad the reservation to
+   * the signal granularity. A reused cursor is only guaranteed to be
+   * 16-byte-aligned, so reserve space for the worst possible tail padding.
+   * The tile geometry requires a 16-byte-aligned window and slot, with the
+   * slot no larger than and evenly dividing the window. Invalid geometry
+   * returns zero.
+   */
+  __host__ __device__ __forceinline__ std::size_t
+  max_payload_without_peer_progress(std::size_t maxSignalBytes) const {
+    constexpr std::size_t kProtocolAlignment = 16;
+    const std::size_t window = options_.per_channel_buffer;
+    const std::size_t slot = options_.per_channel_slot;
+    if (window < kProtocolAlignment || window % kProtocolAlignment != 0 ||
+        slot < kProtocolAlignment || slot % kProtocolAlignment != 0 ||
+        slot > window || window % slot != 0) {
+      return 0;
+    }
+
+    const std::size_t signalAlignment = signal_alignment(maxSignalBytes, slot);
+    return window - (signalAlignment - kProtocolAlignment);
+  }
+
   // Getters for testing
   __host__ const LocalState& getLocalState() const {
     return localState_;
@@ -1627,7 +1657,7 @@ class P2pNvlTransportDevice {
     return ((value + alignment64 - 1) / alignment64) * alignment64;
   }
 
-  __device__ __forceinline__ static std::size_t signal_alignment(
+  __host__ __device__ __forceinline__ static std::size_t signal_alignment(
       std::size_t maxSignalBytes,
       std::size_t perChannelSlot) {
     const bool usesPartialSlot =


### PR DESCRIPTION
Summary:
Keep Direct NVLink reservation arithmetic with the transport that implements it. Expose the largest payload that can be reserved without peer progress, plus one small peer-minimum helper for send-before-receive collective phases. Document the one-outstanding-send contract; do not add collective geometry, ownership, reduction, or execution abstractions.

Clarify that the bound assumes a drained channel, reports static geometry rather than live capacity, and requires the production tile geometry. Keep the implementation unchanged and use independent literal expectations in its unit test.

Reviewed By: Scusemua

Differential Revision: D119263568


