### PR TITLE
Flush received RDMA writes in send/recv

### DIFF
--- a/comms/ctran/algos/SendRecv/SendRecvImpl.h
+++ b/comms/ctran/algos/SendRecv/SendRecvImpl.h
@@ -320,6 +320,16 @@ inline commResult_t sendRecvImpl(
     FB_COMMCHECK(mapper->waitNotify(notifyVec[i].get()));
   }
 
+  // One flush covers the group: it is a loopback RDMA READ per local NIC, not
+  // per peer QP. Skip empty recvs so it targets a real registration.
+  for (auto i = 0; i < recvOpGroup.size(); i++) {
+    auto op = recvOpGroup[i];
+    if (notifyVec[i]->backend == CtranMapperBackend::IB && op->recv.count > 0) {
+      FB_COMMCHECK(mapper->flush(op->recv.recvbuff, recvMemHdl[i]));
+      break;
+    }
+  }
+
   // Deregister temporary registrations
   for (auto hdl : tmpRegHdls) {
     FB_COMMCHECK(mapper->deregDynamic(hdl));


### PR DESCRIPTION
Summary:
`SendRecv` is the only ctran IB algorithm that never calls `mapper->flush()`.
`AllToAllv`, `AllToAllP`, `AllGatherP`, `StreamedRd` `AllGather`,
`AllReduceDirect` and `AllReduceRing` all flush after waiting on notifies;
`comms/ctran/algos/SendRecv/` has no flush reference in any of its files.

`CtranIb::shouldEnableLocalFlushByDefault` returning true only arms
`CtranIb::iflush`; the algorithm still has to issue it. So on a platform that
relies on the flush for receive visibility, send/recv does not get it.

That matters most under `spray`, where the RDMA put and its notification are
separate operations with no ordering between them. GB200 avoids this by forcing
`dqplb` in `GB200_ENVS` (its arch does not enable flush); GB300 runs the cvar
default `spray` and is covered only because its arch does enable flush -- and
that cover does not reach send/recv.

## One flush per group, not per recv op

`LocalVirtualConn::iflush` posts a 4-byte `IBV_WR_RDMA_READ` on a dedicated
loopback QP per local NIC, never on a peer QP. It is a PCIe posted-write drain
of the local NIC, so the sending peer is not part of the ordering scope and one
call covers every recv in the group.

The existing ctran call sites do not settle this on their own -- each of them
has a single destination buffer, so "flush once" and "flush each buffer" are
the same thing there. `ncclIbIflush` does settle it: it takes an array of `n`
receives with distinct `mhandles` and posts exactly one READ against
`data[last]`, commented `// Only flush once using the last non-zero receive`,
then fans out across devices for the same reason ctran does. send/recv is the
first ctran flush site whose group holds N independent user buffers, so it is
the first place the distinction is observable.

Zero-size recvs are skipped when picking the buffer, matching `ncclIbIflush`'s
`if (sizes[i]) last = i`. A zero-length recv can produce a degenerate
registration, and the single flush should land on a buffer that actually
received data.

Non-IB recvs are skipped as well: `requiresRecvNotify` is `NVL`/`TCPDM`-only, so
NVL peers are already ordered by their kernel elem and flushing them would post
a pointless RDMA READ.

On platforms where local flush is off the call is a no-op, so `dqplb` platforms
are unaffected.

## Known limitation, pre-existing

`iflush` reads `sizeof(int)` bytes where `ncclIbIflush` reads 1. Device buffers
are safe -- `pinRange` registers the whole `cuMemGetAddressRange` allocation --
but a host-memory recv registers exactly `[ptr, ptr+len)`, so a sub-4-byte host
recv could take a protection error. That is a property of `iflush` shared by
every flush call site, not something this diff introduces; worth fixing
separately by narrowing the read to 1 byte.

Reviewed By: minsii

Differential Revision: D119270413


