### PR TITLE
Materialize PRIMS IBGDA channels on demand

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -61,6 +61,9 @@ struct ctranPrimsConfig {
   // cap. Multimem requires it not to exceed maxChannels because a launch
   // cannot consume more blocks than the provisioned channel capacity.
   int64_t maxBlocks{-1};
+  // Materialize only the IB channel prefix requested by each collective.
+  // Appended to preserve positional aggregate initialization of older fields.
+  bool lazyChannels{false};
 
   bool operator==(const ctranPrimsConfig& other) const {
     return enablePrims == other.enablePrims &&
@@ -68,16 +71,14 @@ struct ctranPrimsConfig {
         ibLazyConnect == other.ibLazyConnect &&
         channelBufferSize == other.channelBufferSize &&
         channelPipelineDepth == other.channelPipelineDepth &&
-        maxChannels == other.maxChannels && maxBlocks == other.maxBlocks;
+        maxChannels == other.maxChannels && maxBlocks == other.maxBlocks &&
+        lazyChannels == other.lazyChannels;
   }
 };
 
-// Per-communicator override first, global CVAR second. Both the transport
-// (comm init) and the collective launch geometry (per call) must resolve these
-// the same way, so they share these helpers rather than reading the CVAR
-// directly. NOTE: mccl's own launch-geometry validation still reads
-// MCCL_MAX_NCHANNELS / MCCL_MAX_NBLOCKS globally; a communicator that overrides
-// these and also runs mccl collectives would be validated against the global.
+// Per-communicator override first, global CVAR second. Transport setup resolves
+// both values here; collective channel validation reads the resulting transport
+// capacity so it stays consistent with the communicator override.
 inline int64_t ctranPrimsResolvedMaxChannels(const ctranPrimsConfig& pc) {
   return pc.maxChannels > 0 ? pc.maxChannels
                             : static_cast<int64_t>(MCCL_MAX_NCHANNELS);
@@ -244,8 +245,8 @@ class CtranComm {
     return parentRanks_;
   }
 
-  // Materializes `peers` and returns the Transport array indexed by global
-  // rank. An empty peer list initializes no IB transport slots.
+  // Materializes `peers` at full IB channel capacity and returns the stable
+  // Transport array indexed by global rank.
   comms::prims::Transport* getMultiPeerTransportsPtr(
       const std::vector<int>& peers);
 

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -168,6 +168,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
 
     const auto& pc = comm->config_.primsConfig;
     comms::prims::MultiPeerTransportConfig config{};
+    config.ibConfig.lazyChannels = pc.lazyChannels;
 
     config.nvlConfig.pipelineDepth =
         static_cast<size_t>(NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH);
@@ -435,7 +436,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
 
     CTRAN_LOG(
         INFO,
-        "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} enableMultimem={} multimemPerChannelSize={} multimemPipelineDepth={} multimemMaxChannels={} multimemMaxBlocks={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={}",
+        "CTRAN-PRIMS: config prepared rank={} nvlPipelineDepth={} nvlSharedDevbufSize={} nvlDataBufferSize={} nvlMaxNumChannels={} nvlPerChannelSize={} enableMultimem={} multimemPerChannelSize={} multimemPipelineDepth={} multimemMaxChannels={} multimemMaxBlocks={} hierAgOverlapEnabled={} disableIb={} p2pDisable={} mnnvlMode={} ibgdaDataBufferSize={} ibgdaQpDepth={} ibLazyConnect={} lazyChannels={}",
         comm->statex_->rank(),
         config.nvlConfig.pipelineDepth,
         nvlSharedDevbufSize,
@@ -459,7 +460,8 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         static_cast<int>(config.topoConfig.mnnvlMode),
         config.ibConfig.dataBufferSize,
         config.ibConfig.qpDepth,
-        config.ibConfig.ibLazyConnect);
+        config.ibConfig.ibLazyConnect,
+        config.ibConfig.lazyChannels);
 
     CTRAN_LOG(
         INFO,

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterDirectIb.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterDirectIb.cc
@@ -261,18 +261,7 @@ static commResult_t ctranReduceScatterDirectIbImpl(
     return commInvalidArgument;
   }
 
-  auto* mpt = comm->multiPeerTransport_.get();
-  std::vector<int> peers;
-  peers.reserve(static_cast<size_t>(nRanks - 1));
-  for (int peer = 0; peer < nRanks; ++peer) {
-    if (peer != statex->rank()) {
-      peers.push_back(peer);
-    }
-  }
-
   try {
-    mpt->materializePeers(peers);
-
     size_t wireRecvBytes = recvBytes;
     size_t wireTotalBytes = totalBytes;
     if (quantized &&
@@ -292,6 +281,16 @@ static commResult_t ctranReduceScatterDirectIbImpl(
             wireTotalBytes,
             static_cast<int>(ctranPrimsResolvedMaxChannels(primsConfig)),
             static_cast<int>(ctranPrimsResolvedMaxBlocks(primsConfig)));
+
+    auto* mpt = comm->multiPeerTransport_.get();
+    std::vector<int> peers;
+    peers.reserve(static_cast<size_t>(nRanks - 1));
+    for (int peer = 0; peer < nRanks; ++peer) {
+      if (peer != statex->rank()) {
+        peers.push_back(peer);
+      }
+    }
+    mpt->prepare_ib_channels(peers, static_cast<uint32_t>(numBlocks));
 
     comms::prims::DirectReduceScatterIbLaunchParams params{};
     params.my_rank = statex->rank();
@@ -317,7 +316,7 @@ static commResult_t ctranReduceScatterDirectIbImpl(
     // comms/common/fault_tolerance/FAULT_TOLERANCE.md.
     params.stream = stream;
 
-    for (int peer : peers) {
+    for (const int peer : peers) {
       params.peers[peer] = comms::prims::P2pIbTransportDevice(
           mpt->get_p2p_ibgda_transport_device(peer));
     }

--- a/comms/ctran/tests/CtranCommTest.cc
+++ b/comms/ctran/tests/CtranCommTest.cc
@@ -100,14 +100,18 @@ TEST(CtranCommTest, AbortAvailableAndDisabled) {
 TEST(CtranCommTest, ctranCommConfigTest) {
   auto abort = comms::fault_tolerance::createAbort(/*enabled=*/true);
   ctranConfig config = {
-      .backends = {CommBackend::IB, CommBackend::NVL, CommBackend::SOCKET}};
+      .backends = {CommBackend::IB, CommBackend::NVL, CommBackend::SOCKET},
+      .primsConfig = {.lazyChannels = true},
+  };
 
   CtranComm comm(abort, config);
   EXPECT_EQ(comm.config_.backends.size(), 3);
+  EXPECT_TRUE(comm.config_.primsConfig.lazyChannels);
 
   /// Explicitly create comm with false abort as first argument is unomittable
   CtranComm comm2(comms::fault_tolerance::createAbort(false));
   EXPECT_EQ(comm2.config_.backends.size(), 0);
+  EXPECT_FALSE(comm2.config_.primsConfig.lazyChannels);
 }
 
 TEST(CtranCommTest, PrimsPolicyIsPerCommunicator) {

--- a/comms/prims/benchmarks/IbgdaSendRecv.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cu
@@ -587,63 +587,52 @@ void launch_ibgda_drain_send_recv(
 
 __global__ void __launch_bounds__(256, 1) ibgda_reset_send_recv_kernel(
     P2pIbgdaTransportDevice* transport,
-    int maxGroups) {
-  const auto& layout = transport->channel_layout();
+    int numPreparedChannels) {
   const auto idx = blockIdx.x * blockDim.x + threadIdx.x;
   const auto stride = blockDim.x * gridDim.x;
-
-  // Zero the whole signal region: a numLanes-per-channel DATA_READY block plus
-  // a one-per-channel SLOT_FREE block. Grid-stride so the loop covers it for
-  // any launch grid size.
-  const uint32_t dataReadySlots =
-      static_cast<uint32_t>(layout.numLanes * maxGroups);
-  const uint32_t slotFreeSlots = static_cast<uint32_t>(maxGroups);
-  const uint32_t totalSignalSlots = dataReadySlots + slotFreeSlots;
-  for (auto slot = idx; slot < totalSignalSlots; slot += stride) {
-    if (SignalState* signal = layout.localSignalState(static_cast<int>(slot))) {
-      signal->signal_ = 0;
-    }
-    if (slot < static_cast<uint32_t>(layout.numChannels)) {
-      auto& channel = transport->local_channel(slot);
-      // Every protocol slot on this channel: the signal region zeroed above
-      // spans all of them.
-      for (int protoSlot = 0; protoSlot < kNumProtoSlots; ++protoSlot) {
-        auto& proto = channel.protos[protoSlot];
-        proto.sendProgress = IbChannelProgress{};
-        proto.recvProgress = IbChannelProgress{};
-        // Zero the per-lane receiver DATA_READY expectations so they stay
-        // aligned with the DATA_READY slots zeroed above.
-        // recvDataReadyLaneCursor is deliberately NOT reset here: it mirrors
-        // the channel-shared sendQp.cursor, which this kernel also leaves
-        // untouched, so zeroing it would desync the round-robin lane mapping
-        // on the next stream.
-        for (int lane = 0; lane < kIbMaxQpLanesPerChannelDirection; ++lane) {
-          proto.recvLaneExpected[lane] = 0;
+  const int numLanes = transport->channel_layout().numLanes;
+  for (auto channelId = idx;
+       channelId < static_cast<uint32_t>(numPreparedChannels);
+       channelId += stride) {
+    auto& channel = transport->local_channel(channelId);
+    for (int protoSlot = 0; protoSlot < kNumProtoSlots; ++protoSlot) {
+      auto& proto = channel.protos[protoSlot];
+      for (int lane = 0; lane < numLanes; ++lane) {
+        if (proto.dataReady.ptr != nullptr) {
+          auto* signal = reinterpret_cast<SignalState*>(
+              static_cast<char*>(proto.dataReady.ptr) +
+              lane * kSendRecvSignalSlotStride);
+          signal->signal_ = 0;
         }
       }
+      if (proto.slotFree.ptr != nullptr) {
+        reinterpret_cast<SignalState*>(proto.slotFree.ptr)->signal_ = 0;
+      }
+      if (proto.nicDoneWait.ptr != nullptr) {
+        reinterpret_cast<SignalState*>(proto.nicDoneWait.ptr)->signal_ = 0;
+      }
+      proto.sendProgress = IbChannelProgress{};
+      proto.recvProgress = IbChannelProgress{};
+      for (int lane = 0; lane < kIbMaxQpLanesPerChannelDirection; ++lane) {
+        proto.recvLaneExpected[lane] = 0;
+      }
     }
-  }
-
-  for (auto slot = idx; slot < static_cast<uint32_t>(maxGroups);
-       slot += stride) {
-    if (SignalState* counter =
-            layout.localCounterState(static_cast<int>(slot))) {
-      counter->signal_ = 0;
-    }
+    // recvDataReadyLaneCursor mirrors the sender's free-running QP cursor and
+    // is intentionally not reset here.
   }
 }
 
 void launch_ibgda_reset_send_recv(
     P2pIbgdaTransportDevice* transport,
-    int maxGroups,
+    int numPreparedChannels,
     cudaStream_t stream) {
-  if (maxGroups == 0) {
+  if (numPreparedChannels == 0) {
     return;
   }
   constexpr int kThreads = 256;
-  const int blocks = (2 * maxGroups + kThreads - 1) / kThreads;
-  ibgda_reset_send_recv_kernel<<<blocks, kThreads, 0, stream>>>(
-      transport, maxGroups);
+  const int gridBlocks = (numPreparedChannels + kThreads - 1) / kThreads;
+  ibgda_reset_send_recv_kernel<<<gridBlocks, kThreads, 0, stream>>>(
+      transport, numPreparedChannels);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf("[PIPES] Reset launch failed: %s\n", cudaGetErrorString(err));

--- a/comms/prims/benchmarks/IbgdaSendRecv.h
+++ b/comms/prims/benchmarks/IbgdaSendRecv.h
@@ -170,12 +170,12 @@ void launch_ibgda_drain_send_recv(
     AbortDevice abortDevice = AbortDevice());
 
 /**
- * Reset benchmark-owned send/recv transport state after outstanding work has
- * been drained.
+ * Reset benchmark-owned send/recv transport state across the prepared logical
+ * channel prefix after outstanding work has been drained.
  */
 void launch_ibgda_reset_send_recv(
     P2pIbgdaTransportDevice* transport,
-    int maxGroups,
+    int numPreparedChannels,
     cudaStream_t stream);
 
 /**

--- a/comms/prims/core/ThreadGroup.cuh
+++ b/comms/prims/core/ThreadGroup.cuh
@@ -85,10 +85,10 @@ struct ThreadGroup {
   // For warps: global warp ID. Use for work distribution.
   uint32_t group_id;
 
-  // block_id - Physical CUDA block ID that owns transport resources.
-  // Unlike group_id, this is preserved when groups are partitioned or
-  // renumbered. IBGDA QP selection uses block_id so logical group routing
-  // cannot accidentally move a group onto another block's QPs.
+  // block_id - Physical CUDA block ID. Unlike group_id, this is preserved when
+  // groups are partitioned or renumbered. Channel-indexed IB transports use
+  // group_id; block_id remains available to algorithms that need physical
+  // launch identity.
   uint32_t block_id;
 
   // total_groups - Total number of groups in entire kernel

--- a/comms/prims/docs/LazyChannels.md
+++ b/comms/prims/docs/LazyChannels.md
@@ -1,0 +1,304 @@
+# PRIMS Lazy Channels
+
+Status: Target design for the dependent implementation changes in this stack
+
+## Summary
+
+The existing peer-lazy connection path creates backend-global NIC/control state
+and fixed descriptor tables at communicator initialization, but defers
+peer/channel-specific QPs, buffers, CQs, and FIFOs until MCCL first uses a peer.
+Without lazy channels, that first use creates every configured channel for the
+peer.
+
+Lazy channels add a channel-prefix dimension to the same materialization path:
+
+```text
+kEager:
+  first positive demand for peer P -> create channels [0, capacity)
+
+kLazyPrefix:
+  demand (peer P, N channels) -> create missing channels [oldK, N)
+```
+
+For `kLazyPrefix`, PRIMS validates `N <= capacity` and materializes the exact
+requested prefix. Channels are always a prefix, never a sparse set. V1 is
+grow-only: a peer's materialized prefix can increase but never decrease, and
+resources are released only at communicator teardown. For example, a demand
+for three channels materializes `[0, 3)`.
+
+`MCCL_PRIMS_LAZY_CHANNELS` selects the mode and defaults to off. There is no
+user-facing lazy API.
+
+## Scope and ownership
+
+This design covers the MCCL API -> MCCL launcher/kernel -> PRIMS transport path
+for IBGDA and IBRC, plus PRIMS-backed CTRAN launchers using the same readiness
+contract.
+
+- MCCL selects the algorithm, peers, and channel counts.
+- The MCCL algorithm prepares all required peer/channel prefixes before
+  obtaining device transport pointers and launching the kernel.
+- PRIMS allocates, exchanges, connects, and publishes transport resources.
+- PRIMS kernels consume prepared transport descriptors; they never allocate or
+  connect.
+
+Tree, ring, and other algorithms do not own separate transport buffers. They
+reuse the same PRIMS resource for a `(peer, channel)` and differ only in which
+peers and channel prefixes they request.
+
+NVL lazy storage is out of scope.
+
+## Data model
+
+### Peer/channel readiness
+
+The existing peer materialization state is extended with one host-side
+readiness watermark per peer:
+
+```cpp
+struct PendingPeer {
+  int rank;
+  uint32_t targetChannels;
+};
+
+std::mutex materializationMutex;
+std::vector<PendingPeer> pendingPeers;
+std::vector<uint32_t> materializedChannels;
+std::atomic<bool> materializationFailed;
+```
+
+`materializedChannels[peerIndex] == K` means every channel in `[0, K)` is ready
+for a kernel. A request for `N <= K` is a local no-op. A larger request appends
+only the exact missing range `[K, N)`.
+
+The mutex protects request merging, distributed materialization, and watermark
+publication. Backend range allocations are immutable teardown ownership; there
+is no separate per-range state machine. The terminal bit is atomic so the IBRC
+progress thread can poison the transport without waiting behind an in-flight
+bootstrap exchange.
+
+### Stable device descriptors
+
+Communicator initialization reserves lightweight descriptor storage for the
+full logical capacity:
+
+```text
+outerTransport[peer]
+channelDescriptors[peer][channel]
+ibgdaQpSlots[peer][NIC][main|companion][channel][direction][lane]
+ibrcQueueSlots[peer][NIC][channel][direction][lane]
+```
+
+IBGDA keeps separate fixed spans for main and companion QP pointers; IBRC keeps
+a fixed command-queue table. All outer and inner addresses remain stable.
+Entries begin empty and are populated only when their channel is materialized.
+Kernels and older CUDA graphs can therefore keep using an existing prefix while
+later launches append channels.
+
+Each channel descriptor contains exact resource bindings and mutable progress
+state for that `(peer, channel)`, including:
+
+- local send and receive staging
+- remote receive staging
+- DATA_READY, SLOT_FREE, and NIC_DONE state
+- completion and QP state
+
+Device code selects the descriptor directly. It does not derive channel
+addresses by offsetting a peer-wide buffer. Allocation, publication, and lookup
+share one canonical `(channel, direction, lane)` to backend-slot mapping.
+
+### Physical resources
+
+| Lifetime | Resources |
+| --- | --- |
+| Communicator initialization | NIC/PD state, fixed-capacity tables, and backend-global control resources |
+| First positive peer demand | peer-wide signal/counter state; start the IBRC progress thread |
+| Each materialized channel range | staging/control buffers, completion storage, MRs, and backend transport objects |
+| Communicator teardown | every materialized range and fixed descriptor table |
+
+An IBGDA range owns main and companion QPs, loopback responders, completion
+slots, and registered staging/control memory. An IBRC range owns QPs, CQs,
+command FIFOs, completion storage, registered staging/control memory, and
+host-mapped NIC_DONE counters. Each published channel descriptor contains the
+exact pointer and key for that channel.
+
+## MCCL submission contract
+
+### Existing MCCL boundary
+
+The existing MCCL architecture remains unchanged:
+
+- `McclComm` dispatches to an `ICollective` algorithm.
+- `CommContext` carries the communicator state and `MultiPeerTransport`.
+- `ICollective::run()` selects the final topology and launch geometry, prepares
+  transport readiness, binds device transport pointers, and enqueues the
+  kernel.
+
+Dispatch in `McclComm` is too early because final peers and channel width are
+known inside `run()`. The readiness call must occur before device transport
+pointers are embedded in launch parameters. Therefore `ICollective::run()` is
+the host readiness boundary; algorithms may fill transport-independent launch
+fields before that call.
+
+After selecting topology and geometry, the algorithm requests its IB resources
+through `MultiPeerTransport`:
+
+```cpp
+struct PeerChannelDemand {
+  int peerRank;
+  uint32_t ibChannels;
+};
+
+MultiPeerDeviceHandle get_device_handle(
+    std::span<const PeerChannelDemand> demands);
+```
+
+`get_device_handle()` validates the complete batch, sorts peers, max-merges
+duplicate demands, materializes missing ranges, and returns the stable device
+handle. Only then does the algorithm obtain and embed device transport pointers
+and launch. Kernels and kernel ABIs do not change.
+
+The demand overload is the canonical MCCL readiness path. The compatibility
+peer-list overload converts each preferred-route IB peer to a full-capacity
+demand and forwards to the same implementation.
+
+The materialization mutex serializes host growth. No lock is held through
+kernel enqueue because growth only appends resources and never invalidates an
+in-flight kernel's prefix. Operation overlap follows MCCL's existing
+same-communicator execution contract.
+
+### Initial algorithm demands
+
+V1 uses each launcher's existing launch geometry, including any existing
+message-size-dependent `numBlocks` selection. It does not add an independent
+channel planner. Lazy growth follows whole launch-block resource bundles: for
+`B` blocks, the collective includes every channel used by blocks `[0, B)`, even
+when one block maps to multiple channels. It then requests the exact highest
+channel ID used plus one. PRIMS receives this flattened channel prefix; it does
+not reinterpret or round the block demand.
+
+| Launcher | IB demand |
+| --- | --- |
+| CTRAN Direct ReduceScatter | every remote peer: `numBlocks` |
+| Ring ReduceScatter | ring peers: `kNumBlocks * kNumRings` |
+| Fused Tree AllReduce | tree peers: `numBlocks * virtualStripes * kTreeLanes` |
+| Fused Ring AllReduce | participating prev/next: `numBlocks * virtualStripes` |
+| Fused Direct AllReduce | participating IBGDA peers: `numBlocks` |
+| Hierarchical Ring AllGather | participating prev/next: `numBlocks` |
+| Batched SendRecv | each IB peer: maximum `op.blocks` across that peer's operations |
+| Legacy blocking SendRecv | full capacity until matched per-edge geometry is implemented |
+
+Both endpoints of an IB edge must derive the same effective prefix. Batched
+SendRecv derives `op.blocks` from the matched edge's message size and channel
+capacity; send and receive operations for the same peer are max-merged.
+
+## Materialization protocol
+
+The implementation extends the existing PRIMS lazy-peer hierarchy:
+
+```text
+ICollective::run()
+  -> MultiPeerTransport::get_device_handle(demands)
+     -> MultiPeerTransport::materializePeerChannels()
+        -> MultiPeerIbTransport<Backend>::connectPeers()
+           -> Backend::materializePeerChannelRange(peer, oldK, newK)
+```
+
+`kEager` retains the existing two backend phases: exchange/connect QPs, then
+exchange/bind buffers. Any positive demand is promoted to full capacity, and no
+channel REQUEST/READY records are exchanged.
+
+`kLazyPrefix` adds agreement around those same backend phases:
+
+1. Validate, sort, and max-merge the complete demand batch before mutation.
+2. Merge each exact target with pending state under the materialization mutex.
+3. Exchange an exact `PeerChannelRequest` containing backend, range, capacity,
+   NIC, direction, QP, pipeline, slot, and staging geometry.
+4. Allocate QPs and related backend objects for `[oldK, newK)`. Exchange the
+   fixed-capacity `PeerQpPayload` with only that range's entries populated and
+   consumed, then connect those QPs.
+5. Allocate staging/control resources for the range and exchange buffer
+   addresses and keys.
+6. Populate the stable device tables for the range and complete device-side
+   initialization.
+7. Exchange READY by echoing the same `PeerChannelRequest`, then advance the
+   peer's materialized-channel watermark to `newK`.
+
+Every growth generation uses a distinct peer-pair bootstrap tag range. This is
+required by store-backed bootstraps, whose received keys remain present after a
+round completes.
+
+Device entries may be populated before READY, but the host does not return a
+launchable handle until READY succeeds and the watermark advances. Existing
+bindings in `[0, oldK)` are never replaced or rewritten by growth.
+
+IBRC also maintains a backend publication watermark in command-queue-slot
+units. After populating its fixed tables, it release-publishes
+`publishedCmdQueueCounts[peerIndex]`; the progress thread acquire-loads this
+prefix and never scans partially initialized queues. READY and the common
+`materializedChannels` watermark remain the later kernel-admission boundary.
+
+## CUDA graphs
+
+Cold first use while the user's launch stream is under capture is supported:
+
+1. PRIMS enters relaxed thread capture mode for host-side materialization.
+2. Allocation, bootstrap exchange, and QP connection remain graph-external host
+   work.
+3. Device initialization and descriptor uploads use short-lived nonblocking
+   initialization streams where required. They are synchronized and destroyed
+   before readiness is published.
+4. The MCCL kernel is then enqueued on the user's captured stream.
+
+Materialization contributes no graph nodes; the algorithm's normal device work
+is captured. Replay performs no allocation, connection, bootstrap exchange, or
+descriptor upload. Stable append-only tables also allow an older graph to
+replay after a later launch grows the prefix.
+
+PRIMS does not add a communicator-owned control stream or couple growth to a
+CUDA event.
+
+## Failure behavior
+
+Batch validation before materialization is non-terminal. Once `connectPeers()`
+starts a materialization transaction, any exception is terminal, including a
+local allocation failure before the first wire exchange:
+
+1. atomically latch `materializationFailed`
+2. clear pending work and unlock the materialization mutex when the failing
+   path owns it
+3. run backend terminal handling and rethrow the original error
+4. reject later readiness calls and device-transport accessors
+
+There is no retry or rollback. Partial resources remain owned for best-effort
+communicator teardown. IBRC also publishes failed device status and stops its
+progress thread. IBGDA has no backend-specific device poison path; the host
+poison prevents later submissions but does not itself stop an already-running
+IBGDA kernel.
+
+A cancellation-aware bootstrap can wake both endpoints after an asymmetric
+materialization failure. A generic blocking bootstrap such as `MpiBootstrap`
+cannot cancel a peer already blocked in an exchange, so that peer may remain
+blocked until the upper-layer operation or job watchdog expires. The transport
+does not guarantee bilateral fail-fast behavior for such bootstrap
+implementations.
+
+## Configuration
+
+`MCCL_PRIMS_LAZY_CHANNELS` is a process-wide cvar and defaults to off. MCCL
+samples it while creating each communicator and stores the resulting immutable
+mode in that communicator's PRIMS configuration. MCCL has no public
+per-communicator option today, while direct/internal transport construction can
+set the per-communicator configuration explicitly.
+
+Ranks exchange a fixed `ChannelProtocolRecord` containing mode and capacity
+during communicator initialization. Route symmetry is validated separately.
+Backend, NIC, QP, staging, pipeline, and slot geometry are validated
+bilaterally before an IB range is published.
+
+## Deferred extensions
+
+- suffix shrink and reclaim
+- independent transport-level channel planning
+- matched per-edge demand for legacy blocking SendRecv
+- NVL VMM/fabric-handle prefix mapping

--- a/comms/prims/docs/tile_sendrecv.md
+++ b/comms/prims/docs/tile_sendrecv.md
@@ -32,30 +32,33 @@ The config carries the fixed-channel geometry explicitly:
 
 | Field | Role in tile API |
 |---|---|
-| `perChannelSize` | Bytes owned by one channel in one pipeline slot. |
-| `pipelineDepth` | Number of slots in the pipeline ring. |
-| `maxNumChannels` | Number of **channels** allocated per peer. Each channel owns one fixed `perChannelSize` staging slice in every pipeline slot, plus one `NvlChannelState` for cursors + signals. |
+| `perChannelSize` | Total bytes in one channel's contiguous staging window. |
+| `pipelineDepth` | Number of slots that divide each channel window. |
+| `maxNumChannels` | Number of **channels** allocated per peer. Each channel owns one fixed `perChannelSize` staging window, plus one `NvlChannelState` for cursors + signals. |
 
 The host derives `data_buffer_size = perChannelSize * maxNumChannels` for
-the pipeline slot. Channel sizing is fixed at init.
+the complete per-peer staging allocation. Channel sizing is fixed at init.
 
 ### IB (`MultipeerIbTransportConfig`)
 
-IB uses the same fixed-channel shape. The config exposes the first-order
-geometry and derives the total staging slot size:
+IB uses the same fixed logical-channel shape. The config describes the maximum
+addressable geometry. In eager mode, the first positive peer demand
+materializes that full capacity; lazy mode reserves stable descriptor tables
+for it but commits QPs and backing storage only for the exact channel prefix
+requested by launch geometry:
 
 ```cpp
 struct MultipeerIbTransportConfig {
   // ... existing fields (qpDepth, qpsPerConnection, etc.) ...
 
-  // Raw put()/signal() buffer size. For send()/recv(), this is derived as
-  // perChannelSize * max_num_channels when perChannelSize is set.
+  // Raw put()/signal() buffer size. For send()/recv(), this records the
+  // full-capacity size derived from perChannelSize * totalChannelSlots().
   std::size_t dataBufferSize{0};
 
-  // Bytes owned by one channel in one pipeline slot.
+  // Total staging-window bytes owned by one (protocol, channel) resource slot.
   std::size_t perChannelSize{0};
 
-  // Number of channels allocated per peer.
+  // Maximum number of logical channels addressable per peer.
   int max_num_channels{64};
 
   // Number of pipeline slots for send/recv staging.
@@ -67,19 +70,26 @@ struct MultipeerIbTransportConfig {
 
 - `pipelineDepth >= 1`
 - `maxNumChannels` / `max_num_channels >= 1`
-- per-channel size is `>= 16` and 16-byte aligned, so each channel slot fits
-  at least one 16-byte vectorized memcpy.
+- `perChannelSize` is divisible by `pipelineDepth`
+- `perChannelSize / pipelineDepth` is `>= 16` and 16-byte aligned, so each
+  channel slot fits at least one 16-byte vectorized memcpy.
 
 **Defaults rationale:** NVL and IB default to channel counts that cover the
 largest NCCL P2P channel counts we expect to mirror. With
-`perChannelSize=128 KiB` and `maxNumChannels=64`, one pipeline slot is 8 MiB.
+`perChannelSize=128 KiB` and 64 logical channels, NVL uses 8 MiB per peer.
+At full capacity, IB needs that much per protocol slot and direction; with two
+protocol slots, send and receive staging total 32 MiB per peer before control
+storage and allocation rounding. Lazy IB allocates only the materialized
+prefix. At `pipelineDepth=2`, each resource slot has two 64 KiB pipeline slots.
 
 ---
 
 ## 2. Internal State
 
-Owned by the transport, allocated and registered at construction. **Invisible
-to users** — referenced here only for implementer reference.
+Owned by the transport and **invisible to users**. NVL storage and IB's stable
+descriptor tables are allocated during setup before peer materialization. Lazy
+IB backing storage is allocated and registered when the host materializes a
+channel range.
 
 The NVLink and IB transports use separate per-channel state structs because
 the IB transport requires additional fields for NIC completion tracking and
@@ -116,9 +126,10 @@ NvlChannelState* remote_channels_;  // remote rank's endpoint via IPC; this rank
 ```
 
 Both arrays have length `options_.max_num_channels`. Both
-the channel index and the per-channel staging slice index are `group.group_id`.
+the channel index and the per-channel staging-window index are
+`group.group_id`.
 
-### IB: `IbLocalChannel`, `IbRemoteChannel`, and `IbChannelLayout`
+### IB: protocol slots and `IbChannelLayout`
 
 ```cpp
 // One protocol's resources on a channel. Duplicated per protocol because these
@@ -129,6 +140,7 @@ struct IbChannelProtoSlot {
   IbChannelProgress recvProgress;
   // Local DATA_READY, SLOT_FREE, and NIC_DONE endpoints for this protocol.
   // Per-lane receiver DATA_READY expectations for this protocol.
+  // Exact local/remote staging and peer signal bindings for this protocol.
 };
 
 struct IbLocalChannel {
@@ -147,40 +159,49 @@ struct IbRemoteChannel {
 };
 
 struct IbChannelLayout {
-  std::byte* sendStaging;
-  std::byte* recvStaging;
-  DeviceSpan<IbLocalChannel> localChannels;
-  DeviceSpan<IbRemoteChannel> remoteChannels;
-  int max_num_channels;
+  // Registered staging, signal, and counter backing buffers.
+  int maxChannels;  // Flattened (protocol, channel) resource-slot capacity.
+  int numChannels;  // Logical channels selected by group.group_id.
+  int numLanes;
   int pipelineDepth;
-  std::size_t perChannelSize;
+  std::size_t perChannelBufferSize;
 };
 ```
 
-**Per-slot layout** (one slot is `data_buffer_size` bytes, partitioned across
-fixed channels):
+The device reserves a stable `IbLocalChannel[max_num_channels]` descriptor
+table. Each materialized descriptor embeds the exact local and remote views for
+all of its protocol slots, so device code does not derive a backing address from
+a peer-wide allocation. Lazy population can therefore fill a channel range
+without changing kernel-visible table pointers or CUDA graph captures.
+
+Each immutable allocation for `[begin, end)` uses protocol-major range-local
+layout, where `R = end - begin`:
 
 ```
-slot k  (= step / chunks_per_slot % pipeline_depth):
-┌──────────────┬──────────────┬─────┬────────────────────┐
-│ channel 0 row│ channel 1 row│ ... │ channel (N-1) row  │
-└──────────────┴──────────────┴─────┴────────────────────┘
-   N = maxNumChannels / max_num_channels (fixed at init).
-   each row = per_channel_slot = per_channel_size
+┌──────────────────────────── protocol 0 ────────────────────────────┐
+│ channel begin    │ channel begin+1  │ ... │ channel (end-1)      │
+├──────────────────────────── protocol 1 ────────────────────────────┤
+│ channel begin    │ channel begin+1  │ ... │ channel (end-1)      │
+└────────────────────────────────────────────────────────────────────┘
+   range resource slot = protocol_slot * R + (channel - begin)
+   resource window     = per_channel_size
+   pipeline slot       = per_channel_size / pipeline_depth
 ```
 
-Using fewer-than-max channels wastes the unused channels' slices but does not
-change live channels' bandwidth.
+The unmaterialized suffix has descriptor capacity but no QPs, staging windows,
+signals, or counters. Existing ranges remain owned until communicator teardown.
 
 **Construction responsibilities (host):**
 - NVL: allocate one IPC-shared `NvlChannelState[nPeers * maxNumChannels]`
   buffer; exchange via `GpuMemHandler::exchangeMemPtrs()`. P2P-enable
   `recv_staging` access; exchange device pointers. Zero-init the channel
   buffer (zeros cursors and signals).
-- IB: allocate local channels, remote channel descriptors, send staging, and
-  recv staging. Register MRs for staging and signal/counter storage; exchange
-  peer channel descriptors and rkeys. Zero-init channel progress, signals, and
-  counters.
+- IB: allocate the fixed logical-channel descriptor and pointer tables. For
+  each materialized `[old, target)` range, allocate and register its
+  protocol-slot-indexed staging, signals, and counters; exchange peer addresses
+  and rkeys; then populate the stable descriptor range. Eager mode promotes a
+  positive request to the full capacity. Zero-init channel progress, signals,
+  and counters.
 
 **Destruction:** deregister MRs (IB), free buffers. Outstanding ops are the
 caller's responsibility (kernel must finish before the host destructor runs).
@@ -191,8 +212,9 @@ caller's responsibility (kernel must finish before the host destructor runs).
 
 ### Cpp
 
-NVL and IB use the same call shape for blocking send/recv. Channel count is
-fixed at init.
+NVL and IB use the same call shape for blocking send/recv. Logical channel
+capacity is fixed at init; lazy IB may grow the materialized prefix before a
+kernel launch.
 
 ```cpp
 class P2pNvlTransportDevice {
@@ -264,18 +286,18 @@ def recv(dst_ptr, nbytes, block_id, max_signal_bytes, timeout_ns,
 
 | Param | Required | Default | Meaning |
 |---|---|---|---|
-| `group` (cpp) / `block_id` (Triton) | yes | — | Identifies this calling block. Slot routing uses `group.group_id` (cpp) or the `block_id` arg (Triton). |
-| `src` / `dst` | yes | — | This block's pre-sliced data pointer. Caller computes per-block offset (see `TiledBuffer`). |
-| `nbytes` | yes | — | This block's data size. May exceed `per_channel_size` — chunked internally over pipeline slots. |
-| `max_signal_bytes` | no | `0` → `per_channel_size` | Hint for the maximum number of bytes between consecutive DATA_READY signals. Capped at `per_channel_size` if larger (sub-slot signaling only). |
+| `group` (cpp) / `block_id` (Triton) | yes | — | Identifies the logical channel used by this call. A CUDA block may partition into multiple groups and therefore use multiple channels. |
+| `src` / `dst` | yes | — | This channel's pre-sliced data pointer. Caller computes the corresponding offset (see `TiledBuffer`). |
+| `nbytes` | yes | — | This channel's data size. May exceed `per_channel_size` — chunked internally over pipeline slots. |
+| `max_signal_bytes` | no | `0` → `per_channel_slot` | Hint for the maximum number of bytes between consecutive DATA_READY signals. Capped at `per_channel_slot` if larger (sub-slot signaling only). |
 | `timeout` | no | `AbortDevice()` (no limit) | Per-wait abort handle. Reuses `comms::fault_tolerance::AbortDevice`. On expiry the wait terminates; see `comms/common/fault_tolerance/FAULT_TOLERANCE.md`. |
 
 ### Special values
 
-- **`nbytes == 0`** — block participates in convergent control flow but does no
+- **`nbytes == 0`** — group participates in convergent control flow but does no
   copy and no signal; channel progress does not advance. Sender and receiver MUST
-  both pass `nbytes==0` for the same `block_id` (per-block matching rule below).
-- **`max_signal_bytes > per_channel_size`** — silently capped to `per_channel_size`.
+  both pass `nbytes==0` for the same logical channel.
+- **`max_signal_bytes > per_channel_slot`** — silently capped to `per_channel_slot`.
   The protocol never signals less frequently than once per slot fill (sub-slot
   signaling only).
 - **`group.group_id >= max_num_channels`** — `__trap()`. Catches a kernel
@@ -291,20 +313,20 @@ def recv(dst_ptr, nbytes, block_id, max_signal_bytes, timeout_ns,
 1. **CTA-cooperative.** All threads in `group` MUST call `send` /
    `recv` convergently. Cooperative memcpy across the block; leader thread
    issues signals and RDMA puts.
-2. **Slot routing index = `group.group_id`** (cpp) / `block_id` extern arg
+2. **Channel routing index = `group.group_id`** (cpp) / `block_id` extern arg
    (Triton). The *logical index within the calling group*, not raw `blockIdx.x`.
    So a kernel that does `auto [role, sub] = group.partition(2)` passes `sub`
    to `send` / `recv`, and `sub.group_id` (range `[0, sub.total_groups)`)
-   is the slot row index.
+   is the channel index.
 3. **Trap precondition (debug-mode `__trap`):**
    - `group.group_id < max_num_channels`. The channel index is
-     `group.group_id`; selecting a channel outside the allocated range would
-     alias state or corrupt adjacent staging.
+     `group.group_id`; host readiness must also have materialized that prefix
+     before launch. Bypassing readiness can access an unpublished descriptor.
 
 ### Cross-rank coordination
 
 - For each `group_id k`: sender block_k's `(nbytes, max_signal_bytes)` MUST
-  equal receiver block_k's. The protocol routes data through slot row `k` on
+  equal receiver block_k's. The protocol routes data through channel `k` on
   both sides; mismatched values cause deadlock (receiver waits for more
   signals) or silent drop (receiver consumes too few).
 - Across blocks within the same call: `nbytes` may differ per block (uneven tile
@@ -347,7 +369,8 @@ primitives are used.
 channel         = group.group_id
 trap if group.total_groups > options.max_num_channels
 
-per_channel_slot = options.per_channel_slot            // fixed at host init
+per_channel_window = options.per_channel_buffer         // fixed at host init
+per_channel_slot = per_channel_window / pipeline_depth
 trap if per_channel_slot == 0
 chunk_size      = min(max_signal_bytes > 0 ? max_signal_bytes : per_channel_slot,
                       per_channel_slot)
@@ -362,8 +385,10 @@ remote_ch       = remote_channels_[channel]           // this rank writes here v
 ```text
 channel         = group.group_id
 trap if channel >= max_num_channels
+protocol_slot   = P::kProtoSlot
 
-per_block_slot  = perChannelSize & ~15ULL
+per_channel_window = perChannelSize
+per_block_slot  = per_channel_window / pipeline_depth
 trap if per_block_slot == 0
 chunk_size      = min(max_signal_bytes > 0 ? max_signal_bytes : per_block_slot,
                       per_block_slot)
@@ -371,7 +396,12 @@ chunks_per_slot = per_block_slot / chunk_size      // sub-slot signaling factor
 total_chunks    = ceil(nbytes / chunk_size)
 
 local_ch        = local_channels_[channel]
-remote_ch       = remote_channels_[channel]
+local_slot      = local_ch.protos[protocol_slot]
+remote_ch       = {local_slot.remoteDataReady,
+                   local_slot.remoteSlotFree,
+                   local_slot.remoteRecvStaging}
+send_staging    = local_slot.sendStaging
+recv_staging    = local_slot.recvStaging
 ```
 
 ### `send` (NVL)
@@ -384,14 +414,14 @@ vary between calls without losing monotonicity.
 if nbytes == 0: return
 
 base_byte    = local_ch.send_cursor
-staging_off  = channel * per_channel_slot
-pipeline_bytes = per_channel_slot * pipeline_depth
+channel_base = channel * per_channel_window
+pipeline_bytes = per_channel_window
 
 for data_off in [0, protocol_bytes):           // protocol_bytes = align16(nbytes)
     stream_start    = base_byte + data_off
     pipeline_off    = stream_start % pipeline_bytes
     slot            = pipeline_off / per_channel_slot
-    slot_off        = slot * data_buffer_size
+    slot_off        = channel_base + slot * per_channel_slot
     chunk_off       = pipeline_off - slot * per_channel_slot
     copy_bytes      = min(chunk_size, protocol_bytes - data_off,
                           per_channel_slot - chunk_off)
@@ -404,7 +434,7 @@ for data_off in [0, protocol_bytes):           // protocol_bytes = align16(nbyte
 
     // (2) Cooperative P2P memcpy: src chunk -> remote staging via NVLink.
     memcpy_vectorized(
-        remote_recv_staging + slot_off + staging_off + chunk_off,
+        remote_recv_staging + slot_off + chunk_off,
         src + data_off,
         valid_payload(copy_bytes, nbytes, data_off),
         group)
@@ -433,14 +463,14 @@ remain.
 if nbytes == 0: return
 
 base_byte    = local_ch.recv_cursor
-staging_off  = channel * per_channel_slot
-pipeline_bytes = per_channel_slot * pipeline_depth
+channel_base = channel * per_channel_window
+pipeline_bytes = per_channel_window
 
 for data_off in [0, protocol_bytes):
     stream_start    = base_byte + data_off
     pipeline_off    = stream_start % pipeline_bytes
     slot            = pipeline_off / per_channel_slot
-    slot_off        = slot * data_buffer_size
+    slot_off        = channel_base + slot * per_channel_slot
     chunk_off       = pipeline_off - slot * per_channel_slot
     copy_bytes      = min(chunk_size, protocol_bytes - data_off,
                           per_channel_slot - chunk_off)
@@ -452,7 +482,7 @@ for data_off in [0, protocol_bytes):
     // (2) Cooperative memcpy: local recv_staging -> dst.
     memcpy_vectorized(
         dst + data_off,
-        local_recv_staging + slot_off + staging_off + chunk_off,
+        local_recv_staging + slot_off + chunk_off,
         valid_payload(copy_bytes, nbytes, data_off),
         group)
 
@@ -478,15 +508,15 @@ group.sync()
 if nbytes == 0: return
 
 base_byte = local_ch.sendProgress.cursor
-pipeline_bytes = per_block_slot * pipeline_depth
+pipeline_bytes = per_channel_window
 
 for s in [0, total_chunks):
     slot_step     = s / chunks_per_slot
     sub_step      = s % chunks_per_slot
     slot          = slot_step % pipeline_depth
-    slot_off      = slot * data_buffer_size
+    slot_off      = slot * per_block_slot
     chunk_off     = sub_step * chunk_size
-    staging_off   = slot_off + channel * per_block_slot + chunk_off
+    staging_off   = slot_off + chunk_off
     data_off      = s * chunk_size
     bytes_this    = min(chunk_size, nbytes - data_off)
     stream_end    = base_byte + data_off + bytes_this
@@ -499,7 +529,7 @@ for s in [0, total_chunks):
                      timeout)
 
     // (2) Cooperative memcpy: src chunk -> local send_staging.
-    memcpy_vectorized(send_staging + staging_off,
+    memcpy_vectorized(local_ch.send_staging + staging_off,
                       src + data_off,
                       bytes_this, group)
     group.sync()
@@ -514,8 +544,8 @@ for s in [0, total_chunks):
     // (4) Fused RDMA put + remote DATA_READY signal + local NIC_DONE bump.
     if group.is_leader():
         put_signal_counter_remote(
-            local_src     = send_staging        + staging_off,
-            remote_dst    = recv_staging_remote + staging_off,
+            local_src     = local_ch.send_staging  + staging_off,
+            remote_dst    = remote_ch.recv_staging + staging_off,
             nbytes        = bytes_this,
             remote_signal = remote_ch.data_ready,
             signal_val    = stream_end,
@@ -541,9 +571,9 @@ for s in [0, total_chunks):
     slot_step     = s / chunks_per_slot
     sub_step      = s % chunks_per_slot
     slot          = slot_step % pipeline_depth
-    slot_off      = slot * data_buffer_size
+    slot_off      = slot * per_block_slot
     chunk_off     = sub_step * chunk_size
-    staging_off   = slot_off + channel * per_block_slot + chunk_off
+    staging_off   = slot_off + chunk_off
     data_off      = s * chunk_size
     bytes_this    = min(chunk_size, nbytes - data_off)
     stream_end    = base_byte + data_off + bytes_this
@@ -556,7 +586,7 @@ for s in [0, total_chunks):
 
     // (2) Cooperative memcpy: local recv_staging -> dst.
     memcpy_vectorized(dst + data_off,
-                      recv_staging + staging_off,
+                      local_ch.recv_staging + staging_off,
                       bytes_this, group)
     group.sync()
 

--- a/comms/prims/tests/IbgdaBufferTest.cc
+++ b/comms/prims/tests/IbgdaBufferTest.cc
@@ -155,4 +155,192 @@ TEST(IbgdaBufferTest, DefaultConstructorZeroInitsAllKeys) {
   }
 }
 
+TEST(IbgdaBufferTest, MakeChannelSlicesEveryProtocolResource) {
+  constexpr int kNumChannels = 3;
+  constexpr int kNumResourceSlots = kNumChannels * kNumProtoSlots;
+  constexpr int kNumLanes = 2;
+  constexpr int kChannel = 2;
+  constexpr int kProtoSlot = 1;
+  constexpr std::size_t kChannelBytes = 64;
+  constexpr int kPipelineDepth = 4;
+
+  char sendStaging[kNumResourceSlots * kChannelBytes]{};
+  char recvStaging[kNumResourceSlots * kChannelBytes]{};
+  char remoteRecvStaging[kNumResourceSlots * kChannelBytes]{};
+  char localSignals
+      [(kNumLanes * kNumResourceSlots + kNumResourceSlots) *
+       kSendRecvSignalSlotStride]{};
+  char remoteSignals[sizeof(localSignals)]{};
+  char localCounters[kNumResourceSlots * kSendRecvSignalSlotStride]{};
+  char localCompletions[kNumResourceSlots * kSendRecvSignalSlotStride]{};
+  IbSendCompletionSlot completionSlots[kPipelineDepth]{};
+
+  NetworkLKeys localKeys(2);
+  localKeys[0] = NetworkLKey(0x1111);
+  localKeys[1] = NetworkLKey(0x2222);
+  NetworkRKeys remoteKeys(2);
+  remoteKeys[0] = NetworkRKey(0x3333);
+  remoteKeys[1] = NetworkRKey(0x4444);
+
+  const IbChannelLayout layout{
+      .sendStagingBuf = IbgdaLocalBuffer(sendStaging, localKeys),
+      .recvStagingBuf = IbgdaRemoteBuffer(remoteRecvStaging, remoteKeys),
+      .recvStagingPtr = recvStaging,
+      .localSignalBuf = IbgdaLocalBuffer(localSignals, localKeys),
+      .remoteSignalBuf = IbgdaRemoteBuffer(remoteSignals, remoteKeys),
+      .localCounterBuf = IbgdaLocalBuffer(localCounters, localKeys),
+      .localCounterCompletionBuf =
+          IbgdaLocalBuffer(localCompletions, localKeys),
+      .maxChannels = kNumResourceSlots,
+      .numChannels = kNumChannels,
+      .numLanes = kNumLanes,
+      .pipelineDepth = kPipelineDepth,
+      .perChannelBufferSize = kChannelBytes,
+  };
+
+  const IbLocalChannel channel =
+      makeIbLocalChannel(layout, kChannel, completionSlots);
+  const IbLocalChannel previousChannel =
+      makeIbLocalChannel(layout, kChannel - 1);
+  const int resourceSlot = layout.protoChannelSlot(kChannel, kProtoSlot);
+  const int previousResourceSlot =
+      layout.protoChannelSlot(kChannel - 1, kProtoSlot);
+  const IbRemoteChannel remoteChannel =
+      makeIbRemoteChannel(layout, resourceSlot);
+  const IbRemoteChannel previousRemoteChannel =
+      makeIbRemoteChannel(layout, previousResourceSlot);
+  const auto& local = channel.protos[kProtoSlot];
+  const auto& previousLocal = previousChannel.protos[kProtoSlot];
+  const std::size_t stagingOffset =
+      static_cast<std::size_t>(resourceSlot) * kChannelBytes;
+  const int dataReadySlot = resourceSlot * kNumLanes;
+  const int slotFreeSlot = kNumLanes * kNumResourceSlots + resourceSlot;
+
+  EXPECT_EQ(
+      layout.sendStagingBuf.subBuffer(stagingOffset).ptr,
+      sendStaging + stagingOffset);
+  EXPECT_EQ(layout.recvStagingPtr + stagingOffset, recvStaging + stagingOffset);
+  EXPECT_EQ(
+      remoteChannel.recvStaging.subBuffer(stagingOffset).ptr,
+      remoteRecvStaging + stagingOffset);
+  EXPECT_EQ(local.sendStaging.ptr, sendStaging + stagingOffset);
+  EXPECT_EQ(local.recvStaging, recvStaging + stagingOffset);
+  EXPECT_EQ(local.remoteRecvStaging.ptr, remoteRecvStaging + stagingOffset);
+  EXPECT_EQ(
+      local.dataReady.ptr,
+      localSignals + sendRecvSignalSlotOffset(dataReadySlot));
+  EXPECT_EQ(
+      remoteChannel.dataReady.ptr,
+      remoteSignals + sendRecvSignalSlotOffset(dataReadySlot));
+  EXPECT_EQ(
+      local.remoteDataReady.ptr,
+      remoteSignals + sendRecvSignalSlotOffset(dataReadySlot));
+  EXPECT_EQ(
+      local.slotFree.ptr,
+      localSignals + sendRecvSignalSlotOffset(slotFreeSlot));
+  EXPECT_EQ(
+      remoteChannel.slotFree.ptr,
+      remoteSignals + sendRecvSignalSlotOffset(slotFreeSlot));
+  EXPECT_EQ(
+      local.remoteSlotFree.ptr,
+      remoteSignals + sendRecvSignalSlotOffset(slotFreeSlot));
+  EXPECT_EQ(
+      local.nicDoneWait.ptr,
+      localCounters + sendRecvSignalSlotOffset(resourceSlot));
+  EXPECT_EQ(
+      local.nicDoneCompletion.ptr,
+      localCompletions + sendRecvSignalSlotOffset(resourceSlot));
+  EXPECT_EQ(local.sendCompletionSlots, completionSlots);
+  EXPECT_EQ(
+      stagingOffset,
+      static_cast<std::size_t>(previousResourceSlot + 1) * kChannelBytes);
+  EXPECT_NE(local.dataReady.ptr, previousLocal.dataReady.ptr);
+  EXPECT_NE(local.slotFree.ptr, previousLocal.slotFree.ptr);
+  EXPECT_NE(local.nicDoneWait.ptr, previousLocal.nicDoneWait.ptr);
+  EXPECT_NE(remoteChannel.dataReady.ptr, previousRemoteChannel.dataReady.ptr);
+  EXPECT_NE(local.sendStaging.ptr, previousLocal.sendStaging.ptr);
+  EXPECT_NE(local.recvStaging, previousLocal.recvStaging);
+  EXPECT_NE(local.remoteRecvStaging.ptr, previousLocal.remoteRecvStaging.ptr);
+
+  EXPECT_EQ(layout.sendStagingBuf.lkey_per_device.size, 2);
+  EXPECT_EQ(layout.sendStagingBuf.lkey_per_device[0], localKeys[0]);
+  EXPECT_EQ(layout.sendStagingBuf.lkey_per_device[1], localKeys[1]);
+  EXPECT_EQ(remoteChannel.recvStaging.rkey_per_device.size, 2);
+  EXPECT_EQ(remoteChannel.recvStaging.rkey_per_device[0], remoteKeys[0]);
+  EXPECT_EQ(remoteChannel.recvStaging.rkey_per_device[1], remoteKeys[1]);
+  EXPECT_EQ(remoteChannel.dataReady.rkey_per_device[0], remoteKeys[0]);
+  EXPECT_EQ(remoteChannel.slotFree.rkey_per_device[1], remoteKeys[1]);
+  EXPECT_EQ(local.sendStaging.lkey_per_device[0], localKeys[0]);
+  EXPECT_EQ(local.remoteRecvStaging.rkey_per_device[1], remoteKeys[1]);
+}
+
+TEST(IbgdaBufferTest, QpSlotWithinNicUsesChannelDirectionLaneOrder) {
+  constexpr uint32_t kDirectionCount = 2;
+  constexpr uint32_t kQpsPerConnection = 2;
+
+  EXPECT_EQ(
+      ibQpSlotWithinNic(
+          0, IbDirection::Send, kDirectionCount, kQpsPerConnection, 0),
+      0);
+  EXPECT_EQ(
+      ibQpSlotWithinNic(
+          0, IbDirection::Send, kDirectionCount, kQpsPerConnection, 1),
+      1);
+  EXPECT_EQ(
+      ibQpSlotWithinNic(
+          0, IbDirection::Recv, kDirectionCount, kQpsPerConnection, 0),
+      2);
+  EXPECT_EQ(
+      ibQpSlotWithinNic(
+          1, IbDirection::Send, kDirectionCount, kQpsPerConnection, 0),
+      4);
+  EXPECT_EQ(
+      ibQpSlotWithinNic(
+          1, IbDirection::Recv, kDirectionCount, kQpsPerConnection, 1),
+      7);
+  EXPECT_EQ(
+      ibQpSlotWithinNic(
+          1,
+          IbDirection::Send,
+          /*directionCount=*/1,
+          kQpsPerConnection,
+          1),
+      3);
+
+  EXPECT_EQ(
+      ibCommandQueueSlot(
+          1,
+          IbDirection::Recv,
+          kDirectionCount,
+          kQpsPerConnection,
+          1,
+          /*numNics=*/3,
+          /*nicId=*/2),
+      23);
+}
+
+TEST(IbgdaBufferTest, MakeChannelAllowsDisabledSendRecvLayout) {
+  IbSendCompletionSlot completionSlots[2]{};
+
+  const IbLocalChannel channel =
+      makeIbLocalChannel(IbChannelLayout{}, 3, completionSlots);
+  const IbRemoteChannel remoteChannel =
+      makeIbRemoteChannel(IbChannelLayout{}, 3);
+  const auto& local = channel.protos[0];
+
+  EXPECT_EQ(local.dataReady.ptr, nullptr);
+  EXPECT_EQ(remoteChannel.dataReady.ptr, nullptr);
+  EXPECT_EQ(local.slotFree.ptr, nullptr);
+  EXPECT_EQ(remoteChannel.slotFree.ptr, nullptr);
+  EXPECT_EQ(local.nicDoneWait.ptr, nullptr);
+  EXPECT_EQ(local.nicDoneCompletion.ptr, nullptr);
+  EXPECT_EQ(local.sendStaging.ptr, nullptr);
+  EXPECT_EQ(local.recvStaging, nullptr);
+  EXPECT_EQ(local.remoteDataReady.ptr, nullptr);
+  EXPECT_EQ(local.remoteSlotFree.ptr, nullptr);
+  EXPECT_EQ(local.remoteRecvStaging.ptr, nullptr);
+  EXPECT_EQ(remoteChannel.recvStaging.ptr, nullptr);
+  EXPECT_EQ(local.sendCompletionSlots, completionSlots);
+}
+
 } // namespace comms::prims::tests

--- a/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
+++ b/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
@@ -1,5 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <array>
+#include <cerrno>
+
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -11,7 +14,12 @@
 #include <utility>
 #include <vector>
 
+#include "comms/common/bootstrap/tests/MockBootstrap.h"
 #include "comms/prims/transport/MultiPeerIbTransport.h"
+#include "comms/prims/transport/MultiPeerTransport.h"
+
+using ::testing::_;
+using ::testing::StrictMock;
 
 namespace comms::prims {
 namespace {
@@ -639,6 +647,124 @@ TEST(MultiPeerIbTransportConfigTest, QpOrderingWireDefaultMatchesIbta) {
   const PeerQpPayload payload;
   EXPECT_EQ(
       payload.qpOrderingSemantic, static_cast<int>(IbQpOrderingSemantic::Ibta));
+}
+
+TEST(MultiPeerIbTransportConfigTest, LazyChannelsDefaultOff) {
+  const MultipeerIbTransportConfig config;
+  EXPECT_FALSE(config.lazyChannels);
+}
+
+TEST(MultiPeerTransportInitTest, MatchingRecordsSucceed) {
+  const detail::ChannelProtocolRecord record{
+      .mode = detail::PrimsChannelMode::kLazyPrefix,
+      .channelCapacity = 64,
+  };
+  const std::array records{record, record};
+  EXPECT_NO_THROW(detail::validateChannelProtocolRecords(records));
+}
+
+TEST(MultiPeerTransportInitTest, MismatchedChannelModesFail) {
+  detail::ChannelProtocolRecord eager;
+  auto lazy = eager;
+  lazy.mode = detail::PrimsChannelMode::kLazyPrefix;
+  const std::array records{eager, lazy};
+  EXPECT_THROW(
+      detail::validateChannelProtocolRecords(records), std::runtime_error);
+}
+
+TEST(MultiPeerTransportInitTest, MismatchedChannelCapacitiesFail) {
+  detail::ChannelProtocolRecord smaller;
+  smaller.channelCapacity = 4;
+  auto larger = smaller;
+  larger.channelCapacity = 8;
+  const std::array records{smaller, larger};
+  EXPECT_THROW(
+      detail::validateChannelProtocolRecords(records), std::runtime_error);
+}
+
+TEST(MultiPeerTransportInitTest, SymmetricRoutesSucceed) {
+  using Route = detail::PrimsTransportRoute;
+  const std::array routes{
+      Route::kSelf,
+      Route::kIbgda,
+      Route::kIbgda,
+      Route::kSelf,
+  };
+  EXPECT_NO_THROW(detail::validatePrimsTransportRoutes(routes, 2));
+}
+
+TEST(MultiPeerTransportInitTest, AsymmetricRoutesFail) {
+  using Route = detail::PrimsTransportRoute;
+  const std::array routes{
+      Route::kSelf,
+      Route::kNvl,
+      Route::kIbgda,
+      Route::kSelf,
+  };
+  EXPECT_THROW(
+      detail::validatePrimsTransportRoutes(routes, 2), std::runtime_error);
+}
+
+TEST(MultiPeerTransportInitTest, AllGatherFailureFailsInitialization) {
+  StrictMock<meta::comms::testing::MockBootstrap> bootstrap;
+  EXPECT_CALL(
+      bootstrap,
+      allGather(
+          _, static_cast<int>(sizeof(detail::ChannelProtocolRecord)), 0, 2))
+      .WillOnce(
+          [](void*, int, int, int) { return folly::makeSemiFuture(EIO); });
+
+  EXPECT_THROW(
+      detail::exchangeAndValidateChannelProtocol(
+          bootstrap, 0, 2, detail::ChannelProtocolRecord{}),
+      std::runtime_error);
+}
+
+class TestLegacyIbTransport
+    : public MultiPeerIbTransport<TestLegacyIbTransport> {
+ public:
+  TestLegacyIbTransport()
+      : MultiPeerIbTransport<TestLegacyIbTransport>(
+            /*myRank=*/0,
+            /*nRanks=*/2,
+            std::make_shared<
+                ::testing::NiceMock<meta::comms::testing::MockBootstrap>>(),
+            makeConfig()) {}
+
+  int materializedPeer{-1};
+
+  bool legacyPeerMaterialized(int peerRank) const {
+    return peerMaterialized_[rankToPeerIndex(peerRank)];
+  }
+
+ private:
+  friend class MultiPeerIbTransport<TestLegacyIbTransport>;
+
+  void doMaterializePeer(int peerRank) {
+    materializedPeer = peerRank;
+    peerMaterialized_[rankToPeerIndex(peerRank)] = true;
+  }
+
+  void cleanupPeerOnFailure(int peerIndex) {
+    peerMaterialized_[peerIndex] = false;
+  }
+
+  static MultipeerIbTransportConfig makeConfig() {
+    MultipeerIbTransportConfig config;
+    config.gpuNicMap[0] = {"test_nic"};
+    config.maxGroups = 8;
+    return config;
+  }
+};
+
+TEST(MultiPeerIbTransportConfigTest, LegacyBackendHookMaterializesCapacity) {
+  TestLegacyIbTransport transport;
+
+  transport.materializePeer(/*peerRank=*/1);
+
+  EXPECT_EQ(1, transport.materializedPeer);
+  EXPECT_TRUE(transport.legacyPeerMaterialized(/*peerRank=*/1));
+  EXPECT_EQ(8, transport.materializedChannelCount(/*peerRank=*/1));
 }
 
 } // namespace

--- a/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
+++ b/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
@@ -243,6 +243,54 @@ TEST(MultiPeerIbTransportConfigTest, PeerMaterializationDefaultsOnDemand) {
   EXPECT_TRUE(config.ibLazyConnect);
 }
 
+TEST(MultiPeerIbTransportConfigTest, RawPutGeometryUsesLegacyFields) {
+  MultipeerIbTransportConfig config;
+  config.dataBufferSize = 4096;
+  config.maxGroups = 17;
+  config.qpsPerBlockPerNic = 3;
+  config.max_num_channels = 29;
+  config.qpsPerConnection = 5;
+
+  const auto normalized = config.normalizedChannelGeometry();
+  EXPECT_EQ(normalized.dataBufferSize, 4096);
+  EXPECT_EQ(normalized.maxGroups, 17);
+  EXPECT_EQ(normalized.max_num_channels, 17);
+  EXPECT_EQ(normalized.qpsPerBlockPerNic, 3);
+  EXPECT_EQ(normalized.qpsPerConnection, 3);
+}
+
+TEST(MultiPeerIbTransportConfigTest, FixedChannelGeometryUsesFixedFields) {
+  MultipeerIbTransportConfig config;
+  config.dataBufferSize = 4096;
+  config.maxGroups = 29;
+  config.qpsPerBlockPerNic = 5;
+  config.perChannelSize = 256;
+  config.max_num_channels = 17;
+  config.qpsPerConnection = 3;
+
+  const auto normalized = config.normalizedChannelGeometry();
+  EXPECT_EQ(normalized.dataBufferSize, 256 * 17 * kNumProtoSlots);
+  EXPECT_EQ(normalized.maxGroups, 17);
+  EXPECT_EQ(normalized.max_num_channels, 17);
+  EXPECT_EQ(normalized.qpsPerBlockPerNic, 3);
+  EXPECT_EQ(normalized.qpsPerConnection, 3);
+  EXPECT_EQ(normalized.totalChannelSlots(), 17 * kNumProtoSlots);
+}
+
+TEST(MultiPeerIbTransportConfigTest, RejectsInvalidFixedChannelGeometry) {
+  MultipeerIbTransportConfig config;
+  config.perChannelSize = 16;
+  config.max_num_channels = 0;
+  EXPECT_THROW(config.normalizedChannelGeometry(), std::invalid_argument);
+
+  config.max_num_channels = 1;
+  config.perChannelSize = 8;
+  EXPECT_THROW(config.normalizedChannelGeometry(), std::invalid_argument);
+
+  config.perChannelSize = 24;
+  EXPECT_THROW(config.normalizedChannelGeometry(), std::invalid_argument);
+}
+
 // connectPeers() walks each rank's pending peers in peerMaterializationKey
 // order and materializes them one at a time against a peer that must be doing
 // the same. The checks below cover the two properties that buys: the schedule

--- a/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
+++ b/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
@@ -1,18 +1,20 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <algorithm>
 #include <array>
 #include <cerrno>
-
-#include <gtest/gtest.h>
-
-#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
+#include <memory>
 #include <random>
 #include <set>
 #include <stdexcept>
 #include <utility>
 #include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 #include "comms/common/bootstrap/tests/MockBootstrap.h"
 #include "comms/prims/transport/MultiPeerIbTransport.h"
@@ -654,6 +656,11 @@ TEST(MultiPeerIbTransportConfigTest, LazyChannelsDefaultOff) {
   EXPECT_FALSE(config.lazyChannels);
 }
 
+TEST(MultiPeerIbTransportConfigTest, LegacyBootstrapPhaseValuesRemainStable) {
+  EXPECT_EQ(0, kIbPeerQpExchangeTag);
+  EXPECT_EQ(1, kIbPeerBufferExchangeTag);
+}
+
 TEST(MultiPeerTransportInitTest, MatchingRecordsSucceed) {
   const detail::ChannelProtocolRecord record{
       .mode = detail::PrimsChannelMode::kLazyPrefix,
@@ -732,6 +739,8 @@ class TestLegacyIbTransport
             makeConfig()) {}
 
   int materializedPeer{-1};
+  int cleanedPeerIndex{-1};
+  bool failMaterialization{false};
 
   bool legacyPeerMaterialized(int peerRank) const {
     return peerMaterialized_[rankToPeerIndex(peerRank)];
@@ -743,10 +752,14 @@ class TestLegacyIbTransport
   void doMaterializePeer(int peerRank) {
     materializedPeer = peerRank;
     peerMaterialized_[rankToPeerIndex(peerRank)] = true;
+    if (failMaterialization) {
+      throw std::runtime_error("injected legacy materialization failure");
+    }
   }
 
   void cleanupPeerOnFailure(int peerIndex) {
     peerMaterialized_[peerIndex] = false;
+    cleanedPeerIndex = peerIndex;
   }
 
   static MultipeerIbTransportConfig makeConfig() {
@@ -765,6 +778,272 @@ TEST(MultiPeerIbTransportConfigTest, LegacyBackendHookMaterializesCapacity) {
   EXPECT_EQ(1, transport.materializedPeer);
   EXPECT_TRUE(transport.legacyPeerMaterialized(/*peerRank=*/1));
   EXPECT_EQ(8, transport.materializedChannelCount(/*peerRank=*/1));
+}
+
+TEST(MultiPeerIbTransportConfigTest, LegacyBackendFailureRunsCleanupHook) {
+  TestLegacyIbTransport transport;
+  transport.failMaterialization = true;
+
+  EXPECT_THROW(transport.materializePeer(/*peerRank=*/1), std::runtime_error);
+
+  EXPECT_EQ(1, transport.materializedPeer);
+  EXPECT_EQ(0, transport.cleanedPeerIndex);
+}
+
+class TestLazyChannelTransport
+    : public MultiPeerIbTransport<TestLazyChannelTransport> {
+ public:
+  struct MaterializedRange {
+    int peerRank;
+    uint32_t beginChannel;
+    uint32_t endChannel;
+
+    bool operator==(const MaterializedRange&) const = default;
+  };
+
+  static constexpr bool supportsLazyChannelPrefixGrowth() {
+    return true;
+  }
+
+  static constexpr PeerChannelBackend kPeerChannelBackend =
+      PeerChannelBackend::kIbgda;
+
+  explicit TestLazyChannelTransport(bool lazyChannels)
+      : MultiPeerIbTransport<TestLazyChannelTransport>(
+            /*myRank=*/0,
+            /*nRanks=*/2,
+            std::make_shared<
+                ::testing::NiceMock<meta::comms::testing::MockBootstrap>>(),
+            makeConfig(lazyChannels)) {
+    // This fake isolates local target and watermark behavior.
+    channelRangeProtocolEnabled_ = false;
+  }
+
+  explicit TestLazyChannelTransport(
+      int myRank,
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+      int maxGroups = 8)
+      : MultiPeerIbTransport<TestLazyChannelTransport>(
+            myRank,
+            /*nRanks=*/2,
+            std::move(bootstrap),
+            makeConfig(/*lazyChannels=*/true, maxGroups)) {}
+
+  void materializePeerChannelRange(
+      int peerRank,
+      uint32_t beginChannel,
+      uint32_t endChannel) {
+    observedWatermarks.push_back(
+        materializedChannels_[rankToPeerIndex(peerRank)]);
+    materializedRanges.push_back({peerRank, beginChannel, endChannel});
+    if (failNextMaterialization) {
+      throw std::runtime_error("injected materialization failure");
+    }
+  }
+
+  uint32_t rawMaterializedChannelCount(int peerRank) const {
+    return materializedChannels_[rankToPeerIndex(peerRank)];
+  }
+
+  int configuredQpsPerConnection() const {
+    return config_.qpsPerConnection;
+  }
+
+  std::vector<MaterializedRange> materializedRanges;
+  std::vector<uint32_t> observedWatermarks;
+  bool failNextMaterialization{false};
+  int terminalFailureCount{0};
+
+ private:
+  friend class MultiPeerIbTransport<TestLazyChannelTransport>;
+
+  void onTerminalMaterializationFailure() noexcept {
+    ++terminalFailureCount;
+  }
+
+  static MultipeerIbTransportConfig makeConfig(
+      bool lazyChannels,
+      int maxGroups = 8) {
+    MultipeerIbTransportConfig config;
+    config.gpuNicMap[0] = {"test_nic"};
+    config.maxGroups = maxGroups;
+    config.qpsPerBlockPerNic = 2;
+    config.lazyChannels = lazyChannels;
+    return config;
+  }
+};
+
+TEST(MultiPeerIbTransportConfigTest, LegacyQpGeometryIsNormalized) {
+  const TestLazyChannelTransport transport(/*lazyChannels=*/false);
+  EXPECT_EQ(8, transport.channelCapacity());
+  EXPECT_EQ(2, transport.configuredQpsPerConnection());
+}
+
+TEST(
+    MultiPeerIbTransportConfigTest,
+    LazyChannelsMaterializeExactMissingPrefix) {
+  TestLazyChannelTransport transport(/*lazyChannels=*/true);
+
+  transport.queuePeerForMaterialization(/*peerRank=*/1, /*targetChannels=*/1);
+  transport.connectPeers();
+  transport.queuePeerForMaterialization(/*peerRank=*/1, /*targetChannels=*/3);
+  transport.connectPeers();
+  transport.queuePeerForMaterialization(/*peerRank=*/1, /*targetChannels=*/2);
+  transport.connectPeers();
+
+  const std::vector<TestLazyChannelTransport::MaterializedRange> expected{
+      {1, 0, 1},
+      {1, 1, 3},
+  };
+  EXPECT_EQ(expected, transport.materializedRanges);
+  EXPECT_EQ((std::vector<uint32_t>{0, 1}), transport.observedWatermarks);
+  EXPECT_EQ(3, transport.materializedChannelCount(/*peerRank=*/1));
+}
+
+TEST(MultiPeerIbTransportConfigTest, LazyGrowthUsesUniqueBootstrapTags) {
+  auto bootstrap = std::make_shared<
+      ::testing::NiceMock<meta::comms::testing::MockBootstrap>>();
+  std::vector<std::byte> payload;
+  std::vector<int> sendTags;
+  std::vector<int> recvTags;
+  ON_CALL(*bootstrap, send(_, _, /*peer=*/0, _))
+      .WillByDefault([&](void* buf, int len, int, int tag) {
+        const auto* const begin = static_cast<const std::byte*>(buf);
+        payload.assign(begin, begin + len);
+        sendTags.push_back(tag);
+        return folly::makeSemiFuture(0);
+      });
+  ON_CALL(*bootstrap, recv(_, _, /*peer=*/0, _))
+      .WillByDefault([&](void* buf, int len, int, int tag) {
+        EXPECT_EQ(static_cast<std::size_t>(len), payload.size());
+        std::copy(payload.begin(), payload.end(), static_cast<std::byte*>(buf));
+        recvTags.push_back(tag);
+        return folly::makeSemiFuture(0);
+      });
+
+  TestLazyChannelTransport transport(/*myRank=*/1, std::move(bootstrap));
+  transport.queuePeerForMaterialization(/*peerRank=*/0, /*targetChannels=*/1);
+  transport.connectPeers();
+  transport.queuePeerForMaterialization(/*peerRank=*/0, /*targetChannels=*/4);
+  transport.connectPeers();
+
+  EXPECT_EQ(sendTags, recvTags);
+  EXPECT_EQ(4, sendTags.size());
+  EXPECT_EQ(sendTags.size(), std::set(sendTags.begin(), sendTags.end()).size());
+}
+
+TEST(MultiPeerIbTransportConfigTest, LazyBootstrapTagsIgnoreLocalCapacity) {
+  const auto firstGrowthTags = [](int maxGroups) {
+    auto bootstrap = std::make_shared<
+        ::testing::NiceMock<meta::comms::testing::MockBootstrap>>();
+    std::vector<std::byte> payload;
+    std::vector<int> sendTags;
+    ON_CALL(*bootstrap, send(_, _, /*peer=*/0, _))
+        .WillByDefault([&](void* buf, int len, int, int tag) {
+          const auto* const begin = static_cast<const std::byte*>(buf);
+          payload.assign(begin, begin + len);
+          sendTags.push_back(tag);
+          return folly::makeSemiFuture(0);
+        });
+    ON_CALL(*bootstrap, recv(_, _, /*peer=*/0, _))
+        .WillByDefault([&](void* buf, int len, int, int) {
+          std::copy(
+              payload.begin(), payload.end(), static_cast<std::byte*>(buf));
+          return folly::makeSemiFuture(0);
+        });
+
+    TestLazyChannelTransport transport(
+        /*myRank=*/1, std::move(bootstrap), maxGroups);
+    transport.queuePeerForMaterialization(/*peerRank=*/0, /*targetChannels=*/1);
+    transport.connectPeers();
+    return sendTags;
+  };
+
+  EXPECT_EQ(firstGrowthTags(4), firstGrowthTags(8));
+}
+
+TEST(MultiPeerIbTransportConfigTest, EagerChannelsMaterializeCapacity) {
+  TestLazyChannelTransport transport(/*lazyChannels=*/false);
+
+  transport.queuePeerForMaterialization(/*peerRank=*/1, /*targetChannels=*/1);
+  transport.connectPeers();
+
+  const std::vector<TestLazyChannelTransport::MaterializedRange> expected{
+      {1, 0, 8},
+  };
+  EXPECT_EQ(expected, transport.materializedRanges);
+  EXPECT_EQ(8, transport.materializedChannelCount(/*peerRank=*/1));
+}
+
+TEST(
+    MultiPeerIbTransportConfigTest,
+    FailedGrowthDoesNotPublishAndPoisonsTransport) {
+  TestLazyChannelTransport transport(/*lazyChannels=*/true);
+  transport.queuePeerForMaterialization(/*peerRank=*/1, /*targetChannels=*/1);
+  transport.connectPeers();
+  transport.failNextMaterialization = true;
+
+  transport.queuePeerForMaterialization(/*peerRank=*/1, /*targetChannels=*/4);
+  EXPECT_THROW(transport.connectPeers(), std::runtime_error);
+
+  EXPECT_EQ(1, transport.rawMaterializedChannelCount(/*peerRank=*/1));
+  EXPECT_EQ(1, transport.terminalFailureCount);
+  EXPECT_THROW(
+      transport.materializedChannelCount(/*peerRank=*/1), std::runtime_error);
+  EXPECT_THROW(
+      transport.queuePeerForMaterialization(
+          /*peerRank=*/1, /*targetChannels=*/2),
+      std::runtime_error);
+}
+
+class TestRangeAllocationTransport
+    : public MultiPeerIbTransport<TestRangeAllocationTransport> {
+ public:
+  static constexpr bool supportsLazyChannelPrefixGrowth() {
+    return true;
+  }
+
+  static constexpr PeerChannelBackend kPeerChannelBackend =
+      PeerChannelBackend::kIbgda;
+
+  TestRangeAllocationTransport()
+      : MultiPeerIbTransport<TestRangeAllocationTransport>(
+            /*myRank=*/0,
+            /*nRanks=*/2,
+            std::make_shared<
+                ::testing::NiceMock<meta::comms::testing::MockBootstrap>>(),
+            makeConfig()) {}
+
+  void allocateOneChannelRange() {
+    PeerBufferPayload payload{};
+    (void)allocateSendRecvChannelRange(
+        /*peerIndex=*/0,
+        /*beginChannel=*/0,
+        /*endChannel=*/1,
+        payload);
+  }
+
+ private:
+  static MultipeerIbTransportConfig makeConfig() {
+    constexpr std::size_t kAlignment = 16;
+    const std::size_t perChannelSize =
+        (std::numeric_limits<std::size_t>::max() / 4 / kAlignment + 1) *
+        kAlignment;
+    MultipeerIbTransportConfig config;
+    config.gpuNicMap[0] = {"test_nic"};
+    config.max_num_channels = 1;
+    config.qpsPerConnection = 1;
+    config.pipelineDepth = 1;
+    config.perChannelSize = perChannelSize;
+    config.lazyChannels = true;
+    return config;
+  }
+};
+
+TEST(MultiPeerIbTransportConfigTest, LazyRangeAllocationRejectsSizeOverflow) {
+  TestRangeAllocationTransport transport;
+
+  EXPECT_THROW(transport.allocateOneChannelRange(), std::overflow_error);
 }
 
 } // namespace

--- a/comms/prims/tests/MultiPeerTransportIntegrationTest.cc
+++ b/comms/prims/tests/MultiPeerTransportIntegrationTest.cc
@@ -70,7 +70,8 @@ TEST_F(MultiPeerIntegrationTestFixture, DeviceHandleTypeMap) {
   }
 
   auto states = create_and_exchange();
-  auto handle = states->get_device_handle(states->ib_peer_ranks());
+  const std::vector<PeerChannelDemand> demands;
+  auto handle = states->get_device_handle(demands);
 
   // Allocate output array on GPU
   int* output_d = nullptr;
@@ -142,7 +143,8 @@ TEST_F(MultiPeerIntegrationTestFixture, SelfTransportPut) {
 
   ASSERT_EQ(states->get_transport_type(globalRank), TransportType::SELF);
 
-  auto handle = states->get_device_handle(states->ib_peer_ranks());
+  const std::vector<PeerChannelDemand> demands;
+  auto handle = states->get_device_handle(demands);
 
   const size_t nbytes = 4096;
   void* src_d = nullptr;

--- a/comms/prims/tests/MultiPeerTransportMultiNodeTest.cc
+++ b/comms/prims/tests/MultiPeerTransportMultiNodeTest.cc
@@ -201,7 +201,14 @@ TEST_F(MultiPeerTransportMultiNodeFixture, DeviceHandleMultiNode) {
   auto states = create_transport_states();
   states->exchange();
 
-  auto handle = states->get_device_handle(states->ib_peer_ranks());
+  std::vector<PeerChannelDemand> demands;
+  for (const int peer : states->ib_peer_ranks()) {
+    demands.push_back({
+        .peerRank = peer,
+        .ibChannels = states->ib_channel_capacity(),
+    });
+  }
+  auto handle = states->get_device_handle(demands);
   EXPECT_EQ(handle.myRank, globalRank);
   EXPECT_EQ(handle.nRanks, numRanks);
   EXPECT_EQ(handle.transports.size(), static_cast<uint32_t>(numRanks));
@@ -243,7 +250,15 @@ TEST_F(MultiPeerTransportMultiNodeFixture, DeviceHandleAcrossPeerRounds) {
   std::vector<int> ringPeers;
   addIbPeer(ringPeers, (globalRank + numRanks - 1) % numRanks);
   addIbPeer(ringPeers, (globalRank + 1) % numRanks);
-  auto ringHandle = states->get_device_handle(ringPeers);
+  std::vector<PeerChannelDemand> ringDemands;
+  ringDemands.reserve(ringPeers.size());
+  for (const int peer : ringPeers) {
+    ringDemands.push_back({
+        .peerRank = peer,
+        .ibChannels = states->ib_channel_capacity(),
+    });
+  }
+  auto ringHandle = states->get_device_handle(ringDemands);
 
   std::vector<int> treePeers;
   if (globalRank > 0) {
@@ -252,7 +267,15 @@ TEST_F(MultiPeerTransportMultiNodeFixture, DeviceHandleAcrossPeerRounds) {
   addIbPeer(treePeers, globalRank * 2 + 1);
   addIbPeer(treePeers, globalRank * 2 + 2);
   std::reverse(treePeers.begin(), treePeers.end());
-  auto handle = states->get_device_handle(treePeers);
+  std::vector<PeerChannelDemand> treeDemands;
+  treeDemands.reserve(treePeers.size());
+  for (const int peer : treePeers) {
+    treeDemands.push_back({
+        .peerRank = peer,
+        .ibChannels = states->ib_channel_capacity(),
+    });
+  }
+  auto handle = states->get_device_handle(treeDemands);
 
   EXPECT_EQ(ringHandle.transports.data(), handle.transports.data());
   EXPECT_EQ(handle.myRank, globalRank);
@@ -271,6 +294,7 @@ TEST_F(MultiPeerTransportMultiNodeFixture, HostAccessorsMultiNode) {
   }
 
   auto states = create_transport_states();
+  EXPECT_EQ(states->ib_channel_capacity(), kIbgdaMaxGroups);
   states->exchange();
 
   // NVL peer accessor — always has at least same-node peers.
@@ -288,30 +312,34 @@ TEST_F(MultiPeerTransportMultiNodeFixture, HostAccessorsMultiNode) {
   if (!states->has_ibgda(probePeer)) {
     GTEST_SKIP() << "Communicator has no underlying IBGDA transport";
   }
-  EXPECT_EQ(states->ibgda_max_groups(), kIbgdaMaxGroups);
 
   // Once constructed, the underlying IBGDA transport can serve every
   // non-self peer, including NVL-preferred peers.
-  std::vector<int> fallbackPeers;
-  fallbackPeers.reserve(numRanks - 1);
+  std::vector<PeerChannelDemand> demands;
+  demands.reserve(numRanks - 1);
   for (int peer = 0; peer < numRanks; ++peer) {
     if (peer == globalRank) {
       continue;
     }
-    fallbackPeers.push_back(peer);
+    demands.push_back({
+        .peerRank = peer,
+        .ibChannels = states->ib_channel_capacity(),
+    });
   }
-  (void)states->get_device_handle(fallbackPeers);
-  for (int peer : fallbackPeers) {
-    auto* p2p = states->get_p2p_ibgda_transport_device(peer);
-    EXPECT_NE(p2p, nullptr) << "IBGDA transport device null for peer " << peer;
+  (void)states->get_device_handle(demands);
+  for (const auto& demand : demands) {
+    auto* p2p = states->get_p2p_ibgda_transport_device(demand.peerRank);
+    EXPECT_NE(p2p, nullptr)
+        << "IBGDA transport device null for peer " << demand.peerRank;
   }
 
   COMMS_LOG(
       INFO,
-      "Rank {}: isMnnvl={}, validated {} NVL peers and IBGDA fallback",
+      "Rank {}: isMnnvl={}, validated {} NVL peers, {} underlying IBGDA peers",
       globalRank,
       isMnnvl_,
-      states->nvl_peer_ranks().size());
+      states->nvl_peer_ranks().size(),
+      demands.size());
 
   MPI_Barrier(MPI_COMM_WORLD);
 }

--- a/comms/prims/tests/MultiPeerTransportMultiNodeTest.cc
+++ b/comms/prims/tests/MultiPeerTransportMultiNodeTest.cc
@@ -120,7 +120,7 @@ class MultiPeerTransportMultiNodeFixture : public MpiBaseTestFixture {
         .ibConfig =
             {
                 .cudaDevice = localRank,
-                .max_num_channels = kIbgdaMaxGroups,
+                .maxGroups = kIbgdaMaxGroups,
             },
         .topoConfig =
             {
@@ -136,10 +136,9 @@ class MultiPeerTransportMultiNodeFixture : public MpiBaseTestFixture {
   int localSize_{0};
 };
 
-// MNNVL (GB200 NVL72):  all peers in the same fabric → NVL preferred, IBGDA
-// universal. Non-MNNVL (H100 / standalone GB200): same-node → NVL preferred,
-// cross-node → IBGDA preferred. On both platforms, IBGDA covers ALL non-self
-// peers.
+// MNNVL (GB200 NVL72): all peers in the same fabric, so NVL is preferred.
+// Non-MNNVL (H100 / standalone GB200): same-node peers prefer NVL and
+// cross-node peers prefer IBGDA.
 TEST_F(MultiPeerTransportMultiNodeFixture, TopologyDiscoveryMultiNode) {
   if (numRanks < 4) {
     GTEST_SKIP() << "Requires >= 4 ranks (nnodes=2, ppn=2)";
@@ -150,24 +149,21 @@ TEST_F(MultiPeerTransportMultiNodeFixture, TopologyDiscoveryMultiNode) {
   int nvlCount = states->nvl_peer_ranks().size();
   int ibgdaCount = states->ib_peer_ranks().size();
 
-  // IBGDA is universal — always covers all non-self peers.
-  EXPECT_EQ(ibgdaCount, numRanks - 1)
-      << "IBGDA should cover all non-self peers regardless of platform";
-
   if (isMnnvl_) {
-    // All ranks share the same NVLink fabric → every peer also has NVL.
+    // All ranks share the same NVLink fabric, so no preferred-IB peers exist.
     EXPECT_EQ(nvlCount, numRanks - 1) << "MNNVL: all peers should be NVL";
+    EXPECT_EQ(ibgdaCount, 0) << "MNNVL: no peers should prefer IBGDA";
   } else {
-    // Same-node peers use NVL, cross-node peers use IBGDA as preferred.
     EXPECT_EQ(nvlCount, localSize_ - 1)
         << "Non-MNNVL: NVL peers should be same-node only";
+    EXPECT_EQ(ibgdaCount, numRanks - localSize_)
+        << "Non-MNNVL: IBGDA peers should be cross-node only";
   }
 
   // Self should always be SELF.
   EXPECT_EQ(states->get_transport_type(globalRank), TransportType::SELF);
 
-  // Invariant: NVL peers are a subset of IBGDA peers.
-  EXPECT_LE(nvlCount, ibgdaCount);
+  EXPECT_EQ(nvlCount + ibgdaCount, numRanks - 1);
 
   COMMS_LOG(
       INFO,
@@ -195,9 +191,8 @@ TEST_F(MultiPeerTransportMultiNodeFixture, ExchangeMultiNode) {
 
 // Verify the device handle reflects the platform-specific topology.
 //
-// IBGDA transports are always populated for all peers.
-// NVL transports are populated based on platform:
-//   MNNVL: all peers,  Non-MNNVL: same-node peers only.
+// Preferred transport counts vary by platform:
+//   MNNVL: all NVL, Non-MNNVL: same-node NVL and cross-node IBGDA.
 TEST_F(MultiPeerTransportMultiNodeFixture, DeviceHandleMultiNode) {
   if (numRanks < 4) {
     GTEST_SKIP() << "Requires >= 4 ranks (nnodes=2, ppn=2)";
@@ -222,9 +217,8 @@ TEST_F(MultiPeerTransportMultiNodeFixture, DeviceHandleMultiNode) {
         << "Non-MNNVL: NVL peers should be same-node only";
   }
 
-  // IBGDA is universal — all non-self peers.
-  EXPECT_EQ(handle.numIbPeers, numRanks - 1)
-      << "IBGDA transports should cover all peers";
+  const int expectedIbPeers = isMnnvl_ ? 0 : numRanks - localSize_;
+  EXPECT_EQ(handle.numIbPeers, expectedIbPeers);
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -277,7 +271,6 @@ TEST_F(MultiPeerTransportMultiNodeFixture, HostAccessorsMultiNode) {
   }
 
   auto states = create_transport_states();
-  EXPECT_EQ(states->ibgda_max_groups(), kIbgdaMaxGroups);
   states->exchange();
 
   // NVL peer accessor — always has at least same-node peers.
@@ -291,20 +284,34 @@ TEST_F(MultiPeerTransportMultiNodeFixture, HostAccessorsMultiNode) {
     (void)p2p;
   }
 
-  // IBGDA is universal — accessor works for ALL non-self peers.
-  ASSERT_EQ(static_cast<int>(states->ib_peer_ranks().size()), numRanks - 1);
-  for (int r : states->ib_peer_ranks()) {
-    auto* p2p = states->get_p2p_ibgda_transport_device(r);
-    EXPECT_NE(p2p, nullptr) << "IBGDA transport device null for peer " << r;
+  const int probePeer = (globalRank + 1) % numRanks;
+  if (!states->has_ibgda(probePeer)) {
+    GTEST_SKIP() << "Communicator has no underlying IBGDA transport";
+  }
+  EXPECT_EQ(states->ibgda_max_groups(), kIbgdaMaxGroups);
+
+  // Once constructed, the underlying IBGDA transport can serve every
+  // non-self peer, including NVL-preferred peers.
+  std::vector<int> fallbackPeers;
+  fallbackPeers.reserve(numRanks - 1);
+  for (int peer = 0; peer < numRanks; ++peer) {
+    if (peer == globalRank) {
+      continue;
+    }
+    fallbackPeers.push_back(peer);
+  }
+  (void)states->get_device_handle(fallbackPeers);
+  for (int peer : fallbackPeers) {
+    auto* p2p = states->get_p2p_ibgda_transport_device(peer);
+    EXPECT_NE(p2p, nullptr) << "IBGDA transport device null for peer " << peer;
   }
 
   COMMS_LOG(
       INFO,
-      "Rank {}: isMnnvl={}, validated {} NVL peers, {} IBGDA peers",
+      "Rank {}: isMnnvl={}, validated {} NVL peers and IBGDA fallback",
       globalRank,
       isMnnvl_,
-      states->nvl_peer_ranks().size(),
-      states->ib_peer_ranks().size());
+      states->nvl_peer_ranks().size());
 
   MPI_Barrier(MPI_COMM_WORLD);
 }

--- a/comms/prims/tests/MultiPeerTransportTest.cc
+++ b/comms/prims/tests/MultiPeerTransportTest.cc
@@ -223,11 +223,29 @@ TEST_F(MultiPeerTransportTestFixture, DeviceHandleMetadata) {
   auto transport = createTransport();
   transport->exchange();
 
-  auto handle = transport->get_device_handle(transport->ib_peer_ranks());
+  std::vector<PeerChannelDemand> demands;
+  for (const int peer : transport->ib_peer_ranks()) {
+    demands.push_back(
+        PeerChannelDemand{
+            .peerRank = peer,
+            .ibChannels = transport->ib_channel_capacity(),
+        });
+    demands.push_back(
+        PeerChannelDemand{
+            .peerRank = peer,
+            .ibChannels = 1,
+        });
+  }
+  auto handle = transport->get_device_handle(demands);
+  for (auto& demand : demands) {
+    demand.ibChannels = 1;
+  }
+  auto repeatedHandle = transport->get_device_handle(demands);
   EXPECT_EQ(handle.myRank, globalRank);
   EXPECT_EQ(handle.nRanks, numRanks);
   EXPECT_EQ(handle.transports.size(), static_cast<uint32_t>(numRanks));
   EXPECT_FALSE(handle.abort.isEnabled());
+  EXPECT_EQ(handle.transports.data(), repeatedHandle.transports.data());
   EXPECT_GT(handle.numNvlPeers, 0);
   // Every remote rank is classified either as NVL or IB (see
   // TopologyDiscovery). Old assertion `numIbPeers == numRanks-1` held only on
@@ -248,6 +266,55 @@ TEST_F(MultiPeerTransportTestFixture, DeviceHandleCarriesEnabledAbort) {
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
+TEST_F(MultiPeerTransportTestFixture, DeviceHandleDemandValidation) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
+  }
+
+  auto transport = createTransport();
+  transport->exchange();
+  if (numRanks % 2 != 0) {
+    GTEST_SKIP() << "Requires an even rank count for symmetric peer pairs";
+  }
+  const int peer = globalRank ^ 1;
+
+  EXPECT_THROW(
+      transport->get_device_handle(
+          std::vector<PeerChannelDemand>{{.peerRank = -1, .ibChannels = 0}}),
+      std::invalid_argument);
+  EXPECT_THROW(
+      transport->get_device_handle(
+          std::vector<PeerChannelDemand>{
+              {.peerRank = globalRank, .ibChannels = 0}}),
+      std::invalid_argument);
+  EXPECT_THROW(
+      transport->get_device_handle(
+          std::vector<PeerChannelDemand>{{
+              .peerRank = peer,
+              .ibChannels = transport->ib_channel_capacity() + 1,
+          }}),
+      std::invalid_argument);
+
+  const auto handle = transport->get_device_handle(
+      std::vector<PeerChannelDemand>{{.peerRank = peer, .ibChannels = 0}});
+  EXPECT_EQ(handle.transports.size(), static_cast<uint32_t>(numRanks));
+
+  if (transport->is_nvl_peer(peer)) {
+    if (transport->has_ibgda(peer)) {
+      EXPECT_NO_THROW(transport->get_device_handle(
+          std::vector<PeerChannelDemand>{{.peerRank = peer, .ibChannels = 1}}));
+    } else {
+      EXPECT_THROW(
+          transport->get_device_handle(
+              std::vector<PeerChannelDemand>{
+                  {.peerRank = peer, .ibChannels = 1}}),
+          std::invalid_argument);
+    }
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
 TEST_F(MultiPeerTransportTestFixture, DeviceHandleBeforeExchange) {
   auto transport = createTransport();
   EXPECT_THROW(transport->get_device_handle({}), std::runtime_error);
@@ -255,34 +322,24 @@ TEST_F(MultiPeerTransportTestFixture, DeviceHandleBeforeExchange) {
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-TEST_F(MultiPeerTransportTestFixture, HostIbgdaAccessorForNvlPeer) {
-  if (numRanks < 2) {
-    GTEST_SKIP() << "Requires >= 2 ranks, got " << numRanks;
+TEST_F(MultiPeerTransportTestFixture, HostIbgdaAccessorSupportsColdFallback) {
+  if (numRanks < 2 || numRanks % 2 != 0) {
+    GTEST_SKIP() << "Requires an even rank count >= 2, got " << numRanks;
   }
 
   auto transport = createTransport();
   transport->exchange();
 
-  int peer = (globalRank == 0) ? 1 : 0;
+  const int peer = globalRank ^ 1;
   ASSERT_TRUE(transport->is_nvl_peer(peer));
-  // `has_ibgda(peer)` is a comm-level predicate -- it returns true iff the
-  // MultiPeerTransport built an IBGDA sub-transport at all, which happens
-  // iff at least one peer is IB-classified (see
-  // MultiPeerTransport.cc:172-188). Per-peer classification is strictly
-  // NVL-xor-IB (MultiPeerTransport.cc:111-119), so there is no per-peer
-  // IBGDA fallback provisioned for NVL-classified peers. This test still
-  // asserts the historic dual-path property that on a comm that DOES have
-  // IBGDA, the accessor returns a device even for NVL peers -- something
-  // the underlying MultipeerIbgdaTransport supports for backward
-  // compatibility. On MNNVL every peer is NVL-classified so no IBGDA
-  // sub-transport is built and has_ibgda is false for all peers; skip
-  // cleanly rather than assert has_ibgda == true.
   if (!transport->has_ibgda(peer)) {
     GTEST_SKIP()
         << "comm has no IBGDA sub-transport (all peers NVL-classified); "
            "dual-path accessor assertion not applicable";
   }
-  EXPECT_NE(transport->get_p2p_ibgda_transport_device(peer), nullptr);
+  auto* device = transport->get_p2p_ibgda_transport_device(peer);
+  EXPECT_NE(device, nullptr);
+  EXPECT_EQ(device, transport->get_p2p_ibgda_transport_device(peer));
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -831,6 +888,24 @@ TEST(MultiPeerTransportDisableIbTest, SucceedsWhenAllPeersNvl) {
   } catch (const std::exception&) {
     // NVL transport creation failed (expected without GPU).
   }
+}
+
+TEST(MultiPeerTransportDisableIbTest, IgnoresUnusedIbConfiguration) {
+  constexpr int kMyRank = 0;
+  constexpr int kNRanks = 1;
+  auto topo = makeTopology(kMyRank, {});
+  MultiPeerTransportConfig config{
+      .ibConfig = {.max_num_channels = -1},
+      .disableIb = true,
+  };
+
+  EXPECT_NO_THROW(MultiPeerTransport(
+      kMyRank,
+      kNRanks,
+      /*deviceId=*/0,
+      std::make_shared<MockBootstrap>(),
+      config,
+      std::move(topo)));
 }
 
 // NCCL_P2P_DISABLE + disableIb: P2P disabled removes NVL peers from topology,

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -138,10 +138,7 @@ class TestIbTransport {
     if (ibgda_) {
       return P2pIbTransportDevice(ibgda_->getP2pTransportDevice(peerRank));
     }
-    if (!ibrc_->isPeerMaterialized(peerRank)) {
-      ibrc_->materializePeer(peerRank);
-    }
-    return P2pIbTransportDevice(ibrc_->getP2pTransportDeviceSlot(peerRank));
+    return P2pIbTransportDevice(ibrc_->getP2pTransportDevice(peerRank));
   }
 
   IbgdaLocalBuffer registerBuffer(void* ptr, std::size_t size) {
@@ -155,11 +152,11 @@ class TestIbTransport {
                   : ibrc_->exchangeBuffer(localBuf);
   }
 
-  void queuePeerForMaterialization(int peerRank) {
+  void queuePeerForMaterialization(int peerRank, uint32_t targetChannels) {
     if (ibgda_) {
-      ibgda_->queuePeerForMaterialization(peerRank);
+      ibgda_->queuePeerForMaterialization(peerRank, targetChannels);
     } else {
-      ibrc_->queuePeerForMaterialization(peerRank);
+      ibrc_->queuePeerForMaterialization(peerRank, targetChannels);
     }
   }
 
@@ -178,6 +175,15 @@ class TestIbTransport {
 
   bool collapsedCqActive() const {
     return ibgda_ != nullptr && ibgda_->collapsedCqActive();
+  }
+
+  uint32_t materializedChannelCount(int peerRank) const {
+    return ibgda_ ? ibgda_->materializedChannelCount(peerRank)
+                  : ibrc_->materializedChannelCount(peerRank);
+  }
+
+  uint32_t channelCapacity() const {
+    return static_cast<uint32_t>(config_.max_num_channels);
   }
 
  private:
@@ -3941,12 +3947,14 @@ class LazyModeTestFixture
     return GetParam();
   }
 
-  std::unique_ptr<TestIbTransport> createLazyTransport() {
+  std::unique_ptr<TestIbTransport> createLazyTransport(
+      bool lazyChannels = false) {
     MultipeerIbTransportConfig config{
         .cudaDevice = localRank,
         .numSignalSlots = 1,
         .numCounterSlots = 1,
         .ibLazyConnect = true,
+        .lazyChannels = lazyChannels,
     };
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     return std::make_unique<TestIbTransport>(
@@ -3979,22 +3987,37 @@ TEST_P(LazyModeTestFixture, MaterializeOnAccess) {
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 }
 
-TEST_P(LazyModeTestFixture, QueueThenConnect) {
+TEST_P(LazyModeTestFixture, LazyChannelsUseEagerCapacity) {
   if (numRanks != 2) {
     GTEST_SKIP() << "Requires exactly 2 ranks";
   }
   try {
-    auto transport = createLazyTransport();
-    int peerRank = (globalRank == 0) ? 1 : 0;
-
-    transport->queuePeerForMaterialization(peerRank);
-    EXPECT_FALSE(transport->isPeerMaterialized(peerRank));
-
-    transport->connectPeers();
-    EXPECT_TRUE(transport->isPeerMaterialized(peerRank));
+    auto availabilityProbe = createLazyTransport();
+    (void)availabilityProbe;
   } catch (const std::exception& e) {
     GTEST_SKIP() << backendName(backend()) << " not available: " << e.what();
   }
+
+  auto transport = createLazyTransport(/*lazyChannels=*/true);
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  constexpr uint32_t kRequestedChannels = 1;
+
+  transport->queuePeerForMaterialization(peerRank, kRequestedChannels);
+  EXPECT_FALSE(transport->isPeerMaterialized(peerRank));
+  EXPECT_EQ(0u, transport->materializedChannelCount(peerRank));
+
+  transport->connectPeers();
+  EXPECT_TRUE(transport->isPeerMaterialized(peerRank));
+  EXPECT_EQ(
+      transport->channelCapacity(),
+      transport->materializedChannelCount(peerRank));
+
+  transport->queuePeerForMaterialization(peerRank, kRequestedChannels);
+  transport->connectPeers();
+  EXPECT_EQ(
+      transport->channelCapacity(),
+      transport->materializedChannelCount(peerRank));
+
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 }
 

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -19,6 +19,9 @@
 #endif
 #include "comms/common/fault_tolerance/Abort.h"
 #include "comms/prims/tests/MultipeerIbgdaTransportTest.h"
+#include "comms/prims/tests/TopologyTestUtils.h"
+#include "comms/prims/transport/MultiPeerDeviceHandle.cuh"
+#include "comms/prims/transport/MultiPeerTransport.h"
 #include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 #include "comms/prims/transport/ibgda/MultipeerIbgdaTransport.h"
 #include "comms/prims/transport/ibrc/MultipeerIbrcTransport.h"
@@ -139,6 +142,13 @@ class TestIbTransport {
       return P2pIbTransportDevice(ibgda_->getP2pTransportDevice(peerRank));
     }
     return P2pIbTransportDevice(ibrc_->getP2pTransportDevice(peerRank));
+  }
+
+  P2pIbTransportDevice getP2pTransportDeviceSlot(int peerRank) const {
+    if (ibgda_) {
+      return P2pIbTransportDevice(ibgda_->getP2pTransportDeviceSlot(peerRank));
+    }
+    return P2pIbTransportDevice(ibrc_->getP2pTransportDeviceSlot(peerRank));
   }
 
   IbgdaLocalBuffer registerBuffer(void* ptr, std::size_t size) {
@@ -3934,6 +3944,51 @@ TEST_P(MultipeerIbTransportTestFixture, MultiNicAggregateBandwidth) {
 // Lazy Mode Tests
 // =============================================================================
 
+namespace {
+
+constexpr int kLazyChannelBlockSize = 128;
+constexpr std::size_t kLazyBytesPerChannel = 4096;
+constexpr std::size_t kLazyTransferPartBytes = kLazyBytesPerChannel / 2;
+
+void prepareLazyChannelBuffers(
+    void* sendBuffer,
+    void* recvBuffer,
+    int channelCount,
+    uint8_t localPattern) {
+  auto* const sendBytes = static_cast<char*>(sendBuffer);
+  for (int channel = 0; channel < channelCount; ++channel) {
+    CUDACHECK_TEST(cudaMemset(
+        sendBytes + channel * kLazyBytesPerChannel,
+        static_cast<uint8_t>(localPattern + channel),
+        kLazyBytesPerChannel));
+  }
+  CUDACHECK_TEST(
+      cudaMemset(recvBuffer, 0, channelCount * kLazyBytesPerChannel));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+}
+
+void expectLazyChannelPatterns(
+    const void* recvBuffer,
+    int channelCount,
+    uint8_t remotePattern) {
+  const std::size_t bytes = channelCount * kLazyBytesPerChannel;
+  std::vector<uint8_t> actual(bytes);
+  std::vector<uint8_t> expected(bytes);
+  CUDACHECK_TEST(
+      cudaMemcpy(actual.data(), recvBuffer, bytes, cudaMemcpyDeviceToHost));
+  for (int channel = 0; channel < channelCount; ++channel) {
+    const auto pattern = static_cast<uint8_t>(remotePattern + channel);
+    const std::size_t begin = channel * kLazyBytesPerChannel;
+    const std::size_t end = begin + kLazyBytesPerChannel;
+    for (std::size_t offset = begin; offset < end; ++offset) {
+      expected[offset] = pattern;
+    }
+  }
+  EXPECT_EQ(actual, expected);
+}
+
+} // namespace
+
 class LazyModeTestFixture
     : public MpiBaseTestFixture,
       public ::testing::WithParamInterface<IbTestBackend> {
@@ -3947,18 +4002,46 @@ class LazyModeTestFixture
     return GetParam();
   }
 
-  std::unique_ptr<TestIbTransport> createLazyTransport(
-      bool lazyChannels = false) {
-    MultipeerIbTransportConfig config{
+  MultipeerIbTransportConfig lazyIbConfig(bool lazyChannels) const {
+    return MultipeerIbTransportConfig{
         .cudaDevice = localRank,
+        .perChannelSize = 4096,
+        .max_num_channels = 8,
+        .pipelineDepth = 2,
         .numSignalSlots = 1,
         .numCounterSlots = 1,
         .ibLazyConnect = true,
         .lazyChannels = lazyChannels,
     };
+  }
+
+  std::unique_ptr<TestIbTransport> createLazyTransport(
+      bool lazyChannels = false) {
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     return std::make_unique<TestIbTransport>(
-        backend(), globalRank, numRanks, std::move(bootstrap), config);
+        backend(),
+        globalRank,
+        numRanks,
+        std::move(bootstrap),
+        lazyIbConfig(lazyChannels));
+  }
+
+  std::unique_ptr<MultiPeerTransport> createLazyMultiPeerTransport() {
+    MultiPeerTransportConfig config{
+        .nvlConfig = {.maxNumChannels = 0},
+        .ibConfig = lazyIbConfig(/*lazyChannels=*/true),
+        .ibMode = backend() == IbTestBackend::Ibgda ? IbBackendMode::kIbgda
+                                                    : IbBackendMode::kIbrc,
+    };
+    auto transport = std::make_unique<MultiPeerTransport>(
+        globalRank,
+        numRanks,
+        localRank,
+        std::make_shared<meta::comms::MpiBootstrap>(),
+        config,
+        makeTopology(globalRank, {}));
+    transport->exchange();
+    return transport;
   }
 };
 
@@ -3973,7 +4056,7 @@ TEST_P(LazyModeTestFixture, MaterializeOnAccess) {
     GTEST_SKIP() << "Requires exactly 2 ranks";
   }
   try {
-    auto transport = createLazyTransport();
+    auto transport = createLazyTransport(/*lazyChannels=*/true);
     int peerRank = (globalRank == 0) ? 1 : 0;
 
     EXPECT_FALSE(transport->isPeerMaterialized(peerRank));
@@ -3981,13 +4064,16 @@ TEST_P(LazyModeTestFixture, MaterializeOnAccess) {
     auto peerTransport = transport->getP2pTransportDevice(peerRank);
     (void)peerTransport;
     EXPECT_TRUE(transport->isPeerMaterialized(peerRank));
+    EXPECT_EQ(
+        transport->channelCapacity(),
+        transport->materializedChannelCount(peerRank));
   } catch (const std::exception& e) {
     GTEST_SKIP() << backendName(backend()) << " not available: " << e.what();
   }
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 }
 
-TEST_P(LazyModeTestFixture, LazyChannelsUseEagerCapacity) {
+TEST_P(LazyModeTestFixture, LazyChannelsGrowAndTransfer) {
   if (numRanks != 2) {
     GTEST_SKIP() << "Requires exactly 2 ranks";
   }
@@ -4001,24 +4087,225 @@ TEST_P(LazyModeTestFixture, LazyChannelsUseEagerCapacity) {
   auto transport = createLazyTransport(/*lazyChannels=*/true);
   const int peerRank = (globalRank == 0) ? 1 : 0;
   constexpr uint32_t kRequestedChannels = 1;
+  const void* const deviceTransport = transport->getDeviceTransportPtr();
+  const auto peerTransport = transport->getP2pTransportDeviceSlot(peerRank);
+  const uint8_t localPattern = globalRank == 0 ? 0x30 : 0xA0;
+  const uint8_t remotePattern = globalRank == 0 ? 0xA0 : 0x30;
+  const bool supportsPrefixGrowth = backend() == IbTestBackend::Ibgda;
+  const auto exerciseChannels = [&](int channelCount) {
+    const std::size_t bytes = channelCount * kLazyBytesPerChannel;
+    DeviceBuffer sendBuffer(bytes);
+    DeviceBuffer recvBuffer(bytes);
+    prepareLazyChannelBuffers(
+        sendBuffer.get(), recvBuffer.get(), channelCount, localPattern);
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    test::testChannelRoundTrip(
+        peerTransport,
+        sendBuffer.get(),
+        recvBuffer.get(),
+        kLazyTransferPartBytes,
+        kLazyTransferPartBytes,
+        /*maxSignalBytes=*/1024,
+        /*sendFirst=*/globalRank == 0,
+        channelCount,
+        kLazyChannelBlockSize);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    expectLazyChannelPatterns(recvBuffer.get(), channelCount, remotePattern);
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  };
 
   transport->queuePeerForMaterialization(peerRank, kRequestedChannels);
   EXPECT_FALSE(transport->isPeerMaterialized(peerRank));
   EXPECT_EQ(0u, transport->materializedChannelCount(peerRank));
 
   transport->connectPeers();
-  EXPECT_TRUE(transport->isPeerMaterialized(peerRank));
-  EXPECT_EQ(
-      transport->channelCapacity(),
-      transport->materializedChannelCount(peerRank));
+  EXPECT_EQ(deviceTransport, transport->getDeviceTransportPtr());
+  if (supportsPrefixGrowth) {
+    EXPECT_FALSE(transport->isPeerMaterialized(peerRank));
+    EXPECT_EQ(
+        kRequestedChannels, transport->materializedChannelCount(peerRank));
+  } else {
+    EXPECT_TRUE(transport->isPeerMaterialized(peerRank));
+    EXPECT_EQ(
+        transport->channelCapacity(),
+        transport->materializedChannelCount(peerRank));
+  }
+  exerciseChannels(/*channelCount=*/1);
 
-  transport->queuePeerForMaterialization(peerRank, kRequestedChannels);
+  transport->queuePeerForMaterialization(peerRank, /*targetChannels=*/3);
   transport->connectPeers();
   EXPECT_EQ(
-      transport->channelCapacity(),
+      supportsPrefixGrowth ? 3 : transport->channelCapacity(),
       transport->materializedChannelCount(peerRank));
+  EXPECT_EQ(deviceTransport, transport->getDeviceTransportPtr());
+  exerciseChannels(/*channelCount=*/3);
+
+  transport->queuePeerForMaterialization(peerRank, /*targetChannels=*/2);
+  transport->connectPeers();
+  EXPECT_EQ(
+      supportsPrefixGrowth ? 3 : transport->channelCapacity(),
+      transport->materializedChannelCount(peerRank));
+  exerciseChannels(/*channelCount=*/1);
 
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+TEST_P(LazyModeTestFixture, IbgdaAccessorPreservesPreparedPrefix) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+  }
+  if (backend() != IbTestBackend::Ibgda) {
+    GTEST_SKIP() << "The compatibility accessor is IBGDA-specific";
+  }
+
+  std::unique_ptr<TestIbTransport> transport;
+  try {
+    transport = createLazyTransport(/*lazyChannels=*/true);
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA not available: " << e.what();
+  }
+
+  const int peerRank = globalRank == 0 ? 1 : 0;
+  const auto preparedSlot = transport->getP2pTransportDeviceSlot(peerRank);
+  transport->queuePeerForMaterialization(peerRank, /*targetChannels=*/1);
+  transport->connectPeers();
+  EXPECT_EQ(1, transport->materializedChannelCount(peerRank));
+  (void)transport->getP2pTransportDevice(peerRank);
+  EXPECT_EQ(1, transport->materializedChannelCount(peerRank));
+
+  DeviceBuffer sendBuffer(kLazyBytesPerChannel);
+  DeviceBuffer recvBuffer(kLazyBytesPerChannel);
+  const uint8_t localPattern = globalRank == 0 ? 0x35 : 0xA5;
+  const uint8_t remotePattern = globalRank == 0 ? 0xA5 : 0x35;
+  prepareLazyChannelBuffers(
+      sendBuffer.get(), recvBuffer.get(), /*channelCount=*/1, localPattern);
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  test::testChannelRoundTrip(
+      preparedSlot,
+      sendBuffer.get(),
+      recvBuffer.get(),
+      kLazyTransferPartBytes,
+      kLazyTransferPartBytes,
+      /*maxSignalBytes=*/1024,
+      /*sendFirst=*/globalRank == 0,
+      /*numBlocks=*/1,
+      kLazyChannelBlockSize);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  expectLazyChannelPatterns(
+      recvBuffer.get(), /*channelCount=*/1, remotePattern);
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+TEST_P(LazyModeTestFixture, ColdGraphCaptureGrowAndReplayOldGraph) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+  }
+  if (backend() != IbTestBackend::Ibgda) {
+    GTEST_SKIP() << "IBRC prefix growth is introduced by a later diff";
+  }
+
+  std::unique_ptr<MultiPeerTransport> transport;
+  try {
+    transport = createLazyMultiPeerTransport();
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA not available: " << e.what();
+  }
+
+  constexpr int kMaxChannels = 4;
+  constexpr std::size_t kMaxBytes = kMaxChannels * kLazyBytesPerChannel;
+  const int peerRank = globalRank == 0 ? 1 : 0;
+  const uint8_t localPattern = globalRank == 0 ? 0x40 : 0xB0;
+  const uint8_t remotePattern = globalRank == 0 ? 0xB0 : 0x40;
+  DeviceBuffer sendBuffer(kMaxBytes);
+  DeviceBuffer recvBuffer(kMaxBytes);
+
+  const MultiPeerDeviceHandle initialHandle =
+      transport->get_device_handle(std::span<const PeerChannelDemand>{});
+  const Transport* const stableTransportTable = initialHandle.transports.data();
+
+  cudaStream_t stream = nullptr;
+  cudaGraph_t graph = nullptr;
+  cudaGraphExec_t graphExec = nullptr;
+  CUDACHECK_TEST(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+
+  prepareLazyChannelBuffers(
+      sendBuffer.get(), recvBuffer.get(), kMaxChannels, localPattern);
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  CUDACHECK_TEST(
+      cudaStreamBeginCapture(stream, cudaStreamCaptureModeThreadLocal));
+  const std::vector<PeerChannelDemand> oneChannelDemand{{
+      .peerRank = peerRank,
+      .ibChannels = 1,
+  }};
+  const MultiPeerDeviceHandle capturedHandle =
+      transport->get_device_handle(oneChannelDemand);
+  EXPECT_EQ(stableTransportTable, capturedHandle.transports.data());
+  test::testMultiPeerChannelRoundTrip(
+      capturedHandle,
+      peerRank,
+      sendBuffer.get(),
+      recvBuffer.get(),
+      kLazyTransferPartBytes,
+      kLazyTransferPartBytes,
+      /*maxSignalBytes=*/1024,
+      /*sendFirst=*/globalRank == 0,
+      /*numBlocks=*/1,
+      kLazyChannelBlockSize,
+      stream);
+  CUDACHECK_TEST(cudaStreamEndCapture(stream, &graph));
+  CUDACHECK_TEST(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  CUDACHECK_TEST(cudaGraphLaunch(graphExec, stream));
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  expectLazyChannelPatterns(
+      recvBuffer.get(), /*channelCount=*/1, remotePattern);
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  const std::vector<PeerChannelDemand> fourChannelDemand{{
+      .peerRank = peerRank,
+      .ibChannels = kMaxChannels,
+  }};
+  const MultiPeerDeviceHandle grownHandle =
+      transport->get_device_handle(fourChannelDemand);
+  EXPECT_EQ(stableTransportTable, grownHandle.transports.data());
+
+  prepareLazyChannelBuffers(
+      sendBuffer.get(), recvBuffer.get(), kMaxChannels, localPattern);
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  test::testMultiPeerChannelRoundTrip(
+      grownHandle,
+      peerRank,
+      sendBuffer.get(),
+      recvBuffer.get(),
+      kLazyTransferPartBytes,
+      kLazyTransferPartBytes,
+      /*maxSignalBytes=*/1024,
+      /*sendFirst=*/globalRank == 0,
+      kMaxChannels,
+      kLazyChannelBlockSize,
+      stream);
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  expectLazyChannelPatterns(recvBuffer.get(), kMaxChannels, remotePattern);
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  prepareLazyChannelBuffers(
+      sendBuffer.get(), recvBuffer.get(), kMaxChannels, localPattern);
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  CUDACHECK_TEST(cudaGraphLaunch(graphExec, stream));
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  expectLazyChannelPatterns(
+      recvBuffer.get(), /*channelCount=*/1, remotePattern);
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
 }
 
 TEST_P(LazyModeTestFixture, DefaultModeDefersAllPeers) {

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -2,6 +2,7 @@
 
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/tests/MultipeerIbgdaTransportTest.cuh"
+#include "comms/prims/transport/MultiPeerDeviceHandle.cuh"
 
 #include <cuda_runtime.h>
 #include <stdexcept>
@@ -410,6 +411,94 @@ __global__ void sendRecvKernel(
   }
 }
 
+__device__ void runChannelRoundTrip(
+    P2pIbTransportDevice transport,
+    const void* sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t maxSignalBytes,
+    bool sendFirst,
+    AbortDevice abortDevice) {
+  auto group = make_block_group();
+  abortDevice.start();
+  const std::size_t channelOffset = group.group_id * (firstBytes + secondBytes);
+  auto* const sendBytes = static_cast<const char*>(sendBuffer) + channelOffset;
+  auto* const recvBytes = static_cast<char*>(recvBuffer) + channelOffset;
+
+  if (sendFirst) {
+    transport.send(group, sendBytes, firstBytes, maxSignalBytes, abortDevice);
+    transport.recv(group, recvBytes, firstBytes, maxSignalBytes, abortDevice);
+    transport.send(
+        group,
+        sendBytes + firstBytes,
+        secondBytes,
+        maxSignalBytes,
+        abortDevice);
+    transport.recv(
+        group,
+        recvBytes + firstBytes,
+        secondBytes,
+        maxSignalBytes,
+        abortDevice);
+  } else {
+    transport.recv(group, recvBytes, firstBytes, maxSignalBytes, abortDevice);
+    transport.send(group, sendBytes, firstBytes, maxSignalBytes, abortDevice);
+    transport.recv(
+        group,
+        recvBytes + firstBytes,
+        secondBytes,
+        maxSignalBytes,
+        abortDevice);
+    transport.send(
+        group,
+        sendBytes + firstBytes,
+        secondBytes,
+        maxSignalBytes,
+        abortDevice);
+  }
+}
+
+__global__ void channelRoundTripKernel(
+    P2pIbTransportDevice transport,
+    const void* sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t maxSignalBytes,
+    bool sendFirst,
+    AbortDevice abortDevice) {
+  runChannelRoundTrip(
+      transport,
+      sendBuffer,
+      recvBuffer,
+      firstBytes,
+      secondBytes,
+      maxSignalBytes,
+      sendFirst,
+      abortDevice);
+}
+
+__global__ void multiPeerChannelRoundTripKernel(
+    MultiPeerDeviceHandle handle,
+    int peerRank,
+    const void* sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t maxSignalBytes,
+    bool sendFirst) {
+  runChannelRoundTrip(
+      handle.get_ib(peerRank),
+      sendBuffer,
+      recvBuffer,
+      firstBytes,
+      secondBytes,
+      maxSignalBytes,
+      sendFirst,
+      handle.abort);
+}
+
 __global__ void twoCallSendThenRecvKernel(
     P2pIbTransportDevice transport,
     const void* sendBuffer,
@@ -442,6 +531,61 @@ void testSendRecv(
   sendRecvKernel<<<numBlocks, blockSize>>>(
       transport, buffer, nbytes, maxSignalBytes, send, testAbortDevice());
   cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
+void testChannelRoundTrip(
+    P2pIbTransportDevice transport,
+    const void* sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t maxSignalBytes,
+    bool sendFirst,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream) {
+  channelRoundTripKernel<<<numBlocks, blockSize, 0, stream>>>(
+      transport,
+      sendBuffer,
+      recvBuffer,
+      firstBytes,
+      secondBytes,
+      maxSignalBytes,
+      sendFirst,
+      testAbortDevice());
+  const cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
+void testMultiPeerChannelRoundTrip(
+    MultiPeerDeviceHandle handle,
+    int peerRank,
+    const void* sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t maxSignalBytes,
+    bool sendFirst,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream) {
+  multiPeerChannelRoundTripKernel<<<numBlocks, blockSize, 0, stream>>>(
+      handle,
+      peerRank,
+      sendBuffer,
+      recvBuffer,
+      firstBytes,
+      secondBytes,
+      maxSignalBytes,
+      sendFirst);
+  const cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(
         std::string("Kernel launch failed: ") + cudaGetErrorString(err));

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -12,6 +12,7 @@ namespace comms::prims {
 
 // Forward declaration - full definition in P2pIbTransportDevice.cuh
 struct P2pIbTransportDevice;
+struct MultiPeerDeviceHandle;
 // Forward declaration - full definition in P2pIbgdaTransportDevice.cuh
 class P2pIbgdaTransportDevice;
 
@@ -189,6 +190,34 @@ void testSendRecv(
     bool send,
     int numBlocks,
     int blockSize);
+
+/**
+ * Test kernel: bidirectional two-part transfer on independent channel slices.
+ */
+void testChannelRoundTrip(
+    P2pIbTransportDevice transport,
+    const void* sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t maxSignalBytes,
+    bool sendFirst,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+void testMultiPeerChannelRoundTrip(
+    MultiPeerDeviceHandle handle,
+    int peerRank,
+    const void* sendBuffer,
+    void* recvBuffer,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    std::size_t maxSignalBytes,
+    bool sendFirst,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream);
 
 /**
  * Test kernel: Blocking pipelined send or recv driving the variable-size

--- a/comms/prims/tests/P2pIbTransportDeviceAbortTest.cu
+++ b/comms/prims/tests/P2pIbTransportDeviceAbortTest.cu
@@ -43,6 +43,7 @@ __device__ P2pIbrcTransportDevice makeLocalIbrcTransport(
       /*nics=*/1,
       /*maxChannels=*/1,
       /*qpsPerConnection=*/1,
+      /*qpDirectionCount=*/kIbDirections,
       DeviceSpan<IbLocalChannel>{scratch.channels, 1},
       /*ownedRemoteSignalBuf=*/{},
       /*ownedLocalSignalBuf=*/{},

--- a/comms/prims/topology/TopologyDiscovery.h
+++ b/comms/prims/topology/TopologyDiscovery.h
@@ -85,7 +85,7 @@ struct TopologyConfig {
   // Follows NCCL's NCCL_P2P_DISABLE semantics (PATH_LOC — self only):
   //   - false (default): use NVLink when available (MNNVL or peer access)
   //   - true: skip both Tier 1 and Tier 2; all non-self peers fall back to
-  //     IBGDA
+  //     the selected IB backend
   bool p2pDisable{false};
 };
 
@@ -97,8 +97,8 @@ struct TopologyConfig {
  *   - nvlNRanks        = nvlPeerRanks.size() + 1
  *   - nvlLocalRank     = globalToNvlLocal.at(myRank)
  *   - typePerRank[r]   = SELF if r==myRank, P2P_NVL if in globalToNvlLocal,
- *                         P2P_IBGDA otherwise
- *   - ibgdaPeerRanks   = all ranks except self (universal fallback)
+ *                         selected IB backend otherwise
+ *   - ibPeerRanks      = non-self ranks not in globalToNvlLocal
  */
 struct TopologyResult {
   /// Global ranks of NVLink-connected peers (excluding self), sorted.

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -156,6 +156,7 @@ bool nicSupportsRelaxedOrdering(ibverbx::ibv_pd* pd) {
 
 #ifdef __HIP_PLATFORM_AMD__
 using SlotGpuError = hipError_t;
+using SlotGpuStream = hipStream_t;
 constexpr SlotGpuError kSlotGpuSuccess = hipSuccess;
 
 const char* slotGpuGetErrorString(SlotGpuError err) {
@@ -170,8 +171,24 @@ SlotGpuError slotGpuFree(void* ptr) {
   return hipFree(ptr);
 }
 
-SlotGpuError slotGpuMemset(void* ptr, int value, std::size_t bytes) {
-  return hipMemset(ptr, value, bytes);
+SlotGpuError slotGpuStreamCreate(SlotGpuStream* stream) {
+  return hipStreamCreateWithFlags(stream, hipStreamNonBlocking);
+}
+
+SlotGpuError slotGpuMemsetAsync(
+    void* ptr,
+    int value,
+    std::size_t bytes,
+    SlotGpuStream stream) {
+  return hipMemsetAsync(ptr, value, bytes, stream);
+}
+
+SlotGpuError slotGpuStreamSynchronize(SlotGpuStream stream) {
+  return hipStreamSynchronize(stream);
+}
+
+SlotGpuError slotGpuStreamDestroy(SlotGpuStream stream) {
+  return hipStreamDestroy(stream);
 }
 
 SlotGpuError slotHostPinnedAlloc(void** ptr, std::size_t bytes) {
@@ -187,6 +204,7 @@ SlotGpuError slotHostFree(void* ptr) {
 }
 #else
 using SlotGpuError = cudaError_t;
+using SlotGpuStream = cudaStream_t;
 constexpr SlotGpuError kSlotGpuSuccess = cudaSuccess;
 
 const char* slotGpuGetErrorString(SlotGpuError err) {
@@ -201,8 +219,24 @@ SlotGpuError slotGpuFree(void* ptr) {
   return cudaFree(ptr);
 }
 
-SlotGpuError slotGpuMemset(void* ptr, int value, std::size_t bytes) {
-  return cudaMemset(ptr, value, bytes);
+SlotGpuError slotGpuStreamCreate(SlotGpuStream* stream) {
+  return cudaStreamCreateWithFlags(stream, cudaStreamNonBlocking);
+}
+
+SlotGpuError slotGpuMemsetAsync(
+    void* ptr,
+    int value,
+    std::size_t bytes,
+    SlotGpuStream stream) {
+  return cudaMemsetAsync(ptr, value, bytes, stream);
+}
+
+SlotGpuError slotGpuStreamSynchronize(SlotGpuStream stream) {
+  return cudaStreamSynchronize(stream);
+}
+
+SlotGpuError slotGpuStreamDestroy(SlotGpuStream stream) {
+  return cudaStreamDestroy(stream);
 }
 
 SlotGpuError slotHostPinnedAlloc(void** ptr, std::size_t bytes) {
@@ -217,6 +251,20 @@ SlotGpuError slotHostFree(void* ptr) {
   return cudaFreeHost(ptr);
 }
 #endif
+
+SlotGpuError slotGpuMemset(void* ptr, int value, std::size_t bytes) {
+  SlotGpuStream stream{};
+  SlotGpuError result = slotGpuStreamCreate(&stream);
+  if (result != kSlotGpuSuccess) {
+    return result;
+  }
+  result = slotGpuMemsetAsync(ptr, value, bytes, stream);
+  if (result == kSlotGpuSuccess) {
+    result = slotGpuStreamSynchronize(stream);
+  }
+  const SlotGpuError destroyResult = slotGpuStreamDestroy(stream);
+  return result == kSlotGpuSuccess ? destroyResult : result;
+}
 
 void checkSlotGpu(SlotGpuError err, const std::string& what) {
   if (err != kSlotGpuSuccess) {
@@ -240,8 +288,31 @@ void* checkedSlotAlloc(
   return ptr;
 }
 
-std::size_t alignUp(std::size_t x, std::size_t a) {
-  return ((x + a - 1) / a) * a;
+std::size_t checkedMul(std::size_t lhs, std::size_t rhs, const char* label) {
+  if (lhs != 0 && rhs > std::numeric_limits<std::size_t>::max() / lhs) {
+    throw std::overflow_error(
+        fmt::format("MultiPeerIbTransport: {} size overflow", label));
+  }
+  return lhs * rhs;
+}
+
+std::size_t checkedAdd(std::size_t lhs, std::size_t rhs, const char* label) {
+  if (rhs > std::numeric_limits<std::size_t>::max() - lhs) {
+    throw std::overflow_error(
+        fmt::format("MultiPeerIbTransport: {} size overflow", label));
+  }
+  return lhs + rhs;
+}
+
+std::size_t alignUp(std::size_t value, std::size_t alignment) {
+  if (alignment == 0) {
+    throw std::invalid_argument(
+        "MultiPeerIbTransport: alignment must be non-zero");
+  }
+  const std::size_t remainder = value % alignment;
+  return remainder == 0
+      ? value
+      : checkedAdd(value, alignment - remainder, "aligned allocation");
 }
 
 void checkSendRecvSignalAlignment(const void* ptr, const char* label) {
@@ -304,11 +375,16 @@ MultiPeerIbTransportBase::MultiPeerIbTransportBase(
     int myRank,
     int nRanks,
     std::shared_ptr<meta::comms::IBootstrap> bootstrap,
-    MultipeerIbTransportConfig config)
+    MultipeerIbTransportConfig config,
+    bool supportsLazyChannelPrefixGrowth)
     : myRank_(myRank),
       nRanks_(nRanks),
       bootstrap_(std::move(bootstrap)),
-      config_(config.normalizedChannelGeometry()) {
+      config_(config.normalizedChannelGeometry()),
+      channelRangeProtocolEnabled_(
+          config_.lazyChannels && supportsLazyChannelPrefixGrowth),
+      lazyChannelGrowthEnabled_(
+          config_.lazyChannels && supportsLazyChannelPrefixGrowth) {
   if (myRank_ < 0 || myRank_ >= nRanks_) {
     throw std::invalid_argument("Invalid rank");
   }
@@ -317,6 +393,7 @@ MultiPeerIbTransportBase::MultiPeerIbTransportBase(
   }
   peerMaterialized_.resize(nRanks_ - 1, false);
   materializedChannels_.resize(nRanks_ - 1, 0);
+  materializationGenerations_.resize(nRanks_ - 1, 0);
   if (auto isolatedBootstrap = bootstrap_->duplicate()) {
     bootstrap_ =
         std::shared_ptr<meta::comms::IBootstrap>(std::move(isolatedBootstrap));
@@ -486,6 +563,48 @@ void MultiPeerIbTransportBase::validateSendRecvConfig() const {
   }
 }
 
+std::size_t MultiPeerIbTransportBase::deviceMrAllocationAlignment() const {
+#ifdef __HIP_PLATFORM_AMD__
+  return 1;
+#else
+  std::size_t alignment = std::size_t{2} << 20;
+  if (cuda_driver_lazy_init() != 0 || pfn_cuDeviceGet == nullptr ||
+      pfn_cuMemGetAllocationGranularity == nullptr) {
+    return alignment;
+  }
+
+  CUdevice device = 0;
+  if (pfn_cuDeviceGet(&device, config_.cudaDevice) != CUDA_SUCCESS) {
+    return alignment;
+  }
+  CUmemAllocationProp properties{};
+  properties.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  properties.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  properties.location.id = device;
+  std::size_t granularity = 0;
+  if (pfn_cuMemGetAllocationGranularity(
+          &granularity, &properties, CU_MEM_ALLOC_GRANULARITY_MINIMUM) ==
+          CUDA_SUCCESS &&
+      granularity != 0) {
+    alignment = granularity;
+  }
+  return alignment;
+#endif
+}
+
+std::unique_ptr<meta::comms::DeviceBuffer>
+MultiPeerIbTransportBase::allocateDeviceMrBuffer(
+    std::size_t usedBytes,
+    std::size_t allocationAlignment,
+    const char* label) const {
+  const std::size_t allocationBytes = alignUp(usedBytes, allocationAlignment);
+  auto buffer = std::make_unique<meta::comms::DeviceBuffer>(allocationBytes);
+  checkSlotGpu(
+      slotGpuMemset(buffer->get(), 0, allocationBytes),
+      fmt::format("MultiPeerIbTransport: zero {}", label));
+  return buffer;
+}
+
 std::size_t MultiPeerIbTransportBase::sendRecvStagingBytesPerPeer() const {
   return config_.dataBufferSize;
 }
@@ -513,23 +632,11 @@ std::size_t MultiPeerIbTransportBase::sendRecvCounterBytesPerPeer() const {
       kSendRecvSignalSlotStride;
 }
 
-IbChannelLayout MultiPeerIbTransportBase::channelLayoutForPeer(
-    int peerIndex) const {
-  if (!sendRecvBuffersEnabled() || sendRecvPeerBuffers_.empty() ||
-      peerIndex < 0 ||
-      peerIndex >= static_cast<int>(sendRecvPeerBuffers_.size())) {
+IbChannelLayout MultiPeerIbTransportBase::sendRecvChannelGeometry() const {
+  if (!sendRecvBuffersEnabled()) {
     return {};
   }
-  const auto& pb = sendRecvPeerBuffers_[peerIndex];
   return IbChannelLayout{
-      .sendStagingBuf = pb.sendStaging,
-      .recvStagingBuf = pb.remoteRecvStaging,
-      .sendStagingPtr = static_cast<char*>(pb.sendStaging.ptr),
-      .recvStagingPtr = static_cast<char*>(pb.recvStaging.ptr),
-      .localSignalBuf = pb.signal,
-      .remoteSignalBuf = pb.remoteSignal,
-      .localCounterBuf = pb.counter,
-      .localCounterCompletionBuf = pb.counterCompletion,
       .maxChannels = config_.totalChannelSlots(),
       .numChannels = config_.max_num_channels,
       .numLanes = numNics_ * config_.qpsPerConnection,
@@ -537,6 +644,25 @@ IbChannelLayout MultiPeerIbTransportBase::channelLayoutForPeer(
       .perChannelSize = config_.perChannelSize,
       .perChannelBufferSize = config_.perChannelSize,
   };
+}
+
+IbChannelLayout MultiPeerIbTransportBase::channelLayoutForPeer(
+    int peerIndex) const {
+  if (!sendRecvBuffersEnabled() || peerIndex < 0 ||
+      peerIndex >= static_cast<int>(sendRecvPeerBuffers_.size())) {
+    return {};
+  }
+  IbChannelLayout layout = sendRecvChannelGeometry();
+  const auto& pb = sendRecvPeerBuffers_[peerIndex];
+  layout.sendStagingBuf = pb.sendStaging;
+  layout.recvStagingBuf = pb.remoteRecvStaging;
+  layout.sendStagingPtr = static_cast<char*>(pb.sendStaging.ptr);
+  layout.recvStagingPtr = static_cast<char*>(pb.recvStaging.ptr);
+  layout.localSignalBuf = pb.signal;
+  layout.remoteSignalBuf = pb.remoteSignal;
+  layout.localCounterBuf = pb.counter;
+  layout.localCounterCompletionBuf = pb.counterCompletion;
+  return layout;
 }
 
 void MultiPeerIbTransportBase::allocateSendRecvBuffersEager(
@@ -566,41 +692,14 @@ void MultiPeerIbTransportBase::allocateSendRecvBuffersEager(
   // a few MB of rounding on the small bulks. Granularity is queried from the
   // driver (2 MiB fallback); AMD (no Data-Direct) keeps the natural allocation
   // size.
-  std::size_t ddAlign = 1;
-#ifndef __HIP_PLATFORM_AMD__
-  ddAlign = std::size_t{2} << 20; // fallback if the query below fails
-  if (cuda_driver_lazy_init() == 0 && pfn_cuDeviceGet != nullptr &&
-      pfn_cuMemGetAllocationGranularity != nullptr) {
-    CUdevice dev = 0;
-    if (pfn_cuDeviceGet(&dev, config_.cudaDevice) == CUDA_SUCCESS) {
-      CUmemAllocationProp prop = {};
-      prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
-      prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-      prop.location.id = dev;
-      std::size_t granularity = 0;
-      if (pfn_cuMemGetAllocationGranularity(
-              &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM) ==
-              CUDA_SUCCESS &&
-          granularity > 0) {
-        ddAlign = granularity;
-      }
-    }
-  }
-#endif
-  auto allocateBulk = [&](std::size_t perPeer, const char* label) {
-    const std::size_t used = perPeer * numPeers;
-    const std::size_t allocBytes = ((used + ddAlign - 1) / ddAlign) * ddAlign;
-    auto buf = std::make_unique<meta::comms::DeviceBuffer>(allocBytes);
-    checkSlotGpu(
-        slotGpuMemset(buf->get(), 0, allocBytes),
-        fmt::format("MultiPeerIbTransport: zero send/recv {}", label));
-    return buf;
-  };
+  const std::size_t allocationAlignment = deviceMrAllocationAlignment();
 
   sendRecvPeerBuffers_.resize(numPeers);
 
-  sendRecvSendStagingBulk_ = allocateBulk(stagingPerPeer, "send staging bulk");
-  sendRecvRecvStagingBulk_ = allocateBulk(stagingPerPeer, "recv staging bulk");
+  sendRecvSendStagingBulk_ = allocateDeviceMrBuffer(
+      stagingPerPeer * numPeers, allocationAlignment, "send staging bulk");
+  sendRecvRecvStagingBulk_ = allocateDeviceMrBuffer(
+      stagingPerPeer * numPeers, allocationAlignment, "recv staging bulk");
 
   // Signal and the device counter are the small RDMA-registered control
   // buffers; pack them into ONE granularity-aligned allocation so they cost a
@@ -613,12 +712,9 @@ void MultiPeerIbTransportBase::allocateSendRecvBuffersEager(
   const std::size_t counterTotal =
       deviceCounter ? counterPerPeer * numPeers : 0;
   const std::size_t counterOff = alignUp(signalTotal, alignof(SignalState));
-  const std::size_t controlBytes = alignUp(counterOff + counterTotal, ddAlign);
-  sendRecvControlBulk_ =
-      std::make_unique<meta::comms::DeviceBuffer>(controlBytes);
-  checkSlotGpu(
-      slotGpuMemset(sendRecvControlBulk_->get(), 0, controlBytes),
-      "MultiPeerIbTransport: zero send/recv control bulk");
+  const std::size_t controlBytes = counterOff + counterTotal;
+  sendRecvControlBulk_ = allocateDeviceMrBuffer(
+      controlBytes, allocationAlignment, "send/recv control bulk");
   char* controlBase = static_cast<char*>(sendRecvControlBulk_->get());
   checkSendRecvSignalAlignment(
       controlBase, "MultiPeerIbTransport: send/recv signal base");
@@ -756,6 +852,12 @@ void MultiPeerIbTransportBase::cleanupSendRecvBuffers() noexcept {
     freeCounterSlotAllocation(counter);
   }
   lazySendRecvHostCounters_.clear();
+  for (int peerIndex = 0;
+       peerIndex < static_cast<int>(lazyPeerChannelRangeBufs_.size());
+       ++peerIndex) {
+    cleanupSendRecvChannelRangesForPeer(peerIndex);
+  }
+  lazyPeerChannelRangeBufs_.clear();
   sendRecvCounterStorage_ = IbCounterStorage::Device;
   sendRecvPeerBuffers_.clear();
 }
@@ -857,6 +959,140 @@ void MultiPeerIbTransportBase::applyRemoteSendRecvBuffer(
   auto& pb = sendRecvPeerBuffers_[peerIndex];
   pb.remoteRecvStaging = remotePayload.recvStaging.toRemoteBuffer();
   pb.remoteSignal = remotePayload.srSignal.toRemoteBuffer();
+}
+
+IbChannelLayout MultiPeerIbTransportBase::allocateSendRecvChannelRange(
+    int peerIndex,
+    uint32_t beginChannel,
+    uint32_t endChannel,
+    PeerBufferPayload& payload) {
+  if (!sendRecvBuffersEnabled()) {
+    return {};
+  }
+  validateSendRecvConfig();
+  const int numPeers = nRanks_ - 1;
+  if (peerIndex < 0 || peerIndex >= numPeers) {
+    throw std::invalid_argument(
+        fmt::format(
+            "allocateSendRecvChannelRange: invalid peerIndex={}", peerIndex));
+  }
+  if (beginChannel >= endChannel || endChannel > channelCapacity()) {
+    throw std::invalid_argument(
+        fmt::format(
+            "allocateSendRecvChannelRange: invalid range=[{}, {}) capacity={}",
+            beginChannel,
+            endChannel,
+            channelCapacity()));
+  }
+
+  const std::size_t channelCount = endChannel - beginChannel;
+  const std::size_t channelSlotCount =
+      checkedMul(channelCount, kNumProtoSlots, "channel slots");
+  const std::size_t numLanes = checkedMul(
+      static_cast<std::size_t>(numNics_),
+      static_cast<std::size_t>(config_.qpsPerConnection),
+      "QP lanes");
+  const std::size_t stagingBytes = checkedMul(
+      channelSlotCount, config_.perChannelSize, "channel-range staging");
+  const std::size_t signalSlotCount = checkedMul(
+      checkedAdd(numLanes, 1, "signal lanes"),
+      channelSlotCount,
+      "channel-range signal slots");
+  const std::size_t signalBytes = checkedMul(
+      signalSlotCount, kSendRecvSignalSlotStride, "channel-range signal");
+  const std::size_t counterBytes = checkedMul(
+      channelSlotCount, kSendRecvSignalSlotStride, "channel-range counter");
+
+  lazyPeerChannelRangeBufs_.resize(numPeers);
+  auto& ownedBuffers = lazyPeerChannelRangeBufs_[peerIndex];
+  ownedBuffers.reserve(ownedBuffers.size() + 2);
+  const std::size_t allocationAlignment = deviceMrAllocationAlignment();
+
+  const std::size_t stagingAllocationBytes =
+      checkedMul(2, stagingBytes, "channel-range staging allocation");
+  auto stagingBuffer = allocateDeviceMrBuffer(
+      stagingAllocationBytes,
+      allocationAlignment,
+      "channel-range staging buffer");
+  const auto registeredStaging = registerBuffer(
+      stagingBuffer->get(),
+      stagingAllocationBytes,
+      /*relaxedOrdering=*/true);
+  char* const stagingBase = static_cast<char*>(stagingBuffer->get());
+  void* const recvStaging = stagingBase + stagingBytes;
+  ownedBuffers.push_back(std::move(stagingBuffer));
+
+  const std::size_t counterOff = alignUp(signalBytes, alignof(SignalState));
+  const std::size_t controlAllocationBytes =
+      checkedAdd(counterOff, counterBytes, "channel-range control allocation");
+  auto controlBuffer = allocateDeviceMrBuffer(
+      controlAllocationBytes,
+      allocationAlignment,
+      "channel-range control buffer");
+  const auto registeredControl =
+      registerBuffer(controlBuffer->get(), controlAllocationBytes);
+  char* const controlBase = static_cast<char*>(controlBuffer->get());
+  void* const signal = controlBase;
+  void* const counter = controlBase + counterOff;
+  checkSendRecvSignalAlignment(
+      signal, "MultiPeerIbTransport: channel-range signal base");
+  checkSendRecvSignalAlignment(
+      counter, "MultiPeerIbTransport: channel-range counter base");
+  ownedBuffers.push_back(std::move(controlBuffer));
+
+  payload.recvStaging = registeredSlotMemoryExchInfo(recvStaging);
+  payload.srSignal = registeredSlotMemoryExchInfo(signal);
+
+  return IbChannelLayout{
+      .sendStagingBuf =
+          IbgdaLocalBuffer(stagingBase, registeredStaging.lkey_per_device),
+      .sendStagingPtr = stagingBase,
+      .recvStagingPtr = static_cast<char*>(recvStaging),
+      .localSignalBuf =
+          IbgdaLocalBuffer(signal, registeredControl.lkey_per_device),
+      .localCounterBuf =
+          IbgdaLocalBuffer(counter, registeredControl.lkey_per_device),
+      .localCounterCompletionBuf =
+          IbgdaLocalBuffer(counter, registeredControl.lkey_per_device),
+      .maxChannels = static_cast<int>(channelSlotCount),
+      .numChannels = static_cast<int>(channelCount),
+      .numLanes = static_cast<int>(numLanes),
+      .pipelineDepth = config_.pipelineDepth,
+      .perChannelSize = config_.perChannelSize,
+      .perChannelBufferSize = config_.perChannelSize,
+  };
+}
+
+void MultiPeerIbTransportBase::applyRemoteSendRecvChannelRange(
+    IbChannelLayout& layout,
+    const PeerBufferPayload& remotePayload) const {
+  if (layout.maxChannels == 0) {
+    return;
+  }
+  layout.recvStagingBuf = remotePayload.recvStaging.toRemoteBuffer();
+  layout.remoteSignalBuf = remotePayload.srSignal.toRemoteBuffer();
+}
+
+void MultiPeerIbTransportBase::cleanupSendRecvChannelRangesForPeer(
+    int peerIndex) noexcept {
+  if (peerIndex < 0 ||
+      peerIndex >= static_cast<int>(lazyPeerChannelRangeBufs_.size())) {
+    return;
+  }
+  for (auto& buffer : lazyPeerChannelRangeBufs_[peerIndex]) {
+    if (!buffer) {
+      continue;
+    }
+    try {
+      deregisterBuffer(buffer->get());
+    } catch (const std::exception& ex) {
+      LOG(ERROR) << "MultiPeerIbTransport: failed to deregister channel-range "
+                    "send/recv buffer: "
+                 << ex.what();
+    }
+    buffer.reset();
+  }
+  lazyPeerChannelRangeBufs_[peerIndex].clear();
 }
 
 void MultiPeerIbTransportBase::cleanupSendRecvBufferForPeer(
@@ -1703,12 +1939,13 @@ MultiPeerIbTransportBase::allocateDeviceSlotAllocation(
   allocation.isHostPinned = true;
   std::memset(allocation.ptr, 0, bytes);
 #else
+  allocation.bytes = alignUp(bytes, deviceMrAllocationAlignment());
   allocation.ptr = checkedSlotAlloc(
       slotGpuMalloc,
-      bytes,
+      allocation.bytes,
       fmt::format("MultiPeerIbTransport: device allocation for {}", label));
   checkSlotGpu(
-      slotGpuMemset(allocation.ptr, 0, bytes),
+      slotGpuMemset(allocation.ptr, 0, allocation.bytes),
       fmt::format(
           "MultiPeerIbTransport: zero device allocation for {}", label));
 #endif
@@ -1733,12 +1970,13 @@ MultiPeerIbTransportBase::allocateCounterSlotAllocation(
   switch (storage) {
     case IbCounterStorage::Device:
       // NIC loopback atomic target: device memory, zeroed.
+      allocation.bytes = alignUp(bytes, deviceMrAllocationAlignment());
       allocation.devicePtr = checkedSlotAlloc(
           slotGpuMalloc,
-          bytes,
+          allocation.bytes,
           fmt::format("MultiPeerIbTransport: device allocation for {}", label));
       checkSlotGpu(
-          slotGpuMemset(allocation.devicePtr, 0, bytes),
+          slotGpuMemset(allocation.devicePtr, 0, allocation.bytes),
           fmt::format(
               "MultiPeerIbTransport: zero device allocation for {}", label));
       break;
@@ -2040,8 +2278,9 @@ void MultiPeerIbTransportBase::allocatePeerSignalCounterResources(
   if (config_.numSignalSlots > 0) {
     const std::size_t signalBytes =
         static_cast<std::size_t>(config_.numSignalSlots) * sizeof(uint64_t);
-    freeDeviceSlotAllocation(lazySlotSignalAllocations_[peerIndex]);
-    auto allocation =
+    auto& allocation = lazySlotSignalAllocations_[peerIndex];
+    freeDeviceSlotAllocation(allocation);
+    allocation =
         allocateDeviceSlotAllocation(signalBytes, "lazy slot signal buffer");
     auto localSignalBuf = registerSlotMemory(
         allocation.ptr,
@@ -2050,21 +2289,20 @@ void MultiPeerIbTransportBase::allocatePeerSignalCounterResources(
         allocation.registered);
     payload.slotSignal = registeredSlotMemoryExchInfo(allocation.ptr);
     slotLocalSignalViews_[peerIndex] = localSignalBuf;
-    lazySlotSignalAllocations_[peerIndex] = std::move(allocation);
   }
 
   if (config_.numCounterSlots > 0) {
     const std::size_t counterBytes =
         static_cast<std::size_t>(config_.numCounterSlots) * sizeof(uint64_t);
-    freeCounterSlotAllocation(lazySlotCounterAllocations_[peerIndex]);
-    auto allocation = allocateCounterSlotAllocation(
+    auto& allocation = lazySlotCounterAllocations_[peerIndex];
+    freeCounterSlotAllocation(allocation);
+    allocation = allocateCounterSlotAllocation(
         counterStorage, counterBytes, "lazy slot counter buffer");
     if (counterStorage == IbCounterStorage::HostPinned) {
       slotCounterDeviceViews_[peerIndex] =
           IbgdaLocalBuffer(allocation.devicePtr, NetworkLKeys{});
       slotCounterHostViews_[peerIndex] =
           IbgdaLocalBuffer(allocation.hostPtr, NetworkLKeys{});
-      lazySlotCounterAllocations_[peerIndex] = std::move(allocation);
     } else {
       auto localCounterBuf = registerSlotMemory(
           allocation.devicePtr,
@@ -2073,13 +2311,13 @@ void MultiPeerIbTransportBase::allocatePeerSignalCounterResources(
           allocation.registered);
       slotCounterDeviceViews_[peerIndex] = localCounterBuf;
       slotCounterHostViews_[peerIndex] = localCounterBuf;
-      lazySlotCounterAllocations_[peerIndex] = std::move(allocation);
     }
   }
 
   if (allocateDiscardSignal && config_.numCounterSlots > 0) {
-    freeDeviceSlotAllocation(lazySlotDiscardSignalAllocations_[peerIndex]);
-    auto allocation = allocateDeviceSlotAllocation(
+    auto& allocation = lazySlotDiscardSignalAllocations_[peerIndex];
+    freeDeviceSlotAllocation(allocation);
+    allocation = allocateDeviceSlotAllocation(
         sizeof(uint64_t), "lazy slot discard-signal buffer");
     (void)registerSlotMemory(
         allocation.ptr,
@@ -2087,7 +2325,6 @@ void MultiPeerIbTransportBase::allocatePeerSignalCounterResources(
         allocation.bytes,
         allocation.registered);
     payload.slotDiscard = registeredSlotMemoryExchInfo(allocation.ptr);
-    lazySlotDiscardSignalAllocations_[peerIndex] = std::move(allocation);
   }
 }
 
@@ -2154,6 +2391,10 @@ uint32_t MultiPeerIbTransportBase::materializedChannelCount(
             nRanks_));
   }
   const std::lock_guard<std::mutex> lock(materializationMutex_);
+  if (materializationFailed_) {
+    throw std::runtime_error(
+        "MultiPeerIbTransport: peer materialization previously failed");
+  }
   return materializedChannels_[rankToPeerIndex(peerRank)];
 }
 
@@ -2169,6 +2410,14 @@ void MultiPeerIbTransportBase::logPeersMaterialized(
   }
   LOG(INFO) << "MultiPeerIbTransport: rank " << myRank_ << " materialized "
             << peerCount << " peer(s) in " << elapsedMs << " ms";
+}
+
+void MultiPeerIbTransportBase::throwIfMaterializationFailed() const {
+  const std::lock_guard<std::mutex> lock(materializationMutex_);
+  if (materializationFailed_) {
+    throw std::runtime_error(
+        "MultiPeerIbTransport: peer materialization previously failed");
+  }
 }
 
 void MultiPeerIbTransportBase::queuePeerForMaterialization(
@@ -2197,9 +2446,8 @@ void MultiPeerIbTransportBase::queuePeerForMaterialization(
             channelCapacity()));
   }
   const int peerIndex = rankToPeerIndex(peerRank);
-  // Requested lazy-channel mode remains an eager fallback until the
-  // incremental backend and rank-agreement protocol are available.
-  const uint32_t materializationTarget = channelCapacity();
+  const uint32_t materializationTarget =
+      lazyChannelGrowthEnabled_ ? targetChannels : channelCapacity();
   if (materializationTarget <= materializedChannels_[peerIndex]) {
     return;
   }
@@ -2286,10 +2534,44 @@ void MultiPeerIbTransportBase::exchangeRawWithPeer(
     std::size_t bytes,
     int phase) {
   constexpr int64_t kPrimsPeerTagBase = 1 << 16;
+  constexpr int64_t kLazyPhasesPerPeerPair = 4;
+  constexpr int64_t kEagerPhasesPerPeerPair = 2;
+  int wirePhase = phase;
+  int64_t phasesPerPeerPair = kLazyPhasesPerPeerPair;
+  int64_t generationsPerPeerPair = kMaxIbGroups;
+  uint32_t generation =
+      materializationGenerations_.at(rankToPeerIndex(peerRank));
+  if (!channelRangeProtocolEnabled_) {
+    phasesPerPeerPair = kEagerPhasesPerPeerPair;
+    generationsPerPeerPair = 1;
+    generation = 0;
+    if (phase == kIbPeerQpExchangeTag) {
+      wirePhase = 0;
+    } else if (phase == kIbPeerBufferExchangeTag) {
+      wirePhase = 1;
+    } else {
+      throw std::invalid_argument(
+          fmt::format("invalid eager peer materialization phase {}", phase));
+    }
+  } else {
+    if (phase < 0 || phase >= kLazyPhasesPerPeerPair) {
+      throw std::invalid_argument(
+          fmt::format("invalid peer materialization phase {}", phase));
+    }
+    if (generation >= kMaxIbGroups) {
+      throw std::invalid_argument(
+          fmt::format(
+              "invalid peer materialization generation {}; maximum is {}",
+              generation,
+              kMaxIbGroups - 1));
+    }
+  }
   const int lowRank = std::min(myRank_, peerRank);
   const int highRank = std::max(myRank_, peerRank);
   const int64_t pairIndex = static_cast<int64_t>(lowRank) * nRanks_ + highRank;
-  const int64_t tagValue = kPrimsPeerTagBase + pairIndex * 2 + phase;
+  const int64_t tagValue = kPrimsPeerTagBase +
+      (pairIndex * generationsPerPeerPair + generation) * phasesPerPeerPair +
+      wirePhase;
   if (tagValue > std::numeric_limits<int>::max()) {
     throw std::runtime_error("materializePeer: bootstrap tag overflow");
   }

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -274,6 +274,32 @@ checkedRangeEnd(const void* ptr, std::size_t size, const char* operation) {
 }
 } // namespace
 
+MultipeerIbTransportConfig
+MultipeerIbTransportConfig::normalizedChannelGeometry() const {
+  auto normalized = *this;
+  if (normalized.perChannelSize > 0) {
+    if (normalized.max_num_channels <= 0) {
+      throw std::invalid_argument(
+          "max_num_channels must be positive when perChannelSize is set");
+    }
+    if (normalized.perChannelSize < 16) {
+      throw std::invalid_argument(
+          "IB fixed-channel perChannelSize must be >= 16");
+    }
+    if (normalized.perChannelSize % 16 != 0) {
+      throw std::invalid_argument(
+          "IB fixed-channel perChannelSize must be 16-byte aligned");
+    }
+    normalized.dataBufferSize = normalized.fixedChannelDataBufferSize();
+    normalized.maxGroups = normalized.max_num_channels;
+    normalized.qpsPerBlockPerNic = normalized.qpsPerConnection;
+  } else {
+    normalized.max_num_channels = normalized.maxGroups;
+    normalized.qpsPerConnection = normalized.qpsPerBlockPerNic;
+  }
+  return normalized;
+}
+
 MultiPeerIbTransportBase::MultiPeerIbTransportBase(
     int myRank,
     int nRanks,
@@ -282,23 +308,7 @@ MultiPeerIbTransportBase::MultiPeerIbTransportBase(
     : myRank_(myRank),
       nRanks_(nRanks),
       bootstrap_(std::move(bootstrap)),
-      config_(std::move(config)) {
-  if (config_.perChannelSize > 0) {
-    if (config_.max_num_channels <= 0) {
-      throw std::invalid_argument(
-          "max_num_channels must be positive when perChannelSize is set");
-    }
-    if (config_.perChannelSize < 16) {
-      throw std::invalid_argument(
-          "IB fixed-channel perChannelSize must be >= 16");
-    }
-    if (config_.perChannelSize % 16 != 0) {
-      throw std::invalid_argument(
-          "IB fixed-channel perChannelSize must be 16-byte aligned");
-    }
-    config_.dataBufferSize = config_.fixedChannelDataBufferSize();
-    config_.maxGroups = config_.max_num_channels;
-  }
+      config_(config.normalizedChannelGeometry()) {
   if (myRank_ < 0 || myRank_ >= nRanks_) {
     throw std::invalid_argument("Invalid rank");
   }

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -315,6 +315,8 @@ MultiPeerIbTransportBase::MultiPeerIbTransportBase(
   if (nRanks_ < 2) {
     throw std::invalid_argument("Need at least 2 ranks");
   }
+  peerMaterialized_.resize(nRanks_ - 1, false);
+  materializedChannels_.resize(nRanks_ - 1, 0);
   if (auto isolatedBootstrap = bootstrap_->duplicate()) {
     bootstrap_ =
         std::shared_ptr<meta::comms::IBootstrap>(std::move(isolatedBootstrap));
@@ -382,6 +384,67 @@ MultiPeerIbTransportBase::MultiPeerIbTransportBase(
 // against a complete type (DeviceBuffer is only forward-declared in the
 // header).
 MultiPeerIbTransportBase::~MultiPeerIbTransportBase() = default;
+
+void MultiPeerIbTransportBase::populatePeerGeometry(
+    PeerQpPayload& payload) const {
+  payload.numNics = numNics_;
+  payload.numQpsPerPeerPerNic = config_.fixedChannelMainQpsPerPeerPerNic();
+  payload.maxGroups = config_.max_num_channels;
+  payload.qpsPerBlockPerNic = config_.qpsPerConnection;
+  payload.directionCount = config_.fixedChannelDirectionCount();
+  payload.pipelineDepth = config_.pipelineDepth;
+  payload.numSignalSlots = config_.numSignalSlots;
+  payload.numCounterSlots = config_.numCounterSlots;
+  payload.perChannelSize = static_cast<uint64_t>(config_.perChannelSize);
+}
+
+void MultiPeerIbTransportBase::validatePeerGeometry(
+    int peerRank,
+    const PeerQpPayload& remotePayload) const {
+  if (remotePayload.numNics != numNics_ ||
+      remotePayload.numQpsPerPeerPerNic !=
+          config_.fixedChannelMainQpsPerPeerPerNic() ||
+      remotePayload.maxGroups != config_.max_num_channels ||
+      remotePayload.qpsPerBlockPerNic != config_.qpsPerConnection) {
+    throw std::runtime_error(
+        fmt::format(
+            "peer {} IB QP geometry mismatch: remote nics={} qps={} "
+            "channels={} qpsPerConnection={}, local nics={} qps={} "
+            "channels={} qpsPerConnection={}",
+            peerRank,
+            remotePayload.numNics,
+            remotePayload.numQpsPerPeerPerNic,
+            remotePayload.maxGroups,
+            remotePayload.qpsPerBlockPerNic,
+            numNics_,
+            config_.fixedChannelMainQpsPerPeerPerNic(),
+            config_.max_num_channels,
+            config_.qpsPerConnection));
+  }
+  if (remotePayload.directionCount != config_.fixedChannelDirectionCount() ||
+      remotePayload.pipelineDepth != config_.pipelineDepth ||
+      remotePayload.numSignalSlots != config_.numSignalSlots ||
+      remotePayload.numCounterSlots != config_.numCounterSlots ||
+      remotePayload.perChannelSize !=
+          static_cast<uint64_t>(config_.perChannelSize)) {
+    throw std::runtime_error(
+        fmt::format(
+            "peer {} IB channel geometry mismatch: remote directions={} "
+            "pipeline={} signals={} counters={} bytes={}, local directions={} "
+            "pipeline={} signals={} counters={} bytes={}",
+            peerRank,
+            remotePayload.directionCount,
+            remotePayload.pipelineDepth,
+            remotePayload.numSignalSlots,
+            remotePayload.numCounterSlots,
+            remotePayload.perChannelSize,
+            config_.fixedChannelDirectionCount(),
+            config_.pipelineDepth,
+            config_.numSignalSlots,
+            config_.numCounterSlots,
+            config_.perChannelSize));
+  }
+}
 
 // ---- shared send/recv staging-ring lifecycle (eager mode) ----
 
@@ -2077,16 +2140,21 @@ IbgdaRemoteBuffer MultiPeerIbTransportBase::slotDiscardSignalRemoteView(
 }
 
 bool MultiPeerIbTransportBase::isPeerMaterialized(int peerRank) const {
+  return materializedChannelCount(peerRank) == channelCapacity();
+}
+
+uint32_t MultiPeerIbTransportBase::materializedChannelCount(
+    int peerRank) const {
   if (peerRank == myRank_ || peerRank < 0 || peerRank >= nRanks_) {
     throw std::invalid_argument(
         fmt::format(
-            "isPeerMaterialized: invalid peerRank={} (myRank={}, nRanks={})",
+            "materializedChannelCount: invalid peerRank={} (myRank={}, nRanks={})",
             peerRank,
             myRank_,
             nRanks_));
   }
   const std::lock_guard<std::mutex> lock(materializationMutex_);
-  return peerMaterialized_[rankToPeerIndex(peerRank)];
+  return materializedChannels_[rankToPeerIndex(peerRank)];
 }
 
 void MultiPeerIbTransportBase::logPeersMaterialized(
@@ -2103,7 +2171,9 @@ void MultiPeerIbTransportBase::logPeersMaterialized(
             << peerCount << " peer(s) in " << elapsedMs << " ms";
 }
 
-void MultiPeerIbTransportBase::queuePeerForMaterialization(int peerRank) {
+void MultiPeerIbTransportBase::queuePeerForMaterialization(
+    int peerRank,
+    uint32_t targetChannels) {
   const std::lock_guard<std::mutex> lock(materializationMutex_);
   if (materializationFailed_) {
     throw std::runtime_error(
@@ -2119,15 +2189,28 @@ void MultiPeerIbTransportBase::queuePeerForMaterialization(int peerRank) {
             myRank_,
             nRanks_));
   }
-  if (peerMaterialized_[rankToPeerIndex(peerRank)]) {
+  if (targetChannels == 0 || targetChannels > channelCapacity()) {
+    throw std::invalid_argument(
+        fmt::format(
+            "queuePeerForMaterialization: targetChannels={} must be in [1, {}]",
+            targetChannels,
+            channelCapacity()));
+  }
+  const int peerIndex = rankToPeerIndex(peerRank);
+  // Requested lazy-channel mode remains an eager fallback until the
+  // incremental backend and rank-agreement protocol are available.
+  const uint32_t materializationTarget = channelCapacity();
+  if (materializationTarget <= materializedChannels_[peerIndex]) {
     return;
   }
-  for (int p : pendingPeers_) {
-    if (p == peerRank) {
+  for (auto& pending : pendingPeers_) {
+    if (pending.rank == peerRank) {
+      pending.targetChannels =
+          std::max(pending.targetChannels, materializationTarget);
       return;
     }
   }
-  pendingPeers_.push_back(peerRank);
+  pendingPeers_.push_back({peerRank, materializationTarget});
 }
 
 std::vector<IbTransportExchInfoAll> MultiPeerIbTransportBase::allGatherExchInfo(

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -503,7 +503,9 @@ struct MultipeerIbTransportConfig {
   // on demand; false no longer enables eager all-peer allocation.
   bool ibLazyConnect{true};
 
-  // Materialize only the demanded channel prefix when the backend supports it.
+  // Enable per-peer channel-prefix growth on supporting backends. Unsupported
+  // backends retain full-capacity materialization on first peer use. All ranks
+  // in a communicator must use the same value.
   bool lazyChannels{false};
 };
 
@@ -747,9 +749,31 @@ struct IbTransportExchInfoAll {
 // exchangeRawWithPeer().
 constexpr int kIbPeerQpExchangeTag = 0;
 constexpr int kIbPeerBufferExchangeTag = 1;
+constexpr int kIbPeerChannelRequestTag = 2;
+constexpr int kIbPeerChannelReadyTag = 3;
 
-// Wire formats for bilateral peer materialization. Split into two phases: QP
-// info first (to connect), then buffer info (acts as QP-ready barrier).
+enum class PeerChannelBackend : uint32_t {
+  kIbgda = 0,
+};
+
+struct PeerChannelRequest {
+  uint32_t backend{0};
+  uint32_t beginChannel{0};
+  uint32_t endChannel{0};
+  uint32_t capacity{0};
+  uint32_t numNics{0};
+  uint32_t directionCount{0};
+  uint32_t qpsPerConnection{0};
+  uint32_t pipelineDepth{0};
+  uint64_t perChannelSize{0};
+
+  bool operator==(const PeerChannelRequest&) const = default;
+};
+
+static_assert(sizeof(PeerChannelRequest) == 40);
+
+// Wire formats for the request, QP, buffer, and ready phases of bilateral peer
+// materialization.
 //
 // WIRE FORMAT: PeerQpPayload is exchanged between peer ranks as raw bytes by
 // exchangeWithPeer(), which sends and expects exactly sizeof(PeerQpPayload).
@@ -938,6 +962,9 @@ class MultiPeerIbTransportBase {
         .count();
   }
 
+  /** Throw after a terminal materialization failure. */
+  void throwIfMaterializationFailed() const;
+
   /** @return Configured logical channel capacity for each peer. */
   uint32_t channelCapacity() const {
     return static_cast<uint32_t>(config_.max_num_channels);
@@ -951,7 +978,8 @@ class MultiPeerIbTransportBase {
       int myRank,
       int nRanks,
       std::shared_ptr<meta::comms::IBootstrap> bootstrap,
-      MultipeerIbTransportConfig config);
+      MultipeerIbTransportConfig config,
+      bool supportsLazyChannelPrefixGrowth = false);
 
   // Non-virtual protected dtor: the base is never owned/deleted polymorphically
   // (the dispatcher holds the concrete backend type). Defined out-of-line in
@@ -1001,10 +1029,10 @@ class MultiPeerIbTransportBase {
   // timeout and cancellation so caller-owned payloads remain live until the
   // exchange completes.
   template <typename T>
-  T exchangeWithPeer(int peerRank, const T& localPayload, int tag) {
+  T exchangeWithPeer(int peerRank, const T& localPayload, int phase) {
     T remotePayload{};
     exchangeRawWithPeer(
-        peerRank, &localPayload, &remotePayload, sizeof(T), tag);
+        peerRank, &localPayload, &remotePayload, sizeof(T), phase);
     return remotePayload;
   }
   void exchangeRawWithPeer(
@@ -1012,7 +1040,7 @@ class MultiPeerIbTransportBase {
       const void* localPayload,
       void* remotePayload,
       std::size_t bytes,
-      int tag);
+      int phase);
 
   // ---- shared send/recv staging-ring lifecycle (eager mode) ----
   // Backend-agnostic host send/recv buffer management, shared by IBGDA (Device
@@ -1024,6 +1052,7 @@ class MultiPeerIbTransportBase {
   bool sendRecvBuffersEnabled() const {
     return config_.perChannelSize > 0;
   }
+  IbChannelLayout sendRecvChannelGeometry() const;
   IbChannelLayout channelLayoutForPeer(int peerIndex) const;
   // Allocate + register the per-peer staging/signal bulks and slice them.
   // counterStorage selects the NIC_DONE counter: Device (transport-allocated,
@@ -1054,7 +1083,25 @@ class MultiPeerIbTransportBase {
   // its views. Safe on an unmaterialized peer.
   void cleanupSendRecvBufferForPeer(int peerIndex) noexcept;
 
+  // Allocate one immutable send/recv resource range. Channel descriptors keep
+  // these addresses for the communicator lifetime, so a later prefix growth
+  // appends another range instead of moving an already-published allocation.
+  IbChannelLayout allocateSendRecvChannelRange(
+      int peerIndex,
+      uint32_t beginChannel,
+      uint32_t endChannel,
+      PeerBufferPayload& payload);
+  void applyRemoteSendRecvChannelRange(
+      IbChannelLayout& layout,
+      const PeerBufferPayload& remotePayload) const;
+  void cleanupSendRecvChannelRangesForPeer(int peerIndex) noexcept;
+
   void validateSendRecvConfig() const;
+  std::size_t deviceMrAllocationAlignment() const;
+  std::unique_ptr<meta::comms::DeviceBuffer> allocateDeviceMrBuffer(
+      std::size_t usedBytes,
+      std::size_t allocationAlignment,
+      const char* label) const;
   std::size_t sendRecvStagingBytesPerPeer() const;
   std::size_t sendRecvSignalBytesPerPeer() const;
   std::size_t sendRecvCounterBytesPerPeer() const;
@@ -1098,6 +1145,8 @@ class MultiPeerIbTransportBase {
   const int nRanks_{0};
   std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
   MultipeerIbTransportConfig config_;
+  bool channelRangeProtocolEnabled_{false};
+  bool lazyChannelGrowthEnabled_{false};
 
   // Number of NICs (rails) in use; resolved by the base constructor.
   int numNics_{1};
@@ -1177,6 +1226,7 @@ class MultiPeerIbTransportBase {
   // materializedChannels_ as the authoritative readiness state.
   std::vector<bool> peerMaterialized_;
   std::vector<uint32_t> materializedChannels_;
+  std::vector<uint32_t> materializationGenerations_;
   bool materializationFailed_{false};
 
  private:
@@ -1266,6 +1316,8 @@ class MultiPeerIbTransportBase {
   // NIC_DONE counter below.
   std::vector<std::unique_ptr<meta::comms::DeviceBuffer>> lazyPeerBufs_;
   std::vector<CounterSlotAllocation> lazySendRecvHostCounters_;
+  std::vector<std::vector<std::unique_ptr<meta::comms::DeviceBuffer>>>
+      lazyPeerChannelRangeBufs_;
 };
 
 /**
@@ -1273,8 +1325,8 @@ class MultiPeerIbTransportBase {
  *
  * Holds ONLY the small piece of control plane that must call into the concrete
  * backend: the lazy connect loop (connectPeers) drives the backend's per-peer
- * doMaterializePeer()/cleanupPeerOnFailure() hooks via a static `backend()`
- * downcast (no vtable). Each backend derives as
+ * materializePeerChannelRange() hook via a static `backend()` downcast (no
+ * vtable). Each backend derives as
  *   `class MultipeerIbgdaTransport : public
  * MultiPeerIbTransport<MultipeerIbgdaTransport>`.
  * All backend-agnostic state and methods are inherited from the non-template
@@ -1305,7 +1357,8 @@ class MultiPeerIbTransport : public MultiPeerIbTransportBase {
             myRank,
             nRanks,
             std::move(bootstrap),
-            std::move(config)) {}
+            std::move(config),
+            backendSupportsLazyChannelPrefixGrowth()) {}
 
   ~MultiPeerIbTransport() = default;
 
@@ -1315,6 +1368,20 @@ class MultiPeerIbTransport : public MultiPeerIbTransportBase {
   }
   const Backend& backend() const {
     return static_cast<const Backend&>(*this);
+  }
+
+  static constexpr bool backendSupportsLazyChannelPrefixGrowth() {
+    if constexpr (requires { Backend::supportsLazyChannelPrefixGrowth(); }) {
+      return Backend::supportsLazyChannelPrefixGrowth();
+    }
+    return false;
+  }
+
+  static constexpr PeerChannelBackend backendPeerChannel() {
+    if constexpr (backendSupportsLazyChannelPrefixGrowth()) {
+      return Backend::kPeerChannelBackend;
+    }
+    return PeerChannelBackend::kIbgda;
   }
 
   void materializeBackendRange(
@@ -1339,6 +1406,21 @@ class MultiPeerIbTransport : public MultiPeerIbTransportBase {
             "legacy IB backend requires full-capacity materialization");
       }
       backend().doMaterializePeer(peerRank);
+    }
+  }
+
+  void handleBackendMaterializationFailure(
+      const std::vector<int>& touchedPeerIndexes) {
+    if constexpr (requires(Backend& value) {
+                    value.onTerminalMaterializationFailure();
+                  }) {
+      backend().onTerminalMaterializationFailure();
+    } else if constexpr (requires(Backend& value, int peerIndex) {
+                           value.cleanupPeerOnFailure(peerIndex);
+                         }) {
+      for (const int peerIndex : touchedPeerIndexes) {
+        backend().cleanupPeerOnFailure(peerIndex);
+      }
     }
   }
 };
@@ -1372,6 +1454,7 @@ void MultiPeerIbTransport<Backend>::connectPeers() {
   touchedPeerIndexes.reserve(peers.size());
 
   const auto startTime = std::chrono::steady_clock::now();
+  std::size_t touchedPeerCount = 0;
   try {
     for (const auto& peer : peers) {
       const int peerIndex = rankToPeerIndex(peer.rank);
@@ -1379,33 +1462,53 @@ void MultiPeerIbTransport<Backend>::connectPeers() {
         continue;
       }
       const uint32_t oldChannels = materializedChannels_[peerIndex];
+      ++touchedPeerCount;
       touchedPeerIndexes.push_back(peerIndex);
+      const PeerChannelRequest request{
+          .backend = static_cast<uint32_t>(backendPeerChannel()),
+          .beginChannel = oldChannels,
+          .endChannel = peer.targetChannels,
+          .capacity = channelCapacity(),
+          .numNics = static_cast<uint32_t>(numNics_),
+          .directionCount =
+              static_cast<uint32_t>(config_.fixedChannelDirectionCount()),
+          .qpsPerConnection = static_cast<uint32_t>(config_.qpsPerConnection),
+          .pipelineDepth = static_cast<uint32_t>(config_.pipelineDepth),
+          .perChannelSize = config_.perChannelSize,
+      };
+      if (channelRangeProtocolEnabled_ &&
+          exchangeWithPeer(peer.rank, request, kIbPeerChannelRequestTag) !=
+              request) {
+        throw std::runtime_error(
+            "MultiPeerIbTransport: peer channel request mismatch");
+      }
       materializeBackendRange(peer.rank, oldChannels, peer.targetChannels);
+      if (channelRangeProtocolEnabled_ &&
+          exchangeWithPeer(peer.rank, request, kIbPeerChannelReadyTag) !=
+              request) {
+        throw std::runtime_error(
+            "MultiPeerIbTransport: peer channel ready mismatch");
+      }
       materializedChannels_[peerIndex] = peer.targetChannels;
       peerMaterialized_[peerIndex] = true;
+      ++materializationGenerations_[peerIndex];
     }
   } catch (...) {
     materializationFailed_ = true;
     pendingPeers_.clear();
-    for (int peerIndex : touchedPeerIndexes) {
-      peerMaterialized_[peerIndex] = false;
-      materializedChannels_[peerIndex] = 0;
-    }
     lock.unlock();
     // Report elapsed on the way out too: a rendezvous that stalls and then
     // errors is the case where the timing matters most.
-    logPeersMaterialized(
-        touchedPeerIndexes.size(), elapsedMsSince(startTime), /*failed=*/true);
-    for (int peerIndex : touchedPeerIndexes) {
-      backend().cleanupPeerOnFailure(peerIndex);
-    }
+    const std::int64_t elapsedMs = elapsedMsSince(startTime);
+    handleBackendMaterializationFailure(touchedPeerIndexes);
+    logPeersMaterialized(touchedPeerCount, elapsedMs, /*failed=*/true);
     throw;
   }
   // A rank blocks here until each peer reaches the matching rendezvous, so this
   // reports queue wait as well as local work. Elapsed far above the per-peer
   // cost means peers are arriving late, not that materialization is slow.
   logPeersMaterialized(
-      touchedPeerIndexes.size(), elapsedMsSince(startTime), /*failed=*/false);
+      touchedPeerCount, elapsedMsSince(startTime), /*failed=*/false);
 }
 
 } // namespace comms::prims

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -502,6 +502,9 @@ struct MultipeerIbTransportConfig {
   // Deprecated compatibility setting. Per-peer state is always materialized
   // on demand; false no longer enables eager all-peer allocation.
   bool ibLazyConnect{true};
+
+  // Materialize only the demanded channel prefix when the backend supports it.
+  bool lazyChannels{false};
 };
 
 // Whether Data-Direct MR registration applies for a NIC: Data-Direct is
@@ -777,6 +780,11 @@ struct PeerQpPayload {
   // agree or one side's log_rra_max will not cover the other's log_sra_max.
   // Defaults to the same 1 the transport resolves when nobody raises the depth.
   int maxRdAtomic{1};
+  int directionCount{0};
+  int pipelineDepth{0};
+  int numSignalSlots{0};
+  int numCounterSlots{0};
+  uint64_t perChannelSize{0};
 };
 
 struct PeerBufferPayload {
@@ -903,8 +911,16 @@ class MultiPeerIbTransportBase {
   std::vector<IbgdaRemoteBuffer> exchangeBuffer(
       const IbgdaLocalBuffer& localBuf);
 
-  /** Queue a peer for lazy materialization (no network I/O). */
-  void queuePeerForMaterialization(int peerRank);
+  /** Queue a peer/channel target, max-merging repeated requests. */
+  void queuePeerForMaterialization(int peerRank, uint32_t targetChannels);
+
+  /** Compatibility wrapper that requests the peer's full channel capacity. */
+  void queuePeerForMaterialization(int peerRank) {
+    queuePeerForMaterialization(peerRank, channelCapacity());
+  }
+
+  /** @return Number of materialized channels currently ready for this peer. */
+  uint32_t materializedChannelCount(int peerRank) const;
 
   /**
    * Report the outcome of a connectPeers() round. Defined out-of-line so this
@@ -922,7 +938,12 @@ class MultiPeerIbTransportBase {
         .count();
   }
 
-  /** @return true if the peer is materialized and ready for kernel use. */
+  /** @return Configured logical channel capacity for each peer. */
+  uint32_t channelCapacity() const {
+    return static_cast<uint32_t>(config_.max_num_channels);
+  }
+
+  /** @return true if the peer's full capacity is ready for legacy access. */
   bool isPeerMaterialized(int peerRank) const;
 
  protected:
@@ -963,6 +984,10 @@ class MultiPeerIbTransportBase {
   // info (indexed by global rank).
   std::vector<IbTransportExchInfoAll> allGatherExchInfo(
       const IbTransportExchInfoAll& localInfo);
+
+  void populatePeerGeometry(PeerQpPayload& payload) const;
+  void validatePeerGeometry(int peerRank, const PeerQpPayload& remotePayload)
+      const;
 
   // Validate every peer agrees on numNics (same-rail pairing precondition) and
   // numQpsPerPeerPerNic. Throws std::runtime_error on mismatch.
@@ -1142,9 +1167,16 @@ class MultiPeerIbTransportBase {
   // Lazy materialization state machine.
   // connectPeers() holds this lock through the backend/bootstrap exchange so
   // fixed bootstrap tags cannot be reused concurrently on one communicator.
+  struct PendingPeer {
+    int rank;
+    uint32_t targetChannels;
+  };
   mutable std::mutex materializationMutex_;
-  std::vector<int> pendingPeers_;
+  std::vector<PendingPeer> pendingPeers_;
+  // Kept for source compatibility with legacy CRTP backends. The base uses
+  // materializedChannels_ as the authoritative readiness state.
   std::vector<bool> peerMaterialized_;
+  std::vector<uint32_t> materializedChannels_;
   bool materializationFailed_{false};
 
  private:
@@ -1251,7 +1283,7 @@ class MultiPeerIbTransportBase {
 template <typename Backend>
 class MultiPeerIbTransport : public MultiPeerIbTransportBase {
  public:
-  /** Materialize one peer (queue + connect). */
+  /** Compatibility wrapper that materializes one peer at full capacity. */
   void materializePeer(int peerRank) {
     queuePeerForMaterialization(peerRank);
     connectPeers();
@@ -1284,13 +1316,38 @@ class MultiPeerIbTransport : public MultiPeerIbTransportBase {
   const Backend& backend() const {
     return static_cast<const Backend&>(*this);
   }
+
+  void materializeBackendRange(
+      int peerRank,
+      uint32_t oldChannels,
+      uint32_t newChannels) {
+    if constexpr (requires(Backend& value) {
+                    value.materializePeerChannelRange(
+                        peerRank, oldChannels, newChannels);
+                  }) {
+      backend().materializePeerChannelRange(peerRank, oldChannels, newChannels);
+    } else if constexpr (requires(Backend& value) {
+                           value.doMaterializePeer(
+                               peerRank, oldChannels, newChannels);
+                         }) {
+      backend().doMaterializePeer(peerRank, oldChannels, newChannels);
+    } else {
+      static_assert(
+          requires(Backend& value) { value.doMaterializePeer(peerRank); });
+      if (oldChannels != 0 || newChannels != channelCapacity()) {
+        throw std::logic_error(
+            "legacy IB backend requires full-capacity materialization");
+      }
+      backend().doMaterializePeer(peerRank);
+    }
+  }
 };
 
 template <typename Backend>
 void MultiPeerIbTransport<Backend>::connectPeers() {
   // queuePeerForMaterialization() releases this mutex before entering here;
-  // backend hooks must not recursively call materializePeer()/connectPeers().
-  const std::lock_guard<std::mutex> lock(materializationMutex_);
+  // backend hooks must not recursively call connectPeers().
+  std::unique_lock<std::mutex> lock(materializationMutex_);
   if (materializationFailed_) {
     pendingPeers_.clear();
     throw std::runtime_error(
@@ -1301,24 +1358,40 @@ void MultiPeerIbTransport<Backend>::connectPeers() {
     return;
   }
   // Deadlock-free on a symmetric request graph; see peerMaterializationKey.
-  sortPendingPeers(myRank_, pendingPeers_);
+  std::sort(
+      pendingPeers_.begin(),
+      pendingPeers_.end(),
+      [this](const auto& lhs, const auto& rhs) {
+        return peerMaterializationKey(myRank_, lhs.rank) <
+            peerMaterializationKey(myRank_, rhs.rank);
+      });
 
-  std::vector<int> peers;
+  std::vector<PendingPeer> peers;
   peers.swap(pendingPeers_);
   std::vector<int> touchedPeerIndexes;
   touchedPeerIndexes.reserve(peers.size());
 
   const auto startTime = std::chrono::steady_clock::now();
   try {
-    for (int peerRank : peers) {
-      if (peerMaterialized_[rankToPeerIndex(peerRank)]) {
+    for (const auto& peer : peers) {
+      const int peerIndex = rankToPeerIndex(peer.rank);
+      if (peer.targetChannels <= materializedChannels_[peerIndex]) {
         continue;
       }
-      touchedPeerIndexes.push_back(rankToPeerIndex(peerRank));
-      backend().doMaterializePeer(peerRank);
+      const uint32_t oldChannels = materializedChannels_[peerIndex];
+      touchedPeerIndexes.push_back(peerIndex);
+      materializeBackendRange(peer.rank, oldChannels, peer.targetChannels);
+      materializedChannels_[peerIndex] = peer.targetChannels;
+      peerMaterialized_[peerIndex] = true;
     }
   } catch (...) {
     materializationFailed_ = true;
+    pendingPeers_.clear();
+    for (int peerIndex : touchedPeerIndexes) {
+      peerMaterialized_[peerIndex] = false;
+      materializedChannels_[peerIndex] = 0;
+    }
+    lock.unlock();
     // Report elapsed on the way out too: a rendezvous that stalls and then
     // errors is the case where the timing matters most.
     logPeersMaterialized(

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -280,13 +280,13 @@ struct MultipeerIbTransportConfig {
   // Per-peer data buffer size in bytes for raw put()/signal() users. When
   // perChannelSize is set for send()/recv(), the transport derives this as the
   // total fixed-channel staging size:
-  //   perChannelSize * max_num_channels
+  //   perChannelSize * totalChannelSlots()
   std::size_t dataBufferSize{0};
 
-  // Fixed-channel send/recv staging window size in bytes for one channel. When
-  // this is nonzero, pipelineDepth is the number of chunks within this channel
-  // window and dataBufferSize is derived as the total staging size across all
-  // channels.
+  // Fixed-channel send/recv staging window size in bytes for one
+  // (protocol, channel) resource slot. When this is nonzero, pipelineDepth is
+  // the number of chunks within this window and dataBufferSize is derived as
+  // the total staging size across all resource slots.
   std::size_t perChannelSize{0};
 
   // Maximum number of logical IB channels per peer in the fixed-channel model.
@@ -305,14 +305,12 @@ struct MultipeerIbTransportConfig {
   // slot-index API. Independent of send/recv's private counter buffers.
   int numCounterSlots{0};
 
-  // Maximum number of physical block groups that may own IB QP resources.
-  // Device-side IB QP selection uses ThreadGroup::block_id and requires
-  // block_id < maxGroups.
+  // Legacy raw put() channel count. When perChannelSize is zero, the transport
+  // uses this value as max_num_channels.
   int maxGroups{64};
 
-  // Legacy block-owned QP count for IBRC. IBGDA send/recv uses
-  // qpsPerConnection with the fixed-channel helpers below; IBRC moves to the
-  // fixed-channel shape in the following stack diff.
+  // Legacy raw put() QPs per channel and NIC. When perChannelSize is zero, the
+  // transport uses this value as qpsPerConnection.
   int qpsPerBlockPerNic{1};
 
   // Queue pair depth (outstanding WQEs per peer). BNXT bumps the default
@@ -337,6 +335,8 @@ struct MultipeerIbTransportConfig {
   // every selected NIC and enables the format only when all accept it, true
   // requires every NIC to accept it, and false forces ordinary ring CQs.
   std::optional<bool> enableCollapsedCq;
+
+  MultipeerIbTransportConfig normalizedChannelGeometry() const;
 
   int numQpsPerPeerPerNic() const {
     if (maxGroups < 0 || qpsPerBlockPerNic < 0) {
@@ -735,7 +735,7 @@ struct IbTransportExchInfoAll {
   // Number of QPs per (peer, NIC) used by this rank.
   int numQpsPerPeerPerNic{1};
 
-  // Block-owned QP shape.
+  // Legacy wire names for logical channel capacity and QP lanes per channel.
   int maxGroups{64};
   int qpsPerBlockPerNic{1};
 };
@@ -812,7 +812,7 @@ struct IbSendRecvPeerBuffers {
 
 /**
  * MultiPeerIbTransportBase - backend-agnostic host control plane shared by the
- * multi-peer IB transports (IBGDA today, IBRC next).
+ * multi-peer IB transports (IBGDA and IBRC).
  *
  * This is a NON-template base so its (heavy) method bodies live in
  * MultiPeerIbTransport.cc and are compiled exactly once, reused by every
@@ -992,10 +992,10 @@ class MultiPeerIbTransportBase {
   // ---- shared send/recv staging-ring lifecycle (eager mode) ----
   // Backend-agnostic host send/recv buffer management, shared by IBGDA (Device
   // counter, NIC loopback atomic) and IBRC (Host counter, CPU proxy). Staging
-  // = max_num_channels * perChannelSize per direction; signal is sized
-  // off max_num_channels. Per-peer staging + signal are device-registered;
-  // recvStaging + signal are collectively exchanged so peers can RDMA into our
-  // ring.
+  // = totalChannelSlots() * perChannelSize per direction; signal storage is
+  // sized from the same protocol-slot capacity. Per-peer staging + signal are
+  // device-registered; recvStaging + signal are collectively exchanged so
+  // peers can RDMA into our ring.
   bool sendRecvBuffersEnabled() const {
     return config_.perChannelSize > 0;
   }

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -2,6 +2,7 @@
 
 #include "comms/prims/transport/MultiPeerTransport.h"
 
+#include <algorithm>
 #include <stdexcept>
 #include <utility>
 #include <vector>
@@ -64,6 +65,106 @@ comms::fault_tolerance::AbortDevice makeAbortDeviceHandle(
 }
 
 } // namespace
+
+namespace detail {
+
+void validateChannelProtocolRecords(
+    std::span<const ChannelProtocolRecord> records) {
+  if (records.empty()) {
+    throw std::invalid_argument(
+        "channel protocol validation requires at least one rank");
+  }
+  for (size_t rank = 0; rank < records.size(); ++rank) {
+    const auto& record = records[rank];
+    if (record.mode != PrimsChannelMode::kEager &&
+        record.mode != PrimsChannelMode::kLazyPrefix) {
+      throw std::runtime_error(
+          "invalid channel protocol record from rank " + std::to_string(rank));
+    }
+  }
+  for (size_t rank = 1; rank < records.size(); ++rank) {
+    if (records[rank] != records.front()) {
+      throw std::runtime_error(
+          "channel protocol mismatch between rank 0 and rank " +
+          std::to_string(rank));
+    }
+  }
+}
+
+void exchangeAndValidateChannelProtocol(
+    meta::comms::IBootstrap& bootstrap,
+    int rank,
+    int nRanks,
+    const ChannelProtocolRecord& localRecord) {
+  std::vector<ChannelProtocolRecord> records(nRanks);
+  records.at(rank) = localRecord;
+  const int rc =
+      bootstrap
+          .allGather(
+              records.data(), sizeof(ChannelProtocolRecord), rank, nRanks)
+          .get();
+  if (rc != 0) {
+    throw std::runtime_error(
+        "channel protocol allGather failed with error " + std::to_string(rc));
+  }
+  validateChannelProtocolRecords(records);
+}
+
+void validatePrimsTransportRoutes(
+    std::span<const PrimsTransportRoute> routeMatrix,
+    int nRanks) {
+  const auto ranks = static_cast<size_t>(nRanks);
+  if (nRanks <= 0 || routeMatrix.size() != ranks * ranks) {
+    throw std::invalid_argument("invalid PRIMS transport route matrix");
+  }
+  const auto route = [&](int from, int to) {
+    return routeMatrix[static_cast<size_t>(from) * ranks + to];
+  };
+  for (int rank = 0; rank < nRanks; ++rank) {
+    if (route(rank, rank) != PrimsTransportRoute::kSelf) {
+      throw std::runtime_error(
+          "PRIMS transport route matrix has an invalid self edge");
+    }
+    for (int peer = rank + 1; peer < nRanks; ++peer) {
+      if (route(rank, peer) != route(peer, rank)) {
+        throw std::runtime_error(
+            "PRIMS transport route mismatch between rank " +
+            std::to_string(rank) + " and rank " + std::to_string(peer));
+      }
+    }
+  }
+}
+
+void exchangeAndValidatePrimsTransportRoutes(
+    meta::comms::IBootstrap& bootstrap,
+    int rank,
+    int nRanks,
+    std::span<const PrimsTransportRoute> localRoutes) {
+  if (localRoutes.size() != static_cast<size_t>(nRanks)) {
+    throw std::invalid_argument("invalid local PRIMS transport route row");
+  }
+  std::vector<PrimsTransportRoute> routeMatrix(
+      static_cast<size_t>(nRanks) * nRanks);
+  std::copy(
+      localRoutes.begin(),
+      localRoutes.end(),
+      routeMatrix.begin() + static_cast<size_t>(rank) * nRanks);
+  const int rc = bootstrap
+                     .allGather(
+                         routeMatrix.data(),
+                         nRanks * sizeof(PrimsTransportRoute),
+                         rank,
+                         nRanks)
+                     .get();
+  if (rc != 0) {
+    throw std::runtime_error(
+        "PRIMS transport route allGather failed with error " +
+        std::to_string(rc));
+  }
+  validatePrimsTransportRoutes(routeMatrix, nRanks);
+}
+
+} // namespace detail
 
 MultiPeerTransport::MultiPeerTransport(
     int myRank,
@@ -185,11 +286,14 @@ void MultiPeerTransport::initFromTopology(
             << " nvlLocalRank=" << nvlLocalRank_;
   }
 
-  // Create the IB sub-transport — the universal fallback for all non-NVL peers.
-  // Exactly one backend is built, selected by config.ibMode (kIbgda default;
-  // kIbrc selects the CPU-proxy backend).
+  // Create the selected IB backend when at least one peer prefers IB. Its
+  // global-rank table can also serve NVL-preferred peers when an algorithm
+  // explicitly requests an IBGDA fallback.
   if (!config.disableIb && !ibPeerRanks_.empty()) {
-    auto ibConfig = config.ibConfig;
+    auto ibConfig = config.ibConfig.normalizedChannelGeometry();
+    channelMode_ = ibConfig.lazyChannels ? detail::PrimsChannelMode::kLazyPrefix
+                                         : detail::PrimsChannelMode::kEager;
+    ibChannelCapacity_ = static_cast<uint32_t>(ibConfig.max_num_channels);
     ibConfig.cudaDevice = deviceId_;
     if (config.ibMode == IbBackendMode::kIbrc) {
       // IBRC's device waits sit on the CPU proxy, so the backend needs the
@@ -211,6 +315,10 @@ void MultiPeerTransport::initFromTopology(
 
 MultiPeerTransport::~MultiPeerTransport() {
   free_device_handle();
+}
+
+bool MultiPeerTransport::is_lazy_mode() const {
+  return true;
 }
 
 std::optional<int> MultiPeerTransport::ibgda_max_groups() const {
@@ -252,6 +360,32 @@ void MultiPeerTransport::setExternalNvlDataBuffers(
 }
 
 void MultiPeerTransport::exchange() {
+  const detail::ChannelProtocolRecord channelProtocol{
+      .mode = channelMode_,
+      .channelCapacity = ibChannelCapacity_,
+  };
+  detail::exchangeAndValidateChannelProtocol(
+      *bootstrap_, myRank_, nRanks_, channelProtocol);
+  std::vector<detail::PrimsTransportRoute> localRoutes;
+  localRoutes.reserve(typePerRank_.size());
+  for (const auto type : typePerRank_) {
+    switch (type) {
+      case TransportType::SELF:
+        localRoutes.push_back(detail::PrimsTransportRoute::kSelf);
+        break;
+      case TransportType::P2P_NVL:
+        localRoutes.push_back(detail::PrimsTransportRoute::kNvl);
+        break;
+      case TransportType::P2P_IBGDA:
+        localRoutes.push_back(detail::PrimsTransportRoute::kIbgda);
+        break;
+      case TransportType::P2P_IBRC:
+        localRoutes.push_back(detail::PrimsTransportRoute::kIbrc);
+        break;
+    }
+  }
+  detail::exchangeAndValidatePrimsTransportRoutes(
+      *bootstrap_, myRank_, nRanks_, localRoutes);
 #ifndef __HIP_PLATFORM_AMD__
   // CUDA driver-API init is required for the cuMem-based fabric / POSIX-FD
   // exchange paths. On AMD only the cudaIpc (hipIpc) path is available, so
@@ -345,15 +479,7 @@ P2pSelfTransportDevice MultiPeerTransport::get_p2p_self_transport_device()
   return P2pSelfTransportDevice{};
 }
 
-MultiPeerDeviceHandle MultiPeerTransport::get_device_handle(
-    const std::vector<int>& peers) {
-  if (!deviceHandleBuilt_) {
-    throw std::runtime_error(
-        "MultiPeerTransport::get_device_handle(peers) called before exchange()");
-  }
-  if (!peers.empty()) {
-    materializePeers(peers);
-  }
+MultiPeerDeviceHandle MultiPeerTransport::make_device_handle() const {
   return MultiPeerDeviceHandle{
       myRank_,
       nRanks_,
@@ -364,25 +490,41 @@ MultiPeerDeviceHandle MultiPeerTransport::get_device_handle(
   };
 }
 
-bool MultiPeerTransport::is_lazy_mode() const {
-  return true;
+MultiPeerDeviceHandle MultiPeerTransport::get_device_handle(
+    const std::vector<int>& peers) {
+  std::vector<PeerChannelDemand> demands;
+  demands.reserve(peers.size());
+  for (const int peer : peers) {
+    if (peer < 0 || peer >= nRanks_ || peer == myRank_) {
+      continue;
+    }
+    const auto type = typePerRank_[peer];
+    if (type == TransportType::P2P_IBGDA || type == TransportType::P2P_IBRC) {
+      demands.push_back({.peerRank = peer, .ibChannels = ibChannelCapacity_});
+    }
+  }
+  return get_device_handle(demands);
+}
+
+MultiPeerDeviceHandle MultiPeerTransport::get_device_handle(
+    std::initializer_list<int> peers) {
+  return get_device_handle(std::vector<int>(peers));
 }
 
 void MultiPeerTransport::materializePeers(const std::vector<int>& peers) {
-  auto materializeOn = [&](auto& ibTransport) {
-    for (int peer : peers) {
-      if (peer >= 0 && peer < nRanks_ && peer != myRank_ &&
-          (typePerRank_[peer] == TransportType::P2P_IBGDA ||
-           typePerRank_[peer] == TransportType::P2P_IBRC)) {
-        ibTransport->queuePeerForMaterialization(peer);
-      }
+  std::vector<PeerChannelDemand> demands;
+  demands.reserve(peers.size());
+  for (const int peer : peers) {
+    if (peer < 0 || peer >= nRanks_ || peer == myRank_) {
+      continue;
     }
-    ibTransport->connectPeers();
-  };
-  if (ibgdaTransport_) {
-    materializeOn(ibgdaTransport_);
-  } else if (ibrcTransport_) {
-    materializeOn(ibrcTransport_);
+    const auto type = typePerRank_[peer];
+    if (type == TransportType::P2P_IBGDA || type == TransportType::P2P_IBRC) {
+      demands.push_back({.peerRank = peer, .ibChannels = ibChannelCapacity_});
+    }
+  }
+  if (!demands.empty()) {
+    materializePeerChannels(demands);
   }
 }
 
@@ -391,6 +533,88 @@ void MultiPeerTransport::connectPeers() {
     ibgdaTransport_->connectPeers();
   } else if (ibrcTransport_) {
     ibrcTransport_->connectPeers();
+  }
+}
+
+MultiPeerDeviceHandle MultiPeerTransport::get_device_handle(
+    std::span<const PeerChannelDemand> demands) {
+  if (!deviceHandleBuilt_) {
+    throw std::runtime_error(
+        "MultiPeerTransport::get_device_handle called before exchange()");
+  }
+  for (const auto& demand : demands) {
+    if (demand.peerRank < 0 || demand.peerRank >= nRanks_ ||
+        demand.peerRank == myRank_) {
+      throw std::invalid_argument(
+          "peer channel demand contains an invalid peer rank");
+    }
+    if (demand.ibChannels > ibChannelCapacity_) {
+      throw std::invalid_argument(
+          "peer channel demand exceeds the configured IB capacity");
+    }
+    if (demand.ibChannels != 0) {
+      const auto type = typePerRank_[demand.peerRank];
+      const bool prefersIb =
+          type == TransportType::P2P_IBGDA || type == TransportType::P2P_IBRC;
+      if (!prefersIb && !ibgdaTransport_) {
+        throw std::invalid_argument(
+            "positive channel demand requires a preferred IB peer or an "
+            "IBGDA fallback");
+      }
+    }
+  }
+
+  std::vector<PeerChannelDemand> sortedDemands(demands.begin(), demands.end());
+  std::sort(
+      sortedDemands.begin(),
+      sortedDemands.end(),
+      [](const auto& lhs, const auto& rhs) {
+        return lhs.peerRank < rhs.peerRank;
+      });
+
+  std::vector<PeerChannelDemand> mergedDemands;
+  mergedDemands.reserve(sortedDemands.size());
+  for (size_t i = 0; i < sortedDemands.size();) {
+    const int peerRank = sortedDemands[i].peerRank;
+    uint32_t ibChannels = 0;
+    do {
+      ibChannels = std::max(ibChannels, sortedDemands[i].ibChannels);
+      ++i;
+    } while (i < sortedDemands.size() && sortedDemands[i].peerRank == peerRank);
+    if (ibChannels != 0) {
+      mergedDemands.push_back({.peerRank = peerRank, .ibChannels = ibChannels});
+    }
+  }
+  if (!mergedDemands.empty()) {
+    materializePeerChannels(mergedDemands);
+  }
+  return make_device_handle();
+}
+
+void MultiPeerTransport::prepare_ib_channels(
+    std::span<const int> peers,
+    uint32_t ibChannels) {
+  std::vector<PeerChannelDemand> demands;
+  demands.reserve(peers.size());
+  for (const int peer : peers) {
+    demands.push_back({.peerRank = peer, .ibChannels = ibChannels});
+  }
+  (void)get_device_handle(demands);
+}
+
+void MultiPeerTransport::materializePeerChannels(
+    std::span<const PeerChannelDemand> demands) {
+  auto materializeOn = [&](auto& ibTransport) {
+    for (const auto& demand : demands) {
+      ibTransport->queuePeerForMaterialization(
+          demand.peerRank, demand.ibChannels);
+    }
+    ibTransport->connectPeers();
+  };
+  if (ibgdaTransport_) {
+    materializeOn(ibgdaTransport_);
+  } else if (ibrcTransport_) {
+    materializeOn(ibrcTransport_);
   }
 }
 

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -542,6 +542,11 @@ MultiPeerDeviceHandle MultiPeerTransport::get_device_handle(
     throw std::runtime_error(
         "MultiPeerTransport::get_device_handle called before exchange()");
   }
+  if (ibgdaTransport_) {
+    ibgdaTransport_->throwIfMaterializationFailed();
+  } else if (ibrcTransport_) {
+    ibrcTransport_->throwIfMaterializationFailed();
+  }
   for (const auto& demand : demands) {
     if (demand.peerRank < 0 || demand.peerRank >= nRanks_ ||
         demand.peerRank == myRank_) {

--- a/comms/prims/transport/MultiPeerTransport.h
+++ b/comms/prims/transport/MultiPeerTransport.h
@@ -282,8 +282,9 @@ class MultiPeerTransport {
   MultimemNvlTransportDevice get_multimem_nvl_transport_device() const;
 
   /**
-   * Return the IBGDA device slot after materializing the peer at full capacity.
-   * Both endpoint ranks must enter this compatibility path for the same edge.
+   * Return the IBGDA device slot. If the peer has no prepared channels, both
+   * endpoint ranks must enter this compatibility path and the peer is
+   * materialized at full capacity. An already-prepared prefix is not expanded.
    *
    * @param globalPeerRank Global rank of the IBGDA peer.
    * @return Non-owning pointer to the GPU transport slot.
@@ -344,9 +345,13 @@ class MultiPeerTransport {
    * demand. The merged batch is passed to the backend's canonical peer-edge
    * ordering. Channel-lazy mode materializes the exact merged prefix without
    * rounding it upward.
-   * Both endpoints must demand each IB edge in the same connect round.
+   * Both endpoints must request the same exact prefix for each IB edge in the
+   * same connect round.
    * Channel-eager mode promotes every positive demand to full capacity.
-   * Demanded peers must be materialized before CUDA graph capture begins.
+   * On backends that support prefix growth, capture-time growth completes on
+   * graph-external device work before this call returns; graph replay performs
+   * no allocation or connection. Other backends must be prepared before
+   * capture and retain full-capacity materialization.
    */
   MultiPeerDeviceHandle get_device_handle(
       std::span<const PeerChannelDemand> demands);

--- a/comms/prims/transport/MultiPeerTransport.h
+++ b/comms/prims/transport/MultiPeerTransport.h
@@ -3,8 +3,11 @@
 #pragma once
 
 #include <cstdint>
+#include <initializer_list>
 #include <memory>
 #include <optional>
+#include <span>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
@@ -36,9 +39,57 @@ class Abort;
 
 namespace comms::prims {
 
-// Forward declaration — include MultiPeerDeviceHandle.cuh to use
-// get_device_handle(peers).
 struct MultiPeerDeviceHandle;
+
+namespace detail {
+
+enum class PrimsChannelMode : uint32_t {
+  kEager = 0,
+  kLazyPrefix = 1,
+};
+
+enum class PrimsTransportRoute : uint8_t {
+  kSelf = 0,
+  kNvl = 1,
+  kIbgda = 2,
+  kIbrc = 3,
+};
+
+struct ChannelProtocolRecord {
+  PrimsChannelMode mode{PrimsChannelMode::kEager};
+  uint32_t channelCapacity{0};
+
+  bool operator==(const ChannelProtocolRecord&) const = default;
+};
+
+static_assert(sizeof(ChannelProtocolRecord) == 8);
+static_assert(std::is_trivially_copyable_v<ChannelProtocolRecord>);
+
+void validateChannelProtocolRecords(
+    std::span<const ChannelProtocolRecord> records);
+
+void exchangeAndValidateChannelProtocol(
+    meta::comms::IBootstrap& bootstrap,
+    int rank,
+    int nRanks,
+    const ChannelProtocolRecord& localRecord);
+
+void validatePrimsTransportRoutes(
+    std::span<const PrimsTransportRoute> routeMatrix,
+    int nRanks);
+
+void exchangeAndValidatePrimsTransportRoutes(
+    meta::comms::IBootstrap& bootstrap,
+    int rank,
+    int nRanks,
+    std::span<const PrimsTransportRoute> localRoutes);
+
+} // namespace detail
+
+struct PeerChannelDemand {
+  int peerRank;
+  uint32_t ibChannels;
+};
 
 struct MultiPeerTransportConfig {
   MultiPeerNvlTransportConfig nvlConfig;
@@ -51,31 +102,32 @@ struct MultiPeerTransportConfig {
   // See TopologyConfig for field-level documentation.
   TopologyConfig topoConfig;
 
-  // When true, IBGDA transport is never constructed and all non-self peers
+  // When true, no IB transport is constructed and all non-self peers
   // are routed over NVLink. Requires all ranks in the same NVL domain.
   bool disableIb{false};
 };
 
 /**
- * MultiPeerTransport - Host-side wrapper unifying NVLink, IBGDA, and
+ * MultiPeerTransport - Host-side wrapper unifying NVLink, IBGDA, IBRC, and
  * Self transports.
  *
- * IBGDA is the universal transport created for ALL non-self peers.
- * NVL is additionally created for NVLink-connected peers and is preferred
- * when available. get_transport_type() returns the preferred transport.
+ * NVL is created for NVLink-connected peers. The selected IB backend is
+ * created when at least one peer prefers IB; IBGDA can then also serve any
+ * non-self peer as an explicit fallback. get_transport_type() returns the
+ * preferred transport.
  *
  * Construction:
  *   1. Discovers topology (NVLink peers) via bootstrap allGather
  *      + cudaDeviceCanAccessPeer
  *   2. Creates MultiPeerNvlTransport for NVLink-reachable peers
  *      (using NvlBootstrapAdapter for local rank mapping)
- *   3. Always creates MultipeerIbgdaTransport for ALL peers
- *      (using full global rank space)
+ *   3. Creates the selected IB backend when the topology has IB peers
+ *      (using the full global rank space)
  *
  * Usage:
  *   auto transport = MultiPeerTransport(myRank, nRanks, deviceId, bootstrap,
- * config); transport.exchange();                            // COLLECTIVE auto
- * handle = transport.get_device_handle(peers); // For kernels
+ * config); transport.exchange(); // COLLECTIVE
+ * handle = transport.get_device_handle(demands); // For kernels
  */
 class MultiPeerTransport {
  public:
@@ -102,7 +154,7 @@ class MultiPeerTransport {
   MultiPeerTransport& operator=(MultiPeerTransport&&) = delete;
 
   /**
-   * COLLECTIVE: exchanges NVLink memory handles and IBGDA RDMA info.
+   * COLLECTIVE: exchanges NVLink memory handles and IB RDMA info.
    * All nRanks must call this.
    */
   void exchange();
@@ -230,8 +282,11 @@ class MultiPeerTransport {
   MultimemNvlTransportDevice get_multimem_nvl_transport_device() const;
 
   /**
+   * Return the IBGDA device slot after materializing the peer at full capacity.
+   * Both endpoint ranks must enter this compatibility path for the same edge.
+   *
    * @param globalPeerRank Global rank of the IBGDA peer.
-   * @return Non-owning pointer to GPU-allocated P2pIbgdaTransportDevice.
+   * @return Non-owning pointer to the GPU transport slot.
    */
   P2pIbgdaTransportDevice* get_p2p_ibgda_transport_device(
       int globalPeerRank) const;
@@ -242,14 +297,16 @@ class MultiPeerTransport {
   // --- Device handle (for passing to kernels) ---
 
   /**
-   * Materialize the specified IBGDA peers, then return the device handle.
-   * Use with lazy mode for DeviceWindow or direct Transport[] access.
+   * Compatibility overload for callers without channel geometry. Each valid
+   * IB peer is materialized at full configured capacity.
    *
-   * @param peers List of peer ranks to materialize
    * @throws std::runtime_error if called before exchange() or if peer
    * materialization fails.
    */
   MultiPeerDeviceHandle get_device_handle(const std::vector<int>& peers);
+
+  // Preserve source compatibility for calls such as get_device_handle({}).
+  MultiPeerDeviceHandle get_device_handle(std::initializer_list<int> peers);
 
   bool is_lazy_mode() const;
 
@@ -278,13 +335,44 @@ class MultiPeerTransport {
    */
   std::optional<int> nvl_max_num_channels() const;
 
-  /*
-   * Every requested edge must be requested by both endpoint ranks in the same
-   * connect round. Peer-vector order may differ between ranks.
+  /**
+   * Ensure the requested peer/channel prefixes are ready and return the
+   * stable device handle.
+   *
+   * A positive demand performs the peer's first connection when needed and
+   * grows an existing connection otherwise. Duplicate peers use their maximum
+   * demand. The merged batch is passed to the backend's canonical peer-edge
+   * ordering. Channel-lazy mode materializes the exact merged prefix without
+   * rounding it upward.
+   * Both endpoints must demand each IB edge in the same connect round.
+   * Channel-eager mode promotes every positive demand to full capacity.
+   * Demanded peers must be materialized before CUDA graph capture begins.
+   */
+  MultiPeerDeviceHandle get_device_handle(
+      std::span<const PeerChannelDemand> demands);
+
+  /**
+   * Ensure the same IB channel prefix is ready for every requested peer.
+   * This is the uniform-demand form for collectives that use the same channel
+   * count on every involved peer. It has the same validation and ordering
+   * requirements as the demand overload above.
+   */
+  void prepare_ib_channels(std::span<const int> peers, uint32_t ibChannels);
+
+  /**
+   * Compatibility entry point that materializes valid IB peers at full
+   * capacity. Every requested edge must be requested by both endpoint ranks in
+   * the same connect round; peer-vector order may differ between ranks.
    */
   void materializePeers(const std::vector<int>& peers);
 
+  /** Connect peers previously queued directly on the selected IB backend. */
   void connectPeers();
+
+  /** @return Configured IB channel capacity for each peer. */
+  uint32_t ib_channel_capacity() const {
+    return ibChannelCapacity_;
+  }
 
   // --- IBGDA buffer registration (delegates to ibgdaTransport_) ---
 
@@ -381,6 +469,8 @@ class MultiPeerTransport {
   // IBRC functional entry points fail fast until the backend is implemented.
   std::unique_ptr<MultipeerIbgdaTransport> ibgdaTransport_;
   std::unique_ptr<MultipeerIbrcTransport> ibrcTransport_;
+  detail::PrimsChannelMode channelMode_{detail::PrimsChannelMode::kEager};
+  uint32_t ibChannelCapacity_{0};
 
   // --- GPU-allocated transport array for device handle ---
   Transport* transportsGpu_{nullptr};
@@ -390,6 +480,8 @@ class MultiPeerTransport {
   void initFromTopology(
       TopologyResult topo,
       const MultiPeerTransportConfig& config);
+  MultiPeerDeviceHandle make_device_handle() const;
+  void materializePeerChannels(std::span<const PeerChannelDemand> demands);
   void build_device_handle();
   void free_device_handle();
 

--- a/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
@@ -174,7 +174,6 @@ struct ChannelSlotView {
   IbLocalChannel& channel; ///< shared: sendQp, recvQp, recvDataReadyLaneCursor
   IbChannelProtoSlot& local; ///< this protocol's cursors and local buffer views
   IbRemoteChannel remote; ///< this protocol's peer-side views
-  std::size_t stagingBase; ///< byte offset of this slot's staging window
 };
 
 template <typename P, typename Transport>
@@ -1328,7 +1327,6 @@ __device__ __forceinline__ void send_impl(
       const int ringSlot = static_cast<int>(absSlot % pipelineDepth);
       const uint64_t pipelineCycle = absSlot / pipelineDepth;
       const std::size_t stagingOff =
-          static_cast<std::size_t>(groupId) * pipelineBytes +
           static_cast<std::size_t>(ringSlot) * perBlockSlot +
           subStep * chunkStride;
       const std::size_t dataOff = s * chunkSize;
@@ -1349,7 +1347,7 @@ __device__ __forceinline__ void send_impl(
       //     return value is the compressed byte count the leader uses to size
       //     the RDMA put.
       const std::size_t copyResult = CopyOp::send(
-          channelLayout.sendStagingPtr + stagingOff,
+          static_cast<char*>(ch.local.sendStaging.ptr) + stagingOff,
           static_cast<const char*>(src) + dataOff,
           bytesThis,
           group,
@@ -1391,7 +1389,7 @@ __device__ __forceinline__ void send_impl(
             0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
         const auto completion = transport.put(
             solo,
-            channelLayout.sendStagingBuf.subBuffer(stagingOff),
+            ch.local.sendStaging.subBuffer(stagingOff),
             remoteChannel.recvStaging.subBuffer(stagingOff),
             copyResult,
             remoteChannel.dataReady,
@@ -1446,7 +1444,7 @@ __device__ __forceinline__ void send_impl(
           (isFinalChunk ? Proto::wire_bytes(protocolTailPadding) : 0);
       const std::size_t validBytes =
           valid_payload_bytes(dataOff, payloadBytes, nbytes);
-      const std::size_t stagingOff = ch.stagingBase +
+      const std::size_t stagingOff =
           static_cast<std::size_t>(slot) * perBlockSlotWire +
           Proto::wire_bytes(chunkOff);
       const uint64_t streamWire = Proto::wire_bytes(streamPayload);
@@ -1495,7 +1493,7 @@ __device__ __forceinline__ void send_impl(
       [[maybe_unused]] const SendSignal sig = prepareSendBuf<CopyOp>(
           Proto{},
           group,
-          channelLayout.sendStagingPtr + stagingOff,
+          static_cast<char*>(ch.local.sendStaging.ptr) + stagingOff,
           static_cast<const char*>(src) + dataOff,
           payloadBytes,
           nbytes,
@@ -1575,7 +1573,7 @@ __device__ __forceinline__ void send_impl(
               bytesThis);
           const auto completion = transport.put(
               solo,
-              channelLayout.sendStagingBuf.subBuffer(stagingOff),
+              ch.local.sendStaging.subBuffer(stagingOff),
               remoteChannel.recvStaging.subBuffer(stagingOff),
               bytesThis,
               sig.buf,
@@ -1614,7 +1612,7 @@ __device__ __forceinline__ void send_impl(
         ibOps->submit_send(
             transport,
             group,
-            channelLayout.sendStagingBuf.subBuffer(stagingOff),
+            ch.local.sendStaging.subBuffer(stagingOff),
             stagingOff,
             bytesThis,
             protocolBytesThis,
@@ -1766,13 +1764,11 @@ __device__ __forceinline__ void recv_impl(
   auto& channelLayout = transport.channel_layout();
   const SendRecvGeometry geometry =
       calcGeometry(Proto{}, channelLayout, group, nbytes, max_signal_bytes);
-  const int groupId = geometry.groupId;
   const std::size_t perBlockSlotWire = geometry.perBlockSlotWire;
   const std::size_t perBlockSlotPayload = geometry.perBlockSlotPayload;
   [[maybe_unused]] const std::size_t chunkPayload = geometry.chunkPayload;
   [[maybe_unused]] const std::size_t pipelineBytesPayload =
       geometry.pipelineBytesPayload;
-  const std::size_t pipelineBytesWire = geometry.pipelineBytesWire;
   [[maybe_unused]] const std::size_t payloadProtocolBytes =
       geometry.payloadProtocolBytes;
 
@@ -1895,7 +1891,6 @@ __device__ __forceinline__ void recv_impl(
       const std::size_t absSlot = baseSlot + slotIdx;
       const int ringSlot = static_cast<int>(absSlot % pipelineDepth);
       const std::size_t stagingOff =
-          static_cast<std::size_t>(groupId) * pipelineBytesWire +
           static_cast<std::size_t>(ringSlot) * perBlockSlot +
           subStep * chunkStride;
       const std::size_t dataOff = s * chunkSize;
@@ -1914,7 +1909,7 @@ __device__ __forceinline__ void recv_impl(
       // (2) Cooperative decompress: local recvStaging -> dst via CopyOp.
       CopyOp::recv(
           static_cast<char*>(dst) + dataOff,
-          channelLayout.recvStagingPtr + stagingOff,
+          ch.local.recvStaging + stagingOff,
           bytesThis,
           group,
           dataOff,
@@ -1958,7 +1953,7 @@ __device__ __forceinline__ void recv_impl(
       // wire_bytes(cursor)). Identity for Simple; kPacketBytes:kData for LL.
       const std::size_t protocolBytesThis = bytesThis +
           (isFinalChunk ? Proto::wire_bytes(protocolTailPadding) : 0);
-      const std::size_t stagingOff = ch.stagingBase +
+      const std::size_t stagingOff =
           static_cast<std::size_t>(slot) * perBlockSlotWire +
           Proto::wire_bytes(chunkOff);
       // flagVal (a per-ring-pass counter) for this chunk's slot; LL stamps it
@@ -1980,7 +1975,7 @@ __device__ __forceinline__ void recv_impl(
             localChannel,
             localDataReady,
             static_cast<char*>(dst) + dataOff,
-            channelLayout.recvStagingPtr + stagingOff,
+            ch.local.recvStaging + stagingOff,
             payloadBytes,
             nbytes,
             dataOff,
@@ -2025,7 +2020,7 @@ __device__ __forceinline__ void recv_impl(
         if (validBytes > 0) {
           CopyOp::recv(
               static_cast<char*>(dst) + dataOff,
-              channelLayout.recvStagingPtr + stagingOff,
+              ch.local.recvStaging + stagingOff,
               validBytes,
               group,
               dataOff,
@@ -2262,7 +2257,7 @@ __device__ __forceinline__ void forward_impl(
         static_cast<int>(recvPipelineOff / recvGeo.perBlockSlotPayload);
     const std::size_t recvChunkOff =
         recvPipelineOff - recvSlot * recvGeo.perBlockSlotPayload;
-    const std::size_t recvStagingOff = recvCh.stagingBase +
+    const std::size_t recvStagingOff =
         static_cast<std::size_t>(recvSlot) * recvGeo.perBlockSlotWire +
         Proto::wire_bytes(recvChunkOff);
     const std::size_t recvSlotRemaining =
@@ -2276,7 +2271,7 @@ __device__ __forceinline__ void forward_impl(
         static_cast<int>(fwdPipelineOff / fwdGeo.perBlockSlotPayload);
     const std::size_t fwdChunkOff =
         fwdPipelineOff - fwdSlot * fwdGeo.perBlockSlotPayload;
-    const std::size_t fwdStagingOff = fwdCh.stagingBase +
+    const std::size_t fwdStagingOff =
         static_cast<std::size_t>(fwdSlot) * fwdGeo.perBlockSlotWire +
         Proto::wire_bytes(fwdChunkOff);
     const std::size_t fwdSlotRemaining =
@@ -2329,8 +2324,8 @@ __device__ __forceinline__ void forward_impl(
           recvLocalChannel,
           recvDataReady,
           dst ? static_cast<char*>(dst) + dataOff : nullptr,
-          fwdChannelLayout.sendStagingPtr + fwdStagingOff,
-          channelLayout.recvStagingPtr + recvStagingOff,
+          static_cast<char*>(fwdCh.local.sendStaging.ptr) + fwdStagingOff,
+          recvCh.local.recvStaging + recvStagingOff,
           payloadBytes,
           nbytes,
           dataOff,
@@ -2428,7 +2423,7 @@ __device__ __forceinline__ void forward_impl(
             bytesThis);
         const auto completion = fwdTransport.put(
             solo,
-            fwdChannelLayout.sendStagingBuf.subBuffer(fwdStagingOff),
+            fwdCh.local.sendStaging.subBuffer(fwdStagingOff),
             fwdRemoteChannel.recvStaging.subBuffer(fwdStagingOff),
             bytesThis,
             sig.buf,
@@ -2477,8 +2472,8 @@ __device__ __forceinline__ void forward_impl(
       if (validBytes > 0) {
         CopyOp::forward(
             dst ? static_cast<char*>(dst) + dataOff : nullptr,
-            fwdChannelLayout.sendStagingPtr + fwdStagingOff,
-            channelLayout.recvStagingPtr + recvStagingOff,
+            static_cast<char*>(fwdCh.local.sendStaging.ptr) + fwdStagingOff,
+            recvCh.local.recvStaging + recvStagingOff,
             validBytes,
             group,
             dataOff,
@@ -2493,7 +2488,7 @@ __device__ __forceinline__ void forward_impl(
       ibOps->submit_send(
           fwdTransport,
           group,
-          fwdChannelLayout.sendStagingBuf.subBuffer(fwdStagingOff),
+          fwdCh.local.sendStaging.subBuffer(fwdStagingOff),
           fwdStagingOff,
           bytesThis,
           fwdProtocolBytesThis,
@@ -2747,15 +2742,18 @@ __device__ __forceinline__ ChannelSlotView acquire_channel(
     ThreadGroup& group) {
   validate_progress_group(channelLayout, group);
   const int channelId = static_cast<int>(group.group_id);
-  const int slotIndex =
-      channelLayout.protoChannelSlot(channelId, P::kProtoSlot);
+  IbLocalChannel& channel =
+      transport.local_channel(static_cast<uint32_t>(channelId));
+  IbChannelProtoSlot& local = channel.protos[P::kProtoSlot];
   return ChannelSlotView{
-      .channel = transport.local_channel(static_cast<uint32_t>(channelId)),
-      .local = transport.template local_channel_slot<P>(
-          static_cast<uint32_t>(channelId)),
-      .remote = makeIbRemoteChannel(channelLayout, slotIndex),
-      .stagingBase =
-          static_cast<std::size_t>(slotIndex) * pipeline_window(channelLayout),
+      .channel = channel,
+      .local = local,
+      .remote =
+          IbRemoteChannel{
+              .dataReady = local.remoteDataReady,
+              .slotFree = local.remoteSlotFree,
+              .recvStaging = local.remoteRecvStaging,
+          },
   };
 }
 

--- a/comms/prims/transport/P2pIbTransportProgressImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportProgressImpl.cuh
@@ -18,7 +18,7 @@ constexpr uint32_t kProgressAborted = 2U;
  *
  * `stagingOff` is an offset into the transport-owned send/recv staging
  * buffers. `dataOff` is the matching protocol offset into the caller's user
- * buffer. `bytes` never crosses a per-block staging partition or the
+ * buffer. `bytes` never crosses a per-channel pipeline slot or the
  * reserved protocol byte count. `streamEnd` is the absolute protocol byte
  * value after this chunk and is used as the DATA_READY and SLOT_FREE readiness
  * threshold. `slotId` and `pipelineGeneration` identify the local completion
@@ -46,12 +46,9 @@ struct ProgressChunk {
  * and `group`, so caching them would duplicate HBM state for no gain.
  */
 struct ProgressGeometry {
-  // Two independent coordinates, never merged: `groupId` is the LOGICAL channel
-  // (and therefore the QP channel); `slotIndex` is this protocol's flat
-  // resource slot, addressing slot-indexed storage. Merging them would force a
-  // division to recover one from the other on the QP path.
+  // groupId is the logical channel and therefore the QP channel. Protocol-
+  // specific buffer bindings are resolved through that channel's stable slot.
   int groupId;
-  int slotIndex;
   std::size_t payloadBytes; // raw nbytes, for valid-byte masking
   std::size_t
       protocolBytes; // payload rounded up to Proto::kData (cursor bound)
@@ -355,7 +352,7 @@ template <typename CopyOp = Memcpy, typename... Args>
 __device__ __forceinline__ void progress_send_prepare_buf(
     protocol::Simple,
     ThreadGroup& group,
-    const IbChannelLayout& channelLayout,
+    char* sendStaging,
     const ProgressChunk& chunk,
     const void* __restrict__ src,
     std::size_t payloadBytes,
@@ -365,7 +362,7 @@ __device__ __forceinline__ void progress_send_prepare_buf(
       valid_payload_bytes(chunk.dataOff, chunk.payloadBytes, payloadBytes);
   if (validBytes > 0) {
     CopyOp::send(
-        channelLayout.sendStagingPtr + chunk.stagingOff,
+        sendStaging + chunk.stagingOff,
         static_cast<const char*>(src) + chunk.dataOff,
         validBytes,
         group,
@@ -374,7 +371,7 @@ __device__ __forceinline__ void progress_send_prepare_buf(
   }
 #else
   (void)group;
-  (void)channelLayout;
+  (void)sendStaging;
   (void)chunk;
   (void)src;
   (void)payloadBytes;
@@ -406,7 +403,7 @@ template <typename CopyOp = Memcpy, typename... Args>
 __device__ __forceinline__ void progress_send_prepare_buf(
     protocol::LL,
     ThreadGroup& group,
-    const IbChannelLayout& channelLayout,
+    char* sendStaging,
     const ProgressChunk& chunk,
     const void* __restrict__ src,
     std::size_t payloadBytes,
@@ -422,7 +419,7 @@ __device__ __forceinline__ void progress_send_prepare_buf(
       valid_payload_bytes(chunk.dataOff, chunk.payloadBytes, payloadBytes);
   CopyOp::template sendLL<P>(
       group,
-      channelLayout.sendStagingPtr + chunk.stagingOff,
+      sendStaging + chunk.stagingOff,
       static_cast<const char*>(src) + chunk.dataOff,
       validBytes,
       chunk.dataOff,
@@ -430,7 +427,7 @@ __device__ __forceinline__ void progress_send_prepare_buf(
       args...);
 #else
   (void)group;
-  (void)channelLayout;
+  (void)sendStaging;
   (void)chunk;
   (void)src;
   (void)payloadBytes;
@@ -545,7 +542,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
     progress_send_prepare_buf<CopyOp>(
         Proto{},
         group,
-        channelLayout,
+        static_cast<char*>(ch.local.sendStaging.ptr),
         chunk,
         state.activeUserBuf,
         progress_params.payloadBytes,
@@ -668,7 +665,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once_impl(
           protocolBytesThis);
       const auto completion = transport.put(
           solo,
-          channelLayout.sendStagingBuf.subBuffer(chunk.stagingOff),
+          ch.local.sendStaging.subBuffer(chunk.stagingOff),
           remoteChannel.recvStaging.subBuffer(chunk.stagingOff),
           chunk.wireBytes,
           sig.buf,
@@ -1130,7 +1127,7 @@ __device__ __forceinline__ bool poll_recv_data_ready(
  */
 // Non-blocking readiness check for one recv chunk (Simple: poll the round-robin
 // DATA_READY lane that carried this chunk; leader-only + broadcast, no spin).
-// `channelLayout`/`chunk` are unused by Simple (they carry the recv staging +
+// `recvStaging`/`chunk` are unused by Simple (they carry the recv staging +
 // packet geometry the LL overload polls); the seam passes them so both
 // protocols share the call site in progress_recv_once.
 template <typename Transport>
@@ -1138,7 +1135,7 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
     protocol::Simple,
     Transport& transport,
     ThreadGroup& group,
-    const IbChannelLayout& channelLayout,
+    const char* recvStaging,
     const ProgressChunk& chunk,
     IbLocalChannel& localChannel,
     const IbgdaLocalBuffer& localDataReady,
@@ -1148,7 +1145,7 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
     PipesTraceProgressState* traceState,
     uint8_t qpLane) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-  (void)channelLayout;
+  (void)recvStaging;
   (void)chunk;
   uint32_t ready = 1;
   if (group.is_leader()) {
@@ -1209,7 +1206,7 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
 #else
   (void)transport;
   (void)group;
-  (void)channelLayout;
+  (void)recvStaging;
   (void)chunk;
   (void)localChannel;
   (void)localDataReady;
@@ -1228,7 +1225,7 @@ template <typename CopyOp = Memcpy, typename... Args>
 __device__ __forceinline__ void progress_recv_consume_buf(
     protocol::Simple,
     ThreadGroup& group,
-    const IbChannelLayout& channelLayout,
+    const char* recvStaging,
     const ProgressChunk& chunk,
     void* __restrict__ dst,
     std::size_t payloadBytes,
@@ -1248,7 +1245,7 @@ __device__ __forceinline__ void progress_recv_consume_buf(
     }
     CopyOp::recv(
         static_cast<char*>(dst) + chunk.dataOff,
-        channelLayout.recvStagingPtr + chunk.stagingOff,
+        recvStaging + chunk.stagingOff,
         validBytes,
         group,
         chunk.dataOff,
@@ -1263,7 +1260,7 @@ __device__ __forceinline__ void progress_recv_consume_buf(
   }
 #else
   (void)group;
-  (void)channelLayout;
+  (void)recvStaging;
   (void)chunk;
   (void)dst;
   (void)payloadBytes;
@@ -1292,7 +1289,7 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
     protocol::LL,
     Transport& transport,
     ThreadGroup& group,
-    const IbChannelLayout& channelLayout,
+    const char* recvStaging,
     const ProgressChunk& chunk,
     IbLocalChannel& localChannel,
     const IbgdaLocalBuffer& localDataReady,
@@ -1309,7 +1306,7 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
   (void)traceContext;
   (void)traceState;
   (void)qpLane;
-  const char* staging = channelLayout.recvStagingPtr + chunk.stagingOff;
+  const char* staging = recvStaging + chunk.stagingOff;
   // Packet geometry lives in LLImpl, which owns the format; this seam only
   // decides what to do with the verdict -- report not-ready on false, rather
   // than spin.
@@ -1357,7 +1354,7 @@ __device__ __forceinline__ uint32_t progress_recv_ready(
 #else
   (void)transport;
   (void)group;
-  (void)channelLayout;
+  (void)recvStaging;
   (void)chunk;
   (void)localChannel;
   (void)localDataReady;
@@ -1382,7 +1379,7 @@ template <typename CopyOp = Memcpy, typename... Args>
 __device__ __forceinline__ void progress_recv_consume_buf(
     protocol::LL,
     ThreadGroup& group,
-    const IbChannelLayout& channelLayout,
+    const char* recvStaging,
     const ProgressChunk& chunk,
     void* __restrict__ dst,
     std::size_t payloadBytes,
@@ -1407,7 +1404,7 @@ __device__ __forceinline__ void progress_recv_consume_buf(
   CopyOp::template recvLL<P>(
       group,
       static_cast<char*>(dst) + chunk.dataOff,
-      channelLayout.recvStagingPtr + chunk.stagingOff,
+      recvStaging + chunk.stagingOff,
       validBytes,
       chunk.dataOff,
       static_cast<typename P::FlagType>(chunk.flagVal),
@@ -1415,7 +1412,7 @@ __device__ __forceinline__ void progress_recv_consume_buf(
       args...);
 #else
   (void)group;
-  (void)channelLayout;
+  (void)recvStaging;
   (void)chunk;
   (void)dst;
   (void)payloadBytes;
@@ -1485,7 +1482,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once_impl(
       Proto{},
       transport,
       group,
-      channelLayout,
+      ch.local.recvStaging,
       chunk,
       localChannel,
       localDataReady,
@@ -1505,7 +1502,7 @@ __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once_impl(
   progress_recv_consume_buf<CopyOp>(
       Proto{},
       group,
-      channelLayout,
+      ch.local.recvStaging,
       chunk,
       state.activeUserBuf,
       progress_params.payloadBytes,
@@ -1656,7 +1653,7 @@ progress_recv_acquire_once(
       Proto{},
       transport,
       group,
-      channelLayout,
+      ch.local.recvStaging,
       chunk,
       ch.channel,
       ch.local.dataReady,
@@ -1673,7 +1670,7 @@ progress_recv_acquire_once(
     return IbgdaSendRecvProgressStatus::Waiting;
   }
 
-  out.staging = channelLayout.recvStagingPtr + chunk.stagingOff;
+  out.staging = ch.local.recvStaging + chunk.stagingOff;
   out.validBytes = valid_payload_bytes(
       chunk.dataOff, chunk.payloadBytes, geometry.payloadBytes);
   out.dataOff = chunk.dataOff;
@@ -1936,7 +1933,6 @@ __device__ __forceinline__ ProgressGeometry make_progress_geometry(
   }
   return ProgressGeometry{
       .groupId = groupId,
-      .slotIndex = channelLayout.protoChannelSlot(groupId, Proto::kProtoSlot),
       .payloadBytes = nbytes,
       .protocolBytes = protocolBytes,
       .perBlockSlotWire = perBlockSlotWire,
@@ -2136,9 +2132,7 @@ __device__ __forceinline__ ProgressChunk next_chunk(
       : dataRemaining;
   payloadBytes = payloadBytes < slotRemaining ? payloadBytes : slotRemaining;
   return ProgressChunk{
-      .stagingOff = static_cast<std::size_t>(geometry.slotIndex) *
-              geometry.perChannelBufferSize +
-          static_cast<std::size_t>(slot) * geometry.perBlockSlotWire +
+      .stagingOff = static_cast<std::size_t>(slot) * geometry.perBlockSlotWire +
           Proto::wire_bytes(chunkOff),
       .dataOff = payloadNextByte,
       .payloadBytes = payloadBytes,

--- a/comms/prims/transport/ibgda/IbgdaBuffer.h
+++ b/comms/prims/transport/ibgda/IbgdaBuffer.h
@@ -491,9 +491,8 @@ struct IbChannelLayout {
   IbgdaRemoteBuffer remoteSignalBuf; ///< Peer's signal inbox
   IbgdaLocalBuffer localCounterBuf; ///< GPU-readable NIC_DONE counter inbox
   IbgdaLocalBuffer localCounterCompletionBuf; ///< Transport completion target
-  int maxChannels{0}; ///< Layout size for SLOT-indexed resources. Equals
-                      ///< numChannels today; the diff that adds a second
-                      ///< protocol makes it numChannels * kNumProtoSlots.
+  int maxChannels{0}; ///< Flat protocol-slot capacity for SLOT-indexed
+                      ///< resources: numChannels * kNumProtoSlots.
   int numChannels{0}; ///< Logical channels; a caller's group_id selects within
                       ///< [0, numChannels). Also the QP channel: protocols
                       ///< share a channel's QPs and are separated by resource
@@ -504,10 +503,17 @@ struct IbChannelLayout {
   std::size_t perChannelSize{0}; ///< Backward-compatible channel window alias
   std::size_t perChannelBufferSize{0}; ///< Total staging bytes for one channel
 
-  __host__ __device__ std::size_t data_buffer_size() const {
-    const std::size_t perChannel =
-        perChannelBufferSize != 0 ? perChannelBufferSize : perChannelSize;
-    return perChannel * static_cast<std::size_t>(maxChannels);
+  IBGDA_HOST_DEVICE std::size_t channelBufferSize() const {
+    return perChannelBufferSize != 0 ? perChannelBufferSize : perChannelSize;
+  }
+
+  IBGDA_HOST_DEVICE std::size_t channelBufferOffset(int channelId) const {
+    assert(channelId >= 0 && channelId < maxChannels);
+    return static_cast<std::size_t>(channelId) * channelBufferSize();
+  }
+
+  IBGDA_HOST_DEVICE std::size_t data_buffer_size() const {
+    return channelBufferSize() * static_cast<std::size_t>(maxChannels);
   }
 
   // Flat resource slot for (logical channel, protocol slot). Proto-major, so
@@ -589,6 +595,31 @@ enum class IbDirection : uint8_t {
 inline constexpr int kIbDirections = 2;
 inline constexpr int kIbMaxQpLanesPerChannelDirection = 64;
 
+IBGDA_HOST_DEVICE inline uint32_t ibQpSlotWithinNic(
+    uint32_t channelId,
+    IbDirection direction,
+    uint32_t directionCount,
+    uint32_t qpsPerConnection,
+    uint32_t lane) {
+  return ((channelId * directionCount + static_cast<uint32_t>(direction)) *
+          qpsPerConnection) +
+      lane;
+}
+
+IBGDA_HOST_DEVICE inline uint32_t ibCommandQueueSlot(
+    uint32_t channelId,
+    IbDirection direction,
+    uint32_t directionCount,
+    uint32_t qpsPerConnection,
+    uint32_t qpIndex,
+    uint32_t numNics,
+    uint32_t nicId) {
+  return ibQpSlotWithinNic(
+             channelId, direction, directionCount, qpsPerConnection, qpIndex) *
+      numNics +
+      nicId;
+}
+
 // Per-protocol resource slots reserved on every channel, indexed by a protocol
 // tag's kProtoSlot (Simple = 0, LL = 1). The layout reserves this many
 // channels' worth of staging, signal, and counter slots per peer, so raising it
@@ -658,8 +689,16 @@ struct IbChannelProtoSlot {
   IbgdaLocalBuffer slotFree;
   IbgdaLocalBuffer nicDoneWait;
   IbgdaLocalBuffer nicDoneCompletion;
-
   IbSendCompletionSlot* sendCompletionSlots{nullptr};
+
+  // Exact staging and peer bindings for this protocol slot. Lazy channel
+  // ranges use independent allocations, so these cannot be derived from the
+  // peer-wide geometry stored in the outer transport.
+  IbgdaLocalBuffer sendStaging;
+  char* recvStaging{nullptr};
+  IbgdaRemoteBuffer remoteDataReady;
+  IbgdaRemoteBuffer remoteSlotFree;
+  IbgdaRemoteBuffer remoteRecvStaging;
 };
 
 // A channel: the state every protocol on it shares, plus one slot per protocol.
@@ -714,6 +753,15 @@ IBGDA_HOST_DEVICE inline IbLocalChannel makeIbLocalChannel(
     proto.slotFree = layout.localSlotFreeSignal(slot);
     proto.nicDoneWait = layout.localCounter(slot);
     proto.nicDoneCompletion = layout.localCompletionCounter(slot);
+    const std::size_t stagingOffset =
+        layout.maxChannels == 0 ? 0 : layout.channelBufferOffset(slot);
+    proto.sendStaging = layout.sendStagingBuf.subBuffer(stagingOffset);
+    proto.recvStaging = layout.recvStagingPtr == nullptr
+        ? nullptr
+        : layout.recvStagingPtr + stagingOffset;
+    proto.remoteDataReady = layout.remoteDataReadySignal(slot);
+    proto.remoteSlotFree = layout.remoteSlotFreeSignal(slot);
+    proto.remoteRecvStaging = layout.recvStagingBuf.subBuffer(stagingOffset);
     proto.sendCompletionSlots = sendCompletionSlots;
   }
   return channel;

--- a/comms/prims/transport/ibgda/IbgdaWarpProxy.cuh
+++ b/comms/prims/transport/ibgda/IbgdaWarpProxy.cuh
@@ -78,7 +78,7 @@ class IbgdaWarpProxy {
   struct SendCommand {
     P2pIbgdaTransportDevice* transport;
     IbgdaLocalBuffer source;
-    uint64_t remoteOffset;
+    uint64_t stagingOffset;
     uint64_t bytes;
     uint64_t protocolBytes;
     uint64_t slotFreeExpected;
@@ -249,7 +249,7 @@ class IbgdaWarpProxy {
         P2pIbgdaTransportDevice& transport,
         ThreadGroup& workers,
         const IbgdaLocalBuffer& source,
-        std::size_t remoteOffset,
+        std::size_t stagingOffset,
         std::size_t bytes,
         std::size_t protocolBytes,
         uint64_t slotFreeExpected,
@@ -271,7 +271,7 @@ class IbgdaWarpProxy {
           SendCommand{
               .transport = &transport,
               .source = source,
-              .remoteOffset = remoteOffset,
+              .stagingOffset = stagingOffset,
               .bytes = bytes,
               .protocolBytes = protocolBytes,
               .slotFreeExpected = slotFreeExpected,
@@ -676,12 +676,15 @@ class IbgdaWarpProxy {
     const uint64_t copiedTail = copied.load(cuda::memory_order_acquire);
     while (head < copiedTail) {
       const RecvCommand command = storage.recv.commands[head % kQueueCapacity];
-      const IbRemoteChannel remote = makeIbRemoteChannel(
-          command.transport->channel_layout(),
-          static_cast<int>(command.channel));
+      const IbChannelProtoSlot& localSlot =
+          command.transport->template local_channel_slot<protocol::Simple>(
+              command.channel);
       ThreadGroup solo = make_solo_group(command.channel, fullBlock);
       command.transport->signal(
-          solo, remote.slotFree, command.protocolBytes, IbDirection::Recv);
+          solo,
+          localSlot.remoteSlotFree,
+          command.protocolBytes,
+          IbDirection::Recv);
       credited.store(++head, cuda::memory_order_release);
     }
   }
@@ -756,10 +759,10 @@ class IbgdaWarpProxy {
           static_cast<unsigned long long>(command.requiredRecvCredit));
       return;
     }
+    const IbChannelProtoSlot& localSlot =
+        command.transport->template local_channel_slot<protocol::Simple>(
+            command.channel);
     if (command.slotFreeExpected != 0) {
-      const IbChannelProtoSlot& localSlot =
-          command.transport->template local_channel_slot<protocol::Simple>(
-              command.channel);
       const uint64_t current =
           command.transport->read_signal(localSlot.slotFree);
       if (current < command.slotFreeExpected) {
@@ -775,15 +778,13 @@ class IbgdaWarpProxy {
       }
     }
 
-    const IbRemoteChannel remote = makeIbRemoteChannel(
-        command.transport->channel_layout(), static_cast<int>(command.channel));
     ThreadGroup solo = make_solo_group(command.channel, fullBlock);
     const IbLocalCompletionTicket ticket = command.transport->put(
         solo,
         command.source,
-        remote.recvStaging.subBuffer(command.remoteOffset),
+        localSlot.remoteRecvStaging.subBuffer(command.stagingOffset),
         command.bytes,
-        remote.dataReady,
+        localSlot.remoteDataReady,
         command.protocolBytes,
         /*counterBuf=*/{},
         /*counterVal=*/0,

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -1332,8 +1332,6 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
       nic.loopbackCompanionQps.resize(
           static_cast<size_t>(numPeers) * companionSlots);
     }
-    peerMaterialized_.resize(numPeers, false);
-
     // Allocate and register sink buffer for atomic return values
     allocateResources();
     registerMemory();
@@ -1511,7 +1509,8 @@ MultipeerIbgdaDeviceTransport MultipeerIbgdaTransport::getDeviceTransport()
 P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getP2pTransportDevice(
     int peerRank) {
   if (!isPeerMaterialized(peerRank)) {
-    materializePeer(peerRank);
+    queuePeerForMaterialization(peerRank, channelCapacity());
+    connectPeers();
   }
   return ibgdaDeviceSlot(getDeviceTransportPtr(), rankToPeerIndex(peerRank));
 }
@@ -1524,10 +1523,6 @@ P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getDeviceTransportPtr()
 
 P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getP2pTransportDeviceSlot(
     int peerRank) const {
-  LOG_FIRST_N(WARNING, 1)
-      << "MultipeerIbgdaTransport: Transport[] array is being built with "
-      << "possibly unmaterialized IBGDA slots. Call get_device_handle(peers) "
-      << "before kernels access those peers.";
   auto* const transports = getDeviceTransportPtr();
   return transports == nullptr
       ? nullptr
@@ -1557,15 +1552,11 @@ int MultipeerIbgdaTransport::qpsPerBlockPerNic() const {
 
 PeerQpPayload MultipeerIbgdaTransport::buildLocalQpPayload(
     int peerIndex) const {
-  const int mainQpsPerPeerPerNic = config_.fixedChannelMainQpsPerPeerPerNic();
   const int companionSlots = config_.fixedChannelCompanionQpsPerPeerPerNic();
   PeerQpPayload payload{};
+  populatePeerGeometry(payload);
   payload.gidIndex = gidIndex_;
   payload.mtu = static_cast<int>(localMtu_);
-  payload.numNics = numNics_;
-  payload.numQpsPerPeerPerNic = mainQpsPerPeerPerNic;
-  payload.maxGroups = config_.max_num_channels;
-  payload.qpsPerBlockPerNic = config_.qpsPerConnection;
   payload.qpOrderingSemantic = static_cast<int>(qpOrderingSemantic_);
   payload.maxRdAtomic = static_cast<int>(maxRdAtomic_);
 
@@ -1638,10 +1629,16 @@ void MultipeerIbgdaTransport::cleanupPeerOnFailure(int peerIndex) {
   }
   cleanupSendRecvBufferForPeer(peerIndex);
   cleanupPeerSignalCounterResources(peerIndex);
-  peerMaterialized_[peerIndex] = false;
 }
 
-void MultipeerIbgdaTransport::doMaterializePeer(int peerRank) {
+void MultipeerIbgdaTransport::doMaterializePeer(
+    int peerRank,
+    uint32_t oldChannels,
+    uint32_t newChannels) {
+  if (oldChannels != 0 || newChannels != channelCapacity()) {
+    throw std::runtime_error(
+        "IBGDA eager materialization requires the full channel range");
+  }
   int peerIndex = rankToPeerIndex(peerRank);
 
   createPeerQps(peerIndex);
@@ -1649,15 +1646,8 @@ void MultipeerIbgdaTransport::doMaterializePeer(int peerRank) {
   // Phase 1: exchange QP info, connect QPs.
   auto localQp = buildLocalQpPayload(peerIndex);
   auto remoteQp = exchangeWithPeer(peerRank, localQp, kIbPeerQpExchangeTag);
+  validatePeerGeometry(peerRank, remoteQp);
 
-  if (remoteQp.numNics != numNics_) {
-    throw std::runtime_error(
-        fmt::format(
-            "materializePeer: peer {} numNics={} vs local {}",
-            peerRank,
-            remoteQp.numNics,
-            numNics_));
-  }
   // The read/atomic depth is a per-QP-pair property: one end's responder
   // window (log_rra_max) has to cover the other end's initiator window
   // (log_sra_max), so the two ends must have resolved the same value.
@@ -1668,18 +1658,6 @@ void MultipeerIbgdaTransport::doMaterializePeer(int peerRank) {
             peerRank,
             remoteQp.maxRdAtomic,
             static_cast<int>(maxRdAtomic_)));
-  }
-  if (remoteQp.maxGroups != config_.max_num_channels ||
-      remoteQp.qpsPerBlockPerNic != config_.qpsPerConnection) {
-    throw std::runtime_error(
-        fmt::format(
-            "materializePeer: peer {} maxGroups={} qpsPerBlockPerNic={} "
-            "vs local maxGroups={} qpsPerBlockPerNic={}",
-            peerRank,
-            remoteQp.maxGroups,
-            remoteQp.qpsPerBlockPerNic,
-            config_.max_num_channels,
-            config_.qpsPerConnection));
   }
   // dp_ordering has to match on both ends of a connection: fail closed and name
   // both sides rather than silently let one end reassemble in order while the
@@ -1747,7 +1725,6 @@ void MultipeerIbgdaTransport::doMaterializePeer(int peerRank) {
       params,
       localChannels);
   publishIbgdaDeviceSlot(*fixedDeviceTables_, peerIndex, params);
-  peerMaterialized_[peerIndex] = true;
 
   VLOG(1) << "MultipeerIbgdaTransport: rank " << myRank_
           << " materialized peer " << peerRank;

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -52,6 +52,32 @@ constexpr int kHopLimit = 255;
 // mainAttr and therefore uses config_.qpDepth.
 constexpr uint32_t kLoopbackCompanionQpDepth = 32;
 constexpr uint32_t kCollapsedCqProbeDepth = 32;
+
+std::vector<IbLocalChannel> buildLocalChannelDescriptors(
+    const P2pIbgdaTransportBuildParams& params,
+    int beginChannel,
+    int endChannel,
+    IbSendCompletionSlot* completionSlots) {
+  CHECK_GE(beginChannel, 0);
+  CHECK_LE(beginChannel, endChannel);
+  CHECK_LE(endChannel, params.maxChannels);
+  CHECK_GE(params.channelLayout.pipelineDepth, 0);
+  const std::size_t pipelineDepth =
+      static_cast<std::size_t>(params.channelLayout.pipelineDepth);
+  CHECK(pipelineDepth == 0 || completionSlots != nullptr);
+
+  std::vector<IbLocalChannel> localChannels;
+  localChannels.reserve(endChannel - beginChannel);
+  for (int channel = beginChannel; channel < endChannel; ++channel) {
+    IbSendCompletionSlot* channelCompletionSlots = pipelineDepth == 0
+        ? nullptr
+        : completionSlots +
+            static_cast<std::size_t>(channel - beginChannel) * pipelineDepth;
+    localChannels.push_back(makeIbLocalChannel(
+        params.channelLayout, channel, channelCompletionSlots));
+  }
+  return localChannels;
+}
 } // namespace
 
 namespace {
@@ -1219,6 +1245,9 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
           nRanks,
           std::move(bootstrap),
           config) {
+  if (sendRecvBuffersEnabled()) {
+    validateSendRecvConfig();
+  }
   if (config_.max_num_channels < 1) {
     throw std::invalid_argument("max_num_channels must be >= 1");
   }
@@ -1343,7 +1372,7 @@ void MultipeerIbgdaTransport::cleanup() {
     }
   }
   gpuAllocations_.clear();
-  peerTransportsGpu_ = nullptr;
+  fixedDeviceTables_.reset();
 
   // Free send/recv staging buffers (eager bulks + any lazy per-peer
   // allocations) via the shared base cleanup.
@@ -1454,21 +1483,20 @@ void MultipeerIbgdaTransport::cleanup() {
 
 void MultipeerIbgdaTransport::exchange() {
   const int numPeers = nRanks_ - 1;
-  peerTransportSize_ = getP2pIbgdaTransportDeviceSize();
-  const std::size_t totalBytes = numPeers * peerTransportSize_;
-  cudaError_t err = cudaMalloc(&peerTransportsGpu_, totalBytes);
-  if (err != cudaSuccess) {
-    throw std::runtime_error(
-        "Failed to allocate on-demand device transport array: " +
-        std::string(cudaGetErrorString(err)));
-  }
-  gpuAllocations_.push_back(peerTransportsGpu_);
-  err = cudaMemset(peerTransportsGpu_, 0, totalBytes);
-  if (err != cudaSuccess) {
-    throw std::runtime_error("Failed to zero on-demand device transport array");
-  }
+  CHECK(fixedDeviceTables_ == nullptr)
+      << "MultipeerIbgdaTransport::exchange may only be called once";
+  fixedDeviceTables_ =
+      std::make_unique<IbgdaFixedDeviceTables>(allocateIbgdaFixedDeviceTables(
+          numPeers,
+          numNics_,
+          config_.max_num_channels,
+          config_.qpsPerConnection,
+          config_.fixedChannelDirectionCount(),
+          sendRecvBuffersEnabled() ? config_.pipelineDepth : 0,
+          gpuAllocations_));
   VLOG(1) << "MultipeerIbgdaTransport: rank " << myRank_
-          << " exchange complete (per-peer state deferred to materializePeer)";
+          << " exchange complete (fixed device tables reserved; per-peer state "
+             "deferred to materializePeerChannelRange)";
 }
 
 MultipeerIbgdaDeviceTransport MultipeerIbgdaTransport::getDeviceTransport()
@@ -1476,7 +1504,8 @@ MultipeerIbgdaDeviceTransport MultipeerIbgdaTransport::getDeviceTransport()
   return MultipeerIbgdaDeviceTransport(
       myRank_,
       nRanks_,
-      DeviceSpan<P2pIbgdaTransportDevice>(peerTransportsGpu_, nRanks_ - 1));
+      DeviceSpan<P2pIbgdaTransportDevice>(
+          getDeviceTransportPtr(), nRanks_ - 1));
 }
 
 P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getP2pTransportDevice(
@@ -1484,15 +1513,13 @@ P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getP2pTransportDevice(
   if (!isPeerMaterialized(peerRank)) {
     materializePeer(peerRank);
   }
-  int peerIndex = rankToPeerIndex(peerRank);
-  return reinterpret_cast<P2pIbgdaTransportDevice*>(
-      reinterpret_cast<char*>(peerTransportsGpu_) +
-      peerIndex * peerTransportSize_);
+  return ibgdaDeviceSlot(getDeviceTransportPtr(), rankToPeerIndex(peerRank));
 }
 
 P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getDeviceTransportPtr()
     const {
-  return peerTransportsGpu_;
+  return fixedDeviceTables_ == nullptr ? nullptr
+                                       : fixedDeviceTables_->transports;
 }
 
 P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getP2pTransportDeviceSlot(
@@ -1501,10 +1528,10 @@ P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getP2pTransportDeviceSlot(
       << "MultipeerIbgdaTransport: Transport[] array is being built with "
       << "possibly unmaterialized IBGDA slots. Call get_device_handle(peers) "
       << "before kernels access those peers.";
-  int peerIndex = rankToPeerIndex(peerRank);
-  return reinterpret_cast<P2pIbgdaTransportDevice*>(
-      reinterpret_cast<char*>(peerTransportsGpu_) +
-      peerIndex * peerTransportSize_);
+  auto* const transports = getDeviceTransportPtr();
+  return transports == nullptr
+      ? nullptr
+      : ibgdaDeviceSlot(transports, rankToPeerIndex(peerRank));
 }
 
 int MultipeerIbgdaTransport::getGidIndex() const {
@@ -1583,6 +1610,16 @@ void MultipeerIbgdaTransport::connectPeerMainQps(
 }
 
 void MultipeerIbgdaTransport::cleanupPeerOnFailure(int peerIndex) {
+  if (fixedDeviceTables_ != nullptr &&
+      fixedDeviceTables_->transports != nullptr) {
+    const bool rangeCleared = clearIbgdaDeviceRange(
+        *fixedDeviceTables_, peerIndex, 0, config_.max_num_channels);
+    const bool slotReset = resetIbgdaDeviceSlot(*fixedDeviceTables_, peerIndex);
+    if (!rangeCleared || !slotReset) {
+      LOG(WARNING) << "Failed to clear fixed device tables for lazy peerIndex="
+                   << peerIndex;
+    }
+  }
   for (int nic = 0; nic < numNics_; nic++) {
     auto& nicQps = nicDoca_[nic].blockQpGroups;
     auto& nicLoopback = nicDoca_[nic].loopbackCompanionQps;
@@ -1602,17 +1639,6 @@ void MultipeerIbgdaTransport::cleanupPeerOnFailure(int peerIndex) {
   cleanupSendRecvBufferForPeer(peerIndex);
   cleanupPeerSignalCounterResources(peerIndex);
   peerMaterialized_[peerIndex] = false;
-  if (peerTransportsGpu_ != nullptr && peerTransportSize_ != 0) {
-    cudaError_t err = cudaMemset(
-        reinterpret_cast<char*>(peerTransportsGpu_) +
-            static_cast<std::size_t>(peerIndex) * peerTransportSize_,
-        0,
-        peerTransportSize_);
-    if (err != cudaSuccess) {
-      LOG(WARNING) << "Failed to zero failed lazy peer transport slot: "
-                   << cudaGetErrorString(err);
-    }
-  }
 }
 
 void MultipeerIbgdaTransport::doMaterializePeer(int peerRank) {
@@ -1707,8 +1733,20 @@ void MultipeerIbgdaTransport::doMaterializePeer(int peerRank) {
       peerIndex, remoteBuf, /*hasDiscardSignal=*/true);
 
   auto params = buildPeerTransportParams(peerIndex);
-  writeDeviceTransportSlot(
-      peerTransportsGpu_, peerIndex, params, gpuAllocations_);
+  auto* completionSlots = allocateIbgdaCompletionSlots(
+      config_.max_num_channels,
+      sendRecvBuffersEnabled() ? config_.pipelineDepth : 0,
+      gpuAllocations_);
+  const auto localChannels = buildLocalChannelDescriptors(
+      params, 0, config_.max_num_channels, completionSlots);
+  populateIbgdaDeviceRange(
+      *fixedDeviceTables_,
+      peerIndex,
+      0,
+      config_.max_num_channels,
+      params,
+      localChannels);
+  publishIbgdaDeviceSlot(*fixedDeviceTables_, peerIndex, params);
   peerMaterialized_[peerIndex] = true;
 
   VLOG(1) << "MultipeerIbgdaTransport: rank " << myRank_

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -53,28 +53,74 @@ constexpr int kHopLimit = 255;
 constexpr uint32_t kLoopbackCompanionQpDepth = 32;
 constexpr uint32_t kCollapsedCqProbeDepth = 32;
 
+#ifdef __HIP_PLATFORM_AMD__
+class HipStreamCaptureModeGuard {
+ public:
+  HipStreamCaptureModeGuard() {
+    const hipError_t error = hipThreadExchangeStreamCaptureMode(&previous_);
+    if (error != hipSuccess) {
+      throw std::runtime_error(
+          "hipThreadExchangeStreamCaptureMode failed: " +
+          std::string(hipGetErrorString(error)));
+    }
+  }
+
+  ~HipStreamCaptureModeGuard() {
+    const hipError_t error = hipThreadExchangeStreamCaptureMode(&previous_);
+    if (error != hipSuccess) {
+      LOG(ERROR) << "Failed to restore HIP stream capture mode: "
+                 << hipGetErrorString(error);
+    }
+  }
+
+ private:
+  hipStreamCaptureMode previous_{hipStreamCaptureModeRelaxed};
+};
+#endif
+
+struct QpSlotRange {
+  int begin;
+  int end;
+};
+
+QpSlotRange qpSlotRange(
+    const MultipeerIbTransportConfig& config,
+    uint32_t beginChannel,
+    uint32_t endChannel) {
+  const int slotsPerChannel =
+      config.fixedChannelDirectionCount() * config.qpsPerConnection;
+  return {
+      .begin = static_cast<int>(beginChannel) * slotsPerChannel,
+      .end = static_cast<int>(endChannel) * slotsPerChannel,
+  };
+}
+
 std::vector<IbLocalChannel> buildLocalChannelDescriptors(
-    const P2pIbgdaTransportBuildParams& params,
+    const IbChannelLayout& rangeLayout,
     int beginChannel,
     int endChannel,
     IbSendCompletionSlot* completionSlots) {
   CHECK_GE(beginChannel, 0);
   CHECK_LE(beginChannel, endChannel);
-  CHECK_LE(endChannel, params.maxChannels);
-  CHECK_GE(params.channelLayout.pipelineDepth, 0);
+  const int channelCount = endChannel - beginChannel;
+  if (rangeLayout.maxChannels != 0) {
+    CHECK_EQ(rangeLayout.numChannels, channelCount);
+    CHECK_EQ(rangeLayout.maxChannels, channelCount * kNumProtoSlots);
+  }
+  CHECK_GE(rangeLayout.pipelineDepth, 0);
   const std::size_t pipelineDepth =
-      static_cast<std::size_t>(params.channelLayout.pipelineDepth);
+      static_cast<std::size_t>(rangeLayout.pipelineDepth);
   CHECK(pipelineDepth == 0 || completionSlots != nullptr);
 
   std::vector<IbLocalChannel> localChannels;
-  localChannels.reserve(endChannel - beginChannel);
+  localChannels.reserve(channelCount);
   for (int channel = beginChannel; channel < endChannel; ++channel) {
     IbSendCompletionSlot* channelCompletionSlots = pipelineDepth == 0
         ? nullptr
         : completionSlots +
             static_cast<std::size_t>(channel - beginChannel) * pipelineDepth;
     localChannels.push_back(makeIbLocalChannel(
-        params.channelLayout, channel, channelCompletionSlots));
+        rangeLayout, channel - beginChannel, channelCompletionSlots));
   }
   return localChannels;
 }
@@ -919,57 +965,6 @@ void MultipeerIbgdaTransport::registerMemory() {
             << " (zero-based MR, iova=0)";
   }
 }
-void MultipeerIbgdaTransport::createQpGroups() {
-  const int numPeers = nRanks_ - 1;
-  const int directionCount = config_.fixedChannelDirectionCount();
-  const int mainQpsPerPeerPerNic = config_.fixedChannelMainQpsPerPeerPerNic();
-  const int totalMainQpsPerPeer = numNics_ * mainQpsPerPeerPerNic;
-  const int companionQpsPerPeerPerNic =
-      config_.fixedChannelCompanionQpsPerPeerPerNic();
-  const int totalCompanionQpsPerPeer = numNics_ * companionQpsPerPeerPerNic;
-  for (auto& nic : nicDoca_) {
-    nic.blockQpGroups.resize(
-        static_cast<size_t>(numPeers) * companionQpsPerPeerPerNic);
-    nic.extraMainQps.clear();
-    nic.loopbackCompanionQps.resize(
-        static_cast<size_t>(numPeers) * companionQpsPerPeerPerNic);
-  }
-
-  // Verify CUDA device is still set correctly
-  int currentDevice = -1;
-  cudaError_t cudaErr = cudaGetDevice(&currentDevice);
-  if (cudaErr != cudaSuccess) {
-    throw std::runtime_error(
-        "Failed to get CUDA device: " +
-        std::string(cudaGetErrorString(cudaErr)));
-  }
-  VLOG(1) << "MultipeerIbgdaTransport::createQpGroups: current CUDA device="
-          << currentDevice << " expected=" << config_.cudaDevice;
-
-  // Query IB device capabilities for debugging (NIC 0 is representative).
-  ibverbx::ibv_device_attr devAttr{};
-  auto& symbols = ibverbx::ibvSymbols;
-  if (symbols.ibv_internal_query_device(nics_[0].ibvCtx, &devAttr) == 0) {
-    VLOG(1) << "MultipeerIbgdaTransport: IB device - max_qp=" << devAttr.max_qp
-            << " max_cq=" << devAttr.max_cq << " max_mr=" << devAttr.max_mr
-            << " max_qp_wr=" << devAttr.max_qp_wr;
-  }
-
-  VLOG(1) << "MultipeerIbgdaTransport: creating " << totalMainQpsPerPeer
-          << " main QPs/peer and " << totalCompanionQpsPerPeer
-          << " companion QPs/peer (" << numNics_
-          << " NICs × max_num_channels=" << config_.max_num_channels
-          << " × direction_count=" << directionCount
-          << " × qpsPerConnection=" << config_.qpsPerConnection
-          << ", peers=" << numPeers << ") gpu_dev=" << (void*)docaGpu_
-          << " sq_nwqe=" << config_.qpDepth
-          << " nic_handler=AUTO mreg_type=DEFAULT";
-
-  for (int peer = 0; peer < numPeers; peer++) {
-    createPeerQps(peer);
-  }
-}
-
 void MultipeerIbgdaTransport::connectQp(
     doca_gpu_verbs_qp_hl* qpHl,
     const IbgdaTransportExchInfo& peerInfo,
@@ -1098,7 +1093,11 @@ void MultipeerIbgdaTransport::connectQp(
           << peerInfo.qpn;
 }
 
-void MultipeerIbgdaTransport::createPeerQps(int peerIndex) {
+void MultipeerIbgdaTransport::createPeerQps(
+    int peerIndex,
+    uint32_t beginChannel,
+    uint32_t endChannel) {
+  const auto slots = qpSlotRange(config_, beginChannel, endChannel);
   for (int nic = 0; nic < numNics_; nic++) {
     doca_gpu_verbs_qp_init_attr_hl mainAttr{};
     mainAttr.gpu_dev = docaGpu_;
@@ -1149,8 +1148,10 @@ void MultipeerIbgdaTransport::createPeerQps(int peerIndex) {
     auto& nicQps = nicDoca_[nic].blockQpGroups;
     auto& nicLoopback = nicDoca_[nic].loopbackCompanionQps;
     const int companionSlots = config_.fixedChannelCompanionQpsPerPeerPerNic();
-    for (int slot = 0; slot < companionSlots; slot++) {
+    for (int slot = slots.begin; slot < slots.end; slot++) {
       const int slotIdx = peerIndex * companionSlots + slot;
+      CHECK(nicQps[slotIdx] == nullptr);
+      CHECK(nicLoopback[slotIdx] == nullptr);
       doca_error_t err =
           doca_gpu_verbs_create_qp_group_hl(&mainAttr, &nicQps[slotIdx]);
       checkDocaError(err, "Failed to create QP group");
@@ -1160,7 +1161,11 @@ void MultipeerIbgdaTransport::createPeerQps(int peerIndex) {
   }
 }
 
-void MultipeerIbgdaTransport::connectPeerLoopback(int peerIndex) {
+void MultipeerIbgdaTransport::connectPeerLoopback(
+    int peerIndex,
+    uint32_t beginChannel,
+    uint32_t endChannel) {
+  const auto slots = qpSlotRange(config_, beginChannel, endChannel);
   for (int nic = 0; nic < numNics_; nic++) {
     auto& nicQps = nicDoca_[nic].blockQpGroups;
     auto& nicLoopback = nicDoca_[nic].loopbackCompanionQps;
@@ -1176,7 +1181,7 @@ void MultipeerIbgdaTransport::connectPeerLoopback(int peerIndex) {
     }
 
     const int companionSlots = config_.fixedChannelCompanionQpsPerPeerPerNic();
-    for (int slot = 0; slot < companionSlots; slot++) {
+    for (int slot = slots.begin; slot < slots.end; slot++) {
       const int slotIdx = peerIndex * companionSlots + slot;
       selfInfo.qpn = doca_verbs_qp_get_qpn(nicLoopback[slotIdx]->qp);
       connectQp(&nicQps[slotIdx]->qp_companion, selfInfo, nic);
@@ -1187,11 +1192,14 @@ void MultipeerIbgdaTransport::connectPeerLoopback(int peerIndex) {
 }
 
 P2pIbgdaTransportBuildParams MultipeerIbgdaTransport::buildPeerTransportParams(
-    int peerIndex) const {
+    int peerIndex,
+    uint32_t beginChannel,
+    uint32_t endChannel) const {
   const int mainQpsPerPeerPerNic = config_.fixedChannelMainQpsPerPeerPerNic();
   const int companionSlots = config_.fixedChannelCompanionQpsPerPeerPerNic();
+  const auto slots = qpSlotRange(config_, beginChannel, endChannel);
   // Build the device-side send/recv layout from the shared base.
-  P2pIbgdaTransportBuildParams params(channelLayoutForPeer(peerIndex));
+  P2pIbgdaTransportBuildParams params(sendRecvChannelGeometry());
   params.maxChannels = config_.max_num_channels;
   params.qpDirectionCount = config_.fixedChannelDirectionCount();
   params.qpsPerConnection = config_.qpsPerConnection;
@@ -1208,7 +1216,7 @@ P2pIbgdaTransportBuildParams MultipeerIbgdaTransport::buildPeerTransportParams(
   for (int nic = 0; nic < numNics_; nic++) {
     auto& nicQps = nicDoca_[nic].blockQpGroups;
     auto& nicSpec = params.h_nicDeviceIbgdaResources[nic];
-    for (int slot = 0; slot < companionSlots; slot++) {
+    for (int slot = slots.begin; slot < slots.end; slot++) {
       const int slotIdx = peerIndex * companionSlots + slot;
       doca_error_t err = doca_gpu_verbs_get_qp_dev(
           nicQps[slotIdx]->qp_main.qp_gverbs, &nicSpec.qps[slot]);
@@ -1288,6 +1296,9 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
             numNics_,
             config_.qpsPerConnection,
             kIbMaxQpLanesPerChannelDirection));
+  }
+  if (sendRecvBuffersEnabled()) {
+    validateSendRecvConfig();
   }
   if (mainQpsPerPeerPerNic * (nRanks_ - 1) * 3 > 1000) {
     LOG(WARNING) << "MultipeerIbgdaTransport: high QP count: "
@@ -1508,7 +1519,8 @@ MultipeerIbgdaDeviceTransport MultipeerIbgdaTransport::getDeviceTransport()
 
 P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getP2pTransportDevice(
     int peerRank) {
-  if (!isPeerMaterialized(peerRank)) {
+  throwIfMaterializationFailed();
+  if (materializedChannelCount(peerRank) == 0) {
     queuePeerForMaterialization(peerRank, channelCapacity());
     connectPeers();
   }
@@ -1517,12 +1529,14 @@ P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getP2pTransportDevice(
 
 P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getDeviceTransportPtr()
     const {
+  throwIfMaterializationFailed();
   return fixedDeviceTables_ == nullptr ? nullptr
                                        : fixedDeviceTables_->transports;
 }
 
 P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getP2pTransportDeviceSlot(
     int peerRank) const {
+  throwIfMaterializationFailed();
   auto* const transports = getDeviceTransportPtr();
   return transports == nullptr
       ? nullptr
@@ -1547,12 +1561,15 @@ int MultipeerIbgdaTransport::qpsPerBlockPerNic() const {
 
 // Eager send/recv staging allocation, exchange, and cleanup are now provided by
 // MultiPeerIbTransportBase (allocateSendRecvBuffersEager(Device) /
-// exchangeSendRecvBuffersEager() / cleanupSendRecvBuffers()). The lazy per-peer
-// path below fills the inherited sendRecvPeerBuffers_ directly.
+// exchangeSendRecvBuffersEager() / cleanupSendRecvBuffers()). Lazy channel
+// ranges retain immutable allocations in lazyPeerChannelRangeBufs_.
 
 PeerQpPayload MultipeerIbgdaTransport::buildLocalQpPayload(
-    int peerIndex) const {
+    int peerIndex,
+    uint32_t beginChannel,
+    uint32_t endChannel) const {
   const int companionSlots = config_.fixedChannelCompanionQpsPerPeerPerNic();
+  const auto slots = qpSlotRange(config_, beginChannel, endChannel);
   PeerQpPayload payload{};
   populatePeerGeometry(payload);
   payload.gidIndex = gidIndex_;
@@ -1571,7 +1588,7 @@ PeerQpPayload MultipeerIbgdaTransport::buildLocalQpPayload(
       payload.nicInfo[n].lid = portAttr.lid;
     }
     auto& nicQps = nicDoca_[n].blockQpGroups;
-    for (int slot = 0; slot < companionSlots; slot++) {
+    for (int slot = slots.begin; slot < slots.end; slot++) {
       const int slotIdx = peerIndex * companionSlots + slot;
       payload.nicInfo[n].qpns[slot] =
           doca_verbs_qp_get_qpn(nicQps[slotIdx]->qp_main.qp);
@@ -1582,11 +1599,14 @@ PeerQpPayload MultipeerIbgdaTransport::buildLocalQpPayload(
 
 void MultipeerIbgdaTransport::connectPeerMainQps(
     int peerIndex,
+    uint32_t beginChannel,
+    uint32_t endChannel,
     const PeerQpPayload& remotePayload) {
+  const auto slots = qpSlotRange(config_, beginChannel, endChannel);
   for (int nic = 0; nic < numNics_; nic++) {
     auto& nicQps = nicDoca_[nic].blockQpGroups;
     const int companionSlots = config_.fixedChannelCompanionQpsPerPeerPerNic();
-    for (int slot = 0; slot < companionSlots; slot++) {
+    for (int slot = slots.begin; slot < slots.end; slot++) {
       const int slotIdx = peerIndex * companionSlots + slot;
       IbgdaTransportExchInfo peerInfo;
       peerInfo.qpn = remotePayload.nicInfo[nic].qpns[slot];
@@ -1600,52 +1620,33 @@ void MultipeerIbgdaTransport::connectPeerMainQps(
   }
 }
 
-void MultipeerIbgdaTransport::cleanupPeerOnFailure(int peerIndex) {
-  if (fixedDeviceTables_ != nullptr &&
-      fixedDeviceTables_->transports != nullptr) {
-    const bool rangeCleared = clearIbgdaDeviceRange(
-        *fixedDeviceTables_, peerIndex, 0, config_.max_num_channels);
-    const bool slotReset = resetIbgdaDeviceSlot(*fixedDeviceTables_, peerIndex);
-    if (!rangeCleared || !slotReset) {
-      LOG(WARNING) << "Failed to clear fixed device tables for lazy peerIndex="
-                   << peerIndex;
-    }
-  }
-  for (int nic = 0; nic < numNics_; nic++) {
-    auto& nicQps = nicDoca_[nic].blockQpGroups;
-    auto& nicLoopback = nicDoca_[nic].loopbackCompanionQps;
-    const int companionSlots = config_.fixedChannelCompanionQpsPerPeerPerNic();
-    for (int slot = 0; slot < companionSlots; slot++) {
-      const int slotIdx = peerIndex * companionSlots + slot;
-      if (nicQps[slotIdx] != nullptr) {
-        doca_gpu_verbs_destroy_qp_group_hl(nicQps[slotIdx]);
-        nicQps[slotIdx] = nullptr;
-      }
-      if (nicLoopback[slotIdx] != nullptr) {
-        doca_gpu_verbs_destroy_qp_hl(nicLoopback[slotIdx]);
-        nicLoopback[slotIdx] = nullptr;
-      }
-    }
-  }
-  cleanupSendRecvBufferForPeer(peerIndex);
-  cleanupPeerSignalCounterResources(peerIndex);
-}
-
-void MultipeerIbgdaTransport::doMaterializePeer(
+void MultipeerIbgdaTransport::materializePeerChannelRange(
     int peerRank,
-    uint32_t oldChannels,
-    uint32_t newChannels) {
-  if (oldChannels != 0 || newChannels != channelCapacity()) {
-    throw std::runtime_error(
-        "IBGDA eager materialization requires the full channel range");
+    uint32_t beginChannel,
+    uint32_t endChannel) {
+  if (beginChannel >= endChannel || endChannel > channelCapacity()) {
+    throw std::invalid_argument(
+        fmt::format(
+            "materializePeerChannelRange: invalid range=[{}, {}) capacity={}",
+            beginChannel,
+            endChannel,
+            channelCapacity()));
   }
-  int peerIndex = rankToPeerIndex(peerRank);
+  const int peerIndex = rankToPeerIndex(peerRank);
+#ifdef __HIP_PLATFORM_AMD__
+  HipStreamCaptureModeGuard captureModeGuard;
+#else
+  meta::comms::StreamCaptureModeGuard captureModeGuard{
+      cudaStreamCaptureModeRelaxed};
+#endif
+  meta::comms::CudaDeviceGuard deviceGuard{config_.cudaDevice};
 
-  createPeerQps(peerIndex);
+  createPeerQps(peerIndex, beginChannel, endChannel);
 
   // Phase 1: exchange QP info, connect QPs.
-  auto localQp = buildLocalQpPayload(peerIndex);
-  auto remoteQp = exchangeWithPeer(peerRank, localQp, kIbPeerQpExchangeTag);
+  const auto localQp = buildLocalQpPayload(peerIndex, beginChannel, endChannel);
+  const auto remoteQp =
+      exchangeWithPeer(peerRank, localQp, kIbPeerQpExchangeTag);
   validatePeerGeometry(peerRank, remoteQp);
 
   // The read/atomic depth is a per-QP-pair property: one end's responder
@@ -1693,41 +1694,68 @@ void MultipeerIbgdaTransport::doMaterializePeer(
             ibQpOrderingSemanticName(qpOrderingSemantic_)));
   }
 
-  connectPeerMainQps(peerIndex, remoteQp);
-  connectPeerLoopback(peerIndex);
+  connectPeerMainQps(peerIndex, beginChannel, endChannel, remoteQp);
+  connectPeerLoopback(peerIndex, beginChannel, endChannel);
 
   // Phase 2: exchange buffer info (acts as QP-ready barrier).
   PeerBufferPayload localBuf{};
-  allocateSendRecvBufferForPeer(peerIndex, localBuf, IbCounterStorage::Device);
-  allocatePeerSignalCounterResources(
-      peerIndex,
-      localBuf,
-      IbCounterStorage::Device,
-      /*allocateDiscardSignal=*/true);
-  auto remoteBuf =
+  IbChannelLayout channelLayout;
+  if (config_.lazyChannels) {
+    channelLayout = allocateSendRecvChannelRange(
+        peerIndex, beginChannel, endChannel, localBuf);
+  } else {
+    if (beginChannel != 0 || endChannel != channelCapacity()) {
+      throw std::logic_error(
+          "eager IBGDA materialization requires the full channel range");
+    }
+    allocateSendRecvBufferForPeer(
+        peerIndex, localBuf, IbCounterStorage::Device);
+    channelLayout = channelLayoutForPeer(peerIndex);
+  }
+  if (beginChannel == 0) {
+    allocatePeerSignalCounterResources(
+        peerIndex,
+        localBuf,
+        IbCounterStorage::Device,
+        /*allocateDiscardSignal=*/true);
+  }
+  const auto remoteBuf =
       exchangeWithPeer(peerRank, localBuf, kIbPeerBufferExchangeTag);
-  applyRemoteSendRecvBuffer(peerIndex, remoteBuf);
-  applyRemoteSignalCounterResources(
-      peerIndex, remoteBuf, /*hasDiscardSignal=*/true);
+  if (config_.lazyChannels) {
+    applyRemoteSendRecvChannelRange(channelLayout, remoteBuf);
+  } else {
+    applyRemoteSendRecvBuffer(peerIndex, remoteBuf);
+    channelLayout = channelLayoutForPeer(peerIndex);
+  }
+  if (beginChannel == 0) {
+    applyRemoteSignalCounterResources(
+        peerIndex, remoteBuf, /*hasDiscardSignal=*/true);
+  }
 
-  auto params = buildPeerTransportParams(peerIndex);
+  auto params = buildPeerTransportParams(peerIndex, beginChannel, endChannel);
+  if (!config_.lazyChannels) {
+    params.channelLayout = channelLayout;
+  }
   auto* completionSlots = allocateIbgdaCompletionSlots(
-      config_.max_num_channels,
+      endChannel - beginChannel,
       sendRecvBuffersEnabled() ? config_.pipelineDepth : 0,
       gpuAllocations_);
   const auto localChannels = buildLocalChannelDescriptors(
-      params, 0, config_.max_num_channels, completionSlots);
+      channelLayout, beginChannel, endChannel, completionSlots);
   populateIbgdaDeviceRange(
       *fixedDeviceTables_,
       peerIndex,
-      0,
-      config_.max_num_channels,
+      beginChannel,
+      endChannel,
       params,
       localChannels);
-  publishIbgdaDeviceSlot(*fixedDeviceTables_, peerIndex, params);
+  if (beginChannel == 0) {
+    publishIbgdaDeviceSlot(*fixedDeviceTables_, peerIndex, params);
+  }
 
   VLOG(1) << "MultipeerIbgdaTransport: rank " << myRank_
-          << " materialized peer " << peerRank;
+          << " materialized peer " << peerRank << " channels [" << beginChannel
+          << ", " << endChannel << ")";
 }
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
@@ -174,10 +174,9 @@ class MultipeerIbgdaTransport
    */
   P2pIbgdaTransportDevice* getP2pTransportDevice(int peerRank);
 
-  // materializePeer()/queuePeerForMaterialization()/connectPeers()/
-  // isPeerMaterialized() are inherited from MultiPeerIbTransport (the lazy
-  // state machine lives in the base; this backend supplies the
-  // doMaterializePeer()/cleanupPeerOnFailure() hooks below).
+  // queuePeerForMaterialization()/connectPeers()/isPeerMaterialized() are
+  // inherited from MultiPeerIbTransport. This backend supplies the
+  // doMaterializePeer()/cleanupPeerOnFailure() hooks below.
 
   /**
    * getDeviceTransportPtr - Get pointer to device transport array
@@ -239,12 +238,13 @@ class MultipeerIbgdaTransport
   // rankToPeerIndex()/peerIndexToRank() are inherited from
   // MultiPeerIbTransport.
 
-  // Per-peer helpers shared by eager exchange() and lazy materializePeer()
+  // Per-peer helpers used by lazy materialization.
   void createPeerQps(int peerIndex);
   void connectPeerLoopback(int peerIndex);
   P2pIbgdaTransportBuildParams buildPeerTransportParams(int peerIndex) const;
 
-  void doMaterializePeer(int peerRank);
+  void
+  doMaterializePeer(int peerRank, uint32_t oldChannels, uint32_t newChannels);
 
   PeerQpPayload buildLocalQpPayload(int peerIndex) const;
   void connectPeerMainQps(int peerIndex, const PeerQpPayload& remotePayload);
@@ -336,8 +336,7 @@ class MultipeerIbgdaTransport
   // cleanupSendRecvBuffers(); the lazy path below fills the inherited
   // sendRecvPeerBuffers_ directly.
 
-  // Lazy state (pendingPeers_/peerMaterialized_/materializationFailed_) is
-  // inherited (protected) from MultiPeerIbTransport.
+  // Lazy readiness state is inherited from MultiPeerIbTransport.
 };
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
@@ -116,6 +116,13 @@ using IbgdaTransportExchInfoAll = IbTransportExchInfoAll;
 class MultipeerIbgdaTransport
     : public MultiPeerIbTransport<MultipeerIbgdaTransport> {
  public:
+  static constexpr bool supportsLazyChannelPrefixGrowth() {
+    return true;
+  }
+
+  static constexpr PeerChannelBackend kPeerChannelBackend =
+      PeerChannelBackend::kIbgda;
+
   /**
    * Constructor - Initialize multi-peer IBGDA transport
    */
@@ -166,8 +173,10 @@ class MultipeerIbgdaTransport
    * This method handles the rank-to-index mapping internally and provides
    * explicit peer selection without requiring CUDA headers.
    *
-   * In lazy mode, this materializes the requested peer before returning, so
-   * the returned pointer is ready for kernel use.
+   * If no channel has been prepared, this materializes the peer at full
+   * capacity for compatibility with callers that do not declare demand. If a
+   * prefix is already prepared, it returns the stable slot without expanding
+   * that prefix; the caller may use only the prepared channels.
    *
    * @param peerRank Global rank of the peer (must be != myRank and < nRanks)
    * @return Pointer to P2pIbgdaTransportDevice for the specified peer
@@ -176,7 +185,7 @@ class MultipeerIbgdaTransport
 
   // queuePeerForMaterialization()/connectPeers()/isPeerMaterialized() are
   // inherited from MultiPeerIbTransport. This backend supplies the
-  // doMaterializePeer()/cleanupPeerOnFailure() hooks below.
+  // materializePeerChannelRange() hook below.
 
   /**
    * getDeviceTransportPtr - Get pointer to device transport array
@@ -226,7 +235,6 @@ class MultipeerIbgdaTransport
   void openIbDevice();
   void allocateResources();
   void registerMemory();
-  void createQpGroups();
   void cleanup();
   // Connect a QP to a peer (or self for loopback). The nic argument selects
   // which local NIC's AH attrs / port to use; the peerInfo carries the
@@ -239,20 +247,34 @@ class MultipeerIbgdaTransport
   // MultiPeerIbTransport.
 
   // Per-peer helpers used by lazy materialization.
-  void createPeerQps(int peerIndex);
-  void connectPeerLoopback(int peerIndex);
-  P2pIbgdaTransportBuildParams buildPeerTransportParams(int peerIndex) const;
+  void createPeerQps(int peerIndex, uint32_t beginChannel, uint32_t endChannel);
+  void connectPeerLoopback(
+      int peerIndex,
+      uint32_t beginChannel,
+      uint32_t endChannel);
+  P2pIbgdaTransportBuildParams buildPeerTransportParams(
+      int peerIndex,
+      uint32_t beginChannel,
+      uint32_t endChannel) const;
 
-  void
-  doMaterializePeer(int peerRank, uint32_t oldChannels, uint32_t newChannels);
+  void materializePeerChannelRange(
+      int peerRank,
+      uint32_t beginChannel,
+      uint32_t endChannel);
 
-  PeerQpPayload buildLocalQpPayload(int peerIndex) const;
-  void connectPeerMainQps(int peerIndex, const PeerQpPayload& remotePayload);
-  void cleanupPeerOnFailure(int peerIndex);
+  PeerQpPayload buildLocalQpPayload(
+      int peerIndex,
+      uint32_t beginChannel,
+      uint32_t endChannel) const;
+  void connectPeerMainQps(
+      int peerIndex,
+      uint32_t beginChannel,
+      uint32_t endChannel,
+      const PeerQpPayload& remotePayload);
 
   // MultiPeerIbTransport drives the shared control plane (config, MR registry,
   // lazy materialization, bootstrap exchangeWithPeer) and calls back into this
-  // backend's doMaterializePeer()/cleanupPeerOnFailure() hooks.
+  // backend's materializePeerChannelRange() hook.
   friend class MultiPeerIbTransport<MultipeerIbgdaTransport>;
 
   // myRank_/nRanks_/bootstrap_/config_/registrationState_/nics_/lazy-state are
@@ -329,12 +351,9 @@ class MultipeerIbgdaTransport
   // Exchange info received from peers
   std::vector<IbgdaTransportExchInfo> peerExchInfo_;
 
-  // Per-peer send/recv buffer views (IbSendRecvPeerBuffers) and the eager-mode
-  // bulk allocations now live in MultiPeerIbTransportBase
-  // (sendRecvPeerBuffers_). Eager allocation/exchange/cleanup delegate to the
-  // base's allocateSendRecvBuffersEager(Device)/exchangeSendRecvBuffersEager()/
-  // cleanupSendRecvBuffers(); the lazy path below fills the inherited
-  // sendRecvPeerBuffers_ directly.
+  // Eager send/recv views and bulk allocations live in
+  // MultiPeerIbTransportBase. Lazy growth retains separate immutable range
+  // buffers there until communicator teardown.
 
   // Lazy readiness state is inherited from MultiPeerIbTransport.
 };

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
@@ -34,6 +34,7 @@
 // Forward declarations for device types (defined in .cuh files)
 namespace comms::prims {
 class P2pIbgdaTransportDevice;
+struct IbgdaFixedDeviceTables;
 struct MultipeerIbgdaDeviceTransport;
 struct P2pIbgdaTransportBuildParams;
 struct PeerQpPayload;
@@ -136,10 +137,10 @@ class MultipeerIbgdaTransport
   MultipeerIbgdaTransport& operator=(MultipeerIbgdaTransport&&) = delete;
 
   /**
-   * exchange - Exchange connection info and connect QPs
+   * exchange - Reserve stable device descriptor tables
    *
-   * COLLECTIVE OPERATION: All ranks MUST call this before using
-   * getDeviceTransportPtr().
+   * All ranks must call this before using getDeviceTransportPtr(). Peer QPs
+   * and channel resources are materialized separately on demand.
    */
   void exchange();
 
@@ -149,6 +150,7 @@ class MultipeerIbgdaTransport
    * Returns a MultipeerIbgdaDeviceTransport wrapper that provides convenient
    * access to per-peer transport handles with rank-to-index mapping.
    * Use .get(peerRank) to get the transport for a specific peer.
+   * This accessor does not materialize peers.
    *
    * NOTE: Requires including MultipeerIbgdaDeviceTransport.cuh in CUDA files.
    * For non-CUDA code, use getP2pTransportDevice(peerRank) instead.
@@ -271,10 +273,9 @@ class MultipeerIbgdaTransport
   // numNics_ is inherited (protected) from MultiPeerIbTransport;
   // nicDoca_.size() == numNics_ after openIbDevice().
 
-  // Per-NIC host-side IB verbs resources. blockQpGroups and
-  // loopbackCompanionQps are indexed [peer * maxGroups + block]. The lane-0
-  // main QP comes from blockQpGroups; extra main QPs are indexed
-  // [(peer * maxGroups + block) * (qpsPerBlockPerNic - 1) + (lane - 1)].
+  // Per-NIC host-side IB verbs resources. The legacy-named blockQpGroups and
+  // loopbackCompanionQps use flattened fixed-capacity peer/channel/direction
+  // slots. extraMainQps additionally indexes the lane within each channel.
   // Backend-specific (DOCA) per-NIC state. The generic per-NIC resources
   // (device name, context, PD, GID) live in MultiPeerIbTransport::nics_,
   // index-aligned with this vector; openIbDevice() fills both.
@@ -321,11 +322,8 @@ class MultipeerIbgdaTransport
   // MultiPeerIbTransportBase (set by openNics()); the backend reads them
   // (inherited) when building DOCA AH attrs and connecting QPs.
 
-  // Per-peer device transports (GPU accessible)
-  P2pIbgdaTransportDevice* peerTransportsGpu_{nullptr};
-  std::size_t peerTransportSize_{0};
-
-  // All GPU allocations from buildDeviceTransportsOnGpu (freed in cleanup)
+  // Host view of communicator-lifetime tables; gpuAllocations_ owns storage.
+  std::unique_ptr<IbgdaFixedDeviceTables> fixedDeviceTables_;
   std::vector<void*> gpuAllocations_;
 
   // Exchange info received from peers

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cu
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cu
@@ -5,19 +5,15 @@
 #include <cuda_runtime.h>
 #include <glog/logging.h>
 
-#include <cstring>
+#include <cstdint>
 #include <limits>
+#include <stdexcept>
+#include <string>
 
 #include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
 
 namespace comms::prims {
 namespace {
-
-std::size_t checkedAdd(std::size_t lhs, std::size_t rhs, const char* label) {
-  CHECK_LE(lhs, std::numeric_limits<std::size_t>::max() - rhs)
-      << label << " size overflow";
-  return lhs + rhs;
-}
 
 std::size_t checkedMul(std::size_t lhs, std::size_t rhs, const char* label) {
   CHECK(lhs == 0 || rhs <= std::numeric_limits<std::size_t>::max() / lhs)
@@ -25,348 +21,347 @@ std::size_t checkedMul(std::size_t lhs, std::size_t rhs, const char* label) {
   return lhs * rhs;
 }
 
-} // namespace
-
-P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
-    const std::vector<P2pIbgdaTransportBuildParams>& params,
-    int numPeers,
-    std::vector<void*>& outGpuAllocations) {
-  // All peers must have the same shape: same numNics, and same per-NIC QP
-  // counts. Take peer 0's layout as canonical and validate the rest.
-  CHECK(!params.empty() && !params[0].h_nicDeviceIbgdaResources.empty())
-      << "buildDeviceTransportsOnGpu: empty params or zero NICs";
-  int numNics = static_cast<int>(params[0].h_nicDeviceIbgdaResources.size());
-  int mainQpsPerNic =
-      static_cast<int>(params[0].h_nicDeviceIbgdaResources[0].qps.size());
-  int companionQpsPerNic = static_cast<int>(
-      params[0].h_nicDeviceIbgdaResources[0].companionQps.size());
-  for (int i = 0; i < numPeers; ++i) {
-    CHECK_EQ(params[i].maxChannels, params[0].maxChannels)
-        << "All peers must have the same maxChannels";
-    CHECK_EQ(params[i].qpsPerConnection, params[0].qpsPerConnection)
-        << "All peers must have the same qpsPerConnection";
-    CHECK_EQ(params[i].qpDirectionCount, params[0].qpDirectionCount)
-        << "All peers must have the same qpDirectionCount";
-    CHECK_EQ(params[i].collapsedCq, params[0].collapsedCq)
-        << "All local device transports must use the resolved CQ format";
-    CHECK_EQ(
-        static_cast<int>(params[i].h_nicDeviceIbgdaResources.size()), numNics)
-        << "All peers must have the same numNics";
-    for (int n = 0; n < numNics; ++n) {
-      CHECK_EQ(
-          static_cast<int>(params[i].h_nicDeviceIbgdaResources[n].qps.size()),
-          params[i].maxChannels * params[i].qpDirectionCount *
-              params[i].qpsPerConnection)
-          << "Main QP count must equal maxChannels * qpDirectionCount * "
-             "qpsPerConnection";
-      CHECK_EQ(
-          static_cast<int>(
-              params[i].h_nicDeviceIbgdaResources[n].companionQps.size()),
-          params[i].maxChannels * params[i].qpDirectionCount *
-              params[i].qpsPerConnection)
-          << "Companion QP count must equal maxChannels * qpDirectionCount * "
-             "qpsPerConnection";
-      CHECK_EQ(
-          static_cast<int>(params[i].h_nicDeviceIbgdaResources[n].qps.size()),
-          mainQpsPerNic)
-          << "All peers' NICs must have the same QP count";
-      CHECK_EQ(
-          static_cast<int>(
-              params[i].h_nicDeviceIbgdaResources[n].companionQps.size()),
-          companionQpsPerNic)
-          << "All peers' NICs must have the same companion QP count";
-    }
+void throwOnCudaError(cudaError_t error, const char* operation) {
+  if (error != cudaSuccess) {
+    throw std::runtime_error(
+        std::string(operation) + ": " + cudaGetErrorString(error));
   }
-
-  // 1. Allocate one contiguous GPU buffer for all QP pointer arrays.
-  //    Layout per peer: [nic0_main][nic0_comp][nic1_main][nic1_comp]...
-  //    Total: numPeers * numNics * (mainQpsPerNic + companionQpsPerNic).
-  std::size_t qpsPerPeer = static_cast<std::size_t>(numNics) *
-      (static_cast<std::size_t>(mainQpsPerNic) + companionQpsPerNic);
-  std::size_t totalQpBytes =
-      numPeers * qpsPerPeer * sizeof(doca_gpu_dev_verbs_qp*);
-  doca_gpu_dev_verbs_qp** d_allQps = nullptr;
-  cudaError_t err = cudaMalloc(&d_allQps, totalQpBytes);
-  CHECK(err == cudaSuccess)
-      << "Failed to allocate GPU QP arrays: " << cudaGetErrorString(err);
-  outGpuAllocations.push_back(d_allQps);
-
-  std::vector<doca_gpu_dev_verbs_qp*> h_qps;
-  h_qps.reserve(numPeers * qpsPerPeer);
-  for (int i = 0; i < numPeers; ++i) {
-    for (int n = 0; n < numNics; ++n) {
-      const auto& nicSpec = params[i].h_nicDeviceIbgdaResources[n];
-      h_qps.insert(h_qps.end(), nicSpec.qps.begin(), nicSpec.qps.end());
-      h_qps.insert(
-          h_qps.end(),
-          nicSpec.companionQps.begin(),
-          nicSpec.companionQps.end());
-    }
-  }
-  err =
-      cudaMemcpy(d_allQps, h_qps.data(), totalQpBytes, cudaMemcpyHostToDevice);
-  CHECK(err == cudaSuccess)
-      << "Failed to copy QP arrays to GPU: " << cudaGetErrorString(err);
-
-  // 2. Allocate one contiguous GPU buffer for all NicDeviceIbgdaResources
-  // structs:
-  //    [peer0_nic0..nicN-1][peer1_nic0..nicN-1]...
-  std::size_t totalNicBytes =
-      numPeers * numNics * sizeof(NicDeviceIbgdaResources);
-  NicDeviceIbgdaResources* d_allNicResources = nullptr;
-  err = cudaMalloc(&d_allNicResources, totalNicBytes);
-  CHECK(err == cudaSuccess)
-      << "Failed to allocate GPU NicDeviceIbgdaResources array: "
-      << cudaGetErrorString(err);
-  outGpuAllocations.push_back(d_allNicResources);
-
-  std::vector<NicDeviceIbgdaResources> h_nicResources;
-  h_nicResources.reserve(numPeers * numNics);
-  for (int i = 0; i < numPeers; ++i) {
-    for (int n = 0; n < numNics; ++n) {
-      auto* d_mainQps = d_allQps + (i * qpsPerPeer) +
-          n * (mainQpsPerNic + companionQpsPerNic);
-      auto* d_companionQps = d_mainQps + mainQpsPerNic;
-      h_nicResources.push_back(
-          NicDeviceIbgdaResources{
-              DeviceSpan<doca_gpu_dev_verbs_qp*>(d_mainQps, mainQpsPerNic),
-              DeviceSpan<doca_gpu_dev_verbs_qp*>(
-                  d_companionQps, companionQpsPerNic),
-              params[i].h_nicDeviceIbgdaResources[n].sinkLkey,
-              params[i].h_nicDeviceIbgdaResources[n].deviceId,
-          });
-    }
-  }
-  err = cudaMemcpy(
-      d_allNicResources,
-      h_nicResources.data(),
-      totalNicBytes,
-      cudaMemcpyHostToDevice);
-  CHECK(err == cudaSuccess)
-      << "Failed to copy NicDeviceIbgdaResources array to GPU: "
-      << cudaGetErrorString(err);
-
-  // 3. Build transport objects pointing into the contiguous
-  // NicDeviceIbgdaResources array.
-  IbLocalChannel* d_allLocalChannels = nullptr;
-  std::size_t blockStateBytes = static_cast<std::size_t>(numPeers) *
-      params[0].maxChannels * sizeof(IbLocalChannel);
-  err = cudaMalloc(&d_allLocalChannels, blockStateBytes);
-  CHECK(err == cudaSuccess)
-      << "Failed to allocate GPU IB channel state: " << cudaGetErrorString(err);
-  outGpuAllocations.push_back(d_allLocalChannels);
-  std::size_t totalCompletionSlots = 0;
-  for (int i = 0; i < numPeers; ++i) {
-    const int pipelineDepth = params[i].channelLayout.pipelineDepth;
-    CHECK_GE(pipelineDepth, 0) << "pipelineDepth must not be negative";
-    const std::size_t peerCompletionSlots = checkedMul(
-        static_cast<std::size_t>(params[i].maxChannels),
-        static_cast<std::size_t>(pipelineDepth),
-        "send completion slots");
-    totalCompletionSlots = checkedAdd(
-        totalCompletionSlots, peerCompletionSlots, "send completion slots");
-  }
-  IbSendCompletionSlot* d_allCompletionSlots = nullptr;
-  const std::size_t completionSlotBytes = checkedMul(
-      totalCompletionSlots,
-      sizeof(IbSendCompletionSlot),
-      "send completion slots");
-  if (completionSlotBytes != 0) {
-    err = cudaMalloc(&d_allCompletionSlots, completionSlotBytes);
-    CHECK(err == cudaSuccess)
-        << "Failed to allocate GPU send completion slots: "
-        << cudaGetErrorString(err);
-    outGpuAllocations.push_back(d_allCompletionSlots);
-    err = cudaMemset(d_allCompletionSlots, 0, completionSlotBytes);
-    CHECK(err == cudaSuccess)
-        << "Failed to initialize GPU send completion slots: "
-        << cudaGetErrorString(err);
-  }
-  std::vector<IbLocalChannel> h_localChannels(
-      static_cast<std::size_t>(numPeers) * params[0].maxChannels);
-  std::size_t completionSlotOffset = 0;
-  for (int i = 0; i < numPeers; ++i) {
-    for (int channel = 0; channel < params[i].maxChannels; ++channel) {
-      const auto channelIndex =
-          static_cast<std::size_t>(i) * params[0].maxChannels + channel;
-      const std::size_t pipelineDepth =
-          static_cast<std::size_t>(params[i].channelLayout.pipelineDepth);
-      IbSendCompletionSlot* completionSlots = pipelineDepth == 0
-          ? nullptr
-          : d_allCompletionSlots + completionSlotOffset;
-      h_localChannels[channelIndex] =
-          makeIbLocalChannel(params[i].channelLayout, channel, completionSlots);
-      completionSlotOffset += pipelineDepth;
-    }
-  }
-  err = cudaMemcpy(
-      d_allLocalChannels,
-      h_localChannels.data(),
-      blockStateBytes,
-      cudaMemcpyHostToDevice);
-  CHECK(err == cudaSuccess) << "Failed to initialize GPU IB channel state: "
-                            << cudaGetErrorString(err);
-
-  std::vector<P2pIbgdaTransportDevice> h_transports;
-  h_transports.reserve(numPeers);
-  for (int i = 0; i < numPeers; ++i) {
-    NicDeviceIbgdaResources* d_peerNicResources =
-        d_allNicResources + i * numNics;
-    h_transports.emplace_back(
-        DeviceSpan<NicDeviceIbgdaResources>(d_peerNicResources, numNics),
-        params[i].remoteSignalBuf,
-        params[i].localSignalBuf,
-        params[i].counterBuf,
-        params[i].numSignalSlots,
-        params[i].numCounterSlots,
-        params[i].maxChannels,
-        params[i].qpsPerConnection,
-        params[i].qpDirectionCount,
-        DeviceSpan<IbLocalChannel>(
-            d_allLocalChannels + i * params[i].maxChannels,
-            params[i].maxChannels),
-        params[i].channelLayout,
-        params[i].collapsedCq);
-  }
-
-  // 4. Allocate and copy transport objects to GPU.
-  P2pIbgdaTransportDevice* gpuPtr = nullptr;
-  std::size_t transportSize = numPeers * sizeof(P2pIbgdaTransportDevice);
-  err = cudaMalloc(&gpuPtr, transportSize);
-  CHECK(err == cudaSuccess) << "Failed to allocate GPU device transports: "
-                            << cudaGetErrorString(err);
-  outGpuAllocations.push_back(gpuPtr); // track before memcpy for leak safety
-  err = cudaMemcpy(
-      gpuPtr, h_transports.data(), transportSize, cudaMemcpyHostToDevice);
-  CHECK(err == cudaSuccess)
-      << "Failed to copy device transports to GPU: " << cudaGetErrorString(err);
-
-  return gpuPtr;
 }
 
-void writeDeviceTransportSlot(
-    P2pIbgdaTransportDevice* deviceArray,
-    int peerIndex,
+struct QpTableLayout {
+  std::size_t qpsPerChannel;
+  std::size_t qpsPerNic;
+  std::size_t qpsPerPeer;
+};
+
+QpTableLayout qpTableLayout(const IbgdaFixedDeviceTables& tables) {
+  const std::size_t qpsPerChannel = checkedMul(
+      static_cast<std::size_t>(tables.qpDirectionCount),
+      static_cast<std::size_t>(tables.qpsPerConnection),
+      "QP slots per channel");
+  const std::size_t qpsPerNic = checkedMul(
+      static_cast<std::size_t>(tables.maxChannels),
+      qpsPerChannel,
+      "QP slots per NIC");
+  return QpTableLayout{
+      .qpsPerChannel = qpsPerChannel,
+      .qpsPerNic = qpsPerNic,
+      .qpsPerPeer = checkedMul(
+          static_cast<std::size_t>(tables.numNics),
+          checkedMul(std::size_t{2}, qpsPerNic, "main and companion QP slots"),
+          "QP slots per peer"),
+  };
+}
+
+doca_gpu_dev_verbs_qp** peerQps(
+    const IbgdaFixedDeviceTables& tables,
+    const QpTableLayout& layout,
+    int peerIndex) {
+  return tables.qps + static_cast<std::size_t>(peerIndex) * layout.qpsPerPeer;
+}
+
+IbLocalChannel* peerLocalChannels(
+    const IbgdaFixedDeviceTables& tables,
+    int peerIndex) {
+  return tables.localChannels +
+      static_cast<std::size_t>(peerIndex) * tables.maxChannels;
+}
+
+bool tryCudaMemset(void* ptr, std::size_t bytes, const char* label) noexcept {
+  if (bytes == 0) {
+    return true;
+  }
+  const cudaError_t error = cudaMemset(ptr, 0, bytes);
+  if (error == cudaSuccess) {
+    return true;
+  }
+  LOG(ERROR) << "Failed to clear fixed IBGDA " << label << ": "
+             << cudaGetErrorString(error);
+  return false;
+}
+
+std::vector<IbLocalChannel> buildLegacyLocalChannels(
     const P2pIbgdaTransportBuildParams& params,
-    std::vector<void*>& outGpuAllocations) {
-  CHECK(!params.h_nicDeviceIbgdaResources.empty())
-      << "writeDeviceTransportSlot needs >= 1 NIC";
-  int numNics = static_cast<int>(params.h_nicDeviceIbgdaResources.size());
-  int mainQpsPerNic =
-      static_cast<int>(params.h_nicDeviceIbgdaResources[0].qps.size());
-  int companionQpsPerNic =
-      static_cast<int>(params.h_nicDeviceIbgdaResources[0].companionQps.size());
-  for (int n = 0; n < numNics; ++n) {
-    CHECK_EQ(
-        static_cast<int>(params.h_nicDeviceIbgdaResources[n].qps.size()),
-        mainQpsPerNic)
-        << "All NICs must have the same QP count";
-    CHECK_EQ(
-        static_cast<int>(
-            params.h_nicDeviceIbgdaResources[n].companionQps.size()),
-        companionQpsPerNic)
-        << "All NICs must have the same companion QP count";
-  }
-
-  std::size_t qpsPerPeer = static_cast<std::size_t>(numNics) *
-      (static_cast<std::size_t>(mainQpsPerNic) + companionQpsPerNic);
-  std::size_t qpBytes = qpsPerPeer * sizeof(doca_gpu_dev_verbs_qp*);
-  doca_gpu_dev_verbs_qp** d_qps = nullptr;
-  cudaError_t err = cudaMalloc(&d_qps, qpBytes);
-  CHECK(err == cudaSuccess) << "Failed to allocate per-peer GPU QP array: "
-                            << cudaGetErrorString(err);
-  outGpuAllocations.push_back(d_qps);
-
-  std::vector<doca_gpu_dev_verbs_qp*> h_qps;
-  h_qps.reserve(qpsPerPeer);
-  for (int n = 0; n < numNics; ++n) {
-    const auto& nicSpec = params.h_nicDeviceIbgdaResources[n];
-    h_qps.insert(h_qps.end(), nicSpec.qps.begin(), nicSpec.qps.end());
-    h_qps.insert(
-        h_qps.end(), nicSpec.companionQps.begin(), nicSpec.companionQps.end());
-  }
-  err = cudaMemcpy(d_qps, h_qps.data(), qpBytes, cudaMemcpyHostToDevice);
-  CHECK(err == cudaSuccess)
-      << "Failed to copy per-peer QP array to GPU: " << cudaGetErrorString(err);
-
-  std::size_t nicBytes = numNics * sizeof(NicDeviceIbgdaResources);
-  NicDeviceIbgdaResources* d_nicResources = nullptr;
-  err = cudaMalloc(&d_nicResources, nicBytes);
-  CHECK(err == cudaSuccess)
-      << "Failed to allocate per-peer NicDeviceIbgdaResources: "
-      << cudaGetErrorString(err);
-  outGpuAllocations.push_back(d_nicResources);
-
-  std::vector<NicDeviceIbgdaResources> h_nicResources;
-  h_nicResources.reserve(numNics);
-  for (int n = 0; n < numNics; ++n) {
-    auto* d_mainQps = d_qps + n * (mainQpsPerNic + companionQpsPerNic);
-    auto* d_companionQps = d_mainQps + mainQpsPerNic;
-    h_nicResources.push_back(
-        NicDeviceIbgdaResources{
-            DeviceSpan<doca_gpu_dev_verbs_qp*>(d_mainQps, mainQpsPerNic),
-            DeviceSpan<doca_gpu_dev_verbs_qp*>(
-                d_companionQps, companionQpsPerNic),
-            params.h_nicDeviceIbgdaResources[n].sinkLkey,
-            params.h_nicDeviceIbgdaResources[n].deviceId,
-        });
-  }
-  err = cudaMemcpy(
-      d_nicResources, h_nicResources.data(), nicBytes, cudaMemcpyHostToDevice);
-  CHECK(err == cudaSuccess)
-      << "Failed to copy per-peer NicDeviceIbgdaResources to GPU: "
-      << cudaGetErrorString(err);
-
-  IbLocalChannel* d_localChannels = nullptr;
-  std::size_t blockStateBytes =
-      static_cast<std::size_t>(params.maxChannels) * sizeof(IbLocalChannel);
-  err = cudaMalloc(&d_localChannels, blockStateBytes);
-  CHECK(err == cudaSuccess) << "Failed to allocate per-peer IB channel state: "
-                            << cudaGetErrorString(err);
-  outGpuAllocations.push_back(d_localChannels);
-  CHECK_GE(params.channelLayout.pipelineDepth, 0)
-      << "pipelineDepth must not be negative";
+    IbSendCompletionSlot* completionSlots) {
+  CHECK_GE(params.channelLayout.pipelineDepth, 0);
   const std::size_t pipelineDepth =
       static_cast<std::size_t>(params.channelLayout.pipelineDepth);
-  const std::size_t completionSlotCount = checkedMul(
-      static_cast<std::size_t>(params.maxChannels),
-      pipelineDepth,
-      "send completion slots");
-  IbSendCompletionSlot* d_completionSlots = nullptr;
-  const std::size_t completionSlotBytes = checkedMul(
-      completionSlotCount,
-      sizeof(IbSendCompletionSlot),
-      "send completion slots");
-  if (completionSlotBytes != 0) {
-    err = cudaMalloc(&d_completionSlots, completionSlotBytes);
-    CHECK(err == cudaSuccess) << "Failed to allocate per-peer send completion "
-                                 "slots: "
-                              << cudaGetErrorString(err);
-    outGpuAllocations.push_back(d_completionSlots);
-    err = cudaMemset(d_completionSlots, 0, completionSlotBytes);
-    CHECK(err == cudaSuccess)
-        << "Failed to initialize per-peer send completion slots: "
-        << cudaGetErrorString(err);
-  }
-  std::vector<IbLocalChannel> h_localChannels(params.maxChannels);
+  std::vector<IbLocalChannel> localChannels;
+  localChannels.reserve(params.maxChannels);
   for (int channel = 0; channel < params.maxChannels; ++channel) {
-    IbSendCompletionSlot* completionSlots = pipelineDepth == 0
-        ? nullptr
-        : d_completionSlots + static_cast<std::size_t>(channel) * pipelineDepth;
-    h_localChannels[channel] =
-        makeIbLocalChannel(params.channelLayout, channel, completionSlots);
+    localChannels.push_back(makeIbLocalChannel(
+        params.channelLayout,
+        channel,
+        pipelineDepth == 0 ? nullptr
+                           : completionSlots +
+                static_cast<std::size_t>(channel) * pipelineDepth));
   }
-  err = cudaMemcpy(
-      d_localChannels,
-      h_localChannels.data(),
-      blockStateBytes,
-      cudaMemcpyHostToDevice);
-  CHECK(err == cudaSuccess)
-      << "Failed to initialize per-peer IB channel state: "
-      << cudaGetErrorString(err);
+  return localChannels;
+}
 
+} // namespace
+
+IbgdaFixedDeviceTables allocateIbgdaFixedDeviceTables(
+    int numPeers,
+    int numNics,
+    int maxChannels,
+    int qpsPerConnection,
+    int qpDirectionCount,
+    int pipelineDepth,
+    std::vector<void*>& outGpuAllocations) {
+  CHECK_GT(numPeers, 0);
+  CHECK_GT(numNics, 0);
+  CHECK_GT(maxChannels, 0);
+  CHECK_GT(qpsPerConnection, 0);
+  CHECK_GT(qpDirectionCount, 0);
+  CHECK_GE(pipelineDepth, 0);
+
+  IbgdaFixedDeviceTables tables{
+      .numPeers = numPeers,
+      .numNics = numNics,
+      .maxChannels = maxChannels,
+      .qpsPerConnection = qpsPerConnection,
+      .qpDirectionCount = qpDirectionCount,
+      .pipelineDepth = pipelineDepth,
+  };
+  const QpTableLayout layout = qpTableLayout(tables);
+
+  const std::size_t qpBytes = checkedMul(
+      checkedMul(
+          static_cast<std::size_t>(numPeers),
+          layout.qpsPerPeer,
+          "fixed QP slots"),
+      sizeof(doca_gpu_dev_verbs_qp*),
+      "fixed QP table");
+  cudaError_t err = cudaMalloc(&tables.qps, qpBytes);
+  throwOnCudaError(err, "Failed to allocate fixed GPU QP tables");
+  outGpuAllocations.push_back(tables.qps);
+  err = cudaMemset(tables.qps, 0, qpBytes);
+  throwOnCudaError(err, "Failed to zero fixed GPU QP tables");
+
+  const std::size_t nicBytes = checkedMul(
+      checkedMul(
+          static_cast<std::size_t>(numPeers),
+          static_cast<std::size_t>(numNics),
+          "fixed NIC resources"),
+      sizeof(NicDeviceIbgdaResources),
+      "fixed NIC resource table");
+  err = cudaMalloc(&tables.nicResources, nicBytes);
+  throwOnCudaError(err, "Failed to allocate fixed GPU NIC resource table");
+  outGpuAllocations.push_back(tables.nicResources);
+  err = cudaMemset(tables.nicResources, 0, nicBytes);
+  throwOnCudaError(err, "Failed to zero fixed GPU NIC resource table");
+
+  const std::size_t localChannelCount = checkedMul(
+      static_cast<std::size_t>(numPeers),
+      static_cast<std::size_t>(maxChannels),
+      "fixed local channel descriptors");
+  const std::size_t localChannelBytes = checkedMul(
+      localChannelCount,
+      sizeof(IbLocalChannel),
+      "fixed local channel descriptor table");
+  err = cudaMalloc(&tables.localChannels, localChannelBytes);
+  throwOnCudaError(
+      err, "Failed to allocate fixed GPU local channel descriptor table");
+  outGpuAllocations.push_back(tables.localChannels);
+  err = cudaMemset(tables.localChannels, 0, localChannelBytes);
+  throwOnCudaError(
+      err, "Failed to zero fixed GPU local channel descriptor table");
+
+  const std::size_t transportBytes = checkedMul(
+      static_cast<std::size_t>(numPeers),
+      sizeof(P2pIbgdaTransportDevice),
+      "fixed device transport table");
+  err = cudaMalloc(&tables.transports, transportBytes);
+  throwOnCudaError(err, "Failed to allocate fixed GPU device transport table");
+  outGpuAllocations.push_back(tables.transports);
+  err = cudaMemset(tables.transports, 0, transportBytes);
+  throwOnCudaError(err, "Failed to zero fixed GPU device transport table");
+
+  return tables;
+}
+
+P2pIbgdaTransportDevice* ibgdaDeviceSlot(
+    P2pIbgdaTransportDevice* transports,
+    int peerIndex) {
+  return transports + peerIndex;
+}
+
+IbSendCompletionSlot* allocateIbgdaCompletionSlots(
+    std::size_t numChannels,
+    int pipelineDepth,
+    std::vector<void*>& outGpuAllocations) {
+  CHECK_GE(pipelineDepth, 0);
+  const std::size_t completionCount = checkedMul(
+      numChannels,
+      static_cast<std::size_t>(pipelineDepth),
+      "send completion slots");
+  const std::size_t completionBytes = checkedMul(
+      completionCount, sizeof(IbSendCompletionSlot), "send completion slots");
+  if (completionBytes == 0) {
+    return nullptr;
+  }
+
+  IbSendCompletionSlot* completionSlots = nullptr;
+  cudaError_t err = cudaMalloc(&completionSlots, completionBytes);
+  throwOnCudaError(err, "Failed to allocate GPU send completion slots");
+  outGpuAllocations.push_back(completionSlots);
+  err = cudaMemset(completionSlots, 0, completionBytes);
+  throwOnCudaError(err, "Failed to zero GPU send completion slots");
+  return completionSlots;
+}
+
+bool resetIbgdaDeviceSlot(
+    const IbgdaFixedDeviceTables& tables,
+    int peerIndex) noexcept {
+  if (tables.transports == nullptr || tables.qps == nullptr ||
+      tables.nicResources == nullptr || tables.localChannels == nullptr ||
+      peerIndex < 0 || peerIndex >= tables.numPeers) {
+    LOG(ERROR) << "Invalid fixed IBGDA reset peer=" << peerIndex;
+    return false;
+  }
+
+  const std::size_t nicBytes = static_cast<std::size_t>(tables.numNics) *
+      sizeof(NicDeviceIbgdaResources);
+  const bool nicsCleared = tryCudaMemset(
+      tables.nicResources +
+          static_cast<std::size_t>(peerIndex) * tables.numNics,
+      nicBytes,
+      "NIC resource entries");
+  const bool transportCleared = tryCudaMemset(
+      tables.transports + peerIndex,
+      sizeof(P2pIbgdaTransportDevice),
+      "device transport entry");
+  return nicsCleared && transportCleared;
+}
+
+void populateIbgdaDeviceRange(
+    const IbgdaFixedDeviceTables& tables,
+    int peerIndex,
+    int beginChannel,
+    int endChannel,
+    const P2pIbgdaTransportBuildParams& params,
+    const std::vector<IbLocalChannel>& rangeLocalChannels) {
+  CHECK(tables.transports != nullptr);
+  CHECK(tables.qps != nullptr);
+  CHECK(tables.nicResources != nullptr);
+  CHECK(tables.localChannels != nullptr);
+  CHECK_GE(peerIndex, 0);
+  CHECK_LT(peerIndex, tables.numPeers);
+  CHECK_GE(beginChannel, 0);
+  CHECK_LE(beginChannel, endChannel);
+  CHECK_LE(endChannel, tables.maxChannels);
+  CHECK_EQ(params.maxChannels, tables.maxChannels);
+  CHECK_EQ(params.qpsPerConnection, tables.qpsPerConnection);
+  CHECK_EQ(params.qpDirectionCount, tables.qpDirectionCount);
+  CHECK_EQ(params.channelLayout.pipelineDepth, tables.pipelineDepth);
+  CHECK_EQ(
+      rangeLocalChannels.size(),
+      static_cast<std::size_t>(endChannel - beginChannel));
+  CHECK_EQ(
+      static_cast<int>(params.h_nicDeviceIbgdaResources.size()),
+      tables.numNics);
+
+  const QpTableLayout layout = qpTableLayout(tables);
+  const std::size_t beginQp =
+      static_cast<std::size_t>(beginChannel) * layout.qpsPerChannel;
+  const std::size_t qpCount =
+      static_cast<std::size_t>(endChannel - beginChannel) *
+      layout.qpsPerChannel;
+  auto* const peerQpTable = peerQps(tables, layout, peerIndex);
+
+  cudaError_t err = cudaSuccess;
+  for (int nic = 0; nic < tables.numNics; ++nic) {
+    const auto& nicSpec = params.h_nicDeviceIbgdaResources[nic];
+    CHECK_EQ(nicSpec.qps.size(), layout.qpsPerNic);
+    CHECK_EQ(nicSpec.companionQps.size(), layout.qpsPerNic);
+    auto* mainQps =
+        peerQpTable + static_cast<std::size_t>(nic) * 2 * layout.qpsPerNic;
+    if (qpCount != 0) {
+      const std::size_t qpBytes = qpCount * sizeof(doca_gpu_dev_verbs_qp*);
+      err = cudaMemcpy(
+          mainQps + beginQp,
+          nicSpec.qps.data() + beginQp,
+          qpBytes,
+          cudaMemcpyHostToDevice);
+      throwOnCudaError(err, "Failed to populate fixed main QP range");
+      err = cudaMemcpy(
+          mainQps + layout.qpsPerNic + beginQp,
+          nicSpec.companionQps.data() + beginQp,
+          qpBytes,
+          cudaMemcpyHostToDevice);
+      throwOnCudaError(err, "Failed to populate fixed companion QP range");
+    }
+  }
+
+  auto* const peerLocalChannelTable = peerLocalChannels(tables, peerIndex);
+  if (beginChannel != endChannel) {
+    err = cudaMemcpy(
+        peerLocalChannelTable + beginChannel,
+        rangeLocalChannels.data(),
+        rangeLocalChannels.size() * sizeof(IbLocalChannel),
+        cudaMemcpyHostToDevice);
+    throwOnCudaError(
+        err, "Failed to populate fixed local channel descriptor range");
+  }
+}
+
+void publishIbgdaDeviceSlot(
+    const IbgdaFixedDeviceTables& tables,
+    int peerIndex,
+    const P2pIbgdaTransportBuildParams& params) {
+  CHECK(tables.transports != nullptr);
+  CHECK(tables.qps != nullptr);
+  CHECK(tables.nicResources != nullptr);
+  CHECK(tables.localChannels != nullptr);
+  CHECK_GE(peerIndex, 0);
+  CHECK_LT(peerIndex, tables.numPeers);
+  CHECK_EQ(params.maxChannels, tables.maxChannels);
+  CHECK_EQ(params.qpsPerConnection, tables.qpsPerConnection);
+  CHECK_EQ(params.qpDirectionCount, tables.qpDirectionCount);
+  CHECK_EQ(params.channelLayout.pipelineDepth, tables.pipelineDepth);
+  CHECK_EQ(
+      static_cast<int>(params.h_nicDeviceIbgdaResources.size()),
+      tables.numNics);
+  CHECK_LE(tables.numNics, kMaxNicsPerGpu);
+
+  const QpTableLayout layout = qpTableLayout(tables);
+  CHECK_LE(layout.qpsPerNic, static_cast<std::size_t>(UINT32_MAX));
+  const auto qpsPerNicSpan = static_cast<uint32_t>(layout.qpsPerNic);
+  auto* const peerQpTable = peerQps(tables, layout, peerIndex);
+
+  std::vector<NicDeviceIbgdaResources> hostNicResources;
+  hostNicResources.reserve(tables.numNics);
+  for (int nic = 0; nic < tables.numNics; ++nic) {
+    const auto& nicSpec = params.h_nicDeviceIbgdaResources[nic];
+    CHECK_EQ(nicSpec.qps.size(), layout.qpsPerNic);
+    CHECK_EQ(nicSpec.companionQps.size(), layout.qpsPerNic);
+    auto* mainQps =
+        peerQpTable + static_cast<std::size_t>(nic) * 2 * layout.qpsPerNic;
+    hostNicResources.push_back(
+        NicDeviceIbgdaResources{
+            DeviceSpan<doca_gpu_dev_verbs_qp*>(mainQps, qpsPerNicSpan),
+            DeviceSpan<doca_gpu_dev_verbs_qp*>(
+                mainQps + layout.qpsPerNic, qpsPerNicSpan),
+            nicSpec.sinkLkey,
+            nicSpec.deviceId,
+        });
+  }
+  cudaError_t err = cudaMemcpy(
+      tables.nicResources +
+          static_cast<std::size_t>(peerIndex) * tables.numNics,
+      hostNicResources.data(),
+      static_cast<std::size_t>(tables.numNics) *
+          sizeof(NicDeviceIbgdaResources),
+      cudaMemcpyHostToDevice);
+  throwOnCudaError(err, "Failed to publish fixed NIC resource entries");
+
+  auto* const peerLocalChannelTable = peerLocalChannels(tables, peerIndex);
   P2pIbgdaTransportDevice hostTransport(
-      DeviceSpan<NicDeviceIbgdaResources>(d_nicResources, numNics),
+      DeviceSpan<NicDeviceIbgdaResources>(
+          tables.nicResources +
+              static_cast<std::size_t>(peerIndex) * tables.numNics,
+          tables.numNics),
       params.remoteSignalBuf,
       params.localSignalBuf,
       params.counterBuf,
@@ -375,17 +370,141 @@ void writeDeviceTransportSlot(
       params.maxChannels,
       params.qpsPerConnection,
       params.qpDirectionCount,
-      DeviceSpan<IbLocalChannel>(d_localChannels, params.maxChannels),
+      DeviceSpan<IbLocalChannel>(peerLocalChannelTable, params.maxChannels),
       params.channelLayout,
       params.collapsedCq);
-
   err = cudaMemcpy(
-      deviceArray + peerIndex,
+      tables.transports + peerIndex,
       &hostTransport,
       sizeof(P2pIbgdaTransportDevice),
       cudaMemcpyHostToDevice);
-  CHECK(err == cudaSuccess) << "Failed to copy per-peer device transport slot: "
-                            << cudaGetErrorString(err);
+  throwOnCudaError(err, "Failed to publish fixed device transport slot");
+}
+
+bool clearIbgdaDeviceRange(
+    const IbgdaFixedDeviceTables& tables,
+    int peerIndex,
+    int beginChannel,
+    int endChannel) noexcept {
+  if (tables.qps == nullptr || tables.localChannels == nullptr ||
+      peerIndex < 0 || peerIndex >= tables.numPeers || beginChannel < 0 ||
+      beginChannel > endChannel || endChannel > tables.maxChannels) {
+    LOG(ERROR) << "Invalid fixed IBGDA clear range: peer=" << peerIndex
+               << " begin=" << beginChannel << " end=" << endChannel;
+    return false;
+  }
+
+  const QpTableLayout layout = qpTableLayout(tables);
+  const std::size_t beginQp =
+      static_cast<std::size_t>(beginChannel) * layout.qpsPerChannel;
+  const std::size_t qpCount =
+      static_cast<std::size_t>(endChannel - beginChannel) *
+      layout.qpsPerChannel;
+  auto* const peerQpTable = peerQps(tables, layout, peerIndex);
+
+  bool ok = true;
+  const std::size_t qpBytes = qpCount * sizeof(doca_gpu_dev_verbs_qp*);
+  for (int nic = 0; nic < tables.numNics; ++nic) {
+    auto* mainQps =
+        peerQpTable + static_cast<std::size_t>(nic) * 2 * layout.qpsPerNic;
+    ok = tryCudaMemset(mainQps + beginQp, qpBytes, "main QP range") && ok;
+    ok = tryCudaMemset(
+             mainQps + layout.qpsPerNic + beginQp,
+             qpBytes,
+             "companion QP range") &&
+        ok;
+  }
+
+  const std::size_t localChannelCount =
+      static_cast<std::size_t>(endChannel - beginChannel);
+  ok = tryCudaMemset(
+           peerLocalChannels(tables, peerIndex) + beginChannel,
+           localChannelCount * sizeof(IbLocalChannel),
+           "local channel descriptor range") &&
+      ok;
+  return ok;
+}
+
+P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
+    const std::vector<P2pIbgdaTransportBuildParams>& params,
+    int numPeers,
+    std::vector<void*>& outGpuAllocations) {
+  CHECK_GT(numPeers, 0);
+  CHECK_EQ(params.size(), static_cast<std::size_t>(numPeers));
+  const auto& shape = params.front();
+  CHECK(!shape.h_nicDeviceIbgdaResources.empty());
+
+  const int numNics = static_cast<int>(shape.h_nicDeviceIbgdaResources.size());
+  const std::size_t mainQpsPerNic =
+      shape.h_nicDeviceIbgdaResources.front().qps.size();
+  const std::size_t companionQpsPerNic =
+      shape.h_nicDeviceIbgdaResources.front().companionQps.size();
+  for (const auto& peerParams : params) {
+    CHECK_EQ(peerParams.maxChannels, shape.maxChannels);
+    CHECK_EQ(peerParams.qpsPerConnection, shape.qpsPerConnection);
+    CHECK_EQ(peerParams.qpDirectionCount, shape.qpDirectionCount);
+    CHECK_EQ(peerParams.collapsedCq, shape.collapsedCq);
+    CHECK_EQ(
+        peerParams.h_nicDeviceIbgdaResources.size(),
+        static_cast<std::size_t>(numNics));
+    for (const auto& nicParams : peerParams.h_nicDeviceIbgdaResources) {
+      CHECK_EQ(nicParams.qps.size(), mainQpsPerNic);
+      CHECK_EQ(nicParams.companionQps.size(), companionQpsPerNic);
+    }
+  }
+
+  P2pIbgdaTransportDevice* deviceArray = nullptr;
+  const std::size_t transportBytes = checkedMul(
+      static_cast<std::size_t>(numPeers),
+      sizeof(P2pIbgdaTransportDevice),
+      "legacy device transport table");
+  throwOnCudaError(
+      cudaMalloc(&deviceArray, transportBytes),
+      "Failed to allocate legacy IBGDA device transport table");
+  outGpuAllocations.push_back(deviceArray);
+  for (int peerIndex = 0; peerIndex < numPeers; ++peerIndex) {
+    writeDeviceTransportSlot(
+        deviceArray, peerIndex, params[peerIndex], outGpuAllocations);
+  }
+  return deviceArray;
+}
+
+void writeDeviceTransportSlot(
+    P2pIbgdaTransportDevice* deviceArray,
+    int peerIndex,
+    const P2pIbgdaTransportBuildParams& params,
+    std::vector<void*>& outGpuAllocations) {
+  CHECK(deviceArray != nullptr);
+  CHECK_GE(peerIndex, 0);
+  CHECK(!params.h_nicDeviceIbgdaResources.empty());
+  const IbgdaFixedDeviceTables tables = allocateIbgdaFixedDeviceTables(
+      /*numPeers=*/1,
+      static_cast<int>(params.h_nicDeviceIbgdaResources.size()),
+      params.maxChannels,
+      params.qpsPerConnection,
+      params.qpDirectionCount,
+      params.channelLayout.pipelineDepth,
+      outGpuAllocations);
+  auto* const completionSlots = allocateIbgdaCompletionSlots(
+      params.maxChannels,
+      params.channelLayout.pipelineDepth,
+      outGpuAllocations);
+  const auto localChannels = buildLegacyLocalChannels(params, completionSlots);
+  populateIbgdaDeviceRange(
+      tables,
+      /*peerIndex=*/0,
+      /*beginChannel=*/0,
+      params.maxChannels,
+      params,
+      localChannels);
+  publishIbgdaDeviceSlot(tables, /*peerIndex=*/0, params);
+  throwOnCudaError(
+      cudaMemcpy(
+          deviceArray + peerIndex,
+          tables.transports,
+          sizeof(P2pIbgdaTransportDevice),
+          cudaMemcpyDeviceToDevice),
+      "Failed to copy legacy IBGDA device transport slot");
 }
 
 std::size_t getP2pIbgdaTransportDeviceSize() {

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cu
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cu
@@ -28,6 +28,52 @@ void throwOnCudaError(cudaError_t error, const char* operation) {
   }
 }
 
+// Initializes and publishes device transport state outside active stream
+// capture.
+class CaptureSafeDeviceInitStream {
+ public:
+  CaptureSafeDeviceInitStream() {
+    throwOnCudaError(
+        cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking),
+        "Failed to create IBGDA device initialization stream");
+  }
+
+  ~CaptureSafeDeviceInitStream() {
+    if (stream_ != nullptr) {
+      cudaStream_t stream = stream_;
+      stream_ = nullptr;
+      (void)cudaStreamSynchronize(stream);
+      (void)cudaStreamDestroy(stream);
+    }
+  }
+
+  void memset(void* dst, int value, std::size_t bytes) {
+    throwOnCudaError(
+        cudaMemsetAsync(dst, value, bytes, stream_),
+        "Failed to enqueue IBGDA device initialization memset");
+  }
+
+  void copyHostToDevice(void* dst, const void* src, std::size_t bytes) {
+    throwOnCudaError(
+        cudaMemcpyAsync(dst, src, bytes, cudaMemcpyHostToDevice, stream_),
+        "Failed to enqueue IBGDA device initialization copy");
+  }
+
+  void synchronize() {
+    cudaStream_t stream = stream_;
+    stream_ = nullptr;
+    const cudaError_t syncError = cudaStreamSynchronize(stream);
+    const cudaError_t destroyError = cudaStreamDestroy(stream);
+    throwOnCudaError(
+        syncError, "Failed to synchronize IBGDA device initialization");
+    throwOnCudaError(
+        destroyError, "Failed to destroy IBGDA device initialization stream");
+  }
+
+ private:
+  cudaStream_t stream_{nullptr};
+};
+
 struct QpTableLayout {
   std::size_t qpsPerChannel;
   std::size_t qpsPerNic;
@@ -67,19 +113,6 @@ IbLocalChannel* peerLocalChannels(
       static_cast<std::size_t>(peerIndex) * tables.maxChannels;
 }
 
-bool tryCudaMemset(void* ptr, std::size_t bytes, const char* label) noexcept {
-  if (bytes == 0) {
-    return true;
-  }
-  const cudaError_t error = cudaMemset(ptr, 0, bytes);
-  if (error == cudaSuccess) {
-    return true;
-  }
-  LOG(ERROR) << "Failed to clear fixed IBGDA " << label << ": "
-             << cudaGetErrorString(error);
-  return false;
-}
-
 std::vector<IbLocalChannel> buildLegacyLocalChannels(
     const P2pIbgdaTransportBuildParams& params,
     IbSendCompletionSlot* completionSlots) {
@@ -98,7 +131,6 @@ std::vector<IbLocalChannel> buildLegacyLocalChannels(
   }
   return localChannels;
 }
-
 } // namespace
 
 IbgdaFixedDeviceTables allocateIbgdaFixedDeviceTables(
@@ -206,33 +238,10 @@ IbSendCompletionSlot* allocateIbgdaCompletionSlots(
   cudaError_t err = cudaMalloc(&completionSlots, completionBytes);
   throwOnCudaError(err, "Failed to allocate GPU send completion slots");
   outGpuAllocations.push_back(completionSlots);
-  err = cudaMemset(completionSlots, 0, completionBytes);
-  throwOnCudaError(err, "Failed to zero GPU send completion slots");
+  CaptureSafeDeviceInitStream deviceInitStream;
+  deviceInitStream.memset(completionSlots, 0, completionBytes);
+  deviceInitStream.synchronize();
   return completionSlots;
-}
-
-bool resetIbgdaDeviceSlot(
-    const IbgdaFixedDeviceTables& tables,
-    int peerIndex) noexcept {
-  if (tables.transports == nullptr || tables.qps == nullptr ||
-      tables.nicResources == nullptr || tables.localChannels == nullptr ||
-      peerIndex < 0 || peerIndex >= tables.numPeers) {
-    LOG(ERROR) << "Invalid fixed IBGDA reset peer=" << peerIndex;
-    return false;
-  }
-
-  const std::size_t nicBytes = static_cast<std::size_t>(tables.numNics) *
-      sizeof(NicDeviceIbgdaResources);
-  const bool nicsCleared = tryCudaMemset(
-      tables.nicResources +
-          static_cast<std::size_t>(peerIndex) * tables.numNics,
-      nicBytes,
-      "NIC resource entries");
-  const bool transportCleared = tryCudaMemset(
-      tables.transports + peerIndex,
-      sizeof(P2pIbgdaTransportDevice),
-      "device transport entry");
-  return nicsCleared && transportCleared;
 }
 
 void populateIbgdaDeviceRange(
@@ -270,7 +279,7 @@ void populateIbgdaDeviceRange(
       layout.qpsPerChannel;
   auto* const peerQpTable = peerQps(tables, layout, peerIndex);
 
-  cudaError_t err = cudaSuccess;
+  CaptureSafeDeviceInitStream deviceInitStream;
   for (int nic = 0; nic < tables.numNics; ++nic) {
     const auto& nicSpec = params.h_nicDeviceIbgdaResources[nic];
     CHECK_EQ(nicSpec.qps.size(), layout.qpsPerNic);
@@ -279,31 +288,23 @@ void populateIbgdaDeviceRange(
         peerQpTable + static_cast<std::size_t>(nic) * 2 * layout.qpsPerNic;
     if (qpCount != 0) {
       const std::size_t qpBytes = qpCount * sizeof(doca_gpu_dev_verbs_qp*);
-      err = cudaMemcpy(
-          mainQps + beginQp,
-          nicSpec.qps.data() + beginQp,
-          qpBytes,
-          cudaMemcpyHostToDevice);
-      throwOnCudaError(err, "Failed to populate fixed main QP range");
-      err = cudaMemcpy(
+      deviceInitStream.copyHostToDevice(
+          mainQps + beginQp, nicSpec.qps.data() + beginQp, qpBytes);
+      deviceInitStream.copyHostToDevice(
           mainQps + layout.qpsPerNic + beginQp,
           nicSpec.companionQps.data() + beginQp,
-          qpBytes,
-          cudaMemcpyHostToDevice);
-      throwOnCudaError(err, "Failed to populate fixed companion QP range");
+          qpBytes);
     }
   }
 
   auto* const peerLocalChannelTable = peerLocalChannels(tables, peerIndex);
   if (beginChannel != endChannel) {
-    err = cudaMemcpy(
+    deviceInitStream.copyHostToDevice(
         peerLocalChannelTable + beginChannel,
         rangeLocalChannels.data(),
-        rangeLocalChannels.size() * sizeof(IbLocalChannel),
-        cudaMemcpyHostToDevice);
-    throwOnCudaError(
-        err, "Failed to populate fixed local channel descriptor range");
+        rangeLocalChannels.size() * sizeof(IbLocalChannel));
   }
+  deviceInitStream.synchronize();
 }
 
 void publishIbgdaDeviceSlot(
@@ -347,14 +348,13 @@ void publishIbgdaDeviceSlot(
             nicSpec.deviceId,
         });
   }
-  cudaError_t err = cudaMemcpy(
+  CaptureSafeDeviceInitStream deviceInitStream;
+  deviceInitStream.copyHostToDevice(
       tables.nicResources +
           static_cast<std::size_t>(peerIndex) * tables.numNics,
       hostNicResources.data(),
       static_cast<std::size_t>(tables.numNics) *
-          sizeof(NicDeviceIbgdaResources),
-      cudaMemcpyHostToDevice);
-  throwOnCudaError(err, "Failed to publish fixed NIC resource entries");
+          sizeof(NicDeviceIbgdaResources));
 
   auto* const peerLocalChannelTable = peerLocalChannels(tables, peerIndex);
   P2pIbgdaTransportDevice hostTransport(
@@ -373,56 +373,11 @@ void publishIbgdaDeviceSlot(
       DeviceSpan<IbLocalChannel>(peerLocalChannelTable, params.maxChannels),
       params.channelLayout,
       params.collapsedCq);
-  err = cudaMemcpy(
+  deviceInitStream.copyHostToDevice(
       tables.transports + peerIndex,
       &hostTransport,
-      sizeof(P2pIbgdaTransportDevice),
-      cudaMemcpyHostToDevice);
-  throwOnCudaError(err, "Failed to publish fixed device transport slot");
-}
-
-bool clearIbgdaDeviceRange(
-    const IbgdaFixedDeviceTables& tables,
-    int peerIndex,
-    int beginChannel,
-    int endChannel) noexcept {
-  if (tables.qps == nullptr || tables.localChannels == nullptr ||
-      peerIndex < 0 || peerIndex >= tables.numPeers || beginChannel < 0 ||
-      beginChannel > endChannel || endChannel > tables.maxChannels) {
-    LOG(ERROR) << "Invalid fixed IBGDA clear range: peer=" << peerIndex
-               << " begin=" << beginChannel << " end=" << endChannel;
-    return false;
-  }
-
-  const QpTableLayout layout = qpTableLayout(tables);
-  const std::size_t beginQp =
-      static_cast<std::size_t>(beginChannel) * layout.qpsPerChannel;
-  const std::size_t qpCount =
-      static_cast<std::size_t>(endChannel - beginChannel) *
-      layout.qpsPerChannel;
-  auto* const peerQpTable = peerQps(tables, layout, peerIndex);
-
-  bool ok = true;
-  const std::size_t qpBytes = qpCount * sizeof(doca_gpu_dev_verbs_qp*);
-  for (int nic = 0; nic < tables.numNics; ++nic) {
-    auto* mainQps =
-        peerQpTable + static_cast<std::size_t>(nic) * 2 * layout.qpsPerNic;
-    ok = tryCudaMemset(mainQps + beginQp, qpBytes, "main QP range") && ok;
-    ok = tryCudaMemset(
-             mainQps + layout.qpsPerNic + beginQp,
-             qpBytes,
-             "companion QP range") &&
-        ok;
-  }
-
-  const std::size_t localChannelCount =
-      static_cast<std::size_t>(endChannel - beginChannel);
-  ok = tryCudaMemset(
-           peerLocalChannels(tables, peerIndex) + beginChannel,
-           localChannelCount * sizeof(IbLocalChannel),
-           "local channel descriptor range") &&
-      ok;
-  return ok;
+      sizeof(P2pIbgdaTransportDevice));
+  deviceInitStream.synchronize();
 }
 
 P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cuh
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cuh
@@ -27,7 +27,8 @@ struct doca_gpu_dev_verbs_qp;
 
 namespace comms::prims {
 
-// Forward declaration for return type
+// Forward declarations for device-table types.
+struct NicDeviceIbgdaResources;
 class P2pIbgdaTransportDevice;
 
 /**
@@ -47,11 +48,11 @@ struct NicDeviceIbgdaResourcesBuildSpec {
 };
 
 /**
- * Parameters for building a single P2pIbgdaTransportDevice.
+ * Host resources used to populate one peer's fixed device tables.
  *
- * The build function reads `nicResources` (one entry per NIC), copies QP
- * pointers to GPU memory, and constructs a DeviceSpan<NicDeviceIbgdaResources>
- * for the device transport.
+ * Range population reads the full-capacity per-NIC QP vectors and the exact
+ * channel descriptors supplied for that call. Slot publication installs the
+ * stable spans after the first prefix has been populated.
  *
  * Single-NIC callers populate `nicResources` with one element.
  * Multi-NIC callers populate `nicResources` with one element per NIC. qps and
@@ -78,36 +79,89 @@ struct P2pIbgdaTransportBuildParams {
 };
 
 /**
- * Build P2pIbgdaTransportDevice array on GPU.
- *
- * For each peer, allocates GPU arrays for QP pointers, copies them,
- * then constructs P2pIbgdaTransportDevice objects in GPU memory.
- * All GPU allocations are pushed into outGpuAllocations for cleanup.
- * If channelLayout is populated in the build params, it is passed through
- * the transport constructor before copying to GPU.
- *
- * @param params Build parameters (one per peer)
- * @param numPeers Number of peers
- * @param outGpuAllocations Output: all GPU allocations (caller frees)
- * @return Pointer to GPU array of transport objects (also in outGpuAllocations)
+ * Communicator-lifetime device publication tables. All pointers remain stable
+ * until transport teardown; range operations only update their contents.
  */
+struct IbgdaFixedDeviceTables {
+  P2pIbgdaTransportDevice* transports{nullptr};
+  doca_gpu_dev_verbs_qp** qps{nullptr};
+  NicDeviceIbgdaResources* nicResources{nullptr};
+  IbLocalChannel* localChannels{nullptr};
+  int numPeers{0};
+  int numNics{0};
+  int maxChannels{0};
+  int qpsPerConnection{0};
+  int qpDirectionCount{0};
+  int pipelineDepth{0};
+};
+
+/** Allocate and initialize every fixed-capacity device publication table. */
+IbgdaFixedDeviceTables allocateIbgdaFixedDeviceTables(
+    int numPeers,
+    int numNics,
+    int maxChannels,
+    int qpsPerConnection,
+    int qpDirectionCount,
+    int pipelineDepth,
+    std::vector<void*>& outGpuAllocations);
+
+/** Return one slot from the stable outer transport table. */
+P2pIbgdaTransportDevice* ibgdaDeviceSlot(
+    P2pIbgdaTransportDevice* transports,
+    int peerIndex);
+
+/** Allocate zeroed physical completion state for a channel range. */
+IbSendCompletionSlot* allocateIbgdaCompletionSlots(
+    std::size_t numChannels,
+    int pipelineDepth,
+    std::vector<void*>& outGpuAllocations);
+
+/**
+ * Populate one peer's canonical channel range without allocating memory.
+ * QP vectors retain full-capacity indexing; `rangeLocalChannels` contains
+ * exactly [beginChannel, endChannel). The outer slot is published separately
+ * once the first prefix is complete.
+ */
+void populateIbgdaDeviceRange(
+    const IbgdaFixedDeviceTables& tables,
+    int peerIndex,
+    int beginChannel,
+    int endChannel,
+    const P2pIbgdaTransportBuildParams& params,
+    const std::vector<IbLocalChannel>& rangeLocalChannels);
+
+/** Publish the stable outer and per-NIC spans after the first prefix exists. */
+void publishIbgdaDeviceSlot(
+    const IbgdaFixedDeviceTables& tables,
+    int peerIndex,
+    const P2pIbgdaTransportBuildParams& params);
+
+/** Clear one peer's canonical channel range without freeing table storage. */
+bool clearIbgdaDeviceRange(
+    const IbgdaFixedDeviceTables& tables,
+    int peerIndex,
+    int beginChannel,
+    int endChannel) noexcept;
+
+/** Restore one outer slot to an unpublished shape while retaining table bases.
+ */
+bool resetIbgdaDeviceSlot(
+    const IbgdaFixedDeviceTables& tables,
+    int peerIndex) noexcept;
+
+// Compatibility entry points retained for callers that build complete device
+// tables outside MultipeerIbgdaTransport.
 P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
     const std::vector<P2pIbgdaTransportBuildParams>& params,
     int numPeers,
     std::vector<void*>& outGpuAllocations);
 
-/**
- * Write a single P2pIbgdaTransportDevice into the pre-allocated array.
- */
 void writeDeviceTransportSlot(
     P2pIbgdaTransportDevice* deviceArray,
     int peerIndex,
     const P2pIbgdaTransportBuildParams& params,
     std::vector<void*>& outGpuAllocations);
 
-/**
- * Get size of P2pIbgdaTransportDevice struct.
- */
 std::size_t getP2pIbgdaTransportDeviceSize();
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cuh
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cuh
@@ -136,21 +136,7 @@ void publishIbgdaDeviceSlot(
     int peerIndex,
     const P2pIbgdaTransportBuildParams& params);
 
-/** Clear one peer's canonical channel range without freeing table storage. */
-bool clearIbgdaDeviceRange(
-    const IbgdaFixedDeviceTables& tables,
-    int peerIndex,
-    int beginChannel,
-    int endChannel) noexcept;
-
-/** Restore one outer slot to an unpublished shape while retaining table bases.
- */
-bool resetIbgdaDeviceSlot(
-    const IbgdaFixedDeviceTables& tables,
-    int peerIndex) noexcept;
-
-// Compatibility entry points retained for callers that build complete device
-// tables outside MultipeerIbgdaTransport.
+/** Build complete device tables for callers outside the host transport. */
 P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
     const std::vector<P2pIbgdaTransportBuildParams>& params,
     int numPeers,
@@ -163,5 +149,4 @@ void writeDeviceTransportSlot(
     std::vector<void*>& outGpuAllocations);
 
 std::size_t getP2pIbgdaTransportDeviceSize();
-
 } // namespace comms::prims

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -1072,7 +1072,7 @@ class P2pIbgdaTransportDevice {
     if (numNics == 0) {
       printf(
           "P2pIbgdaTransportDevice: transport not initialized "
-          "(peer not materialized? call get_device_handle(peers) first) "
+          "(peer not materialized? prepare it on the host first) "
           "at %s:%d block=(%u,%u,%u) thread=(%u,%u,%u)\n",
           __FILE__,
           __LINE__,
@@ -1137,7 +1137,7 @@ class P2pIbgdaTransportDevice {
     if (nicDevices_.empty()) {
       printf(
           "P2pIbgdaTransportDevice: transport not initialized "
-          "(peer not materialized? call get_device_handle(peers) first) "
+          "(peer not materialized? prepare it on the host first) "
           "at %s:%d block=(%u,%u,%u) thread=(%u,%u,%u)\n",
           __FILE__,
           __LINE__,

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -127,7 +127,8 @@ __device__ __forceinline__ int prims_ibgda_wait_collapsed_cq(
 //
 // `IbgdaSendRecvProgressStatus` and the pipelined send/recv algorithm live in
 // private shared helpers in P2pIbTransportDeviceImpl.cuh; backend-owned
-// `channelLayout_` carries the actual protocol state.
+// `channelLayout_` carries shared geometry while each `IbLocalChannel` carries
+// channel-specific resources and mutable protocol state.
 
 // Slot-id bounds checks for the slot-index API. Catches both
 // out-of-range slot ids and slot-index calls made when the transport was
@@ -181,9 +182,9 @@ struct NicDeviceIbgdaResources {
  *
  * Every method has two overloads:
  *   Group-scope: put(group, ...) — all threads in group must call.
- *     QP selection is owned by the physical CUDA block. The block
- *     round-robins put operations across NIC-first QP lanes and preserves
- *     signal/flush ordering for operations issued by the same block_id.
+ *     group.group_id selects the logical channel. That channel round-robins
+ *     put operations across NIC-first QP lanes and preserves signal/flush
+ *     ordering for operations issued on the same channel.
  *     Data transfer uses the exact buffer span supplied by the caller.
  *     Threads in the group coordinate the operation; callers that want the
  *     transport to shard a larger buffer should use put_cooperative().
@@ -192,9 +193,8 @@ struct NicDeviceIbgdaResources {
  *     group-scope wait_local() consumes that leader's ticket collectively.
  *
  *   Thread-scope: put(...) — single thread calls.
- *     QP selection uses the caller's physical blockIdx.x. Implemented as a
- *     thin wrapper: creates a solo ThreadGroup with block_id=blockIdx.x, then
- *     forwards to the group-scope implementation.
+ *     Implemented as a thin wrapper that maps blockIdx.x to the solo group's
+ *     group_id, then forwards to the group-scope implementation.
  *
  * CRITICAL: Do not rely on scope-family mixing for synchronization.
  *   Thread-scope wrappers do not synchronize with other threads in the block.
@@ -203,12 +203,11 @@ struct NicDeviceIbgdaResources {
  *   standalone signal when the signal is meant to announce completion of prior
  *   puts.
  *
- * CRITICAL: Same-block warp-scope batching is not a supported ordering
- * contract in this implementation. The block_id owns one logical ordered
- * stream. If multiple independent warps use the same block_id, this transport
- * does not infer cross-warp order for a later signal() or flush(); the caller
- * must use a CTA-level barrier or another protocol-level synchronization
- * before issuing the covering signal/flush. In particular, do not rely on:
+ * CRITICAL: Multiple independent warps sharing one logical channel are not a
+ * supported ordering contract. The transport does not infer cross-warp order
+ * for a later signal() or flush(); the caller must use a CTA-level barrier or
+ * another protocol-level synchronization before issuing the covering
+ * signal/flush. In particular, do not rely on:
  *
  *   warp0: put(A); put(B); signal(S);
  *   warp1: put(C); put(D); signal(S);
@@ -236,18 +235,17 @@ struct NicDeviceIbgdaResources {
  */
 class P2pIbgdaTransportDevice {
  public:
-  // Default ctor required so an array of these can be cudaMemcpy'd from host
-  // (see MultipeerIbgdaTransportCuda.cu::buildDeviceTransportsOnGpu). Do not
-  // call methods on a default-constructed instance — nicDevices_ is empty.
+  // Default ctor supports unpublished entries in the fixed device table. Do
+  // not call methods on a default-constructed instance: nicDevices_ is empty.
   P2pIbgdaTransportDevice() = default;
 
   /**
    * Construct a per-peer device transport handle.
    *
    * Each P2p instance owns one peer's NICs. Each NicDeviceIbgdaResources
-   * carries its main and companion QPs plus a sink lkey. Lane selection is
-   * block-owned: each physical CUDA block round-robins its puts across
-   * numNics * qpsPerBlockPerNic lanes, using NIC-first lane ordinals.
+   * carries its main and companion QPs plus a sink lkey. Each logical channel
+   * round-robins its puts across numNics * qpsPerConnection lanes, using
+   * NIC-first lane ordinals.
    *
    * Single-NIC usage: pass a 1-element nicDevices span. All ops fall through
    * to NIC 0.
@@ -1050,7 +1048,7 @@ class P2pIbgdaTransportDevice {
       const ThreadGroup& group) const {
     if (group.scope == SyncScope::CLUSTER) {
       printf(
-          "[PIPES] FATAL: IBGDA per-block QP selection does not support "
+          "[PIPES] FATAL: IBGDA channel QP selection does not support "
           "cluster-scope ThreadGroup yet\n");
       PIPES_DEVICE_TRAP();
     }
@@ -1097,11 +1095,12 @@ class P2pIbgdaTransportDevice {
           qpDirectionCount_);
       PIPES_DEVICE_TRAP();
     }
-    const uint32_t qpSlotPerNic =
-        ((channelId * static_cast<uint32_t>(qpDirectionCount_) +
-          directionIndex) *
-         static_cast<uint32_t>(qpsPerConnection_)) +
-        qpIndex;
+    const uint32_t qpSlotPerNic = ibQpSlotWithinNic(
+        channelId,
+        direction,
+        static_cast<uint32_t>(qpDirectionCount_),
+        static_cast<uint32_t>(qpsPerConnection_),
+        qpIndex);
     const uint32_t companionSlotPerNic = qpSlotPerNic;
     const NicDeviceIbgdaResources& nic = nicDevices_[nicId];
     if (qpIndex >= static_cast<uint32_t>(qpsPerConnection_) ||
@@ -2389,7 +2388,7 @@ class P2pIbgdaTransportDevice {
    *   pipelineBytes = perChannelBufferSize
    *   pipelineOff   = streamStart % pipelineBytes
    *   slot          = pipelineOff / perBlockSlot
-   *   stagingOff    = groupId * pipelineBytes + slot * perBlockSlot +
+   *   stagingOff    = slot * perBlockSlot +
    *                   (pipelineOff - slot * perBlockSlot)
    *
    * Sender chunk state machine:
@@ -3123,9 +3122,7 @@ class P2pIbgdaTransportDevice {
    *   pipeline_chunk() = pipeline_window() / pipeline_depth()
    */
   __device__ __forceinline__ std::size_t pipeline_window() const {
-    return channelLayout_.perChannelBufferSize != 0
-        ? channelLayout_.perChannelBufferSize
-        : channelLayout_.perChannelSize;
+    return channelLayout_.channelBufferSize();
   }
 
   __device__ __forceinline__ std::size_t pipeline_window(

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -307,6 +307,9 @@ MultipeerIbrcTransport::MultipeerIbrcTransport(
             config_.qpsPerConnection,
             numQpsPerPeerPerNic));
   }
+  if (sendRecvBuffersEnabled()) {
+    validateSendRecvConfig();
+  }
   peerResources_.resize(nRanks_ - 1);
   peerQueuesPublished_ = std::make_unique<std::atomic<bool>[]>(nRanks_ - 1);
 
@@ -777,6 +780,12 @@ void MultipeerIbrcTransport::publishTransportError(
     __atomic_store_n(&status->error, 1, __ATOMIC_RELEASE);
   }
   stopProgress_.store(true, std::memory_order_release);
+}
+
+void MultipeerIbrcTransport::onTerminalMaterializationFailure() noexcept {
+  publishTransportError(
+      ECANCELED, "terminal peer/channel materialization failure");
+  stopProgressThread();
 }
 
 void MultipeerIbrcTransport::initializeControlResources() {
@@ -1614,6 +1623,7 @@ void MultipeerIbrcTransport::exchangeAndConnectQps() {
 
 P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDeviceSlot(
     int peerRank) const {
+  throwIfMaterializationFailed();
   if (p2pTransportDevices_.device == nullptr) {
     throw std::runtime_error(
         "getP2pTransportDeviceSlot: IBRC device transport slots are not initialized");
@@ -1626,6 +1636,7 @@ P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDeviceSlot(
 
 P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDevice(
     int peerRank) {
+  throwIfMaterializationFailed();
   if (!isPeerMaterialized(peerRank)) {
     queuePeerForMaterialization(peerRank, channelCapacity());
     connectPeers();
@@ -1640,7 +1651,7 @@ P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDevice(
       peerIndex * ibrcDeviceSlotSize());
 }
 
-void MultipeerIbrcTransport::doMaterializePeer(
+void MultipeerIbrcTransport::materializePeerChannelRange(
     int peerRank,
     uint32_t oldChannels,
     uint32_t newChannels) {
@@ -1674,15 +1685,6 @@ void MultipeerIbrcTransport::doMaterializePeer(
   applyRemoteSendRecvBuffer(peerIndex, remoteBuf);
   allocatePeerCmdQueues(peerIndex);
   startProgressThread();
-}
-
-void MultipeerIbrcTransport::cleanupPeerOnFailure(int peerIndex) {
-  publishTransportError(EIO, "peer materialization failed");
-  stopProgressThread();
-  cleanupPeerCmdQueues(peerIndex);
-  cleanupPeerQps(peerIndex);
-  cleanupPeerSignalCounterResources(peerIndex);
-  cleanupSendRecvBufferForPeer(peerIndex);
 }
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <fstream>
 #include <limits>
+#include <memory>
 #include <new>
 #include <sstream>
 #include <stdexcept>
@@ -274,6 +275,7 @@ MultipeerIbrcTransport::MultipeerIbrcTransport(
           std::move(bootstrap),
           config),
       abortDevice_(abort) {
+  const int directionCount = config_.fixedChannelDirectionCount();
   const int numQpsPerPeerPerNic = config_.fixedChannelMainQpsPerPeerPerNic();
   if (config_.max_num_channels < 1) {
     throw std::invalid_argument("max_num_channels must be >= 1");
@@ -298,9 +300,10 @@ MultipeerIbrcTransport::MultipeerIbrcTransport(
   if (numQpsPerPeerPerNic > kMaxIbQpsPerPeerPerNic) {
     throw std::invalid_argument(
         fmt::format(
-            "max_num_channels * 2 * qpsPerConnection must be <= {}, got {} * 2 * {} = {}",
+            "max_num_channels * directionCount * qpsPerConnection must be <= {}, got {} * {} * {} = {}",
             kMaxIbQpsPerPeerPerNic,
             config_.max_num_channels,
+            directionCount,
             config_.qpsPerConnection,
             numQpsPerPeerPerNic));
   }
@@ -377,6 +380,8 @@ void MultipeerIbrcTransport::cleanup() {
   statusDeviceByNic_.clear();
   statusControl_.reset();
   p2pTransportDevices_.reset();
+  cmdQueueDevices_.reset();
+  localChannelStates_.reset();
 
   closeNics();
 }
@@ -835,9 +840,9 @@ void MultipeerIbrcTransport::cleanupPeerCmdQueues(int peerIndex) noexcept {
   // Unpublish before clearing so progressOnce can't walk a half-cleared vector.
   peerQueuesPublished_[peerIndex].store(false, std::memory_order_release);
   auto& peer = peerResources_[peerIndex];
+  clearPeerDeviceRange(peerIndex, 0, config_.max_num_channels);
   peer.cmdQueues.clear();
-  peer.cmdQueueDevices.reset();
-  peer.channelState.reset();
+  peer.completionSlots.reset();
   peer.cmdQueuesAllocated = false;
   if (p2pTransportDevices_.host != nullptr) {
     updatePeerDeviceTransport(peerIndex);
@@ -911,18 +916,7 @@ void MultipeerIbrcTransport::allocatePeerCmdQueues(int peerIndex) {
     }
   }
 
-  peer.cmdQueueDevices = allocateMapped(
-      deviceCmdQueues.size() * sizeof(IbrcCmdQueueDevice),
-      "per-peer command queue device descriptors");
-  std::memcpy(
-      peer.cmdQueueDevices.host,
-      deviceCmdQueues.data(),
-      deviceCmdQueues.size() * sizeof(IbrcCmdQueueDevice));
-  const std::size_t channelBytes =
-      static_cast<std::size_t>(config_.max_num_channels) *
-      sizeof(IbLocalChannel);
-  const std::size_t completionSlotsOffset =
-      alignUp(channelBytes, alignof(IbSendCompletionSlot));
+  CHECK_EQ(deviceCmdQueues.size(), cmdQueuesPerPeer_);
   const IbChannelLayout channelLayout = channelLayoutForPeer(peerIndex);
   CHECK_GE(channelLayout.pipelineDepth, 0);
   const std::size_t completionSlotCount = checkedMul(
@@ -933,29 +927,26 @@ void MultipeerIbrcTransport::allocatePeerCmdQueues(int peerIndex) {
       completionSlotCount,
       sizeof(IbSendCompletionSlot),
       "per-peer send completion slots");
-  const std::size_t channelStateBytes = completionSlotBytes == 0
-      ? channelBytes
-      : checkedAdd(
-            completionSlotsOffset,
-            completionSlotBytes,
-            "per-peer channel state");
-  peer.channelState =
-      allocateMapped(channelStateBytes, "per-peer channel state");
-  auto* channels = static_cast<IbLocalChannel*>(peer.channelState.host);
-  auto* completionSlots = completionSlotBytes == 0
+  if (completionSlotBytes != 0) {
+    peer.completionSlots =
+        allocateMapped(completionSlotBytes, "per-peer send completion slots");
+  }
+  auto* const completionSlots = completionSlotBytes == 0
       ? nullptr
-      : reinterpret_cast<IbSendCompletionSlot*>(
-            static_cast<std::byte*>(peer.channelState.device) +
-            completionSlotsOffset);
-  const uint32_t pipelineDepth =
-      static_cast<uint32_t>(channelLayout.pipelineDepth);
+      : static_cast<IbSendCompletionSlot*>(peer.completionSlots.device);
+  std::vector<IbLocalChannel> localChannels;
+  localChannels.reserve(config_.max_num_channels);
+  const std::size_t pipelineDepth =
+      static_cast<std::size_t>(channelLayout.pipelineDepth);
   for (int channel = 0; channel < config_.max_num_channels; ++channel) {
     IbSendCompletionSlot* channelCompletionSlots = pipelineDepth == 0
         ? nullptr
         : completionSlots + static_cast<std::size_t>(channel) * pipelineDepth;
-    channels[channel] =
-        makeIbLocalChannel(channelLayout, channel, channelCompletionSlots);
+    localChannels.push_back(
+        makeIbLocalChannel(channelLayout, channel, channelCompletionSlots));
   }
+  populatePeerDeviceRange(
+      peerIndex, 0, config_.max_num_channels, deviceCmdQueues, localChannels);
   peer.cmdQueues = std::move(cmdQueues);
   peer.cmdQueuesAllocated = true;
   updatePeerDeviceTransport(peerIndex);
@@ -965,10 +956,140 @@ void MultipeerIbrcTransport::allocatePeerCmdQueues(int peerIndex) {
 
 void MultipeerIbrcTransport::initializeDeviceTransportSlots() {
   const std::size_t numPeers = static_cast<std::size_t>(nRanks_ - 1);
+  const std::size_t qpsPerPeerPerNic =
+      static_cast<std::size_t>(config_.fixedChannelMainQpsPerPeerPerNic());
+  cmdQueuesPerPeer_ = checkedMul(
+      static_cast<std::size_t>(numNics_),
+      qpsPerPeerPerNic,
+      "fixed command queue descriptors per peer");
+  const std::size_t cmdQueueDeviceCount = checkedMul(
+      numPeers, cmdQueuesPerPeer_, "fixed command queue descriptors");
+  cmdQueueDevices_ = allocateMapped(
+      checkedMul(
+          cmdQueueDeviceCount,
+          sizeof(IbrcCmdQueueDevice),
+          "fixed command queue descriptors"),
+      "fixed command queue device descriptors");
+  std::uninitialized_value_construct_n(
+      static_cast<IbrcCmdQueueDevice*>(cmdQueueDevices_.host),
+      cmdQueueDeviceCount);
+  const std::size_t localChannelCount = checkedMul(
+      numPeers,
+      static_cast<std::size_t>(config_.max_num_channels),
+      "fixed local channel states");
+  localChannelStates_ = allocateMapped(
+      checkedMul(
+          localChannelCount,
+          sizeof(IbLocalChannel),
+          "fixed local channel states"),
+      "fixed local channel states");
+  std::uninitialized_value_construct_n(
+      static_cast<IbLocalChannel*>(localChannelStates_.host),
+      localChannelCount);
   p2pTransportDevices_ = allocateMapped(
       numPeers * ibrcDeviceSlotSize(), "P2pIbrcTransportDevice slots");
-  constructIbrcDeviceSlots(
-      p2pTransportDevices_.host, static_cast<int>(numPeers));
+  for (int peerIndex = 0; peerIndex < static_cast<int>(numPeers); ++peerIndex) {
+    updatePeerDeviceTransport(peerIndex);
+  }
+}
+
+void MultipeerIbrcTransport::populatePeerDeviceRange(
+    int peerIndex,
+    int channelBegin,
+    int channelEnd,
+    const std::vector<IbrcCmdQueueDevice>& rangeCmdQueues,
+    const std::vector<IbLocalChannel>& rangeLocalChannels) {
+  CHECK_GE(peerIndex, 0);
+  CHECK_LT(peerIndex, static_cast<int>(peerResources_.size()));
+  CHECK_GE(channelBegin, 0);
+  CHECK_LE(channelBegin, channelEnd);
+  CHECK_LE(channelEnd, config_.max_num_channels);
+  CHECK_EQ(
+      rangeLocalChannels.size(),
+      static_cast<std::size_t>(channelEnd - channelBegin));
+  CHECK(cmdQueueDevices_.host != nullptr);
+  CHECK(localChannelStates_.host != nullptr);
+
+  const std::size_t queuesPerChannel = checkedMul(
+      checkedMul(
+          static_cast<std::size_t>(config_.fixedChannelDirectionCount()),
+          static_cast<std::size_t>(config_.qpsPerConnection),
+          "command queues per channel"),
+      static_cast<std::size_t>(numNics_),
+      "command queues per channel");
+  const std::size_t queueBegin = ibCommandQueueSlot(
+      static_cast<uint32_t>(channelBegin),
+      IbDirection::Send,
+      static_cast<uint32_t>(config_.fixedChannelDirectionCount()),
+      static_cast<uint32_t>(config_.qpsPerConnection),
+      0,
+      static_cast<uint32_t>(numNics_),
+      0);
+  const std::size_t queueCount = checkedMul(
+      static_cast<std::size_t>(channelEnd - channelBegin),
+      queuesPerChannel,
+      "command queue range");
+  CHECK_EQ(rangeCmdQueues.size(), queueCount);
+  auto* const peerCmdQueueDevices =
+      static_cast<IbrcCmdQueueDevice*>(cmdQueueDevices_.host) +
+      static_cast<std::size_t>(peerIndex) * cmdQueuesPerPeer_;
+  if (queueCount != 0) {
+    std::copy(
+        rangeCmdQueues.begin(),
+        rangeCmdQueues.end(),
+        peerCmdQueueDevices + queueBegin);
+  }
+
+  auto* const peerLocalChannels =
+      static_cast<IbLocalChannel*>(localChannelStates_.host) +
+      static_cast<std::size_t>(peerIndex) * config_.max_num_channels;
+  if (channelBegin != channelEnd) {
+    std::copy(
+        rangeLocalChannels.begin(),
+        rangeLocalChannels.end(),
+        peerLocalChannels + channelBegin);
+  }
+}
+
+void MultipeerIbrcTransport::clearPeerDeviceRange(
+    int peerIndex,
+    int channelBegin,
+    int channelEnd) noexcept {
+  if (peerIndex < 0 || peerIndex >= static_cast<int>(peerResources_.size()) ||
+      channelBegin < 0 || channelBegin > channelEnd ||
+      channelEnd > config_.max_num_channels) {
+    return;
+  }
+  const std::size_t queuesPerChannel = static_cast<std::size_t>(numNics_) *
+      config_.fixedChannelDirectionCount() * config_.qpsPerConnection;
+  const std::size_t queueBegin = ibCommandQueueSlot(
+      static_cast<uint32_t>(channelBegin),
+      IbDirection::Send,
+      static_cast<uint32_t>(config_.fixedChannelDirectionCount()),
+      static_cast<uint32_t>(config_.qpsPerConnection),
+      0,
+      static_cast<uint32_t>(numNics_),
+      0);
+  const std::size_t queueCount =
+      static_cast<std::size_t>(channelEnd - channelBegin) * queuesPerChannel;
+  if (cmdQueueDevices_.host != nullptr && queueCount != 0) {
+    auto* const peerCmdQueueDevices =
+        static_cast<IbrcCmdQueueDevice*>(cmdQueueDevices_.host) +
+        static_cast<std::size_t>(peerIndex) * cmdQueuesPerPeer_;
+    std::memset(
+        peerCmdQueueDevices + queueBegin,
+        0,
+        queueCount * sizeof(IbrcCmdQueueDevice));
+  }
+  if (localChannelStates_.host != nullptr && channelBegin != channelEnd) {
+    auto* const peerLocalChannels =
+        static_cast<IbLocalChannel*>(localChannelStates_.host) +
+        static_cast<std::size_t>(peerIndex) * config_.max_num_channels;
+    std::fill_n(
+        peerLocalChannels + channelBegin,
+        static_cast<std::size_t>(channelEnd - channelBegin),
+        IbLocalChannel{});
+  }
 }
 
 void MultipeerIbrcTransport::updatePeerDeviceTransport(int peerIndex) noexcept {
@@ -978,46 +1099,53 @@ void MultipeerIbrcTransport::updatePeerDeviceTransport(int peerIndex) noexcept {
   }
 
   auto& peer = peerResources_[peerIndex];
-  if (!peer.cmdQueuesAllocated || peer.cmdQueueDevices.device == nullptr) {
-    constructIbrcDeviceSlots(
-        static_cast<char*>(p2pTransportDevices_.host) +
-            peerIndex * ibrcDeviceSlotSize(),
-        1);
-    return;
-  }
-
   IbgdaRemoteBuffer remoteSignalBuf{};
   IbgdaLocalBuffer localSignalBuf{};
-  if (config_.numSignalSlots > 0) {
+  if (peer.cmdQueuesAllocated && config_.numSignalSlots > 0) {
     remoteSignalBuf = slotRemoteSignalView(peerIndex);
     localSignalBuf = slotLocalSignalView(peerIndex);
   }
   IbgdaLocalBuffer counterDeviceBuf{};
   IbgdaLocalBuffer counterHostBuf{};
-  if (config_.numCounterSlots > 0) {
+  if (peer.cmdQueuesAllocated && config_.numCounterSlots > 0) {
     counterDeviceBuf = slotCounterDeviceView(peerIndex);
     counterHostBuf = slotCounterHostView(peerIndex);
   }
+  const IbChannelLayout channelLayout = peer.cmdQueuesAllocated
+      ? channelLayoutForPeer(peerIndex)
+      : IbChannelLayout{};
+  const int numSignalSlots =
+      peer.cmdQueuesAllocated ? config_.numSignalSlots : 0;
+  const int numCounterSlots =
+      peer.cmdQueuesAllocated ? config_.numCounterSlots : 0;
+  const uint32_t maxChannels = peer.cmdQueuesAllocated
+      ? static_cast<uint32_t>(config_.max_num_channels)
+      : 0;
+  auto* const peerCmdQueueDevices =
+      static_cast<IbrcCmdQueueDevice*>(cmdQueueDevices_.device) +
+      static_cast<std::size_t>(peerIndex) * cmdQueuesPerPeer_;
+  auto* const peerLocalChannels =
+      static_cast<IbLocalChannel*>(localChannelStates_.device) +
+      static_cast<std::size_t>(peerIndex) * config_.max_num_channels;
 
   writeIbrcDeviceSlot(
       p2pTransportDevices_.host,
       peerIndex,
       DeviceSpan<IbrcCmdQueueDevice>(
-          static_cast<IbrcCmdQueueDevice*>(peer.cmdQueueDevices.device),
-          static_cast<uint32_t>(peer.cmdQueues.size())),
+          peerCmdQueueDevices, static_cast<uint32_t>(cmdQueuesPerPeer_)),
       static_cast<uint32_t>(numNics_),
-      static_cast<uint32_t>(config_.max_num_channels),
+      maxChannels,
       static_cast<uint32_t>(config_.qpsPerConnection),
+      static_cast<uint32_t>(config_.fixedChannelDirectionCount()),
       DeviceSpan<IbLocalChannel>(
-          static_cast<IbLocalChannel*>(peer.channelState.device),
-          static_cast<uint32_t>(config_.max_num_channels)),
+          peerLocalChannels, static_cast<uint32_t>(config_.max_num_channels)),
       remoteSignalBuf,
       localSignalBuf,
       counterDeviceBuf,
       counterHostBuf,
-      config_.numSignalSlots,
-      config_.numCounterSlots,
-      channelLayoutForPeer(peerIndex),
+      numSignalSlots,
+      numCounterSlots,
+      channelLayout,
       abortDevice_);
 }
 
@@ -1065,11 +1193,8 @@ MultipeerIbrcTransport::MappedAllocation MultipeerIbrcTransport::allocateMapped(
   return allocation;
 }
 
-// Send/recv staging allocation, exchange, cleanup, and IbChannelLayout
-// construction are provided by MultiPeerIbTransportBase. IBRC delegates via
-// allocateSendRecvBuffersEager(IbCounterStorage::HostPinned) /
-// exchangeSendRecvBuffersEager() / cleanupSendRecvBuffers() /
-// channelLayoutForPeer().
+// Peer-lazy send/recv staging allocation, exchange, cleanup, and channel-layout
+// construction are provided by MultiPeerIbTransportBase.
 
 void MultipeerIbrcTransport::destroyPeerQps(
     std::vector<PeerQpResource>& qpResources) noexcept {

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -328,7 +328,6 @@ MultipeerIbrcTransport::MultipeerIbrcTransport(
     progressCpus_ = selectProgressCpus();
     initializeControlResources();
     initializeDeviceTransportSlots();
-    peerMaterialized_.resize(nRanks_ - 1, false);
   } catch (const std::exception&) {
     cleanup();
     throw;
@@ -1410,12 +1409,9 @@ MultipeerIbrcTransport::qpResourceAt(int peerIndex, int nic, int qpSlot) const {
 PeerQpPayload MultipeerIbrcTransport::buildLocalQpPayload(int peerIndex) const {
   const int numQps = config_.fixedChannelMainQpsPerPeerPerNic();
   PeerQpPayload payload{};
+  populatePeerGeometry(payload);
   payload.gidIndex = gidIndex_;
   payload.mtu = static_cast<int>(localMtu_);
-  payload.numNics = numNics_;
-  payload.numQpsPerPeerPerNic = numQps;
-  payload.maxGroups = config_.max_num_channels;
-  payload.qpsPerBlockPerNic = config_.qpsPerConnection;
 
   auto& symbols = ibverbx::ibvSymbols;
   for (int n = 0; n < numNics_; ++n) {
@@ -1535,35 +1531,7 @@ void MultipeerIbrcTransport::connectPeerQp(
 void MultipeerIbrcTransport::connectPeerQps(
     int peerIndex,
     const PeerQpPayload& remotePayload) {
-  if (remotePayload.numNics != numNics_) {
-    throw std::runtime_error(
-        fmt::format(
-            "IBRC peerIndex={} numNics={} vs local {}",
-            peerIndex,
-            remotePayload.numNics,
-            numNics_));
-  }
-  if (remotePayload.numQpsPerPeerPerNic !=
-      config_.fixedChannelMainQpsPerPeerPerNic()) {
-    throw std::runtime_error(
-        fmt::format(
-            "IBRC peerIndex={} numQps={} vs local {}",
-            peerIndex,
-            remotePayload.numQpsPerPeerPerNic,
-            config_.fixedChannelMainQpsPerPeerPerNic()));
-  }
-  if (remotePayload.maxGroups != config_.max_num_channels ||
-      remotePayload.qpsPerBlockPerNic != config_.qpsPerConnection) {
-    throw std::runtime_error(
-        fmt::format(
-            "IBRC peerIndex={} fixed-channel QP shape max_num_channels={} "
-            "qpsPerConnection={} vs local {} {}",
-            peerIndex,
-            remotePayload.maxGroups,
-            remotePayload.qpsPerBlockPerNic,
-            config_.max_num_channels,
-            config_.qpsPerConnection));
-  }
+  validatePeerGeometry(peerIndexToRank(peerIndex), remotePayload);
 
   const int numQps = config_.fixedChannelMainQpsPerPeerPerNic();
   for (int nic = 0; nic < numNics_; ++nic) {
@@ -1646,10 +1614,6 @@ void MultipeerIbrcTransport::exchangeAndConnectQps() {
 
 P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDeviceSlot(
     int peerRank) const {
-  LOG_FIRST_N(WARNING, 1)
-      << "MultipeerIbrcTransport: Transport[] array is being built with "
-      << "possibly unmaterialized IBRC slots. Call get_device_handle(peers) "
-      << "before kernels access those peers.";
   if (p2pTransportDevices_.device == nullptr) {
     throw std::runtime_error(
         "getP2pTransportDeviceSlot: IBRC device transport slots are not initialized");
@@ -1663,7 +1627,8 @@ P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDeviceSlot(
 P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDevice(
     int peerRank) {
   if (!isPeerMaterialized(peerRank)) {
-    materializePeer(peerRank);
+    queuePeerForMaterialization(peerRank, channelCapacity());
+    connectPeers();
   }
   if (p2pTransportDevices_.device == nullptr) {
     throw std::runtime_error(
@@ -1675,7 +1640,14 @@ P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDevice(
       peerIndex * ibrcDeviceSlotSize());
 }
 
-void MultipeerIbrcTransport::doMaterializePeer(int peerRank) {
+void MultipeerIbrcTransport::doMaterializePeer(
+    int peerRank,
+    uint32_t oldChannels,
+    uint32_t newChannels) {
+  if (oldChannels != 0 || newChannels != channelCapacity()) {
+    throw std::runtime_error(
+        "IBRC eager materialization requires the full channel range");
+  }
   const int peerIndex = rankToPeerIndex(peerRank);
 
   createPeerQps(peerIndex);
@@ -1702,7 +1674,6 @@ void MultipeerIbrcTransport::doMaterializePeer(int peerRank) {
   applyRemoteSendRecvBuffer(peerIndex, remoteBuf);
   allocatePeerCmdQueues(peerIndex);
   startProgressThread();
-  peerMaterialized_[peerIndex] = true;
 }
 
 void MultipeerIbrcTransport::cleanupPeerOnFailure(int peerIndex) {
@@ -1712,10 +1683,6 @@ void MultipeerIbrcTransport::cleanupPeerOnFailure(int peerIndex) {
   cleanupPeerQps(peerIndex);
   cleanupPeerSignalCounterResources(peerIndex);
   cleanupSendRecvBufferForPeer(peerIndex);
-  if (peerIndex >= 0 &&
-      peerIndex < static_cast<int>(peerMaterialized_.size())) {
-    peerMaterialized_[peerIndex] = false;
-  }
 }
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
@@ -44,9 +44,9 @@ class P2pIbrcTransportDevice;
  * updating host-mapped counter memory directly, instead of adding IBGDA-style
  * companion counter QPs.
  *
- * IBRC supports both eager exchange() and lazy per-peer materialization from
- * day one: the base's lazy connect loop drives the doMaterializePeer() hook
- * below, so there is no design-level eager-only restriction.
+ * IBRC always materializes peer resources lazily. exchange() leaves per-peer
+ * QPs, staging, and command queues deferred; the base's lazy connect loop
+ * drives the doMaterializePeer() hook below on first peer use.
  */
 class MultipeerIbrcTransport
     : public MultiPeerIbTransport<MultipeerIbrcTransport> {
@@ -71,15 +71,13 @@ class MultipeerIbrcTransport
   MultipeerIbrcTransport& operator=(MultipeerIbrcTransport&&) = delete;
 
   /**
-   * exchange - COLLECTIVE. Connect QPs eagerly, then build command queues,
-   * device transports, and the CPU progress thread once those slices land.
+   * exchange - COLLECTIVE. Complete communicator setup without materializing
+   * any peer; peer resources remain deferred until first use.
    */
   void exchange();
 
   // numPeers() / myRank() / nRanks() / numNics() are inherited from
-  // MultiPeerIbTransport(Base). Buffer registration/exchange and lazy
-  // materialization are intentionally blocked by MultiPeerTransport until the
-  // IBRC backend initializes the required resources.
+  // MultiPeerIbTransport(Base). exchange() does not materialize any peer.
 
   P2pIbrcTransportDevice* getP2pTransportDeviceSlot(int peerRank) const;
 
@@ -88,9 +86,9 @@ class MultipeerIbrcTransport
   P2pIbrcTransportDevice* getP2pTransportDevice(int peerRank);
 
  private:
-  // Lazy per-peer materialization hook. The shared base owns queueing,
-  // ordering, and failure rollback; IBRC fills in per-peer QPs and command
-  // queues here, then later slices will attach the device transport.
+  // The shared base owns queueing, ordering, and failure rollback. IBRC creates
+  // the peer's QPs, exchanges staging, builds command queues, and publishes the
+  // device transport here.
   void doMaterializePeer(int peerRank);
   void cleanupPeerOnFailure(int peerIndex);
 
@@ -147,8 +145,7 @@ class MultipeerIbrcTransport
   struct PeerResources {
     std::vector<PeerQpResource> qpResources;
     std::vector<IbrcCmdQueueHost> cmdQueues;
-    MappedAllocation cmdQueueDevices;
-    MappedAllocation channelState;
+    MappedAllocation completionSlots;
     bool qpsConnected{false};
     bool cmdQueuesAllocated{false};
   };
@@ -185,19 +182,28 @@ class MultipeerIbrcTransport
   void allocateCmdQueuesForAllPeers();
   void allocatePeerCmdQueues(int peerIndex);
   void initializeDeviceTransportSlots();
+  // Both descriptor vectors contain exactly [channelBegin, channelEnd).
+  void populatePeerDeviceRange(
+      int peerIndex,
+      int channelBegin,
+      int channelEnd,
+      const std::vector<IbrcCmdQueueDevice>& rangeCmdQueues,
+      const std::vector<IbLocalChannel>& rangeLocalChannels);
+  void clearPeerDeviceRange(
+      int peerIndex,
+      int channelBegin,
+      int channelEnd) noexcept;
   void updatePeerDeviceTransport(int peerIndex) noexcept;
   std::size_t allocatedCmdQueueCount() const;
   MappedAllocation allocateMapped(std::size_t bytes, const char* label);
 
-  // ---- Pipelined send/recv staging (eager mode only) ----
+  // ---- Pipelined send/recv staging (peer-lazy) ----
   //
   // Host send/recv buffer management is shared with IBGDA in
-  // MultiPeerIbTransportBase. IBRC delegates to
-  // allocateSendRecvBuffersEager(IbCounterStorage::HostPinned) — the NIC_DONE
+  // MultiPeerIbTransportBase. doMaterializePeer() allocates and exchanges only
+  // the requested peer's staging and signal/counter resources. The NIC_DONE
   // counter is host-mapped and updated by the CPU proxy (NCCL GIN style)
-  // instead of an IBGDA companion-QP loopback counter — plus
-  // exchangeSendRecvBuffersEager(), sendRecvStateForPeer(), and
-  // cleanupSendRecvBuffers().
+  // instead of an IBGDA companion-QP loopback counter.
 
   void createPeerQps(int peerIndex);
   PeerQpPayload buildLocalQpPayload(int peerIndex) const;
@@ -223,8 +229,11 @@ class MultipeerIbrcTransport
   std::unique_ptr<std::atomic<bool>[]> peerQueuesPublished_;
   MappedAllocation statusControl_;
   MappedAllocation p2pTransportDevices_;
+  MappedAllocation cmdQueueDevices_;
+  MappedAllocation localChannelStates_;
   std::vector<IbrcNicStatus*> statusHostByNic_;
   std::vector<IbrcNicStatus*> statusDeviceByNic_;
+  std::size_t cmdQueuesPerPeer_{0};
   uint32_t cmdQueueDepth_{kIbrcDefaultCmdQueueDepth};
   std::size_t cmdQueuePiOffset_{0};
   std::size_t cmdQueueCiOffset_{0};
@@ -234,8 +243,8 @@ class MultipeerIbrcTransport
   std::vector<int> progressCpus_;
   comms::fault_tolerance::AbortDevice abortDevice_;
 
-  // Send/recv staging state (eager mode) lives in MultiPeerIbTransportBase
-  // (sendRecvPeerBuffers_ + bulks); IBRC delegates allocation/exchange/cleanup.
+  // Peer-lazy send/recv staging state and cleanup live in
+  // MultiPeerIbTransportBase.
 };
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
@@ -89,7 +89,8 @@ class MultipeerIbrcTransport
   // The shared base owns queueing, ordering, and failure rollback. IBRC creates
   // the peer's QPs, exchanges staging, builds command queues, and publishes the
   // device transport here.
-  void doMaterializePeer(int peerRank);
+  void
+  doMaterializePeer(int peerRank, uint32_t oldChannels, uint32_t newChannels);
   void cleanupPeerOnFailure(int peerIndex);
 
   struct PeerQpResource {

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
@@ -46,11 +46,15 @@ class P2pIbrcTransportDevice;
  *
  * IBRC always materializes peer resources lazily. exchange() leaves per-peer
  * QPs, staging, and command queues deferred; the base's lazy connect loop
- * drives the doMaterializePeer() hook below on first peer use.
+ * drives the materializePeerChannelRange() hook below on first peer use.
  */
 class MultipeerIbrcTransport
     : public MultiPeerIbTransport<MultipeerIbrcTransport> {
  public:
+  static constexpr bool supportsLazyChannelPrefixGrowth() {
+    return false;
+  }
+
   // `abort` is the owning communicator's device handle. It is baked into every
   // per-peer device slot so the device-side waits on the CPU proxy terminate on
   // abort instead of trapping. A default-constructed handle keeps the legacy
@@ -86,12 +90,14 @@ class MultipeerIbrcTransport
   P2pIbrcTransportDevice* getP2pTransportDevice(int peerRank);
 
  private:
-  // The shared base owns queueing, ordering, and failure rollback. IBRC creates
-  // the peer's QPs, exchanges staging, builds command queues, and publishes the
-  // device transport here.
-  void
-  doMaterializePeer(int peerRank, uint32_t oldChannels, uint32_t newChannels);
-  void cleanupPeerOnFailure(int peerIndex);
+  // The shared base owns queueing, ordering, and terminal failure state. IBRC
+  // creates the peer's QPs, exchanges staging, builds command queues, and
+  // publishes the device transport here.
+  void materializePeerChannelRange(
+      int peerRank,
+      uint32_t oldChannels,
+      uint32_t newChannels);
+  void onTerminalMaterializationFailure() noexcept;
 
   struct PeerQpResource {
     ibverbx::ibv_cq* cq{nullptr};
@@ -201,9 +207,10 @@ class MultipeerIbrcTransport
   // ---- Pipelined send/recv staging (peer-lazy) ----
   //
   // Host send/recv buffer management is shared with IBGDA in
-  // MultiPeerIbTransportBase. doMaterializePeer() allocates and exchanges only
-  // the requested peer's staging and signal/counter resources. The NIC_DONE
-  // counter is host-mapped and updated by the CPU proxy (NCCL GIN style)
+  // MultiPeerIbTransportBase. materializePeerChannelRange() allocates and
+  // exchanges only the requested peer's staging and signal/counter resources.
+  // The NIC_DONE counter is host-mapped and updated by the CPU proxy (NCCL GIN
+  // style)
   // instead of an IBGDA companion-QP loopback counter.
 
   void createPeerQps(int peerIndex);

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cu
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cu
@@ -35,12 +35,49 @@ void writeIbrcDeviceSlot(
     int numCounterSlots,
     IbChannelLayout channelLayout,
     comms::fault_tolerance::AbortDevice abort) {
+  writeIbrcDeviceSlot(
+      slotsHost,
+      peerIndex,
+      queues,
+      numNics,
+      maxChannels,
+      qpsPerConnection,
+      kIbDirections,
+      localChannels,
+      remoteSignalBuf,
+      localSignalBuf,
+      counterDeviceBuf,
+      counterHostBuf,
+      numSignalSlots,
+      numCounterSlots,
+      channelLayout,
+      abort);
+}
+
+void writeIbrcDeviceSlot(
+    void* slotsHost,
+    int peerIndex,
+    DeviceSpan<IbrcCmdQueueDevice> queues,
+    uint32_t numNics,
+    uint32_t maxChannels,
+    uint32_t qpsPerConnection,
+    uint32_t qpDirectionCount,
+    DeviceSpan<IbLocalChannel> localChannels,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    IbgdaLocalBuffer localSignalBuf,
+    IbgdaLocalBuffer counterDeviceBuf,
+    IbgdaLocalBuffer counterHostBuf,
+    int numSignalSlots,
+    int numCounterSlots,
+    IbChannelLayout channelLayout,
+    comms::fault_tolerance::AbortDevice abort) {
   auto* slots = static_cast<P2pIbrcTransportDevice*>(slotsHost);
   new (&slots[peerIndex]) P2pIbrcTransportDevice(
       queues,
       numNics,
       maxChannels,
       qpsPerConnection,
+      qpDirectionCount,
       localChannels,
       remoteSignalBuf,
       localSignalBuf,

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cuh
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cuh
@@ -24,9 +24,25 @@ class P2pIbrcTransportDevice;
 // into the host-pinned mapped array of device handles).
 std::size_t ibrcDeviceSlotSize();
 
-// Default-construct (placement-new) each P2pIbrcTransportDevice slot in a
-// host-pinned mapped array.
+// Default-construct every slot in a host-pinned mapped array.
 void constructIbrcDeviceSlots(void* slotsHost, int numSlots);
+
+void writeIbrcDeviceSlot(
+    void* slotsHost,
+    int peerIndex,
+    DeviceSpan<IbrcCmdQueueDevice> queues,
+    uint32_t numNics,
+    uint32_t maxChannels,
+    uint32_t qpsPerConnection,
+    DeviceSpan<IbLocalChannel> localChannels,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    IbgdaLocalBuffer localSignalBuf,
+    IbgdaLocalBuffer counterDeviceBuf,
+    IbgdaLocalBuffer counterHostBuf,
+    int numSignalSlots,
+    int numCounterSlots,
+    IbChannelLayout channelLayout,
+    comms::fault_tolerance::AbortDevice abort);
 
 // Placement-new a single populated P2pIbrcTransportDevice into the host-pinned
 // mapped array. Args mirror the device-handle constructor; all are plain-data
@@ -38,6 +54,7 @@ void writeIbrcDeviceSlot(
     uint32_t numNics,
     uint32_t maxChannels,
     uint32_t qpsPerConnection,
+    uint32_t qpDirectionCount,
     DeviceSpan<IbLocalChannel> localChannels,
     IbgdaRemoteBuffer remoteSignalBuf,
     IbgdaLocalBuffer localSignalBuf,

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -90,10 +90,42 @@ class P2pIbrcTransportDevice {
       int numCounterSlots = 0,
       IbChannelLayout channelLayout = {},
       AbortDevice abort = {})
+      : P2pIbrcTransportDevice(
+            queues,
+            nics,
+            maxChannels,
+            qpsPerConnection,
+            kIbDirections,
+            localChannels,
+            ownedRemoteSignalBuf,
+            ownedLocalSignalBuf,
+            ownedCounterDeviceBuf,
+            ownedCounterHostBuf,
+            numSignalSlots,
+            numCounterSlots,
+            channelLayout,
+            abort) {}
+
+  __host__ __device__ P2pIbrcTransportDevice(
+      DeviceSpan<IbrcCmdQueueDevice> queues,
+      uint32_t nics,
+      uint32_t maxChannels,
+      uint32_t qpsPerConnection,
+      uint32_t qpDirectionCount,
+      DeviceSpan<IbLocalChannel> localChannels,
+      IbgdaRemoteBuffer ownedRemoteSignalBuf = {},
+      IbgdaLocalBuffer ownedLocalSignalBuf = {},
+      IbgdaLocalBuffer ownedCounterDeviceBuf = {},
+      IbgdaLocalBuffer ownedCounterHostBuf = {},
+      int numSignalSlots = 0,
+      int numCounterSlots = 0,
+      IbChannelLayout channelLayout = {},
+      AbortDevice abort = {})
       : cmdQueues(queues),
         numNics(nics),
         maxChannels_(maxChannels),
         qpsPerConnection_(qpsPerConnection),
+        qpDirectionCount_(qpDirectionCount),
         localChannels_(localChannels),
         ownedRemoteSignalBuf_(ownedRemoteSignalBuf),
         ownedLocalSignalBuf_(ownedLocalSignalBuf),
@@ -614,9 +646,7 @@ class P2pIbrcTransportDevice {
   }
 
   __device__ __forceinline__ std::size_t pipeline_window() const {
-    return channelLayout_.perChannelBufferSize != 0
-        ? channelLayout_.perChannelBufferSize
-        : channelLayout_.perChannelSize;
+    return channelLayout_.channelBufferSize();
   }
 
   __device__ __forceinline__ std::size_t pipeline_window(
@@ -755,7 +785,7 @@ class P2pIbrcTransportDevice {
   }
 
   __device__ __forceinline__ uint32_t num_qps_per_peer_per_nic() const {
-    return maxChannels_ * kIbDirections * qpsPerConnection_;
+    return maxChannels_ * qpDirectionCount_ * qpsPerConnection_;
   }
 
   __device__ __forceinline__ void validate_channel_id(
@@ -779,8 +809,9 @@ class P2pIbrcTransportDevice {
     if (cmdQueues.empty()) {
       trap("P2pIbrcTransportDevice: no command queues");
     }
-    if (numNics == 0 || qpsPerConnection_ == 0 || maxChannels_ == 0 ||
-        localChannels_.empty() || channelId >= maxChannels_) {
+    if (numNics == 0 || qpsPerConnection_ == 0 || qpDirectionCount_ == 0 ||
+        maxChannels_ == 0 || localChannels_.empty() ||
+        channelId >= maxChannels_) {
       printf(
           "P2pIbrcTransportDevice: invalid channel QP state channel_id=%u "
           "maxChannels=%u qpsPerConnection=%u numNics=%u stateSize=%u\n",
@@ -820,14 +851,22 @@ class P2pIbrcTransportDevice {
     }
     const uint32_t nicId = laneOrdinal % numNics;
     const uint32_t qpIndex = laneOrdinal / numNics;
-    const uint32_t directionIndex = static_cast<uint32_t>(direction);
-    const uint32_t qpSlot =
-        ((channelId * kIbDirections + directionIndex) * qpsPerConnection_) +
-        qpIndex;
+    if (static_cast<uint32_t>(direction) >= qpDirectionCount_) {
+      trap("P2pIbrcTransportDevice: direction out of range");
+    }
+    const uint32_t qpSlot = ibQpSlotWithinNic(
+        channelId, direction, qpDirectionCount_, qpsPerConnection_, qpIndex);
     if (qpSlot >= num_qps_per_peer_per_nic()) {
       trap("P2pIbrcTransportDevice: QP slot out of range");
     }
-    const uint32_t queueId = qpSlot * numNics + nicId;
+    const uint32_t queueId = ibCommandQueueSlot(
+        channelId,
+        direction,
+        qpDirectionCount_,
+        qpsPerConnection_,
+        qpIndex,
+        numNics,
+        nicId);
     if (queueId >= cmdQueues.size()) {
       trap("P2pIbrcTransportDevice: command queue id out of range");
     }
@@ -908,7 +947,7 @@ class P2pIbrcTransportDevice {
   __device__ void check_channel_status(uint32_t channelId) const {
     validate_channel_id(channelId);
     const uint32_t lanes = num_qp_lanes();
-    for (uint32_t dir = 0; dir < kIbDirections; ++dir) {
+    for (uint32_t dir = 0; dir < qpDirectionCount_; ++dir) {
       for (uint32_t lane = 0; lane < lanes; ++lane) {
         check_status(
             cmdQueues[queue_for_lane(
@@ -1187,6 +1226,7 @@ class P2pIbrcTransportDevice {
   uint32_t numNics{0};
   uint32_t maxChannels_{0};
   uint32_t qpsPerConnection_{0};
+  uint32_t qpDirectionCount_{0};
   DeviceSpan<IbLocalChannel> localChannels_{};
   IbgdaRemoteBuffer ownedRemoteSignalBuf_{};
   IbgdaLocalBuffer ownedLocalSignalBuf_{};

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3444,8 +3444,9 @@ cvars:
    description : |-
      Globally request grow-only lazy IB channel materialization for MCCL Prims
      communicators. Ranks validate the same setting during communicator
-     initialization. Until incremental channel growth is supported, the
-     transport retains eager full-capacity behavior.
+     initialization. Supporting backends grow to the exact channel prefix
+     required by each launch's block geometry; other backends retain
+     full-capacity materialization.
 
  - name        : MCCL_IB_MODE
    type        : enum

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3438,6 +3438,15 @@ cvars:
      not necessarily map one-to-one to CUDA blocks; for example, ctree uses
      two channels per block.
 
+ - name        : MCCL_PRIMS_LAZY_CHANNELS
+   type        : bool
+   default     : false
+   description : |-
+     Globally request grow-only lazy IB channel materialization for MCCL Prims
+     communicators. Ranks validate the same setting during communicator
+     initialization. Until incremental channel growth is supported, the
+     transport retains eager full-capacity behavior.
+
  - name        : MCCL_IB_MODE
    type        : enum
    default     : ibgda


### PR DESCRIPTION
Summary:
Grow each IBGDA peer from its published channel watermark to a canonical requested prefix. The shared PRIMS control path exchanges matching range geometry before allocation and a ready record after graph-external device publication, then advances the host watermark.

Allocate only the missing IBGDA QP groups, loopback QPs, send/recv staging and control MRs, and completion slots. Fixed-capacity descriptor tables retain stable addresses for existing kernels and CUDA graphs. Cold capture uses relaxed capture mode with synchronized nonblocking side streams, so graph replay performs no allocation or connection.

When lazy channels are disabled, preserve the legacy two-phase peer tags, combined per-peer send/recv allocation, bound eager channel layout, and full-capacity first use.

Differential Revision: D114917352
