### PR TITLE
Fix reduce_kernel_bench link failure under CUDA 13.3 (#4082)

### DIFF
--- a/comms/ctran/algos/common/benchmarks/ReduceKernelBench.cc
+++ b/comms/ctran/algos/common/benchmarks/ReduceKernelBench.cc
@@ -12,13 +12,6 @@
 #include "comms/utils/commSpecs.h"
 
 //------------------------------------------------------------------------------
-// External Kernel Declaration
-//------------------------------------------------------------------------------
-
-template <typename T, commRedOp_t redOp>
-extern __global__ void LocalReduceKernel(ReduceKernelBenchArg arg, int iters);
-
-//------------------------------------------------------------------------------
 // Common Helper Functions
 //------------------------------------------------------------------------------
 
@@ -84,12 +77,6 @@ class ReduceKernelBenchSetup : public CudaBenchBase {
   void* dstBuf_{nullptr};
 };
 
-// Template function pointers for different reduction operations
-template <typename T, commRedOp_t redOp>
-void* getReduceKernelFn() {
-  return reinterpret_cast<void*>(LocalReduceKernel<T, redOp>);
-}
-
 } // anonymous namespace
 
 //------------------------------------------------------------------------------
@@ -118,7 +105,7 @@ static void ReduceKernelPerf(uint32_t iters, folly::UserCounters& counters) {
   ReduceKernelBenchSetup bench(cudaDev, count, nGroups, nSrcs, nDsts);
   float totalTimeMs = 0.0f;
 
-  void* fn = getReduceKernelFn<int, op>();
+  void* fn = getLocalReduceKernelFn<int, op>();
 
   dim3 grid = {(unsigned int)nGroups, 1, 1};
   dim3 blocks = {1024, 1, 1};

--- a/comms/ctran/algos/common/benchmarks/ReduceKernelBench.cu
+++ b/comms/ctran/algos/common/benchmarks/ReduceKernelBench.cu
@@ -39,6 +39,9 @@ __global__ void __launch_bounds__(1024, 1)
 // Template Instantiations
 //------------------------------------------------------------------------------
 
-template __global__ void LocalReduceKernel<int, commSum>(
-    ReduceKernelBenchArg arg,
-    int iters);
+template <typename T, commRedOp_t redOp>
+void* getLocalReduceKernelFn() {
+  return reinterpret_cast<void*>(LocalReduceKernel<T, redOp>);
+}
+
+template void* getLocalReduceKernelFn<int, commSum>();

--- a/comms/ctran/algos/common/benchmarks/ReduceKernelBench.h
+++ b/comms/ctran/algos/common/benchmarks/ReduceKernelBench.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/utils/commSpecs.h"
 
 //------------------------------------------------------------------------------
 // Benchmark Kernel Arguments
@@ -15,3 +16,14 @@ struct ReduceKernelBenchArg {
   const void* srcs[CTRAN_MAX_NVL_PEERS];
   void* dsts[CTRAN_MAX_NVL_PEERS];
 };
+
+//------------------------------------------------------------------------------
+// Kernel Accessor
+//------------------------------------------------------------------------------
+
+// nvcc gives the host-side launch stub of an explicitly instantiated
+// __global__ template internal linkage, so the stub cannot be named from
+// another translation unit. Hand the kernel address out of the .cu instead.
+// Instantiated in ReduceKernelBench.cu for every <T, redOp> benchmarked.
+template <typename T, commRedOp_t redOp>
+void* getLocalReduceKernelFn();


### PR DESCRIPTION
Summary:

`comms/ctran/algos/common/benchmarks:reduce_kernel_bench` fails to link once the
tree moves to CUDA `13.3`:

```
ld.lld: error: undefined symbol: void LocalReduceKernel<int, (commRedOp_t)0>(ReduceKernelBenchArg, int)
>>> referenced by cuda_runtime.h:217
>>>               .../__objects__/ReduceKernelBench.cc.o
```

`ReduceKernelBench.cu` defines `LocalReduceKernel` as a `__global__` *template*
and explicitly instantiates it for `<int, commSum>`; `ReduceKernelBench.cc`
redeclares it as `extern __global__` and takes its address to pass to
`cudaLaunchKernel`. That relies on the host-side launch stub nvcc emits for the
explicit instantiation having external linkage. Under CUDA `13.3` nvcc emits
that stub with *internal* linkage instead, so the `.cc` translation unit can no
longer name it:

```
$ nm ReduceKernelBench.cu.o | c++filt | grep LocalReduceKernelIi
0000000000000000 t void LocalReduceKernel<int, (commRedOp_t)0>(ReduceKernelBenchArg, int)
```

Note the lowercase `t` — a local symbol, not the `T` the linker needs.

Stop naming the stub across a translation-unit boundary. `ReduceKernelBench.h`
now declares a plain host function template `getLocalReduceKernelFn<T, redOp>()`
that is defined and explicitly instantiated inside `ReduceKernelBench.cu`, where
the stub is still visible. The `.cc` calls it instead of declaring the kernel
itself, so the only symbol crossing TUs is ordinary host code with external
linkage. This is version-agnostic and does not depend on nvcc's stub-linkage
choice.

The sibling benchmarks in this directory (`copy_kernel_bench`,
`multi_tb_sync_bench`, `device_sync_bench`, `kernel_elem_bench`,
`spsc_p2p_sync_bench`) launch non-template `__global__` kernels, whose stubs are
unaffected — which is why `reduce_kernel_bench` is the only target in the
directory that breaks.

This unblocks the CUDA `13.3` wave-2 pin codemod (D119281262).

___

Differential Revision: D119379257
