### PR TITLE
comms/uniflow/tcp: keep an exception out of put() from returning slabs under live DMA (#4083)

### DIFF
--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -986,6 +986,41 @@ std::future<Status> TcpTransport::put(
   // dropping one with a copy still running would return its slab under an
   // active DMA.
   std::deque<PendingPutWave> inFlight;
+  // The comment above holds for every *explicit* exit -- each was checked --
+  // but not for unwinding. PendingPutWave is a plain aggregate with no
+  // destructor, so an exception destroys `inFlight` directly: every held slab
+  // goes back to the pool while the device is still copying into it, and the
+  // events leak. The throw sites are all allocation failures inside the window
+  // -- enqueueFrames, the deque push_back of a launched wave, the Err string in
+  // state->fail, and lock_guard throwing system_error.
+  //
+  // Same shape as the read path's CopyBarrier in startReadReply, which covers
+  // that function only. abandonPutWaves is noexcept, which is what makes it
+  // safe during unwinding, and it retires each wave -- event wait with the
+  // streamSynchronize fallback -- before clearing, which is exactly the quiesce
+  // the slabs need. The emptiness check keeps this from double-retiring: the
+  // explicit paths drain first and leave nothing to do here.
+  // Copy and move are deleted because a second WaveBarrier over the same deque
+  // would abandon the waves twice. That makes this a non-aggregate, hence the
+  // constructor.
+  class WaveBarrier {
+   public:
+    WaveBarrier(TcpTransport* self, std::deque<PendingPutWave>* waves)
+        : self_(self), waves_(waves) {}
+    WaveBarrier(const WaveBarrier&) = delete;
+    WaveBarrier& operator=(const WaveBarrier&) = delete;
+    WaveBarrier(WaveBarrier&&) = delete;
+    WaveBarrier& operator=(WaveBarrier&&) = delete;
+    ~WaveBarrier() {
+      if (waves_ != nullptr && !waves_->empty()) {
+        self_->abandonPutWaves(*waves_);
+      }
+    }
+
+   private:
+    TcpTransport* self_;
+    std::deque<PendingPutWave>* waves_;
+  } waveBarrier{this, &inFlight};
   // Retires and queues launched waves, oldest first, until at most `keep`
   // remain. Returns false once it has already failed the operation, so callers
   // just return. Everything before the wave it failed on stays

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -3139,7 +3139,26 @@ void TcpTransport::handleFrameImpl(
         std::lock_guard<std::mutex> lk(inflightMu_);
         auto it = inflight_.find(header.reqId);
         if (it != inflight_.end()) {
-          entry = it->second;
+          // reqId is peer-supplied and there is one reader per lane, so
+          // claiming the entry here is what makes a duplicate miss. Copying it
+          // and erasing further down lets two Acks naming one reqId pass this
+          // check on different lanes and both reach completeOne(), which
+          // decrements `remaining` twice and settles a multi-chunk put at its
+          // first chunk -- the caller is told Ok with a chunk still
+          // outstanding. This was the original shape; it was given up when the
+          // entry had to outlive the lock for the async H2D handoff.
+          //
+          // ReadReply keeps the copy, because only that path hands off: its
+          // record has to stay in inflight_ until startAsyncH2d publishes into
+          // the H2D queue, or a concurrent failAllPending() finds it in neither
+          // and the caller's promise never resolves. Claiming it for every kind
+          // would trade a silent wrong success for a silent hang.
+          if (op == TcpOp::ReadReply) {
+            entry = it->second;
+          } else {
+            entry = std::move(it->second);
+            inflight_.erase(it);
+          }
           found = true;
         }
       }
@@ -3147,6 +3166,13 @@ void TcpTransport::handleFrameImpl(
         break;
       }
 
+      // Meaningful on the ReadReply path ONLY. Every other kind was claimed and
+      // erased above, under the same lock, so on those branches this erases an
+      // absent key and does nothing. It is called from them anyway rather than
+      // hoisted into the ReadReply branch, so that no branch can reach
+      // completeOne() with the entry still present if the claim above ever
+      // grows another kind that keeps its copy -- but do not read the calls as
+      // each branch owning the erase, because only one of them does.
       const auto eraseInflight = [&]() {
         std::lock_guard<std::mutex> lk(inflightMu_);
         inflight_.erase(header.reqId);


### PR DESCRIPTION
Summary:

`put()`'s comment says "every exit path below either retires or abandons these,
because dropping one with a copy still running would return its slab under an
active DMA". That holds for every *explicit* exit -- each was checked -- but not
for unwinding.

`PendingPutWave` is a plain aggregate with no destructor, so an exception thrown
inside `put()` destroys `inFlight` directly: every held slab goes back to the pool
while the device is still copying into it, and the events leak. The throw sites are
all allocation failures inside the window -- `enqueueFrames`, the `deque::push_back`
of a launched wave, the `Err` string construction in `state->fail`, and `lock_guard`
throwing `system_error`.

Raised by mahi on D118010137. Filed as C-104.

This is the put-path sibling of C-066, which D118422177 fixed for the read path with
a `CopyBarrier`. That guard covers `startReadReply` only, so the read path holds the
invariant on every exit and the put path held it only on the enumerated ones. This
removes that asymmetry with the same mechanism.

`abandonPutWaves` is already `noexcept`, which is what makes it safe to call during
unwinding, and it already retires each wave -- event wait with the
`streamSynchronize` fallback -- before clearing. So the guard is only about *when* it
runs, not about new machinery.

**Inert on every path the code takes deliberately**, which is the point of the
emptiness check. On success `drainWaves(0)` retires everything and pops as it goes;
on an explicit error `abandonPutWaves()` retires and then `waves.clear()`. Both leave
`inFlight` empty, so the destructor does nothing and no wave can be retired twice.
The guard only becomes live when an exception passes through a window where slabs are
held.

Reviewed By: yexiangd

Differential Revision: D118747681


