### PR TITLE
comms/uniflow/tcp: claim the inflight entry so a duplicate reqId cannot settle a put early (#4084)

### DIFF
--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -3139,7 +3139,26 @@ void TcpTransport::handleFrameImpl(
         std::lock_guard<std::mutex> lk(inflightMu_);
         auto it = inflight_.find(header.reqId);
         if (it != inflight_.end()) {
-          entry = it->second;
+          // reqId is peer-supplied and there is one reader per lane, so
+          // claiming the entry here is what makes a duplicate miss. Copying it
+          // and erasing further down lets two Acks naming one reqId pass this
+          // check on different lanes and both reach completeOne(), which
+          // decrements `remaining` twice and settles a multi-chunk put at its
+          // first chunk -- the caller is told Ok with a chunk still
+          // outstanding. This was the original shape; it was given up when the
+          // entry had to outlive the lock for the async H2D handoff.
+          //
+          // ReadReply keeps the copy, because only that path hands off: its
+          // record has to stay in inflight_ until startAsyncH2d publishes into
+          // the H2D queue, or a concurrent failAllPending() finds it in neither
+          // and the caller's promise never resolves. Claiming it for every kind
+          // would trade a silent wrong success for a silent hang.
+          if (op == TcpOp::ReadReply) {
+            entry = it->second;
+          } else {
+            entry = std::move(it->second);
+            inflight_.erase(it);
+          }
           found = true;
         }
       }
@@ -3147,6 +3166,13 @@ void TcpTransport::handleFrameImpl(
         break;
       }
 
+      // Meaningful on the ReadReply path ONLY. Every other kind was claimed and
+      // erased above, under the same lock, so on those branches this erases an
+      // absent key and does nothing. It is called from them anyway rather than
+      // hoisted into the ReadReply branch, so that no branch can reach
+      // completeOne() with the entry still present if the claim above ever
+      // grows another kind that keeps its copy -- but do not read the calls as
+      // each branch owning the erase, because only one of them does.
       const auto eraseInflight = [&]() {
         std::lock_guard<std::mutex> lk(inflightMu_);
         inflight_.erase(header.reqId);


### PR DESCRIPTION
Summary:

The Ack/ReadReply/Error lookup copied the inflight entry under `inflightMu_` and
left it in the map, with the erase happening much further down. `reqId` is
peer-supplied and there is one reader per lane, so two Acks naming one `reqId` on
different lanes both passed the `found` check and both reached
`entry.state->completeOne()`.

`completeOneLocked` is `if (done) return; if (remaining > 0) --remaining;
settleLocked();`. The `remaining > 0` guard prevents underflow but not premature
settle, so a two-chunk put whose first chunk is acked twice goes 2 -> 1 -> 0 and
resolves **Ok** while the second chunk is still outstanding. The genuine second Ack
then finds `done` and returns. **The caller is told the put succeeded when a chunk
may never have landed** -- silent success with incomplete state, which is the same
class as the crossed-reply-kind bug D117927060 closed, and reachable through the
same threat model: a buggy, hostile, or version-skewed peer. A same-version sender
emits exactly one Ack per Write.

Raised by mahi on D117927060. Filed as C-099.

**This is a regression, not a latent gap.** At D117053165 the block was
`entry = std::move(it->second); inflight_.erase(it);` under one lock, so a
duplicate hit `!found`. The atomicity existed and was given up when the entry had
to outlive the lock for the async H2D handoff.

# Scoped to the Ack path on purpose

Only `ReadReply` needs the late erase, and the reason is documented at the erase
site: the pending record must stay visible in `inflight_` until `startAsyncH2d`
publishes into the H2D queue, so a concurrent `failAllPending()` finds it in one
place or the other. Claiming the entry for every kind would open a window where it
is in neither, and the caller's promise would never resolve -- trading a silent
wrong success for a silent hang. So `ReadReply` keeps the copy and every other kind
claims.

`ReadReply` therefore still carries the same duplicate exposure: two replies for
one `reqId` both copy, both write `entry.dst`, and both eventually complete.
Closing that means moving the record atomically from `inflight_` into the H2D
queue, which is a change to the handoff protocol rather than a local edit, and it
is left open under C-099.

The three `eraseInflight()` calls on the non-ReadReply branches are now no-ops on
an absent key and are deliberately left in place: the kind-mismatch one is still
reachable with `op == ReadReply`, and removing only the other two would leave the
branches inconsistent about who owns the erase.

# One behaviour change in a race, stated rather than buried

Today a concurrent `failAllPending()` landing between the lookup and the erase can
fail an op whose Ack had already arrived, after which `completeOne()` sees `done`
and returns -- the op reports failed. With the claim, `failAllPending()` no longer
sees that entry and the op reports Ok. That is the more defensible outcome, since
the Ack did arrive, and the promise still settles exactly once because
`completeOneLocked` and `failLocked` share `mu` and the `done` flag. But it is a
real change in behaviour under a race, not a pure no-op.

Reviewed By: yexiangd

Differential Revision: D118714811


