### PR TITLE
Launch the p2p send/recv kernel with 1 thread when it has no NVL work

### DIFF
--- a/comms/ctran/algos/SendRecv/SendRecvP2pImpl.cc
+++ b/comms/ctran/algos/SendRecv/SendRecvP2pImpl.cc
@@ -151,13 +151,18 @@ commResult_t setupP2pKernelConfig(
   kernArgs.numSends = sendIdx;
   kernArgs.numRecvs = recvIdx;
 
-  // If no kernel ops, still need to launch kernel for GPE to start: so at least
-  // 1 block needed.
-  config.numBlocks =
-      std::max((size_t)1, kernArgs.numSendBlocks + kernArgs.numRecvBlocks);
   // TODO: tunning needed
   kernArgs.useBlockGroup = true;
-  config.numThreads = NCCL_CTRAN_NVL_SENDRECV_P2P_THREAD_BLOCK_SIZE;
+
+  // Launch geometry. Both fields default to 1, which is what an op group with
+  // no NVL work needs: the kernel only starts the GPE and spins until it is
+  // done, and that is thread 0's job alone. The blocks and the NVL block size
+  // exist to drive the copy loops in `sendImpl` / `recvImpl`.
+  const size_t nvlBlocks = kernArgs.numSendBlocks + kernArgs.numRecvBlocks;
+  if (nvlBlocks > 0) {
+    config.numBlocks = nvlBlocks;
+    config.numThreads = NCCL_CTRAN_NVL_SENDRECV_P2P_THREAD_BLOCK_SIZE;
+  }
   config.algoArgs = &kernArgs;
   return commSuccess;
 }


### PR DESCRIPTION
Summary:
`setupP2pKernelConfig` sets the block size unconditionally:

```
config.numThreads = NCCL_CTRAN_NVL_SENDRECV_P2P_THREAD_BLOCK_SIZE;  // default 512
```

The cvar is NVL-specific -- its own description is "number of threads in each
thread block used for intra-node p2p sendrecv kernel" -- and 512 threads exist
to drive the NVLink copy loops in `sendImpl` / `recvImpl`.

An IB-only group has no copy loops to drive. `setupGpeOp` hands the IB ops to
the GPE thread, `numSendBlocks` and `numRecvBlocks` are both 0, and the kernel
body reduces to thread 0 calling `KernelStartGpe` and then
`KernelWaitGpeTerminate`; `sendImpl` and `recvImpl` iterate zero times. The
other 511 threads only spin.

Observed on a PP job whose `PP_P2P_*` groups are IB-only, where every
`ncclKernelSendRecvP2p` launch is:

```
grid=(1,1,1)  block=(512,1,1)  regs=128  smem=39856
```

so 512 threads and 39 KB of shared memory are reserved on that SM for a
single-thread wait, for the whole duration of the transfer (median 32.5 ms on
the recv side).

Keep the NVL block size whenever there is NVL work, and use 1 thread when there
is none.

Reviewed By: Regina8023

Differential Revision: D119371272


