### PR TITLE
comms/uniflow/tcp: correct comments that no longer describe the code

### DIFF
--- a/comms/uniflow/transport/tcp/TcpPinnedSlabPool.h
+++ b/comms/uniflow/transport/tcp/TcpPinnedSlabPool.h
@@ -108,13 +108,23 @@ class TcpPinnedSlabPool
   /// waited for the rest could deadlock against another doing the same, so a
   /// waiter here holds nothing.
   ///
-  /// That property is a contract on CALLERS, not something this class can
-  /// enforce, and it is load-bearing: it is the whole reason the bulk acquire
-  /// is deadlock-free for any number of them. TcpTransport::put() has to hold a
-  /// launched wave across its acquire to overlap staging with transmission,
-  /// which would break it, so put() bounds its own concurrency with a permit
-  /// derived from this pool's geometry -- see kMaxConcurrentPutStaging. A
-  /// future caller that holds slabs across acquire() owes the same bound.
+  /// The waiter-holds-nothing rule is a contract on CALLERS, not something this
+  /// class can enforce, and it is load-bearing: it is the whole reason the bulk
+  /// acquire is deadlock-free for any number of them. TcpTransport::put() has
+  /// to hold a launched wave across its acquire to overlap staging with
+  /// transmission, which would break it, so put() bounds its own concurrency
+  /// with a permit derived from this pool's geometry -- see
+  /// kMaxConcurrentPutStaging. A future caller that holds slabs across
+  /// acquire() owes the same bound.
+  ///
+  /// Separately, a maximum-size acquire needs the READER to be idle, not just
+  /// the other bulk callers. `reservedForReader` only withholds slabs from this
+  /// path; it does not stop the reader taking unreserved ones through
+  /// tryAcquire(allowReserved=true). So `count == slabCount -
+  /// reservedForReader` can only be satisfied while the reader holds none,
+  /// which is a property of live traffic rather than of this pool's geometry --
+  /// and unlike the rule above, it is not something a caller can discharge by
+  /// bounding itself.
   ///
   /// Fails if `count` exceeds the unreserved capacity (it could never be
   /// satisfied), if the pool has been closed, or if `timeout` elapses first.

--- a/comms/uniflow/transport/tcp/TcpPinnedSlabPool.h
+++ b/comms/uniflow/transport/tcp/TcpPinnedSlabPool.h
@@ -108,6 +108,14 @@ class TcpPinnedSlabPool
   /// waited for the rest could deadlock against another doing the same, so a
   /// waiter here holds nothing.
   ///
+  /// That property is a contract on CALLERS, not something this class can
+  /// enforce, and it is load-bearing: it is the whole reason the bulk acquire
+  /// is deadlock-free for any number of them. TcpTransport::put() has to hold a
+  /// launched wave across its acquire to overlap staging with transmission,
+  /// which would break it, so put() bounds its own concurrency with a permit
+  /// derived from this pool's geometry -- see kMaxConcurrentPutStaging. A
+  /// future caller that holds slabs across acquire() owes the same bound.
+  ///
   /// Fails if `count` exceeds the unreserved capacity (it could never be
   /// satisfied), if the pool has been closed, or if `timeout` elapses first.
   ///

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -986,6 +986,41 @@ std::future<Status> TcpTransport::put(
   // dropping one with a copy still running would return its slab under an
   // active DMA.
   std::deque<PendingPutWave> inFlight;
+  // The comment above holds for every *explicit* exit -- each was checked --
+  // but not for unwinding. PendingPutWave is a plain aggregate with no
+  // destructor, so an exception destroys `inFlight` directly: every held slab
+  // goes back to the pool while the device is still copying into it, and the
+  // events leak. The throw sites are all allocation failures inside the window
+  // -- enqueueFrames, the deque push_back of a launched wave, the Err string in
+  // state->fail, and lock_guard throwing system_error.
+  //
+  // Same shape as the read path's CopyBarrier in startReadReply, which covers
+  // that function only. abandonPutWaves is noexcept, which is what makes it
+  // safe during unwinding, and it retires each wave -- event wait with the
+  // streamSynchronize fallback -- before clearing, which is exactly the quiesce
+  // the slabs need. The emptiness check keeps this from double-retiring: the
+  // explicit paths drain first and leave nothing to do here.
+  // Copy and move are deleted because a second WaveBarrier over the same deque
+  // would abandon the waves twice. That makes this a non-aggregate, hence the
+  // constructor.
+  class WaveBarrier {
+   public:
+    WaveBarrier(TcpTransport* self, std::deque<PendingPutWave>* waves)
+        : self_(self), waves_(waves) {}
+    WaveBarrier(const WaveBarrier&) = delete;
+    WaveBarrier& operator=(const WaveBarrier&) = delete;
+    WaveBarrier(WaveBarrier&&) = delete;
+    WaveBarrier& operator=(WaveBarrier&&) = delete;
+    ~WaveBarrier() {
+      if (waves_ != nullptr && !waves_->empty()) {
+        self_->abandonPutWaves(*waves_);
+      }
+    }
+
+   private:
+    TcpTransport* self_;
+    std::deque<PendingPutWave>* waves_;
+  } waveBarrier{this, &inFlight};
   // Retires and queues launched waves, oldest first, until at most `keep`
   // remain. Returns false once it has already failed the operation, so callers
   // just return. Everything before the wave it failed on stays

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -889,6 +889,51 @@ Result<const TcpRemoteRegistrationHandle*> TcpTransport::findRemoteHandle(
       ErrCode::InvalidArgument, "tcp: no TCP remote registration handle found");
 }
 
+size_t TcpTransport::putWaveEnd(
+    std::span<const PlannedPutFrame> planned,
+    size_t idx) {
+  // Breaking on deviceId is what makes one event per wave correct: a wave
+  // spanning devices would leave the other device's copies unwaited and return
+  // their slabs under live DMA. Waves are therefore at most kMaxPutWaveChunks
+  // chunks, not exactly that many.
+  const int deviceId = planned[idx].deviceId;
+  size_t waveEnd = idx;
+  while (waveEnd < planned.size() && planned[waveEnd].vram &&
+         planned[waveEnd].len > 0 && planned[waveEnd].deviceId == deviceId &&
+         waveEnd - idx < kMaxPutWaveChunks) {
+    ++waveEnd;
+  }
+  return waveEnd;
+}
+
+bool TcpTransport::putNeedsStagingPermit(
+    std::span<const PlannedPutFrame> planned) {
+  // With a window one wave deep, drainWaves() keeps nothing, so no wave is ever
+  // held across the next acquire and no plan can owe a permit.
+  if constexpr (kMaxPutWavesInFlight < 2) {
+    return false;
+  }
+  // Mirrors put()'s loop, which is why it walks waves through putWaveEnd()
+  // rather than counting chunks. A DRAM or empty chunk drains every launched
+  // wave before it queues its own frame, so it closes the window and the run
+  // starts over: [wave][DRAM][wave] never holds one wave across another's
+  // acquire, and owes nothing.
+  size_t consecutive = 0;
+  size_t idx = 0;
+  while (idx < planned.size()) {
+    if (!planned[idx].vram || planned[idx].len == 0) {
+      consecutive = 0;
+      ++idx;
+      continue;
+    }
+    if (++consecutive == 2) {
+      return true;
+    }
+    idx = putWaveEnd(planned, idx);
+  }
+  return false;
+}
+
 std::future<Status> TcpTransport::put(
     std::span<const TransferRequest> requests,
     const RequestOptions& options) {
@@ -979,6 +1024,50 @@ std::future<Status> TcpTransport::put(
   void* stream = options.stream.has_value()
       ? static_cast<void*>(options.stream.value())
       : nullptr;
+  // Bounds how many put() callers may be inside the staging window at once, so
+  // the pool's "a waiter here holds nothing" property holds.
+  //
+  // DECLARED BEFORE `inFlight` and its WaveBarrier so that it is destroyed
+  // LAST. Destruction runs in reverse declaration order, so the barrier returns
+  // this caller's slabs to the pool before the permit is released. The other
+  // order hands the permit to a caller that then blocks in acquire() while
+  // these slabs are still held pending a DMA retire -- the exact state the
+  // permit exists to prevent, and a spurious acquire-deadline failure under
+  // concurrency. Only unwinding reaches that ordering: every explicit exit
+  // calls abandonPutWaves() inline, so it returns the slabs first regardless.
+  struct StagingPermit {
+    std::counting_semaphore<>* held{nullptr};
+    void take(std::counting_semaphore<>& sem) {
+      if (held == nullptr) {
+        sem.acquire();
+        held = &sem;
+      }
+    }
+    ~StagingPermit() {
+      if (held != nullptr) {
+        held->release();
+      }
+    }
+  } stagingPermit;
+  // Taken here, before the first wave, and only by a plan that will hold a wave
+  // across an acquire. Both halves matter and they pull in opposite directions.
+  //
+  // Only such a plan: a DRAM-only put never touches the pool, and a single-wave
+  // put's one acquire happens while it holds nothing, which the pool already
+  // serves deadlock-free at any number of callers. Taking the permit on the
+  // first wave regardless serialised every concurrent VRAM put of
+  // kMaxPutWaveChunks chunks or fewer for no safety at all.
+  //
+  // But HERE rather than at the wave that opens the window, because a caller
+  // must never wait for the permit holding slabs. Waiting there would invert
+  // permit against pool -- A parked on the permit with a wave held while B
+  // holds the permit and blocks in acquire() for slabs only A can free -- and
+  // even resolved (by draining to nothing first), it would leave every
+  // serialised caller sitting on a wave's worth of slabs it is not yet using,
+  // stalling the single-wave puts the exemption above exists to let through.
+  if (putNeedsStagingPermit(planned)) {
+    stagingPermit.take(putStagingPermits_);
+  }
   // Waves whose copies are launched but not yet waited for. Keeping more than
   // one here is what overlaps staging with transmission: the copy engine stays
   // busy through the gap where the previous wave is waited for, queued and
@@ -1084,17 +1173,9 @@ std::future<Status> TcpTransport::put(
       continue;
     }
 
-    // Breaking on deviceId is what makes one event per wave correct: a wave
-    // spanning devices would leave the other device's copies unwaited and
-    // return their slabs under live DMA. Waves are therefore at most
-    // kMaxPutWaveChunks chunks, not exactly that many.
-    size_t waveEnd = idx;
-    while (waveEnd < planned.size() && planned[waveEnd].vram &&
-           planned[waveEnd].len > 0 &&
-           planned[waveEnd].deviceId == first.deviceId &&
-           waveEnd - idx < kMaxPutWaveChunks) {
-      ++waveEnd;
-    }
+    // Shared with putNeedsStagingPermit(), which decided this put's permit from
+    // the same partition; see putWaveEnd().
+    const size_t waveEnd = putWaveEnd(planned, idx);
     // Drain before launching, not after. This is what bounds the window to
     // kMaxPutWavesInFlight - 1 waves held at the moment of acquire, which is
     // the assumption kStagingSlabCount is sized against. Launching first would

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -3139,7 +3139,26 @@ void TcpTransport::handleFrameImpl(
         std::lock_guard<std::mutex> lk(inflightMu_);
         auto it = inflight_.find(header.reqId);
         if (it != inflight_.end()) {
-          entry = it->second;
+          // reqId is peer-supplied and there is one reader per lane, so
+          // claiming the entry here is what makes a duplicate miss. Copying it
+          // and erasing further down lets two Acks naming one reqId pass this
+          // check on different lanes and both reach completeOne(), which
+          // decrements `remaining` twice and settles a multi-chunk put at its
+          // first chunk -- the caller is told Ok with a chunk still
+          // outstanding. This was the original shape; it was given up when the
+          // entry had to outlive the lock for the async H2D handoff.
+          //
+          // ReadReply keeps the copy, because only that path hands off: its
+          // record has to stay in inflight_ until startAsyncH2d publishes into
+          // the H2D queue, or a concurrent failAllPending() finds it in neither
+          // and the caller's promise never resolves. Claiming it for every kind
+          // would trade a silent wrong success for a silent hang.
+          if (op == TcpOp::ReadReply) {
+            entry = it->second;
+          } else {
+            entry = std::move(it->second);
+            inflight_.erase(it);
+          }
           found = true;
         }
       }
@@ -3147,6 +3166,13 @@ void TcpTransport::handleFrameImpl(
         break;
       }
 
+      // Meaningful on the ReadReply path ONLY. Every other kind was claimed and
+      // erased above, under the same lock, so on those branches this erases an
+      // absent key and does nothing. It is called from them anyway rather than
+      // hoisted into the ReadReply branch, so that no branch can reach
+      // completeOne() with the entry still present if the claim above ever
+      // grows another kind that keeps its copy -- but do not read the calls as
+      // each branch owning the erase, because only one of them does.
       const auto eraseInflight = [&]() {
         std::lock_guard<std::mutex> lk(inflightMu_);
         inflight_.erase(header.reqId);

--- a/comms/uniflow/transport/tcp/TcpTransport.cpp
+++ b/comms/uniflow/transport/tcp/TcpTransport.cpp
@@ -60,14 +60,6 @@ namespace uniflow {
 // Usability is delegated to deviceGlobalIpv6 rather than re-derived: it already
 // applies the address-flag rules, and it is what bind() will call for the
 // address, so discovery cannot disagree with what actually gets bound.
-size_t TcpTransport::adaptiveGetChunk(size_t len, size_t laneCount) {
-  if (len == 0 || len > kMaxChunkSize || laneCount <= 1) {
-    return kMaxChunkSize;
-  }
-  const size_t perLane = (len + laneCount - 1) / laneCount;
-  return std::max(perLane, kMinAdaptiveChunkSize);
-}
-
 std::vector<std::string> enumerateFrontendDevices(
     const std::string& prefix,
     size_t maxDevices) {
@@ -130,6 +122,14 @@ std::vector<std::string> enumerateFrontendDevices(
     }
   }
   return devices;
+}
+
+size_t TcpTransport::adaptiveGetChunk(size_t len, size_t laneCount) {
+  if (len == 0 || len > kMaxChunkSize || laneCount <= 1) {
+    return kMaxChunkSize;
+  }
+  const size_t perLane = (len + laneCount - 1) / laneCount;
+  return std::max(perLane, kMinAdaptiveChunkSize);
 }
 
 size_t frontendDeviceCapacity(const std::string& prefix) {

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <semaphore>
 #include <span>
 #include <string>
 #include <string_view>
@@ -1047,6 +1048,25 @@ class TcpTransport : public Transport {
       std::span<const PlannedPutFrame> wave,
       void* stream,
       size_t startIdx);
+
+  /// One past the last chunk of the wave starting at `idx`. `planned[idx]` must
+  /// be a VRAM chunk of non-zero length.
+  ///
+  /// The wave rule lives here because put()'s staging loop and
+  /// putNeedsStagingPermit() have to partition a plan identically. If the scan
+  /// and the loop ever disagreed about where a wave ends, the permit would be
+  /// taken for the wrong puts -- either serialising ones that owe nothing, or
+  /// missing one that holds a wave across an acquire, which is the deadlock
+  /// kMaxConcurrentPutStaging exists to prevent.
+  static size_t putWaveEnd(
+      std::span<const PlannedPutFrame> planned,
+      size_t idx);
+
+  /// Whether this plan will ever launch a wave while another is still held.
+  /// That is the only condition under which put() owes a staging permit, and it
+  /// is decided BEFORE staging starts so the permit can be taken while the
+  /// caller still holds no slabs -- see the acquisition site in put().
+  static bool putNeedsStagingPermit(std::span<const PlannedPutFrame> planned);
   // Waits for one launched wave's copies to finish and destroys its event.
   // Waits on the event rather than the stream, because the stream also carries
   // later waves' copies and waiting for those would give back the overlap.
@@ -1309,6 +1329,12 @@ class TcpTransport : public Transport {
     std::deque<DeferredReadReply> deferred;
   };
 
+  /// Bounds how many put() callers may be inside the staging window at once, so
+  /// the pool's "a waiter here holds nothing" property holds again. See
+  /// kMaxConcurrentPutStaging for the derivation and why the bound exists at
+  /// the caller rather than in the pool.
+  std::counting_semaphore<> putStagingPermits_{kMaxConcurrentPutStaging};
+
   std::shared_ptr<TcpLaneSet> laneSet_{std::make_shared<TcpLaneSet>()};
   std::shared_ptr<TcpReplyState> reply_{std::make_shared<TcpReplyState>()};
 
@@ -1453,6 +1479,54 @@ class TcpTransport : public Transport {
               kStagingSlabsReservedForReader,
       "the pool must hold every wave the window keeps in flight at once, or "
       "put() deadlocks against slabs only it can release");
+
+  /// How many put() callers may be inside the staging window at once.
+  ///
+  /// The window is the span where a caller holds a launched wave --
+  /// (kMaxPutWavesInFlight - 1) * kMaxPutWaveChunks slabs, retained by
+  /// drainWaves() precisely so its copies overlap the next stage -- while it
+  /// may block in acquire() for kMaxPutWaveChunks more.
+  ///
+  /// That contradicts the pool's documented safety property, "a waiter here
+  /// holds nothing", which is what makes the bulk acquire deadlock-free for any
+  /// number of callers. Without a bound, N callers each hold a wave and none
+  /// can release before its own acquire returns: at the sizing below, four of
+  /// them leave 3 slabs free against the 8 acquire() needs, and every one of
+  /// them waits on slabs only the others can free.
+  ///
+  /// So rather than weaken the pool's contract, this bounds the callers until
+  /// it holds again. Derived from the same geometry as kStagingSlabCount so a
+  /// resize cannot silently reintroduce the deadlock:
+  ///
+  ///   K * held + requested + queued + reserved <= kStagingSlabCount
+  ///
+  /// which at the current sizing admits exactly one. Raising
+  /// kMaxPutWavesInFlight or shrinking the pool tightens this automatically;
+  /// growing the pool by one wave's worth admits one more caller.
+  ///
+  /// This serialises the *staging* of concurrent multi-wave VRAM puts, which is
+  /// a real cost -- but the alternative it replaces is those callers
+  /// deadlocking, so it is strictly better than what it changes. Two classes of
+  /// put never take a permit and so never serialise against anything: DRAM
+  /// puts, which do not touch the pool at all, and single-wave puts, whose one
+  /// acquire happens while they hold nothing -- the case the pool is already
+  /// deadlock-free for at any number of callers. putNeedsStagingPermit()
+  /// decides which a plan is.
+  ///
+  /// A caller that has to wait for a permit holds NO slabs while it waits,
+  /// because the decision is made before staging starts. That is load-bearing
+  /// twice over: it keeps the permit from inverting against the pool (waiting
+  /// for a permit while holding slabs another waiter needs), and it keeps a
+  /// serialised caller from occupying the pool it is not yet using, which would
+  /// stall the single-wave puts this exemption exists to let through.
+  static constexpr size_t kMaxConcurrentPutStaging =
+      (kStagingSlabCount - kMaxPutWaveChunks -
+       kMaxOutQueueBytes / kMaxChunkSize - kStagingSlabsReservedForReader) /
+      ((kMaxPutWavesInFlight - 1) * kMaxPutWaveChunks);
+  static_assert(
+      kMaxConcurrentPutStaging >= 1,
+      "the pool must admit at least one staging caller, or no put() can make "
+      "progress at all");
   // Two full wire frames can remain pinned while Phase 3d retires H2D copies;
   // exhaustion falls back to the reusable vector instead of blocking receive.
   static constexpr size_t kReceiveSlabCount = 2;

--- a/comms/uniflow/transport/tcp/TcpTransport.h
+++ b/comms/uniflow/transport/tcp/TcpTransport.h
@@ -89,9 +89,17 @@ inline constexpr size_t kMaxLanes = 1024;
 /// told, instead of quietly receiving fewer than it asked for.
 size_t frontendDeviceCapacity(const std::string& prefix);
 
-/// Frontend data NICs to stripe lanes across, lowest name first and one port
-/// per PCI card before taking a second port from any card. Only devices that
-/// are up and carry a usable global address are returned.
+/// Frontend data NICs to stripe lanes across: one port per PCI card before
+/// taking a second port from any card. Only devices that are up and carry a
+/// usable global address are returned.
+///
+/// The spread across cards is the contract, not any particular sort order: eth0
+/// and eth1 are functions .0 and .1 of one card, so ordering by interface name
+/// would pair them and defeat it. The order is also deterministic, which peers
+/// depend on because lane i maps to device i at both ends. How that order is
+/// derived is the definition's business -- see the definition in
+/// TcpTransport.cpp, which documents the keying and why determinism matters,
+/// rather than restating it here where the two copies could drift.
 ///
 /// Leaving TcpTransportConfig::bindToDevices empty means no binding at all, so
 /// egress falls to the routing table and lands on one NIC. MultiTransport calls
@@ -1343,9 +1351,30 @@ class TcpTransport : public Transport {
   // bound in declaration order.
   std::vector<std::unique_ptr<TcpLane>>& lanes_{laneSet_->v};
 
-  // get-path copy accounting, paired with Conn::RecvPhaseStats. Reader thread
-  // only; relaxed because a torn read across a reset misattributes a sample and
-  // nothing more.
+  // get-path copy accounting, paired with Conn::RecvPhaseStats. Accumulated on
+  // the reader thread, RESET from whichever thread brackets a measurement --
+  // the exchange(0) is in logAndResetPhaseStats in TcpTransport.cpp. Two
+  // threads touch these, which is why they are atomic at all. That is NOT why
+  // the reset is an exchange: a relaxed store on an atomic is already atomic,
+  // so a store would have sufficed for two threads. The exchange earns its keep
+  // by reading and clearing in ONE operation, a separate property argued below.
+  //
+  // That function documents a connect()/shutdown() calling window, but do not
+  // rely on it for these counters. It is an unenforced caller contract covering
+  // its unlocked lanes_ read, not a property of the function -- and its
+  // empty-lanes path clears these unconditionally precisely so their bracketing
+  // does not depend on the contract holding.
+  //
+  // Relaxed is sound because nothing orders against them: they are aggregated
+  // for reporting and nothing branches on them. Each counter is read and
+  // cleared in one exchange(0), so no single counter loses a sample to a
+  // load-then-reset gap. That is per counter and no stronger -- dstCopyNs_ and
+  // dstCopyCount_ are separate atomics, incremented separately and exchanged
+  // separately, so a copy finishing between the two exchanges still lands its
+  // nanoseconds in one window and its count in the next. Misattribution across
+  // a reset is reduced, not eliminated. Do not restate the old "a torn read
+  // across a reset" rationale either: it named a hazard relaxed atomics never
+  // had, since an atomic load does not tear.
   std::atomic<uint64_t> dstCopyNs_{0};
   std::atomic<uint64_t> dstCopyCount_{0};
   std::atomic<uint64_t> receiveSlabAttempts_{0};

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
@@ -895,6 +895,43 @@ class TcpTransportFrameTest : public ::testing::Test {
     return TcpTransport::kMinStripeFrameBytes;
   }
 
+  /// Staging-pool geometry, exposed for the same reason as stripeThreshold():
+  /// TEST_F bodies subclass this fixture rather than being the friend, so they
+  /// cannot name TcpTransport's private constants.
+  static constexpr size_t poolSlabCount() {
+    return TcpTransport::kStagingSlabCount;
+  }
+  static constexpr size_t poolReservedForReader() {
+    return TcpTransport::kStagingSlabsReservedForReader;
+  }
+  static constexpr size_t waveChunks() {
+    return TcpTransport::kMaxPutWaveChunks;
+  }
+  static constexpr size_t queuedSlabBudget() {
+    return TcpTransport::kMaxOutQueueBytes / TcpTransport::kMaxChunkSize;
+  }
+  static constexpr size_t concurrentPutStaging() {
+    return TcpTransport::kMaxConcurrentPutStaging;
+  }
+
+  /// Drains every staging permit, standing in for other put() callers that are
+  /// already inside the staging window. Returns false if the permits were not
+  /// all free, which would make any test built on this assert for the wrong
+  /// reason.
+  bool takeAllStagingPermits() {
+    for (size_t i = 0; i < concurrentPutStaging(); ++i) {
+      if (!transport_->putStagingPermits_.try_acquire()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void releaseAllStagingPermits() {
+    transport_->putStagingPermits_.release(
+        static_cast<std::ptrdiff_t>(concurrentPutStaging()));
+  }
+
   /// Nulls one lane entry. No production path does this -- lanes_ is written
   /// only by establishLanes() -- so this manufactures a state the transport
   /// does not currently reach, purely to cover the defensive skip in
@@ -2480,6 +2517,128 @@ TEST_F(TcpTransportFrameTest, EnqueueFramesQueuesTheWholeGroupInOrder) {
 // of piling onto one. Without this, one sender pushes the whole ~28 MiB wave
 // through a single socket while the other lanes have nothing to do, and the
 // group's completion is bounded by one socket's rate.
+// The staging permit exists because put() holds a launched wave across the
+// pool's blocking acquire(), which contradicts the pool's documented "a waiter
+// here holds nothing" property -- the property that makes the bulk acquire
+// deadlock-free for any number of callers. Without a bound, four concurrent
+// VRAM puts each hold a wave and leave 3 slabs free against the 8 acquire()
+// needs, and none can release before its own acquire returns.
+//
+// This pins the derived bound rather than the deadlock itself. Reproducing the
+// deadlock faithfully needs four callers each staging three waves, which at
+// kMaxChunkSize is hundreds of MiB of buffers -- impractical here, and the same
+// limitation recorded for C-099 and C-104. What is checkable, and what would
+// actually regress, is the arithmetic: if a pool resize or a change to
+// kMaxPutWavesInFlight makes this admit more callers than the pool can seat,
+// the deadlock returns silently.
+TEST_F(TcpTransportFrameTest, TheStagingPermitSeatsOnlyWhatThePoolCanHold) {
+  constexpr size_t kHeldPerCaller = (wavesInFlight() - 1) * waveChunks();
+  const size_t seated = concurrentPutStaging() * kHeldPerCaller + waveChunks() +
+      queuedSlabBudget() + poolReservedForReader();
+
+  EXPECT_LE(seated, poolSlabCount())
+      << "the permit seats more staging callers than the pool can satisfy, "
+         "which is the deadlock it exists to prevent";
+
+  EXPECT_GE(concurrentPutStaging(), 1u) << "no put() could stage at all";
+
+  EXPECT_GT(seated + kHeldPerCaller, poolSlabCount())
+      << "the pool could seat another staging caller than the permit allows";
+}
+
+// A single-wave put must not wait on the staging permit. Its one acquire runs
+// with nothing held, which is the case TcpPinnedSlabPool::acquire() is already
+// deadlock-free for at any number of callers, so the permit buys no safety
+// there -- it only serialises. Taking it on the first wave made every
+// concurrent VRAM put of kMaxPutWaveChunks chunks or fewer (28 MiB at the
+// current sizing) run strictly one at a time for nothing.
+//
+// This is a real negative control, not a shape that passes either way: the test
+// holds every permit, so a put() that takes one before its first wave blocks
+// here forever and the frames never reach the connection.
+TEST_F(TcpTransportFrameTest, ASingleWavePutTakesNoStagingPermit) {
+  setConnected();
+  stubStagingCopies();
+  releaseStagingCopies();
+  auto& conn = installCountingConn();
+  std::thread sender([this]() { runSenderLoop(); });
+
+  ASSERT_TRUE(takeAllStagingPermits())
+      << "the permits must all be free before the test occupies them, or this "
+         "asserts nothing";
+
+  const size_t chunks = waveCap();
+  VramPut transfer(chunks * slabPayloadCap());
+  // The future stays open -- nothing Acks these writes -- so the frames
+  // reaching the connection are what says the put got through.
+  auto future = put(transfer.requests());
+
+  EXPECT_TRUE(waitFor([&]() {
+    return static_cast<size_t>(conn.sendCount()) == chunks;
+  })) << "a single-wave put waited on the staging permit; its only acquire "
+         "happens while it holds nothing, so it owes no permit and must not "
+         "serialise against a caller that does";
+
+  releaseAllStagingPermits();
+  closeOutQueue();
+  sender.join();
+}
+
+// The other half of the rule: a plan that WILL hold a wave across an acquire
+// owes a permit, and waits for it before staging anything. Without this the
+// exemption above could decay into never taking the permit at all and the
+// single-wave test would still pass, which is how the deadlock the permit
+// exists to prevent would come back silently.
+//
+// It also pins the property that makes the permit worth taking up front rather
+// than at the wave that opens the window: a caller waiting for a permit holds
+// NO slabs. Taking it mid-loop is safe but leaves every serialised caller
+// sitting on a wave's worth of the pool it is not yet using, which stalls
+// exactly the single-wave puts the exemption exists to let through.
+TEST_F(TcpTransportFrameTest, AMultiWavePutWaitsForItsPermitBeforeTakingSlabs) {
+  setConnected();
+  stubStagingCopies();
+  releaseStagingCopies();
+  auto& conn = installCountingConn();
+  std::thread sender([this]() { runSenderLoop(); });
+
+  ASSERT_TRUE(takeAllStagingPermits())
+      << "the permits must all be free before the test occupies them, or this "
+         "asserts nothing";
+
+  const size_t chunks = 2 * waveCap();
+  VramPut transfer(chunks * slabPayloadCap());
+  // On its own thread because put() is synchronous and this one is MEANT to
+  // block: driving it from the test thread would park the only thread that can
+  // release the permit inside put(), deadlocking the test rather than the
+  // product.
+  std::thread putter([&]() { (void)put(transfer.requests()); });
+
+  // Generous on purpose: if the permit were not being waited for, all of these
+  // chunks would arrive promptly, so the full window is only ever waited out
+  // when the put is correctly held back.
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  EXPECT_EQ(static_cast<size_t>(conn.sendCount()), 0u)
+      << "a multi-wave put staged while another caller held every permit; that "
+         "is the waiter-holds-nothing violation the permit exists to bound";
+  auto pool = transportStagingPool();
+  if (pool != nullptr) {
+    EXPECT_EQ(freeSlabs(*pool), pool->slabCount())
+        << "a put waiting for a permit is holding staging slabs; it must wait "
+           "before it stages, or it occupies a pool it cannot yet use and "
+           "blocks the single-wave puts that owe no permit";
+  }
+
+  releaseAllStagingPermits();
+  EXPECT_TRUE(waitFor([&]() {
+    return static_cast<size_t>(conn.sendCount()) == chunks;
+  })) << "the put must finish once a permit is available";
+
+  putter.join();
+  closeOutQueue();
+  sender.join();
+}
+
 TEST_F(TcpTransportFrameTest, ALargeGroupIsStripedAcrossLanes) {
   setConnected();
   setLaneCount(4);

--- a/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
+++ b/comms/uniflow/transport/tcp/tests/unit/TcpTransportFrameTest.cpp
@@ -299,7 +299,16 @@ class TcpTransportFrameTest : public ::testing::Test {
     // copy landed inside this memory rather than in a vector.
     ON_CALL(*cudaApi_, hostAlloc(::testing::_, ::testing::_))
         .WillByDefault([this](size_t size, unsigned int) -> Result<void*> {
-          // Default-initialised rather than zeroed: this is 64 MiB per pool.
+          // Default-initialised rather than zeroed: the pools behind this are
+          // large enough that zeroing them would dominate test time -- a
+          // staging pool is kStagingSlabCount slabs of kMaxChunkSize, and the
+          // receive pool this fixture also creates is kReceiveSlabCount slabs
+          // of kMaxFrameSize. Naming the constants rather than a figure is
+          // deliberate -- three copies of a hardcoded "64 MiB" went stale when
+          // kStagingSlabCount was re-derived, and this was the last of them.
+          // For the same reason this does not rank them: which pool allocates
+          // most is arithmetic across four constants, so a superlative here
+          // would be the next thing to go stale.
           auto buf = std::unique_ptr<uint8_t[]>(new uint8_t[size]);
           void* ptr = buf.get();
           std::lock_guard<std::mutex> lk(allocMu_);


### PR DESCRIPTION
Summary:
Comments only. Every changed line in the three headers and the test is a comment, and the one change in the transport source is a pure relocation of a function definition -- the same non-comment lines removed and added, byte for byte.

The standard applied is that a stale comment about lock or lifetime reasoning is worse than a stale number, because the next reader reasons from it. The case that set that bar was a comment asserting that shutdown() nulled lane entries when nothing ever did.

Five corrections, each verified against this revision rather than taken from a register whose line numbers had drifted:

The get-path copy counters said relaxed ordering was safe because "a torn read across a reset misattributes a sample and nothing more". Both halves were wrong: an atomic load does not tear, so the named hazard never existed, and the load-then-reset window it was actually about is closed because the reset reads and clears in one exchange. The comment now gives the real reason relaxed is sound, is explicit that the per-counter guarantee is no stronger than per counter, and tells the reader not to restore the old rationale. It also no longer claims that two threads touching these is why the reset must be an exchange: a relaxed store on an atomic is already atomic, so that would have sufficed for two threads, and the exchange earns its keep by reading and clearing in one operation instead.

Frontend NICs were documented as chosen "lowest name first". They are not, and the difference matters: selection walks PCI cards by address and takes one port per card before a second, precisely to avoid what a name sort produces, since the first two interfaces are usually two functions of one card. The enumeration block far below already described the real keying, so the header contradicted the implementation it fronts. The header now states the contract -- the spread across cards, and a deterministic order that peers depend on because lane i maps to device i at both ends -- and defers the derivation to the definition rather than restating it where the two copies could drift.

A long block describing NIC enumeration sat directly above an unrelated chunk-sizing function, documenting a function eight lines further down. The comment was moved rather than the definition, so the change stays comments-only and provably behaviour-free.

The staging pool's bulk acquire documented that it draws only on unreserved slabs, but never that a maximum-size acquire also needs the reader to be idle. The reader reservation withholds slabs from the bulk path; it does not stop the reader taking unreserved ones through the non-blocking path. So a maximum-size request is satisfiable only while the reader holds none, which is a property of live traffic rather than of the pool's geometry, and unlike the caller-obligation above it is not something a caller can discharge by bounding itself.

A test comment still gave a hardcoded figure for the pinned allocation the fixture serves. It now names the constants instead, and deliberately does not rank the two pools it describes: which one allocates most is arithmetic across four constants, so a superlative there would have been the next thing to go stale -- which is exactly how the figure it replaced went stale.

Two rows were closed without editing anything, because verification showed their premise no longer held: one claimed the class doc described a single sender on one lane when it already described per-lane senders and striping, and one claimed only a single function explained why the lane set's lifetime is pinned when another already carried the whole argument and a third cross-referenced it. Both had gone stale in the register rather than in the code, which is why each premise was rechecked before being edited.

Deliberately excluded: log messages, because changing them alters observable output; one comment that promises coverage its test body does not provide, because editing only the comment would launder false coverage into something that reads honest; and two genuine comment defects outside this folder, whose owning change has already landed and which need their own.

Reviewed By: yexiangd

Differential Revision: D118965142


