### PR TITLE
Fall back to VALID_DBR on QP refusal

### DIFF
--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -1072,6 +1072,54 @@ void MultipeerIbgdaTransport::connectQp(
           << peerInfo.qpn;
 }
 
+doca_error_t MultipeerIbgdaTransport::createQpGroupWithDoorbellFallback(
+    int nic,
+    int slot,
+    int companionSlots,
+    doca_gpu_verbs_qp_init_attr_hl& mainAttr,
+    doca_gpu_verbs_qp_group_hl** outGroup) {
+  doca_error_t err = doca_gpu_verbs_create_qp_group_hl(&mainAttr, outGroup);
+#ifndef __HIP_PLATFORM_AMD__
+  // Only the auto policy may degrade. An explicit enableReliableDoorbell is a
+  // hard requirement -- reliableDoorbellActiveForNic() throws for it -- so it
+  // must fail here too rather than be silently satisfied with the other mode.
+  if (err == DOCA_SUCCESS || !nicDoca_[nic].useReliableDoorbell ||
+      config_.enableReliableDoorbell.has_value()) {
+    return err;
+  }
+
+  // The NIC caps DBR-less QPs and the capability is a bare bit with no count,
+  // so the ceiling is only observable as a create refusal. DOCA_ERROR_DRIVER
+  // is generic, so the retry -- same attrs, only the doorbell mode changed --
+  // is what identifies it. Mode is local (not exchanged, dispatched per QP),
+  // so switching mid-job is safe. On failure the callee leaves *outGroup
+  // untouched, so the retry cannot orphan an allocation.
+  const doca_error_t noDbrErr = err;
+  mainAttr.send_dbr_mode_ext = DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR;
+  err = doca_gpu_verbs_create_qp_group_hl(&mainAttr, outGroup);
+
+  if (err != DOCA_SUCCESS) {
+    // Not a doorbell problem; report the original error.
+    mainAttr.send_dbr_mode_ext =
+        DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_HW;
+    return noDbrErr;
+  }
+
+  // Latch, or every remaining slot re-fails against the same ceiling.
+  nicDoca_[nic].useReliableDoorbell = false;
+  LOG(WARNING) << "MultipeerIbgdaTransport: NIC " << nics_[nic].deviceName
+               << " hit its NO_DBR_HW QP limit at slot " << slot << "/"
+               << companionSlots << " (" << docaErrorToString(noDbrErr)
+               << "); using VALID_DBR for the rest of this NIC. Lower "
+                  "max_num_channels or qpsPerConnection to stay under it.";
+#else
+  (void)nic;
+  (void)slot;
+  (void)companionSlots;
+#endif
+  return err;
+}
+
 void MultipeerIbgdaTransport::createPeerQps(int peerIndex) {
   for (int nic = 0; nic < numNics_; nic++) {
     doca_gpu_verbs_qp_init_attr_hl mainAttr{};
@@ -1125,8 +1173,8 @@ void MultipeerIbgdaTransport::createPeerQps(int peerIndex) {
     const int companionSlots = config_.fixedChannelCompanionQpsPerPeerPerNic();
     for (int slot = 0; slot < companionSlots; slot++) {
       const int slotIdx = peerIndex * companionSlots + slot;
-      doca_error_t err =
-          doca_gpu_verbs_create_qp_group_hl(&mainAttr, &nicQps[slotIdx]);
+      doca_error_t err = createQpGroupWithDoorbellFallback(
+          nic, slot, companionSlots, mainAttr, &nicQps[slotIdx]);
       checkDocaError(err, "Failed to create QP group");
       err = doca_gpu_verbs_create_qp_hl(&loopbackAttr, &nicLoopback[slotIdx]);
       checkDocaError(err, "Failed to create loopback companion QP");

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
@@ -239,6 +239,15 @@ class MultipeerIbgdaTransport
 
   // Per-peer helpers shared by eager exchange() and lazy materializePeer()
   void createPeerQps(int peerIndex);
+
+  // Create one QP group, degrading this NIC to VALID_DBR if the NIC refuses a
+  // DBR-less one. Returns the original error if the group could not be made.
+  doca_error_t createQpGroupWithDoorbellFallback(
+      int nic,
+      int slot,
+      int companionSlots,
+      doca_gpu_verbs_qp_init_attr_hl& mainAttr,
+      doca_gpu_verbs_qp_group_hl** outGroup);
   void connectPeerLoopback(int peerIndex);
   P2pIbgdaTransportBuildParams buildPeerTransportParams(int peerIndex) const;
 


### PR DESCRIPTION
Summary:
A ConnectX-8 NIC will only create a bounded number of DBR-less (reliable-doorbell) queue pairs. Past that ceiling the firmware refuses `CREATE_QP` outright, and IBGDA turned that refusal into a fatal `std::runtime_error` that aborted the whole job during peer materialization.

There is no way to avoid the ceiling by planning ahead. The device advertises DBR-less support as a single capability bit (`cmd_hca_cap_2.send_dbr_mode_no_dbr_ext`) with no companion count, so the limit is not knowable up front -- it is only observable at the point of refusal. This change therefore degrades on the actual failure rather than trying to predict it: when a NIC refuses a `NO_DBR_HW` QP group, the transport switches that NIC to `VALID_DBR` and retries, and logs a warning naming the NIC and the QP index where the ceiling was hit.

The fallback is self-validating rather than keyed on the error code. `DOCA_ERROR_DRIVER` is generic -- UAR failures and others return it too -- so the code alone cannot identify the ceiling. Instead the group is retried with only the doorbell mode changed: if `VALID_DBR` succeeds where `NO_DBR_HW` did not, that was the one variable that differed and the NIC is latched. If the retry also fails, the doorbell mode was not the problem, the mode is restored, and the original error is surfaced unchanged -- so an unrelated failure is never mislabelled as a DBR-less limit.

Only the `auto` policy degrades. An explicit `enableReliableDoorbell` is a hard requirement -- `reliableDoorbellActiveForNic()` throws when the NIC lacks the capability -- so it must fail at creation too rather than be quietly satisfied with the other mode.

Switching mid-job is safe. The doorbell mode is how a GPU signals its own NIC; it never goes on the wire. It is not part of the peer exchange, no peer validates it, and the device selects the submit path per QP from `qp->nic_handler`, so queue pairs already created keep their mode and remote ends are unaffected. The decision is latched per NIC, because without that every remaining slot would retry and re-fail against the same ceiling.

Jobs that fit under the ceiling are untouched and keep the reliable-doorbell path. Jobs that exceed it now lose that optimization on the affected NIC instead of dying, and say so loudly -- the warning also points at the two knobs (`max_num_channels`, `qpsPerConnection`) that control how fast the ceiling is consumed.

The loopback companion QPs already used `VALID_DBR` and are unchanged. The fallback is compiled out on AMD, which does not take this path.

Reviewed By: saifhhasan

Differential Revision: D119430099


