### PR TITLE
Harden warp-proxy completion handling

### DIFF
--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -534,7 +534,9 @@ TEST_P(MultipeerIbTransportTestFixture, BadRkeyCompletionErrorUnwinds) {
           /*maxGroups=*/64,
           /*qpsPerBlockPerNic=*/1,
           collapsed);
-      EXPECT_EQ(transport->collapsedCqActive(), collapsed);
+      if (transport->collapsedCqActive() != collapsed) {
+        throw std::runtime_error("requested CQ format was not activated");
+      }
       dataBuffer = std::make_unique<DeviceBuffer>(nbytes);
       localDataBuf = transport->registerBuffer(dataBuffer->get(), nbytes);
       remoteDataBufs = transport->exchangeBuffer(localDataBuf);
@@ -621,6 +623,145 @@ TEST_P(MultipeerIbTransportTestFixture, BadRkeyCompletionErrorUnwinds) {
     ASSERT_EQ(allRunOk, 1) << "bad-rkey exercise failed on one rank: "
                            << runFailure;
   }
+}
+
+TEST_P(
+    MultipeerIbTransportTestFixture,
+    BadRkeyPrepareSendSlotConfirmationUnwinds) {
+#ifdef __HIP_PLATFORM_AMD__
+  GTEST_SKIP() << "send-slot CQ error handling is NVIDIA-only";
+#else
+  if (numRanks != 2) {
+    GTEST_SKIP() << "requires exactly 2 ranks, got " << numRanks;
+  }
+  if (backend() != IbTestBackend::Ibgda) {
+    GTEST_SKIP() << "completion-error handling under test is IBGDA-specific";
+  }
+
+  constexpr std::size_t kBytes = 64 * 1024;
+  constexpr std::chrono::milliseconds kDeadline{30000};
+  constexpr std::chrono::milliseconds kMaxElapsed{5000};
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  const int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
+
+  for (const bool collapsed : {false, true}) {
+    SCOPED_TRACE(collapsed ? "collapsed" : "ring");
+    std::unique_ptr<TestIbTransport> transport;
+    std::unique_ptr<DeviceBuffer> dataBuffer;
+    IbgdaLocalBuffer localDataBuf{};
+    std::vector<IbgdaRemoteBuffer> remoteDataBufs;
+    P2pIbgdaTransportDevice* peerTransport = nullptr;
+
+    int localSetupOk = 0;
+    std::string skipReason;
+    try {
+      MultipeerIbTransportConfig config{
+          .cudaDevice = localRank,
+          .perChannelSize = kBytes,
+          .max_num_channels = 1,
+          .pipelineDepth = 2,
+      };
+      config.enableCollapsedCq = collapsed;
+      auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+      transport = std::make_unique<TestIbTransport>(
+          backend(), globalRank, numRanks, std::move(bootstrap), config);
+      if (transport->collapsedCqActive() != collapsed) {
+        throw std::runtime_error("requested CQ format was not activated");
+      }
+      dataBuffer = std::make_unique<DeviceBuffer>(kBytes);
+      localDataBuf = transport->registerBuffer(dataBuffer->get(), kBytes);
+      remoteDataBufs = transport->exchangeBuffer(localDataBuf);
+      peerTransport = transport->getIbgdaTransportDevice(peerRank);
+      localSetupOk = 1;
+    } catch (const std::exception& e) {
+      skipReason = e.what();
+    }
+    int allSetupOk = 0;
+    MPI_CHECK(MPI_Allreduce(
+        &localSetupOk, &allSetupOk, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD));
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    if (allSetupOk == 0) {
+      GTEST_SKIP() << "IB transport not available on some rank: " << skipReason;
+    }
+
+    int localRunOk = 1;
+    std::string runFailure;
+    if (globalRank == 0) {
+      try {
+        auto poisonedRemote = remoteDataBufs[peerIndex];
+        if (poisonedRemote.rkey_per_device.size <= 0) {
+          throw std::runtime_error("remote buffer has no populated device key");
+        }
+        for (int nic = 0; nic < poisonedRemote.rkey_per_device.size; ++nic) {
+          poisonedRemote.rkey_per_device[nic].value ^=
+              comms::prims::detail::ibgdaNetworkByteOrderKey(0xFFU);
+        }
+
+        DeviceBuffer observationBuffer(sizeof(uint32_t));
+        if (const cudaError_t status =
+                cudaMemset(observationBuffer.get(), 0, sizeof(uint32_t));
+            status != cudaSuccess) {
+          throw std::runtime_error(
+              std::string("cudaMemset failed: ") + cudaGetErrorString(status));
+        }
+        comms::fault_tolerance::Abort abort(/*enabled=*/true);
+        auto deviceAbort = abort.getDeviceHandle();
+        deviceAbort.setOpTimeoutMs(kDeadline.count());
+
+        const auto start = std::chrono::steady_clock::now();
+        test::testPrepareSendSlotBadRkey(
+            peerTransport,
+            localDataBuf,
+            poisonedRemote,
+            kBytes,
+            static_cast<uint32_t*>(observationBuffer.get()),
+            deviceAbort,
+            /*numBlocks=*/1,
+            /*blockSize=*/32);
+        const cudaError_t syncStatus = cudaDeviceSynchronize();
+        const auto elapsed =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - start);
+
+        if (syncStatus != cudaSuccess) {
+          throw std::runtime_error(
+              std::string("confirmation poll trapped: ") +
+              cudaGetErrorString(syncStatus));
+        }
+        if (elapsed >= kMaxElapsed) {
+          throw std::runtime_error("confirmation poll did not unwind promptly");
+        }
+        if (abort.reason() !=
+            comms::fault_tolerance::AbortReason::NETWORK_ERROR) {
+          throw std::runtime_error(
+              "completion error did not latch NETWORK_ERROR");
+        }
+        uint32_t observedUnretired = 0;
+        if (const cudaError_t status = cudaMemcpy(
+                &observedUnretired,
+                observationBuffer.get(),
+                sizeof(observedUnretired),
+                cudaMemcpyDeviceToHost);
+            status != cudaSuccess) {
+          throw std::runtime_error(
+              std::string("cudaMemcpy failed: ") + cudaGetErrorString(status));
+        }
+        if (observedUnretired != 1U) {
+          throw std::runtime_error("failed completion slot was retired");
+        }
+      } catch (const std::exception& e) {
+        localRunOk = 0;
+        runFailure = e.what();
+      }
+    }
+    int allRunOk = 0;
+    MPI_CHECK(MPI_Allreduce(
+        &localRunOk, &allRunOk, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD));
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    ASSERT_EQ(allRunOk, 1) << "send-slot CQ error exercise failed: "
+                           << runFailure;
+  }
+#endif
 }
 
 /*

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -1679,6 +1679,78 @@ void testRegisteredSendDrainWithAbort(
 #endif
 }
 
+#ifndef __HIP_PLATFORM_AMD__
+__global__ void prepareSendSlotBadRkeyKernel(
+    P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer poisonedRemoteBuf,
+    std::size_t nbytes,
+    uint32_t* observedUnretired,
+    comms::fault_tolerance::AbortDevice abort) {
+  auto group = make_block_group();
+  abort.start();
+
+  if (group.is_leader()) {
+    ThreadGroup solo{
+        0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+    const auto ticket = transport->put(
+        solo,
+        localBuf,
+        poisonedRemoteBuf,
+        nbytes,
+        /*signalId=*/-1,
+        /*signalVal=*/0);
+    detail::record_send_completion<protocol::Simple>(
+        *transport,
+        group.group_id,
+        /*slotId=*/0,
+        /*generation=*/0,
+        ticket);
+  }
+  group.sync();
+
+  const bool unretired = detail::prepare_send_slot<protocol::Simple>(
+      *transport,
+      group,
+      /*slotId=*/0,
+      /*generation=*/1,
+      abort);
+  if (group.is_leader()) {
+    *observedUnretired = static_cast<uint32_t>(unretired);
+  }
+}
+#endif
+
+void testPrepareSendSlotBadRkey(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& poisonedRemoteBuf,
+    std::size_t nbytes,
+    uint32_t* observedUnretired,
+    comms::fault_tolerance::AbortDevice abort,
+    int numBlocks,
+    int blockSize) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)localBuf;
+  (void)poisonedRemoteBuf;
+  (void)nbytes;
+  (void)observedUnretired;
+  (void)abort;
+  (void)numBlocks;
+  (void)blockSize;
+  throw std::runtime_error("send-slot CQ error test is NVIDIA-only");
+#else
+  prepareSendSlotBadRkeyKernel<<<numBlocks, blockSize>>>(
+      transport, localBuf, poisonedRemoteBuf, nbytes, observedUnretired, abort);
+  const cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+#endif
+}
+
 void testPutAndFlushWithAbort(
     P2pIbTransportDevice transport,
     const IbgdaLocalBuffer& localBuf,

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -554,6 +554,19 @@ void testRegisteredSendDrainWithAbort(
     int numBlocks,
     int blockSize);
 
+/**
+ * Test the blocking send-slot retirement error path against a bad-rkey CQE.
+ */
+void testPrepareSendSlotBadRkey(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& poisonedRemoteBuf,
+    std::size_t nbytes,
+    uint32_t* observedUnretired,
+    comms::fault_tolerance::AbortDevice abort,
+    int numBlocks,
+    int blockSize);
+
 void testPutAndFlushWithAbort(
     P2pIbTransportDevice transport,
     const IbgdaLocalBuffer& localBuf,

--- a/comms/prims/tests/P2pIbTransportDeviceAbortTest.cc
+++ b/comms/prims/tests/P2pIbTransportDeviceAbortTest.cc
@@ -250,7 +250,65 @@ class PutFixture {
   uint32_t* posted_{nullptr};
 };
 
+class PrepareSendSlotObservationFixture {
+ public:
+  PrepareSendSlotObservationFixture() {
+    CUDACHECK_TEST(cudaSetDevice(0));
+    CUDACHECK_TEST(cudaMalloc(&device_, sizeof(*device_)));
+    CUDACHECK_TEST(cudaMemset(device_, 0, sizeof(*device_)));
+  }
+
+  ~PrepareSendSlotObservationFixture() {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaFree(device_);
+  }
+
+  PrepareSendSlotObservationFixture(const PrepareSendSlotObservationFixture&) =
+      delete;
+  PrepareSendSlotObservationFixture& operator=(
+      const PrepareSendSlotObservationFixture&) = delete;
+  PrepareSendSlotObservationFixture(PrepareSendSlotObservationFixture&&) =
+      delete;
+  PrepareSendSlotObservationFixture& operator=(
+      PrepareSendSlotObservationFixture&&) = delete;
+
+  test::PrepareSendSlotAbortObservation* device() {
+    return device_;
+  }
+
+  test::PrepareSendSlotAbortObservation read() const {
+    test::PrepareSendSlotAbortObservation observation;
+    CUDACHECK_TEST(cudaMemcpy(
+        &observation, device_, sizeof(observation), cudaMemcpyDeviceToHost));
+    return observation;
+  }
+
+ private:
+  test::PrepareSendSlotAbortObservation* device_{nullptr};
+};
+
 } // namespace
+
+TEST(
+    P2pIbTransportDeviceAbortTest,
+    PrepareSendSlotForwardsAbortToConfirmation) {
+  PrepareSendSlotObservationFixture fixture;
+  comms::fault_tolerance::Abort abort(/*enabled=*/true);
+  abort.setAbort();
+
+  test::launchPrepareSendSlotAbortForwarding(
+      fixture.device(), abort.getDeviceHandle());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  const auto observation = fixture.read();
+  const auto expectedReason =
+      static_cast<uint32_t>(comms::fault_tolerance::AbortReason::ABORTED);
+  EXPECT_EQ(observation.waitReason, expectedReason);
+  EXPECT_EQ(observation.confirmationReason, expectedReason);
+  EXPECT_EQ(observation.slotUnretired, 1U);
+  EXPECT_EQ(observation.remainingLaneMask, 1U);
+  EXPECT_EQ(observation.generation, 0U);
+}
 
 // A put that finds the ring full has to unwind, not trap: under fault tolerance
 // a device trap takes down the CUDA context for the whole process, which is the

--- a/comms/prims/tests/P2pIbTransportDeviceAbortTest.cu
+++ b/comms/prims/tests/P2pIbTransportDeviceAbortTest.cu
@@ -15,6 +15,83 @@ namespace comms::prims::test {
 
 namespace {
 
+struct PrepareSendSlotProbeChannel {
+  IbSendCompletionSlot sendCompletionSlots[1];
+};
+
+class PrepareSendSlotProbeTransport {
+ public:
+  __device__ explicit PrepareSendSlotProbeTransport(
+      PrepareSendSlotProbeChannel* slot,
+      PrepareSendSlotAbortObservation* observation)
+      : slot_(slot), observation_(observation) {}
+
+  template <typename P>
+  __device__ PrepareSendSlotProbeChannel& local_channel_slot(
+      uint32_t /*channelId*/) {
+    return *slot_;
+  }
+
+  __device__ uint32_t send_completion_lane_count() const {
+    return 1;
+  }
+
+  __device__ void wait_local_completion(
+      uint32_t /*channelId*/,
+      const IbLocalCompletionTicket& /*ticket*/,
+      const comms::fault_tolerance::AbortDevice& abort) {
+    observation_->waitReason = static_cast<uint32_t>(abort.reason());
+  }
+
+  __device__ bool is_local_completion_ready(
+      uint32_t /*channelId*/,
+      const IbLocalCompletionTicket& /*ticket*/) = delete;
+
+  __device__ bool is_local_completion_ready(
+      uint32_t /*channelId*/,
+      const IbLocalCompletionTicket& /*ticket*/,
+      const comms::fault_tolerance::AbortDevice& abort) {
+    observation_->confirmationReason = static_cast<uint32_t>(abort.reason());
+    return false;
+  }
+
+  __device__ const PrepareSendSlotProbeChannel& slot() const {
+    return *slot_;
+  }
+
+ private:
+  PrepareSendSlotProbeChannel* slot_{nullptr};
+  PrepareSendSlotAbortObservation* observation_{nullptr};
+};
+
+__global__ void prepareSendSlotAbortForwardingKernel(
+    PrepareSendSlotAbortObservation* observation,
+    comms::fault_tolerance::AbortDevice abort) {
+  auto group = make_block_group();
+  __shared__ PrepareSendSlotProbeChannel slot;
+  if (group.is_leader()) {
+    auto& completion = slot.sendCompletionSlots[0];
+    completion.generation = 0;
+    completion.laneMask = 1;
+    completion.values[0] = 1;
+  }
+  group.sync();
+  PrepareSendSlotProbeTransport transport(&slot, observation);
+
+  const bool slotUnretired = detail::prepare_send_slot<protocol::Simple>(
+      transport,
+      group,
+      /*slotId=*/0,
+      /*generation=*/1,
+      abort);
+  if (group.is_leader()) {
+    const auto& completion = transport.slot().sendCompletionSlots[0];
+    observation->slotUnretired = static_cast<uint32_t>(slotUnretired);
+    observation->remainingLaneMask = completion.laneMask;
+    observation->generation = completion.generation;
+  }
+}
+
 // Queue and channel state backing the transport under test.
 //
 // Must be one block-wide object: `wait_signal` is a group primitive whose
@@ -251,6 +328,13 @@ __global__ void flushNeverDrainsKernel(
 
 uint32_t ibrcTestQueueDepth() {
   return kIbrcTestQueueDepth;
+}
+
+void launchPrepareSendSlotAbortForwarding(
+    PrepareSendSlotAbortObservation* observation,
+    comms::fault_tolerance::AbortDevice abort) {
+  prepareSendSlotAbortForwardingKernel<<<1, 32>>>(observation, abort);
+  PIPES_KERNEL_LAUNCH_CHECK();
 }
 
 void launchIbrcPutUntilQueueFull(

--- a/comms/prims/tests/P2pIbTransportDeviceAbortTest.cuh
+++ b/comms/prims/tests/P2pIbTransportDeviceAbortTest.cuh
@@ -9,6 +9,18 @@
 
 namespace comms::prims::test {
 
+struct PrepareSendSlotAbortObservation {
+  uint32_t waitReason{0};
+  uint32_t confirmationReason{0};
+  uint32_t slotUnretired{0};
+  uint64_t remainingLaneMask{0};
+  uint64_t generation{0};
+};
+
+void launchPrepareSendSlotAbortForwarding(
+    PrepareSendSlotAbortObservation* observation,
+    comms::fault_tolerance::AbortDevice abort);
+
 /*
  * Runs `wait_signal(group, signal, expected, abort)` on a locally constructed
  * IBRC transport and stores the wait's return value in `waitResult`.

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTest.cu
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTest.cu
@@ -497,27 +497,54 @@ __global__ void testCollapsedCqPoll(
     doca_gpu_dev_verbs_cq* cq,
     uint64_t ticket,
     bool blocking,
+    bool abortAware,
+    bool collapsedCq,
+    bool gpuSharing,
+    comms::fault_tolerance::AbortDevice abort,
     CollapsedCqPollResult* result) {
   if (blocking) {
     result->status = prims_ibgda_wait_collapsed_cq<
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
         DOCA_GPUNETIO_VERBS_SYNC_SCOPE_CTA>(cq, ticket);
+    result->aborted = 0;
+  } else if (abortAware) {
+    const auto pollResult = gpuSharing
+        ? detail::pollIbgdaSqOnce<
+              DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+              DOCA_GPUNETIO_VERBS_SYNC_SCOPE_CTA>(
+              cq, ticket, collapsedCq, abort)
+        : detail::pollIbgdaSqOnce<
+              DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE,
+              DOCA_GPUNETIO_VERBS_SYNC_SCOPE_CTA>(
+              cq, ticket, collapsedCq, abort);
+    result->status = pollResult.status;
+    result->aborted = pollResult.aborted ? 1U : 0U;
   } else {
     result->status = prims_ibgda_poll_collapsed_cq_once<
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
         DOCA_GPUNETIO_VERBS_SYNC_SCOPE_CTA>(cq, ticket);
+    result->aborted = 0;
   }
   result->finalConsumerIndex = cq->cqe_ci;
 }
 
-cudaError_t runTestCollapsedCqPoll(
+namespace {
+
+cudaError_t runTestIbgdaSqPoll(
     const CollapsedCqPollCase& testCase,
+    bool abortAware,
+    bool collapsedCq,
+    bool gpuSharing,
+    comms::fault_tolerance::AbortDevice abort,
     CollapsedCqPollResult* result) {
   doca_gpunetio_ib_mlx5_cqe64 hostCqe{};
   hostCqe.wqe_counter = static_cast<__be16>(
       (testCase.wqeCounter >> 8) | (testCase.wqeCounter << 8));
   hostCqe.op_own = static_cast<uint8_t>(
       testCase.opcode << DOCA_GPUNETIO_VERBS_MLX5_CQE_OPCODE_SHIFT);
+  if (!collapsedCq) {
+    hostCqe.op_own |= DOCA_GPUNETIO_IB_MLX5_CQE_OWNER_MASK;
+  }
 
   doca_gpunetio_ib_mlx5_cqe64* deviceCqe = nullptr;
   doca_gpu_dev_verbs_cq* deviceCq = nullptr;
@@ -550,7 +577,14 @@ cudaError_t runTestCollapsedCqPoll(
   }
   if (status == cudaSuccess) {
     testCollapsedCqPoll<<<1, 1>>>(
-        deviceCq, testCase.ticket, testCase.blocking, deviceResult);
+        deviceCq,
+        testCase.ticket,
+        testCase.blocking,
+        abortAware,
+        collapsedCq,
+        gpuSharing,
+        abort,
+        deviceResult);
     status = cudaDeviceSynchronize();
   }
   if (status == cudaSuccess) {
@@ -574,6 +608,35 @@ cudaError_t runTestCollapsedCqPoll(
     return cqFreeStatus;
   }
   return cqeFreeStatus;
+}
+
+} // namespace
+
+cudaError_t runTestCollapsedCqPoll(
+    const CollapsedCqPollCase& testCase,
+    CollapsedCqPollResult* result) {
+  return runTestIbgdaSqPoll(
+      testCase,
+      /*abortAware=*/false,
+      /*collapsedCq=*/true,
+      /*gpuSharing=*/true,
+      comms::fault_tolerance::AbortDevice{},
+      result);
+}
+
+cudaError_t runTestIbgdaSqPollWithAbort(
+    const CollapsedCqPollCase& testCase,
+    bool collapsedCq,
+    bool gpuSharing,
+    comms::fault_tolerance::AbortDevice abort,
+    CollapsedCqPollResult* result) {
+  return runTestIbgdaSqPoll(
+      testCase,
+      /*abortAware=*/true,
+      collapsedCq,
+      gpuSharing,
+      abort,
+      result);
 }
 #endif
 

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh
@@ -105,10 +105,18 @@ struct CollapsedCqPollCase {
 struct CollapsedCqPollResult {
   int status;
   uint64_t finalConsumerIndex;
+  uint32_t aborted;
 };
 
 cudaError_t runTestCollapsedCqPoll(
     const CollapsedCqPollCase& testCase,
+    CollapsedCqPollResult* result);
+
+cudaError_t runTestIbgdaSqPollWithAbort(
+    const CollapsedCqPollCase& testCase,
+    bool collapsedCq,
+    bool gpuSharing,
+    comms::fault_tolerance::AbortDevice abort,
     CollapsedCqPollResult* result);
 #endif
 

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTestMain.cc
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTestMain.cc
@@ -156,6 +156,28 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, CollapsedCqWaitReturnsError) {
     EXPECT_EQ(result.finalConsumerIndex, 0);
   }
 }
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, SqCapacityPollObservesAbort) {
+  constexpr uint8_t kInvalidCompletion = 15;
+  const CollapsedCqPollCase testCase{0, 0, 1, 0, kInvalidCompletion, false};
+  for (const auto& [collapsedCq, gpuSharing] :
+       std::vector<std::pair<bool, bool>>{{true, true}, {false, false}}) {
+    SCOPED_TRACE(
+        ::testing::Message()
+        << "collapsedCq=" << collapsedCq << ", gpuSharing=" << gpuSharing);
+    comms::fault_tolerance::Abort abort(/*enabled=*/true);
+    abort.setAbort();
+    CollapsedCqPollResult result{};
+
+    CUDACHECK_TEST(runTestIbgdaSqPollWithAbort(
+        testCase, collapsedCq, gpuSharing, abort.getDeviceHandle(), &result));
+
+    EXPECT_EQ(result.status, EBUSY);
+    EXPECT_EQ(result.aborted, 1U);
+    EXPECT_EQ(result.finalConsumerIndex, 0U);
+    EXPECT_TRUE(abort.isAborted());
+  }
+}
 #endif
 
 TEST_F(P2pIbgdaTransportDeviceTestFixture, ReadSignal) {

--- a/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
@@ -2020,6 +2020,9 @@ __device__ __forceinline__ void recv_impl(
       } else {
         const uint64_t recvToken =
             ibOps->wait_recv(transport, group, protocolBytesThis, abortDevice);
+        if (!ibOps->recv_token_valid(recvToken)) {
+          break;
+        }
         const std::size_t validBytes =
             valid_payload_bytes(dataOff, payloadBytes, nbytes);
         if (validBytes > 0) {
@@ -2462,6 +2465,9 @@ __device__ __forceinline__ void forward_impl(
     } else {
       const uint64_t recvToken = ibOps->wait_recv(
           transport, group, recvProtocolBytesThis, abortDevice);
+      if (!ibOps->recv_token_valid(recvToken)) {
+        break;
+      }
       if (ibOps->prepare_send_slot(
               fwdTransport,
               group,
@@ -2844,7 +2850,8 @@ template <typename P, typename Transport>
         // Confirm rather than assume: the wait above cannot report that it gave
         // up, and a lane earlier in this loop may already have latched the
         // abort, so later lanes can fall straight through it.
-        if (transport.is_local_completion_ready(group.group_id, ticket)) {
+        if (transport.is_local_completion_ready(
+                group.group_id, ticket, abortDevice)) {
           pending &= ~laneBit;
         }
       }
@@ -2867,6 +2874,9 @@ __device__ __forceinline__ void record_send_completion(
     uint64_t generation,
     const IbLocalCompletionTicket& ticket) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  if (!ticket.posted) {
+    return;
+  }
   auto& slot = transport.template local_channel_slot<P>(channelId)
                    .sendCompletionSlots[slotId];
   slot.generation = generation;

--- a/comms/prims/transport/ibgda/IbgdaBuffer.h
+++ b/comms/prims/transport/ibgda/IbgdaBuffer.h
@@ -602,9 +602,11 @@ inline constexpr int kNumProtoSlots = 2;
 
 // Identifies a lane-local completion threshold returned by put().
 // completionId is the send-lane ordinal; value is complete once that lane's
-// backend-specific completion frontier reaches it.
+// backend-specific completion frontier reaches it. posted is false when the
+// operation stopped before publishing a WQE.
 struct IbLocalCompletionTicket {
   uint32_t completionId{0};
+  bool posted{false};
   uint64_t value{0};
 };
 

--- a/comms/prims/transport/ibgda/IbgdaWarpProxy.cuh
+++ b/comms/prims/transport/ibgda/IbgdaWarpProxy.cuh
@@ -329,6 +329,11 @@ class IbgdaWarpProxy {
       IbgdaWarpProxy::publish_recv_copied(storage_, workers, sequence);
     }
 
+    [[nodiscard]] __device__ __forceinline__ bool recv_token_valid(
+        uint64_t sequence) const {
+      return sequence != kInvalidSequence;
+    }
+
    private:
     friend class IbgdaWarpProxy<WorkerThreads, MaxPipelineDepth>;
 
@@ -669,7 +674,8 @@ class IbgdaWarpProxy {
 
   __device__ __forceinline__ static void post_recv_credits(
       SharedState& storage,
-      const ThreadGroup& fullBlock) {
+      const ThreadGroup& fullBlock,
+      const AbortDevice& abortDevice) {
     BlockAtomicU64 copied(storage.recv.copied);
     BlockAtomicU64 credited(storage.recv.credited);
     uint64_t head = credited.load(cuda::memory_order_relaxed);
@@ -680,8 +686,14 @@ class IbgdaWarpProxy {
           command.transport->channel_layout(),
           static_cast<int>(command.channel));
       ThreadGroup solo = make_solo_group(command.channel, fullBlock);
-      command.transport->signal(
-          solo, remote.slotFree, command.protocolBytes, IbDirection::Recv);
+      if (!command.transport->try_signal(
+              solo,
+              remote.slotFree,
+              command.protocolBytes,
+              IbDirection::Recv,
+              abortDevice)) {
+        return;
+      }
       credited.store(++head, cuda::memory_order_release);
     }
   }
@@ -787,7 +799,11 @@ class IbgdaWarpProxy {
         command.protocolBytes,
         /*counterBuf=*/{},
         /*counterVal=*/0,
-        /*signalPerLane=*/true);
+        /*signalPerLane=*/true,
+        abortDevice);
+    if (!ticket.posted) {
+      return;
+    }
     detail::record_send_completion(
         *command.transport,
         command.channel,
@@ -826,10 +842,11 @@ class IbgdaWarpProxy {
         // between each abortable step, rather than once at the bottom. Both are
         // needed, and for different reasons:
         //
-        //   - `post_recv_credits()` emits `signal(slotFree)` and has no abort
-        //     check of its own; `post_send_once()` issues a `put` with a fused
-        //     `DATA_READY`. With the check below them, the iteration on which
-        //     the abort first becomes visible has already sent one more round.
+        //   - `post_recv_credits()` emits `signal(slotFree)` and
+        //     `post_send_once()` issues a `put` with a fused `DATA_READY`.
+        //     Their SQ-capacity waits are abort-aware, but this check also
+        //     prevents entering either posting path after an earlier step
+        //     latched the abort.
         //   - Hoisting alone does not close it: `publish_recv_readiness()` is
         //     itself abortable, so an abort first observed *inside* it would
         //     still be followed by `post_send_once()` in the same iteration.
@@ -855,7 +872,7 @@ class IbgdaWarpProxy {
           emit();
           aborted = abortDevice.isAborted();
         };
-        step([&] { post_recv_credits(storage, fullBlock); });
+        step([&] { post_recv_credits(storage, fullBlock, abortDevice); });
         step([&] { publish_recv_readiness(storage, abortDevice); });
         step([&] { post_send_once(storage, fullBlock, abortDevice); });
 

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -122,6 +122,110 @@ __device__ __forceinline__ int prims_ibgda_wait_collapsed_cq(
 }
 #endif
 
+#ifndef __HIP_PLATFORM_AMD__
+namespace detail {
+
+struct IbgdaWqeReservation {
+  uint64_t firstWqe{0};
+  bool acquired{false};
+};
+
+struct IbgdaSqPollResult {
+  int status{EBUSY};
+  bool aborted{false};
+};
+
+template <
+    doca_gpu_dev_verbs_resource_sharing_mode CqSharingMode,
+    doca_gpu_dev_verbs_sync_scope AcquireScope>
+__device__ __forceinline__ IbgdaSqPollResult pollIbgdaSqOnce(
+    doca_gpu_dev_verbs_cq* cq,
+    uint64_t ticket,
+    bool collapsedCq,
+    const AbortDevice& abortDevice) {
+  int status;
+#if !defined(PRIMS_IBGDA_DISABLE_COLLAPSED_CQ)
+  if (collapsedCq) {
+    status = prims_ibgda_poll_collapsed_cq_once<CqSharingMode, AcquireScope>(
+        cq, ticket);
+  } else
+#endif
+  {
+#ifdef DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE
+    status = doca_gpu_dev_verbs_poll_one_cq_at<
+        CqSharingMode,
+        DOCA_GPUNETIO_VERBS_QP_SQ,
+        AcquireScope>(cq, ticket);
+#else
+    status = doca_gpu_dev_verbs_poll_one_cq_at<CqSharingMode>(cq, ticket);
+#endif
+  }
+  const bool aborted = status == EBUSY &&
+      FT_ABORT_CHECK(abortDevice,
+                     "IBGDA SQ capacity wait timed out (ticket=%llu)",
+                     static_cast<unsigned long long>(ticket));
+  return {.status = status, .aborted = aborted};
+}
+
+template <
+    doca_gpu_dev_verbs_resource_sharing_mode SqSharingMode,
+    doca_gpu_dev_verbs_resource_sharing_mode CqSharingMode,
+    doca_gpu_dev_verbs_sync_scope AcquireScope>
+__device__ __forceinline__ IbgdaWqeReservation tryReserveIbgdaWqes(
+    doca_gpu_dev_verbs_qp* qp,
+    uint32_t count,
+    bool collapsedCq,
+    const AbortDevice& abortDevice) {
+  const uint64_t firstWqe = doca_gpu_dev_verbs_reserve_wq_slots<SqSharingMode>(
+      qp, count, DOCA_GPUNETIO_VERBS_GPU_CODE_OPT_SKIP_AVAILABILITY_CHECK);
+  const uint64_t lastWqe = firstWqe + count - 1;
+  const uint16_t sqDepth = __ldg(&qp->sq_wqe_num);
+  if (lastWqe < sqDepth) {
+    return {.firstWqe = firstWqe, .acquired = true};
+  }
+
+  const uint64_t completionTicket = lastWqe - sqDepth;
+  auto* cq = doca_gpu_dev_verbs_qp_get_cq_sq(qp);
+  IbgdaSqPollResult pollResult;
+  do {
+    pollResult = pollIbgdaSqOnce<CqSharingMode, AcquireScope>(
+        cq, completionTicket, collapsedCq, abortDevice);
+    if (pollResult.aborted) {
+      return {.firstWqe = firstWqe, .acquired = false};
+    }
+  } while (pollResult.status == EBUSY);
+
+  if (pollResult.status == 0) {
+    return {.firstWqe = firstWqe, .acquired = true};
+  }
+  if (!abortDevice.isEnabled()) {
+    printf(
+        "P2pIbgdaTransportDevice: SQ capacity poll failed "
+        "(ticket=%llu status=%d)\n",
+        static_cast<unsigned long long>(completionTicket),
+        pollResult.status);
+    PIPES_DEVICE_TRAP();
+    return {.firstWqe = firstWqe, .acquired = false};
+  }
+  if (abortDevice.setAbort(
+          comms::fault_tolerance::AbortReason::NETWORK_ERROR)) {
+    printf(
+        "P2pIbgdaTransportDevice: SQ capacity poll failed "
+        "(ticket=%llu status=%d)\n",
+        static_cast<unsigned long long>(completionTicket),
+        pollResult.status);
+  }
+  (void)FT_ABORT_CHECK(
+      abortDevice,
+      "IBGDA SQ capacity poll failed (ticket=%llu status=%d)",
+      static_cast<unsigned long long>(completionTicket),
+      pollResult.status);
+  return {.firstWqe = firstWqe, .acquired = false};
+}
+
+} // namespace detail
+#endif
+
 // `PIPES_DEVICE_TRAP()` is defined in `comms/prims/core/DeviceMacros.cuh` and
 // is intentionally available across all `comms/prims` device headers.
 //
@@ -599,7 +703,8 @@ class P2pIbgdaTransportDevice {
       uint64_t signalVal = 1,
       const IbgdaLocalBuffer& counterBuf = {},
       uint64_t counterVal = 1,
-      bool signalPerLane = false) {
+      bool signalPerLane = false,
+      const AbortDevice& abortDevice = AbortDevice()) {
     return put_impl(
         group,
         localBuf,
@@ -609,7 +714,8 @@ class P2pIbgdaTransportDevice {
         signalVal,
         counterBuf,
         counterVal,
-        signalPerLane);
+        signalPerLane,
+        abortDevice);
   }
 
   /**
@@ -707,6 +813,26 @@ class P2pIbgdaTransportDevice {
       record_signal_wqe(lane, signalTicket);
     }
     group.sync();
+  }
+
+  [[nodiscard]] __device__ bool try_signal(
+      ThreadGroup& group,
+      const IbgdaRemoteBuffer& signalBuf,
+      uint64_t signalVal,
+      IbDirection direction,
+      const AbortDevice& abortDevice) {
+    uint32_t posted = 0;
+    if (group.is_leader()) {
+      validate_group_scope(group);
+      IbgdaLane lane = control_lane(group, direction);
+      uint64_t signalTicket = 0;
+      if (try_signal_fenced(
+              lane, signalBuf, signalVal, abortDevice, signalTicket)) {
+        record_signal_wqe(lane, signalTicket);
+        posted = 1;
+      }
+    }
+    return group.broadcast<uint32_t>(posted) != 0;
   }
 
   /**
@@ -1006,6 +1132,7 @@ class P2pIbgdaTransportDevice {
   struct IbgdaPutSignalTickets {
     uint64_t put_wqe{0};
     uint64_t signal_wqe{0};
+    bool posted{false};
   };
 
   __device__ __forceinline__ static uint64_t load_acquire_system_u64(
@@ -1311,7 +1438,8 @@ class P2pIbgdaTransportDevice {
       uint64_t signalVal,
       const IbgdaLocalBuffer& counterBuf,
       uint64_t counterVal,
-      bool signalPerLane = false) {
+      bool signalPerLane,
+      const AbortDevice& abortDevice) {
     const bool hasSignal = signalBuf.ptr != nullptr;
     if (nbytes == 0) {
       if (group.is_leader()) {
@@ -1340,6 +1468,7 @@ class P2pIbgdaTransportDevice {
           ? signalBuf.subBuffer(sendRecvSignalSlotOffset(lane.lane_ordinal))
           : signalBuf;
       uint64_t dataTicket = 0;
+      bool dataPosted = true;
       if (hasSignal && hasCounter) {
         const auto tickets = put_signal_counter_single_impl(
             lane,
@@ -1355,10 +1484,20 @@ class P2pIbgdaTransportDevice {
         record_signal_wqe(lane, tickets.signal_wqe);
       } else if (hasSignal) {
         const auto tickets = put_signal_single_impl(
-            lane, localBuf, remoteBuf, nbytes, effectiveSignalBuf, signalVal);
-        dataTicket = tickets.put_wqe;
-        record_put_wqe(lane, tickets.put_wqe);
-        record_signal_wqe(lane, tickets.signal_wqe);
+            lane,
+            localBuf,
+            remoteBuf,
+            nbytes,
+            effectiveSignalBuf,
+            signalVal,
+            abortDevice);
+        if (tickets.posted) {
+          dataTicket = tickets.put_wqe;
+          record_put_wqe(lane, tickets.put_wqe);
+          record_signal_wqe(lane, tickets.signal_wqe);
+        } else {
+          dataPosted = false;
+        }
       } else if (hasCounter) {
         const uint64_t putTicket = put_counter_single_impl(
             lane, localBuf, remoteBuf, nbytes, counterBuf, counterVal);
@@ -1370,10 +1509,13 @@ class P2pIbgdaTransportDevice {
         dataTicket = putTicket;
         record_put_wqe(lane, putTicket);
       }
-      completion = IbLocalCompletionTicket{
-          .completionId = lane.lane_ordinal,
-          .value = dataTicket,
-      };
+      if (dataPosted) {
+        completion = IbLocalCompletionTicket{
+            .completionId = lane.lane_ordinal,
+            .posted = true,
+            .value = dataTicket,
+        };
+      }
     }
     group.sync();
     return completion;
@@ -1620,6 +1762,8 @@ class P2pIbgdaTransportDevice {
 
   static constexpr auto kQpSharingMode =
       DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_EXCLUSIVE;
+  static constexpr auto kCqSharingMode =
+      DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU;
 
   // Scope of the acquire fence DOCA runs after observing a completion. On
   // Blackwell the SYS form is `CCTL.IVALL`, a whole-L1 invalidate, worth ~1.6us
@@ -1662,18 +1806,17 @@ class P2pIbgdaTransportDevice {
 #if !defined(__HIP_PLATFORM_AMD__) && !defined(PRIMS_IBGDA_DISABLE_COLLAPSED_CQ)
     if (collapsedCq_) {
       return prims_ibgda_poll_collapsed_cq_once<
-          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+          kCqSharingMode,
           kCqAcquireScope>(cq, ticket);
     }
 #endif
 #ifdef DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE
     return doca_gpu_dev_verbs_poll_one_cq_at<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        kCqSharingMode,
         DOCA_GPUNETIO_VERBS_QP_SQ,
         kCqAcquireScope>(cq, ticket);
 #else
-    return doca_gpu_dev_verbs_poll_one_cq_at<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(cq, ticket);
+    return doca_gpu_dev_verbs_poll_one_cq_at<kCqSharingMode>(cq, ticket);
 #endif
   }
 
@@ -1682,19 +1825,18 @@ class P2pIbgdaTransportDevice {
       doca_gpu_dev_verbs_ticket_t ticket) const {
 #if !defined(__HIP_PLATFORM_AMD__) && !defined(PRIMS_IBGDA_DISABLE_COLLAPSED_CQ)
     if (collapsedCq_) {
-      return prims_ibgda_wait_collapsed_cq<
-          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
-          kCqAcquireScope>(doca_gpu_dev_verbs_qp_get_cq_sq(qp), ticket);
+      return prims_ibgda_wait_collapsed_cq<kCqSharingMode, kCqAcquireScope>(
+          doca_gpu_dev_verbs_qp_get_cq_sq(qp), ticket);
     }
 #endif
 #ifdef DOCA_GPUNETIO_VERBS_META_HAS_ACQUIRE_SCOPE
     doca_gpu_dev_verbs_wait<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        kCqSharingMode,
         DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO,
         kCqAcquireScope>(qp, ticket);
 #else
     doca_gpu_dev_verbs_wait<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        kCqSharingMode,
         DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp, ticket);
 #endif
     return 0;
@@ -1737,6 +1879,28 @@ class P2pIbgdaTransportDevice {
     return doca_gpu_dev_verbs_reserve_wq_slots<SharingMode>(qp, count);
 #endif
   }
+
+#ifndef __HIP_PLATFORM_AMD__
+  template <
+      doca_gpu_dev_verbs_resource_sharing_mode SqSharingMode,
+      doca_gpu_dev_verbs_resource_sharing_mode CqSharingMode>
+  __device__ __forceinline__ detail::IbgdaWqeReservation try_reserve_wqes_mode(
+      doca_gpu_dev_verbs_qp* qp,
+      uint32_t count,
+      const AbortDevice& abortDevice) const {
+    return detail::
+        tryReserveIbgdaWqes<SqSharingMode, CqSharingMode, kCqAcquireScope>(
+            qp, count, collapsedCq_, abortDevice);
+  }
+
+  __device__ __forceinline__ detail::IbgdaWqeReservation try_reserve_wqes(
+      doca_gpu_dev_verbs_qp* qp,
+      uint32_t count,
+      const AbortDevice& abortDevice) const {
+    return try_reserve_wqes_mode<kQpSharingMode, kQpSharingMode>(
+        qp, count, abortDevice);
+  }
+#endif
 
 #ifndef __HIP_PLATFORM_AMD__
   __device__ __forceinline__ uint64_t put_single_local(
@@ -1802,6 +1966,42 @@ class P2pIbgdaTransportDevice {
     return reserve_wqes_mode<kQpSharingMode>(qp, count);
   }
 
+  __device__ __forceinline__ uint64_t
+  reserve_wqes_shared_cq(doca_gpu_dev_verbs_qp* qp, uint32_t count) const {
+    PIPES_DEVICE_CHECK_MSG(
+        count > 0, "reserve_wqes_shared_cq requires a non-zero WQE count");
+#ifdef __HIP_PLATFORM_AMD__
+    return reserve_wqes(qp, count);
+#else
+    // The service warp is the sole SQ producer, but worker warps also retire
+    // this CQ. Keep reservation EXCLUSIVE and make only CQ reclamation shared.
+    const uint64_t firstWqe =
+        doca_gpu_dev_verbs_reserve_wq_slots<kQpSharingMode>(
+            qp,
+            count,
+            DOCA_GPUNETIO_VERBS_GPU_CODE_OPT_SKIP_AVAILABILITY_CHECK);
+    const uint64_t lastWqe = firstWqe + count - 1;
+    const uint16_t sqDepth = __ldg(&qp->sq_wqe_num);
+    if (lastWqe >= sqDepth) {
+      (void)wait_cq(qp, lastWqe - sqDepth);
+    }
+    return firstWqe;
+#endif
+  }
+
+#ifndef __HIP_PLATFORM_AMD__
+  __device__ __forceinline__
+      detail::IbgdaWqeReservation try_reserve_wqes_shared_cq(
+          doca_gpu_dev_verbs_qp* qp,
+          uint32_t count,
+          const AbortDevice& abortDevice) const {
+    PIPES_DEVICE_CHECK_MSG(
+        count > 0, "try_reserve_wqes_shared_cq requires a non-zero WQE count");
+    return try_reserve_wqes_mode<kQpSharingMode, kCqSharingMode>(
+        qp, count, abortDevice);
+  }
+#endif
+
   __device__ __forceinline__ void mark_wqes_ready_mode(
       doca_gpu_dev_verbs_qp* qp,
       uint64_t fromWqe,
@@ -1832,7 +2032,8 @@ class P2pIbgdaTransportDevice {
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes,
       const IbgdaRemoteBuffer& signalBuf,
-      uint64_t signalVal) {
+      uint64_t signalVal,
+      const AbortDevice& abortDevice) {
     const NicDeviceIbgdaResources& nic = nicDevices_[lane.nic_id];
     doca_gpu_dev_verbs_addr localAddr = {
         .addr = reinterpret_cast<uint64_t>(localBuf.ptr),
@@ -1859,12 +2060,19 @@ class P2pIbgdaTransportDevice {
         sigSinkAddr,
         signalVal,
         &ticket);
-    return IbgdaPutSignalTickets{ticket, ticket};
+    (void)abortDevice;
+    return IbgdaPutSignalTickets{
+        .put_wqe = ticket, .signal_wqe = ticket, .posted = true};
 #else
     uint64_t numChunks = doca_gpu_dev_verbs_div_ceil_aligned_pow2(
         nbytes, DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE_SHIFT);
     numChunks = numChunks > 1 ? numChunks : 1;
-    uint64_t baseWqeIdx = reserve_wqes(lane.qp, numChunks + 1);
+    const auto reservation =
+        try_reserve_wqes_shared_cq(lane.qp, numChunks + 1, abortDevice);
+    if (!reservation.acquired) {
+      return {};
+    }
+    uint64_t baseWqeIdx = reservation.firstWqe;
     uint64_t wqeIdx = baseWqeIdx;
     std::size_t remainingSize = nbytes;
 
@@ -1911,7 +2119,8 @@ class P2pIbgdaTransportDevice {
         0);
     mark_wqes_ready_mode(lane.qp, baseWqeIdx, wqeIdx);
     submit_wqes(lane.qp, wqeIdx);
-    return IbgdaPutSignalTickets{lastPutWqeIdx, wqeIdx};
+    return IbgdaPutSignalTickets{
+        .put_wqe = lastPutWqeIdx, .signal_wqe = wqeIdx, .posted = true};
 #endif
   }
 
@@ -2057,7 +2266,8 @@ class P2pIbgdaTransportDevice {
     put_counter_single_impl(
         lane, localBuf, remoteBuf, nbytes, counterBuf, counterVal);
     const uint64_t signalTicket = signal_fenced(lane, signalBuf, signalVal);
-    return IbgdaPutSignalTickets{signalTicket, signalTicket};
+    return IbgdaPutSignalTickets{
+        .put_wqe = signalTicket, .signal_wqe = signalTicket, .posted = true};
 #else
     constexpr unsigned int kNumQps = 2;
     const NicDeviceIbgdaResources& nic = nicDevices_[lane.nic_id];
@@ -2174,7 +2384,8 @@ class P2pIbgdaTransportDevice {
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
         DOCA_GPUNETIO_VERBS_SYNC_SCOPE_THREAD,
         DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qps, prodIndices);
-    return IbgdaPutSignalTickets{lastPutWqeIdx, signalWqeIdx};
+    return IbgdaPutSignalTickets{
+        .put_wqe = lastPutWqeIdx, .signal_wqe = signalWqeIdx, .posted = true};
 #endif
   }
 
@@ -2257,10 +2468,12 @@ class P2pIbgdaTransportDevice {
 
   // --- signal_fenced: atomic fetch-add with NIC FENCE (always fenced) ---
 
-  __device__ uint64_t signal_fenced(
+  __device__ bool try_signal_fenced(
       const IbgdaLane& lane,
       const IbgdaRemoteBuffer& signalBuf,
-      uint64_t signalVal) {
+      uint64_t signalVal,
+      const AbortDevice& abortDevice,
+      uint64_t& signalTicket) {
     const NicDeviceIbgdaResources& nic = nicDevices_[lane.nic_id];
     doca_gpu_dev_verbs_qp* qp = lane.qp;
     doca_gpu_dev_verbs_addr remoteAddr = {
@@ -2268,7 +2481,16 @@ class P2pIbgdaTransportDevice {
         .key = signalBuf.rkey_per_device[lane.nic_id].value};
     doca_gpu_dev_verbs_addr sinkAddr = {.addr = 0, .key = nic.sink_lkey.value};
 
+#ifdef __HIP_PLATFORM_AMD__
+    (void)abortDevice;
     uint64_t wqe_idx = reserve_wqes(qp, 1);
+#else
+    const auto reservation = try_reserve_wqes(qp, 1, abortDevice);
+    if (!reservation.acquired) {
+      return false;
+    }
+    uint64_t wqe_idx = reservation.firstWqe;
+#endif
 
     doca_gpu_dev_verbs_wqe* wqe_ptr =
         doca_gpu_dev_verbs_get_wqe_ptr(qp, wqe_idx);
@@ -2291,7 +2513,18 @@ class P2pIbgdaTransportDevice {
 
     mark_wqes_ready_mode(qp, wqe_idx, wqe_idx);
     submit_wqes(qp, wqe_idx);
-    return wqe_idx;
+    signalTicket = wqe_idx;
+    return true;
+  }
+
+  __device__ uint64_t signal_fenced(
+      const IbgdaLane& lane,
+      const IbgdaRemoteBuffer& signalBuf,
+      uint64_t signalVal) {
+    uint64_t signalTicket = 0;
+    (void)try_signal_fenced(
+        lane, signalBuf, signalVal, AbortDevice{}, signalTicket);
+    return signalTicket;
   }
 
   // --- Slot resolution helpers ---

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -354,6 +354,7 @@ class P2pIbrcTransportDevice {
       if (seq != kIbrcInvalidReadySeq) {
         completion = IbLocalCompletionTicket{
             .completionId = laneOrdinal,
+            .posted = true,
             .value = seq + 1,
         };
       }


### PR DESCRIPTION
Summary:
- Keep SQ reservation single-producer while reclaiming its shared send CQ before wrapped WQE slots are reused. Use one CQ sharing mode consistently for ring and collapsed CQs.
- Stop forwarding after `wait_recv()` returns an invalid receive token, so aborted receive work cannot be copied or made peer-visible.
- Pass `AbortDevice` through local-completion confirmation so an errored CQE remains unretired and the failure unwinds through the existing fault-tolerance path.
- Make Warp Proxy SQ-capacity reclamation abort-aware and status-bearing for both fused data posts and receive-credit signals. A failed reservation stops before WQE preparation or peer-visible publication and leaves completion records, `send.posted`, and `recv.credited` unchanged.

This transport-only diff is split from D118781828. It deliberately excludes the AllReduce fusion, relaxed `SLOT_FREE` polling, duplex specialization, and the DOCA README update.

Reviewed By: Scusemua, saifhhasan

Differential Revision: D119237115


