### PR TITLE
Track device timing samples

### DIFF
--- a/comms/common/CollectiveStats.h
+++ b/comms/common/CollectiveStats.h
@@ -16,7 +16,7 @@
 
 namespace comms {
 
-// Host-drive timing for one bucket of collectives, in microseconds.
+// Timing and abort totals; latency fields are zero when count is zero.
 struct CollectiveStat {
   uint64_t count{0};
   uint64_t total_us{0};
@@ -32,6 +32,9 @@ struct CollectiveStat {
   // SM residency: sum of ceil(num_blocks / blocks_per_sm) * duration. Survives
   // roll-ups where the geometry above collapses to unknown.
   uint64_t total_sm_us{0};
+
+  // Extension counters follow the base layout to preserve its ABI.
+  uint64_t aborted_count{0};
 
   void add(
       uint64_t durationUs,
@@ -76,17 +79,24 @@ struct CollectiveStat {
   }
 
   void merge(const CollectiveStat& other) {
+    if (other.count == 0 && other.aborted_count == 0) {
+      return;
+    }
     if (other.count == 0) {
+      aborted_count += other.aborted_count;
       return;
     }
     if (count == 0) {
+      const uint64_t existingAbortedCount = aborted_count;
       *this = other;
+      aborted_count += existingAbortedCount;
       return;
     }
     min_us = std::min(min_us, other.min_us);
     max_us = std::max(max_us, other.max_us);
     total_us += other.total_us;
     count += other.count;
+    aborted_count += other.aborted_count;
     total_sm_us += other.total_sm_us;
 
     // Roll-ups span buckets whose geometry differs.
@@ -132,6 +142,17 @@ class CollectiveStats {
     });
   }
 
+  void recordAborted(std::string_view collective, std::string_view key) {
+    stats_.withWLock([&](auto& m) {
+      auto it = m.find(key);
+      if (it == m.end()) {
+        it = m.emplace(std::string(key), Entry{std::string(collective), {}})
+                 .first;
+      }
+      ++it->second.stat.aborted_count;
+    });
+  }
+
   CollectiveStatsMap getAndClear() {
     EntryMap drained;
     stats_.withWLock([&](auto& m) { drained.swap(m); });
@@ -148,7 +169,7 @@ class CollectiveStats {
       }
       out[key].merge(entry.stat);
     }
-    if (overall.count > 0) {
+    if (overall.count > 0 || overall.aborted_count > 0) {
       out[std::string(kCollectiveStatsAllKey)].merge(overall);
     }
     return out;
@@ -172,11 +193,12 @@ class CollectiveStats {
 
 inline std::ostream& operator<<(std::ostream& os, const CollectiveStat& s) {
   os << fmt::format(
-      "count={} total_us={} min_us={} max_us={} total_sm_us={}",
+      "count={} total_us={} min_us={} max_us={} aborted_count={} total_sm_us={}",
       s.count,
       s.total_us,
       s.min_us,
       s.max_us,
+      s.aborted_count,
       s.total_sm_us);
   if (s.block_size != 0) {
     os << fmt::format(

--- a/comms/ctran/algos/AllReduce/AllReduce.cc
+++ b/comms/ctran/algos/AllReduce/AllReduce.cc
@@ -39,6 +39,21 @@ bool ctranAllReduceSupport(CtranComm* comm, enum NCCL_ALLREDUCE_ALGO algo) {
   }
 }
 
+enum NCCL_ALLREDUCE_ALGO resolveCtranAllReduceAlgorithm(
+    enum NCCL_ALLREDUCE_ALGO requestedAlgorithm,
+    size_t count,
+    int numRanks,
+    bool forceSmallMessageRing) {
+  if (requestedAlgorithm != NCCL_ALLREDUCE_ALGO::ctring) {
+    return NCCL_ALLREDUCE_ALGO::ctdirect;
+  }
+  if (numRanks <= 1 ||
+      (count < static_cast<size_t>(numRanks) && !forceSmallMessageRing)) {
+    return NCCL_ALLREDUCE_ALGO::ctdirect;
+  }
+  return NCCL_ALLREDUCE_ALGO::ctring;
+}
+
 commResult_t ctranAllReduce(
     const void* sendbuff,
     void* recvbuff,
@@ -49,38 +64,12 @@ commResult_t ctranAllReduce(
     cudaStream_t stream,
     enum NCCL_ALLREDUCE_ALGO algo,
     std::optional<std::chrono::milliseconds> timeout) {
-  switch (algo) {
+  const auto selectedAlgorithm = resolveCtranAllReduceAlgorithm(
+      algo, count, comm->statex_->nRanks(), MCCL_FORCE_SMALL_MSG_AR_RING);
+  switch (selectedAlgorithm) {
     case NCCL_ALLREDUCE_ALGO::ctring:
-      if (comm->statex_->nRanks() == 1) {
-        // TODO(T242570177): this is a temp workaround for nRanks == 1. Remove
-        // the warning below if fixed.
-        CTRAN_LOG(
-            DBG,
-            "AllReduce ctring currently requires nRanks > 1, fallback to ctdirect");
-        return ctranAllReduceDirect(
-            sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
-      }
       if (count < comm->statex_->nRanks()) {
-        // Opt-in: pad the message up to nRanks and run the ring anyway. This
-        // unblocks TCPDM, which is only exposed to the ring path.
-        // TODO: remove once small messages are fully supported through TCPDM.
-        if (MCCL_FORCE_SMALL_MSG_AR_RING) {
-          return ctranAllReduceRingSmallMsg(
-              sendbuff,
-              recvbuff,
-              count,
-              datatype,
-              redOp,
-              comm,
-              stream,
-              timeout);
-        }
-        CTRAN_LOG(
-            DBG,
-            "AllReduce ctring requires count {} > nRanks {}, fallback to ctdirect",
-            count,
-            comm->statex_->nRanks());
-        return ctranAllReduceDirect(
+        return ctranAllReduceRingSmallMsg(
             sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
       }
       return ctranAllReduceRing(
@@ -91,6 +80,19 @@ commResult_t ctranAllReduce(
      */
     case NCCL_ALLREDUCE_ALGO::ctdirect:
     default:
+      if (algo == NCCL_ALLREDUCE_ALGO::ctring) {
+        if (comm->statex_->nRanks() == 1) {
+          CTRAN_LOG(
+              DBG,
+              "AllReduce ctring currently requires nRanks > 1, fallback to ctdirect");
+        } else {
+          CTRAN_LOG(
+              DBG,
+              "AllReduce ctring requires count {} >= nRanks {}, fallback to ctdirect",
+              count,
+              comm->statex_->nRanks());
+        }
+      }
       return ctranAllReduceDirect(
           sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
   }

--- a/comms/ctran/algos/AllReduce/AllReduceImpl.h
+++ b/comms/ctran/algos/AllReduce/AllReduceImpl.h
@@ -28,6 +28,12 @@ commResult_t ctranAllReduceRing(
     cudaStream_t stream,
     std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
+enum NCCL_ALLREDUCE_ALGO resolveCtranAllReduceAlgorithm(
+    enum NCCL_ALLREDUCE_ALGO requestedAlgorithm,
+    size_t count,
+    int numRanks,
+    bool forceSmallMessageRing);
+
 /**
  * Run the ctring AllReduce for messages whose element count is smaller than
  * nRanks (opt-in via MCCL_FORCE_SMALL_MSG_AR_RING; selected in ctranAllReduce).

--- a/comms/ctran/tests/CtranAllReduceTest.cc
+++ b/comms/ctran/tests/CtranAllReduceTest.cc
@@ -32,6 +32,44 @@ enum class CtranAllReduceRingMinSizeTestOpt {
   expect_padded_small_msg,
 };
 
+TEST(CtranAllReduceRoutingTest, ResolvesExecutedAlgorithm) {
+  EXPECT_EQ(
+      resolveCtranAllReduceAlgorithm(
+          NCCL_ALLREDUCE_ALGO::ctring,
+          /*count=*/4096,
+          /*numRanks=*/1,
+          /*forceSmallMessageRing=*/false),
+      NCCL_ALLREDUCE_ALGO::ctdirect);
+  EXPECT_EQ(
+      resolveCtranAllReduceAlgorithm(
+          NCCL_ALLREDUCE_ALGO::ctring,
+          /*count=*/1,
+          /*numRanks=*/4,
+          /*forceSmallMessageRing=*/false),
+      NCCL_ALLREDUCE_ALGO::ctdirect);
+  EXPECT_EQ(
+      resolveCtranAllReduceAlgorithm(
+          NCCL_ALLREDUCE_ALGO::ctring,
+          /*count=*/1,
+          /*numRanks=*/4,
+          /*forceSmallMessageRing=*/true),
+      NCCL_ALLREDUCE_ALGO::ctring);
+  EXPECT_EQ(
+      resolveCtranAllReduceAlgorithm(
+          NCCL_ALLREDUCE_ALGO::ctring,
+          /*count=*/4,
+          /*numRanks=*/4,
+          /*forceSmallMessageRing=*/false),
+      NCCL_ALLREDUCE_ALGO::ctring);
+  EXPECT_EQ(
+      resolveCtranAllReduceAlgorithm(
+          NCCL_ALLREDUCE_ALGO::ctran,
+          /*count=*/4096,
+          /*numRanks=*/4,
+          /*forceSmallMessageRing=*/false),
+      NCCL_ALLREDUCE_ALGO::ctdirect);
+}
+
 class CtranAllReduceTest
     : public CtranIntraProcessFixture,
       public ::testing::WithParamInterface<AllReduceTestParam> {

--- a/comms/torchcomms/TorchWork.hpp
+++ b/comms/torchcomms/TorchWork.hpp
@@ -4,9 +4,11 @@
 
 // IWYU pragma: no_include <ATen/ATen.h>
 #include <c10/util/intrusive_ptr.h>
+#include <atomic>
 #include <chrono>
 #include <functional>
 #include <future>
+#include <mutex>
 #include <vector>
 
 namespace at {
@@ -22,9 +24,40 @@ namespace torch::comms {
  * TorchWork - Base class representing asynchronous work.
  *
  * Thread Safety:
- * TorchWork is NOT thread-safe. All methods (status(), isCompleted(), wait())
- * must be called from a single thread. Concurrent calls from multiple threads
- * are not supported.
+ * Partially thread-safe -- read this before assuming either extreme.
+ *
+ * Safe against concurrent access:
+ *  - status() and isCompleted()
+ *  - setStatus(), including two threads racing to a terminal status. The first
+ *    terminal transition wins and is sticky; later ones are ignored entirely.
+ *  - registerWorkStartHook() / registerWorkEndHook() against a concurrent
+ *    transition. A hook is either queued and fired by the transition, or fired
+ *    immediately on the registering thread if the transition already
+ *    happened -- never fired twice. See the start-hook exception below.
+ *
+ * NOT thread-safe, still single-threaded by contract:
+ *  - wait(), waitBlocking(), hostSynchronize() and backend accessors.
+ *  - anything a derived backend owns. This base synchronizes only its own
+ *    status and hook state; backend members (tensor references, events,
+ *    streams) remain single-threaded by contract. Several backends currently
+ *    clear tensor references from both the watchdog and the waiting thread --
+ *    that is a pre-existing race in those backends, not something this class
+ *    makes safe.
+ *
+ * Start-hook exception, by design:
+ *  - a start hook queued before a direct NOT_STARTED -> terminal transition is
+ *    DROPPED, not fired. Start hooks fire only on setStatus(INPROGRESS): a work
+ *    that never started must not report that it did. This is deliberate, and
+ *    TorchWorkTest.StartHookNotFiredOnTerminalStatus pins it. A hook registered
+ *    *after* such a transition still fires immediately, so registering late is
+ *    safe.
+ *
+ * status() is a relaxed atomic load: it is coherent and race-free, and it
+ * publishes nothing else. Do not use it to order access to other state.
+ *
+ * Hooks are invoked outside the internal lock, so a hook may query the work it
+ * is attached to. Do not rely on which thread runs a hook: it is whichever
+ * thread made the transition, or the registering thread on the late path.
  *
  * Work objects should not be destroyed while wait() is in progress.
  */
@@ -91,41 +124,48 @@ class TorchWork : public c10::intrusive_ptr_target {
   // - Wait post hook: fired at the end of wait(), after the sync
   //
   // Multiple hooks can be registered; they fire in registration order.
-  // Hooks are NOT thread-safe -- register before concurrent status changes.
+  // Registration is safe against a concurrent transition -- see the class
+  // comment.
 
   using WorkHook = std::function<void()>;
 
   void registerWorkStartHook(WorkHook hook) {
-    // If work already started (or finished), fire the hook immediately rather
-    // than enqueuing it (it would never fire otherwise). Mirrors
-    // registerWorkEndHook's terminal-state fallback. This handles backends
-    // (e.g. MCCL) whose ctor sets INPROGRESS before the post-hook registers
-    // the start hook; without this the start event is lost (clog has no "S").
-    // Any status other than NOT_STARTED means the start transition has fired.
-    if (status() != WorkStatus::NOT_STARTED) {
-      hook();
-    } else {
-      start_hooks_.push_back(std::move(hook));
+    {
+      std::lock_guard<std::mutex> lock(hooks_mutex_);
+      if (!start_hooks_fired_) {
+        start_hooks_.push_back(std::move(hook));
+        return;
+      }
     }
+    // Already started: fire now, or the event would be lost entirely. This
+    // handles backends (e.g. MCCL) whose ctor sets INPROGRESS before the
+    // post-hook registers the start hook; without it the clog has no "S".
+    hook();
   }
 
   void registerWorkEndHook(WorkHook hook) {
-    // If work already reached a terminal state, fire the hook immediately
-    // rather than enqueuing it (it would never fire otherwise).
-    auto s = status();
-    if (s == WorkStatus::COMPLETED || s == WorkStatus::ERROR ||
-        s == WorkStatus::TIMEDOUT) {
-      hook();
-    } else {
-      end_hooks_.push_back(std::move(hook));
+    {
+      std::lock_guard<std::mutex> lock(hooks_mutex_);
+      if (!end_hooks_fired_) {
+        end_hooks_.push_back(std::move(hook));
+        return;
+      }
     }
+    // Already terminal: fire now rather than enqueuing a hook that would never
+    // run.
+    hook();
   }
 
+  // The wait hooks have no fired-flag: unlike start/end they can run more than
+  // once, so registration only needs to be safe against release_resources()
+  // and against the snapshot taken in runWaitPre/PostHooks().
   void registerWorkWaitPreHook(WorkHook hook) {
+    std::lock_guard<std::mutex> lock(hooks_mutex_);
     wait_pre_hooks_.push_back(std::move(hook));
   }
 
   void registerWorkWaitPostHook(WorkHook hook) {
+    std::lock_guard<std::mutex> lock(hooks_mutex_);
     wait_post_hooks_.push_back(std::move(hook));
   }
 
@@ -136,27 +176,73 @@ class TorchWork : public c10::intrusive_ptr_target {
   TorchWork& operator=(TorchWork&&) = delete;
 
  protected:
-  void setStatus(WorkStatus status) {
-    status_ = status;
+  static bool isTerminal(WorkStatus status) {
+    return status == WorkStatus::COMPLETED || status == WorkStatus::ERROR ||
+        status == WorkStatus::TIMEDOUT;
+  }
 
-    if (status == WorkStatus::INPROGRESS) {
-      runStartHooks();
-    } else if (
-        status == WorkStatus::COMPLETED || status == WorkStatus::ERROR ||
-        status == WorkStatus::TIMEDOUT) {
-      runEndHooks();
+  // The single choke point for status transitions and hook firing. Both
+  // invariants have to be enforced together, which is why this is one
+  // synchronized block rather than a pair of fire-once helpers:
+  //  - the first terminal transition wins and is sticky, so a watchdog TIMEDOUT
+  //    and a training-thread COMPLETED cannot overwrite each other and leave
+  //    the surviving status dependent on scheduling;
+  //  - a work that goes straight from NOT_STARTED to terminal still latches
+  //    start hooks, so one registered afterwards fires instead of queueing
+  //    forever.
+  void setStatus(WorkStatus status) {
+    std::vector<WorkHook> to_fire;
+    {
+      std::lock_guard<std::mutex> lock(hooks_mutex_);
+      if (end_hooks_fired_) {
+        // Terminal already latched: ignore, status included.
+        return;
+      }
+      status_.store(status, std::memory_order_relaxed);
+      if (isTerminal(status)) {
+        end_hooks_fired_ = true;
+        to_fire.swap(end_hooks_);
+        // Start hooks can never fire after this point, so mark them fired and
+        // release them. Hooks queued *before* a direct-to-terminal transition
+        // are dropped, which preserves the pre-existing behavior.
+        start_hooks_fired_ = true;
+        start_hooks_.clear();
+      } else if (status == WorkStatus::INPROGRESS) {
+        if (start_hooks_fired_) {
+          return;
+        }
+        start_hooks_fired_ = true;
+        to_fire.swap(start_hooks_);
+      }
+    }
+    // Invoked outside the lock: a hook may legitimately query this work, and
+    // holding a work-level lock across user code would deadlock.
+    for (auto& hook : to_fire) {
+      hook();
     }
   }
 
   // Backend wait() implementations should call these around the actual wait.
+  // Snapshot under the lock, invoke outside it -- same rule as the start/end
+  // hooks. These copy rather than swap: wait hooks are not one-shot.
   void runWaitPreHooks() {
-    for (auto& hook : wait_pre_hooks_) {
+    std::vector<WorkHook> hooks;
+    {
+      std::lock_guard<std::mutex> lock(hooks_mutex_);
+      hooks = wait_pre_hooks_;
+    }
+    for (auto& hook : hooks) {
       hook();
     }
   }
 
   void runWaitPostHooks() {
-    for (auto& hook : wait_post_hooks_) {
+    std::vector<WorkHook> hooks;
+    {
+      std::lock_guard<std::mutex> lock(hooks_mutex_);
+      hooks = wait_post_hooks_;
+    }
+    for (auto& hook : hooks) {
       hook();
     }
   }
@@ -172,30 +258,16 @@ class TorchWork : public c10::intrusive_ptr_target {
   friend class c10::intrusive_ptr;
 
  private:
-  void runStartHooks() {
-    for (auto& hook : start_hooks_) {
-      hook();
-    }
-  }
-
-  void runEndHooks() {
-    // Guard: end hooks fire at most once, even if setStatus is called
-    // with multiple terminal states (e.g., ERROR then TIMEDOUT).
-    if (end_hooks_fired_) {
-      return;
-    }
-    end_hooks_fired_ = true;
-    for (auto& hook : end_hooks_) {
-      hook();
-    }
-  }
-
   // break weak-ref cycle: hooks registered via postHook() may capture a
   // weak_intrusive_ptr back to this object. after the strong refcount
   // reaches 0, release_resources() clears the hooks, destroying the weak
   // pointers and allowing the weak refcount to reach 0 so the object is
   // deleted.
+  //
+  // Locked: this is a third writer to the hook vectors, alongside registration
+  // and firing.
   void release_resources() override {
+    std::lock_guard<std::mutex> lock(hooks_mutex_);
     start_hooks_.clear();
     end_hooks_.clear();
     wait_pre_hooks_.clear();
@@ -203,6 +275,16 @@ class TorchWork : public c10::intrusive_ptr_target {
   }
 
   std::atomic<WorkStatus> status_{WorkStatus::NOT_STARTED};
+
+  // Guards the hook vectors and their fired flags. The flags are plain bools
+  // on purpose: the "already fired?" test and the append must be atomic with
+  // respect to each other, so both only ever happen under this mutex. Making
+  // them std::atomic would invite testing them outside the lock, which is
+  // exactly the lost-hook bug -- a registrar that reads "not fired", is
+  // preempted by the transition, and then appends to a vector nobody will read
+  // again.
+  std::mutex hooks_mutex_;
+  bool start_hooks_fired_{false};
   bool end_hooks_fired_{false};
 
   std::vector<WorkHook> start_hooks_;

--- a/comms/torchcomms/device/cuda/CudaApi.cpp
+++ b/comms/torchcomms/device/cuda/CudaApi.cpp
@@ -203,6 +203,13 @@ cudaError_t DefaultCudaApi::eventQuery(cudaEvent_t event) {
   return cudaEventQuery(event);
 }
 
+cudaError_t DefaultCudaApi::eventElapsedTime(
+    float* ms,
+    cudaEvent_t start,
+    cudaEvent_t end) {
+  return cudaEventElapsedTime(ms, start, end);
+}
+
 const char* DefaultCudaApi::getErrorString(cudaError_t error) {
   return cudaGetErrorString(error);
 }

--- a/comms/torchcomms/device/cuda/CudaApi.hpp
+++ b/comms/torchcomms/device/cuda/CudaApi.hpp
@@ -129,6 +129,8 @@ class CudaApi {
       cudaStream_t stream,
       unsigned int flags) = 0;
   [[nodiscard]] virtual cudaError_t eventQuery(cudaEvent_t event) = 0;
+  [[nodiscard]] virtual cudaError_t
+  eventElapsedTime(float* ms, cudaEvent_t start, cudaEvent_t end) = 0;
 
   // Error handling
   virtual const char* getErrorString(cudaError_t error) = 0;
@@ -232,6 +234,8 @@ class DefaultCudaApi : public CudaApi {
       cudaStream_t stream,
       unsigned int flags) override;
   [[nodiscard]] cudaError_t eventQuery(cudaEvent_t event) override;
+  [[nodiscard]] cudaError_t
+  eventElapsedTime(float* ms, cudaEvent_t start, cudaEvent_t end) override;
 
   // Error handling
   const char* getErrorString(cudaError_t error) override;

--- a/comms/torchcomms/nccl/tests/unit/cpp/mocks/CudaMock.hpp
+++ b/comms/torchcomms/nccl/tests/unit/cpp/mocks/CudaMock.hpp
@@ -160,6 +160,11 @@ class CudaMock : public CudaApi {
       (cudaEvent_t event, cudaStream_t stream, unsigned int flags),
       (override));
   MOCK_METHOD(cudaError_t, eventQuery, (cudaEvent_t event), (override));
+  MOCK_METHOD(
+      cudaError_t,
+      eventElapsedTime,
+      (float* ms, cudaEvent_t start, cudaEvent_t end),
+      (override));
 
   // Error handling
   MOCK_METHOD(const char*, getErrorString, (cudaError_t error), (override));

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CudaMock.hpp
@@ -160,6 +160,11 @@ class CudaMock : public CudaApi {
       (cudaEvent_t event, cudaStream_t stream, unsigned int flags),
       (override));
   MOCK_METHOD(cudaError_t, eventQuery, (cudaEvent_t event), (override));
+  MOCK_METHOD(
+      cudaError_t,
+      eventElapsedTime,
+      (float* ms, cudaEvent_t start, cudaEvent_t end),
+      (override));
 
   // Error handling
   MOCK_METHOD(const char*, getErrorString, (cudaError_t error), (override));

--- a/comms/torchcomms/tests/unit/cpp/TorchWorkTest.cpp
+++ b/comms/torchcomms/tests/unit/cpp/TorchWorkTest.cpp
@@ -2,6 +2,9 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <thread>
+
 #include <c10/util/intrusive_ptr.h>
 #include "comms/torchcomms/TorchWork.hpp"
 
@@ -181,6 +184,131 @@ TEST(TorchWorkTest, EndHooksFiredAtMostOnce) {
   // Second terminal status should not fire end hooks again
   work->setStatus(TorchWork::WorkStatus::ERROR);
   EXPECT_EQ(end_count, 1);
+}
+
+// -- Thread-safety / state-machine tests --
+
+TEST(TorchWorkTest, StartHookFiredImmediatelyAfterDirectTerminalTransition) {
+  // TorchWorkCompleted goes straight from NOT_STARTED to COMPLETED without
+  // ever passing through INPROGRESS. A start hook registered afterwards must
+  // still fire immediately -- otherwise the lifecycle emits an "E" with no "S".
+  //
+  // Regression guard for a naive start_hooks_fired_ flag, which would stay
+  // false (no INPROGRESS transition ever ran) and queue the hook forever.
+  auto work = c10::make_intrusive<TestWork>();
+  work->setStatus(TorchWork::WorkStatus::COMPLETED);
+
+  int start_count = 0;
+  work->registerWorkStartHook([&start_count]() { start_count++; });
+  EXPECT_EQ(start_count, 1);
+}
+
+TEST(TorchWorkTest, TerminalStatusIsStickyOnSecondTransition) {
+  // The first terminal transition wins, status included. End hooks fire on that
+  // first transition, so letting a later one overwrite the status would leave
+  // status() disagreeing with what the hook observed.
+  auto work = c10::make_intrusive<TestWork>();
+  TorchWork::WorkStatus seen_by_hook = TorchWork::WorkStatus::NOT_STARTED;
+  work->registerWorkEndHook(
+      [&seen_by_hook, &work]() { seen_by_hook = work->status(); });
+
+  work->setStatus(TorchWork::WorkStatus::COMPLETED);
+  work->setStatus(TorchWork::WorkStatus::TIMEDOUT);
+
+  EXPECT_EQ(work->status(), TorchWork::WorkStatus::COMPLETED);
+  EXPECT_EQ(seen_by_hook, TorchWork::WorkStatus::COMPLETED);
+}
+
+TEST(TorchWorkTest, ConcurrentTerminalTransitionsAgreeWithTheFiredHook) {
+  // A watchdog TIMEDOUT racing a training-thread COMPLETED. Whichever wins,
+  // status() and the status the end hook observed must be the same one -- and
+  // the hook must fire exactly once.
+  for (int i = 0; i < 200; ++i) {
+    auto work = c10::make_intrusive<TestWork>();
+    std::atomic<int> end_count{0};
+    TorchWork::WorkStatus seen_by_hook = TorchWork::WorkStatus::NOT_STARTED;
+    work->registerWorkEndHook([&]() {
+      seen_by_hook = work->status();
+      end_count.fetch_add(1, std::memory_order_relaxed);
+    });
+
+    std::atomic<bool> go{false};
+    std::thread watchdog([&] {
+      while (!go.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+      }
+      work->setStatus(TorchWork::WorkStatus::TIMEDOUT);
+    });
+
+    go.store(true, std::memory_order_release);
+    work->setStatus(TorchWork::WorkStatus::COMPLETED);
+    watchdog.join();
+
+    EXPECT_EQ(end_count.load(), 1);
+    EXPECT_EQ(seen_by_hook, work->status());
+  }
+}
+
+TEST(TorchWorkTest, HookRegisteredDuringTerminalTransitionIsNotLost) {
+  // The lost-hook race: a registrar reads "not fired", is preempted by the
+  // transition, then appends to a vector nobody will read again. Either the
+  // transition fires the hook, or registration finds the flag already set and
+  // fires it inline -- never zero times, never twice.
+  //
+  // Several registrars per iteration, because the window is narrow: it is only
+  // the gap between deciding "not yet terminal" and appending. One registrar
+  // lands in it too rarely to be a dependable guard.
+  constexpr int kRegistrars = 8;
+  for (int i = 0; i < 2000; ++i) {
+    auto work = c10::make_intrusive<TestWork>();
+    std::atomic<int> end_count{0};
+    std::atomic<bool> go{false};
+    std::vector<std::thread> registrars;
+    registrars.reserve(kRegistrars);
+
+    for (int r = 0; r < kRegistrars; ++r) {
+      registrars.emplace_back([&] {
+        while (!go.load(std::memory_order_acquire)) {
+          std::this_thread::yield();
+        }
+        work->registerWorkEndHook([&end_count]() {
+          end_count.fetch_add(1, std::memory_order_relaxed);
+        });
+      });
+    }
+
+    go.store(true, std::memory_order_release);
+    work->setStatus(TorchWork::WorkStatus::COMPLETED);
+    for (auto& registrar : registrars) {
+      registrar.join();
+    }
+
+    ASSERT_EQ(end_count.load(), kRegistrars) << "iteration " << i;
+  }
+}
+
+TEST(TorchWorkTest, HookMayQueryTheWorkItIsAttachedTo) {
+  // Race C: hooks must not run while an internal lock is held. Nothing forbids
+  // a hook from querying its own work -- the clog hooks do exactly that -- and
+  // if hooks fired under hooks_mutex_, any such callback would deadlock on a
+  // non-recursive mutex. Registering another hook from inside a hook is the
+  // sharpest form, since that path takes the same lock.
+  auto work = c10::make_intrusive<TestWork>();
+  int inner_count = 0;
+  bool observed_terminal = false;
+
+  work->registerWorkEndHook([&]() {
+    observed_terminal = work->status() == TorchWork::WorkStatus::COMPLETED;
+    // Would deadlock if the transition still held hooks_mutex_.
+    work->registerWorkEndHook([&inner_count]() { inner_count++; });
+  });
+
+  work->setStatus(TorchWork::WorkStatus::COMPLETED);
+
+  EXPECT_TRUE(observed_terminal);
+  // The nested registration arrives after the flag is latched, so it fires
+  // inline rather than queueing behind a transition that already happened.
+  EXPECT_EQ(inner_count, 1);
 }
 
 // -- Release resources / weak-ref cycle tests --

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3616,6 +3616,30 @@ cvars:
    default     : true
    description : Enable per-(collective_op, algorithm, msg_size) host-drive timing stats accumulated by the GPE thread and drained each training step.
 
+ - name        : MCCL_DEBUG
+   type        : string
+   default     : "__MCCL_INHERIT__"
+   description : |-
+     Controls MCCL text-log severity independently from NCCL. When this
+     variable is absent, MCCL inherits NCCL_DEBUG for backward compatibility.
+
+ - name        : MCCL_DEBUG_FILE
+   type        : string
+   default     : "__MCCL_INHERIT__"
+   description : |-
+     Directs MCCL text logs to a separate file. Supports the same %h and %p
+     substitutions as NCCL_DEBUG_FILE. When this variable is absent, MCCL
+     inherits NCCL_DEBUG_FILE for backward compatibility.
+
+ - name        : MCCL_DEBUG_SUBSYS
+   type        : string
+   default     : "__MCCL_INHERIT__"
+   description : |-
+     Filters MCCL INFO logs by subsystem independently from NCCL. Accepts the
+     same comma-separated subsystem names as NCCL_DEBUG_SUBSYS. When this
+     variable is absent, MCCL inherits NCCL_DEBUG_SUBSYS for backward
+     compatibility.
+
  - name        : MCCL_SCUBA_LOG_LEVEL
    type        : enum
    default     : NORMAL

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3616,6 +3616,14 @@ cvars:
    default     : true
    description : Enable per-(collective_op, algorithm, msg_size) host-drive timing stats accumulated by the GPE thread and drained each training step.
 
+ - name        : MCCL_COLLECTIVE_PERF_STATS_ENABLE
+   type        : bool
+   default     : false
+   description : |-
+     Enable algorithm-independent CUDA-event timing for MCCL collectives.
+     Graph-replay samples are drained after the caller synchronizes each step;
+     disabled by default because timing-enabled CUDA events add launch overhead.
+
  - name        : MCCL_DEBUG
    type        : string
    default     : "__MCCL_INHERIT__"


### PR DESCRIPTION
Summary: Collect eager and CUDA-graph replay timings with dedicated CUDA event pools, aggregate completed and aborted samples, preserve released-graph resources until drain, and track abort generations across reconfiguration. Keep eager and graph timing in one collector because they share event ownership, drain semantics, and abort attribution. Treat disabling collection as a reset boundary so stale samples cannot surface after re-enablement, and reclaim released-graph resources immediately when an abort prevents pending events from completing.

Differential Revision: D119547701


