### PR TITLE
Raise kMaxIbGroups 256 -> 1024 (#4097)

### DIFF
--- a/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
+++ b/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
@@ -607,9 +607,9 @@ TEST(MultiPeerIbTransportConfigTest, LazyQpPayloadDoesNotScaleWithGroupLimit) {
   // static_asserts on, so there is no second copy of the number to drift.
   //
   // Deliberately NOT `kMaxIbQpsPerPeerPerNic < kMaxIbGroups *
-  // kMaxIbQpsPerBlockPerNic`: that only holds because kMaxIbGroups is 256
-  // today. Returning it to 64 would make the product exactly 8192 and turn the
-  // check red even though the constant would still be independent -- it
+  // kMaxIbQpsPerBlockPerNic`: that holds only for the values the two constants
+  // happen to have. At kMaxIbGroups=64 the product is exactly 8192, which turns
+  // the check red even though the constants would still be independent -- it
   // expresses the decoupling only by accident.
   //
   // Nor `sizeof(PeerQpPayload) <= kMaxPeerQpPayloadBytes`: that is the header's
@@ -634,9 +634,11 @@ TEST(MultiPeerIbTransportConfigTest, LazyQpPayloadDoesNotScaleWithGroupLimit) {
          "raising kMaxIbGroups past the QP budget needs a wire-format change";
 }
 
-// The shape this limit exists for -- SendRecvTile's 256 channels, both
-// directions -- must fit the QP budget while landing above the eager exchange
-// cap, i.e. it is reachable only with ibLazyConnect=true.
+// The widest shape this limit admits -- kMaxIbGroups channels, both directions
+// -- must fit the QP budget while landing above the eager exchange cap, i.e. it
+// is reachable only with ibLazyConnect=true. Written against the constant, not
+// against a literal, so a bump to the index space re-checks the same property
+// at its new width instead of silently continuing to check the old one.
 TEST(MultiPeerIbTransportConfigTest, MaxGroupShapeFitsBudgetAndRequiresLazy) {
   MultipeerIbTransportConfig config;
   config.perChannelSize = 64 * 1024; // > 0 selects the two-direction shape

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -4026,10 +4026,10 @@ TEST_P(LazyModeTestFixture, MaterializeAndTransferAboveEagerQpLimit) {
 
   // Try only around construction, with the skip decision reduced across ranks
   // -- same shape as FixedChannelSendRecvSpansGroupsAboveLegacyLimit below, and
-  // for the same two reasons: a genuine failure at the 256-group shape is what
-  // this test exists to catch and must not be reported as "backend not
-  // available", and a rank that bailed out mid-body would leave its peer
-  // blocked in an inner barrier.
+  // for the same two reasons: a genuine failure at the full kMaxIbGroups-wide
+  // shape is what this test exists to catch and must not be reported as
+  // "backend not available", and a rank that bailed out mid-body would leave
+  // its peer blocked in an inner barrier.
   std::unique_ptr<TestIbTransport> transport;
   std::string setupError;
   try {
@@ -4115,17 +4115,22 @@ TEST_P(LazyModeTestFixture, MaterializeAndTransferAboveEagerQpLimit) {
   MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 }
 
-// The group ceiling this diff replaces. Named so the test below cannot
-// quietly become vacuous if kMaxIbGroups is ever lowered back toward it.
-constexpr int kLegacyMaxIbGroups = 64;
+// The group ceiling the current kMaxIbGroups replaces. Named so the test below
+// cannot quietly become vacuous if kMaxIbGroups is ever lowered back toward it.
+// Tracks the previous value on every bump -- 64 before kMaxIbGroups went to
+// 256, 256 now that it is 1024 -- so the test always proves coverage of the
+// range the most recent bump added, not of a range some earlier bump already
+// covered.
+constexpr int kLegacyMaxIbGroups = 256;
 
 // MaterializeAndTransferAboveEagerQpLimit proves the lazy peer EXCHANGE
-// survives 512 QPs. It does not prove send/recv can SELECT a channel above the
-// old ceiling: it moves its bytes with a single-block put/signal, so it only
-// ever touches channel 0. Channel selection indexes a different set of
-// structures per block -- the per-(channel, protocol) resource slot, its
-// staging window, its progress cursor and its QP lane -- and none of those
-// above index 63 were reached.
+// survives the widest shape the index space admits (kMaxIbGroups x
+// kIbDirections QPs per peer per NIC). It does not prove send/recv can SELECT a
+// channel above the old ceiling: it moves its bytes with a single-block
+// put/signal, so it only ever touches channel 0. Channel selection indexes a
+// different set of structures per block -- the per-(channel, protocol) resource
+// slot, its staging window, its progress cursor and its QP lane -- and index 0
+// is the only entry of any of them that test reaches.
 //
 // So drive the real fixed-channel send/recv path with one block per channel
 // across the whole 0..kMaxIbGroups-1 range. Two properties make the coverage
@@ -4134,9 +4139,9 @@ constexpr int kLegacyMaxIbGroups = 64;
 //     its slice zeroed instead of being covered by a sibling block writing the
 //     same bytes;
 //   - bytesPerBlock stays inside one pipeline window, so a sender never waits
-//     on a peer's SLOT_FREE. With 256 blocks per rank and far fewer resident,
-//     a sender that could block on a not-yet-scheduled receiver would deadlock
-//     the test rather than fail it.
+//     on a peer's SLOT_FREE. With kMaxIbGroups blocks per rank (1024 today) and
+//     far fewer resident, a sender that could block on a not-yet-scheduled
+//     receiver would deadlock the test rather than fail it.
 TEST_P(LazyModeTestFixture, FixedChannelSendRecvSpansGroupsAboveLegacyLimit) {
   if (numRanks != 2) {
     GTEST_SKIP() << "Requires exactly 2 ranks";
@@ -4156,17 +4161,18 @@ TEST_P(LazyModeTestFixture, FixedChannelSendRecvSpansGroupsAboveLegacyLimit) {
 
   // Only the transport construction is allowed to turn into a skip, and the
   // skip decision is reduced across ranks before it is acted on. Wrapping the
-  // whole body instead would (a) report a genuine failure at the 256-group
-  // shape -- exactly what this test targets -- as "backend not available", and
-  // (b) let one rank bail out mid-test while its peer is still blocked on an
-  // inner barrier, hanging the run instead of failing it.
+  // whole body instead would (a) report a genuine failure at the full
+  // kMaxIbGroups-wide shape -- exactly what this test targets -- as "backend
+  // not available", and (b) let one rank bail out mid-test while its peer is
+  // still blocked on an inner barrier, hanging the run instead of failing it.
   std::unique_ptr<TestIbTransport> transport;
   std::string setupError;
   try {
     // perChannelSize > 0 selects the fixed-channel shape, which is also what
     // makes the transport derive maxGroups from max_num_channels -- device-side
-    // QP selection needs block_id < maxGroups, so a 64-group transport would
-    // fault on block 64 rather than merely mis-route it.
+    // QP selection needs block_id < maxGroups, so a transport built with a
+    // narrower group count would fault on the first block past its own ceiling
+    // rather than merely mis-route it.
     transport = createLazyTransport(kMaxIbGroups, perChannelSize);
   } catch (const std::exception& e) {
     setupError = e.what();

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -711,7 +711,20 @@ constexpr int kMaxEagerExchangeQpsPerPeerPerNic = 128;
 // on it. So the QP cost of a transport is set by `max_num_channels` (times
 // directions, times qpsPerConnection) and the number of peers touched, and the
 // knob for reducing it is `max_num_channels`, not this limit.
-constexpr int kMaxIbGroups = 256;
+//
+// Sized for the a2av 1.5D compressed sweep at high blocks/peer: GB300 runs
+// BPP=170 x 3 IB peers = 510 groups, above the previous 256 ceiling.
+//
+// 1024 rather than 512, which that consumer would also clear: the number that
+// bounds real resource use is kMaxIbQpsPerPeerPerNic below, not this one, so
+// widening the index space costs no memory and no QP -- it only widens the set
+// of shapes the constructor accepts. 512 would leave two spare group indices,
+// so BPP 171, a fourth IB peer (4 x 170 = 680), or a rail-count change would
+// each become a construction-time throw for no reason but this ceiling. At
+// 1024 the widest admissible shape is 1024 x kIbDirections = 2048 QPs per peer
+// per NIC, a quarter of the 8192 budget below, which stays the binding limit
+// on what actually gets created.
+constexpr int kMaxIbGroups = 1024;
 constexpr int kMaxIbQpsPerBlockPerNic = 128;
 
 // Budget for QPs actually created per (peer, NIC): max_num_channels *


### PR DESCRIPTION
Summary:

Raises the IB group (channel) index-space ceiling from 256 to 1024. This widens the set of transport configurations that construct successfully; it changes nothing about what any existing configuration allocates, and nothing on the wire.

`kMaxIbGroups` bounds `max_num_channels`. Device-side IB QP selection uses `ThreadGroup::block_id` and requires `block_id < maxGroups`, so a collective that wants N blocks per rank talking to an IB peer needs N group indices. At runtime the constant appears in exactly one place per backend -- a constructor argument check in each of the IBGDA and IBRC transports -- and it dimensions no array, so raising it creates no queue pair and costs no memory. QPs are materialized lazily per PEER, and how many is set by `max_num_channels` x direction count x `qpsPerConnection`; the knob for reducing that is `max_num_channels`, not this ceiling.

Motivation: the AllToAllv 1.5D compressed kernel at high blocks-per-peer needs more channel indices than 256. On Blackwell Ultra, 170 blocks per peer across 3 IB peers is 510 groups.

**Why 1024 and not 512**, which 510 would also clear. The number that bounds real resource use is `kMaxIbQpsPerPeerPerNic` (8192 per peer per NIC), deliberately independent of this index space and unchanged here. 512 would leave two spare group indices, so 171 blocks per peer, a fourth IB peer (4 x 170 = 680), or a rail-count change would each become a construction-time throw for no reason but this ceiling -- and the failure mode is a runtime exception at transport setup, not a compile error. At 1024 the widest admissible shape is 1024 x 2 = 2048 QPs per peer per NIC, a quarter of the 8192 budget, so nothing this newly admits is outside what that budget was already sized for. The cost of the extra headroom is zero bytes and zero QPs; what actually costs something is a configuration that *uses* the width, and that is bounded by `max_num_channels` exactly as before.

Costs nothing on the wire. The bilateral peer-exchange payload is dimensioned by `kMaxIbQpsPerPeerPerNic`, so `PeerQpPayload` is byte-identical before and after and the `static_assert` on its size still holds. That independence is exactly the case it was argued for.

Also updates the two tests that hard-coded the 64->256-era shape, so they protect the range this change adds rather than one an earlier bump already covered:

- `kLegacyMaxIbGroups` moves 64 -> 256 in `MultipeerIbgdaTransportTest`. `FixedChannelSendRecvSpansGroupsAboveLegacyLimit` asserts `kMaxIbGroups > kLegacyMaxIbGroups` and drives one block per channel across `0..kMaxIbGroups-1`, so it now proves channel selection works above 256 rather than above 64.
- Comments in both that file and `MultiPeerIbTransportConfigTest` now derive from the constants instead of restating their old values -- "512 QPs", "256 blocks per rank", "a 64-group transport would fault on block 64", and "SendRecvTile's 256 channels" were all describing a shape that no longer exists.

Reviewed By: dboyda

Differential Revision: D119571898


