### PR TITLE
Default IB VC mode to dqplb, not spray (#4103)

### DIFF
--- a/comms/utils/cvars/README.md
+++ b/comms/utils/cvars/README.md
@@ -99,8 +99,8 @@ NCCL_RAS_ENABLE - default value changed from 1 to 0 NCCL_CTRAN_IB_MAX_QPS -
 default value changed from 1 to 16 NCCL_CTRAN_IB_QP_MAX_MSGS - default value
 changed from 4 to 128 NCCL_CTRAN_IB_QP_SCALING_THRESHOLD - default value changed
 from 131072 to 524288 NCCL_CTRAN_IB_QP_CONFIG_XDC - default value changed from
-"" to "1048576,16,spray,128" NCCL_CTRAN_IB_QP_CONFIG_XZONE -
-default value changed from "" to "1048576,16,spray,128" NCCL_CTRAN_IB_VC_MODE -
+"" to "1048576,16,dqplb,128" NCCL_CTRAN_IB_QP_CONFIG_XZONE -
+default value changed from "" to "1048576,16,dqplb,128" NCCL_CTRAN_IB_VC_MODE -
 default value changed from "spray" to "dqplb"
 
 ## NCCL Baseline Adapter

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1865,7 +1865,7 @@ cvars:
 
  - name        : NCCL_CTRAN_IB_VC_MODE
    type        : enum
-   default     : spray
+   default     : dqplb
    choices     : spray, dqplb
    description : |-
      Configure IBVCs to support either spray mode (uses extra QP for
@@ -1873,7 +1873,7 @@ cvars:
 
  - name        : NCCL_CTRAN_IB_QP_CONFIG_XZONE
    type        : stringlist
-   default     : "1048576,16,spray,128"
+   default     : "1048576,16,dqplb,128"
    description : |-
      A set of configuration for CTRAN IB over inter-zone communication:
      <QP_SCALING_THRESHOLD>,<MAX_QPS>,<VC_MODE>,<QP_MAX_MSGS>
@@ -1884,7 +1884,7 @@ cvars:
 
  - name        : NCCL_CTRAN_IB_QP_CONFIG_XDC
    type        : stringlist
-   default     : "1048576,16,spray,128"
+   default     : "1048576,16,dqplb,128"
    description : |-
      A set of configuration for CTRAN IB over inter-DC communication:
      <QP_SCALING_THRESHOLD>,<MAX_QPS>,<VC_MODE>,<QP_MAX_MSGS>
@@ -1904,7 +1904,7 @@ cvars:
 
  - name        : NCCL_CTRAN_IB_QP_CONFIG_ALGO
    type        : dictlist
-   default     : alltoall:1048576,4,spray,128,224
+   default     : alltoall:1048576,4,dqplb,128,224
    description : |-
      Specify the vc config for each collective. The format is
      <ALGO0: VAL0>,<ALGO1: VAL1>,<ALGO2: VAL2>,<ALGO3: VAL3>


### PR DESCRIPTION
Summary:

Spray mode signals completion with a zero-byte `RDMA_WRITE_WITH_IMM` on a dedicated notify QP, separate from the QP that carried the data. The InfiniBand architecture does not license a receiver to read an RDMA-written buffer on that basis. IBTA Vol 1 `o9-20` admits exactly three triggers -- the write's own immediate data, a subsequent SEND, or a subsequent ATOMIC -- and IBTA scopes all three to the same queue pair (Annex A19.3). A zero-length write is additionally never R_Key-validated (`C9-88`), so it offers no buffer for the first trigger to attach to. The gate spray uses instead, waiting on the sender's own send CQEs, proves only that the data reached the responder adapter's fault zone (section 9.7.5.1.6) -- not that it is in memory.

`dqplb` carries the notification on the data QP itself, as a per-chunk `RDMA_WRITE_WITH_IMM` with a sequence number. That is exactly the trigger `o9-20` sanctions, on exactly the queue pair IBTA requires.

Flip the four shipped defaults that selected spray:

- `NCCL_CTRAN_IB_VC_MODE`: `spray` -> `dqplb`
- `NCCL_CTRAN_IB_QP_CONFIG_XZONE`: `1048576,16,spray,128` -> `1048576,16,dqplb,128`
- `NCCL_CTRAN_IB_QP_CONFIG_XDC`: same
- `NCCL_CTRAN_IB_QP_CONFIG_ALGO`: `alltoall:1048576,4,spray,128,224` -> `alltoall:1048576,4,dqplb,128,224`

The `_ALGO` entry matters most: it is applied as a per-put override and takes precedence over both the global cvar and the per-topology presets, so AllToAll ran spray even where every other knob selected dqplb.

`spray` remains a valid choice, so existing explicit settings keep working and the config-string validation in `CtranIbVc` is unaffected.

Also corrects two stale entries in the cvars `README.md` changelog, which still described the XZONE/XDC defaults as the spray strings.

Rollout note: on NICs whose out-of-order data-placement tier covers only READ and WRITE, `WRITE_WITH_IMM` is not eligible for fabric packet spraying and sits behind an ordering fence, so jobs that were on the spray default may lose spraying and pay a fence per chunk. A staged rollout is recommended rather than a single flip.

Differential Revision: D119613470


