### PR TITLE
Expose getHostWriter accessor on MultiPeerTransport (#4104)

### DIFF
--- a/comms/prims/tests/P2pIbrcHostWriterTest.cc
+++ b/comms/prims/tests/P2pIbrcHostWriterTest.cc
@@ -1,0 +1,173 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/transport/ibrc/P2pIbrcHostWriter.h"
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <stdexcept>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+namespace comms::prims {
+namespace {
+
+class P2pIbrcHostWriterTest : public ::testing::Test {
+ protected:
+  P2pIbrcHostWriter makeWriter(uint32_t nic = 1) {
+    return P2pIbrcHostWriter(
+        descs_.data(),
+        &pi_,
+        &ci_,
+        &status_,
+        static_cast<uint32_t>(descs_.size()),
+        nic);
+  }
+
+  IbgdaLocalBuffer localBuffer(int keyCount = 2) {
+    NetworkLKeys keys(keyCount);
+    for (int i = 0; i < keyCount; ++i) {
+      keys[i] = NetworkLKey{static_cast<uint32_t>(0x1000 + i)};
+    }
+    return IbgdaLocalBuffer(reinterpret_cast<void*>(0x100000), keys);
+  }
+
+  IbgdaRemoteBuffer remoteBuffer(int keyCount = 2) {
+    NetworkRKeys keys(keyCount);
+    for (int i = 0; i < keyCount; ++i) {
+      keys[i] = NetworkRKey{static_cast<uint32_t>(0x2000 + i)};
+    }
+    return IbgdaRemoteBuffer(reinterpret_cast<void*>(0x200000), keys);
+  }
+
+  std::array<IbrcDesc, 4> descs_{};
+  uint64_t pi_{0};
+  uint64_t ci_{0};
+  IbrcNicStatus status_{};
+};
+
+TEST_F(P2pIbrcHostWriterTest, RejectsInvalidConstruction) {
+  EXPECT_THROW(
+      P2pIbrcHostWriter(nullptr, &pi_, &ci_, &status_, descs_.size(), 0),
+      std::runtime_error);
+  EXPECT_THROW(
+      P2pIbrcHostWriter(
+          descs_.data(), nullptr, &ci_, &status_, descs_.size(), 0),
+      std::runtime_error);
+  EXPECT_THROW(
+      P2pIbrcHostWriter(descs_.data(), &pi_, &ci_, &status_, 3, 0),
+      std::runtime_error);
+}
+
+TEST_F(P2pIbrcHostWriterTest, PublishesPutDescriptor) {
+  auto writer = makeWriter();
+  const auto local = localBuffer();
+  const auto remote = remoteBuffer();
+  const auto signal = remoteBuffer();
+  uint64_t counter = 0;
+
+  const uint64_t seq = writer.put(
+      local,
+      remote,
+      /*nbytes=*/64,
+      &signal,
+      /*signalVal=*/7,
+      &counter,
+      /*counterVal=*/11);
+
+  EXPECT_EQ(seq, 0);
+  EXPECT_EQ(pi_, 1);
+  const IbrcDesc& desc = descs_[0];
+  EXPECT_EQ(desc.ready_seq, 0);
+  EXPECT_EQ(desc.op, static_cast<uint16_t>(IbrcOp::PUT));
+  EXPECT_EQ(desc.local_addr, reinterpret_cast<uint64_t>(local.ptr));
+  EXPECT_EQ(desc.remote_addr, reinterpret_cast<uint64_t>(remote.ptr));
+  EXPECT_EQ(desc.bytes, 64);
+  EXPECT_EQ(desc.signal_addr, reinterpret_cast<uint64_t>(signal.ptr));
+  EXPECT_EQ(desc.signal_value, 7);
+  EXPECT_EQ(desc.counter_addr, reinterpret_cast<uint64_t>(&counter));
+  EXPECT_EQ(desc.counter_value, 11);
+  EXPECT_EQ(desc.lkey_device_order, local.lkey_per_device[1].value);
+  EXPECT_EQ(desc.rkey_device_order, remote.rkey_per_device[1].value);
+  EXPECT_EQ(desc.signal_rkey_device_order, signal.rkey_per_device[1].value);
+  EXPECT_EQ(desc.flags, IBRC_HAS_SIGNAL | IBRC_SIGNAL_ADD | IBRC_HAS_COUNTER);
+}
+
+TEST_F(P2pIbrcHostWriterTest, RejectsUnalignedSignalTarget) {
+  auto writer = makeWriter();
+  NetworkRKeys keys(2);
+  keys[0] = NetworkRKey{0x2000};
+  keys[1] = NetworkRKey{0x2001};
+  const IbgdaRemoteBuffer misaligned(reinterpret_cast<void*>(0x200004), keys);
+
+  EXPECT_THROW(
+      writer.put(localBuffer(), remoteBuffer(), 64, &misaligned),
+      std::runtime_error);
+  EXPECT_THROW(writer.signal(misaligned), std::runtime_error);
+}
+
+TEST_F(P2pIbrcHostWriterTest, RejectsOversizedTransfer) {
+  auto writer = makeWriter();
+  EXPECT_THROW(
+      writer.put(localBuffer(), remoteBuffer(), std::size_t{1} << 32),
+      std::runtime_error);
+}
+
+TEST_F(P2pIbrcHostWriterTest, RejectsInvalidArguments) {
+  auto writer = makeWriter();
+  const auto local = localBuffer();
+  const auto remote = remoteBuffer();
+  const IbgdaRemoteBuffer nullSignal;
+
+  EXPECT_THROW(writer.put(local, remote, 0), std::runtime_error);
+  EXPECT_THROW(writer.put(local, remote, 1, &nullSignal), std::runtime_error);
+  EXPECT_THROW(writer.put(localBuffer(1), remote, 1), std::runtime_error);
+  EXPECT_THROW(writer.put(local, remoteBuffer(1), 1), std::runtime_error);
+  EXPECT_THROW(writer.signal(remoteBuffer(1)), std::runtime_error);
+  EXPECT_THROW(writer.poll_counter(nullptr, 1), std::runtime_error);
+}
+
+TEST_F(P2pIbrcHostWriterTest, WaitPolicyBoundsPollAndBackpressure) {
+  auto writer = makeWriter();
+  writer.set_timeout(std::chrono::milliseconds(1));
+
+  uint64_t counter = 0;
+  EXPECT_THROW(writer.poll_counter(&counter, 1), std::runtime_error);
+
+  pi_ = descs_.size();
+  ci_ = 0;
+  EXPECT_THROW(writer.signal(remoteBuffer()), std::runtime_error);
+}
+
+TEST_F(P2pIbrcHostWriterTest, AbortPredicateBreaksWait) {
+  auto writer = makeWriter();
+  writer.set_wait_policy(std::chrono::seconds(10), [] { return true; });
+
+  uint64_t counter = 0;
+  EXPECT_THROW(writer.poll_counter(&counter, 1), std::runtime_error);
+}
+
+// set_timeout() must not disturb the predicate the transport armed at
+// getHostWriter() time; a caller adjusting only its deadline would otherwise
+// silently drop back to waiting out the full timeout on an aborted job.
+TEST_F(P2pIbrcHostWriterTest, TimeoutChangeKeepsAbortPredicate) {
+  auto writer = makeWriter();
+  writer.set_abort_predicate([] { return true; });
+  writer.set_timeout(std::chrono::seconds(10));
+
+  uint64_t counter = 0;
+  const auto start = std::chrono::steady_clock::now();
+  EXPECT_THROW(writer.poll_counter(&counter, 1), std::runtime_error);
+  EXPECT_LT(std::chrono::steady_clock::now() - start, std::chrono::seconds(5));
+}
+
+TEST_F(P2pIbrcHostWriterTest, MovedWriterRemainsUsable) {
+  auto writer = makeWriter();
+  auto moved = std::move(writer);
+
+  EXPECT_NO_THROW(moved.fence());
+}
+
+} // namespace
+} // namespace comms::prims

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -460,6 +460,16 @@ std::vector<IbgdaRemoteBuffer> MultiPeerTransport::exchangeIbgdaBuffer(
   throw std::runtime_error("exchangeIbgdaBuffer: IB transport not available");
 }
 
+P2pIbrcHostWriter MultiPeerTransport::getHostWriter(
+    int peerRank,
+    uint32_t queueIndex) const {
+  if (ibrcTransport_) {
+    return ibrcTransport_->getHostWriter(peerRank, queueIndex);
+  }
+  throw std::runtime_error(
+      "getHostWriter: IBRC transport not available (build with ibMode=kIbrc)");
+}
+
 IbgdaLocalBuffer MultiPeerTransport::allocateIbCounterBuffer(
     std::size_t size,
     void** hostPtr) {

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -2,6 +2,7 @@
 
 #include "comms/prims/transport/MultiPeerTransport.h"
 
+#include <functional>
 #include <stdexcept>
 #include <utility>
 #include <vector>
@@ -195,7 +196,14 @@ void MultiPeerTransport::initFromTopology(
       // IBRC's device waits sit on the CPU proxy, so the backend needs the
       // handle itself; IBGDA takes one per call on the wait APIs instead.
       ibrcTransport_ = std::make_unique<MultipeerIbrcTransport>(
-          myRank_, nRanks_, bootstrap_, ibConfig, abortDevice_);
+          myRank_,
+          nRanks_,
+          bootstrap_,
+          ibConfig,
+          abortDevice_,
+          abort_ ? std::function<bool()>(
+                       [abort = abort_] { return abort->isAborted(); })
+                 : nullptr);
       VLOG(1) << "MultiPeerTransport: rank " << myRank_
               << " created IBRC sub-transport for " << ibPeerRanks_.size()
               << " peers";

--- a/comms/prims/transport/MultiPeerTransport.h
+++ b/comms/prims/transport/MultiPeerTransport.h
@@ -321,6 +321,17 @@ class MultiPeerTransport {
   std::vector<IbgdaRemoteBuffer> exchangeIbgdaBuffer(
       const IbgdaLocalBuffer& localBuf);
 
+  /**
+   * Host-driven RDMA writer for one peer (CPU posts put/signal into the IBRC
+   * command queue, no GPU kernel involved). Only available when the transport
+   * was built in IBRC mode (config.ibMode == kIbrc); throws otherwise.
+   *
+   * @param peerRank Global rank of the IB peer.
+   * @param queueIndex Command-queue index for this peer (default 0).
+   * @return A P2pIbrcHostWriter bound to that peer's command queue.
+   */
+  P2pIbrcHostWriter getHostWriter(int peerRank, uint32_t queueIndex = 0) const;
+
   IbgdaLocalBuffer allocateIbCounterBuffer(std::size_t size, void** hostPtr);
   IbgdaLocalBuffer registerIbCounterBuffer(
       const IbgdaLocalBuffer& buffer,

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -267,13 +267,15 @@ MultipeerIbrcTransport::MultipeerIbrcTransport(
     int nRanks,
     std::shared_ptr<meta::comms::IBootstrap> bootstrap,
     const MultipeerIbTransportConfig& config,
-    comms::fault_tolerance::AbortDevice abort)
+    comms::fault_tolerance::AbortDevice abort,
+    std::function<bool()> hostAborted)
     : MultiPeerIbTransport<MultipeerIbrcTransport>(
           myRank,
           nRanks,
           std::move(bootstrap),
           config),
-      abortDevice_(abort) {
+      abortDevice_(abort),
+      hostAborted_(std::move(hostAborted)) {
   const int numQpsPerPeerPerNic = config_.fixedChannelMainQpsPerPeerPerNic();
   if (config_.max_num_channels < 1) {
     throw std::invalid_argument("max_num_channels must be >= 1");
@@ -1581,6 +1583,43 @@ P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDevice(
   return reinterpret_cast<P2pIbrcTransportDevice*>(
       static_cast<char*>(p2pTransportDevices_.device) +
       peerIndex * ibrcDeviceSlotSize());
+}
+
+P2pIbrcHostWriter MultipeerIbrcTransport::getHostWriter(
+    int peerRank,
+    uint32_t queueIndex) const {
+  if (peerRank == myRank_ || peerRank < 0 || peerRank >= nRanks_) {
+    throw std::invalid_argument(
+        fmt::format("getHostWriter: invalid peerRank={}", peerRank));
+  }
+  const int peerIndex = rankToPeerIndex(peerRank);
+  const PeerResources& peer = peerResources_[peerIndex];
+  if (!peerQueuesPublished_[peerIndex].load(std::memory_order_acquire)) {
+    throw std::runtime_error(
+        fmt::format(
+            "getHostWriter: peerRank={} command queues not published (materialize the peer first)",
+            peerRank));
+  }
+  if (queueIndex >= peer.cmdQueues.size()) {
+    throw std::out_of_range(
+        fmt::format(
+            "getHostWriter: queueIndex={} out of range (peer has {} rings)",
+            queueIndex,
+            peer.cmdQueues.size()));
+  }
+  const IbrcCmdQueueHost& q = peer.cmdQueues[queueIndex];
+  P2pIbrcHostWriter writer(
+      q.descsHost,
+      q.piHost,
+      q.ciHost,
+      statusHostByNic_.at(q.nic),
+      q.device.depth,
+      q.nic);
+  // Armed here rather than left to the caller: the device path already gets
+  // abortDevice_ baked in, and a writer that missed the predicate would spin
+  // out its ten-minute deadline instead of unwinding when the job aborts.
+  writer.set_abort_predicate(hostAborted_);
+  return writer;
 }
 
 void MultipeerIbrcTransport::doMaterializePeer(int peerRank) {

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <thread>
@@ -24,6 +25,7 @@
 #include "comms/prims/transport/MultiPeerIbTransport.h"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 #include "comms/prims/transport/ibrc/IbrcTypes.h"
+#include "comms/prims/transport/ibrc/P2pIbrcHostWriter.h"
 
 namespace comms::prims {
 
@@ -55,12 +57,18 @@ class MultipeerIbrcTransport
   // per-peer device slot so the device-side waits on the CPU proxy terminate on
   // abort instead of trapping. A default-constructed handle keeps the legacy
   // cycle-deadline trap; see kIbrcDefaultDeviceTimeoutCycles.
+  //
+  // `hostAborted` is the same abort seen from the CPU, and it is separate only
+  // because AbortDevice::isAborted() is __device__-only. Every writer handed
+  // out by getHostWriter() is armed with it, so a host-driven collective cannot
+  // forget to and fall back to the writer's ten-minute deadline.
   MultipeerIbrcTransport(
       int myRank,
       int nRanks,
       std::shared_ptr<meta::comms::IBootstrap> bootstrap,
       const MultipeerIbTransportConfig& config,
-      comms::fault_tolerance::AbortDevice abort = {});
+      comms::fault_tolerance::AbortDevice abort = {},
+      std::function<bool()> hostAborted = nullptr);
 
   ~MultipeerIbrcTransport();
 
@@ -86,6 +94,15 @@ class MultipeerIbrcTransport
   // Per-peer device handle accessor used by Ring/SendRecv algorithms. The
   // requested peer is materialized before its device slot is returned.
   P2pIbrcTransportDevice* getP2pTransportDevice(int peerRank);
+
+  // Host-side writer into a peer's IBRC command-queue ring, so a CPU thread can
+  // post RDMA put/signal without a kernel; the CPU proxy drains host-produced
+  // descriptors unchanged. `queueIndex` selects one (qpSlot, nic) ring. The
+  // peer must already be materialized and remain materialized while the
+  // returned writer is used; P2pIbrcHostWriter is a non-owning view of the
+  // queue's mapped host memory. Do not concurrently drive the same ring from
+  // device code.
+  P2pIbrcHostWriter getHostWriter(int peerRank, uint32_t queueIndex = 0) const;
 
  private:
   // Lazy per-peer materialization hook. The shared base owns queueing,
@@ -233,6 +250,7 @@ class MultipeerIbrcTransport
   std::thread progressThread_;
   std::vector<int> progressCpus_;
   comms::fault_tolerance::AbortDevice abortDevice_;
+  std::function<bool()> hostAborted_;
 
   // Send/recv staging state (eager mode) lives in MultiPeerIbTransportBase
   // (sendRecvPeerBuffers_ + bulks); IBRC delegates allocation/exchange/cleanup.

--- a/comms/prims/transport/ibrc/P2pIbrcHostWriter.cc
+++ b/comms/prims/transport/ibrc/P2pIbrcHostWriter.cc
@@ -1,0 +1,7 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// P2pIbrcHostWriter is header-only; this TU exists so the header is compiled
+// (its inline bodies type-checked against IbrcTypes.h / IbgdaBuffer.h) as part
+// of the :p2p_ibrc_host_writer library rather than only when a consumer uses
+// it.
+#include "comms/prims/transport/ibrc/P2pIbrcHostWriter.h"

--- a/comms/prims/transport/ibrc/P2pIbrcHostWriter.h
+++ b/comms/prims/transport/ibrc/P2pIbrcHostWriter.h
@@ -1,0 +1,453 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include <fmt/core.h>
+
+#include "comms/prims/transport/ibgda/IbgdaBuffer.h"
+#include "comms/prims/transport/ibrc/IbrcTypes.h"
+
+namespace comms::prims {
+
+/**
+ * Host-side writer into a single IBRC command-queue ring.
+ *
+ * The IBRC command queue is host-mapped memory: the same ring is addressable
+ * from GPU device code (via IbrcCmdQueueDevice) and from the CPU (via the host
+ * aliases descsHost/piHost/ciHost). Device code posts RDMA work by writing
+ * IbrcDesc entries and publishing them; the CPU proxy thread drains the ring
+ * (acquire on pi/ready_seq), posts the verbs, and advances ci — and it is
+ * agnostic to whether the GPU or the host produced a descriptor.
+ *
+ * This class lets a CPU thread produce descriptors using the exact same
+ * reserve -> fill -> publish protocol as P2pIbrcTransportDevice, so a
+ * host-driven collective can post RDMA put/signal with no kernel launched.
+ *
+ * One instance wraps ONE (qpSlot, nic) ring. IMPORTANT: do not concurrently
+ * drive the same ring from device code and this host writer — both atomically
+ * increment `pi`, so interleaving is memory-safe but the backpressure/ordering
+ * model assumes a single logical producer per ring. Dedicate specific
+ * (qpSlot, nic) queue paths to the host writer, or quiesce the GPU.
+ *
+ * Completion:
+ *  - counter ("my put completed"): host-mapped u64 the proxy fetch-adds after
+ *    the CQE; poll it directly with poll_counter().
+ *  - signal ("remote's data arrived"): an RDMA fetch-add the remote peer posts
+ *    into a local inbox. Where that inbox lives is the caller's choice and it
+ *    is a correctness decision, not a preference:
+ *      * host-pinned (allocateIbCounterBuffer, registered through its device
+ *        alias) when the host is the only consumer -- poll_counter() reads it
+ *        directly;
+ *      * device memory when a CUDA stream must also gate on arrival, since
+ *        cuStreamWaitValue64 only reads GPU-visible memory. That placement is
+ *        also the stronger one: signal and payload then share a PCIe
+ *        completer, so observing the signal implies the data is visible in
+ *        HBM. A host-pinned signal in that case would need a receiver-side
+ *        flush before consuming the payload, and IBRC has no such primitive.
+ *    A device-resident signal is not host-readable; bridge it to a host flag
+ *    (e.g. a Copy-Engine write) if the host must also observe it.
+ */
+class P2pIbrcHostWriter {
+ public:
+  /**
+   * Non-owning view of one host-mapped IBRC ring.
+   * @param descsHost host alias of the descriptor array
+   * @param piHost    host alias of the producer index
+   * @param ciHost    host alias of the consumer index (advanced by the proxy)
+   * @param statusHost host alias of the NIC status/error block (may be null)
+   * @param depth     ring depth (power of two)
+   * @param nicId     NIC index this ring targets (selects lkey/rkey per device)
+   */
+  P2pIbrcHostWriter(
+      IbrcDesc* descsHost,
+      uint64_t* piHost,
+      uint64_t* ciHost,
+      IbrcNicStatus* statusHost,
+      uint32_t depth,
+      uint32_t nicId)
+      : descs_(descsHost),
+        pi_(piHost),
+        ci_(ciHost),
+        status_(statusHost),
+        depth_(depth),
+        mask_(depth - 1),
+        nic_(nicId) {
+    if (descsHost == nullptr || piHost == nullptr || ciHost == nullptr) {
+      throw std::runtime_error("P2pIbrcHostWriter: null command queue pointer");
+    }
+    // A non-power-of-two depth would desynchronize `seq & mask_` from the
+    // `seq - ci < depth_` backpressure check, silently aliasing live slots.
+    if (depth == 0 || (depth & (depth - 1)) != 0) {
+      throw std::runtime_error(
+          fmt::format(
+              "P2pIbrcHostWriter: ring depth must be a power of two, got {}",
+              depth));
+    }
+  }
+
+  ~P2pIbrcHostWriter() = default;
+  P2pIbrcHostWriter(const P2pIbrcHostWriter&) = delete;
+  P2pIbrcHostWriter& operator=(const P2pIbrcHostWriter&) = delete;
+  P2pIbrcHostWriter(P2pIbrcHostWriter&& other) noexcept {
+    *this = std::move(other);
+  }
+  P2pIbrcHostWriter& operator=(P2pIbrcHostWriter&& other) noexcept {
+    if (this == &other) {
+      return *this;
+    }
+    descs_ = std::exchange(other.descs_, nullptr);
+    pi_ = std::exchange(other.pi_, nullptr);
+    ci_ = std::exchange(other.ci_, nullptr);
+    status_ = std::exchange(other.status_, nullptr);
+    depth_ = std::exchange(other.depth_, 0);
+    mask_ = std::exchange(other.mask_, 0);
+    nic_ = std::exchange(other.nic_, 0);
+    waitTimeout_ = other.waitTimeout_;
+    aborted_ = std::move(other.aborted_);
+    return *this;
+  }
+
+  /**
+   * RDMA-write localBuf -> remoteBuf (nbytes), with an optional remote signal
+   * (fetch-add) and an optional local completion counter.
+   *
+   * The caller must make localBuf complete and NIC-visible first -- drain the
+   * producing stream, or spin on a host flag written behind it. put() does not
+   * synchronize with CUDA; a source still in flight is sent silently.
+   *
+   * @return the reserved sequence number for this descriptor.
+   */
+  uint64_t put(
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      const IbgdaRemoteBuffer* signalBuf = nullptr,
+      uint64_t signalVal = 1,
+      uint64_t* counterHost = nullptr,
+      uint64_t counterVal = 1) {
+    const bool hasData = nbytes > 0;
+    // ibv_sge::length is 32 bits, and the proxy narrows desc.bytes into it
+    // without checking, so an oversized transfer would post silently truncated
+    // (4GiB -> 0) while its signal still fired.
+    if (nbytes > std::numeric_limits<uint32_t>::max()) {
+      throw std::runtime_error(
+          fmt::format(
+              "P2pIbrcHostWriter::put: nbytes {} exceeds the 32-bit verbs SGE "
+              "length limit",
+              nbytes));
+    }
+    const bool hasSignal = signalBuf != nullptr;
+    const bool hasCounter = counterHost != nullptr;
+    if (!hasData && !hasSignal) {
+      throw std::runtime_error(
+          "P2pIbrcHostWriter::put: empty data buffer without signal");
+    }
+
+    IbrcDesc desc{};
+    desc.op = static_cast<uint16_t>(hasData ? IbrcOp::PUT : IbrcOp::SIGNAL);
+
+    if (hasData) {
+      if (localBuf.ptr == nullptr || remoteBuf.ptr == nullptr) {
+        throw std::runtime_error("P2pIbrcHostWriter::put: null data buffer");
+      }
+      desc.local_addr = reinterpret_cast<uint64_t>(localBuf.ptr);
+      desc.remote_addr = reinterpret_cast<uint64_t>(remoteBuf.ptr);
+      desc.bytes = nbytes;
+      check_key_index(
+          "local data buffer",
+          "lkey_per_device",
+          localBuf.lkey_per_device.size);
+      check_key_index(
+          "remote data buffer",
+          "rkey_per_device",
+          remoteBuf.rkey_per_device.size);
+      desc.lkey_device_order = localBuf.lkey_per_device[nic_].value;
+      desc.rkey_device_order = remoteBuf.rkey_per_device[nic_].value;
+    }
+
+    if (hasSignal) {
+      fill_signal(desc, *signalBuf, signalVal);
+    }
+
+    if (hasCounter) {
+      desc.counter_addr = reinterpret_cast<uint64_t>(counterHost);
+      desc.counter_value = counterVal;
+      desc.flags |= IBRC_HAS_COUNTER;
+    }
+
+    return enqueue(desc);
+  }
+
+  /** Post a standalone SIGNAL (RDMA fetch-add into the remote signal slot). */
+  uint64_t signal(const IbgdaRemoteBuffer& signalBuf, uint64_t signalVal = 1) {
+    IbrcDesc desc{};
+    desc.op = static_cast<uint16_t>(IbrcOp::SIGNAL);
+    fill_signal(desc, signalBuf, signalVal);
+    return enqueue(desc);
+  }
+
+  /** Deadline every wait uses unless set_wait_policy() overrides it. */
+  static constexpr std::chrono::milliseconds kDefaultWaitTimeout{
+      std::chrono::minutes(10)};
+
+  /**
+   * Bound every wait this writer performs (poll_counter, fence, and the
+   * enqueue backpressure loop).
+   *
+   * All of them spin on the calling thread, which is the collective's own
+   * thread, so a dead peer or a wedged NIC would otherwise hang it with no way
+   * out. Callers set their operation timeout here, plus an optional abort
+   * predicate so fault tolerance can break a wait before the deadline.
+   *
+   * @param timeout deadline for each individual wait; zero or negative waits
+   *                forever (only appropriate for tests)
+   * @param aborted polled while spinning; the wait throws once it returns true
+   */
+  void set_wait_policy(
+      std::chrono::milliseconds timeout,
+      std::function<bool()> aborted) {
+    waitTimeout_ = timeout;
+    aborted_ = std::move(aborted);
+  }
+
+  /**
+   * Per-operation deadline only. Deliberately separate from the predicate:
+   * set_wait_policy() with a defaulted `aborted` would silently disarm the
+   * abort the transport installed at getHostWriter() time.
+   */
+  void set_timeout(std::chrono::milliseconds timeout) {
+    waitTimeout_ = timeout;
+  }
+
+  /** Normally the communicator's abort, installed by the owning transport. */
+  void set_abort_predicate(std::function<bool()> aborted) {
+    aborted_ = std::move(aborted);
+  }
+
+  /**
+   * Spin on a host-mapped completion counter until it reaches `expected`.
+   * The proxy bumps this counter (release) after polling the CQE for the
+   * corresponding PUT, so an acquire load here observes that the put completed.
+   *
+   * @return the observed counter value
+   */
+  uint64_t poll_counter(const uint64_t* counterHost, uint64_t expected) const {
+    if (counterHost == nullptr) {
+      throw std::runtime_error("P2pIbrcHostWriter::poll_counter: null counter");
+    }
+    uint64_t v = 0;
+    spin_until(
+        [&] {
+          v = __atomic_load_n(counterHost, __ATOMIC_ACQUIRE);
+          return v >= expected;
+        },
+        "counter to reach",
+        expected);
+    return v;
+  }
+
+  /** Block until the proxy has drained everything posted so far (ci == pi). */
+  void fence() const {
+    check_ring();
+    const uint64_t target = __atomic_load_n(pi_, __ATOMIC_ACQUIRE);
+    spin_until(
+        [&] { return __atomic_load_n(ci_, __ATOMIC_ACQUIRE) >= target; },
+        "queue to drain to",
+        target);
+  }
+
+  uint32_t nic() const {
+    return nic_;
+  }
+
+ private:
+  static constexpr uint64_t kNoWaitTarget =
+      std::numeric_limits<uint64_t>::max();
+
+  void check_ring() const {
+    if (descs_ == nullptr || pi_ == nullptr || ci_ == nullptr) {
+      throw std::runtime_error(
+          "P2pIbrcHostWriter: invalid or moved-from writer");
+    }
+  }
+
+  void check_key_index(
+      const char* bufferName,
+      const char* keyName,
+      int keyCount) const {
+    if (keyCount <= 0 || nic_ >= static_cast<uint32_t>(keyCount)) {
+      throw std::runtime_error(
+          fmt::format(
+              "P2pIbrcHostWriter: {} has {} {} entries, missing NIC {}",
+              bufferName,
+              keyCount,
+              keyName,
+              nic_));
+    }
+  }
+
+  /*
+   * A signal is an RDMA fetch-add, so its remote address must be naturally
+   * aligned for a 64-bit atomic. Reject that here rather than letting the
+   * proxy discover it: the proxy's only failure channel is publishQueueError,
+   * which errors every NIC's status block and latches the shared progress
+   * thread off, so one bad argument would take the whole transport down
+   * instead of just this call.
+   */
+  void fill_signal(
+      IbrcDesc& desc,
+      const IbgdaRemoteBuffer& signalBuf,
+      uint64_t signalVal) const {
+    if (signalBuf.ptr == nullptr) {
+      throw std::runtime_error("P2pIbrcHostWriter: null signal buffer");
+    }
+    if (reinterpret_cast<uintptr_t>(signalBuf.ptr) % alignof(uint64_t) != 0) {
+      throw std::runtime_error(
+          fmt::format(
+              "P2pIbrcHostWriter: signal target {} is not 8-byte aligned",
+              signalBuf.ptr));
+    }
+    check_key_index(
+        "signal buffer", "rkey_per_device", signalBuf.rkey_per_device.size);
+    desc.signal_addr = reinterpret_cast<uint64_t>(signalBuf.ptr);
+    desc.signal_value = signalVal;
+    desc.signal_rkey_device_order = signalBuf.rkey_per_device[nic_].value;
+    desc.flags |= IBRC_HAS_SIGNAL | IBRC_SIGNAL_ADD;
+  }
+
+  /**
+   * Wait for a free slot, reserve it, copy the descriptor body, then publish
+   * ready_seq with release ordering — the same reserve -> fill -> publish
+   * protocol as P2pIbrcTransportDevice::reserve()/enqueue().
+   *
+   * Backpressure runs *before* the fetch-add, unlike the device path. The
+   * fetch-add cannot be rolled back, so waiting after it would let a throw
+   * (timeout, abort, NIC error) leave a reserved seq that is never published,
+   * and the in-order proxy would wait on that hole forever. Publishing a
+   * filler descriptor instead is not an option: the slot we failed to acquire
+   * still holds a live, undrained descriptor. Checking first is sound under
+   * the single-logical-producer-per-ring model this class documents — nobody
+   * else advances pi, and ci only moves forward, so space observed here is
+   * still free at reserve time.
+   */
+  uint64_t enqueue(const IbrcDesc& desc) {
+    check_ring();
+    check_status();
+
+    spin_until(
+        [&] {
+          return __atomic_load_n(pi_, __ATOMIC_RELAXED) -
+              __atomic_load_n(ci_, __ATOMIC_ACQUIRE) <
+              depth_;
+        },
+        "a free ring slot",
+        kNoWaitTarget);
+
+    // reserve: relaxed fetch-add on the producer index (matches device).
+    const uint64_t seq = __atomic_fetch_add(pi_, 1, __ATOMIC_RELAXED);
+
+    IbrcDesc& slot = descs_[seq & mask_];
+    /*
+     * Body only -- ready_seq is deliberately left out of the copy. The
+     * fetch-add above already let the proxy start polling this slot, so a
+     * plain store to ready_seq here would race its acquire load: a non-atomic
+     * write concurrent with an atomic read is a data race even when, as today,
+     * it happens to rewrite the same sentinel. IbrcTypes.h puts ready_seq last
+     * and static_asserts the offset and layout precisely so the body can be
+     * copied without it.
+     */
+    std::memcpy(&slot, &desc, offsetof(IbrcDesc, ready_seq));
+    // Publish. The release store is the only writer of ready_seq, and it
+    // orders the body writes above before the proxy's acquire load sees `seq`.
+    __atomic_store_n(&slot.ready_seq, seq, __ATOMIC_RELEASE);
+    return seq;
+  }
+
+  /**
+   * Spin until `ready()` holds, re-checking the NIC status, the abort
+   * predicate and the deadline as it goes. `what`/`target` describe the awaited
+   * condition; they are only formatted on the throwing paths, since fence() and
+   * enqueue() run per step and must not allocate when the wait is satisfied
+   * immediately.
+   */
+  template <typename Ready>
+  void spin_until(Ready&& ready, const char* what, uint64_t target) const {
+    // Reading the clock and calling the abort predicate on every spin would
+    // dominate the wait, so only do it once per kSpinsPerCheck iterations.
+    constexpr uint64_t kSpinsPerCheck = 1024;
+    const bool bounded = waitTimeout_ > std::chrono::milliseconds::zero();
+    // Armed on the first failed ready() rather than up front, so the fast path
+    // -- fence() per ring step, already satisfied -- never reads the clock.
+    std::chrono::steady_clock::time_point deadline{};
+    bool armed = false;
+
+    for (uint64_t spins = 0; !ready(); ++spins) {
+      if (spins % kSpinsPerCheck != 0) {
+        continue;
+      }
+      check_status();
+      if (aborted_ && aborted_()) {
+        throw std::runtime_error(
+            fmt::format(
+                "P2pIbrcHostWriter: aborted while waiting for {}",
+                wait_description(what, target)));
+      }
+      std::this_thread::yield();
+      if (!bounded) {
+        continue;
+      }
+      const auto now = std::chrono::steady_clock::now();
+      if (!armed) {
+        deadline = now + waitTimeout_;
+        armed = true;
+      } else if (now >= deadline) {
+        throw std::runtime_error(
+            fmt::format(
+                "P2pIbrcHostWriter: timed out after {}ms waiting for {}",
+                waitTimeout_.count(),
+                wait_description(what, target)));
+      }
+    }
+  }
+
+  static std::string wait_description(const char* what, uint64_t target) {
+    if (target == kNoWaitTarget) {
+      return what;
+    }
+    return fmt::format("{} {}", what, target);
+  }
+
+  void check_status() const {
+    if (status_ != nullptr &&
+        __atomic_load_n(&status_->error, __ATOMIC_ACQUIRE) != 0) {
+      const uint32_t errorCode =
+          __atomic_load_n(&status_->error_code, __ATOMIC_RELAXED);
+      throw std::runtime_error(
+          fmt::format("P2pIbrcHostWriter: IBRC NIC error, code={}", errorCode));
+    }
+  }
+
+  IbrcDesc* descs_{nullptr};
+  uint64_t* pi_{nullptr};
+  uint64_t* ci_{nullptr};
+  IbrcNicStatus* status_{nullptr};
+  uint32_t depth_{0};
+  uint32_t mask_{0};
+  uint32_t nic_{0};
+  std::chrono::milliseconds waitTimeout_{kDefaultWaitTimeout};
+  std::function<bool()> aborted_{nullptr};
+};
+
+} // namespace comms::prims


### PR DESCRIPTION
Summary:

The IBRC host-driven RDMA writer (`P2pIbrcHostWriter`) is the CPU-posted,
kernel-free put/signal path used by 0-SM collectives. It lives on
`MultipeerIbrcTransport`, but callers hold the `MultiPeerTransport` wrapper. The
wrapper already delegates `registerBuffer`/`exchangeBuffer`/`connectPeers` to the
underlying IBRC transport when built with `ibMode == kIbrc`, but had no way to
reach `getHostWriter` -- so a host-driven collective could not obtain a writer.

This adds a thin `getHostWriter(peerRank, queueIndex)` accessor that delegates to
`ibrcTransport_`, mirroring the existing `exchangeIbgdaBuffer` delegation, and
throws when the transport was not built in IBRC mode. It unblocks the
host-driven AllGather (`mcclhostring`) higher in this stack, which reaches the
writer via `comm.multiPeerTransport->getHostWriter(peer)` on a comm built with
`MCCL_IB_MODE=ibrc`.

No behavior change for existing callers; the accessor is additive.

Differential Revision: D112657277


