### PR TITLE
Free Abort state on its allocating device

### DIFF
--- a/comms/common/fault_tolerance/Abort.cc
+++ b/comms/common/fault_tolerance/Abort.cc
@@ -46,6 +46,7 @@ Abort::Abort(bool enabled, AbortBehavior behavior) : behavior_(behavior) {
     }
   } else {
     stateMapped_ = true;
+    (void)cudaGetDevice(&stateDevice_);
   }
 #else
   state_ = new AbortState;
@@ -61,7 +62,19 @@ Abort::~Abort() {
   }
 #ifdef COMMS_FAULT_TOLERANCE_WITH_CUDA
   if (stateMapped_) {
+    // The last reference may drop on a worker thread with no current device;
+    // a CUDA call there would create a primary context on device 0. Such a
+    // thread reports device 0, so only a non-zero previous device is known to
+    // have been selected on purpose and is restored.
+    int previousDevice = -1;
+    const bool switched = stateDevice_ >= 0 &&
+        cudaGetDevice(&previousDevice) == cudaSuccess &&
+        previousDevice != stateDevice_ &&
+        cudaSetDevice(stateDevice_) == cudaSuccess;
     (void)cudaFreeHost(state_);
+    if (switched && previousDevice != 0) {
+      (void)cudaSetDevice(previousDevice);
+    }
   } else {
     delete state_;
   }

--- a/comms/common/fault_tolerance/Abort.h
+++ b/comms/common/fault_tolerance/Abort.h
@@ -288,6 +288,7 @@ class Abort final {
 
   AbortState* state_{nullptr};
   bool stateMapped_{false};
+  int stateDevice_{-1};
   std::atomic<bool> hasTimeout_{false};
   std::atomic<std::chrono::steady_clock::time_point> deadline_{
       std::chrono::steady_clock::time_point{}};

--- a/comms/common/fault_tolerance/tests/AbortDestructorUT.cc
+++ b/comms/common/fault_tolerance/tests/AbortDestructorUT.cc
@@ -1,0 +1,74 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda_runtime.h>
+#include <dlfcn.h>
+
+#include <memory>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "comms/common/fault_tolerance/Abort.h"
+
+namespace comms::fault_tolerance::testing {
+namespace {
+
+void expectPrimaryContextActive(int deviceOrdinal, bool expected) {
+  void* libcuda = dlopen("libcuda.so.1", RTLD_NOW | RTLD_NOLOAD);
+  ASSERT_NE(libcuda, nullptr) << dlerror();
+  using DeviceGetFn = int (*)(int*, int);
+  using CtxGetStateFn = int (*)(int, unsigned int*, int*);
+  auto deviceGet = reinterpret_cast<DeviceGetFn>(dlsym(libcuda, "cuDeviceGet"));
+  auto ctxGetState = reinterpret_cast<CtxGetStateFn>(
+      dlsym(libcuda, "cuDevicePrimaryCtxGetState"));
+  ASSERT_NE(deviceGet, nullptr);
+  ASSERT_NE(ctxGetState, nullptr);
+  int device = 0;
+  ASSERT_EQ(deviceGet(&device, deviceOrdinal), 0);
+  unsigned int flags = 0;
+  int active = 0;
+  ASSERT_EQ(ctxGetState(device, &flags, &active), 0);
+  EXPECT_EQ(active != 0, expected) << "device " << deviceOrdinal;
+}
+
+} // namespace
+
+// Own binary on purpose: sibling suites leave a context on device 0 behind,
+// which would mask the leak checked here.
+TEST(AbortDestructorTest, unboundThreadDoesNotCreateForeignContext) {
+  int deviceCount = 0;
+  ASSERT_EQ(cudaGetDeviceCount(&deviceCount), cudaSuccess);
+  if (deviceCount < 2) {
+    GTEST_SKIP() << "needs two devices";
+  }
+  ASSERT_EQ(cudaSetDevice(1), cudaSuccess);
+  auto abort = std::make_unique<Abort>(/*enabled=*/true);
+  expectPrimaryContextActive(0, false);
+
+  std::thread([abort = std::move(abort)]() mutable { abort.reset(); }).join();
+
+  expectPrimaryContextActive(0, false);
+  expectPrimaryContextActive(1, true);
+}
+
+TEST(AbortDestructorTest, boundThreadKeepsItsOwnDevice) {
+  int deviceCount = 0;
+  ASSERT_EQ(cudaGetDeviceCount(&deviceCount), cudaSuccess);
+  if (deviceCount < 3) {
+    GTEST_SKIP() << "needs three devices";
+  }
+  ASSERT_EQ(cudaSetDevice(1), cudaSuccess);
+  auto abort = std::make_unique<Abort>(/*enabled=*/true);
+
+  int deviceAfter = -1;
+  std::thread([abort = std::move(abort), &deviceAfter]() mutable {
+    EXPECT_EQ(cudaSetDevice(2), cudaSuccess);
+    abort.reset();
+    EXPECT_EQ(cudaGetDevice(&deviceAfter), cudaSuccess);
+  }).join();
+
+  EXPECT_EQ(deviceAfter, 2);
+  expectPrimaryContextActive(0, false);
+}
+
+} // namespace comms::fault_tolerance::testing


### PR DESCRIPTION
Summary:
Make `Abort::~Abort()` free its host-mapped state on the device it was allocated on. Dropping the last reference from a worker thread that never selected a GPU created a stray primary CUDA context on GPU 0 in every process not running on GPU 0, which broke CUPTI hardware tracing (`CUPTI_ERROR_HARDWARE_BUSY`) and the CUDA-graph capture pre-flight of a downstream trainer.

Context:

- `comms::fault_tolerance::Abort` (`comms/common/fault_tolerance/Abort.cc`) is the object collective-communication code uses to tell CPU threads and GPU kernels that a collective was aborted or timed out. It keeps that flag in one small block of pinned host memory that is also mapped into GPU address space (`cudaHostAlloc` with `cudaHostAllocMapped`), so host code and device code read the same word.

- A communicator owns its `Abort` through a `std::shared_ptr` and hands copies to the components it builds. When the communicator is rebuilt because the set of participants changed, the `Abort` is replaced; whichever thread drops the last reference runs the destructor, which frees the block with `cudaFreeHost`. In the observed failure that thread was a native worker thread.

- In CUDA every CPU thread has its own "current device". A thread that never called `cudaSetDevice` reports device 0. A primary CUDA context is the per-process, per-GPU state the CUDA runtime creates on first use of a GPU. Calling `cudaFreeHost` on a thread whose current device is 0 makes the runtime create the primary context of GPU 0 (observed with gdb: `Abort::~Abort()` -> `cudaFreeHost` -> `cuDevicePrimaryCtxRetain(dev=0)`).

- Training runs one process per GPU. For the processes assigned to GPUs 1..N this context is foreign: it holds memory on a GPU the process does not use, and it collides with CUPTI. CUPTI is NVIDIA's profiling interface; its hardware trace unit is exclusive per GPU across processes, so once a process on GPU 1 also holds a context on GPU 0, its CUPTI calls fail with `CUPTI_ERROR_HARDWARE_BUSY` because the GPU 0 process owns that unit. The downstream trainer checks for exactly this situation before CUDA-graph capture and aborts the rank.

- The fix records the current device when the block is allocated (`stateDevice_`), switches to it before `cudaFreeHost` when the destroying thread is on a different device, and afterwards restores the previous device only when that device was not 0: a thread that never selected a device also reports 0, and selecting device 0 there would create the very context this change removes. The one case left unrestored is a thread that deliberately selected device 0 and destroys an `Abort` allocated elsewhere; it stays on the allocation device.

- Two tests in a dedicated binary (sibling test suites already leave a context on device 0 behind): destroying an `Abort` allocated on GPU 1 from a fresh thread leaves GPU 0 without a primary context; destroying it from a thread bound to GPU 2 leaves that thread on GPU 2.

Reviewed By: anobra

Differential Revision: D119678844


