### PR TITLE
Read VC mode default from its cvar, not a literal

### DIFF
--- a/comms/ctran/backends/CtranCtrl.h
+++ b/comms/ctran/backends/CtranCtrl.h
@@ -61,7 +61,7 @@ struct fmt::formatter<ControlMsgType> : fmt::formatter<const char*> {
 struct CtranIbConfig {
   int numQps{NCCL_CTRAN_IB_MAX_QPS};
   size_t qpScalingTh{NCCL_CTRAN_IB_QP_SCALING_THRESHOLD};
-  enum NCCL_CTRAN_IB_VC_MODE vcMode { NCCL_CTRAN_IB_VC_MODE::spray };
+  enum NCCL_CTRAN_IB_VC_MODE vcMode { NCCL_CTRAN_IB_VC_MODE };
   int qpMsgs{static_cast<int>(NCCL_CTRAN_IB_QP_MAX_MSGS)};
   int64_t trafficClass{NCCL_IB_TC};
 };

--- a/comms/ctran/backends/ib/CtranIbVc.h
+++ b/comms/ctran/backends/ib/CtranIbVc.h
@@ -1959,7 +1959,7 @@ class CtranIbVirtualConn {
   int maxNumQps_{0};
   int numQpsPerDevice_{0};
   size_t qpScalingTh_{NCCL_CTRAN_IB_QP_SCALING_THRESHOLD};
-  enum NCCL_CTRAN_IB_VC_MODE vcMode_ { NCCL_CTRAN_IB_VC_MODE::spray };
+  enum NCCL_CTRAN_IB_VC_MODE vcMode_ { NCCL_CTRAN_IB_VC_MODE };
   // When true and the VC spans multiple NICs, tryToPostOp interleaves a single
   // op's QP-scaling sub-chunks across all NICs (visit order qp0, qpK, qp2K, ...
   // advancing the device first, where K = maxNumQps_ / numActiveDevices)

--- a/comms/utils/cvars/README.md
+++ b/comms/utils/cvars/README.md
@@ -99,8 +99,8 @@ NCCL_RAS_ENABLE - default value changed from 1 to 0 NCCL_CTRAN_IB_MAX_QPS -
 default value changed from 1 to 16 NCCL_CTRAN_IB_QP_MAX_MSGS - default value
 changed from 4 to 128 NCCL_CTRAN_IB_QP_SCALING_THRESHOLD - default value changed
 from 131072 to 524288 NCCL_CTRAN_IB_QP_CONFIG_XDC - default value changed from
-"" to "1048576,16,spray,128" NCCL_CTRAN_IB_QP_CONFIG_XZONE -
-default value changed from "" to "1048576,16,spray,128" NCCL_CTRAN_IB_VC_MODE -
+"" to "1048576,16,dqplb,128" NCCL_CTRAN_IB_QP_CONFIG_XZONE -
+default value changed from "" to "1048576,16,dqplb,128" NCCL_CTRAN_IB_VC_MODE -
 default value changed from "spray" to "dqplb"
 
 ## NCCL Baseline Adapter

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1865,7 +1865,7 @@ cvars:
 
  - name        : NCCL_CTRAN_IB_VC_MODE
    type        : enum
-   default     : spray
+   default     : dqplb
    choices     : spray, dqplb
    description : |-
      Configure IBVCs to support either spray mode (uses extra QP for
@@ -1873,7 +1873,7 @@ cvars:
 
  - name        : NCCL_CTRAN_IB_QP_CONFIG_XZONE
    type        : stringlist
-   default     : "1048576,16,spray,128"
+   default     : "1048576,16,dqplb,128"
    description : |-
      A set of configuration for CTRAN IB over inter-zone communication:
      <QP_SCALING_THRESHOLD>,<MAX_QPS>,<VC_MODE>,<QP_MAX_MSGS>
@@ -1884,7 +1884,7 @@ cvars:
 
  - name        : NCCL_CTRAN_IB_QP_CONFIG_XDC
    type        : stringlist
-   default     : "1048576,16,spray,128"
+   default     : "1048576,16,dqplb,128"
    description : |-
      A set of configuration for CTRAN IB over inter-DC communication:
      <QP_SCALING_THRESHOLD>,<MAX_QPS>,<VC_MODE>,<QP_MAX_MSGS>
@@ -1904,7 +1904,7 @@ cvars:
 
  - name        : NCCL_CTRAN_IB_QP_CONFIG_ALGO
    type        : dictlist
-   default     : alltoall:1048576,4,spray,128,224
+   default     : alltoall:1048576,4,dqplb,128,224
    description : |-
      Specify the vc config for each collective. The format is
      <ALGO0: VAL0>,<ALGO1: VAL1>,<ALGO2: VAL2>,<ALGO3: VAL3>


### PR DESCRIPTION
Summary:
`CtranIbConfig::vcMode` and `CtranIbVirtualConn::vcMode_` were both hardcoded to the literal `NCCL_CTRAN_IB_VC_MODE::spray`, while every sibling field in the same structs initializes from its cvar (`numQps` from `NCCL_CTRAN_IB_MAX_QPS`, `qpScalingTh` from `NCCL_CTRAN_IB_QP_SCALING_THRESHOLD`, `qpMsgs` from `NCCL_CTRAN_IB_QP_MAX_MSGS`, `trafficClass` from `NCCL_IB_TC`). The result was that any default-constructed `CtranIbConfig` silently selected spray regardless of how `NCCL_CTRAN_IB_VC_MODE` was configured.

Initialize both from the cvar so there is a single source of truth. This also makes the two defaults follow the cvar's own default, which is now `dqplb`.

Why `dqplb` is the right default: spray signals completion with a zero-byte `RDMA_WRITE_WITH_IMM` on a dedicated notify QP, separate from the QP that carried the data, which satisfies none of the three triggers IBTA `o9-20` enumerates for reading an RDMA-written buffer -- and a zero-length write is never even R_Key-validated (`C9-88`). `dqplb` carries the notification on the data QP itself as a per-chunk `RDMA_WRITE_WITH_IMM`, which is exactly the trigger `o9-20` sanctions. The in-tree cross-rack benchmark also measures `dqplb >= spray` at every message size, so this is not a performance trade.

`spray` remains a valid value; only the default changes.

Reviewed By: shr

Differential Revision: D119617956


