### PR TITLE
Match mock signature in test lambdas

### DIFF
--- a/comms/uniflow/transport/nvlink/tests/unit/NVLinkTransportTest.cpp
+++ b/comms/uniflow/transport/nvlink/tests/unit/NVLinkTransportTest.cpp
@@ -1900,7 +1900,7 @@ TEST_F(NVLinkTransportPutGetTest, PutMultipleRequestsCopiesAllData) {
 #if CUDART_VERSION >= 12080
   EXPECT_CALL(*cudaApiMock_, memcpyBatchAsync(_, _, _, 3, nullptr))
       .WillOnce(Invoke(
-          [](void** dsts,
+          [](void* const* dsts,
              const void* const* srcs,
              const size_t* sizes,
              size_t count,
@@ -2044,7 +2044,7 @@ TEST_F(NVLinkTransportPutGetTest, PutSubSpanTransfersPartialData) {
 #if CUDART_VERSION >= 12080
   EXPECT_CALL(*cudaApiMock_, memcpyBatchAsync(_, _, _, 3, nullptr))
       .WillOnce(Invoke(
-          [](void** dsts,
+          [](void* const* dsts,
              const void* const* srcs,
              const size_t* sizes,
              size_t count,
@@ -2202,7 +2202,7 @@ TEST_F(NVLinkTransportPutGetTest, GetMultipleRequestsCopiesAllData) {
 #if CUDART_VERSION >= 12080
   EXPECT_CALL(*cudaApiMock_, memcpyBatchAsync(_, _, _, 3, nullptr))
       .WillOnce(Invoke(
-          [](void** dsts,
+          [](void* const* dsts,
              const void* const* srcs,
              const size_t* sizes,
              size_t count,


### PR DESCRIPTION
Summary:
The NVLink transport unit test does not compile against CUDA 12.8 or newer:

```
error: no matching member function for call to 'WillOnce'
note: no known conversion from '(lambda ...)' to 'OnceAction<uniflow::Result<void> (void *const *, const void *const *, const unsigned long *, unsigned long, CUstream_st *)>'
```

`CudaApi::memcpyBatchAsync` takes `void* const* dsts` -- the array is read-only, only the pointed-to buffers are written. The three `Invoke` lambdas standing in for it declared `void** dsts` instead. Binding a `void* const*` argument to a `void**` parameter would discard the top-level `const`, so gmock finds no viable `WillOnce` overload and the whole translation unit fails to compile.

Give the lambdas the parameter type the mock declares. The bodies are unchanged: `dsts[i]` is a `void* const`, which still passes to `std::memcpy` as a destination by value.

Nothing caught this earlier because every `memcpyBatchAsync` expectation sits behind `#if CUDART_VERSION >= 12080`, so the mismatch is invisible to any build on an older CUDA -- including the default one.

Differential Revision: D119701405


