### PR TITLE
Preserve abort in send-slot poll

### DIFF
--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -624,6 +624,152 @@ TEST_P(MultipeerIbTransportTestFixture, BadRkeyCompletionErrorUnwinds) {
 }
 
 /*
+ * A bad-rkey completion retired through the blocking send-slot helper.
+ *
+ * The wait and its confirming CQ poll must use the same abort handle. If the
+ * confirmation falls back to a disabled handle, the error CQE traps and
+ * poisons the process CUDA context instead of unwinding with NETWORK_ERROR.
+ */
+TEST_P(
+    MultipeerIbTransportTestFixture,
+    BlockingSendSlotCompletionErrorUnwinds) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "requires exactly 2 ranks, got " << numRanks;
+  }
+  if (backend() != IbTestBackend::Ibgda) {
+    GTEST_SKIP() << "blocking completion-error handling is IBGDA-specific";
+  }
+
+  constexpr std::size_t nbytes = 64 * 1024;
+  constexpr int pipelineDepth = 2;
+  constexpr int numBlocks = 1;
+  constexpr int blockSize = 128;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  constexpr std::chrono::milliseconds kDeadline{30000};
+  constexpr std::chrono::milliseconds kMaxElapsed{5000};
+
+  std::unique_ptr<TestIbTransport> transport;
+  std::unique_ptr<DeviceBuffer> dataBuffer;
+  IbgdaLocalBuffer localDataBuf{};
+  std::vector<IbgdaRemoteBuffer> remoteDataBufs;
+  P2pIbgdaTransportDevice* peerTransport = nullptr;
+  int localSetupOk = 0;
+  std::string skipReason;
+  try {
+    MultipeerIbTransportConfig config{
+        .cudaDevice = localRank,
+        .perChannelSize = nbytes / numBlocks,
+        .max_num_channels = numBlocks,
+        .pipelineDepth = pipelineDepth,
+    };
+    config.enableCollapsedCq = true;
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    transport = std::make_unique<TestIbTransport>(
+        backend(), globalRank, numRanks, std::move(bootstrap), config);
+    if (!transport->collapsedCqActive()) {
+      throw std::runtime_error("collapsed CQ mode is not active");
+    }
+    dataBuffer = std::make_unique<DeviceBuffer>(nbytes);
+    localDataBuf = transport->registerBuffer(dataBuffer->get(), nbytes);
+    remoteDataBufs = transport->exchangeBuffer(localDataBuf);
+    peerTransport = transport->getIbgdaTransportDevice(peerRank);
+    if (peerTransport == nullptr) {
+      throw std::runtime_error("IBGDA peer transport is unavailable");
+    }
+    localSetupOk = 1;
+  } catch (const std::exception& e) {
+    skipReason = e.what();
+  }
+  int allSetupOk = 0;
+  MPI_CHECK(MPI_Allreduce(
+      &localSetupOk, &allSetupOk, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD));
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  if (allSetupOk == 0) {
+    GTEST_SKIP() << "IBGDA collapsed CQ transport not available on some rank: "
+                 << skipReason;
+  }
+
+  int localRunOk = 1;
+  std::string runFailure;
+  if (globalRank == 0) {
+    try {
+      const int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
+      auto poisonedRemote = remoteDataBufs[peerIndex];
+      if (poisonedRemote.rkey_per_device.size <= 0) {
+        throw std::runtime_error("remote buffer has no populated device key");
+      }
+      for (int nic = 0; nic < poisonedRemote.rkey_per_device.size; ++nic) {
+        poisonedRemote.rkey_per_device[nic].value ^=
+            comms::prims::detail::ibgdaNetworkByteOrderKey(0xFFU);
+      }
+
+      DeviceBuffer unretiredBuffer(sizeof(uint32_t));
+      CUDACHECK_TEST(cudaMemset(unretiredBuffer.get(), 0, sizeof(uint32_t)));
+      comms::fault_tolerance::Abort abort(/*enabled=*/true);
+      auto deviceAbort = abort.getDeviceHandle();
+      deviceAbort.setOpTimeoutMs(kDeadline.count());
+
+      const auto start = std::chrono::steady_clock::now();
+      test::testPrepareSendSlotWithAbort(
+          peerTransport,
+          localDataBuf,
+          poisonedRemote,
+          nbytes,
+          static_cast<uint32_t*>(unretiredBuffer.get()),
+          deviceAbort,
+          numBlocks,
+          blockSize);
+      const cudaError_t syncStatus = cudaDeviceSynchronize();
+      const auto elapsed =
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::steady_clock::now() - start);
+
+      if (syncStatus != cudaSuccess) {
+        localRunOk = 0;
+        runFailure = std::string("completion recheck trapped: ") +
+            cudaGetErrorString(syncStatus);
+      } else {
+        uint32_t unretired = 0;
+        CUDACHECK_TEST(cudaMemcpy(
+            &unretired,
+            unretiredBuffer.get(),
+            sizeof(unretired),
+            cudaMemcpyDeviceToHost));
+        EXPECT_EQ(unretired, 1u)
+            << "an aborted completion must leave the send slot unretired";
+        EXPECT_LT(elapsed.count(), kMaxElapsed.count())
+            << "an error CQE is immediate; this suggests the wait timed out";
+        EXPECT_EQ(
+            comms::fault_tolerance::AbortReason::NETWORK_ERROR, abort.reason());
+
+        test::fillBufferWithPattern(
+            localDataBuf.ptr,
+            nbytes,
+            /*baseValue=*/0xA5,
+            numBlocks,
+            blockSize);
+        const cudaError_t healthStatus = cudaDeviceSynchronize();
+        if (healthStatus != cudaSuccess) {
+          localRunOk = 0;
+          runFailure = std::string("CUDA context remained unhealthy: ") +
+              cudaGetErrorString(healthStatus);
+        }
+      }
+    } catch (const std::exception& e) {
+      localRunOk = 0;
+      runFailure = e.what();
+    }
+  }
+
+  int allRunOk = 0;
+  MPI_CHECK(MPI_Allreduce(
+      &localRunOk, &allRunOk, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD));
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  ASSERT_EQ(allRunOk, 1) << "blocking send-slot completion exercise failed: "
+                         << runFailure;
+}
+
+/*
  * A registered send whose completions never land, drained by the production
  * loop shape -- the case the synthetic progress-slot test in D116982768 cannot
  * reach.

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -1537,6 +1537,62 @@ void testMultiQpPutAndSignal(
 // CQ still reports an error after later completions overwrite its single slot.
 // =============================================================================
 
+__global__ void prepareSendSlotWithAbortKernel(
+    P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer source,
+    IbgdaRemoteBuffer remote,
+    std::size_t nbytes,
+    uint32_t* unretiredOut,
+    comms::fault_tolerance::AbortDevice abort) {
+  auto group = make_block_group();
+  abort.start();
+
+  const auto ticket = transport->put(
+      group,
+      source,
+      remote,
+      nbytes,
+      /*signalId=*/-1,
+      /*signalVal=*/0);
+  if (group.is_leader()) {
+    detail::record_send_completion<protocol::Simple>(
+        *transport,
+        group.group_id,
+        /*slotId=*/0,
+        /*generation=*/0,
+        ticket);
+  }
+  group.sync();
+
+  const bool unretired = detail::prepare_send_slot<protocol::Simple>(
+      *transport,
+      group,
+      /*slotId=*/0,
+      /*generation=*/1,
+      abort);
+  if (group.is_leader()) {
+    *unretiredOut = static_cast<uint32_t>(unretired);
+  }
+}
+
+void testPrepareSendSlotWithAbort(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& source,
+    const IbgdaRemoteBuffer& remote,
+    std::size_t nbytes,
+    uint32_t* unretiredOut,
+    comms::fault_tolerance::AbortDevice abort,
+    int numBlocks,
+    int blockSize) {
+  prepareSendSlotWithAbortKernel<<<numBlocks, blockSize>>>(
+      transport, source, remote, nbytes, unretiredOut, abort);
+  const cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
 __global__ void putAndFlushWithAbortKernel(
     P2pIbTransportDevice transport,
     IbgdaLocalBuffer localBuf,

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -554,6 +554,23 @@ void testRegisteredSendDrainWithAbort(
     int numBlocks,
     int blockSize);
 
+/**
+ * Test kernel: retire a blocking send slot after a completion error.
+ *
+ * Posts a write through a caller-supplied remote buffer, records its local
+ * completion ticket in a blocking send slot, then advances the slot generation
+ * through the production `prepare_send_slot()` helper.
+ */
+void testPrepareSendSlotWithAbort(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& source,
+    const IbgdaRemoteBuffer& remote,
+    std::size_t nbytes,
+    uint32_t* unretiredOut,
+    comms::fault_tolerance::AbortDevice abort,
+    int numBlocks,
+    int blockSize);
+
 void testPutAndFlushWithAbort(
     P2pIbTransportDevice transport,
     const IbgdaLocalBuffer& localBuf,

--- a/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceImpl.cuh
@@ -2844,7 +2844,8 @@ template <typename P, typename Transport>
         // Confirm rather than assume: the wait above cannot report that it gave
         // up, and a lane earlier in this loop may already have latched the
         // abort, so later lanes can fall straight through it.
-        if (transport.is_local_completion_ready(group.group_id, ticket)) {
+        if (transport.is_local_completion_ready(
+                group.group_id, ticket, abortDevice)) {
           pending &= ~laneBit;
         }
       }


### PR DESCRIPTION
Summary:
An IBGDA completion error may be observed once while a blocking send slot waits and again in the confirming readiness poll. The wait supplied the communicator's abort handle, but the confirmation silently used the default disabled handle. A retained error CQE could therefore trap and poison the CUDA context instead of unwinding through fault tolerance.

Pass the same abort handle to both polls. Add a two-rank regression that drives an invalid remote key through the production blocking-slot helper and verifies the error sets `NETWORK_ERROR`, leaves the slot unretired, and preserves the CUDA context for subsequent work.

Differential Revision: D119697447


