### PR TITLE
[ROCm][CI] Run RCCL integration tests on ROCm 10.0

### DIFF
--- a/.github/workflows/build_test_rccl.yaml
+++ b/.github/workflows/build_test_rccl.yaml
@@ -22,9 +22,8 @@ jobs:
           - name: RCCL
             runs-on: linux.rocm.gpu.meta-pytorch.mi350.4
             gpu-arch-type: "rocm"
-            gpu-arch-version: "7.2"
-            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/rocm7.2'
-            docker-image: pytorch/manylinux2_28-builder:rocm7.2
+            gpu-arch-version: "10.0"
+            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/rocm10.0'
             cmake-version: "latest"
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
@@ -32,6 +31,7 @@ jobs:
       runner: ${{ matrix.runs-on }}
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
+      job-name: RCCL ROCm ${{ matrix.gpu-arch-version }}
       script: |
         set -ex
         # use faster libmamba solver
@@ -62,8 +62,26 @@ jobs:
         pip install -r requirements.txt
         pip install -r dev-requirements.txt
 
-        export ROCM_HOME=/opt/rocm
-        export RCCL_INCLUDE=$ROCM_HOME/include/rccl
+        # ROCm 10.0 builders install TheRock wheels; the SDK root is not /opt/rocm.
+        # Prefer rocm-sdk (pulled in with the torch wheel), then the image env file,
+        # then a classic /opt/rocm layout.
+        if [ -f /etc/rocm_env.sh ]; then
+          # shellcheck source=/dev/null
+          source /etc/rocm_env.sh
+        fi
+        if command -v rocm-sdk >/dev/null 2>&1; then
+          export ROCM_HOME="$(rocm-sdk path --root)"
+          export PATH="$(rocm-sdk path --bin):${PATH}"
+        elif [ -z "${ROCM_HOME:-}" ] && [ -d /opt/rocm ]; then
+          export ROCM_HOME=/opt/rocm
+        fi
+        if [ -z "${ROCM_HOME:-}" ] || [ ! -f "${ROCM_HOME}/lib/librccl.so" ]; then
+          echo "Could not find librccl.so (ROCM_HOME=${ROCM_HOME:-unset})" >&2
+          exit 1
+        fi
+        export RCCL_INCLUDE="${ROCM_HOME}/include/rccl"
+        export LD_LIBRARY_PATH="${ROCM_HOME}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+        echo "Using ROCM_HOME=${ROCM_HOME}"
 
         ./build_rccl.sh
         pip install numpy

--- a/.github/workflows/build_test_rccl.yaml
+++ b/.github/workflows/build_test_rccl.yaml
@@ -4,7 +4,12 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/build_test_rccl.yaml
+      - build_rccl.sh
+      - comms/torchcomms/scripts/run_tests_integration_rccl_py.sh
+      - comms/torchcomms/rccl/**
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Point the RCCL CI job at ROCm 10.0 (torch nightly `rocm10.0`, AlmaLinux `rocm10.0` image) so it matches published torchcomms wheels.
- Discover `ROCM_HOME` / `librccl.so` via `rocm-sdk` (TheRock layout) instead of hard-coding `/opt/rocm`.
- Run the job on PRs that touch the RCCL workflow, `build_rccl.sh`, the RCCL integration runner, or `comms/torchcomms/rccl/**`. Drop `workflow_dispatch`.