### PR TITLE
Default AllReduce to ARv2 Ring

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3387,7 +3387,7 @@ cvars:
 
  - name        : MCCL_ALGO
    type        : string
-   default     : none
+   default     : "allreduce:ring"
    description : |-
      MCCL-native collective algorithm override. Use "none" or leave unset to
      preserve the collective's existing selection. Prefer qualified selectors


### PR DESCRIPTION
Summary: Select the native Ring implementation by default for AllReduce operations while preserving explicit `MCCL_ALGO` overrides. Transport and zero-copy defaults remain unchanged.

Reviewed By: saifhhasan

Differential Revision: D119739178


