### PR TITLE
Enable bidirectional Ring by default

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3387,7 +3387,7 @@ cvars:
 
  - name        : MCCL_ALGO
    type        : string
-   default     : none
+   default     : "allreduce:ring"
    description : |-
      MCCL-native collective algorithm override. Use "none" or leave unset to
      preserve the collective's existing selection. Prefer qualified selectors

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2067,7 +2067,7 @@ cvars:
 
  - name        : MCCL_ALLREDUCE_RING_BIDIRECTIONAL_ENABLE
    type        : bool
-   default     : false
+   default     : true
    description : |-
      Enable bidirectional Ring reduce-scatter and all-gather for non-LL
      collectives with more than two nodes on both staged-copy and registered


### PR DESCRIPTION
Summary: Enable the bidirectional Ring path by default for eligible AllReduce operations. Explicit `MCCL_ALLREDUCE_RING_BIDIRECTIONAL_ENABLE` overrides continue to take precedence.

Differential Revision: D119751030


