### PR TITLE
Add required local RDMA flush

### DIFF
--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -632,9 +632,7 @@ void CtranIb::init(
     // FIXME: use initRemoteTransStates() to create cq
   }
 
-  if (enableLocalFlush) {
-    localVc = std::make_unique<LocalVirtualConn>(devices, ncclLogData);
-  }
+  localVc = std::make_unique<LocalVirtualConn>(devices, ncclLogData);
 
   // Record reference to CtranIbSingleton
   if (comm) {
@@ -940,21 +938,34 @@ commResult_t CtranIb::deregMem(void* ibRegElem) {
 commResult_t CtranIb::iflush(
     const void* dbuf,
     const void* localRegHdl,
-    CtranIbRequest* req) {
+    CtranIbRequest* req,
+    const bool force) {
   FB_COMMCHECK(checkEpochLock(this));
 
-  if (enableLocalFlush_ && localRegHdl != nullptr) {
+  if ((enableLocalFlush_ || force) && localRegHdl != nullptr) {
     CTRAN_IB_PER_OBJ_LOCK_GUARD(localVcMutex, {
       auto& vc = localVc;
-      return vc->iflush(dbuf, localRegHdl, req);
+      if (vc != nullptr) {
+        return vc->iflush(dbuf, localRegHdl, req);
+      }
     });
+  }
+
+  if (force) {
+    CTRAN_ERR(
+        commInternalError,
+        "CTRAN-IB: cannot force flush of buffer {}: no local flush connection available (enableLocalFlush {}, localRegHdl {})",
+        dbuf,
+        enableLocalFlush_,
+        localRegHdl);
+    return commInternalError;
   } else {
     // A buffer with no IB registration never received IB RDMA writes, so there
     // is nothing to order against and skipping is correct. Local flush being
     // disabled altogether is the expected steady state, not an anomaly, so it
     // stays silent.
     if (enableLocalFlush_) {
-      CTRAN_LOG(WARN, "CTRAN-IB: No IB registration for flush, skip");
+      CTRAN_LOG(WARN, "CTRAN-IB: No local flush connection available, skip");
     }
     if (req != nullptr) {
       FB_COMMCHECK(req->complete());

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -51,8 +51,8 @@ class CtranIb {
   // to the local rank.
   // Input arguments:
   //   - comm: the Ctran communicator
-  //   - enableLocalFlush: whether to support local flush. If not specified, use
-  //              default config based on cuda arch.
+  //   - enableLocalFlush: whether to issue non-forced local flushes. If not
+  //                       specified, use the default for the CUDA architecture.
   CtranIb(
       CtranComm* comm,
       std::optional<bool> enableLocalFlush = std::nullopt,
@@ -70,7 +70,7 @@ class CtranIb {
   //              mapping NIC
   //   - commHash: for logging only.
   //   - commDesc: for logging only.
-  //   - enableLocalFlush: whether to support local flush.
+  //   - enableLocalFlush: whether to issue non-forced local flushes.
   //   - bootstrapMode: defines the needed bootstrap mode. If kDefaultServer,
   //                    it launches internal listen thread which binds and
   //                    listens to the default server address and port as
@@ -401,10 +401,14 @@ class CtranIb {
   // Input arguments:
   //   - dbuf: the local buffer to flush
   //   - localRegHdl: the local registration handle of the local buffer
+  //   - force: bypass enableLocalFlush and fail if the flush cannot be issued.
   // Output arguments:
   //   - req: the request object to track the progress of the flush.
-  commResult_t
-  iflush(const void* dbuf, const void* localRegHdl, CtranIbRequest* req);
+  commResult_t iflush(
+      const void* dbuf,
+      const void* localRegHdl,
+      CtranIbRequest* req,
+      const bool force = false);
 
   // Notify the remote peer via a zero-byte RDMA_WRITE_WITH_IMM over the
   // established IB connection without extra data transfer.
@@ -1066,17 +1070,21 @@ class CtranIb {
           continueWhileLoop = true;
         }
 
-        if (enableLocalFlush_) {
-          CTRAN_IB_PER_OBJ_LOCK_GUARD(localVcMutex, {
-            auto& vc = localVc;
-            // First check if it is a local flush CQE
-            if (wc.qp_num == vc->qpNum(device)) {
-              CQE_ERROR_CHECK(wc, rank, "localFlush");
-              FB_COMMCHECK(vc->processCqe(wc.opcode, device));
-              continue;
-            }
-          });
-        }
+        CTRAN_IB_PER_OBJ_LOCK_GUARD(localVcMutex, {
+          auto& vc = localVc;
+          if (vc == nullptr) {
+            CTRAN_ERR(
+                commInternalError,
+                "No local virtual connection available while processing CQE on device {}",
+                device);
+            return commInternalError;
+          }
+          if (wc.qp_num == vc->qpNum(device)) {
+            CQE_ERROR_CHECK(wc, rank, "localFlush");
+            FB_COMMCHECK(vc->processCqe(wc.opcode, device));
+            continue;
+          }
+        });
 
         // Next search from remote VCs.
         // Expect received CQE should be with a registered rank and established

--- a/comms/ctran/backends/ib/CtranIbLocalVc.cc
+++ b/comms/ctran/backends/ib/CtranIbLocalVc.cc
@@ -1,6 +1,10 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/ctran/backends/ib/CtranIbLocalVc.h"
+
+#include <algorithm>
+#include <cstdint>
+
 #include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/backends/ib/IbvWrap.h"
 #include "comms/ctran/ibverbx/IbvQpUtils.h"
@@ -28,6 +32,11 @@ LocalVirtualConn::LocalVirtualConn(
   ibvMrs_.reserve(devices_.size());
   ibvQps_.reserve(devices_.size());
   sgs_.resize(devices_.size());
+  sendWr_.wr_id = 0;
+  sendWr_.next = nullptr;
+  sendWr_.num_sge = 1;
+  sendWr_.opcode = ibverbx::IBV_WR_RDMA_READ;
+  sendWr_.send_flags = ibverbx::IBV_SEND_SIGNALED;
 
   for (int device = 0; device < devices_.size(); device++) {
     auto maybeMr = devices_[device].ibvPd->regMr(
@@ -132,19 +141,31 @@ commResult_t LocalVirtualConn::iflush(
     }
   }
 
-  for (int device = 0; device < devices_.size(); device++) {
-    ibverbx::ibv_send_wr wr;
-    memset(&wr, 0, sizeof(wr));
-    wr.wr_id = 0;
-    wr.wr.rdma.remote_addr = reinterpret_cast<uint64_t>(dbuf);
-    wr.wr.rdma.rkey = (*mrs)[device].mr()->rkey;
-    wr.sg_list = &sgs_[device];
-    wr.num_sge = 1;
-    wr.opcode = ibverbx::IBV_WR_RDMA_READ;
-    wr.send_flags = ibverbx::IBV_SEND_SIGNALED;
+  // All NICs register the same range, so compute the bounded read size once.
+  const auto* const mr = mrs->front().mr();
+  const auto dbufAddr = reinterpret_cast<uintptr_t>(dbuf);
+  const auto mrAddr = reinterpret_cast<uintptr_t>(mr->addr);
+  if (dbufAddr < mrAddr || dbufAddr - mrAddr >= mr->length) {
+    CTRAN_ERR(
+        commInvalidArgument,
+        "CTRAN-IB: flush buffer {} is outside registered region [{}, {})",
+        dbuf,
+        mr->addr,
+        static_cast<const void*>(
+            static_cast<const uint8_t*>(mr->addr) + mr->length));
+    return commInvalidArgument;
+  }
+  const size_t mrBytesLeft = mr->length - (dbufAddr - mrAddr);
+  const auto minBytes = std::min(sizeof(int), mrBytesLeft);
+  sendWr_.wr.rdma.remote_addr = reinterpret_cast<uint64_t>(dbuf);
 
-    ibverbx::ibv_send_wr* bad_wr{nullptr};
-    auto maybeSend = ibvQps_[device].postSend(&wr, &bad_wr);
+  for (int device = 0; device < devices_.size(); device++) {
+    sgs_[device].length = static_cast<uint32_t>(minBytes);
+    sendWr_.wr.rdma.rkey = (*mrs)[device].mr()->rkey;
+    sendWr_.sg_list = &sgs_[device];
+
+    ibverbx::ibv_send_wr* badSendWr{nullptr};
+    auto maybeSend = ibvQps_[device].postSend(&sendWr_, &badSendWr);
     if (maybeSend.hasError()) {
       // Devices before this one already posted. Their CQEs will arrive with
       // nothing tracked, so there is no recoverable exit.

--- a/comms/ctran/backends/ib/CtranIbLocalVc.h
+++ b/comms/ctran/backends/ib/CtranIbLocalVc.h
@@ -33,6 +33,7 @@ class LocalVirtualConn {
   std::vector<ibverbx::IbvMr> ibvMrs_;
   std::vector<ibverbx::IbvQp> ibvQps_;
   std::vector<ibverbx::ibv_sge> sgs_;
+  ibverbx::ibv_send_wr sendWr_{};
 
   std::vector<CtranIbDevice> devices_;
 

--- a/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
@@ -396,6 +396,55 @@ TEST_F(CtranIbBootstrapCommonTest, IflushSkipPathsAcceptNullRequest) {
       commSuccess);
 }
 
+TEST_F(CtranIbBootstrapCommonTest, IflushForceOverridesDisabledPolicy) {
+  auto abortCtrl = comms::fault_tolerance::createAbort(/*enabled=*/true);
+  auto ctranIb = createCtranIb(
+      /*rank=*/0, CtranIb::BootstrapMode::kDefaultServer, abortCtrl);
+
+  CtranIbEpochRAII epochRAII(ctranIb.get());
+
+  constexpr size_t kBufferSize = 1024;
+  void* buffer = nullptr;
+  ASSERT_EQ(cudaMalloc(&buffer, kBufferSize), cudaSuccess);
+  void* regHdl = nullptr;
+  ASSERT_EQ(ctranIb->regMem(buffer, kBufferSize, 0, &regHdl), commSuccess);
+
+  CtranIbRequest reqWithRegHdl;
+  EXPECT_EQ(
+      ctranIb->iflush(
+          buffer,
+          regHdl,
+          &reqWithRegHdl,
+          /*force=*/true),
+      commSuccess);
+  while (!reqWithRegHdl.isComplete()) {
+    ASSERT_EQ(ctranIb->progress(), commSuccess);
+  }
+
+  CtranIbRequest reqAtRegionEnd;
+  EXPECT_EQ(
+      ctranIb->iflush(
+          static_cast<char*>(buffer) + kBufferSize,
+          regHdl,
+          &reqAtRegionEnd,
+          /*force=*/true),
+      commInvalidArgument);
+  EXPECT_FALSE(reqAtRegionEnd.isComplete());
+
+  EXPECT_EQ(ctranIb->deregMem(regHdl), commSuccess);
+  EXPECT_EQ(cudaFree(buffer), cudaSuccess);
+
+  CtranIbRequest reqWithoutRegHdl;
+  EXPECT_EQ(
+      ctranIb->iflush(
+          /*dbuf=*/nullptr,
+          /*localRegHdl=*/nullptr,
+          &reqWithoutRegHdl,
+          /*force=*/true),
+      commInternalError);
+  EXPECT_FALSE(reqWithoutRegHdl.isComplete());
+}
+
 // Test bootstrapStart with specified server address
 TEST_P(CtranIbBootstrapParameterizedTest, BootstrapStartSpecifiedServer) {
   SocketServerAddr serverAddr = getSocketServerAddress();


### PR DESCRIPTION
Summary:
- Add a `CtranIb::iflush` operation that fences completed inbound writes with the local loopback RDMA connection.
- Construct the local connection independently of the non-forced flush policy, return internal errors when required flush state is unavailable, and reject addresses outside their registered region.
- Clamp loopback reads to the remaining registered bytes and cover forced, disabled-policy, invalid-address, and small-region behavior.

Differential Revision: D119756594


