### PR TITLE
Add bounded local RDMA flush (#4116)

### DIFF
--- a/comms/torchcomms/transport/RdmaTransport.cpp
+++ b/comms/torchcomms/transport/RdmaTransport.cpp
@@ -156,8 +156,6 @@ RdmaMemory::RdmaMemory(RdmaMemory&& other) noexcept
 }
 
 RdmaMemory::~RdmaMemory() noexcept {
-  // Ownership is keyed on dynRegHdl_: the HIT path has dynRegHdl_ == nullptr,
-  // so this is a no-op there and only the owned dynamic registration is freed.
   if (dynRegHdl_ != nullptr) {
     FB_COMMCHECKIGNORE(regCache_->deregDynamic(
         static_cast<ctran::regcache::RegElem*>(dynRegHdl_)));
@@ -452,6 +450,52 @@ folly::SemiFuture<commResult_t> RdmaTransport::read(
   }
 
   // Add work to pending list and schedule progress
+  auto pendingWorks = pendingWorks_.wlock();
+  pendingWorks->emplace_back(std::move(work));
+  evb_->runInEventBaseThread([this]() { progress(); });
+
+  // NOLINTNEXTLINE(clang-diagnostic-nrvo)
+  return sf;
+}
+
+folly::SemiFuture<commResult_t> RdmaTransport::flush(
+    RdmaMemory::View localBuffer,
+    std::optional<std::chrono::milliseconds> timeout) {
+  if (broken_.load(std::memory_order_relaxed)) {
+    return commInternalError;
+  }
+  CHECK_THROW(evb_, std::runtime_error);
+
+  CHECK_EQ(cudaDev_, localBuffer->getDevice());
+  if (localBuffer.size() == 0) {
+    return commSuccess;
+  }
+
+  auto work = std::make_unique<Work>();
+  // Flush has the same completion and timeout behavior as write.
+  work->type = Work::Type::Write;
+  auto sf = work->promise.getSemiFuture();
+
+  CtranIbEpochRAII epochRAII(ib_.get());
+  const auto ibRes =
+      ib_->iflush(localBuffer.data(), localBuffer->localKey(), &work->ibReq);
+  if (ibRes != commSuccess && ibRes != commInProgress) {
+    XLOGF(
+        ERR,
+        "RdmaTransport::flush: iflush failed with {}",
+        static_cast<int>(ibRes));
+    broken_.store(true, std::memory_order_relaxed);
+    // iflush may have stored a pointer to work->ibReq in the local VC
+    // queues before failing; park the work instead of destroying it.
+    work->promise.setValue(ibRes);
+    retiredWorks_.wlock()->emplace_back(std::move(work));
+    return sf;
+  }
+  if (timeout.has_value()) {
+    work->timeout = timeout;
+    work->creationTime = std::chrono::steady_clock::now();
+  }
+
   auto pendingWorks = pendingWorks_.wlock();
   pendingWorks->emplace_back(std::move(work));
   evb_->runInEventBaseThread([this]() { progress(); });

--- a/comms/torchcomms/transport/RdmaTransport.h
+++ b/comms/torchcomms/transport/RdmaTransport.h
@@ -291,6 +291,7 @@ struct RdmaRemoteBuffer {
  * - `write` -> RDMA write to a remote memory
  * - `read`  -> RDMA read from a remote memory
  * - `waitForWrite` -> Wait for a remote write operation
+ * - `flush` -> Fence inbound remote writes into a local memory region
  *
  * Future APIs that can be supported as per use-case. Given this framework
  * adding new APIs should be relatively straightforward.
@@ -300,25 +301,25 @@ struct RdmaRemoteBuffer {
  * - <Atomic APIs>
  *
  * API return value contracts (commResult_t):
- * All async APIs (write, read, waitForWrite) return a commResult_t via
+ * All async APIs (write, read, waitForWrite, flush) return a commResult_t via
  * SemiFuture. Callers MUST use the timeout parameter to ensure bounded
  * completion — without it, operations may wait indefinitely for IB
  * completion.
  *
  *   commSuccess — normal completion:
- *     write(), read(), waitForWrite(), connect()
+ *     write(), read(), waitForWrite(), flush(), connect()
  *
  *   commTimeout — operation exceeded its timeout duration:
- *     write()
+ *     write(), flush()
  *
  *   commInternalError — IB / transport-level failure:
- *     write(), read(), waitForWrite()
+ *     write(), read(), waitForWrite(), flush()
  *     Any such failure permanently marks the transport as broken: all
  *     subsequent async API calls fail immediately with commInternalError
  *     without issuing IB operations. The owner should destroy the transport.
  *
  *   commUserAbort — transport was destroyed while operations were pending:
- *     write(), read(), waitForWrite()
+ *     write(), read(), waitForWrite(), flush()
  *
  *   Throws (no commResult_t) — unrecoverable setup error:
  *     bind(), connect()
@@ -410,6 +411,14 @@ class __attribute__((visibility("default"))) RdmaTransport {
   folly::SemiFuture<commResult_t> read(
       RdmaMemory::MutableView& localBuffer,
       const RdmaRemoteBuffer& remoteBuffer);
+
+  /* Fence completed inbound writes on every NIC bound to this device.
+   * This local operation requires no peer. An unset timeout waits indefinitely.
+   */
+  folly::SemiFuture<commResult_t> flush(
+      RdmaMemory::View localBuffer,
+      std::optional<std::chrono::milliseconds> timeout = std::nullopt);
+  // TODO: Add flush fault injection when ibverbx supports it.
 
   /*
    * Mock type for testing RDMA transport error scenarios

--- a/comms/torchcomms/transport/tests/cpp/RdmaTransportTest.cc
+++ b/comms/torchcomms/transport/tests/cpp/RdmaTransportTest.cc
@@ -1025,6 +1025,72 @@ TEST_F(RdmaTransportTest, BrokenTransportFailsFast) {
 
   EXPECT_EQ(transport->waitForWrite().get(), commInternalError);
 
+  auto flushFuture = transport->flush(rdmaMemory.createView());
+  EXPECT_EQ(std::move(flushFuture).get(), commInternalError);
+
+  EXPECT_EQ(cudaFree(buffer), cudaSuccess);
+}
+
+TEST_F(RdmaTransportTest, FlushWithoutConnectedPeer) {
+  const size_t bufferSize = 1024;
+  const int cudaDev = 0;
+  EXPECT_EQ(cudaSetDevice(cudaDev), cudaSuccess);
+
+  auto evbThread = std::make_unique<folly::ScopedEventBaseThread>();
+  auto transport = std::make_unique<torch::comms::RdmaTransport>(
+      cudaDev, evbThread->getEventBase());
+  EXPECT_FALSE(transport->bind().empty());
+  EXPECT_FALSE(transport->connected());
+
+  void* buffer = nullptr;
+  EXPECT_EQ(cudaMalloc(&buffer, bufferSize), cudaSuccess);
+  torch::comms::RdmaMemory rdmaMemory(buffer, bufferSize, cudaDev);
+
+  auto flushFuture = transport->flush(rdmaMemory.createView());
+  EXPECT_EQ(std::move(flushFuture).get(), commSuccess);
+
+  EXPECT_EQ(cudaFree(buffer), cudaSuccess);
+}
+
+TEST_F(RdmaTransportTest, FlushEmptyRegion) {
+  const size_t bufferSize = 1024;
+  const int cudaDev = 0;
+  EXPECT_EQ(cudaSetDevice(cudaDev), cudaSuccess);
+
+  auto evbThread = std::make_unique<folly::ScopedEventBaseThread>();
+  auto transport = std::make_unique<torch::comms::RdmaTransport>(
+      cudaDev, evbThread->getEventBase());
+  EXPECT_FALSE(transport->bind().empty());
+
+  void* buffer = nullptr;
+  EXPECT_EQ(cudaMalloc(&buffer, bufferSize), cudaSuccess);
+  torch::comms::RdmaMemory rdmaMemory(buffer, bufferSize, cudaDev);
+  ASSERT_FALSE(rdmaMemory.reusedRegistration());
+
+  auto flushFuture = transport->flush(rdmaMemory.createView(bufferSize, 0));
+  EXPECT_EQ(std::move(flushFuture).get(), commSuccess);
+
+  EXPECT_EQ(cudaFree(buffer), cudaSuccess);
+}
+
+TEST_F(RdmaTransportTest, FlushWithTimeoutSucceeds) {
+  const size_t bufferSize = 1024;
+  const int cudaDev = 0;
+  EXPECT_EQ(cudaSetDevice(cudaDev), cudaSuccess);
+
+  auto evbThread = std::make_unique<folly::ScopedEventBaseThread>();
+  auto transport = std::make_unique<torch::comms::RdmaTransport>(
+      cudaDev, evbThread->getEventBase());
+  EXPECT_FALSE(transport->bind().empty());
+
+  void* buffer = nullptr;
+  EXPECT_EQ(cudaMalloc(&buffer, bufferSize), cudaSuccess);
+  torch::comms::RdmaMemory rdmaMemory(buffer, bufferSize, cudaDev);
+
+  auto flushFuture = transport->flush(
+      rdmaMemory.createView(), std::chrono::milliseconds(30000));
+  EXPECT_EQ(std::move(flushFuture).get(), commSuccess);
+
   EXPECT_EQ(cudaFree(buffer), cudaSuccess);
 }
 


### PR DESCRIPTION
Summary:

- Add `RdmaTransport::flush` to fence completed inbound writes without requiring a peer connection.
- Expose forced-flush behavior and preserve it by default.
- Add optional bounded completion by reusing the existing write completion and timeout path.
- Retain the local registration until outstanding RDMA work retires, including after a caller-visible timeout.
- Treat empty views as successful no-ops and cover unconnected, small-region, empty-view, bounded, and broken-transport behavior.

Differential Revision: D119756595


