### PR TITLE
Fix CUDA 13 graph query signatures

### DIFF
--- a/comms/ctran/gpe/tests/CtranGpeHostNodeSideStreamUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeHostNodeSideStreamUT.cc
@@ -52,10 +52,14 @@ Census censusOf(cudaGraph_t graph) {
   std::vector<cudaGraphNode_t> nodes(c.nodes);
   EXPECT_EQ(cudaGraphGetNodes(graph, nodes.data(), &c.nodes), cudaSuccess);
 
-  EXPECT_EQ(cudaGraphGetEdges(graph, nullptr, nullptr, &c.edges), cudaSuccess);
+  EXPECT_EQ(
+      ctran::utils::cudagraph::getGraphEdges(graph, nullptr, nullptr, &c.edges),
+      cudaSuccess);
   std::vector<cudaGraphNode_t> from(c.edges), to(c.edges);
   EXPECT_EQ(
-      cudaGraphGetEdges(graph, from.data(), to.data(), &c.edges), cudaSuccess);
+      ctran::utils::cudagraph::getGraphEdges(
+          graph, from.data(), to.data(), &c.edges),
+      cudaSuccess);
 
   std::unordered_set<cudaGraphNode_t> hostNodes;
   for (cudaGraphNode_t n : nodes) {

--- a/comms/ctran/tests/CtranDistAllgatherCtwinTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherCtwinTests.cc
@@ -18,6 +18,7 @@
 #include "comms/ctran/tests/CtranTestUtils.h"
 #include "comms/ctran/tests/VerifyAlgoStatsUtil.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/ctran/window/CtranWin.h"
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
@@ -1059,10 +1060,15 @@ TEST_P(CtranAllgatherCtwinHostSpineTest, HostNodeWiring) {
   ASSERT_EQ(cudaGraphGetNodes(graph, nodes.data(), &numNodes), cudaSuccess);
 
   size_t numEdges = 0;
-  ASSERT_EQ(cudaGraphGetEdges(graph, nullptr, nullptr, &numEdges), cudaSuccess);
+  ASSERT_EQ(
+      ctran::utils::cudagraph::getGraphEdges(
+          graph, nullptr, nullptr, &numEdges),
+      cudaSuccess);
   std::vector<cudaGraphNode_t> from(numEdges), to(numEdges);
   ASSERT_EQ(
-      cudaGraphGetEdges(graph, from.data(), to.data(), &numEdges), cudaSuccess);
+      ctran::utils::cudagraph::getGraphEdges(
+          graph, from.data(), to.data(), &numEdges),
+      cudaSuccess);
 
   std::unordered_map<cudaGraphNode_t, cudaGraphNodeType> kind;
   for (cudaGraphNode_t n : nodes) {

--- a/comms/ctran/utils/CudaGraphUtils.h
+++ b/comms/ctran/utils/CudaGraphUtils.h
@@ -26,6 +26,22 @@ inline cudaError_t getStreamCaptureInfo(
 #endif
 }
 
+// CUDA 13 folded the optional edge-data output into cudaGraphGetEdges itself;
+// HIP and earlier CUDA runtimes keep the four-argument form.
+inline cudaError_t getGraphEdges(
+    cudaGraph_t graph,
+    cudaGraphNode_t* from,
+    cudaGraphNode_t* to,
+    size_t* numEdges) {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_HCC__)
+  return hipGraphGetEdges(graph, from, to, numEdges);
+#elif CUDART_VERSION >= 13000
+  return cudaGraphGetEdges(graph, from, to, nullptr, numEdges);
+#else
+  return cudaGraphGetEdges(graph, from, to, numEdges);
+#endif
+}
+
 // Retain a user object on the graph so its destroy callback runs when the
 // graph is destroyed. Use this to tie resource lifetime to graph lifetime
 // (e.g., pinned memory that must outlive graph replays).

--- a/comms/utils/tests/GraphCaptureSideStreamTest.cu
+++ b/comms/utils/tests/GraphCaptureSideStreamTest.cu
@@ -36,24 +36,46 @@ class GraphSideStreamTest : public ::testing::Test {
     return nodes;
   }
 
+  // CUDA 13 folded the optional edge-data output into the dependency queries
+  // themselves; HIP and earlier CUDA runtimes keep the three-argument form.
+  static cudaError_t
+  dependentNodes(cudaGraphNode_t node, cudaGraphNode_t* out, size_t* n) {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_HCC__)
+    return hipGraphNodeGetDependentNodes(node, out, n);
+#elif CUDART_VERSION >= 13000
+    return cudaGraphNodeGetDependentNodes(node, out, nullptr, n);
+#else
+    return cudaGraphNodeGetDependentNodes(node, out, n);
+#endif
+  }
+
+  static cudaError_t
+  dependencies(cudaGraphNode_t node, cudaGraphNode_t* out, size_t* n) {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_HCC__)
+    return hipGraphNodeGetDependencies(node, out, n);
+#elif CUDART_VERSION >= 13000
+    return cudaGraphNodeGetDependencies(node, out, nullptr, n);
+#else
+    return cudaGraphNodeGetDependencies(node, out, n);
+#endif
+  }
+
   static std::vector<cudaGraphNode_t> getSuccs(cudaGraphNode_t node) {
     size_t n = 0;
-    EXPECT_EQ(cudaGraphNodeGetDependentNodes(node, nullptr, &n), cudaSuccess);
+    EXPECT_EQ(dependentNodes(node, nullptr, &n), cudaSuccess);
     std::vector<cudaGraphNode_t> out(n);
     if (n > 0) {
-      EXPECT_EQ(
-          cudaGraphNodeGetDependentNodes(node, out.data(), &n), cudaSuccess);
+      EXPECT_EQ(dependentNodes(node, out.data(), &n), cudaSuccess);
     }
     return out;
   }
 
   static std::vector<cudaGraphNode_t> getPreds(cudaGraphNode_t node) {
     size_t n = 0;
-    EXPECT_EQ(cudaGraphNodeGetDependencies(node, nullptr, &n), cudaSuccess);
+    EXPECT_EQ(dependencies(node, nullptr, &n), cudaSuccess);
     std::vector<cudaGraphNode_t> out(n);
     if (n > 0) {
-      EXPECT_EQ(
-          cudaGraphNodeGetDependencies(node, out.data(), &n), cudaSuccess);
+      EXPECT_EQ(dependencies(node, out.data(), &n), cudaSuccess);
     }
     return out;
   }


### PR DESCRIPTION
Summary:
CUDA 13 reshaped the CUDA graph dependency queries: `cudaGraphGetEdges`, `cudaGraphNodeGetDependencies` and `cudaGraphNodeGetDependentNodes` each absorbed the optional `cudaGraphEdgeData*` output that used to exist only on their `_v2` variants, and the older overloads were removed. Three graph-topology test helpers still called the pre-13 forms, so they no longer compile against a CUDA 13 toolchain:

```
error: no matching function for call to 'cudaGraphGetEdges'
note: candidate function not viable: requires 5 arguments, but 4 were provided
```

- Add `ctran::utils::cudagraph::getGraphEdges` to `CudaGraphUtils.h`, next to the `getStreamCaptureInfo` shim that already absorbs this class of change, and route the two ctran graph-shape tests (`CtranDistAllgatherCtwinTests.cc`, `CtranGpeHostNodeSideStreamUT.cc`) through it.
- Wrap the two per-node dependency queries in `GraphCaptureSideStreamTest.cu` the same way. That file sits below ctran in the dependency order, so it keeps a file-local shim rather than reaching up for the shared one.

Each shim tests the HIP platform macros before the CUDA runtime version, so the ROCm build keeps calling the four- and three-argument entry points it has always used. Behavior is unchanged on every toolchain: the new `edgeData` output is passed as `nullptr`, which is exactly what the pre-13 entry points did internally.

Differential Revision: D119782054


